### PR TITLE
fix: Update demo CLI to use ModelRegistry.resolve pattern (#228)

### DIFF
--- a/demo/lib/ptc_demo/cli.ex
+++ b/demo/lib/ptc_demo/cli.ex
@@ -101,17 +101,17 @@ defmodule PtcDemo.CLI do
   end
 
   defp handle_input("/model " <> name) do
-    presets = PtcDemo.Agent.preset_models()
     name = String.trim(name)
 
-    model =
-      case Map.get(presets, name) do
-        nil -> name
-        preset -> preset
-      end
+    case PtcDemo.ModelRegistry.resolve(name) do
+      {:ok, model} ->
+        PtcDemo.Agent.set_model(model)
+        IO.puts("   [Switched to model: #{model}]\n")
 
-    PtcDemo.Agent.set_model(model)
-    IO.puts("   [Switched to model: #{model}]\n")
+      {:error, reason} ->
+        IO.puts("   [Error] #{reason}\n")
+    end
+
     loop()
   end
 


### PR DESCRIPTION
## Summary

Replace legacy `Map.get(presets, name)` pattern with `ModelRegistry.resolve/1` in the `/model` command handler of `demo/lib/ptc_demo/cli.ex`. This aligns with the pattern already used in `JsonCLI` and `LispCLI`.

## Changes

- Updated `handle_input("/model " <> name)` function to use `PtcDemo.ModelRegistry.resolve/1`
- Replaced silent fallback behavior with explicit error handling
- Model resolution now validates against known presets and custom model aliases
- Consistent error messages when resolution fails

## Closes #228