### PR TITLE
feat: implement collection operations (first, last, nth, reject) - Fixes #26

### DIFF
--- a/lib/ptc_runner/validator.ex
+++ b/lib/ptc_runner/validator.ex
@@ -175,6 +175,36 @@ defmodule PtcRunner.Validator do
     :ok
   end
 
+  defp validate_operation("first", _node) do
+    :ok
+  end
+
+  defp validate_operation("last", _node) do
+    :ok
+  end
+
+  defp validate_operation("nth", node) do
+    case Map.get(node, "index") do
+      nil ->
+        {:error, {:validation_error, "Operation 'nth' requires field 'index'"}}
+
+      index when is_integer(index) and index >= 0 ->
+        :ok
+
+      index when is_integer(index) ->
+        {:error, {:validation_error, "Operation 'nth' index must be non-negative, got #{index}"}}
+
+      _ ->
+        {:error, {:validation_error, "Operation 'nth' field 'index' must be an integer"}}
+    end
+  end
+
+  defp validate_operation("reject", node) do
+    with :ok <- require_field(node, "where", "Operation 'reject' requires field 'where'") do
+      validate_node(Map.get(node, "where"))
+    end
+  end
+
   # Unknown operation
   defp validate_operation(op, _node) do
     {:error, {:validation_error, "Unknown operation '#{op}'"}}


### PR DESCRIPTION
## Summary

This PR implements four Phase 2 collection operations:
- **first**: Get first item from list (returns nil for empty)
- **last**: Get last item from list (returns nil for empty)  
- **nth**: Get item at specific index, 0-indexed (returns nil if out of bounds)
- **reject**: Remove matching items (inverse of filter)

## What was implemented

### Operations Added
- Added full implementations in lib/ptc_runner/operations.ex with proper error handling
- Added validation rules in lib/ptc_runner/validator.ex with upfront index validation
- Updated module documentation to reflect new operations

### Validation Features
- nth requires a non-negative integer index (validated upfront)
- All operations require list input (checked at runtime)
- reject requires a where clause (validated upfront)

### Testing
- 20+ new tests covering happy paths, edge cases, and error scenarios
- Tests for empty lists, out-of-bounds indices, type mismatches
- E2E tests demonstrating realistic data processing pipelines
- Tests for operations without piped input
- Validation error tests for malformed programs

## Test Results
- All 100 tests pass
- No code quality issues (Credo analysis clean)
- Precommit checks pass

## Related Issues
Fixes #26