### PR TITLE
refactor: Split JSON operations.ex into smaller modules by category (#238)

### DIFF
--- a/lib/ptc_runner/json/operations.ex
+++ b/lib/ptc_runner/json/operations.ex
@@ -6,10 +6,20 @@ defmodule PtcRunner.Json.Operations do
   filter, map, select, eq, sum, count; Phase 2: get, neq, gt, gte, lt, lte, first,
   last, nth, reject, contains, avg, min, max; Phase 3: let, if, and, or, not, merge,
   concat, zip; Phase 4: keys, typeof - introspection operations).
+
+  This module acts as a dispatcher, delegating to specialized sub-modules:
+  - PtcRunner.Json.Operations.Comparison - eq, neq, gt, gte, lt, lte, contains
+  - PtcRunner.Json.Operations.Aggregation - sum, count, avg, min, max
+  - PtcRunner.Json.Operations.Collection - filter, map, select, reject
+  - PtcRunner.Json.Operations.Access - get, first, last, nth, sort_by, max_by, min_by
   """
 
   alias PtcRunner.Context
   alias PtcRunner.Json.Interpreter
+  alias PtcRunner.Json.Operations.Access
+  alias PtcRunner.Json.Operations.Aggregation
+  alias PtcRunner.Json.Operations.Collection
+  alias PtcRunner.Json.Operations.Comparison
 
   @doc """
   Evaluates a built-in operation.
@@ -132,317 +142,26 @@ defmodule PtcRunner.Json.Operations do
     eval_pipe(steps, nil, context, eval_fn)
   end
 
-  # Collection operations
-  def eval("filter", node, context, eval_fn) do
-    where_clause = Map.get(node, "where")
-
-    case eval_fn.(context, nil) do
-      {:error, _} = err ->
-        err
-
-      {:ok, data, memory} ->
-        new_context = %{context | memory: memory}
-
-        if is_list(data) do
-          filter_list(data, where_clause, new_context, eval_fn)
-        else
-          {:error, {:execution_error, "filter requires a list, got #{inspect(data)}"}}
-        end
-    end
+  # Comparison operations - delegate to sub-module
+  def eval(op, node, context, eval_fn)
+      when op in ["eq", "neq", "gt", "gte", "lt", "lte", "contains"] do
+    Comparison.eval(op, node, context, eval_fn)
   end
 
-  def eval("map", node, context, eval_fn) do
-    expr = Map.get(node, "expr")
-
-    case eval_fn.(context, nil) do
-      {:error, _} = err ->
-        err
-
-      {:ok, data, memory} ->
-        new_context = %{context | memory: memory}
-
-        if is_list(data) do
-          map_list(data, expr, new_context, eval_fn)
-        else
-          {:error, {:execution_error, "map requires a list, got #{inspect(data)}"}}
-        end
-    end
+  # Collection operations - delegate to sub-module
+  def eval(op, node, context, eval_fn) when op in ["filter", "map", "select", "reject"] do
+    Collection.eval(op, node, context, eval_fn)
   end
 
-  def eval("select", node, context, eval_fn) do
-    fields = Map.get(node, "fields", [])
-
-    case eval_fn.(context, nil) do
-      {:error, _} = err ->
-        err
-
-      {:ok, data, memory} ->
-        if is_list(data) do
-          {:ok, select_list(data, fields), memory}
-        else
-          {:error, {:execution_error, "select requires a list, got #{inspect(data)}"}}
-        end
-    end
+  # Aggregation operations - delegate to sub-module
+  def eval(op, node, context, eval_fn) when op in ["sum", "count", "avg", "min", "max"] do
+    Aggregation.eval(op, node, context, eval_fn)
   end
 
