### PR TITLE
Fix #191: Update ptc-lisp-overview.md to reflect completed flex key access

### DIFF
--- a/docs/ptc-lisp-overview.md
+++ b/docs/ptc-lisp-overview.md
@@ -246,13 +246,8 @@ Testing with LLM-generated code has revealed gaps in string/atom key flexibility
 
 | Operation | String Key Support | Priority | Notes |
 |-----------|-------------------|----------|-------|
-| `where` value comparison | ❌ No | Medium | `:active` doesn't match `"active"` |
+| `where` value comparison | ✅ Yes | Complete | Flexible key matching now standard |
 | `#(...)` anonymous shorthand | ❌ Not supported | Low | Nice-to-have Clojure syntax |
-
-**Recent improvements:**
-
-- **Keyword-as-function** (`(:key map)`): Now supports flexible key matching via `flex_get`
-- **select-keys**: Now supports flexible key matching via `flex_fetch`
 
 ### LLM Guide Enhancements
 


### PR DESCRIPTION
## Summary

Documentation cleanup to mark flexible key access as complete. Updates the "Future Improvements" section in `docs/ptc-lisp-overview.md` to reflect that flex key access is now standard behavior, not a pending feature.

## Changes

- Update `where` value comparison status from "❌ No" to "✅ Yes" with note "Flexible key matching now standard"
- Remove "Recent improvements" subsection (flex key access is now baseline)
- Keep LLM Guide Enhancements section for continued guidance
- Marks completion of epic #186 (Flexible Key Access)

## Test Plan

- [x] All 1068 tests pass
- [x] Pre-commit checks passed
- [x] No regressions detected

Fixes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)