### PR TITLE
Fix #102: Create PtcRunner.Json public API and deprecate PtcRunner

### DIFF
--- a/lib/ptc_runner.ex
+++ b/lib/ptc_runner.ex
@@ -1,229 +1,38 @@
 defmodule PtcRunner do
   @moduledoc """
-  A BEAM-native Programmatic Tool Calling (PTC) runner.
+  BEAM-native Programmatic Tool Calling (PTC) runner.
 
-  PtcRunner enables LLMs to write safe programs that orchestrate tools
-  and transform data inside a sandboxed environment.
+  ## Languages
+
+  PtcRunner supports multiple DSL languages:
+
+  - `PtcRunner.Json` - JSON-based DSL (stable)
+  - `PtcRunner.Lisp` - Clojure-like DSL (experimental)
+
+  ## Migration
+
+  The top-level `run/2` function is deprecated. Use language-specific modules:
+
+      # Before (deprecated)
+      PtcRunner.run(json_program, opts)
+
+      # After
+      PtcRunner.Json.run(json_program, opts)
 
   ## Examples
 
       iex> program = ~s({"program": {"op": "literal", "value": 42}})
-      iex> {:ok, result, _metrics} = PtcRunner.run(program)
+      iex> {:ok, result, _metrics} = PtcRunner.Json.run(program)
       iex> result
       42
   """
 
-  alias PtcRunner.Context
-  alias PtcRunner.Json.Parser
-  alias PtcRunner.Json.Validator
-  alias PtcRunner.Sandbox
+  @deprecated "Use PtcRunner.Json.run/2 instead"
+  defdelegate run(program, opts \\ []), to: PtcRunner.Json
 
-  @typedoc """
-  Execution metrics for a program run.
-  """
-  @type metrics :: %{
-          duration_ms: integer(),
-          memory_bytes: integer()
-        }
+  @deprecated "Use PtcRunner.Json.run!/2 instead"
+  defdelegate run!(program, opts \\ []), to: PtcRunner.Json
 
-  @typedoc """
-  Error types returned by PtcRunner operations.
-  """
-  @type error ::
-          {:parse_error, String.t()}
-          | {:validation_error, String.t()}
-          | {:execution_error, String.t()}
-          | {:timeout, non_neg_integer()}
-          | {:memory_exceeded, non_neg_integer()}
-
-  @doc """
-  Runs a PTC program and returns the result with metrics.
-
-  ## Arguments
-    - program: JSON string or parsed map representing the program
-    - opts: Execution options
-
-  ## Options
-    - `:context` - Map of pre-bound variables (default: `%{}`)
-    - `:tools` - Tool registry (default: `%{}`)
-    - `:timeout` - Timeout in milliseconds (default: 1000)
-    - `:max_heap` - Max heap size in words (default: 1_250_000)
-
-  ## Returns
-    - `{:ok, result, metrics}` on success
-    - `{:error, reason}` on failure
-
-  ## Examples
-
-      iex> {:ok, result, _metrics} = PtcRunner.run(~s({"program": {"op": "literal", "value": 42}}))
-      iex> result
-      42
-  """
-  @spec run(String.t() | map(), keyword()) ::
-          {:ok, any(), metrics()} | {:error, error()}
-
-  def run(program, opts \\ []) do
-    with {:ok, ast} <- Parser.parse(program),
-         :ok <- Validator.validate(ast) do
-      context_map = Keyword.get(opts, :context, %{})
-      tools = Keyword.get(opts, :tools, %{})
-
-      with :ok <- validate_tools(tools) do
-        context = Context.new(context_map, tools)
-
-        sandbox_opts = [
-          timeout: Keyword.get(opts, :timeout, 1000),
-          max_heap: Keyword.get(opts, :max_heap, 1_250_000)
-        ]
-
-        Sandbox.execute(ast, context, sandbox_opts)
-      end
-    else
-      {:error, reason} -> {:error, reason}
-    end
-  end
-
-  @doc """
-  Runs a PTC program, raising on error.
-
-  ## Arguments
-    - program: JSON string or parsed map representing the program
-    - opts: Execution options (same as `run/2`)
-
-  ## Returns
-    - The result value (metrics are discarded)
-
-  ## Raises
-    - Raises an error if parsing, validation, or execution fails
-
-  ## Examples
-
-      iex> result = PtcRunner.run!(~s({"program": {"op": "literal", "value": 42}}))
-      iex> result
-      42
-  """
-  @spec run!(String.t() | map(), keyword()) :: any()
-
-  def run!(program, opts \\ []) do
-    case run(program, opts) do
-      {:ok, result, _metrics} -> result
-      {:error, reason} -> raise "PtcRunner error: #{inspect(reason)}"
-    end
-  end
-
-  @doc """
-  Formats an error into a human-readable message suitable for LLM feedback.
-
-  This function converts internal error tuples into clear, actionable messages
-  that help LLMs understand what went wrong and how to fix their programs.
-
-  ## Examples
-
-      iex> PtcRunner.format_error({:parse_error, "unexpected token"})
-      "ParseError: unexpected token"
-
-      iex> PtcRunner.format_error({:validation_error, "unknown operation"})
-      "ValidationError: unknown operation"
-  """
-  @spec format_error(error() | any()) :: String.t()
-  def format_error({:parse_error, msg}), do: "ParseError: #{msg}"
-  def format_error({:validation_error, msg}), do: "ValidationError: #{msg}"
-  def format_error({:timeout, ms}), do: "TimeoutError: execution exceeded #{ms}ms limit"
-  def format_error({:memory_exceeded, bytes}), do: "MemoryError: exceeded #{bytes} byte limit"
-
-  def format_error({:execution_error, msg}) when is_binary(msg) do
-    cond do
-      msg =~ "badmap" || msg =~ "expected a map" ->
-        extract_type_error(msg)
-
-      msg =~ "badkey" || msg =~ ~r/key .+ not found/ ->
-        extract_key_error(msg)
-
-      msg =~ "undefined_variable" ->
-        extract_undefined_var_error(msg)
-
-      msg =~ "badarith" ->
-        "ArithmeticError: invalid arithmetic operation (e.g., division by zero or wrong types)"
-
-      msg =~ "function_clause" ->
-        "TypeError: function received unexpected argument types"
-
-      true ->
-        # Extract first meaningful line for generic errors
-        msg
-        |> String.split("\n")
-        |> List.first()
-        |> String.slice(0, 200)
-        |> then(&"ExecutionError: #{&1}")
-    end
-  end
-
-  def format_error(other), do: "Error: #{inspect(other, limit: 5)}"
-
-  # Extract type error details from badmap errors
-  defp extract_type_error(msg) do
-    # Try to extract the value that was received instead of a map
-    cond do
-      # Match: expected a map, got:\n\n    "value"
-      match = Regex.run(~r/expected a map, got:\s*\n?\s*"([^"]+)"/s, msg) ->
-        [_, value] = match
-        "TypeError: expected an object but got: \"#{String.slice(value, 0, 50)}\""
-
-      # Match: expected a map, got:\n\n    value (non-quoted)
-      match = Regex.run(~r/expected a map, got:\s*\n?\s*([^\n"]+)/s, msg) ->
-        [_, value] = match
-        "TypeError: expected an object but got: #{String.trim(value) |> String.slice(0, 50)}"
-
-      # Match badmap tuple: {:badmap, "value"}
-      match = Regex.run(~r/badmap,\s*"([^"]+)"/, msg) ->
-        [_, value] = match
-        "TypeError: expected an object but got: \"#{String.slice(value, 0, 50)}\""
-
-      true ->
-        "TypeError: expected an object but got a different type"
-    end
-  end
-
-  # Extract key error details
-  defp extract_key_error(msg) do
-    cond do
-      # Match: key :atom not found
-      match = Regex.run(~r/key\s+:(\w+)\s+not found/, msg) ->
-        [_, key] = match
-        "KeyError: field '#{key}' not found in object"
-
-      # Match: key "string" not found
-      match = Regex.run(~r/key\s+"([^"]+)"\s+not found/, msg) ->
-        [_, key] = match
-        "KeyError: field '#{key}' not found in object"
-
-      true ->
-        "KeyError: field not found in object"
-    end
-  end
-
-  # Extract undefined variable details
-  defp extract_undefined_var_error(msg) do
-    case Regex.run(~r/undefined_variable.*[,{]?\s*"(\w+)"/, msg) do
-      [_, var] -> "UndefinedVariable: '#{var}' is not defined in context"
-      _ -> "UndefinedVariable: variable not found in context"
-    end
-  end
-
-  defp validate_tools(tools) do
-    invalid_tools =
-      tools
-      |> Enum.reject(fn {_name, fun} -> is_function(fun, 1) end)
-      |> Enum.map(fn {name, _fun} -> name end)
-
-    case invalid_tools do
-      [] ->
-        :ok
-
-      names ->
-        {:error,
-         {:validation_error,
-          "Tools must be functions with arity 1. Invalid: #{Enum.join(names, ", ")}"}}
-    end
-  end
+  @deprecated "Use PtcRunner.Json.format_error/1 instead"
+  defdelegate format_error(error), to: PtcRunner.Json
 end

--- a/lib/ptc_runner/json.ex
+++ b/lib/ptc_runner/json.ex
@@ -1,0 +1,229 @@
+defmodule PtcRunner.Json do
+  @moduledoc """
+  Execute PTC programs written in JSON DSL.
+
+  PtcRunner.Json enables LLMs to write safe programs that orchestrate tools
+  and transform data inside a sandboxed environment using JSON syntax.
+
+  ## Examples
+
+      iex> program = ~s({"program": {"op": "literal", "value": 42}})
+      iex> {:ok, result, _metrics} = PtcRunner.Json.run(program)
+      iex> result
+      42
+  """
+
+  alias PtcRunner.Context
+  alias PtcRunner.Json.Parser
+  alias PtcRunner.Json.Validator
+  alias PtcRunner.Sandbox
+
+  @typedoc """
+  Execution metrics for a program run.
+  """
+  @type metrics :: %{
+          duration_ms: integer(),
+          memory_bytes: integer()
+        }
+
+  @typedoc """
+  Error types returned by PtcRunner.Json operations.
+  """
+  @type error ::
+          {:parse_error, String.t()}
+          | {:validation_error, String.t()}
+          | {:execution_error, String.t()}
+          | {:timeout, non_neg_integer()}
+          | {:memory_exceeded, non_neg_integer()}
+
+  @doc """
+  Runs a PTC program and returns the result with metrics.
+
+  ## Arguments
+    - program: JSON string or parsed map representing the program
+    - opts: Execution options
+
+  ## Options
+    - `:context` - Map of pre-bound variables (default: `%{}`)
+    - `:tools` - Tool registry (default: `%{}`)
+    - `:timeout` - Timeout in milliseconds (default: 1000)
+    - `:max_heap` - Max heap size in words (default: 1_250_000)
+
+  ## Returns
+    - `{:ok, result, metrics}` on success
+    - `{:error, reason}` on failure
+
+  ## Examples
+
+      iex> {:ok, result, _metrics} = PtcRunner.Json.run(~s({"program": {"op": "literal", "value": 42}}))
+      iex> result
+      42
+  """
+  @spec run(String.t() | map(), keyword()) ::
+          {:ok, any(), metrics()} | {:error, error()}
+
+  def run(program, opts \\ []) do
+    with {:ok, ast} <- Parser.parse(program),
+         :ok <- Validator.validate(ast) do
+      context_map = Keyword.get(opts, :context, %{})
+      tools = Keyword.get(opts, :tools, %{})
+
+      with :ok <- validate_tools(tools) do
+        context = Context.new(context_map, tools)
+
+        sandbox_opts = [
+          timeout: Keyword.get(opts, :timeout, 1000),
+          max_heap: Keyword.get(opts, :max_heap, 1_250_000)
+        ]
+
+        Sandbox.execute(ast, context, sandbox_opts)
+      end
+    else
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @doc """
+  Runs a PTC program, raising on error.
+
+  ## Arguments
+    - program: JSON string or parsed map representing the program
+    - opts: Execution options (same as `run/2`)
+
+  ## Returns
+    - The result value (metrics are discarded)
+
+  ## Raises
+    - Raises an error if parsing, validation, or execution fails
+
+  ## Examples
+
+      iex> result = PtcRunner.Json.run!(~s({"program": {"op": "literal", "value": 42}}))
+      iex> result
+      42
+  """
+  @spec run!(String.t() | map(), keyword()) :: any()
+
+  def run!(program, opts \\ []) do
+    case run(program, opts) do
+      {:ok, result, _metrics} -> result
+      {:error, reason} -> raise "PtcRunner error: #{inspect(reason)}"
+    end
+  end
+
+  @doc """
+  Formats an error into a human-readable message suitable for LLM feedback.
+
+  This function converts internal error tuples into clear, actionable messages
+  that help LLMs understand what went wrong and how to fix their programs.
+
+  ## Examples
+
+      iex> PtcRunner.Json.format_error({:parse_error, "unexpected token"})
+      "ParseError: unexpected token"
+
+      iex> PtcRunner.Json.format_error({:validation_error, "unknown operation"})
+      "ValidationError: unknown operation"
+  """
+  @spec format_error(error() | any()) :: String.t()
+  def format_error({:parse_error, msg}), do: "ParseError: #{msg}"
+  def format_error({:validation_error, msg}), do: "ValidationError: #{msg}"
+  def format_error({:timeout, ms}), do: "TimeoutError: execution exceeded #{ms}ms limit"
+  def format_error({:memory_exceeded, bytes}), do: "MemoryError: exceeded #{bytes} byte limit"
+
+  def format_error({:execution_error, msg}) when is_binary(msg) do
+    cond do
+      msg =~ "badmap" || msg =~ "expected a map" ->
+        extract_type_error(msg)
+
+      msg =~ "badkey" || msg =~ ~r/key .+ not found/ ->
+        extract_key_error(msg)
+
+      msg =~ "undefined_variable" ->
+        extract_undefined_var_error(msg)
+
+      msg =~ "badarith" ->
+        "ArithmeticError: invalid arithmetic operation (e.g., division by zero or wrong types)"
+
+      msg =~ "function_clause" ->
+        "TypeError: function received unexpected argument types"
+
+      true ->
+        # Extract first meaningful line for generic errors
+        msg
+        |> String.split("\n")
+        |> List.first()
+        |> String.slice(0, 200)
+        |> then(&"ExecutionError: #{&1}")
+    end
+  end
+
+  def format_error(other), do: "Error: #{inspect(other, limit: 5)}"
+
+  # Extract type error details from badmap errors
+  defp extract_type_error(msg) do
+    # Try to extract the value that was received instead of a map
+    cond do
+      # Match: expected a map, got:\n\n    "value"
+      match = Regex.run(~r/expected a map, got:\s*\n?\s*"([^"]+)"/s, msg) ->
+        [_, value] = match
+        "TypeError: expected an object but got: \"#{String.slice(value, 0, 50)}\""
+
+      # Match: expected a map, got:\n\n    value (non-quoted)
+      match = Regex.run(~r/expected a map, got:\s*\n?\s*([^\n"]+)/s, msg) ->
+        [_, value] = match
+        "TypeError: expected an object but got: #{String.trim(value) |> String.slice(0, 50)}"
+
+      # Match badmap tuple: {:badmap, "value"}
+      match = Regex.run(~r/badmap,\s*"([^"]+)"/, msg) ->
+        [_, value] = match
+        "TypeError: expected an object but got: \"#{String.slice(value, 0, 50)}\""
+
+      true ->
+        "TypeError: expected an object but got a different type"
+    end
+  end
+
+  # Extract key error details
+  defp extract_key_error(msg) do
+    cond do
+      # Match: key :atom not found
+      match = Regex.run(~r/key\s+:(\w+)\s+not found/, msg) ->
+        [_, key] = match
+        "KeyError: field '#{key}' not found in object"
+
+      # Match: key "string" not found
+      match = Regex.run(~r/key\s+"([^"]+)"\s+not found/, msg) ->
+        [_, key] = match
+        "KeyError: field '#{key}' not found in object"
+
+      true ->
+        "KeyError: field not found in object"
+    end
+  end
+
+  # Extract undefined variable details
+  defp extract_undefined_var_error(msg) do
+    case Regex.run(~r/undefined_variable.*[,{]?\s*"(\w+)"/, msg) do
+      [_, var] -> "UndefinedVariable: '#{var}' is not defined in context"
+      _ -> "UndefinedVariable: variable not found in context"
+    end
+  end
+
+  defp validate_tools(tools) do
+    invalid_tools =
+      tools
+      |> Enum.reject(fn {_name, fun} -> is_function(fun, 1) end)
+      |> Enum.map(fn {name, _fun} -> name end)
+
+    case invalid_tools do
+      [] ->
+        :ok
+
+      names ->
+        {:error,
+         {:validation_error,
+          "Tools must be functions with arity 1. Invalid: #{Enum.join(names, ", ")}"}}
+    end
+  end
+end

--- a/test/ptc_runner/e2e_test.exs
+++ b/test/ptc_runner/e2e_test.exs
@@ -20,7 +20,7 @@ defmodule PtcRunner.E2ETest do
         ]
       }
 
-      assert {:ok, result, _metrics} = PtcRunner.run(program_json, context: context)
+      assert {:ok, result, _metrics} = PtcRunner.Json.run(program_json, context: context)
 
       assert is_list(result)
       assert length(result) == 2
@@ -39,7 +39,7 @@ defmodule PtcRunner.E2ETest do
         ]
       }
 