-  # Comparison
-  def eval("eq", node, context, eval_fn), do: eval_comparison(node, context, eval_fn, "eq", &==/2)
-
-  def eval("neq", node, context, eval_fn),
-    do: eval_comparison(node, context, eval_fn, "neq", &!=/2)
-
-  def eval("gt", node, context, eval_fn), do: eval_comparison(node, context, eval_fn, "gt", &>/2)
-
-  def eval("gte", node, context, eval_fn),
-    do: eval_comparison(node, context, eval_fn, "gte", &>=/2)
-
-  def eval("lt", node, context, eval_fn), do: eval_comparison(node, context, eval_fn, "lt", &</2)
-
-  def eval("lte", node, context, eval_fn),
-    do: eval_comparison(node, context, eval_fn, "lte", &<=/2)
-
-  def eval("contains", node, context, eval_fn) do
-    field = Map.get(node, "field")
-    value = Map.get(node, "value")
-
-    case eval_fn.(context, nil) do
-      {:error, _} = err ->
-        err
-
-      {:ok, data, memory} ->
-        if is_map(data) do
-          field_value = Map.get(data, field)
-          {:ok, contains_value?(field_value, value), memory}
-        else
-          {:error, {:execution_error, "contains requires a map, got #{inspect(data)}"}}
-        end
-    end
-  end
-
-  # Access operations
-  def eval("get", node, context, eval_fn) do
-    # Support both field (single key) and path (nested access)
-    path =
-      case Map.get(node, "field") do
-        nil -> Map.get(node, "path", [])
-        field -> [field]
-      end
-
-    case eval_fn.(context, nil) do
-      {:error, _} = err ->
-        err
-
-      {:ok, data, memory} ->
-        result =
-          if path == [] do
-            data
-          else
-            get_nested(data, path)
-          end
-
-        {_result_status, result_value} = handle_get_result(result, node)
-        {:ok, result_value, memory}
-    end
-  end
-
-  # Aggregations
-  def eval("sum", node, context, eval_fn) do
-    field = Map.get(node, "field")
-
-    case eval_fn.(context, nil) do
-      {:error, _} = err ->
-        err
-
-      {:ok, data, memory} ->
-        if is_list(data) do
-          case sum_list(data, field) do
-            {:ok, result} -> {:ok, result, memory}
-            {:error, _} = err -> err
-          end
-        else
-          {:error, {:execution_error, "sum requires a list, got #{inspect(data)}"}}
-        end
-    end
-  end
-
-  def eval("count", _node, context, eval_fn) do
-    case eval_fn.(context, nil) do
-      {:error, _} = err ->
-        err
-
-      {:ok, data, memory} ->
-        if is_list(data) do
-          {:ok, length(data), memory}
-        else
-          {:error, {:execution_error, "count requires a list, got #{inspect(data)}"}}
-        end
-    end
-  end
-
-  def eval("avg", node, context, eval_fn) do
-    field = Map.get(node, "field")
-
-    case eval_fn.(context, nil) do
-      {:error, _} = err ->
-        err
-
-      {:ok, data, memory} ->
-        if is_list(data) do
-          case avg_list(data, field) do
-            {:ok, result} -> {:ok, result, memory}
-          end
-        else
-          {:error, {:execution_error, "avg requires a list, got #{inspect(data)}"}}
-        end
-    end
-  end
-
-  def eval("min", node, context, eval_fn) do
-    field = Map.get(node, "field")
-
-    case eval_fn.(context, nil) do
-      {:error, _} = err ->
-        err
-
-      {:ok, data, memory} ->
-        if is_list(data) do
-          case min_list(data, field) do
-            {:ok, result} -> {:ok, result, memory}
-            {:error, _} = err -> err
-          end
-        else
-          {:error, {:execution_error, "min requires a list, got #{inspect(data)}"}}
-        end
-    end
-  end
-
-  def eval("max", node, context, eval_fn) do
-    field = Map.get(node, "field")
-
-    case eval_fn.(context, nil) do
-      {:error, _} = err ->
-        err
-
-      {:ok, data, memory} ->
-        if is_list(data) do
-          case max_list(data, field) do
-            {:ok, result} -> {:ok, result, memory}
-            {:error, _} = err -> err
-          end
-        else
-          {:error, {:execution_error, "max requires a list, got #{inspect(data)}"}}
-        end
-    end
-  end
-
-  def eval("first", _node, context, eval_fn) do
-    case eval_fn.(context, nil) do
-      {:error, _} = err ->
-        err
-
-      {:ok, data, memory} ->
-        if is_list(data) do
-          {:ok, List.first(data), memory}
-        else
-          {:error, {:execution_error, "first requires a list, got #{inspect(data)}"}}
-        end
-    end
-  end
-
-  def eval("last", _node, context, eval_fn) do
-    case eval_fn.(context, nil) do
-      {:error, _} = err ->
-        err
-
-      {:ok, data, memory} ->
-        if is_list(data) do
-          {:ok, List.last(data), memory}
-        else
-          {:error, {:execution_error, "last requires a list, got #{inspect(data)}"}}
-        end
-    end
-  end
-
-  def eval("nth", node, context, eval_fn) do
-    index = Map.get(node, "index")
-
-    case eval_fn.(context, nil) do
-      {:error, _} = err ->
-        err
-
-      {:ok, data, memory} ->
-        case eval_nth(data, index) do
-          {:ok, result} -> {:ok, result, memory}
-          {:error, _} = err -> err
-        end
-    end
-  end
-
-  def eval("reject", node, context, eval_fn) do
-    where_clause = Map.get(node, "where")
-
-    case eval_fn.(context, nil) do
-      {:error, _} = err ->
-        err
-
-      {:ok, data, memory} ->
-        new_context = %{context | memory: memory}
-
-        if is_list(data) do
-          reject_list(data, where_clause, new_context, eval_fn)
-        else
-          {:error, {:execution_error, "reject requires a list, got #{inspect(data)}"}}
-        end
-    end
-  end
-
-  def eval("sort_by", node, context, eval_fn) do
-    field = Map.get(node, "field")
-    order = Map.get(node, "order", "asc")
-
-    case eval_fn.(context, nil) do
-      {:error, _} = err ->
-        err
-
-      {:ok, data, memory} ->
-        if is_list(data) do
-          {:ok, sort_by_list(data, field, order), memory}
-        else
-          {:error, {:execution_error, "sort_by requires a list, got #{inspect(data)}"}}
-        end
-    end
-  end
-
-  def eval("max_by", node, context, eval_fn) do
-    field = Map.get(node, "field")
-
-    case eval_fn.(context, nil) do
-      {:error, _} = err ->
-        err
-
-      {:ok, data, memory} ->
-        if is_list(data) do
-          {:ok, max_by_list(data, field), memory}
-        else
-          {:error, {:execution_error, "max_by requires a list, got #{inspect(data)}"}}
-        end
-    end
-  end
-
-  def eval("min_by", node, context, eval_fn) do
-    field = Map.get(node, "field")
-
-    case eval_fn.(context, nil) do
-      {:error, _} = err ->
-        err
-
-      {:ok, data, memory} ->
-        if is_list(data) do
-          {:ok, min_by_list(data, field), memory}
-        else
-          {:error, {:execution_error, "min_by requires a list, got #{inspect(data)}"}}
-        end
-    end
+  # Access operations - delegate to sub-module
+  def eval(op, node, context, eval_fn)
+      when op in ["get", "first", "last", "nth", "sort_by", "max_by", "min_by"] do
+    Access.eval(op, node, context, eval_fn)
   end
 
   # Introspection operations
