### PR TITLE
docs: Update README.md - add missing operations and fix status (Fixes #69)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,17 +70,17 @@ program = ~s({
 | Category | Operations |
 |----------|------------|
 | **Data** | `literal`, `var`, `load`, `let` |
-| **Collections** | `pipe`, `filter`, `reject`, `map`, `select`, `first`, `last`, `count` |
+| **Collections** | `pipe`, `filter`, `reject`, `map`, `select`, `first`, `last`, `count`, `nth` |
 | **Aggregation** | `sum`, `avg`, `min`, `max` |
 | **Access** | `get` (nested paths) |
 | **Comparison** | `eq`, `neq`, `gt`, `gte`, `lt`, `lte`, `contains` |
 | **Logic** | `and`, `or`, `not`, `if` |
 | **Tools** | `call` |
-| **Combine** | `merge`, `concat` |
+| **Combine** | `merge`, `concat`, `zip` |
 
 ## Status
 
-In development. See the [Architecture](docs/architecture.md) document for full DSL specification and implementation roadmap.
+See the [Architecture](docs/architecture.md) document for full DSL specification.
 
 ## Documentation
 


### PR DESCRIPTION
## Summary

Documentation updates to README.md to reflect completed implementation status and add missing operations.

**Changes:**
- Add 'nth' operation to Collections category in DSL Operations table
- Add 'zip' operation to Combine category in DSL Operations table  
- Remove 'In development' language from Status section

## Verification

✅ All precommit checks passed (mix test, mix format, mix compile, credo)
✅ No code changes - documentation only
✅ All existing tests pass (3 doctests, 318 tests, 0 failures)

Fixes #69