### PR TITLE
Fix #158: Update LLM guide map example to use fn destructuring syntax

### DIFF
--- a/docs/ptc-lisp-llm-guide.md
+++ b/docs/ptc-lisp-llm-guide.md
@@ -260,7 +260,7 @@ memory/results        ; read from persistent memory
 ; Transforming
 (map f coll)  (mapv f coll)  (pluck :key coll)
 ; map over a map: each entry is passed as [key value] vector
-; Example: (map (fn [entry] {:cat (first entry) :avg (avg-by :amount (last entry))}) grouped)
+; Example: (map (fn [[key value]] {:cat key :avg (avg-by :amount value)}) grouped)
 
 ; Ordering
 (sort-by :key coll)  (sort-by :key > coll)  ; > for descending


### PR DESCRIPTION
## Summary

Updates the map iteration example in `docs/ptc-lisp-llm-guide.md` to demonstrate the new vector destructuring syntax instead of the old `first`/`last` workaround pattern.

This completes the documentation updates for Epic #147 (Function Parameter Destructuring).

## Changes

- Line 263: Updated map example from `(map (fn [entry] {:cat (first entry) :avg (avg-by :amount (last entry))}) grouped)` to `(map (fn [[key value]] {:cat key :avg (avg-by :amount value)}) grouped)`

This demonstrates the idiomatic destructuring pattern that is now available and preferred over the verbose workaround.

Fixes #158