@@ -498,38 +217,7 @@ defmodule PtcRunner.Json.Operations do
     {:error, {:execution_error, "Unknown operation '#{op}'"}}
   end
 
-  # Helper functions
-
-  defp eval_nth(data, index) when is_list(data) do
-    if is_integer(index) && index >= 0 do
-      {:ok, Enum.at(data, index)}
-    else
-      {:error,
-       {:execution_error, "nth index must be a non-negative integer, got #{inspect(index)}"}}
-    end
-  end
-
-  defp eval_nth(data, _index) do
-    {:error, {:execution_error, "nth requires a list, got #{inspect(data)}"}}
-  end
-
-  defp eval_comparison(node, context, eval_fn, op_name, compare_fn) do
-    field = Map.get(node, "field")
-    value = Map.get(node, "value")
-
-    case eval_fn.(context, nil) do
-      {:error, _} = err ->
-        err
-
-      {:ok, data, memory} ->
-        if is_map(data) do
-          data_value = Map.get(data, field)
-          {:ok, compare_fn.(data_value, value), memory}
-        else
-          {:error, {:execution_error, "#{op_name} requires a map, got #{inspect(data)}"}}
-        end
-    end
-  end
+  # Helper functions for control flow operations
 
   defp eval_pipe([], acc, context, _eval_fn) do
     {:ok, acc, context.memory}
@@ -579,224 +267,6 @@ defmodule PtcRunner.Json.Operations do
       {:ok, _result, memory} ->
         {:ok, true, memory}
     end
-  end
-
-  defp filter_list(data, where_clause, context, _eval_fn) do
-    Enum.reduce_while(data, {:ok, [], context.memory}, fn item, {:ok, acc, memory} ->
-      # Inject item as __input for evaluation
-      where_clause_with_input = Map.put(where_clause, "__input", item)
-      ctx = %{context | memory: memory}
-
-      case Interpreter.eval(where_clause_with_input, ctx) do
-        {:ok, true, new_memory} ->
-          {:cont, {:ok, acc ++ [item], new_memory}}
-
-        {:ok, false, new_memory} ->
-          {:cont, {:ok, acc, new_memory}}
-
-        {:ok, result, _memory} ->
-          {:halt,
-           {:error,
-            {:execution_error, "filter where clause must return boolean, got #{inspect(result)}"}}}
-
-        {:error, _} = err ->
-          {:halt, err}
-      end
-    end)
-    |> case do
-      {:ok, result, final_memory} -> {:ok, result, final_memory}
-      {:error, _} = err -> err
-    end
-  end
-
-  defp reject_list(data, where_clause, context, _eval_fn) do
-    Enum.reduce_while(data, {:ok, [], context.memory}, fn item, {:ok, acc, memory} ->
-      # Inject item as __input for evaluation
-      where_clause_with_input = Map.put(where_clause, "__input", item)
-      ctx = %{context | memory: memory}
-
-      case Interpreter.eval(where_clause_with_input, ctx) do
-        {:ok, true, new_memory} ->
-          {:cont, {:ok, acc, new_memory}}
-
-        {:ok, false, new_memory} ->
-          {:cont, {:ok, acc ++ [item], new_memory}}
-
-        {:ok, result, _memory} ->
-          {:halt,
-           {:error,
-            {:execution_error, "reject where clause must return boolean, got #{inspect(result)}"}}}
-
-        {:error, _} = err ->
-          {:halt, err}
-      end
-    end)
-    |> case do
-      {:ok, result, final_memory} -> {:ok, result, final_memory}
-      {:error, _} = err -> err
-    end
-  end
-
-  defp map_list(data, expr, context, _eval_fn) do
-    Enum.reduce_while(data, {:ok, [], context.memory}, fn item, {:ok, acc, memory} ->
-      # Inject item as __input for evaluation
-      expr_with_input = Map.put(expr, "__input", item)
-      ctx = %{context | memory: memory}
-
-      case Interpreter.eval(expr_with_input, ctx) do
-        {:ok, result, new_memory} -> {:cont, {:ok, acc ++ [result], new_memory}}
-        {:error, _} = err -> {:halt, err}
-      end
-    end)
-    |> case do
-      {:ok, result, final_memory} -> {:ok, result, final_memory}
-      {:error, _} = err -> err
-    end
-  end
-
-  defp select_list(data, fields) do
-    Enum.map(data, fn item ->
-      if is_map(item) do
-        Map.take(item, fields)
-      else
-        item
-      end
-    end)
-  end
-
-  defp sum_list(data, field) do
-    Enum.reduce_while(data, {:ok, 0}, fn item, {:ok, acc} ->
-      sum_item(item, field, acc)
-    end)
-  end
-
-  defp sum_item(item, field, acc) do
-    if is_map(item) do
-      case Map.get(item, field) do
-        val when is_number(val) ->
-          {:cont, {:ok, acc + val}}
-
-        nil ->
-          {:cont, {:ok, acc}}
-
-        val ->
-          {:halt,
-           {:error, {:execution_error, "sum requires numeric values, got #{inspect(val)}"}}}
-      end
-    else
-      {:halt, {:error, {:execution_error, "sum requires list of maps, got #{inspect(item)}"}}}
-    end
-  end
-
-  defp avg_list([], _field), do: {:ok, nil}
-
-  defp avg_list(data, field) do
-    {sum, count} =
-      Enum.reduce(data, {0, 0}, fn item, {sum_acc, count_acc} ->
-        case get_numeric_value(item, field) do
-          {:ok, val} -> {sum_acc + val, count_acc + 1}
-          :skip -> {sum_acc, count_acc}
-        end
-      end)
-
-    if count == 0, do: {:ok, nil}, else: {:ok, sum / count}
-  end
-
-  defp min_list([], _field), do: {:ok, nil}
-
-  defp min_list(data, field) do
-    Enum.reduce(data, {:ok, nil}, fn item, acc ->
-      update_min(acc, item, field)
-    end)
-  end
-
-  defp update_min({:ok, nil}, item, field) do
-    case get_item_value(item, field) do
-      {:ok, val} -> {:ok, val}
-      :skip -> {:ok, nil}
-    end
-  end
-
-  defp update_min({:ok, min_val}, item, field) do
-    case get_item_value(item, field) do
-      {:ok, val} -> {:ok, min(min_val, val)}
-      :skip -> {:ok, min_val}
-    end
-  end
-
-  defp max_list([], _field), do: {:ok, nil}
-
-  defp max_list(data, field) do
-    Enum.reduce(data, {:ok, nil}, fn item, acc ->
-      update_max(acc, item, field)
-    end)
-  end
-
-  defp update_max({:ok, nil}, item, field) do
-    case get_item_value(item, field) do
-      {:ok, val} -> {:ok, val}
-      :skip -> {:ok, nil}
-    end
-  end
-
-  defp update_max({:ok, max_val}, item, field) do
-    case get_item_value(item, field) do
-      {:ok, val} -> {:ok, max(max_val, val)}
-      :skip -> {:ok, max_val}
-    end
-  end
-
-  defp get_numeric_value(item, field) when is_map(item) do
-    case Map.get(item, field) do
-      val when is_number(val) -> {:ok, val}
-      nil -> :skip
-      _val -> :skip
-    end
-  end
-
-  defp get_numeric_value(_item, _field), do: :skip
-
-  defp get_item_value(item, field) when is_map(item) do
-    case Map.get(item, field) do
-      nil -> :skip
-      val -> {:ok, val}
-    end
-  end
-
-  defp get_item_value(_item, _field), do: :skip
-
-  defp contains_value?(field_value, value) when is_list(field_value), do: value in field_value
-
-  defp contains_value?(field_value, value) when is_binary(field_value) and is_binary(value),
-    do: String.contains?(field_value, value)
-
-  defp contains_value?(field_value, value) when is_map(field_value),
-    do: Map.has_key?(field_value, value)
-
-  defp contains_value?(_field_value, _value), do: false
-
-  defp get_nested(data, path) when is_map(data) do
-    path_as_atoms = Enum.map(path, &Access.key/1)
-    get_in(data, path_as_atoms)
-  end
-
-  defp get_nested(_data, _path) do
-    # Non-map values always return nil when accessing a path
-    nil
-  end
-
-  defp handle_get_result(nil, node) do
-    default = Map.get(node, "default")
-
-    if Map.has_key?(node, "default") do
-      {:ok, default}
-    else
-      {:ok, nil}
-    end
-  end
-
-  defp handle_get_result(value, _node) do
-    {:ok, value}
   end
 
   defp eval_merge([], context) do
