### PR TITLE
feat: implement call operation for tool invocation (fixes #40)

### DIFF
--- a/lib/ptc_runner/validator.ex
+++ b/lib/ptc_runner/validator.ex
@@ -321,6 +321,17 @@ defmodule PtcRunner.Validator do
     end
   end
 
+  # Tool integration
+  defp validate_operation("call", node) do
+    with :ok <- require_field(node, "tool", "Operation 'call' requires field 'tool'") do
+      case Map.get(node, "args") do
+        nil -> :ok
+        args when is_map(args) -> :ok
+        _ -> {:error, {:validation_error, "Field 'args' must be a map"}}
+      end
+    end
+  end
+
   # Unknown operation
   defp validate_operation(op, _node) do
     {:error, {:validation_error, "Unknown operation '#{op}'"}}


### PR DESCRIPTION
## Summary

Implements the `call` operation for Phase 4 (Tool Integration), enabling PTC programs to invoke registered tool functions with provided arguments and handle their results.

## What Changed

### Validator (`lib/ptc_runner/validator.ex`)
- Added validation clause for "call" operation before catch-all clause
- Validates required "tool" field (must be string)
- Validates optional "args" field (must be map if provided)

### Operations (`lib/ptc_runner/operations.ex`)
- Added eval function for "call" operation
- Invokes registered tool by name with args (defaults to `%{}` if not provided)
- Handles all edge cases:
  - Missing tool: returns error with "Tool not found" message
  - Tool returns `{:error, reason}`: propagates as execution error
  - Tool raises exception: caught and converted to execution error
  - Tool has wrong arity: caught with clear error message using `is_function(tool_fn, 1)`

### Tests (`test/ptc_runner_test.exs`)
- 13 comprehensive tests covering all acceptance criteria:
  - Unit tests: tool with args, tool without args, all error cases
  - Validation tests: missing tool field, args not a map
  - E2E test: call tool as first step in pipe with filter and count
  - E2E test: call tool with let binding to store result

## Test Results

All 236 tests pass (including 3 doctests, 13 new tests for call operation).

## Checklist

- [x] Validation pattern matches `literal` and `let` operations
- [x] Operation pattern matches `let` and other operations
- [x] Implementation addresses review suggestion (using `is_function(tool_fn, 1)`)
- [x] All acceptance criteria covered
- [x] Edge cases handled (missing tool, error returns, exceptions, wrong arity)
- [x] E2E tests demonstrate pipe and let integration
- [x] Code formatted and passes all quality checks

Fixes #40

🤖 Generated with Claude Code