-      assert {:ok, result, _metrics} = PtcRunner.run(program_json, context: context)
+      assert {:ok, result, _metrics} = PtcRunner.Json.run(program_json, context: context)
       assert result == 60
     end
 
@@ -55,7 +55,7 @@ defmodule PtcRunner.E2ETest do
         ]
       }
 
-      assert {:ok, result, _metrics} = PtcRunner.run(program_json, context: context)
+      assert {:ok, result, _metrics} = PtcRunner.Json.run(program_json, context: context)
       assert result == 2
     end
 
@@ -74,7 +74,7 @@ defmodule PtcRunner.E2ETest do
         ]
       }
 
-      assert {:ok, result, _metrics} = PtcRunner.run(program_json, context: context)
+      assert {:ok, result, _metrics} = PtcRunner.Json.run(program_json, context: context)
       assert result["name"] == "Bob"
       assert result["years_employed"] == 7
     end
@@ -92,7 +92,7 @@ defmodule PtcRunner.E2ETest do
         ]
       }
 
-      assert {:ok, result, _metrics} = PtcRunner.run(program_json, context: context)
+      assert {:ok, result, _metrics} = PtcRunner.Json.run(program_json, context: context)
       assert result["name"] == "Book"
       assert result["price"] == 15
     end
@@ -110,7 +110,7 @@ defmodule PtcRunner.E2ETest do
         ]
       }
 
-      assert {:ok, result, _metrics} = PtcRunner.run(program_json, context: context)
+      assert {:ok, result, _metrics} = PtcRunner.Json.run(program_json, context: context)
       assert result == ["Apple", "Book", "Laptop"]
     end
 
@@ -127,7 +127,7 @@ defmodule PtcRunner.E2ETest do
         ]
       }
 
-      assert {:ok, result, _metrics} = PtcRunner.run(program_json, context: context)
+      assert {:ok, result, _metrics} = PtcRunner.Json.run(program_json, context: context)
       assert is_list(result)
       assert length(result) == 3
       prices = Enum.map(result, & &1["price"])
@@ -150,7 +150,7 @@ defmodule PtcRunner.E2ETest do
         ]
       }
 
-      assert {:ok, result, _metrics} = PtcRunner.run(program_json, context: context)
+      assert {:ok, result, _metrics} = PtcRunner.Json.run(program_json, context: context)
 
       # Constraint assertions - not exact values
       assert is_list(result)
@@ -171,7 +171,7 @@ defmodule PtcRunner.E2ETest do
         ]
       }
 
-      assert {:ok, result, _metrics} = PtcRunner.run(program_json, context: context)
+      assert {:ok, result, _metrics} = PtcRunner.Json.run(program_json, context: context)
       assert result == 60
     end
 
@@ -188,7 +188,7 @@ defmodule PtcRunner.E2ETest do
         ]
       }
 
-      assert {:ok, result, _metrics} = PtcRunner.run(program_json, context: context)
+      assert {:ok, result, _metrics} = PtcRunner.Json.run(program_json, context: context)
       assert result == 2
     end
   end

--- a/test/ptc_runner/operations/aggregation_test.exs
+++ b/test/ptc_runner/operations/aggregation_test.exs
@@ -11,7 +11,7 @@ defmodule PtcRunner.Operations.AggregationTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == 5
   end
 
@@ -24,7 +24,7 @@ defmodule PtcRunner.Operations.AggregationTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == 0
   end
 
@@ -42,7 +42,7 @@ defmodule PtcRunner.Operations.AggregationTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == 750
   end
 
@@ -55,7 +55,7 @@ defmodule PtcRunner.Operations.AggregationTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == 0
   end
 
@@ -72,7 +72,7 @@ defmodule PtcRunner.Operations.AggregationTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == 150
   end
 
@@ -89,7 +89,7 @@ defmodule PtcRunner.Operations.AggregationTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == 15.0
   end
 
@@ -102,7 +102,7 @@ defmodule PtcRunner.Operations.AggregationTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == nil
   end
 
@@ -118,7 +118,7 @@ defmodule PtcRunner.Operations.AggregationTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == 10.0
   end
 
@@ -133,7 +133,7 @@ defmodule PtcRunner.Operations.AggregationTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == nil
   end
 
@@ -149,7 +149,7 @@ defmodule PtcRunner.Operations.AggregationTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == 10.0
   end
 
@@ -167,7 +167,7 @@ defmodule PtcRunner.Operations.AggregationTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == 1
   end
 
@@ -180,7 +180,7 @@ defmodule PtcRunner.Operations.AggregationTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == nil
   end
 
@@ -193,7 +193,7 @@ defmodule PtcRunner.Operations.AggregationTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == 5
   end
 
@@ -210,7 +210,7 @@ defmodule PtcRunner.Operations.AggregationTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == 1
   end
 
@@ -228,7 +228,7 @@ defmodule PtcRunner.Operations.AggregationTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == 3
   end
 
@@ -241,7 +241,7 @@ defmodule PtcRunner.Operations.AggregationTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == nil
   end
 
@@ -254,7 +254,7 @@ defmodule PtcRunner.Operations.AggregationTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == 5
   end
 
@@ -271,7 +271,7 @@ defmodule PtcRunner.Operations.AggregationTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == 3
   end
 
@@ -289,7 +289,7 @@ defmodule PtcRunner.Operations.AggregationTest do
         ]
       }})
 
-      {:ok, result, _metrics} = PtcRunner.run(program)
+      {:ok, result, _metrics} = PtcRunner.Json.run(program)
       assert result == %{"name" => "Bob", "years" => 7}
     end
 
@@ -302,7 +302,7 @@ defmodule PtcRunner.Operations.AggregationTest do
         ]
       }})
 
-      {:ok, result, _metrics} = PtcRunner.run(program)
+      {:ok, result, _metrics} = PtcRunner.Json.run(program)
       assert result == nil
     end
 
@@ -319,7 +319,7 @@ defmodule PtcRunner.Operations.AggregationTest do
         ]
       }})
 
-      {:ok, result, _metrics} = PtcRunner.run(program)
+      {:ok, result, _metrics} = PtcRunner.Json.run(program)
       assert result == %{"name" => "Bob", "years" => 7}
     end
   end
@@ -338,7 +338,7 @@ defmodule PtcRunner.Operations.AggregationTest do
         ]
       }})
 
-      {:ok, result, _metrics} = PtcRunner.run(program)
+      {:ok, result, _metrics} = PtcRunner.Json.run(program)
       assert result == %{"name" => "Book", "price" => 15}
     end
 
@@ -351,7 +351,7 @@ defmodule PtcRunner.Operations.AggregationTest do
         ]
       }})
 
-      {:ok, result, _metrics} = PtcRunner.run(program)
+      {:ok, result, _metrics} = PtcRunner.Json.run(program)
       assert result == nil
     end
 
@@ -368,7 +368,7 @@ defmodule PtcRunner.Operations.AggregationTest do
         ]
       }})
 
-      {:ok, result, _metrics} = PtcRunner.run(program)
+      {:ok, result, _metrics} = PtcRunner.Json.run(program)
       assert result == %{"name" => "Book", "price" => 15}
     end
   end