@@ -879,46 +349,6 @@ defmodule PtcRunner.Json.Operations do
 
       {:ok, list, _memory} ->
         {:error, {:execution_error, "zip requires list values, got #{inspect(list)}"}}
-    end
-  end
-
-  defp sort_by_list([], _field, _order), do: []
-
-  defp sort_by_list(data, field, order) do
-    sorter =
-      case order do
-        "desc" -> &>=/2
-        _ -> &<=/2
-      end
-
-    Enum.sort_by(
-      data,
-      fn item ->
-        if is_map(item), do: Map.get(item, field), else: nil
-      end,
-      sorter
-    )
-  end
-
-  defp max_by_list([], _field), do: nil
-
-  defp max_by_list(data, field) do
-    data
-    |> Enum.filter(fn item -> is_map(item) and Map.get(item, field) != nil end)
-    |> case do
-      [] -> nil
-      items -> Enum.max_by(items, fn item -> Map.get(item, field) end)
-    end
-  end
-
-  defp min_by_list([], _field), do: nil
-
-  defp min_by_list(data, field) do
-    data
-    |> Enum.filter(fn item -> is_map(item) and Map.get(item, field) != nil end)
-    |> case do
-      [] -> nil
-      items -> Enum.min_by(items, fn item -> Map.get(item, field) end)
     end
   end
 

