### PR TITLE
Fix #179: Add set literal documentation (Phase 7 of #164)

### DIFF
--- a/docs/ptc-lisp-llm-guide.md
+++ b/docs/ptc-lisp-llm-guide.md
@@ -284,6 +284,10 @@ memory/results        ; read from persistent memory
 (contains? #{1 2} 1)   ; membership: true
 (count #{1 2 3})       ; count: 3
 (empty? #{})           ; empty check: true
+
+; Note: map, filter, remove work on sets but return vectors
+(map inc #{1 2})       ; returns vector: [2 3]
+(filter odd? #{1 2 3}) ; returns vector: [1 3]
 ```
 
 ### Tool Calls

--- a/docs/ptc-lisp-specification.md
+++ b/docs/ptc-lisp-specification.md
@@ -232,7 +232,7 @@ Sets are **unordered** - iteration order is not guaranteed.
 | `empty?` | `(empty? #{})` | Returns true if empty |
 | `contains?` | `(contains? #{1 2} 1)` | Membership test (O(1)) |
 
-**Not supported for sets:** `first`, `last`, `nth`, `map`, `filter`, `sort` (sets are unordered).
+**Not supported for sets:** `first`, `last`, `nth`, `sort`, `sort-by` (sets are unordered).
 
 **Not supported:** Lists (`'()`)
 


### PR DESCRIPTION
## Summary

Documentation-only change completing Phase 7 (Documentation) of set literal support. Sets are fully implemented in the codebase (parser, analyzer, evaluator, runtime, formatter) but were missing from the official documentation, causing LLMs to see outdated "Not supported" messages.

- Added Section 3.8 Sets to ptc-lisp-specification.md with syntax, operations, and unsupported operation notes
- Removed "Sets (`#{}`)" from the "Not supported" line (now only Lists remain unsupported)
- Added `set?` type predicate to Section 8.6 Type Predicates
- Updated Section 14 Grammar to include `set` production rule
- Added sets to Data Types section in ptc-lisp-llm-guide.md
- Added set operations reference to Core Functions section in ptc-lisp-llm-guide.md

## Test plan

- ✅ `mix precommit` passes (format, compile, credo, test)
- ✅ All 1010 tests pass with no failures
- ✅ Documentation changes are syntactically correct markdown
- ✅ Grammar additions follow EBNF conventions

Fixes #179