--- a/test/ptc_runner/operations/collection_test.exs
+++ b/test/ptc_runner/operations/collection_test.exs
@@ -11,13 +11,13 @@ defmodule PtcRunner.Operations.CollectionTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == 3
   end
 
   test "empty pipe returns nil" do
     program = ~s({"program": {"op": "pipe", "steps": []}})
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
 
     assert result == nil
   end
@@ -32,7 +32,7 @@ defmodule PtcRunner.Operations.CollectionTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == %{"a" => 1, "b" => 2, "c" => 3}
   end
 
@@ -45,7 +45,7 @@ defmodule PtcRunner.Operations.CollectionTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == %{"a" => 10, "b" => 2}
   end
 
@@ -55,7 +55,7 @@ defmodule PtcRunner.Operations.CollectionTest do
       "objects": []
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == %{}
   end
 
@@ -67,7 +67,7 @@ defmodule PtcRunner.Operations.CollectionTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == %{"a" => 1}
   end
 
@@ -81,7 +81,7 @@ defmodule PtcRunner.Operations.CollectionTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == %{"a" => 1, "b" => 2, "c" => 3}
   end
 
@@ -104,7 +104,7 @@ defmodule PtcRunner.Operations.CollectionTest do
       }
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == %{"a" => 1, "b" => 2}
   end
 
@@ -116,7 +116,7 @@ defmodule PtcRunner.Operations.CollectionTest do
       ]
     }})
 
-    {:error, {:execution_error, message}} = PtcRunner.run(program)
+    {:error, {:execution_error, message}} = PtcRunner.Json.run(program)
     assert String.contains?(message, "merge requires map values")
   end
 
@@ -125,7 +125,7 @@ defmodule PtcRunner.Operations.CollectionTest do
       "op": "merge"
     }})
 
-    {:error, {:validation_error, message}} = PtcRunner.run(program)
+    {:error, {:validation_error, message}} = PtcRunner.Json.run(program)
     assert String.contains?(message, "requires field 'objects'")
   end
 
@@ -135,7 +135,7 @@ defmodule PtcRunner.Operations.CollectionTest do
       "objects": 42
     }})
 
-    {:error, {:validation_error, message}} = PtcRunner.run(program)
+    {:error, {:validation_error, message}} = PtcRunner.Json.run(program)
     assert String.contains?(message, "must be a list")
   end
 
@@ -149,7 +149,7 @@ defmodule PtcRunner.Operations.CollectionTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == [1, 2, 3, 4]
   end
 
@@ -163,7 +163,7 @@ defmodule PtcRunner.Operations.CollectionTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == [1, 2, 3, 4]
   end
 
@@ -173,7 +173,7 @@ defmodule PtcRunner.Operations.CollectionTest do
       "lists": []
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == []
   end
 
@@ -185,7 +185,7 @@ defmodule PtcRunner.Operations.CollectionTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == [1, 2, 3]
   end
 
@@ -208,7 +208,7 @@ defmodule PtcRunner.Operations.CollectionTest do
       }
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == [1, 2, 3, 4]
   end
 
@@ -220,7 +220,7 @@ defmodule PtcRunner.Operations.CollectionTest do
       ]
     }})
 
-    {:error, {:execution_error, message}} = PtcRunner.run(program)
+    {:error, {:execution_error, message}} = PtcRunner.Json.run(program)
     assert String.contains?(message, "concat requires list values")
   end
 
@@ -229,7 +229,7 @@ defmodule PtcRunner.Operations.CollectionTest do
       "op": "concat"
     }})
 
-    {:error, {:validation_error, message}} = PtcRunner.run(program)
+    {:error, {:validation_error, message}} = PtcRunner.Json.run(program)
     assert String.contains?(message, "requires field 'lists'")
   end
 
@@ -239,7 +239,7 @@ defmodule PtcRunner.Operations.CollectionTest do
       "lists": "not a list"
     }})
 
-    {:error, {:validation_error, message}} = PtcRunner.run(program)
+    {:error, {:validation_error, message}} = PtcRunner.Json.run(program)
     assert String.contains?(message, "must be a list")
   end
 
@@ -253,7 +253,7 @@ defmodule PtcRunner.Operations.CollectionTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == [[1, "a"], [2, "b"], [3, "c"]]
   end
 
@@ -266,7 +266,7 @@ defmodule PtcRunner.Operations.CollectionTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == [[1, "a"], [2, "b"]]
   end
 
@@ -276,7 +276,7 @@ defmodule PtcRunner.Operations.CollectionTest do
       "lists": []
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == []
   end
 
@@ -288,7 +288,7 @@ defmodule PtcRunner.Operations.CollectionTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == [[1], [2], [3]]
   end
 
@@ -302,7 +302,7 @@ defmodule PtcRunner.Operations.CollectionTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == [[1, "a", true], [2, "b", false]]
   end
 
@@ -315,7 +315,7 @@ defmodule PtcRunner.Operations.CollectionTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == []
   end
 
@@ -327,7 +327,7 @@ defmodule PtcRunner.Operations.CollectionTest do
       ]
     }})
 
-    {:error, {:execution_error, message}} = PtcRunner.run(program)
+    {:error, {:execution_error, message}} = PtcRunner.Json.run(program)
     assert String.contains?(message, "zip requires list values")
   end
 
@@ -336,7 +336,7 @@ defmodule PtcRunner.Operations.CollectionTest do
       "op": "zip"
     }})
 
-    {:error, {:validation_error, message}} = PtcRunner.run(program)
+    {:error, {:validation_error, message}} = PtcRunner.Json.run(program)
     assert String.contains?(message, "requires field 'lists'")
   end
 
@@ -346,7 +346,7 @@ defmodule PtcRunner.Operations.CollectionTest do
       "lists": {"a": 1}
     }})
 
-    {:error, {:validation_error, message}} = PtcRunner.run(program)
+    {:error, {:validation_error, message}} = PtcRunner.Json.run(program)
     assert String.contains?(message, "must be a list")
   end
 
@@ -378,7 +378,7 @@ defmodule PtcRunner.Operations.CollectionTest do
       }
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == %{"id" => 1, "name" => "Alice", "total" => 100, "status" => "shipped"}
   end
 end

--- a/test/ptc_runner/operations/comparison_test.exs
+++ b/test/ptc_runner/operations/comparison_test.exs
@@ -11,7 +11,7 @@ defmodule PtcRunner.Operations.ComparisonTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == true
   end
 
@@ -24,7 +24,7 @@ defmodule PtcRunner.Operations.ComparisonTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == false
   end
 
@@ -37,7 +37,7 @@ defmodule PtcRunner.Operations.ComparisonTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == false
   end
 
@@ -51,7 +51,7 @@ defmodule PtcRunner.Operations.ComparisonTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == true
   end
 
@@ -64,7 +64,7 @@ defmodule PtcRunner.Operations.ComparisonTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == false
   end
 
@@ -78,7 +78,7 @@ defmodule PtcRunner.Operations.ComparisonTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == true
   end
 
@@ -91,7 +91,7 @@ defmodule PtcRunner.Operations.ComparisonTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == false
   end
 
@@ -105,7 +105,7 @@ defmodule PtcRunner.Operations.ComparisonTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == true
   end
 
@@ -118,7 +118,7 @@ defmodule PtcRunner.Operations.ComparisonTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == false
   end
 
@@ -132,7 +132,7 @@ defmodule PtcRunner.Operations.ComparisonTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == true
   end
 
@@ -145,7 +145,7 @@ defmodule PtcRunner.Operations.ComparisonTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == false
   end
 
@@ -159,7 +159,7 @@ defmodule PtcRunner.Operations.ComparisonTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == true
   end
 
@@ -172,7 +172,7 @@ defmodule PtcRunner.Operations.ComparisonTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == false
   end
 
@@ -186,7 +186,7 @@ defmodule PtcRunner.Operations.ComparisonTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == true
   end
 
@@ -199,7 +199,7 @@ defmodule PtcRunner.Operations.ComparisonTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == false
   end
 
@@ -212,7 +212,7 @@ defmodule PtcRunner.Operations.ComparisonTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == true
   end
 
@@ -225,7 +225,7 @@ defmodule PtcRunner.Operations.ComparisonTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == false
   end
 
@@ -238,7 +238,7 @@ defmodule PtcRunner.Operations.ComparisonTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == true
   end
 
@@ -251,7 +251,7 @@ defmodule PtcRunner.Operations.ComparisonTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == false
   end
 
@@ -264,7 +264,7 @@ defmodule PtcRunner.Operations.ComparisonTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == false
   end
 end

--- a/test/ptc_runner/operations/control_flow_test.exs
+++ b/test/ptc_runner/operations/control_flow_test.exs
@@ -10,7 +10,7 @@ defmodule PtcRunner.Operations.ControlFlowTest do
         "in": {"op": "var", "name": "x"}
       }})
 
-      {:ok, result, _metrics} = PtcRunner.run(program)
+      {:ok, result, _metrics} = PtcRunner.Json.run(program)
       assert result == 5
     end
 
@@ -22,7 +22,7 @@ defmodule PtcRunner.Operations.ControlFlowTest do
         "in": {"op": "var", "name": "y"}
       }})
 
-      {:ok, result, _metrics} = PtcRunner.run(program)
+      {:ok, result, _metrics} = PtcRunner.Json.run(program)
       assert result == nil
     end
 
@@ -40,7 +40,7 @@ defmodule PtcRunner.Operations.ControlFlowTest do
         }
       }})
 
-      {:ok, result, _metrics} = PtcRunner.run(program)
+      {:ok, result, _metrics} = PtcRunner.Json.run(program)
       assert result == 3
     end
 
@@ -57,7 +57,7 @@ defmodule PtcRunner.Operations.ControlFlowTest do
         }
       }})
 
-      {:ok, result, _metrics} = PtcRunner.run(program)
+      {:ok, result, _metrics} = PtcRunner.Json.run(program)
       assert result == 2
     end
 
@@ -74,7 +74,7 @@ defmodule PtcRunner.Operations.ControlFlowTest do
         "in": {"op": "var", "name": "x"}
       }})
 
-      {:ok, result, _metrics} = PtcRunner.run(program)
+      {:ok, result, _metrics} = PtcRunner.Json.run(program)
       assert result == 10
     end
 
@@ -86,7 +86,7 @@ defmodule PtcRunner.Operations.ControlFlowTest do
         "in": {"op": "var", "name": ""}
       }})
 
-      {:ok, result, _metrics} = PtcRunner.run(program)
+      {:ok, result, _metrics} = PtcRunner.Json.run(program)
       assert result == 42
     end
 
@@ -110,7 +110,7 @@ defmodule PtcRunner.Operations.ControlFlowTest do
         ]
       }})
 
-      {:ok, result, _metrics} = PtcRunner.run(program)
+      {:ok, result, _metrics} = PtcRunner.Json.run(program)
       assert result == 3
     end
 
@@ -131,7 +131,7 @@ defmodule PtcRunner.Operations.ControlFlowTest do
         "in": {"op": "var", "name": "sum_val"}
       }})
 
-      {:ok, result, _metrics} = PtcRunner.run(program)
+      {:ok, result, _metrics} = PtcRunner.Json.run(program)
       assert result == 300
     end
 
@@ -149,7 +149,7 @@ defmodule PtcRunner.Operations.ControlFlowTest do
         "in": {"op": "var", "name": "x"}
       }})
 
-      {:error, reason} = PtcRunner.run(program)
+      {:error, reason} = PtcRunner.Json.run(program)
       assert {:execution_error, msg} = reason
       assert String.contains?(msg, "count requires a list")
     end
@@ -177,7 +177,7 @@ defmodule PtcRunner.Operations.ControlFlowTest do
         }
       }})
 
-      {:ok, result, _metrics} = PtcRunner.run(program)
+      {:ok, result, _metrics} = PtcRunner.Json.run(program)
       assert result == 2
     end
 
@@ -204,7 +204,7 @@ defmodule PtcRunner.Operations.ControlFlowTest do
         ]
       }
 
-      {:ok, result, _metrics} = PtcRunner.run(program, context: context)
+      {:ok, result, _metrics} = PtcRunner.Json.run(program, context: context)
       assert result == 2
     end
 
@@ -222,7 +222,7 @@ defmodule PtcRunner.Operations.ControlFlowTest do
         }
       }})
 
-      {:ok, result, _metrics} = PtcRunner.run(program)
+      {:ok, result, _metrics} = PtcRunner.Json.run(program)
       assert result == 10
     end
 