--- a/lib/ptc_runner/json/operations/access.ex
+++ b/lib/ptc_runner/json/operations/access.ex
@@ -1,0 +1,219 @@
+defmodule PtcRunner.Json.Operations.Access do
+  @moduledoc """
+  Element access operations for the JSON DSL.
+
+  Implements element and item access: get, first, last, nth, sort_by, max_by, min_by.
+  """
+
+  @doc """
+  Evaluates an access operation.
+
+  ## Arguments
+    - op: Operation name
+    - node: Operation definition map
+    - context: Execution context
+    - eval_fn: Function to recursively evaluate expressions
+
+  ## Returns
+    - `{:ok, result, memory}` on success
+    - `{:error, reason}` on failure
+  """
+  @spec eval(String.t(), map(), any(), function()) ::
+          {:ok, any(), map()} | {:error, {atom(), String.t()}}
+
+  def eval("get", node, context, eval_fn) do
+    # Support both field (single key) and path (nested access)
+    path =
+      case Map.get(node, "field") do
+        nil -> Map.get(node, "path", [])
+        field -> [field]
+      end
+
+    case eval_fn.(context, nil) do
+      {:error, _} = err ->
+        err
+
+      {:ok, data, memory} ->
+        result =
+          if path == [] do
+            data
+          else
+            get_nested(data, path)
+          end
+
+        {_result_status, result_value} = handle_get_result(result, node)
+        {:ok, result_value, memory}
+    end
+  end
+
+  def eval("first", _node, context, eval_fn) do
+    case eval_fn.(context, nil) do
+      {:error, _} = err ->
+        err
+
+      {:ok, data, memory} ->
+        if is_list(data) do
+          {:ok, List.first(data), memory}
+        else
+          {:error, {:execution_error, "first requires a list, got #{inspect(data)}"}}
+        end
+    end
+  end
+
+  def eval("last", _node, context, eval_fn) do
+    case eval_fn.(context, nil) do
+      {:error, _} = err ->
+        err
+
+      {:ok, data, memory} ->
+        if is_list(data) do
+          {:ok, List.last(data), memory}
+        else
+          {:error, {:execution_error, "last requires a list, got #{inspect(data)}"}}
+        end
+    end
+  end
+
+  def eval("nth", node, context, eval_fn) do
+    index = Map.get(node, "index")
+
+    case eval_fn.(context, nil) do
+      {:error, _} = err ->
+        err
+
+      {:ok, data, memory} ->
+        case eval_nth(data, index) do
+          {:ok, result} -> {:ok, result, memory}
+          {:error, _} = err -> err
+        end
+    end
+  end
+
+  def eval("sort_by", node, context, eval_fn) do
+    field = Map.get(node, "field")
+    order = Map.get(node, "order", "asc")
+
+    case eval_fn.(context, nil) do
+      {:error, _} = err ->
+        err
+
+      {:ok, data, memory} ->
+        if is_list(data) do
+          {:ok, sort_by_list(data, field, order), memory}
+        else
+          {:error, {:execution_error, "sort_by requires a list, got #{inspect(data)}"}}
+        end
+    end
+  end
+
+  def eval("max_by", node, context, eval_fn) do
+    field = Map.get(node, "field")
+
+    case eval_fn.(context, nil) do
+      {:error, _} = err ->
+        err
+
+      {:ok, data, memory} ->
+        if is_list(data) do
+          {:ok, max_by_list(data, field), memory}
+        else
+          {:error, {:execution_error, "max_by requires a list, got #{inspect(data)}"}}
+        end
+    end
+  end
+
+  def eval("min_by", node, context, eval_fn) do
+    field = Map.get(node, "field")
+
+    case eval_fn.(context, nil) do
+      {:error, _} = err ->
+        err
+
+      {:ok, data, memory} ->
+        if is_list(data) do
+          {:ok, min_by_list(data, field), memory}
+        else
+          {:error, {:execution_error, "min_by requires a list, got #{inspect(data)}"}}
+        end
+    end
+  end
+
+  # Private helpers
+
+  defp eval_nth(data, index) when is_list(data) do
+    if is_integer(index) && index >= 0 do
+      {:ok, Enum.at(data, index)}
+    else
+      {:error,
+       {:execution_error, "nth index must be a non-negative integer, got #{inspect(index)}"}}
+    end
+  end
+
+  defp eval_nth(data, _index) do
+    {:error, {:execution_error, "nth requires a list, got #{inspect(data)}"}}
+  end
+
+  defp get_nested(data, path) when is_map(data) do
+    path_as_atoms = Enum.map(path, &Access.key/1)
+    get_in(data, path_as_atoms)
+  end
+
+  defp get_nested(_data, _path) do
+    # Non-map values always return nil when accessing a path
+    nil
+  end
+
+  defp handle_get_result(nil, node) do
+    default = Map.get(node, "default")
+
+    if Map.has_key?(node, "default") do
+      {:ok, default}
+    else
+      {:ok, nil}
+    end
+  end
+
+  defp handle_get_result(value, _node) do
+    {:ok, value}
+  end
+
+  defp sort_by_list([], _field, _order), do: []
+
+  defp sort_by_list(data, field, order) do
+    sorter =
+      case order do
+        "desc" -> &>=/2
+        _ -> &<=/2
+      end
+
+    Enum.sort_by(
+      data,
+      fn item ->
+        if is_map(item), do: Map.get(item, field), else: nil
+      end,
+      sorter
+    )
+  end
+
+  defp max_by_list([], _field), do: nil
+
+  defp max_by_list(data, field) do
+    data
+    |> Enum.filter(fn item -> is_map(item) and Map.get(item, field) != nil end)
+    |> case do
+      [] -> nil
+      items -> Enum.max_by(items, fn item -> Map.get(item, field) end)
+    end
+  end
+
+  defp min_by_list([], _field), do: nil
+
+  defp min_by_list(data, field) do
+    data
+    |> Enum.filter(fn item -> is_map(item) and Map.get(item, field) != nil end)
+    |> case do
+      [] -> nil
+      items -> Enum.min_by(items, fn item -> Map.get(item, field) end)
+    end
+  end
+end

