### PR TITLE
Fix #124: Update README with PTC-Lisp announcement and API migration guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,14 +54,24 @@ program = ~s({
 })
 
 # Execute safely with resource limits
-{:ok, result, metrics} = PtcRunner.run(program, tools: tools)
+{:ok, result, metrics} = PtcRunner.Json.run(program, tools: tools)
 # result = 700
 # metrics = %{duration_ms: 2, memory_bytes: 1024}
 ```
 
+> **Note:** The top-level `PtcRunner.run/2` API is deprecated. Use `PtcRunner.Json.run/2` for JSON DSL or `PtcRunner.Lisp.run/2` for PTC-Lisp programs.
+
 ## Features
 
-- **JSON DSL** with operations for filtering, mapping, aggregation, and control flow
+### Languages
+
+PtcRunner supports multiple DSL languages optimized for LLM-generated code:
+
+- **JSON DSL** - Stable, verbose, universally toolable
+- **PTC-Lisp** - Clojure-like syntax, 3-5x more token-efficient, supports closures and memory persistence
+
+### Core Features
+
 - **Variable bindings** to store and reference results across operations
 - **Tool registry** for user-defined functions
 - **Resource limits**: configurable timeout (default 1s) and memory (default 10MB)
@@ -87,6 +97,7 @@ program = ~s({
 ## Documentation
 
 - **[Architecture](docs/architecture.md)** - System design, DSL specification, API reference
+- **[PTC-Lisp Overview](docs/ptc-lisp-overview.md)** - Introduction to Clojure-like syntax alternative, evaluation plan, and comparisons
 - **[LLM Testing](docs/llm-testing.md)** - Benchmark results, testing modes, model comparison
 - **Demo App** - Interactive CLI chat showing PTC with ReqLLM integration (see `demo/` directory)
 
@@ -102,15 +113,17 @@ end
 
 ## Usage
 
-### Basic Execution
+### JSON DSL
+
+#### Basic Execution
 
 ```elixir
 # Simple program
-{:ok, result, _metrics} = PtcRunner.run(~s({"program": {"op": "literal", "value": 42}}))
+{:ok, result, _metrics} = PtcRunner.Json.run(~s({"program": {"op": "literal", "value": 42}}))
 # result = 42
 
 # With context data
-{:ok, result, _metrics} = PtcRunner.run(
+{:ok, result, _metrics} = PtcRunner.Json.run(
   ~s({"program": {"op": "pipe", "steps": [
     {"op": "load", "name": "numbers"},
     {"op": "sum", "field": "value"}
@@ -120,7 +133,7 @@ end
 # result = 6
 ```
 
-### With Tools
+#### With Tools
 
 ```elixir
 tools = %{
@@ -128,20 +141,49 @@ tools = %{
   "search" => fn %{"query" => q} -> MyApp.search(q) end
 }
 
-{:ok, result, _metrics} = PtcRunner.run(program, tools: tools)
+{:ok, result, _metrics} = PtcRunner.Json.run(program, tools: tools)
 ```
+
+### PTC-Lisp
+
+PTC-Lisp offers a more compact syntax that LLMs find easier to generate correctly:
+
+```elixir
+# Same travel expenses example as above
+tools = %{
+  "get-expenses" => fn _args ->
+    [
+      %{"category" => "travel", "amount" => 500},
+      %{"category" => "food", "amount" => 50},
+      %{"category" => "travel", "amount" => 200}
+    ]
+  end
+}
+
+# PTC-Lisp program (Clojure-like syntax)
+program = ~s(
+  (->> (call "get-expenses" {})
+       (filter (where :category = "travel"))
+       (sum-by :amount))
+)
+
+{:ok, result, metrics} = PtcRunner.Lisp.run(program, tools: tools)
+# result = 700
+```
+
+For a complete PTC-Lisp reference, see [docs/ptc-lisp-overview.md](docs/ptc-lisp-overview.md).
 
 ### Resource Limits
 
 ```elixir
 # Custom limits
-{:ok, result, metrics} = PtcRunner.run(program,
+{:ok, result, metrics} = PtcRunner.Json.run(program,
   timeout: 5000,       # 5 seconds
   max_heap: 5_000_000  # ~40MB
 )
 
 # Handle resource errors
-case PtcRunner.run(program) do
+case PtcRunner.Json.run(program) do
   {:ok, result, metrics} -> handle_success(result)
   {:error, {:timeout, ms}} -> handle_timeout(ms)
   {:error, {:memory_exceeded, bytes}} -> handle_oom(bytes)
@@ -155,10 +197,10 @@ Store results from previous turns and reference them:
 
 ```elixir
 # Turn 1: Fetch data
-{:ok, users, _} = PtcRunner.run(~s({"program": {"op": "call", "tool": "get_users"}}), tools: tools)
+{:ok, users, _} = PtcRunner.Json.run(~s({"program": {"op": "call", "tool": "get_users"}}), tools: tools)
 
 # Turn 2: Use previous result
-{:ok, count, _} = PtcRunner.run(
+{:ok, count, _} = PtcRunner.Json.run(
   ~s({"program": {"op": "pipe", "steps": [
     {"op": "load", "name": "previous_users"},
     {"op": "count"}
@@ -212,7 +254,7 @@ Respond with ONLY valid JSON.
 program = extract_json(response)
 
 # Execute with retry on validation errors
-case PtcRunner.run(program, tools: tools) do
+case PtcRunner.Json.run(program, tools: tools) do
   {:ok, result, _} -> {:ok, result}
   {:error, error} -> retry_with_feedback(prompt, error)
 end
@@ -234,7 +276,7 @@ program = ReqLLM.generate_object!(
 )
 
 # Execute the program
-{:ok, result, _metrics} = PtcRunner.run(Jason.encode!(program),
+{:ok, result, _metrics} = PtcRunner.Json.run(Jason.encode!(program),
   context: %{"input" => products}
 )
 ```


### PR DESCRIPTION
## Summary

Updates README.md to announce PTC-Lisp as an alternative DSL and provide migration guidance from the deprecated `PtcRunner.run/2` API to the new language-specific APIs (`PtcRunner.Json.run/2` and `PtcRunner.Lisp.run/2`).

## Changes

- **Quick Example**: Updated to use `PtcRunner.Json.run/2` with a deprecation note explaining the new API structure
- **Features**: Added Languages subsection highlighting both JSON DSL (stable, verbose) and PTC-Lisp (token-efficient, 3-5x savings)
- **Usage**: Added dedicated PTC-Lisp section with example showing same travel expenses use case in Clojure-like syntax
- **API Migration**: Updated all remaining `PtcRunner.run/2` calls throughout the Usage section to use `PtcRunner.Json.run/2`
- **Documentation**: Added link to `docs/ptc-lisp-overview.md` in the Documentation section

## Verification

- [x] All examples use correct API (`PtcRunner.Json.run/2` and `PtcRunner.Lisp.run/2`)
- [x] Same travel expenses example used for both JSON and Lisp to show syntax comparison
- [x] Examples are concise and serve as entry point (not full documentation)
- [x] PTC-Lisp docs linked for complete reference
- [x] `mix precommit` passes (format, compilation, credo, tests)

Fixes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)