@@ -245,7 +245,7 @@ defmodule PtcRunner.Operations.ControlFlowTest do
         }
       }})
 
-      {:ok, result, _metrics} = PtcRunner.run(program)
+      {:ok, result, _metrics} = PtcRunner.Json.run(program)
       assert result == 30
     end
 
@@ -258,7 +258,7 @@ defmodule PtcRunner.Operations.ControlFlowTest do
         "else": {"op": "literal", "value": "no"}
       }})
 
-      {:ok, result, _metrics} = PtcRunner.run(program)
+      {:ok, result, _metrics} = PtcRunner.Json.run(program)
       assert result == "yes"
     end
 
@@ -270,7 +270,7 @@ defmodule PtcRunner.Operations.ControlFlowTest do
         "else": {"op": "literal", "value": "no"}
       }})
 
-      {:ok, result, _metrics} = PtcRunner.run(program)
+      {:ok, result, _metrics} = PtcRunner.Json.run(program)
       assert result == "no"
     end
 
@@ -282,7 +282,7 @@ defmodule PtcRunner.Operations.ControlFlowTest do
         "else": {"op": "literal", "value": "no"}
       }})
 
-      {:ok, result, _metrics} = PtcRunner.run(program)
+      {:ok, result, _metrics} = PtcRunner.Json.run(program)
       assert result == "no"
     end
 
@@ -294,7 +294,7 @@ defmodule PtcRunner.Operations.ControlFlowTest do
         "else": {"op": "literal", "value": "no"}
       }})
 
-      {:ok, result, _metrics} = PtcRunner.run(program)
+      {:ok, result, _metrics} = PtcRunner.Json.run(program)
       assert result == "yes"
     end
 
@@ -306,7 +306,7 @@ defmodule PtcRunner.Operations.ControlFlowTest do
         "else": {"op": "literal", "value": "no"}
       }})
 
-      {:ok, result, _metrics} = PtcRunner.run(program)
+      {:ok, result, _metrics} = PtcRunner.Json.run(program)
       assert result == "yes"
     end
 
@@ -318,7 +318,7 @@ defmodule PtcRunner.Operations.ControlFlowTest do
         "else": {"op": "literal", "value": "no"}
       }})
 
-      {:ok, result, _metrics} = PtcRunner.run(program)
+      {:ok, result, _metrics} = PtcRunner.Json.run(program)
       assert result == "yes"
     end
 
@@ -330,7 +330,7 @@ defmodule PtcRunner.Operations.ControlFlowTest do
         "else": {"op": "literal", "value": "no"}
       }})
 
-      {:ok, result, _metrics} = PtcRunner.run(program)
+      {:ok, result, _metrics} = PtcRunner.Json.run(program)
       assert result == "yes"
     end
 
@@ -342,7 +342,7 @@ defmodule PtcRunner.Operations.ControlFlowTest do
         "else": {"op": "literal", "value": "no"}
       }})
 
-      {:ok, result, _metrics} = PtcRunner.run(program)
+      {:ok, result, _metrics} = PtcRunner.Json.run(program)
       assert result == "yes"
     end
 
@@ -359,7 +359,7 @@ defmodule PtcRunner.Operations.ControlFlowTest do
         "else": {"op": "literal", "value": "outer-else"}
       }})
 
-      {:ok, result, _metrics} = PtcRunner.run(program)
+      {:ok, result, _metrics} = PtcRunner.Json.run(program)
       assert result == "nested-else"
     end
 
@@ -377,7 +377,7 @@ defmodule PtcRunner.Operations.ControlFlowTest do
         ]
       }})
 
-      {:ok, result, _metrics} = PtcRunner.run(program)
+      {:ok, result, _metrics} = PtcRunner.Json.run(program)
       assert result == "high"
     end
 
@@ -395,7 +395,7 @@ defmodule PtcRunner.Operations.ControlFlowTest do
         ]
       }})
 
-      {:ok, result, _metrics} = PtcRunner.run(program)
+      {:ok, result, _metrics} = PtcRunner.Json.run(program)
       assert result == "low"
     end
 
@@ -413,7 +413,7 @@ defmodule PtcRunner.Operations.ControlFlowTest do
         "else": {"op": "literal", "value": "no"}
       }})
 
-      {:error, reason} = PtcRunner.run(program)
+      {:error, reason} = PtcRunner.Json.run(program)
       assert {:execution_error, msg} = reason
       assert String.contains?(msg, "count requires a list")
     end
@@ -425,7 +425,7 @@ defmodule PtcRunner.Operations.ControlFlowTest do
         "else": {"op": "literal", "value": "no"}
       }})
 
-      {:error, reason} = PtcRunner.run(program)
+      {:error, reason} = PtcRunner.Json.run(program)
       assert {:validation_error, msg} = reason
       assert String.contains?(msg, "condition")
     end
@@ -437,7 +437,7 @@ defmodule PtcRunner.Operations.ControlFlowTest do
         "else": {"op": "literal", "value": "no"}
       }})
 
-      {:error, reason} = PtcRunner.run(program)
+      {:error, reason} = PtcRunner.Json.run(program)
       assert {:validation_error, msg} = reason
       assert String.contains?(msg, "then")
     end
@@ -449,7 +449,7 @@ defmodule PtcRunner.Operations.ControlFlowTest do
         "then": {"op": "literal", "value": "yes"}
       }})
 
-      {:error, reason} = PtcRunner.run(program)
+      {:error, reason} = PtcRunner.Json.run(program)
       assert {:validation_error, msg} = reason
       assert String.contains?(msg, "else")
     end
@@ -462,7 +462,7 @@ defmodule PtcRunner.Operations.ControlFlowTest do
         "else": {"op": "unknown"}
       }})
 
-      {:error, reason} = PtcRunner.run(program)
+      {:error, reason} = PtcRunner.Json.run(program)
       assert {:validation_error, msg} = reason
       assert String.contains?(msg, "Unknown operation")
     end
@@ -481,7 +481,7 @@ defmodule PtcRunner.Operations.ControlFlowTest do
         ]
       }})
 
-      {:ok, result, _metrics} = PtcRunner.run(program)
+      {:ok, result, _metrics} = PtcRunner.Json.run(program)
       assert result == "high_value"
     end
 
@@ -499,7 +499,7 @@ defmodule PtcRunner.Operations.ControlFlowTest do
         ]
       }})
 
-      {:ok, result, _metrics} = PtcRunner.run(program)
+      {:ok, result, _metrics} = PtcRunner.Json.run(program)
       assert result == "standard"
     end
 
@@ -522,7 +522,7 @@ defmodule PtcRunner.Operations.ControlFlowTest do
         }
       }})
 
-      {:ok, result, _metrics} = PtcRunner.run(program)
+      {:ok, result, _metrics} = PtcRunner.Json.run(program)
       assert result == 1000
     end
 
@@ -537,7 +537,7 @@ defmodule PtcRunner.Operations.ControlFlowTest do
         ]
       }})
 
-      {:ok, result, _metrics} = PtcRunner.run(program)
+      {:ok, result, _metrics} = PtcRunner.Json.run(program)
       assert result == true
     end
 
@@ -551,7 +551,7 @@ defmodule PtcRunner.Operations.ControlFlowTest do
         ]
       }})
 
-      {:ok, result, _metrics} = PtcRunner.run(program)
+      {:ok, result, _metrics} = PtcRunner.Json.run(program)
       assert result == false
     end
 
@@ -561,7 +561,7 @@ defmodule PtcRunner.Operations.ControlFlowTest do
         "conditions": []
       }})
 
-      {:ok, result, _metrics} = PtcRunner.run(program)
+      {:ok, result, _metrics} = PtcRunner.Json.run(program)
       assert result == true
     end
 
@@ -575,7 +575,7 @@ defmodule PtcRunner.Operations.ControlFlowTest do
         ]
       }})
 
-      {:ok, result, _metrics} = PtcRunner.run(program)
+      {:ok, result, _metrics} = PtcRunner.Json.run(program)
       assert result == false
     end
 
@@ -590,7 +590,7 @@ defmodule PtcRunner.Operations.ControlFlowTest do
         ]
       }})
 
-      {:ok, result, _metrics} = PtcRunner.run(program)
+      {:ok, result, _metrics} = PtcRunner.Json.run(program)
       assert result == true
     end
 
@@ -604,7 +604,7 @@ defmodule PtcRunner.Operations.ControlFlowTest do
       }})
 
       # Second condition is not evaluated due to short-circuit
-      {:ok, result, _metrics} = PtcRunner.run(program)
+      {:ok, result, _metrics} = PtcRunner.Json.run(program)
       assert result == false
     end
 
@@ -619,7 +619,7 @@ defmodule PtcRunner.Operations.ControlFlowTest do
         ]
       }})
 
-      {:ok, result, _metrics} = PtcRunner.run(program)
+      {:ok, result, _metrics} = PtcRunner.Json.run(program)
       assert result == true
     end
 
@@ -633,7 +633,7 @@ defmodule PtcRunner.Operations.ControlFlowTest do
         ]
       }})
 
-      {:ok, result, _metrics} = PtcRunner.run(program)
+      {:ok, result, _metrics} = PtcRunner.Json.run(program)
       assert result == false
     end
 
@@ -643,7 +643,7 @@ defmodule PtcRunner.Operations.ControlFlowTest do
         "conditions": []
       }})
 
-      {:ok, result, _metrics} = PtcRunner.run(program)
+      {:ok, result, _metrics} = PtcRunner.Json.run(program)
       assert result == false
     end
 
@@ -657,7 +657,7 @@ defmodule PtcRunner.Operations.ControlFlowTest do
         ]
       }})
 
-      {:ok, result, _metrics} = PtcRunner.run(program)
+      {:ok, result, _metrics} = PtcRunner.Json.run(program)
       assert result == false
     end
 
@@ -670,7 +670,7 @@ defmodule PtcRunner.Operations.ControlFlowTest do
         ]
       }})
 
-      {:ok, result, _metrics} = PtcRunner.run(program)
+      {:ok, result, _metrics} = PtcRunner.Json.run(program)
       assert result == true
     end
 
@@ -684,7 +684,7 @@ defmodule PtcRunner.Operations.ControlFlowTest do
       }})
 
       # Second condition is not evaluated due to short-circuit
-      {:ok, result, _metrics} = PtcRunner.run(program)
+      {:ok, result, _metrics} = PtcRunner.Json.run(program)
       assert result == true
     end
 
@@ -695,7 +695,7 @@ defmodule PtcRunner.Operations.ControlFlowTest do
         "condition": {"op": "literal", "value": true}
       }})
 
-      {:ok, result, _metrics} = PtcRunner.run(program)
+      {:ok, result, _metrics} = PtcRunner.Json.run(program)
       assert result == false
     end
 
@@ -705,7 +705,7 @@ defmodule PtcRunner.Operations.ControlFlowTest do
         "condition": {"op": "literal", "value": false}
       }})
 
-      {:ok, result, _metrics} = PtcRunner.run(program)
+      {:ok, result, _metrics} = PtcRunner.Json.run(program)
       assert result == true
     end
 
@@ -715,7 +715,7 @@ defmodule PtcRunner.Operations.ControlFlowTest do
         "condition": {"op": "literal", "value": null}
       }})
 
-      {:ok, result, _metrics} = PtcRunner.run(program)
+      {:ok, result, _metrics} = PtcRunner.Json.run(program)
       assert result == true
     end
 
@@ -725,7 +725,7 @@ defmodule PtcRunner.Operations.ControlFlowTest do
         "condition": {"op": "literal", "value": 42}
       }})
 
-      {:ok, result, _metrics} = PtcRunner.run(program)
+      {:ok, result, _metrics} = PtcRunner.Json.run(program)
       assert result == false
     end
 
@@ -735,7 +735,7 @@ defmodule PtcRunner.Operations.ControlFlowTest do
         "condition": {"op": "literal", "value": ""}
       }})
 
-      {:ok, result, _metrics} = PtcRunner.run(program)
+      {:ok, result, _metrics} = PtcRunner.Json.run(program)
       assert result == false
     end
 
@@ -750,7 +750,7 @@ defmodule PtcRunner.Operations.ControlFlowTest do
         ]
       }})
 