--- a/lib/ptc_runner/json/operations/aggregation.ex
+++ b/lib/ptc_runner/json/operations/aggregation.ex
@@ -1,0 +1,215 @@
+defmodule PtcRunner.Json.Operations.Aggregation do
+  @moduledoc """
+  Aggregation operations for the JSON DSL.
+
+  Implements aggregations: sum, count, avg, min, max.
+  """
+
+  @doc """
+  Evaluates an aggregation operation.
+
+  ## Arguments
+    - op: Operation name
+    - node: Operation definition map
+    - context: Execution context
+    - eval_fn: Function to recursively evaluate expressions
+
+  ## Returns
+    - `{:ok, result, memory}` on success
+    - `{:error, reason}` on failure
+  """
+  @spec eval(String.t(), map(), any(), function()) ::
+          {:ok, any(), map()} | {:error, {atom(), String.t()}}
+
+  def eval("sum", node, context, eval_fn) do
+    field = Map.get(node, "field")
+
+    case eval_fn.(context, nil) do
+      {:error, _} = err ->
+        err
+
+      {:ok, data, memory} ->
+        if is_list(data) do
+          case sum_list(data, field) do
+            {:ok, result} -> {:ok, result, memory}
+            {:error, _} = err -> err
+          end
+        else
+          {:error, {:execution_error, "sum requires a list, got #{inspect(data)}"}}
+        end
+    end
+  end
+
+  def eval("count", _node, context, eval_fn) do
+    case eval_fn.(context, nil) do
+      {:error, _} = err ->
+        err
+
+      {:ok, data, memory} ->
+        if is_list(data) do
+          {:ok, length(data), memory}
+        else
+          {:error, {:execution_error, "count requires a list, got #{inspect(data)}"}}
+        end
+    end
+  end
+
+  def eval("avg", node, context, eval_fn) do
+    field = Map.get(node, "field")
+
+    case eval_fn.(context, nil) do
+      {:error, _} = err ->
+        err
+
+      {:ok, data, memory} ->
+        if is_list(data) do
+          case avg_list(data, field) do
+            {:ok, result} -> {:ok, result, memory}
+          end
+        else
+          {:error, {:execution_error, "avg requires a list, got #{inspect(data)}"}}
+        end
+    end
+  end
+
+  def eval("min", node, context, eval_fn) do
+    field = Map.get(node, "field")
+
+    case eval_fn.(context, nil) do
+      {:error, _} = err ->
+        err
+
+      {:ok, data, memory} ->
+        if is_list(data) do
+          case min_list(data, field) do
+            {:ok, result} -> {:ok, result, memory}
+            {:error, _} = err -> err
+          end
+        else
+          {:error, {:execution_error, "min requires a list, got #{inspect(data)}"}}
+        end
+    end
+  end
+
+  def eval("max", node, context, eval_fn) do
+    field = Map.get(node, "field")
+
+    case eval_fn.(context, nil) do
+      {:error, _} = err ->
+        err
+
+      {:ok, data, memory} ->
+        if is_list(data) do
+          case max_list(data, field) do
+            {:ok, result} -> {:ok, result, memory}
+            {:error, _} = err -> err
+          end
+        else
+          {:error, {:execution_error, "max requires a list, got #{inspect(data)}"}}
+        end
+    end
+  end
+
+  # Private helpers
+
+  defp sum_list(data, field) do
+    Enum.reduce_while(data, {:ok, 0}, fn item, {:ok, acc} ->
+      sum_item(item, field, acc)
+    end)
+  end
+
+  defp sum_item(item, field, acc) do
+    if is_map(item) do
+      case Map.get(item, field) do
+        val when is_number(val) ->
+          {:cont, {:ok, acc + val}}
+
+        nil ->
+          {:cont, {:ok, acc}}
+
+        val ->
+          {:halt,
+           {:error, {:execution_error, "sum requires numeric values, got #{inspect(val)}"}}}
+      end
+    else
+      {:halt, {:error, {:execution_error, "sum requires list of maps, got #{inspect(item)}"}}}
+    end
+  end
+
+  defp avg_list([], _field), do: {:ok, nil}
+
+  defp avg_list(data, field) do
+    {sum, count} =
+      Enum.reduce(data, {0, 0}, fn item, {sum_acc, count_acc} ->
+        case get_numeric_value(item, field) do
+          {:ok, val} -> {sum_acc + val, count_acc + 1}
+          :skip -> {sum_acc, count_acc}
+        end
+      end)
+
+    if count == 0, do: {:ok, nil}, else: {:ok, sum / count}
+  end
+
+  defp min_list([], _field), do: {:ok, nil}
+
+  defp min_list(data, field) do
+    Enum.reduce(data, {:ok, nil}, fn item, acc ->
+      update_min(acc, item, field)
+    end)
+  end
+
+  defp update_min({:ok, nil}, item, field) do
+    case get_item_value(item, field) do
+      {:ok, val} -> {:ok, val}
+      :skip -> {:ok, nil}
+    end
+  end
+
+  defp update_min({:ok, min_val}, item, field) do
+    case get_item_value(item, field) do
+      {:ok, val} -> {:ok, min(min_val, val)}
+      :skip -> {:ok, min_val}
+    end
+  end
+
+  defp max_list([], _field), do: {:ok, nil}
+
+  defp max_list(data, field) do
+    Enum.reduce(data, {:ok, nil}, fn item, acc ->
+      update_max(acc, item, field)
+    end)
+  end
+
+  defp update_max({:ok, nil}, item, field) do
+    case get_item_value(item, field) do
+      {:ok, val} -> {:ok, val}
+      :skip -> {:ok, nil}
+    end
+  end
+
+  defp update_max({:ok, max_val}, item, field) do
+    case get_item_value(item, field) do
+      {:ok, val} -> {:ok, max(max_val, val)}
+      :skip -> {:ok, max_val}
+    end
+  end
+
+  defp get_numeric_value(item, field) when is_map(item) do
+    case Map.get(item, field) do
+      val when is_number(val) -> {:ok, val}
+      nil -> :skip
+      _val -> :skip
+    end
+  end
+
+  defp get_numeric_value(_item, _field), do: :skip
+
+  defp get_item_value(item, field) when is_map(item) do
+    case Map.get(item, field) do
+      nil -> :skip
+      val -> {:ok, val}
+    end
+  end
+
+  defp get_item_value(_item, _field), do: :skip
+end

