### PR TITLE
refactor: Use CLIBase in LispCLI to eliminate duplication (#210)

### DIFF
--- a/demo/lib/ptc_demo/lisp_cli.ex
+++ b/demo/lib/ptc_demo/lisp_cli.ex
@@ -16,7 +16,7 @@ defmodule PtcDemo.LispCLI do
     CLIBase.ensure_api_key!()
 
     # Parse command line arguments
-    {opts, _rest} = {CLIBase.parse_common_args(args), []}
+    opts = CLIBase.parse_common_args(args)
 
     data_mode = if opts[:explore], do: :explore, else: :schema
     model = opts[:model]


### PR DESCRIPTION
## Summary

Refactor `LispCLI` to use the shared `CLIBase` module, eliminating ~150 lines of duplicated code. Reduces LispCLI from 514 to 356 lines (~31% reduction).

## Changes

- Replaced local `load_dotenv()` with `CLIBase.load_dotenv()`
- Replaced local `ensure_api_key!()` with `CLIBase.ensure_api_key!()`
- Replaced local `parse_args/1` with `CLIBase.parse_common_args/1`
- Updated `resolve_model/1` to delegate to `CLIBase.resolve_model/2`
- Replaced local formatting functions with CLIBase equivalents:
  - `format_stats/1` → `CLIBase.format_stats/1`
  - `format_number/1` → `CLIBase.format_number/1`
  - `format_cost/1` → `CLIBase.format_cost/1`
- Removed unused `usage/0` function

## Testing

- All 72 demo tests pass
- No compiler warnings
- Code formatted and passes Credo
- Manual testing confirms all CLI modes work correctly:
  - `mix lisp` - interactive REPL works
  - `mix lisp --test` - test mode works
  - `mix lisp --model=haiku` - model selection works
  - `mix lisp --unknown` - error handling works

## Pattern

This follows the refactoring pattern established in PR #209 (LispTestRunner).

Fixes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)