-      {:ok, result, _metrics} = PtcRunner.run(program)
+      {:ok, result, _metrics} = PtcRunner.Json.run(program)
       # undefined variable returns nil, which is falsy, so and returns false
       assert result == false
     end
@@ -765,7 +765,7 @@ defmodule PtcRunner.Operations.ControlFlowTest do
         ]
       }})
 
-      {:ok, result, _metrics} = PtcRunner.run(program)
+      {:ok, result, _metrics} = PtcRunner.Json.run(program)
       # undefined variable returns nil (falsy), continues to next (true), so or returns true
       assert result == true
     end
@@ -776,7 +776,7 @@ defmodule PtcRunner.Operations.ControlFlowTest do
         "condition": {"op": "var", "name": "undefined_var"}
       }})
 
-      {:ok, result, _metrics} = PtcRunner.run(program)
+      {:ok, result, _metrics} = PtcRunner.Json.run(program)
       # undefined variable returns nil, which is falsy, so not returns true
       assert result == true
     end
@@ -787,7 +787,7 @@ defmodule PtcRunner.Operations.ControlFlowTest do
         "op": "and"
       }})
 
-      {:error, {:validation_error, message}} = PtcRunner.run(program)
+      {:error, {:validation_error, message}} = PtcRunner.Json.run(program)
       assert String.contains?(message, "requires field 'conditions'")
     end
 
@@ -797,7 +797,7 @@ defmodule PtcRunner.Operations.ControlFlowTest do
         "conditions": "not a list"
       }})
 
-      {:error, {:validation_error, message}} = PtcRunner.run(program)
+      {:error, {:validation_error, message}} = PtcRunner.Json.run(program)
       assert String.contains?(message, "must be a list")
     end
 
@@ -806,7 +806,7 @@ defmodule PtcRunner.Operations.ControlFlowTest do
         "op": "or"
       }})
 
-      {:error, {:validation_error, message}} = PtcRunner.run(program)
+      {:error, {:validation_error, message}} = PtcRunner.Json.run(program)
       assert String.contains?(message, "requires field 'conditions'")
     end
 
@@ -816,7 +816,7 @@ defmodule PtcRunner.Operations.ControlFlowTest do
         "conditions": 42
       }})
 
-      {:error, {:validation_error, message}} = PtcRunner.run(program)
+      {:error, {:validation_error, message}} = PtcRunner.Json.run(program)
       assert String.contains?(message, "must be a list")
     end
 
@@ -825,7 +825,7 @@ defmodule PtcRunner.Operations.ControlFlowTest do
         "op": "not"
       }})
 
-      {:error, {:validation_error, message}} = PtcRunner.run(program)
+      {:error, {:validation_error, message}} = PtcRunner.Json.run(program)
       assert String.contains?(message, "requires field 'condition'")
     end
 
@@ -835,7 +835,7 @@ defmodule PtcRunner.Operations.ControlFlowTest do
         "condition": {"op": "invalid_op"}
       }})
 
-      {:error, {:validation_error, message}} = PtcRunner.run(program)
+      {:error, {:validation_error, message}} = PtcRunner.Json.run(program)
       assert String.contains?(message, "Unknown operation")
     end
 
@@ -855,7 +855,7 @@ defmodule PtcRunner.Operations.ControlFlowTest do
         ]
       }})
 
-      {:ok, result, _metrics} = PtcRunner.run(program)
+      {:ok, result, _metrics} = PtcRunner.Json.run(program)
       assert result == true
     end
 
@@ -871,7 +871,7 @@ defmodule PtcRunner.Operations.ControlFlowTest do
         ]
       }})
 
-      {:ok, result, _metrics} = PtcRunner.run(program)
+      {:ok, result, _metrics} = PtcRunner.Json.run(program)
       assert result == true
     end
 
@@ -907,7 +907,7 @@ defmodule PtcRunner.Operations.ControlFlowTest do
       }})
 
       context = %{"order" => %{"total" => 150, "status" => "vip", "flagged" => false}}
-      {:ok, result, _metrics} = PtcRunner.run(program, context: context)
+      {:ok, result, _metrics} = PtcRunner.Json.run(program, context: context)
       assert result == "eligible"
     end
 
@@ -942,7 +942,7 @@ defmodule PtcRunner.Operations.ControlFlowTest do
       }})
 
       context = %{"order" => %{"total" => 50, "status" => "vip", "flagged" => false}}
-      {:ok, result, _metrics} = PtcRunner.run(program, context: context)
+      {:ok, result, _metrics} = PtcRunner.Json.run(program, context: context)
       assert result == "not_eligible"
     end
 
@@ -977,7 +977,7 @@ defmodule PtcRunner.Operations.ControlFlowTest do
       }})
 
       context = %{"order" => %{"total" => 150, "status" => "vip", "flagged" => true}}
-      {:ok, result, _metrics} = PtcRunner.run(program, context: context)
+      {:ok, result, _metrics} = PtcRunner.Json.run(program, context: context)
       assert result == "not_eligible"
     end
   end

--- a/test/ptc_runner/operations/data_source_test.exs
+++ b/test/ptc_runner/operations/data_source_test.exs
@@ -4,7 +4,7 @@ defmodule PtcRunner.Operations.DataSourceTest do
   # Basic literal operation
   test "literal returns the specified value" do
     program = ~s({"program": {"op": "literal", "value": 42}})
-    {:ok, result, metrics} = PtcRunner.run(program)
+    {:ok, result, metrics} = PtcRunner.Json.run(program)
 
     assert result == 42
     assert metrics.duration_ms >= 0
@@ -16,14 +16,14 @@ defmodule PtcRunner.Operations.DataSourceTest do
     program = ~s({"program": {"op": "load", "name": "data"}})
 
     {:ok, result, _metrics} =
-      PtcRunner.run(program, context: %{"data" => [1, 2, 3]})
+      PtcRunner.Json.run(program, context: %{"data" => [1, 2, 3]})
 
     assert result == [1, 2, 3]
   end
 
   test "load returns nil for missing variable" do
     program = ~s({"program": {"op": "load", "name": "missing"}})
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
 
     assert result == nil
   end

--- a/test/ptc_runner/operations/error_handling_test.exs
+++ b/test/ptc_runner/operations/error_handling_test.exs
@@ -4,49 +4,49 @@ defmodule PtcRunner.Operations.ErrorHandlingTest do
   # Validation errors
   test "missing 'op' field raises validation error" do
     program = ~s({"program": {"value": 42}})
-    {:error, reason} = PtcRunner.run(program)
+    {:error, reason} = PtcRunner.Json.run(program)
 
     assert reason == {:validation_error, "Missing required field 'op'"}
   end
 
   test "unknown operation raises validation error" do
     program = ~s({"program": {"op": "unknown_op"}})
-    {:error, reason} = PtcRunner.run(program)
+    {:error, reason} = PtcRunner.Json.run(program)
 
     assert reason == {:validation_error, "Unknown operation 'unknown_op'"}
   end
 
   test "typo in operation suggests closest match" do
     program = ~s({"program": {"op": "filer"}})
-    {:error, reason} = PtcRunner.run(program)
+    {:error, reason} = PtcRunner.Json.run(program)
 
     assert reason == {:validation_error, "Unknown operation 'filer'. Did you mean 'filter'?"}
   end
 
   test "missing letter typo suggests closest match" do
     program = ~s({"program": {"op": "selct"}})
-    {:error, reason} = PtcRunner.run(program)
+    {:error, reason} = PtcRunner.Json.run(program)
 
     assert reason == {:validation_error, "Unknown operation 'selct'. Did you mean 'select'?"}
   end
 
   test "extra letter typo suggests closest match" do
     program = ~s({"program": {"op": "filtter"}})
-    {:error, reason} = PtcRunner.run(program)
+    {:error, reason} = PtcRunner.Json.run(program)
 
     assert reason == {:validation_error, "Unknown operation 'filtter'. Did you mean 'filter'?"}
   end
 
   test "case insensitive typo suggestion" do
     program = ~s({"program": {"op": "FILTER"}})
-    {:error, reason} = PtcRunner.run(program)
+    {:error, reason} = PtcRunner.Json.run(program)
 
     assert reason == {:validation_error, "Unknown operation 'FILTER'. Did you mean 'filter'?"}
   end
 
   test "very different operation name has no suggestion" do
     program = ~s({"program": {"op": "xyz"}})
-    {:error, reason} = PtcRunner.run(program)
+    {:error, reason} = PtcRunner.Json.run(program)
 
     assert reason == {:validation_error, "Unknown operation 'xyz'"}
   end
@@ -59,48 +59,48 @@ defmodule PtcRunner.Operations.ErrorHandlingTest do
         {"op": "filer", "where": {"op": "eq", "field": "x", "value": 1}}
       ]
     }})
-    {:error, {:validation_error, msg}} = PtcRunner.run(program)
+    {:error, {:validation_error, msg}} = PtcRunner.Json.run(program)
     assert msg =~ "Did you mean 'filter'?"
   end
 
   test "missing required field in operation raises validation error" do
     program = ~s({"program": {"op": "literal"}})
-    {:error, reason} = PtcRunner.run(program)
+    {:error, reason} = PtcRunner.Json.run(program)
 
     assert reason == {:validation_error, "Operation 'literal' requires field 'value'"}
   end
 
   test "literal with no value field raises validation error" do
     program = ~s({"program": {"op": "load"}})
-    {:error, reason} = PtcRunner.run(program)
+    {:error, reason} = PtcRunner.Json.run(program)
 
     assert reason == {:validation_error, "Operation 'load' requires field 'name'"}
   end
 
   test "nested unknown operation in pipe raises validation error" do
     program = ~s({"program": {"op": "pipe", "steps": [{"op": "unknown_op"}]}})
-    {:error, reason} = PtcRunner.run(program)
+    {:error, reason} = PtcRunner.Json.run(program)
 
     assert reason == {:validation_error, "Unknown operation 'unknown_op'"}
   end
 
   test "get operation missing field and path raises validation error" do
     program = ~s({"program": {"op": "get"}})
-    {:error, reason} = PtcRunner.run(program)
+    {:error, reason} = PtcRunner.Json.run(program)
 
     assert reason == {:validation_error, "Operation 'get' requires either 'field' or 'path'"}
   end
 
   test "get operation with non-array path raises validation error" do
     program = ~s({"program": {"op": "get", "path": "not_an_array"}})
-    {:error, reason} = PtcRunner.run(program)
+    {:error, reason} = PtcRunner.Json.run(program)
 
     assert reason == {:validation_error, "Field 'path' must be a list"}
   end
 
   test "get operation with non-string path elements raises validation error" do
     program = ~s({"program": {"op": "get", "path": ["valid", 123]}})
-    {:error, reason} = PtcRunner.run(program)
+    {:error, reason} = PtcRunner.Json.run(program)
 
     assert reason == {:validation_error, "All path elements in 'path' must be strings"}
   end
@@ -115,7 +115,7 @@ defmodule PtcRunner.Operations.ErrorHandlingTest do
       ]
     }})
 
-    {:error, {:execution_error, msg}} = PtcRunner.run(program)
+    {:error, {:execution_error, msg}} = PtcRunner.Json.run(program)
     assert String.contains?(msg, "count requires a list")
   end
 
@@ -128,7 +128,7 @@ defmodule PtcRunner.Operations.ErrorHandlingTest do
       ]
     }})
 
-    {:error, {:execution_error, msg}} = PtcRunner.run(program)
+    {:error, {:execution_error, msg}} = PtcRunner.Json.run(program)
     assert String.contains?(msg, "sum requires a list")
   end
 
@@ -141,7 +141,7 @@ defmodule PtcRunner.Operations.ErrorHandlingTest do
       ]
     }})
 
-    {:error, {:execution_error, msg}} = PtcRunner.run(program)
+    {:error, {:execution_error, msg}} = PtcRunner.Json.run(program)
     assert String.contains?(msg, "filter requires a list")
   end
 
@@ -154,7 +154,7 @@ defmodule PtcRunner.Operations.ErrorHandlingTest do
       ]
     }})
 
-    {:error, {:execution_error, msg}} = PtcRunner.run(program)
+    {:error, {:execution_error, msg}} = PtcRunner.Json.run(program)
     assert String.contains?(msg, "first requires a list")
   end
 
@@ -167,7 +167,7 @@ defmodule PtcRunner.Operations.ErrorHandlingTest do
       ]
     }})
 
