### PR TITLE
Fix #148: Add sequential destructuring pattern type to CoreAST

### DIFF
--- a/lib/ptc_runner/lisp/core_ast.ex
+++ b/lib/ptc_runner/lisp/core_ast.ex
@@ -35,8 +35,8 @@ defmodule PtcRunner.Lisp.CoreAST do
           | {:let, [binding()], t()}
           # Conditionals
           | {:if, t(), t(), t()}
-          # Anonymous function (simple params only, no destructuring)
-          | {:fn, [simple_param()], t()}
+          # Anonymous function
+          | {:fn, [pattern()], t()}
           # Short-circuit logic (special forms, not calls)
           | {:and, [t()]}
           | {:or, [t()]}
@@ -52,8 +52,7 @@ defmodule PtcRunner.Lisp.CoreAST do
           {:var, atom()}
           | {:destructure, {:keys, [atom()], keyword()}}
           | {:destructure, {:as, atom(), pattern()}}
-
-  @type simple_param :: {:var, atom()}
+          | {:destructure, {:seq, [pattern()]}}
 
   @type field_path :: {:field, [field_segment()]}
   @type field_segment :: {:keyword, atom()} | {:string, String.t()}


### PR DESCRIPTION
## Summary

Implements the type-only changes specified in issue #148 to support sequential (vector) destructuring in function parameters.

**Changes:**
- Added `{:destructure, {:seq, [pattern()]}}` to the `@type pattern` union in CoreAST
- Updated `{:fn, ...}` to accept `[pattern()]` instead of `[simple_param()]`
- Removed the now-unnecessary `@type simple_param` type definition

## Verification

- ✅ All 931 tests passing
- ✅ No regressions detected
- ✅ Code formatting, compilation, and Credo checks all pass
- ✅ Type-only change as specified in ptc-lisp-fn-destructuring-spec.md (Section 3.2)

This change establishes the foundation for subsequent implementation issues that will extend the analyzer and evaluator to handle destructuring patterns.

Fixes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)