### PR TITLE
feat: Implement declarative Schema module (#48)

### DIFF
--- a/lib/ptc_runner/schema.ex
+++ b/lib/ptc_runner/schema.ex
@@ -1,0 +1,277 @@
+defmodule PtcRunner.Schema do
+  @moduledoc """
+  Declarative schema module that defines all DSL operations.
+
+  This module serves as the single source of truth for operation definitions,
+  supporting validation, JSON Schema generation, and documentation.
+  """
+
+  @operations %{
+    # Data operations
+    "literal" => %{
+      "description" => "A literal JSON value",
+      "fields" => %{
+        "value" => %{"type" => :any, "required" => true}
+      }
+    },
+    "load" => %{
+      "description" => "Load a resource by name",
+      "fields" => %{
+        "name" => %{"type" => :string, "required" => true}
+      }
+    },
+    "var" => %{
+      "description" => "Reference a variable",
+      "fields" => %{
+        "name" => %{"type" => :string, "required" => true}
+      }
+    },
+
+    # Binding
+    "let" => %{
+      "description" => "Bind a value to a variable",
+      "fields" => %{
+        "name" => %{"type" => :string, "required" => true},
+        "value" => %{"type" => :expr, "required" => true},
+        "in" => %{"type" => :expr, "required" => true}
+      }
+    },
+
+    # Control flow
+    "if" => %{
+      "description" => "Conditional expression",
+      "fields" => %{
+        "condition" => %{"type" => :expr, "required" => true},
+        "then" => %{"type" => :expr, "required" => true},
+        "else" => %{"type" => :expr, "required" => true}
+      }
+    },
+    "and" => %{
+      "description" => "Logical AND of conditions",
+      "fields" => %{
+        "conditions" => %{"type" => {:list, :expr}, "required" => true}
+      }
+    },
+    "or" => %{
+      "description" => "Logical OR of conditions",
+      "fields" => %{
+        "conditions" => %{"type" => {:list, :expr}, "required" => true}
+      }
+    },
+    "not" => %{
+      "description" => "Logical NOT of a condition",
+      "fields" => %{
+        "condition" => %{"type" => :expr, "required" => true}
+      }
+    },
+
+    # Combining operations
+    "merge" => %{
+      "description" => "Merge multiple objects",
+      "fields" => %{
+        "objects" => %{"type" => {:list, :expr}, "required" => true}
+      }
+    },
+    "concat" => %{
+      "description" => "Concatenate multiple lists",
+      "fields" => %{
+        "lists" => %{"type" => {:list, :expr}, "required" => true}
+      }
+    },
+    "zip" => %{
+      "description" => "Zip multiple lists together",
+      "fields" => %{
+        "lists" => %{"type" => {:list, :expr}, "required" => true}
+      }
+    },
+    "pipe" => %{
+      "description" => "Pipe value through multiple steps",
+      "fields" => %{
+        "steps" => %{"type" => {:list, :expr}, "required" => true}
+      }
+    },
+
+    # Collection operations
+    "filter" => %{
+      "description" => "Filter collection based on condition",
+      "fields" => %{
+        "where" => %{"type" => :expr, "required" => true}
+      }
+    },
+    "map" => %{
+      "description" => "Transform collection elements",
+      "fields" => %{
+        "expr" => %{"type" => :expr, "required" => true}
+      }
+    },
+    "select" => %{
+      "description" => "Select specific fields from objects",
+      "fields" => %{
+        "fields" => %{"type" => {:list, :string}, "required" => true}
+      }
+    },
+    "reject" => %{
+      "description" => "Reject collection elements based on condition",
+      "fields" => %{
+        "where" => %{"type" => :expr, "required" => true}
+      }
+    },
+
+    # Comparison operations
+    "eq" => %{
+      "description" => "Check equality",
+      "fields" => %{
+        "field" => %{"type" => :string, "required" => true},
+        "value" => %{"type" => :any, "required" => true}
+      }
+    },
+    "neq" => %{
+      "description" => "Check inequality",
+      "fields" => %{
+        "field" => %{"type" => :string, "required" => true},
+        "value" => %{"type" => :any, "required" => true}
+      }
+    },
+    "gt" => %{
+      "description" => "Check greater than",
+      "fields" => %{
+        "field" => %{"type" => :string, "required" => true},
+        "value" => %{"type" => :any, "required" => true}
+      }
+    },
+    "gte" => %{
+      "description" => "Check greater than or equal",
+      "fields" => %{
+        "field" => %{"type" => :string, "required" => true},
+        "value" => %{"type" => :any, "required" => true}
+      }
+    },
+    "lt" => %{
+      "description" => "Check less than",
+      "fields" => %{
+        "field" => %{"type" => :string, "required" => true},
+        "value" => %{"type" => :any, "required" => true}
+      }
+    },
+    "lte" => %{
+      "description" => "Check less than or equal",
+      "fields" => %{
+        "field" => %{"type" => :string, "required" => true},
+        "value" => %{"type" => :any, "required" => true}
+      }
+    },
+    "contains" => %{
+      "description" => "Check if field contains value",
+      "fields" => %{
+        "field" => %{"type" => :string, "required" => true},
+        "value" => %{"type" => :any, "required" => true}
+      }
+    },
+
+    # Access operations
+    "get" => %{
+      "description" => "Get value at path",
+      "fields" => %{
+        "path" => %{"type" => {:list, :string}, "required" => true},
+        "default" => %{"type" => :any, "required" => false}
+      }
+    },
+
+    # Aggregations
+    "sum" => %{
+      "description" => "Sum values in a field",
+      "fields" => %{
+        "field" => %{"type" => :string, "required" => true}
+      }
+    },
+    "count" => %{
+      "description" => "Count elements",
+      "fields" => %{}
+    },
+    "avg" => %{
+      "description" => "Average values in a field",
+      "fields" => %{
+        "field" => %{"type" => :string, "required" => true}
+      }
+    },
+    "min" => %{
+      "description" => "Minimum value in a field",
+      "fields" => %{
+        "field" => %{"type" => :string, "required" => true}
+      }
+    },
+    "max" => %{
+      "description" => "Maximum value in a field",
+      "fields" => %{
+        "field" => %{"type" => :string, "required" => true}
+      }
+    },
+    "first" => %{
+      "description" => "Get first element",
+      "fields" => %{}
+    },
+    "last" => %{
+      "description" => "Get last element",
+      "fields" => %{}
+    },
+    "nth" => %{
+      "description" => "Get element at index",
+      "fields" => %{
+        "index" => %{"type" => :non_neg_integer, "required" => true}
+      }
+    },
+
+    # Tool integration
+    "call" => %{
+      "description" => "Call a tool",
+      "fields" => %{
+        "tool" => %{"type" => :string, "required" => true},
+        "args" => %{"type" => :map, "required" => false}
+      }
+    }
+  }
+
+  @doc """
+  Returns all operation definitions.
+
+  ## Returns
+    A map where keys are operation names and values are operation definitions.
+  """
+  @spec operations() :: map()
+  def operations do
+    @operations
+  end
+
+  @doc """
+  Returns a sorted list of valid operation names.
+
+  ## Returns
+    A list of operation names in sorted order.
+  """
+  @spec valid_operation_names() :: list(String.t())
+  def valid_operation_names do
+    @operations
+    |> Map.keys()
+    |> Enum.sort()
+  end
+
+  @doc """
+  Get operation definition by name.
+
+  ## Arguments
+    - operation_name: The name of the operation
+
+  ## Returns
+    - `{:ok, definition}` if the operation exists
+    - `:error` if the operation is unknown
+  """
+  @spec get_operation(String.t()) :: {:ok, map()} | :error
+  def get_operation(operation_name) when is_binary(operation_name) do
+    case Map.fetch(@operations, operation_name) do
+      {:ok, definition} -> {:ok, definition}
+      :error -> :error
+    end
+  end
+
+  def get_operation(_), do: :error
+end

--- a/test/ptc_runner/schema_test.exs
+++ b/test/ptc_runner/schema_test.exs
@@ -1,0 +1,316 @@
+defmodule PtcRunner.SchemaTest do
+  use ExUnit.Case
+
+  describe "Schema module" do
+    test "operations/0 returns a map" do
+      operations = PtcRunner.Schema.operations()
+      assert is_map(operations)
+      assert map_size(operations) == 33
+    end
+
+    test "valid_operation_names/0 returns 33 operation names in sorted order" do
+      names = PtcRunner.Schema.valid_operation_names()
+
+      assert is_list(names)
+      assert length(names) == 33
+      assert names == Enum.sort(names)
+
+      expected_ops =
+        ~w(and avg call concat contains count eq filter first get gt gte if last let literal load lt lte map max merge min neq not nth or pipe reject select sum var zip)
+
+      assert Enum.sort(names) == expected_ops
+    end
+
+    test "get_operation/1 returns operation definition for valid operation" do
+      {:ok, literal_def} = PtcRunner.Schema.get_operation("literal")
+
+      assert is_map(literal_def)
+      assert literal_def["description"] == "A literal JSON value"
+      assert is_map(literal_def["fields"])
+    end
+
+    test "get_operation/1 returns :error for unknown operation" do
+      assert PtcRunner.Schema.get_operation("unknown") == :error
+    end
+
+    test "get_operation/1 returns :error for non-string input" do
+      assert PtcRunner.Schema.get_operation(123) == :error
+      assert PtcRunner.Schema.get_operation(nil) == :error
+      assert PtcRunner.Schema.get_operation(%{}) == :error
+    end
+  end
+
+  describe "Data operations" do
+    test "literal has required 'value' field" do
+      {:ok, def} = PtcRunner.Schema.get_operation("literal")
+      assert def["fields"]["value"]["required"] == true
+      assert def["fields"]["value"]["type"] == :any
+    end
+
+    test "load has required 'name' field" do
+      {:ok, def} = PtcRunner.Schema.get_operation("load")
+      assert def["fields"]["name"]["required"] == true
+      assert def["fields"]["name"]["type"] == :string
+    end
+
+    test "var has required 'name' field" do
+      {:ok, def} = PtcRunner.Schema.get_operation("var")
+      assert def["fields"]["name"]["required"] == true
+      assert def["fields"]["name"]["type"] == :string
+    end
+  end
+
+  describe "Binding operation" do
+    test "let has required fields: name, value, in" do
+      {:ok, def} = PtcRunner.Schema.get_operation("let")
+      assert def["fields"]["name"]["required"] == true
+      assert def["fields"]["name"]["type"] == :string
+      assert def["fields"]["value"]["required"] == true
+      assert def["fields"]["value"]["type"] == :expr
+      assert def["fields"]["in"]["required"] == true
+      assert def["fields"]["in"]["type"] == :expr
+    end
+  end
+
+  describe "Control flow operations" do
+    test "if has required fields: condition, then, else" do
+      {:ok, def} = PtcRunner.Schema.get_operation("if")
+      assert def["fields"]["condition"]["required"] == true
+      assert def["fields"]["condition"]["type"] == :expr
+      assert def["fields"]["then"]["required"] == true
+      assert def["fields"]["then"]["type"] == :expr
+      assert def["fields"]["else"]["required"] == true
+      assert def["fields"]["else"]["type"] == :expr
+    end
+
+    test "and has required 'conditions' field as list of expressions" do
+      {:ok, def} = PtcRunner.Schema.get_operation("and")
+      assert def["fields"]["conditions"]["required"] == true
+      assert def["fields"]["conditions"]["type"] == {:list, :expr}
+    end
+
+    test "or has required 'conditions' field as list of expressions" do
+      {:ok, def} = PtcRunner.Schema.get_operation("or")
+      assert def["fields"]["conditions"]["required"] == true
+      assert def["fields"]["conditions"]["type"] == {:list, :expr}
+    end
+
+    test "not has required 'condition' field" do
+      {:ok, def} = PtcRunner.Schema.get_operation("not")
+      assert def["fields"]["condition"]["required"] == true
+      assert def["fields"]["condition"]["type"] == :expr
+    end
+  end
+
+  describe "Combining operations" do
+    test "merge has required 'objects' field as list of expressions" do
+      {:ok, def} = PtcRunner.Schema.get_operation("merge")
+      assert def["fields"]["objects"]["required"] == true
+      assert def["fields"]["objects"]["type"] == {:list, :expr}
+    end
+
+    test "concat has required 'lists' field as list of expressions" do
+      {:ok, def} = PtcRunner.Schema.get_operation("concat")
+      assert def["fields"]["lists"]["required"] == true
+      assert def["fields"]["lists"]["type"] == {:list, :expr}
+    end
+
+    test "zip has required 'lists' field as list of expressions" do
+      {:ok, def} = PtcRunner.Schema.get_operation("zip")
+      assert def["fields"]["lists"]["required"] == true
+      assert def["fields"]["lists"]["type"] == {:list, :expr}
+    end
+
+    test "pipe has required 'steps' field as list of expressions" do
+      {:ok, def} = PtcRunner.Schema.get_operation("pipe")
+      assert def["fields"]["steps"]["required"] == true
+      assert def["fields"]["steps"]["type"] == {:list, :expr}
+    end
+  end
+
+  describe "Collection operations" do
+    test "filter has required 'where' field" do
+      {:ok, def} = PtcRunner.Schema.get_operation("filter")
+      assert def["fields"]["where"]["required"] == true
+      assert def["fields"]["where"]["type"] == :expr
+    end
+
+    test "map has required 'expr' field" do
+      {:ok, def} = PtcRunner.Schema.get_operation("map")
+      assert def["fields"]["expr"]["required"] == true
+      assert def["fields"]["expr"]["type"] == :expr
+    end
+
+    test "select has required 'fields' field as list of strings" do
+      {:ok, def} = PtcRunner.Schema.get_operation("select")
+      assert def["fields"]["fields"]["required"] == true
+      assert def["fields"]["fields"]["type"] == {:list, :string}
+    end
+
+    test "reject has required 'where' field" do
+      {:ok, def} = PtcRunner.Schema.get_operation("reject")
+      assert def["fields"]["where"]["required"] == true
+      assert def["fields"]["where"]["type"] == :expr
+    end
+  end
+
+  describe "Comparison operations" do
+    test "eq has required 'field' and 'value'" do
+      {:ok, def} = PtcRunner.Schema.get_operation("eq")
+      assert def["fields"]["field"]["required"] == true
+      assert def["fields"]["field"]["type"] == :string
+      assert def["fields"]["value"]["required"] == true
+      assert def["fields"]["value"]["type"] == :any
+    end
+
+    test "neq has required 'field' and 'value'" do
+      {:ok, def} = PtcRunner.Schema.get_operation("neq")
+      assert def["fields"]["field"]["required"] == true
+      assert def["fields"]["field"]["type"] == :string
+      assert def["fields"]["value"]["required"] == true
+      assert def["fields"]["value"]["type"] == :any
+    end
+
+    test "gt has required 'field' and 'value'" do
+      {:ok, def} = PtcRunner.Schema.get_operation("gt")
+      assert def["fields"]["field"]["required"] == true
+      assert def["fields"]["field"]["type"] == :string
+      assert def["fields"]["value"]["required"] == true
+      assert def["fields"]["value"]["type"] == :any
+    end
+
+    test "gte has required 'field' and 'value'" do
+      {:ok, def} = PtcRunner.Schema.get_operation("gte")
+      assert def["fields"]["field"]["required"] == true
+      assert def["fields"]["field"]["type"] == :string
+      assert def["fields"]["value"]["required"] == true
+      assert def["fields"]["value"]["type"] == :any
+    end
+
+    test "lt has required 'field' and 'value'" do
+      {:ok, def} = PtcRunner.Schema.get_operation("lt")
+      assert def["fields"]["field"]["required"] == true
+      assert def["fields"]["field"]["type"] == :string
+      assert def["fields"]["value"]["required"] == true
+      assert def["fields"]["value"]["type"] == :any
+    end
+
+    test "lte has required 'field' and 'value'" do
+      {:ok, def} = PtcRunner.Schema.get_operation("lte")
+      assert def["fields"]["field"]["required"] == true
+      assert def["fields"]["field"]["type"] == :string
+      assert def["fields"]["value"]["required"] == true
+      assert def["fields"]["value"]["type"] == :any
+    end
+
+    test "contains has required 'field' and 'value'" do
+      {:ok, def} = PtcRunner.Schema.get_operation("contains")
+      assert def["fields"]["field"]["required"] == true
+      assert def["fields"]["field"]["type"] == :string
+      assert def["fields"]["value"]["required"] == true
+      assert def["fields"]["value"]["type"] == :any
+    end
+  end
+
+  describe "Access operations" do
+    test "get has required 'path' and optional 'default'" do
+      {:ok, def} = PtcRunner.Schema.get_operation("get")
+      assert def["fields"]["path"]["required"] == true
+      assert def["fields"]["path"]["type"] == {:list, :string}
+      assert def["fields"]["default"]["required"] == false
+      assert def["fields"]["default"]["type"] == :any
+    end
+  end
+
+  describe "Aggregation operations" do
+    test "sum has required 'field'" do
+      {:ok, def} = PtcRunner.Schema.get_operation("sum")
+      assert def["fields"]["field"]["required"] == true
+      assert def["fields"]["field"]["type"] == :string
+    end
+
+    test "count has no required fields" do
+      {:ok, def} = PtcRunner.Schema.get_operation("count")
+      assert map_size(def["fields"]) == 0
+    end
+
+    test "avg has required 'field'" do
+      {:ok, def} = PtcRunner.Schema.get_operation("avg")
+      assert def["fields"]["field"]["required"] == true
+      assert def["fields"]["field"]["type"] == :string
+    end
+
+    test "min has required 'field'" do
+      {:ok, def} = PtcRunner.Schema.get_operation("min")
+      assert def["fields"]["field"]["required"] == true
+      assert def["fields"]["field"]["type"] == :string
+    end
+
+    test "max has required 'field'" do
+      {:ok, def} = PtcRunner.Schema.get_operation("max")
+      assert def["fields"]["field"]["required"] == true
+      assert def["fields"]["field"]["type"] == :string
+    end
+
+    test "first has no required fields" do
+      {:ok, def} = PtcRunner.Schema.get_operation("first")
+      assert map_size(def["fields"]) == 0
+    end
+
+    test "last has no required fields" do
+      {:ok, def} = PtcRunner.Schema.get_operation("last")
+      assert map_size(def["fields"]) == 0
+    end
+
+    test "nth has required 'index' as non-negative integer" do
+      {:ok, def} = PtcRunner.Schema.get_operation("nth")
+      assert def["fields"]["index"]["required"] == true
+      assert def["fields"]["index"]["type"] == :non_neg_integer
+    end
+  end
+
+  describe "Tool integration operation" do
+    test "call has required 'tool' and optional 'args'" do
+      {:ok, def} = PtcRunner.Schema.get_operation("call")
+      assert def["fields"]["tool"]["required"] == true
+      assert def["fields"]["tool"]["type"] == :string
+      assert def["fields"]["args"]["required"] == false
+      assert def["fields"]["args"]["type"] == :map
+    end
+  end
+
+  describe "Operations have descriptions" do
+    test "all operations have descriptions" do
+      operations = PtcRunner.Schema.operations()
+
+      Enum.each(operations, fn {op_name, def} ->
+        assert is_binary(def["description"]),
+               "Operation '#{op_name}' is missing a description"
+
+        assert String.length(def["description"]) > 0,
+               "Operation '#{op_name}' has empty description"
+      end)
+    end
+  end
+
+  describe "Fields have proper structure" do
+    test "all fields have type and required keys" do
+      operations = PtcRunner.Schema.operations()
+
+      Enum.each(operations, fn {op_name, def} ->
+        fields = def["fields"]
+
+        Enum.each(fields, fn {field_name, field_spec} ->
+          assert Map.has_key?(field_spec, "type"),
+                 "Field '#{field_name}' in operation '#{op_name}' missing 'type' key"
+
+          assert Map.has_key?(field_spec, "required"),
+                 "Field '#{field_name}' in operation '#{op_name}' missing 'required' key"
+
+          assert is_boolean(field_spec["required"]),
+                 "Field '#{field_name}' in operation '#{op_name}' has non-boolean 'required' value"
+        end)
+      end)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Implements the declarative schema module as specified in #48, creating a single source of truth for all 33 DSL operations.

- Created `PtcRunner.Schema` module with `@operations` module attribute
- All 33 operations defined with descriptions, field types, and required/optional flags
- Public API: `operations/0`, `valid_operation_names/0`, `get_operation/1`
- Comprehensive test suite with 40+ tests covering all operations and edge cases
- Passes all quality checks: formatting, compilation, credo, tests

## Implementation Details

The schema module uses a declarative data structure where each operation is defined with:
- Description for documentation
- Fields map with type information (`:any`, `:string`, `:expr`, `{:list, type}`, `:map`, `:non_neg_integer`)
- Required/optional flags for each field

This enables:
- Consistent operation validation
- JSON Schema generation (future work)
- Documentation generation
- Reduced duplication with validator

## Test Plan

All tests pass including:
- Operation list completeness (33 operations)
- Valid operation name retrieval
- Operation definition retrieval
- Error handling for unknown operations
- Field structure validation
- Description completeness
- Type and required flag validation

Fixes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)