-    {:error, {:execution_error, msg}} = PtcRunner.run(program)
+    {:error, {:execution_error, msg}} = PtcRunner.Json.run(program)
     assert String.contains?(msg, "last requires a list")
   end
 
@@ -180,7 +180,7 @@ defmodule PtcRunner.Operations.ErrorHandlingTest do
       ]
     }})
 
-    {:error, {:execution_error, msg}} = PtcRunner.run(program)
+    {:error, {:execution_error, msg}} = PtcRunner.Json.run(program)
     assert String.contains?(msg, "nth requires a list")
   end
 
@@ -196,7 +196,7 @@ defmodule PtcRunner.Operations.ErrorHandlingTest do
       ]
     }})
 
-    {:error, {:validation_error, msg}} = PtcRunner.run(program)
+    {:error, {:validation_error, msg}} = PtcRunner.Json.run(program)
     assert String.contains?(msg, "non-negative")
   end
 
@@ -209,7 +209,7 @@ defmodule PtcRunner.Operations.ErrorHandlingTest do
       ]
     }})
 
-    {:error, {:execution_error, msg}} = PtcRunner.run(program)
+    {:error, {:execution_error, msg}} = PtcRunner.Json.run(program)
     assert String.contains?(msg, "reject requires a list")
   end
 
@@ -222,7 +222,7 @@ defmodule PtcRunner.Operations.ErrorHandlingTest do
       ]
     }})
 
-    {:error, {:execution_error, msg}} = PtcRunner.run(program)
+    {:error, {:execution_error, msg}} = PtcRunner.Json.run(program)
     assert String.contains?(msg, "avg requires a list")
   end
 
@@ -235,7 +235,7 @@ defmodule PtcRunner.Operations.ErrorHandlingTest do
       ]
     }})
 
-    {:error, {:execution_error, msg}} = PtcRunner.run(program)
+    {:error, {:execution_error, msg}} = PtcRunner.Json.run(program)
     assert String.contains?(msg, "min requires a list")
   end
 
@@ -248,7 +248,7 @@ defmodule PtcRunner.Operations.ErrorHandlingTest do
       ]
     }})
 
-    {:error, {:execution_error, msg}} = PtcRunner.run(program)
+    {:error, {:execution_error, msg}} = PtcRunner.Json.run(program)
     assert String.contains?(msg, "max requires a list")
   end
 
@@ -261,35 +261,35 @@ defmodule PtcRunner.Operations.ErrorHandlingTest do
       ]
     }})
 
-    {:error, {:execution_error, msg}} = PtcRunner.run(program)
+    {:error, {:execution_error, msg}} = PtcRunner.Json.run(program)
     assert String.contains?(msg, "contains requires a map")
   end
 
   # Validation errors for new operations
   test "nth missing index field raises validation error" do
     program = ~s({"program": {"op": "nth"}})
-    {:error, reason} = PtcRunner.run(program)
+    {:error, reason} = PtcRunner.Json.run(program)
 
     assert reason == {:validation_error, "Operation 'nth' requires field 'index'"}
   end
 
   test "nth with negative index in validation raises validation error" do
     program = ~s({"program": {"op": "nth", "index": -1}})
-    {:error, reason} = PtcRunner.run(program)
+    {:error, reason} = PtcRunner.Json.run(program)
 
     assert reason == {:validation_error, "Operation 'nth' index must be non-negative, got -1"}
   end
 
   test "nth with non-integer index in validation raises validation error" do
     program = ~s({"program": {"op": "nth", "index": "not_an_integer"}})
-    {:error, reason} = PtcRunner.run(program)
+    {:error, reason} = PtcRunner.Json.run(program)
 
     assert reason == {:validation_error, "Operation 'nth' field 'index' must be an integer"}
   end
 
   test "reject missing where field raises validation error" do
     program = ~s({"program": {"op": "reject"}})
-    {:error, reason} = PtcRunner.run(program)
+    {:error, reason} = PtcRunner.Json.run(program)
 
     assert reason == {:validation_error, "Operation 'reject' requires field 'where'"}
   end
@@ -297,28 +297,28 @@ defmodule PtcRunner.Operations.ErrorHandlingTest do
   # Parse errors
   test "malformed JSON raises parse error" do
     program = "{invalid json"
-    {:error, {:parse_error, message}} = PtcRunner.run(program)
+    {:error, {:parse_error, message}} = PtcRunner.Json.run(program)
 
     assert String.contains?(message, "JSON decode error")
   end
 
   test "valid wrapped JSON string extracts program and runs successfully" do
     program = ~s({"program": {"op": "literal", "value": 42}})
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
 
     assert result == 42
   end
 
   test "valid wrapped map extracts program and runs successfully" do
     program = %{"program" => %{"op" => "literal", "value" => 99}}
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
 
     assert result == 99
   end
 
   test "missing program field returns parse error" do
     program = ~s({"data": {"op": "literal", "value": 42}})
-    {:error, {:parse_error, message}} = PtcRunner.run(program)
+    {:error, {:parse_error, message}} = PtcRunner.Json.run(program)
 
     assert message == "Missing required field 'program'"
   end
@@ -326,17 +326,17 @@ defmodule PtcRunner.Operations.ErrorHandlingTest do
   test "program is not a map returns parse error" do
     # Test with null
     program = ~s({"program": null})
-    {:error, {:parse_error, message}} = PtcRunner.run(program)
+    {:error, {:parse_error, message}} = PtcRunner.Json.run(program)
     assert message == "program must be a map"
 
     # Test with string
     program = ~s({"program": "not a map"})
-    {:error, {:parse_error, message}} = PtcRunner.run(program)
+    {:error, {:parse_error, message}} = PtcRunner.Json.run(program)
     assert message == "program must be a map"
 
     # Test with array
     program = ~s({"program": [1, 2, 3]})
-    {:error, {:parse_error, message}} = PtcRunner.run(program)
+    {:error, {:parse_error, message}} = PtcRunner.Json.run(program)
     assert message == "program must be a map"
   end
 
@@ -364,7 +364,7 @@ defmodule PtcRunner.Operations.ErrorHandlingTest do
       ]
 
       for {program, _op_name} <- operations_without_input do
-        {:error, reason} = PtcRunner.run(program)
+        {:error, reason} = PtcRunner.Json.run(program)
         assert reason == {:execution_error, "No input available"}
       end
     end
@@ -380,7 +380,7 @@ defmodule PtcRunner.Operations.ErrorHandlingTest do
         ]
       }})
 
-      {:error, reason} = PtcRunner.run(program)
+      {:error, reason} = PtcRunner.Json.run(program)
       assert reason == {:validation_error, "Operation 'contains' requires field 'field'"}
     end
 
@@ -393,7 +393,7 @@ defmodule PtcRunner.Operations.ErrorHandlingTest do
         ]
       }})
 
-      {:error, reason} = PtcRunner.run(program)
+      {:error, reason} = PtcRunner.Json.run(program)
       assert reason == {:validation_error, "Operation 'contains' requires field 'value'"}
     end
 
@@ -406,7 +406,7 @@ defmodule PtcRunner.Operations.ErrorHandlingTest do
         ]
       }})
 
-      {:error, reason} = PtcRunner.run(program)
+      {:error, reason} = PtcRunner.Json.run(program)
       assert reason == {:validation_error, "Operation 'avg' requires field 'field'"}
     end
 
@@ -419,7 +419,7 @@ defmodule PtcRunner.Operations.ErrorHandlingTest do
         ]
       }})
 
-      {:error, reason} = PtcRunner.run(program)
+      {:error, reason} = PtcRunner.Json.run(program)
       assert reason == {:validation_error, "Operation 'min' requires field 'field'"}
     end
 
@@ -432,7 +432,7 @@ defmodule PtcRunner.Operations.ErrorHandlingTest do
         ]
       }})
 
-      {:error, reason} = PtcRunner.run(program)
+      {:error, reason} = PtcRunner.Json.run(program)
       assert reason == {:validation_error, "Operation 'max' requires field 'field'"}
     end
 
@@ -443,7 +443,7 @@ defmodule PtcRunner.Operations.ErrorHandlingTest do
         "in": {"op": "var", "name": "x"}
       }})
 
-      {:error, reason} = PtcRunner.run(program)
+      {:error, reason} = PtcRunner.Json.run(program)
       assert reason == {:validation_error, "Operation 'let' requires field 'name'"}
     end
 
@@ -455,7 +455,7 @@ defmodule PtcRunner.Operations.ErrorHandlingTest do
         "in": {"op": "var", "name": "x"}
       }})
 
-      {:error, reason} = PtcRunner.run(program)
+      {:error, reason} = PtcRunner.Json.run(program)
       assert reason == {:validation_error, "Field 'name' must be a string"}
     end
 
@@ -466,7 +466,7 @@ defmodule PtcRunner.Operations.ErrorHandlingTest do
         "in": {"op": "var", "name": "x"}
       }})
 
-      {:error, reason} = PtcRunner.run(program)
+      {:error, reason} = PtcRunner.Json.run(program)
       assert reason == {:validation_error, "Operation 'let' requires field 'value'"}
     end
 
@@ -477,7 +477,7 @@ defmodule PtcRunner.Operations.ErrorHandlingTest do
         "value": {"op": "literal", "value": 5}
       }})
 
-      {:error, reason} = PtcRunner.run(program)
+      {:error, reason} = PtcRunner.Json.run(program)
       assert reason == {:validation_error, "Operation 'let' requires field 'in'"}
     end
 
@@ -489,7 +489,7 @@ defmodule PtcRunner.Operations.ErrorHandlingTest do
         "in": {"op": "var", "name": "x"}
       }})
 
-      {:error, reason} = PtcRunner.run(program)
+      {:error, reason} = PtcRunner.Json.run(program)
       assert reason == {:validation_error, "Unknown operation 'unknown_op'"}
     end
 
@@ -501,7 +501,7 @@ defmodule PtcRunner.Operations.ErrorHandlingTest do
         "in": {"op": "unknown_op"}
       }})
 
-      {:error, reason} = PtcRunner.run(program)
+      {:error, reason} = PtcRunner.Json.run(program)
       assert reason == {:validation_error, "Unknown operation 'unknown_op'"}
     end
   end

--- a/test/ptc_runner/operations/tool_call_test.exs
+++ b/test/ptc_runner/operations/tool_call_test.exs
@@ -13,7 +13,7 @@ defmodule PtcRunner.Operations.ToolCallTest do
         "args": {"a": 5, "b": 3}
       }})
 
-      {:ok, result, _metrics} = PtcRunner.run(program, tools: tools)
+      {:ok, result, _metrics} = PtcRunner.Json.run(program, tools: tools)
       assert result == 8
     end
 
@@ -27,7 +27,7 @@ defmodule PtcRunner.Operations.ToolCallTest do
         "tool": "get_default"
       }})
 
-      {:ok, result, _metrics} = PtcRunner.run(program, tools: tools)
+      {:ok, result, _metrics} = PtcRunner.Json.run(program, tools: tools)
       assert result == "default_value"
     end
 
@@ -37,7 +37,7 @@ defmodule PtcRunner.Operations.ToolCallTest do
         "tool": "missing_tool"
       }})
 
-      {:error, {:execution_error, msg}} = PtcRunner.run(program, tools: %{})
+      {:error, {:execution_error, msg}} = PtcRunner.Json.run(program, tools: %{})
       assert String.contains?(msg, "Tool 'missing_tool' not found")
     end
 
@@ -51,7 +51,7 @@ defmodule PtcRunner.Operations.ToolCallTest do
         "tool": "failing_tool"
       }})
 
-      {:error, {:execution_error, msg}} = PtcRunner.run(program, tools: tools)
+      {:error, {:execution_error, msg}} = PtcRunner.Json.run(program, tools: tools)
       assert String.contains?(msg, "Tool 'failing_tool' error")
       assert String.contains?(msg, "Something went wrong")
     end
@@ -66,7 +66,7 @@ defmodule PtcRunner.Operations.ToolCallTest do
         "tool": "raising_tool"
       }})
 
-      {:error, {:execution_error, msg}} = PtcRunner.run(program, tools: tools)
+      {:error, {:execution_error, msg}} = PtcRunner.Json.run(program, tools: tools)
       assert String.contains?(msg, "Tool 'raising_tool' raised")
       assert String.contains?(msg, "Tool crashed")
     end
@@ -81,7 +81,7 @@ defmodule PtcRunner.Operations.ToolCallTest do
         "tool": "wrong_arity"
       }})
 
