### PR TITLE
fix: Extract shared dummy_tool test helper (#183)

### DIFF
--- a/test/ptc_runner/lisp/eval_control_flow_test.exs
+++ b/test/ptc_runner/lisp/eval_control_flow_test.exs
@@ -1,6 +1,8 @@
 defmodule PtcRunner.Lisp.EvalControlFlowTest do
   use ExUnit.Case, async: true
 
+  import PtcRunner.TestSupport.TestHelpers
+
   alias PtcRunner.Lisp.{Env, Eval}
 
   describe "variable access" do
@@ -240,6 +242,4 @@ defmodule PtcRunner.Lisp.EvalControlFlowTest do
       assert fun.(%{a: 1, b: 2})
     end
   end
-
-  defp dummy_tool(_name, _args), do: :ok
 end

--- a/test/ptc_runner/lisp/eval_data_types_test.exs
+++ b/test/ptc_runner/lisp/eval_data_types_test.exs
@@ -1,6 +1,8 @@
 defmodule PtcRunner.Lisp.EvalDataTypesTest do
   use ExUnit.Case, async: true
 
+  import PtcRunner.TestSupport.TestHelpers
+
   alias PtcRunner.Lisp.Eval
 
   describe "literal evaluation" do
@@ -176,6 +178,4 @@ defmodule PtcRunner.Lisp.EvalDataTypesTest do
       assert MapSet.equal?(result, MapSet.new([1, 2, 3]))
     end
   end
-
-  defp dummy_tool(_name, _args), do: :ok
 end

--- a/test/ptc_runner/lisp/eval_errors_test.exs
+++ b/test/ptc_runner/lisp/eval_errors_test.exs
@@ -1,6 +1,8 @@
 defmodule PtcRunner.Lisp.EvalErrorsTest do
   use ExUnit.Case, async: true
 
+  import PtcRunner.TestSupport.TestHelpers
+
   alias PtcRunner.Lisp.{Env, Eval}
 
   describe "error propagation in nested structures" do
@@ -165,6 +167,4 @@ defmodule PtcRunner.Lisp.EvalErrorsTest do
                Eval.eval(call_ast, %{}, %{}, %{}, &dummy_tool/2)
     end
   end
-
-  defp dummy_tool(_name, _args), do: :ok
 end

--- a/test/ptc_runner/lisp/eval_functions_test.exs
+++ b/test/ptc_runner/lisp/eval_functions_test.exs
@@ -1,6 +1,8 @@
 defmodule PtcRunner.Lisp.EvalFunctionsTest do
   use ExUnit.Case, async: true
 
+  import PtcRunner.TestSupport.TestHelpers
+
   alias PtcRunner.Lisp.{Env, Eval}
 
   describe "function definition: fn" do
@@ -392,6 +394,4 @@ defmodule PtcRunner.Lisp.EvalFunctionsTest do
       assert {:ok, 6, %{}} = Eval.eval(call_ast, %{}, %{}, env, &dummy_tool/2)
     end
   end
-
-  defp dummy_tool(_name, _args), do: :ok
 end

--- a/test/ptc_runner/lisp/eval_memory_test.exs
+++ b/test/ptc_runner/lisp/eval_memory_test.exs
@@ -1,6 +1,8 @@
 defmodule PtcRunner.Lisp.EvalMemoryTest do
   use ExUnit.Case, async: true
 
+  import PtcRunner.TestSupport.TestHelpers
+
   alias PtcRunner.Lisp.Eval
 
   describe "memory threading" do
@@ -30,6 +32,4 @@ defmodule PtcRunner.Lisp.EvalMemoryTest do
       assert new_memory == memory
     end
   end
-
-  defp dummy_tool(_name, _args), do: :ok
 end

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -1,0 +1,8 @@
+defmodule PtcRunner.TestSupport.TestHelpers do
+  @moduledoc """
+  Shared test helper functions used across multiple test files.
+  """
+
+  @doc "Dummy tool that ignores name and args and returns :ok"
+  def dummy_tool(_name, _args), do: :ok
+end


### PR DESCRIPTION
## Summary

Extracts the duplicated `dummy_tool/2` test helper function from 5 test files into a new shared module at `test/support/test_helpers.ex`. This eliminates code duplication (99 usages across 5 files) and improves maintainability while following existing patterns in the codebase.

## Changes

- **New file**: `test/support/test_helpers.ex` with the shared `dummy_tool/2` helper
- **Updated files**: All 5 test files now import the helper and remove local definitions:
  - `test/ptc_runner/lisp/eval_control_flow_test.exs`
  - `test/ptc_runner/lisp/eval_data_types_test.exs`
  - `test/ptc_runner/lisp/eval_errors_test.exs`
  - `test/ptc_runner/lisp/eval_functions_test.exs`
  - `test/ptc_runner/lisp/eval_memory_test.exs`

## Test Plan

- [x] All 1014 tests pass
- [x] All quality checks pass (formatting, compilation, credo, pre-commit tests)
- [x] No functionality changed, only code organization

Fixes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)