### PR TITLE
Fix #176: Add test coverage for remove, mapv, empty?, and count on sets

### DIFF
--- a/test/ptc_runner/lisp/eval_test.exs
+++ b/test/ptc_runner/lisp/eval_test.exs
@@ -1037,6 +1037,34 @@ defmodule PtcRunner.Lisp.EvalTest do
       {:ok, result, _} = run(~S"(contains? #{1 2 3} 2)")
       assert result == true
     end
+
+    test "remove on set filters elements" do
+      {:ok, result, _} = run(~S"(remove odd? #{1 2 3 4})")
+      assert is_list(result)
+      assert Enum.sort(result) == [2, 4]
+    end
+
+    test "mapv on set returns vector" do
+      {:ok, result, _} = run(~S"(mapv inc #{1 2 3})")
+      assert is_list(result)
+      assert Enum.sort(result) == [2, 3, 4]
+    end
+
+    test "empty? on set returns true or false" do
+      {:ok, result_true, _} = run(~S"(empty? #{})")
+      assert result_true == true
+
+      {:ok, result_false, _} = run(~S"(empty? #{1 2 3})")
+      assert result_false == false
+    end
+
+    test "count on set returns size" do
+      {:ok, result_zero, _} = run(~S"(count #{})")
+      assert result_zero == 0
+
+      {:ok, result_three, _} = run(~S"(count #{1 2 3})")
+      assert result_three == 3
+    end
   end
 
   defp dummy_tool(_name, _args), do: :ok


### PR DESCRIPTION
## Summary
- Added 4 tests to the "collection operations on sets" describe block in eval_test.exs
- Tests verify MapSet-specific clauses added in PR #175: remove, mapv, empty?, and count
- Tests use strong assertions with specific values and follow the existing test pattern

## Test Plan
- ✅ All 4 new tests added to eval_test.exs lines 1041-1067
- ✅ mix test test/ptc_runner/lisp/eval_test.exs passes (114 tests, 0 failures)
- ✅ mix precommit passes all checks (1014 tests, 0 failures)
- ✅ Code formatted with mix format

Fixes #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)