### PR TITLE
feat: Add domain property tests for arithmetic, collections, types, and logic (#135)

### DIFF
--- a/test/support/lisp_generators_test.exs
+++ b/test/support/lisp_generators_test.exs
@@ -317,14 +317,6 @@ defmodule PtcRunner.TestSupport.LispGeneratorsTest do
         assert {:ok, 0, _, _} = safe_run(source, [])
       end
     end
-
-    defp assert_numbers_equal(a, b) when is_float(a) or is_float(b) do
-      assert abs(a - b) < 1.0e-9, "Expected #{b}, got #{a}"
-    end
-
-    defp assert_numbers_equal(a, b) do
-      assert a == b
-    end
   end
 
   describe "collection invariants" do
@@ -489,6 +481,14 @@ defmodule PtcRunner.TestSupport.LispGeneratorsTest do
 
   defp ast_equivalent?(a, b) do
     a == b
+  end
+
+  defp assert_numbers_equal(a, b) when is_float(a) or is_float(b) do
+    assert abs(a - b) < 1.0e-9, "Expected #{b}, got #{a}"
+  end
+
+  defp assert_numbers_equal(a, b) do
+    assert a == b
   end
 
   defp build_tools_for_source(source, default_result \\ :result) do


### PR DESCRIPTION
## Summary
Implements issue #135 by adding domain-specific property tests for the PTC-Lisp evaluator.

Adds four new describe blocks to `test/support/lisp_generators_test.exs`:
- **Arithmetic identities** (3 properties): x + 0 = x, x * 1 = x, x - x = 0
- **Collection invariants** (3 properties): map preserves count, reverse idempotence, filter doesn't increase count
- **Type predicates** (1 property): exactly one type predicate true for primitives
- **Short-circuit logic** (2 properties): and with false and or with truthy value short-circuit without evaluating downstream code

## Implementation Details
- Follows patterns from sections 4.5-4.8 of `docs/ptc-lisp-property-testing-plan.md`
- Uses existing `safe_run/2` helper for evaluation
- Uses existing `Formatter` and generator infrastructure
- Handles edge cases:
  - Float precision tolerance (1.0e-9)
  - Empty and non-empty collections
  - Mock tools that fail if called to verify short-circuit behavior

## Test Results
- All 39 properties pass (existing 30 + new 9)
- Full test suite: 872 tests passing, 0 failures
- Pre-commit checks: all pass (formatting, compilation, credo)

Fixes #135