### PR TITLE
Fix #152: Add E2E test for group-by with destructuring

### DIFF
--- a/test/ptc_runner/lisp/ptc_lisp_e2e_test.exs
+++ b/test/ptc_runner/lisp/ptc_lisp_e2e_test.exs
@@ -496,4 +496,30 @@ defmodule PtcRunner.Lisp.E2ETest do
       assert message =~ "expected at least 3 elements, got 2"
     end
   end
+
+  describe "group-by with destructuring" do
+    test "average by category using destructuring" do
+      expenses = [
+        %{category: "food", amount: 100},
+        %{category: "food", amount: 50},
+        %{category: "transport", amount: 30}
+      ]
+
+      program = """
+      (->> ctx/expenses
+           (group-by :category)
+           (map (fn [[category items]]
+                  {:category category
+                   :average (avg-by :amount items)}))
+           (sort-by :category))
+      """
+
+      {:ok, result, _, _} = Lisp.run(program, context: %{expenses: expenses})
+
+      assert [
+               %{category: "food", average: 75.0},
+               %{category: "transport", average: 30.0}
+             ] = result
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Adds the E2E test case from Section 4.3 of the fn parameter destructuring specification that validates the motivating use case - using `group-by` with destructured closures for data aggregation.

The test confirms that destructuring patterns in fn parameters work correctly with higher-order functions like `map`, enabling clean and idiomatic PTC-Lisp programs.

## Test Plan

- [x] Test added to `test/ptc_runner/lisp/ptc_lisp_e2e_test.exs` after line 497
- [x] Test runs successfully with `mix test test/ptc_runner/lisp/ptc_lisp_e2e_test.exs`
- [x] All 937 tests pass with `mix precommit`
- [x] No regressions from existing tests

## Changes

- Added E2E test case "group-by with destructuring" that exercises:
  - Vector destructuring in fn parameters (`fn [[category items]] ...)`)
  - Integration with `group-by` for data aggregation
  - Composition with `map`, `avg-by`, and `sort-by`

Fixes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)