### PR TITLE
feat: Add {:set, [t()]} to AST type specifications

### DIFF
--- a/lib/ptc_runner/lisp/ast.ex
+++ b/lib/ptc_runner/lisp/ast.ex
@@ -11,6 +11,7 @@ defmodule PtcRunner.Lisp.AST do
           # Collections
           | {:vector, [t()]}
           | {:map, [{t(), t()}]}
+          | {:set, [t()]}
           # Symbols
           | {:symbol, atom()}
           | {:ns_symbol, :ctx | :memory, atom()}

--- a/lib/ptc_runner/lisp/core_ast.ex
+++ b/lib/ptc_runner/lisp/core_ast.ex
@@ -25,6 +25,7 @@ defmodule PtcRunner.Lisp.CoreAST do
           # Collections
           | {:vector, [t()]}
           | {:map, [{t(), t()}]}
+          | {:set, [t()]}
           # Variables and namespace access
           | {:var, atom()}
           | {:ctx, atom()}


### PR DESCRIPTION
## Summary
Add set literal type definition to both `ast.ex` and `core_ast.ex` to support set literals in the PTC-Lisp AST. Follows the existing pattern for collection types (vector, map).

## Changes
- Added `{:set, [t()]}` to `PtcRunner.Lisp.AST.t` type spec
- Added `{:set, [t()]}` to `PtcRunner.Lisp.CoreAST.t` type spec

## Test plan
- [x] `mix compile --warnings-as-errors` passes
- [x] `mix test` passes (981 tests, 0 failures)

Fixes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)