-      {:error, {:validation_error, msg}} = PtcRunner.run(program, tools: tools)
+      {:error, {:validation_error, msg}} = PtcRunner.Json.run(program, tools: tools)
       assert String.contains?(msg, "Tools must be functions with arity 1")
       assert String.contains?(msg, "wrong_arity")
     end
@@ -93,7 +93,7 @@ defmodule PtcRunner.Operations.ToolCallTest do
 
       program = ~s({"program": {"op": "literal", "value": 42}})
 
-      {:error, {:validation_error, msg}} = PtcRunner.run(program, tools: tools)
+      {:error, {:validation_error, msg}} = PtcRunner.Json.run(program, tools: tools)
       assert String.contains?(msg, "Tools must be functions with arity 1")
       assert String.contains?(msg, "bad_tool")
     end
@@ -105,7 +105,7 @@ defmodule PtcRunner.Operations.ToolCallTest do
 
       program = ~s({"program": {"op": "literal", "value": 42}})
 
-      {:error, {:validation_error, msg}} = PtcRunner.run(program, tools: tools)
+      {:error, {:validation_error, msg}} = PtcRunner.Json.run(program, tools: tools)
       assert String.contains?(msg, "Tools must be functions with arity 1")
       assert String.contains?(msg, "not_a_function")
     end
@@ -120,7 +120,7 @@ defmodule PtcRunner.Operations.ToolCallTest do
 
       program = ~s({"program": {"op": "literal", "value": 42}})
 
-      {:error, {:validation_error, msg}} = PtcRunner.run(program, tools: tools)
+      {:error, {:validation_error, msg}} = PtcRunner.Json.run(program, tools: tools)
       assert String.contains?(msg, "Tools must be functions with arity 1")
       # All three invalid tools should be mentioned
       assert String.contains?(msg, "tool1")
@@ -140,14 +140,14 @@ defmodule PtcRunner.Operations.ToolCallTest do
         "args": {"a": 2, "b": 3}
       }})
 
-      {:ok, result, _metrics} = PtcRunner.run(program, tools: tools)
+      {:ok, result, _metrics} = PtcRunner.Json.run(program, tools: tools)
       assert result == 5
     end
 
     test "tool validation passes with empty tools map" do
       program = ~s({"program": {"op": "literal", "value": 42}})
 
-      {:ok, result, _metrics} = PtcRunner.run(program, tools: %{})
+      {:ok, result, _metrics} = PtcRunner.Json.run(program, tools: %{})
       assert result == 42
     end
 
@@ -156,7 +156,7 @@ defmodule PtcRunner.Operations.ToolCallTest do
         "op": "call"
       }})
 
-      {:error, reason} = PtcRunner.run(program)
+      {:error, reason} = PtcRunner.Json.run(program)
       assert reason == {:validation_error, "Operation 'call' requires field 'tool'"}
     end
 
@@ -167,7 +167,7 @@ defmodule PtcRunner.Operations.ToolCallTest do
         "args": "not a map"
       }})
 
-      {:error, reason} = PtcRunner.run(program)
+      {:error, reason} = PtcRunner.Json.run(program)
       assert reason == {:validation_error, "Field 'args' must be a map"}
     end
 
@@ -190,7 +190,7 @@ defmodule PtcRunner.Operations.ToolCallTest do
         ]
       }})
 
-      {:ok, result, _metrics} = PtcRunner.run(program, tools: tools)
+      {:ok, result, _metrics} = PtcRunner.Json.run(program, tools: tools)
       assert result == 1
     end
 
@@ -206,7 +206,7 @@ defmodule PtcRunner.Operations.ToolCallTest do
         "in": {"op": "var", "name": "balance"}
       }})
 
-      {:ok, result, _metrics} = PtcRunner.run(program, tools: tools)
+      {:ok, result, _metrics} = PtcRunner.Json.run(program, tools: tools)
       assert result == 500
     end
   end

--- a/test/ptc_runner/operations/transformation_test.exs
+++ b/test/ptc_runner/operations/transformation_test.exs
@@ -16,7 +16,7 @@ defmodule PtcRunner.Operations.TransformationTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
 
     assert result == [
              %{"item" => "book", "price" => 50},
@@ -37,7 +37,7 @@ defmodule PtcRunner.Operations.TransformationTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
 
     assert result == [
              %{"category" => "travel", "amount" => 500},
@@ -54,7 +54,7 @@ defmodule PtcRunner.Operations.TransformationTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == []
   end
 
@@ -68,7 +68,7 @@ defmodule PtcRunner.Operations.TransformationTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == ["x", "x", "x"]
   end
 
@@ -81,7 +81,7 @@ defmodule PtcRunner.Operations.TransformationTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == []
   end
 
@@ -98,7 +98,7 @@ defmodule PtcRunner.Operations.TransformationTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
 
     assert result == [
              %{"name" => "Alice", "age" => 30},
@@ -116,7 +116,7 @@ defmodule PtcRunner.Operations.TransformationTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == 1
   end
 
@@ -129,7 +129,7 @@ defmodule PtcRunner.Operations.TransformationTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == 42
   end
 
@@ -142,7 +142,7 @@ defmodule PtcRunner.Operations.TransformationTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == nil
   end
 
@@ -156,7 +156,7 @@ defmodule PtcRunner.Operations.TransformationTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == 5
   end
 
@@ -169,7 +169,7 @@ defmodule PtcRunner.Operations.TransformationTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == 42
   end
 
@@ -182,7 +182,7 @@ defmodule PtcRunner.Operations.TransformationTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == nil
   end
 
@@ -196,7 +196,7 @@ defmodule PtcRunner.Operations.TransformationTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == 30
   end
 
@@ -209,7 +209,7 @@ defmodule PtcRunner.Operations.TransformationTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == 10
   end
 
@@ -222,7 +222,7 @@ defmodule PtcRunner.Operations.TransformationTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == nil
   end
 
@@ -235,7 +235,7 @@ defmodule PtcRunner.Operations.TransformationTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == nil
   end
 
@@ -253,7 +253,7 @@ defmodule PtcRunner.Operations.TransformationTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
 
     assert result == [
              %{"category" => "food", "amount" => 50}
@@ -272,7 +272,7 @@ defmodule PtcRunner.Operations.TransformationTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
 
     assert result == [
              %{"category" => "travel", "amount" => 500},
@@ -292,7 +292,7 @@ defmodule PtcRunner.Operations.TransformationTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
 
     assert result == []
   end
@@ -306,7 +306,7 @@ defmodule PtcRunner.Operations.TransformationTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
 
     assert result == []
   end
@@ -327,7 +327,7 @@ defmodule PtcRunner.Operations.TransformationTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
 
     assert result == %{"item" => "book", "price" => 50}
   end
@@ -342,7 +342,7 @@ defmodule PtcRunner.Operations.TransformationTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == "Alice"
   end
 
@@ -355,7 +355,7 @@ defmodule PtcRunner.Operations.TransformationTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == "alice@example.com"
   end
 
@@ -368,7 +368,7 @@ defmodule PtcRunner.Operations.TransformationTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == %{"name" => "Alice"}
   end
 
@@ -381,7 +381,7 @@ defmodule PtcRunner.Operations.TransformationTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == nil
   end
 
@@ -394,7 +394,7 @@ defmodule PtcRunner.Operations.TransformationTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == 25
   end
 
@@ -407,7 +407,7 @@ defmodule PtcRunner.Operations.TransformationTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == 30
   end
 
@@ -420,7 +420,7 @@ defmodule PtcRunner.Operations.TransformationTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == nil
   end
 
@@ -433,7 +433,7 @@ defmodule PtcRunner.Operations.TransformationTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == nil
   end
 
@@ -446,7 +446,7 @@ defmodule PtcRunner.Operations.TransformationTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == 42
   end
 
@@ -462,7 +462,7 @@ defmodule PtcRunner.Operations.TransformationTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == ["alice@example.com", "bob@example.com"]
   end
 
@@ -475,7 +475,7 @@ defmodule PtcRunner.Operations.TransformationTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == nil
   end
 
@@ -488,7 +488,7 @@ defmodule PtcRunner.Operations.TransformationTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == 99
   end
 
@@ -501,7 +501,7 @@ defmodule PtcRunner.Operations.TransformationTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == nil
   end
 
@@ -522,7 +522,7 @@ defmodule PtcRunner.Operations.TransformationTest do
       ]
     }
 
-    {:ok, result, _metrics} = PtcRunner.run(program, context: context)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program, context: context)
     assert result == ["alice@example.com", "bob@example.com"]
   end
 
@@ -536,7 +536,7 @@ defmodule PtcRunner.Operations.TransformationTest do
         ]
       }})
 
-      {:ok, result, _metrics} = PtcRunner.run(program)
+      {:ok, result, _metrics} = PtcRunner.Json.run(program)
       assert Enum.map(result, & &1["price"]) == [15, 599, 999]
     end
 
@@ -549,7 +549,7 @@ defmodule PtcRunner.Operations.TransformationTest do
         ]
       }})
 
-      {:ok, result, _metrics} = PtcRunner.run(program)
+      {:ok, result, _metrics} = PtcRunner.Json.run(program)
       assert Enum.map(result, & &1["price"]) == [999, 599, 15]
     end
 
@@ -562,7 +562,7 @@ defmodule PtcRunner.Operations.TransformationTest do
         ]
       }})
 
-      {:ok, result, _metrics} = PtcRunner.run(program)
+      {:ok, result, _metrics} = PtcRunner.Json.run(program)
       assert result == []
     end
 
@@ -575,7 +575,7 @@ defmodule PtcRunner.Operations.TransformationTest do
         ]
       }})
 
-      {:error, reason} = PtcRunner.run(program)
+      {:error, reason} = PtcRunner.Json.run(program)
       assert reason == {:validation_error, "Field 'order' must be 'asc' or 'desc', got 'invalid'"}
     end
   end
@@ -590,7 +590,7 @@ defmodule PtcRunner.Operations.TransformationTest do
         ]
       }})
 
-      {:ok, result, _metrics} = PtcRunner.run(program)
+      {:ok, result, _metrics} = PtcRunner.Json.run(program)
       assert result == "Alice"
     end
 
@@ -603,7 +603,7 @@ defmodule PtcRunner.Operations.TransformationTest do
         ]
       }})
 
-      {:ok, result, _metrics} = PtcRunner.run(program)
+      {:ok, result, _metrics} = PtcRunner.Json.run(program)
       assert result == "N/A"
     end
 
@@ -619,7 +619,7 @@ defmodule PtcRunner.Operations.TransformationTest do
         ]
       }})
 
-      {:ok, result, _metrics} = PtcRunner.run(program)
+      {:ok, result, _metrics} = PtcRunner.Json.run(program)
       assert result == [1, 2]
     end
 
@@ -630,7 +630,7 @@ defmodule PtcRunner.Operations.TransformationTest do
         "path": ["user", "name"]
       }})
 
-      {:error, reason} = PtcRunner.run(program)
+      {:error, reason} = PtcRunner.Json.run(program)
       assert reason == {:validation_error, "Operation 'get' accepts 'field' or 'path', not both"}
     end
   end

--- a/test/ptc_runner/operations_introspection_test.exs
+++ b/test/ptc_runner/operations_introspection_test.exs
@@ -12,7 +12,7 @@ defmodule PtcRunner.Operations.IntrospectionTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == ["age", "city", "name"]
   end
 
@@ -25,7 +25,7 @@ defmodule PtcRunner.Operations.IntrospectionTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == []
   end
 
@@ -38,7 +38,7 @@ defmodule PtcRunner.Operations.IntrospectionTest do
       ]
     }})
 
-    {:error, {:execution_error, message}} = PtcRunner.run(program)
+    {:error, {:execution_error, message}} = PtcRunner.Json.run(program)
     assert String.contains?(message, "keys requires a map")
   end
 
@@ -51,7 +51,7 @@ defmodule PtcRunner.Operations.IntrospectionTest do
       ]
     }})
 
-    {:error, {:execution_error, message}} = PtcRunner.run(program)
+    {:error, {:execution_error, message}} = PtcRunner.Json.run(program)
     assert String.contains?(message, "keys requires a map")
   end
 
@@ -64,7 +64,7 @@ defmodule PtcRunner.Operations.IntrospectionTest do
       ]
     }})
 