--- a/lib/ptc_runner/json/operations/collection.ex
+++ b/lib/ptc_runner/json/operations/collection.ex
@@ -1,0 +1,180 @@
+defmodule PtcRunner.Json.Operations.Collection do
+  @moduledoc """
+  Collection operations for the JSON DSL.
+
+  Implements collection transformations: filter, map, select, reject.
+  """
+
+  alias PtcRunner.Json.Interpreter
+
+  @doc """
+  Evaluates a collection operation.
+
+  ## Arguments
+    - op: Operation name
+    - node: Operation definition map
+    - context: Execution context
+    - eval_fn: Function to recursively evaluate expressions
+
+  ## Returns
+    - `{:ok, result, memory}` on success
+    - `{:error, reason}` on failure
+  """
+  @spec eval(String.t(), map(), any(), function()) ::
+          {:ok, any(), map()} | {:error, {atom(), String.t()}}
+
+  def eval("filter", node, context, eval_fn) do
+    where_clause = Map.get(node, "where")
+
+    case eval_fn.(context, nil) do
+      {:error, _} = err ->
+        err
+
+      {:ok, data, memory} ->
+        new_context = %{context | memory: memory}
+
+        if is_list(data) do
+          filter_list(data, where_clause, new_context, eval_fn)
+        else
+          {:error, {:execution_error, "filter requires a list, got #{inspect(data)}"}}
+        end
+    end
+  end
+
+  def eval("map", node, context, eval_fn) do
+    expr = Map.get(node, "expr")
+
+    case eval_fn.(context, nil) do
+      {:error, _} = err ->
+        err
+
+      {:ok, data, memory} ->
+        new_context = %{context | memory: memory}
+
+        if is_list(data) do
+          map_list(data, expr, new_context, eval_fn)
+        else
+          {:error, {:execution_error, "map requires a list, got #{inspect(data)}"}}
+        end
+    end
+  end
+
+  def eval("select", node, context, eval_fn) do
+    fields = Map.get(node, "fields", [])
+
+    case eval_fn.(context, nil) do
+      {:error, _} = err ->
+        err
+
+      {:ok, data, memory} ->
+        if is_list(data) do
+          {:ok, select_list(data, fields), memory}
+        else
+          {:error, {:execution_error, "select requires a list, got #{inspect(data)}"}}
+        end
+    end
+  end
+
+  def eval("reject", node, context, eval_fn) do
+    where_clause = Map.get(node, "where")
+
+    case eval_fn.(context, nil) do
+      {:error, _} = err ->
+        err
+
+      {:ok, data, memory} ->
+        new_context = %{context | memory: memory}
+
+        if is_list(data) do
+          reject_list(data, where_clause, new_context, eval_fn)
+        else
+          {:error, {:execution_error, "reject requires a list, got #{inspect(data)}"}}
+        end
+    end
+  end
+
+  # Private helpers
+
+  defp filter_list(data, where_clause, context, _eval_fn) do
+    Enum.reduce_while(data, {:ok, [], context.memory}, fn item, {:ok, acc, memory} ->
+      # Inject item as __input for evaluation
+      where_clause_with_input = Map.put(where_clause, "__input", item)
+      ctx = %{context | memory: memory}
+
+      case Interpreter.eval(where_clause_with_input, ctx) do
+        {:ok, true, new_memory} ->
+          {:cont, {:ok, acc ++ [item], new_memory}}
+
+        {:ok, false, new_memory} ->
+          {:cont, {:ok, acc, new_memory}}
+
+        {:ok, result, _memory} ->
+          {:halt,
+           {:error,
+            {:execution_error, "filter where clause must return boolean, got #{inspect(result)}"}}}
+
+        {:error, _} = err ->
+          {:halt, err}
+      end
+    end)
+    |> case do
+      {:ok, result, final_memory} -> {:ok, result, final_memory}
+      {:error, _} = err -> err
+    end
+  end
+
+  defp reject_list(data, where_clause, context, _eval_fn) do
+    Enum.reduce_while(data, {:ok, [], context.memory}, fn item, {:ok, acc, memory} ->
+      # Inject item as __input for evaluation
+      where_clause_with_input = Map.put(where_clause, "__input", item)
+      ctx = %{context | memory: memory}
+
+      case Interpreter.eval(where_clause_with_input, ctx) do
+        {:ok, true, new_memory} ->
+          {:cont, {:ok, acc, new_memory}}
+
+        {:ok, false, new_memory} ->
+          {:cont, {:ok, acc ++ [item], new_memory}}
+
+        {:ok, result, _memory} ->
+          {:halt,
+           {:error,
+            {:execution_error, "reject where clause must return boolean, got #{inspect(result)}"}}}
+
+        {:error, _} = err ->
+          {:halt, err}
+      end
+    end)
+    |> case do
+      {:ok, result, final_memory} -> {:ok, result, final_memory}
+      {:error, _} = err -> err
+    end
+  end
+
+  defp map_list(data, expr, context, _eval_fn) do
+    Enum.reduce_while(data, {:ok, [], context.memory}, fn item, {:ok, acc, memory} ->
+      # Inject item as __input for evaluation
+      expr_with_input = Map.put(expr, "__input", item)
+      ctx = %{context | memory: memory}
+
+      case Interpreter.eval(expr_with_input, ctx) do
+        {:ok, result, new_memory} -> {:cont, {:ok, acc ++ [result], new_memory}}
+        {:error, _} = err -> {:halt, err}
+      end
+    end)
+    |> case do
+      {:ok, result, final_memory} -> {:ok, result, final_memory}
+      {:error, _} = err -> err
+    end
+  end
+
+  defp select_list(data, fields) do
+    Enum.map(data, fn item ->
+      if is_map(item) do
+        Map.take(item, fields)
+      else
+        item
+      end
+    end)
+  end
+end

