### PR TITLE
test: Add memory contract tests for JSON DSL (#239)

### DIFF
--- a/test/ptc_runner/json/memory_contract_test.exs
+++ b/test/ptc_runner/json/memory_contract_test.exs
@@ -1,0 +1,67 @@
+defmodule PtcRunner.Json.MemoryContractTest do
+  use ExUnit.Case, async: true
+
+  describe "memory contract" do
+    test "scalar result does not update memory" do
+      program = ~s({"program": {"op": "literal", "value": 42}})
+      initial_memory = %{"existing_key" => "preserved"}
+
+      {:ok, result, memory_delta, new_memory} =
+        PtcRunner.Json.run(program, memory: initial_memory)
+
+      assert result == 42
+      assert memory_delta == %{}
+      assert new_memory == initial_memory
+    end
+
+    test "map result merges entire map to memory (JSON doesn't distinguish :result)" do
+      program = ~s({"program": {"op": "literal", "value": {"foo": "bar", "baz": "qux"}}})
+      initial_memory = %{}
+
+      {:ok, result, memory_delta, new_memory} =
+        PtcRunner.Json.run(program, memory: initial_memory)
+
+      # JSON keys are strings, so the entire map is returned and merged into memory
+      assert result == %{"foo" => "bar", "baz" => "qux"}
+      assert memory_delta == %{"foo" => "bar", "baz" => "qux"}
+      assert new_memory == %{"foo" => "bar", "baz" => "qux"}
+    end
+
+    test "empty map result merges nothing but verifies contract" do
+      program = ~s({"program": {"op": "literal", "value": {}}})
+      initial_memory = %{"existing" => "value"}
+
+      {:ok, result, memory_delta, new_memory} =
+        PtcRunner.Json.run(program, memory: initial_memory)
+
+      assert result == %{}
+      assert memory_delta == %{}
+      assert new_memory == %{"existing" => "value"}
+    end
+
+    test "initial memory is preserved with scalar result" do
+      program = ~s({"program": {"op": "literal", "value": 42}})
+      initial_memory = %{"existing_key" => "value1", "another_key" => "value2"}
+
+      {:ok, result, memory_delta, new_memory} =
+        PtcRunner.Json.run(program, memory: initial_memory)
+
+      assert result == 42
+      assert memory_delta == %{}
+      assert new_memory == initial_memory
+      assert new_memory == %{"existing_key" => "value1", "another_key" => "value2"}
+    end
+
+    test "memory merge overwrites initial memory keys" do
+      program = ~s({"program": {"op": "literal", "value": {"foo": 2, "new_key": "added"}}})
+      initial_memory = %{"foo" => 1, "baz" => 3}
+
+      {:ok, result, memory_delta, new_memory} =
+        PtcRunner.Json.run(program, memory: initial_memory)
+
+      assert result == %{"foo" => 2, "new_key" => "added"}
+      assert memory_delta == %{"foo" => 2, "new_key" => "added"}
+      assert new_memory == %{"foo" => 2, "baz" => 3, "new_key" => "added"}
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Add explicit test coverage for the JSON DSL memory contract behavior, matching the Lisp DSL's `eval_memory_test.exs` pattern. These tests verify that the memory contract correctly handles:

- Scalar results that don't update memory
- Map results that merge into memory
- Initial memory preservation and overwriting through the contract

## Test Plan

The implementation covers all 5 test scenarios from the issue:

1. **Scalar result** - Verifies scalar values don't update memory (delta is empty, new_memory equals initial)
2. **Map result merging** - Verifies entire maps merge into memory (JSON doesn't distinguish `:result` like Lisp does)
3. **Empty map handling** - Verifies empty maps merge nothing but preserve initial memory
4. **Initial memory preservation** - Verifies initial memory is preserved with scalar results  
5. **Memory merge overwriting** - Verifies new values overwrite existing keys in memory

All tests pass with strong assertions checking exact values for result, memory_delta, and new_memory.

## Technical Notes

The JSON DSL's memory contract behaves differently from Lisp because JSON parsing produces string keys (e.g., `"result"`) while the contract checks for atom keys (`:result`). This means JSON maps are always treated as full data to merge, not as special `:result`-wrapped responses. The tests reflect this actual behavior.

Closes #239