### PR TITLE
fix: Enable multi-arity for get and get-in builtins

### DIFF
--- a/docs/ptc-lisp-llm-guide.md
+++ b/docs/ptc-lisp-llm-guide.md
@@ -273,7 +273,7 @@ memory/results        ; read from persistent memory
 (min-by :key coll)  (max-by :key coll)  (group-by :key coll)
 
 ; Maps
-(get m :key)  (get-in m [:a :b])  (assoc m :k v)  (merge m1 m2)
+(get m :key)  (get m :key default)  (get-in m [:a :b])  (get-in m [:a :b] default)  (assoc m :k v)  (merge m1 m2)
 (select-keys m [:a :b])  (keys m)  (vals m)
 (:key m)  (:key m default)  ; keyword as function
 ```

--- a/lib/ptc_runner/lisp/env.ex
+++ b/lib/ptc_runner/lisp/env.ex
@@ -69,8 +69,8 @@ defmodule PtcRunner.Lisp.Env do
       # ============================================================
       # Map operations
       # ============================================================
-      {:get, {:normal, &Runtime.get/2}},
-      {:"get-in", {:normal, &Runtime.get_in/2}},
+      {:get, {:multi_arity, {&Runtime.get/2, &Runtime.get/3}}},
+      {:"get-in", {:multi_arity, {&Runtime.get_in/2, &Runtime.get_in/3}}},
       {:assoc, {:normal, &Runtime.assoc/3}},
       {:"assoc-in", {:normal, &Runtime.assoc_in/3}},
       {:dissoc, {:normal, &Runtime.dissoc/2}},


### PR DESCRIPTION
## Summary
- Enable `get` and `get-in` functions to work with optional default arguments using the `{:multi_arity, ...}` pattern
- `get/2`: (get m k) returns value or nil
- `get/3`: (get m k default) returns value or default  
- `get-in/2`: (get-in m path) returns nested value
- `get-in/3`: (get-in m path default) returns nested value or default

## Test plan
- ✅ get with 2 arguments returns value or nil
- ✅ get with 3 arguments returns value or default
- ✅ get arity error with wrong argument count
- ✅ get-in with 2 arguments returns nested value
- ✅ get-in with 3 arguments returns default when path not found
- ✅ get-in arity error with wrong argument count
- ✅ All 970 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)