--- a/lib/ptc_runner/json/operations/comparison.ex
+++ b/lib/ptc_runner/json/operations/comparison.ex
@@ -1,0 +1,86 @@
+defmodule PtcRunner.Json.Operations.Comparison do
+  @moduledoc """
+  Comparison operations for the JSON DSL.
+
+  Implements comparison and containment checks: eq, neq, gt, gte, lt, lte, contains.
+  """
+
+  @doc """
+  Evaluates a comparison operation.
+
+  ## Arguments
+    - op: Operation name
+    - node: Operation definition map
+    - context: Execution context
+    - eval_fn: Function to recursively evaluate expressions
+
+  ## Returns
+    - `{:ok, result, memory}` on success
+    - `{:error, reason}` on failure
+  """
+  @spec eval(String.t(), map(), any(), function()) ::
+          {:ok, any(), map()} | {:error, {atom(), String.t()}}
+
+  def eval("eq", node, context, eval_fn), do: eval_comparison(node, context, eval_fn, "eq", &==/2)
+
+  def eval("neq", node, context, eval_fn),
+    do: eval_comparison(node, context, eval_fn, "neq", &!=/2)
+
+  def eval("gt", node, context, eval_fn), do: eval_comparison(node, context, eval_fn, "gt", &>/2)
+
+  def eval("gte", node, context, eval_fn),
+    do: eval_comparison(node, context, eval_fn, "gte", &>=/2)
+
+  def eval("lt", node, context, eval_fn), do: eval_comparison(node, context, eval_fn, "lt", &</2)
+
+  def eval("lte", node, context, eval_fn),
+    do: eval_comparison(node, context, eval_fn, "lte", &<=/2)
+
+  def eval("contains", node, context, eval_fn) do
+    field = Map.get(node, "field")
+    value = Map.get(node, "value")
+
+    case eval_fn.(context, nil) do
+      {:error, _} = err ->
+        err
+
+      {:ok, data, memory} ->
+        if is_map(data) do
+          field_value = Map.get(data, field)
+          {:ok, contains_value?(field_value, value), memory}
+        else
+          {:error, {:execution_error, "contains requires a map, got #{inspect(data)}"}}
+        end
+    end
+  end
+
+  # Private helpers
+
+  defp eval_comparison(node, context, eval_fn, op_name, compare_fn) do
+    field = Map.get(node, "field")
+    value = Map.get(node, "value")
+
+    case eval_fn.(context, nil) do
+      {:error, _} = err ->
+        err
+
+      {:ok, data, memory} ->
+        if is_map(data) do
+          data_value = Map.get(data, field)
+          {:ok, compare_fn.(data_value, value), memory}
+        else
+          {:error, {:execution_error, "#{op_name} requires a map, got #{inspect(data)}"}}
+        end
+    end
+  end
+
+  defp contains_value?(field_value, value) when is_list(field_value), do: value in field_value
+
+  defp contains_value?(field_value, value) when is_binary(field_value) and is_binary(value),
+    do: String.contains?(field_value, value)
+
+  defp contains_value?(field_value, value) when is_map(field_value),
+    do: Map.has_key?(field_value, value)
+
+  defp contains_value?(_field_value, _value), do: false
+end


### PR DESCRIPTION
## Summary

This refactoring splits the large `operations.ex` file (931 lines) into four specialized sub-modules organized by operation category, improving maintainability and code navigation while maintaining the existing public API.

- **PtcRunner.Json.Operations.Comparison** - eq, neq, gt, gte, lt, lte, contains
- **PtcRunner.Json.Operations.Aggregation** - sum, count, avg, min, max  
- **PtcRunner.Json.Operations.Collection** - filter, map, select, reject
- **PtcRunner.Json.Operations.Access** - get, first, last, nth, sort_by, max_by, min_by

The main Operations module now acts as a dispatcher that delegates to these sub-modules, keeping all core data operations, control flow, introspection, and tool integration in the main module.

## Test Plan

- All 416 existing tests pass without modification
- Code formatted per project style
- Credo checks pass
- No public API changes (callers still use `PtcRunner.Json.Operations.eval/4`)

Closes #238