-    {:error, {:execution_error, message}} = PtcRunner.run(program)
+    {:error, {:execution_error, message}} = PtcRunner.Json.run(program)
     assert String.contains?(message, "keys requires a map")
   end
 
@@ -77,7 +77,7 @@ defmodule PtcRunner.Operations.IntrospectionTest do
       ]
     }})
 
-    {:error, {:execution_error, message}} = PtcRunner.run(program)
+    {:error, {:execution_error, message}} = PtcRunner.Json.run(program)
     assert String.contains?(message, "keys requires a map")
   end
 
@@ -92,7 +92,7 @@ defmodule PtcRunner.Operations.IntrospectionTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == "object"
   end
 
@@ -105,7 +105,7 @@ defmodule PtcRunner.Operations.IntrospectionTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == "list"
   end
 
@@ -118,7 +118,7 @@ defmodule PtcRunner.Operations.IntrospectionTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == "string"
   end
 
@@ -131,7 +131,7 @@ defmodule PtcRunner.Operations.IntrospectionTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == "number"
   end
 
@@ -144,7 +144,7 @@ defmodule PtcRunner.Operations.IntrospectionTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == "number"
   end
 
@@ -157,7 +157,7 @@ defmodule PtcRunner.Operations.IntrospectionTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == "boolean"
   end
 
@@ -170,7 +170,7 @@ defmodule PtcRunner.Operations.IntrospectionTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == "boolean"
   end
 
@@ -183,7 +183,7 @@ defmodule PtcRunner.Operations.IntrospectionTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == "null"
   end
 
@@ -202,7 +202,7 @@ defmodule PtcRunner.Operations.IntrospectionTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == ["id", "name", "price"]
   end
 
@@ -215,7 +215,7 @@ defmodule PtcRunner.Operations.IntrospectionTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program, context: %{"products" => [1, 2, 3]})
+    {:ok, result, _metrics} = PtcRunner.Json.run(program, context: %{"products" => [1, 2, 3]})
     assert result == "list"
   end
 
@@ -232,7 +232,7 @@ defmodule PtcRunner.Operations.IntrospectionTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == ["city", "street", "zip"]
   end
 
@@ -249,7 +249,7 @@ defmodule PtcRunner.Operations.IntrospectionTest do
       ]
     }})
 
-    {:ok, result, _metrics} = PtcRunner.run(program)
+    {:ok, result, _metrics} = PtcRunner.Json.run(program)
     assert result == "object"
   end
 
@@ -263,7 +263,7 @@ defmodule PtcRunner.Operations.IntrospectionTest do
       ]
     }})
 
-    {:ok, type_result, _metrics} = PtcRunner.run(program1)
+    {:ok, type_result, _metrics} = PtcRunner.Json.run(program1)
     assert type_result == "list"
 
     # Second turn explores structure
@@ -276,7 +276,7 @@ defmodule PtcRunner.Operations.IntrospectionTest do
       ]
     }})
 
-    {:ok, keys_result, _metrics} = PtcRunner.run(program2)
+    {:ok, keys_result, _metrics} = PtcRunner.Json.run(program2)
     assert keys_result == ["id", "name"]
   end
 end

--- a/test/ptc_runner_test.exs
+++ b/test/ptc_runner_test.exs
@@ -6,21 +6,21 @@ defmodule PtcRunnerTest do
   describe "run/2" do
     test "valid wrapped JSON string extracts program and runs successfully" do
       program = ~s({"program": {"op": "literal", "value": 42}})
-      {:ok, result, _metrics} = PtcRunner.run(program)
+      {:ok, result, _metrics} = PtcRunner.Json.run(program)
 
       assert result == 42
     end
 
     test "valid wrapped map extracts program and runs successfully" do
       program = %{"program" => %{"op" => "literal", "value" => 99}}
-      {:ok, result, _metrics} = PtcRunner.run(program)
+      {:ok, result, _metrics} = PtcRunner.Json.run(program)
 
       assert result == 99
     end
 
     test "missing program field returns parse error" do
       program = ~s({"data": {"op": "literal", "value": 42}})
-      {:error, {:parse_error, message}} = PtcRunner.run(program)
+      {:error, {:parse_error, message}} = PtcRunner.Json.run(program)
 
       assert message == "Missing required field 'program'"
     end
@@ -28,17 +28,17 @@ defmodule PtcRunnerTest do
     test "program is not a map returns parse error" do
       # Test with null
       program = ~s({"program": null})
-      {:error, {:parse_error, message}} = PtcRunner.run(program)
+      {:error, {:parse_error, message}} = PtcRunner.Json.run(program)
       assert message == "program must be a map"
 
       # Test with string
       program = ~s({"program": "not a map"})
-      {:error, {:parse_error, message}} = PtcRunner.run(program)
+      {:error, {:parse_error, message}} = PtcRunner.Json.run(program)
       assert message == "program must be a map"
 
       # Test with array
       program = ~s({"program": [1, 2, 3]})
-      {:error, {:parse_error, message}} = PtcRunner.run(program)
+      {:error, {:parse_error, message}} = PtcRunner.Json.run(program)
       assert message == "program must be a map"
     end
   end
@@ -46,7 +46,7 @@ defmodule PtcRunnerTest do
   describe "run!/2" do
     test "run! returns result without metrics" do
       program = ~s({"program": {"op": "literal", "value": 42}})
-      result = PtcRunner.run!(program)
+      result = PtcRunner.Json.run!(program)
 
       assert result == 42
     end
@@ -55,7 +55,7 @@ defmodule PtcRunnerTest do
       program = ~s({"program": {"op": "unknown_op"}})
 
       assert_raise RuntimeError, fn ->
-        PtcRunner.run!(program)
+        PtcRunner.Json.run!(program)
       end
     end
   end
@@ -77,7 +77,7 @@ defmodule PtcRunnerTest do
         "tool": "slow_tool"
       }})
 
-      result = PtcRunner.run(program, tools: tools, timeout_ms: 100)
+      result = PtcRunner.Json.run(program, tools: tools, timeout_ms: 100)
 
       assert match?({:error, {:timeout, _}}, result) or
                match?({:error, {:execution_error, _}}, result)
@@ -92,7 +92,7 @@ defmodule PtcRunnerTest do
       }})
 
       # With a reasonable memory limit, this should succeed
-      {:ok, result, _metrics} = PtcRunner.run(program, memory_limit_bytes: 1_000_000)
+      {:ok, result, _metrics} = PtcRunner.Json.run(program, memory_limit_bytes: 1_000_000)
       assert result == [1, 2, 3]
     end
   end
@@ -116,7 +116,7 @@ defmodule PtcRunnerTest do
         ]
       }
 
-      {:ok, result, metrics} = PtcRunner.run(program, context: context)
+      {:ok, result, metrics} = PtcRunner.Json.run(program, context: context)
 
       assert result == 500
       assert metrics.duration_ms >= 0
@@ -139,7 +139,7 @@ defmodule PtcRunnerTest do
         ]
       }
 
-      {:ok, result, _metrics} = PtcRunner.run(program, context: context)
+      {:ok, result, _metrics} = PtcRunner.Json.run(program, context: context)
       assert result == ["alice@example.com", "bob@example.com"]
     end
 
@@ -162,29 +162,29 @@ defmodule PtcRunnerTest do
         ]
       }
 
-      {:ok, result, _metrics} = PtcRunner.run(program, context: context)
+      {:ok, result, _metrics} = PtcRunner.Json.run(program, context: context)
       assert result == 700
     end
   end
 
   describe "format_error/1" do
     test "formats parse errors" do
-      assert PtcRunner.format_error({:parse_error, "unexpected token"}) ==
+      assert PtcRunner.Json.format_error({:parse_error, "unexpected token"}) ==
                "ParseError: unexpected token"
     end
 
     test "formats validation errors" do
-      assert PtcRunner.format_error({:validation_error, "unknown operation 'foo'"}) ==
+      assert PtcRunner.Json.format_error({:validation_error, "unknown operation 'foo'"}) ==
                "ValidationError: unknown operation 'foo'"
     end
 
     test "formats timeout errors" do
-      assert PtcRunner.format_error({:timeout, 5000}) ==
+      assert PtcRunner.Json.format_error({:timeout, 5000}) ==
                "TimeoutError: execution exceeded 5000ms limit"
     end
 
     test "formats memory exceeded errors" do
-      assert PtcRunner.format_error({:memory_exceeded, 10_000_000}) ==
+      assert PtcRunner.Json.format_error({:memory_exceeded, 10_000_000}) ==
                "MemoryError: exceeded 10000000 byte limit"
     end
 
@@ -193,46 +193,46 @@ defmodule PtcRunnerTest do
       Process terminated: {{:badmap, "Employee 1"}, [{Map, :get, ["Employee 1", "years_employed", nil], []}]}
       """
 
-      result = PtcRunner.format_error({:execution_error, error_msg})
+      result = PtcRunner.Json.format_error({:execution_error, error_msg})
       assert result =~ "TypeError:"
       assert result =~ "expected an object"
     end
 
     test "extracts value from badmap error" do
       error_msg = ~s(expected a map, got:\n\n    "some string value")
-      result = PtcRunner.format_error({:execution_error, error_msg})
+      result = PtcRunner.Json.format_error({:execution_error, error_msg})
       assert result == ~s(TypeError: expected an object but got: "some string value")
     end
 
     test "formats badkey execution errors" do
       error_msg = "key :missing not found in: %{name: \"test\"}"
-      result = PtcRunner.format_error({:execution_error, error_msg})
+      result = PtcRunner.Json.format_error({:execution_error, error_msg})
       assert result =~ "KeyError:"
       assert result =~ "not found"
     end
 
     test "formats undefined variable errors" do
       error_msg = ~s({:undefined_variable, "myvar"})
-      result = PtcRunner.format_error({:execution_error, error_msg})
+      result = PtcRunner.Json.format_error({:execution_error, error_msg})
       assert result =~ "UndefinedVariable:"
       assert result =~ "myvar"
     end
 
     test "formats arithmetic errors" do
       error_msg = "Process terminated: {:badarith, ...}"
-      result = PtcRunner.format_error({:execution_error, error_msg})
+      result = PtcRunner.Json.format_error({:execution_error, error_msg})
       assert result =~ "ArithmeticError:"
     end
 
     test "formats unknown errors with inspect" do
-      result = PtcRunner.format_error(:some_unknown_error)
+      result = PtcRunner.Json.format_error(:some_unknown_error)
       assert result =~ "Error:"
       assert result =~ "some_unknown_error"
     end
 
     test "truncates long generic error messages" do
       long_msg = String.duplicate("x", 500)
-      result = PtcRunner.format_error({:execution_error, long_msg})
+      result = PtcRunner.Json.format_error({:execution_error, long_msg})
       assert String.length(result) < 250
     end
   end

--- a/test/support/llm_benchmark.ex
+++ b/test/support/llm_benchmark.ex
@@ -279,7 +279,7 @@ defmodule PtcRunner.TestSupport.LLMBenchmark do
       cleaned = clean_response(text)
 
       # Parse and run
-      case PtcRunner.run(cleaned, context: %{"input" => test.input}) do
+      case PtcRunner.Json.run(cleaned, context: %{"input" => test.input}) do
         {:ok, result, _metrics} ->
           passed = validate(test.validator, result)
           duration = System.monotonic_time(:millisecond) - start_time


### PR DESCRIPTION
## Summary

Implement Phase 1.1/1.4 of the API refactor plan to create `PtcRunner.Json` as the new public API entry point while deprecating the top-level `PtcRunner` module.

- Create `lib/ptc_runner/json.ex` with full implementation (run/2, run!/2, format_error/1)
- Update `lib/ptc_runner.ex` to use deprecation delegates pointing to PtcRunner.Json
- Update all 12 test files to use the new PtcRunner.Json API

This enables clean separation of concerns for future multi-language support (e.g., PTC-Lisp) while maintaining backward compatibility.

## Test Results

✅ All 549 tests pass
✅ Code formatting passes
✅ Compilation with warnings-as-errors passes
✅ Credo static analysis passes

## Changes Made

1. **New file**: `lib/ptc_runner/json.ex` - Full JSON DSL public API
2. **Modified**: `lib/ptc_runner.ex` - Replaced with deprecation delegates
3. **Updated**: 12 test files - Use `PtcRunner.Json.run` instead of deprecated API

Fixes #102