### PR TITLE
Fix #76: Store last_result in Agent state to avoid regenerating random data

### DIFF
--- a/demo/lib/ptc_demo/test_runner.ex
+++ b/demo/lib/ptc_demo/test_runner.ex
@@ -218,22 +218,12 @@ defmodule PtcDemo.TestRunner do
   end
 
   defp get_last_result do
-    case Agent.last_program() do
+    case Agent.last_result() do
       nil ->
-        {:error, "No program generated"}
+        {:error, "No result available"}
 
-      program_json ->
-        datasets = %{
-          "products" => PtcDemo.SampleData.products(),
-          "orders" => PtcDemo.SampleData.orders(),
-          "employees" => PtcDemo.SampleData.employees(),
-          "expenses" => PtcDemo.SampleData.expenses()
-        }
-
-        case PtcRunner.run(program_json, context: datasets, timeout: 5000) do
-          {:ok, result, _metrics} -> {:ok, result}
-          {:error, reason} -> {:error, inspect(reason)}
-        end
+      result ->
+        {:ok, result}
     end
   end
 


### PR DESCRIPTION
## Summary
Fixes the test runner validation inconsistency bug by storing the execution result in Agent state, eliminating the need to regenerate fresh random data for validation.

**Problem**: TestRunner.get_last_result/0 was regenerating fresh random datasets each time, causing validation to run against different data than execution. This masked validation issues and made the test runner unreliable.

**Solution**: Store the execution result alongside last_program in Agent state and expose it via Agent.last_result/0. The test runner now uses the stored result instead of re-executing with fresh data.

## Changes
- Add `last_result` field to Agent struct
- Store result in Agent state after successful execution
- Add `Agent.last_result/0` public API
- Clear `last_result` on `Agent.reset/0`
- Update `TestRunner.get_last_result/0` to use `Agent.last_result/0`

## Test Plan
- All existing tests pass (318 tests, 3 doctests)
- No new tests required - the fix maintains compatibility with existing constraint-based assertions
- The fix makes validation more reliable by ensuring tests validate against the exact data used during execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)