### PR TITLE
Fix #145: Configure StreamData to run 300 iterations in CI

### DIFF
--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,2 +1,6 @@
+if System.get_env("CI") do
+  Application.put_env(:stream_data, :max_runs, 300)
+end
+
 ExUnit.configure(exclude: [:e2e])
 ExUnit.start()


### PR DESCRIPTION
## Summary
- Configure StreamData to run 300 iterations per property test when running in CI environment
- Maintains default 100 iterations for local development to preserve fast feedback loop
- Configuration placed before `ExUnit.start()` to ensure it takes effect

## Test plan
- ✅ Verified with `CI=true mix test test/support/lisp_generators_test.exs` - all 39 properties pass
- ✅ Ran `mix precommit` - all checks pass (credo, compilation, tests)
- ✅ No test files broken, all 924 tests pass

Fixes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)