### PR TITLE
feat: Add keyword/string type coercion to where clause comparisons (#232)

### DIFF
--- a/docs/ptc-lisp-specification.md
+++ b/docs/ptc-lisp-specification.md
@@ -478,6 +478,25 @@ Check if field is truthy (not `nil` or `false`):
 (where [:user :premium])  ; nested truthy check
 ```
 
+#### Keyword/String Coercion
+
+For the equality operators (`=`, `not=`), `in`, and `includes`, keywords are coerced to strings for comparison. This allows LLM-generated keywords to match string data values:
+
+```clojure
+;; Keyword coerces to string
+(where :status = :active)        ; matches if field is "active"
+(where :status in [:active :pending])  ; both keywords coerce to strings
+(where :tags includes :urgent)   ; keyword "urgent" matches in ["urgent" "bug"]
+```
+
+**Coercion rules:**
+- Keywords (atoms that are not booleans) coerce to their string representation
+- `true` and `false` do **not** coerce (prevent `true` from matching `"true"`)
+- Empty keyword `:""` coerces to empty string `""`
+- Other types (`strings`, `numbers`, `nil`) are unchanged
+
+**Note:** Ordering comparisons (`>`, `<`, `>=`, `<=`) do **not** use coercion. Type mismatches return `false` (same as `nil` handling).
+
 ### 7.2 Combining Predicates
 
 Use `all-of`, `any-of`, `none-of` to combine predicate functions:


### PR DESCRIPTION
## Summary
- Implements automatic coercion of keywords to strings in equality operators (`=`, `not=`) and membership operators (`in`, `includes`)
- Allows LLM-generated keywords to match string data values without explicit conversion
- Excludes booleans from coercion to prevent `true` matching `"true"`
- Improves LLM ergonomics by reducing silent failures when keywords are generated instead of strings

## Implementation
- Added `normalize_for_comparison/1` helper that coerces non-boolean atoms to their string representation
- Updated `safe_eq/2`, `safe_in/2`, and `safe_includes/2` to use the coercion helper
- Ordering comparisons (`>`, `<`, `>=`, `<=`) intentionally excluded from coercion (maintain strict type checking)

## Testing
- Added 7 new tests covering keyword/string coercion scenarios:
  - Basic keyword-to-string equality matching
  - Membership testing with `in` operator
  - List membership testing with `includes` operator
  - Boolean non-coercion (true/false don't match "true"/"false")
  - Empty string matching
- All 1088 tests pass, no regressions

## Documentation
- Updated Section 7.1 of ptc-lisp-specification.md with coercion rules and examples
- Clearly documented what types coerce and which operations use coercion
- Noted that ordering comparisons do not use coercion

Closes #232