### PR TITLE
feat: Add enhanced stats to demo test runner report (#246)

### DIFF
--- a/demo/lib/ptc_demo/agent.ex
+++ b/demo/lib/ptc_demo/agent.ex
@@ -298,6 +298,9 @@ defmodule PtcDemo.Agent do
           {:ok, program_json} ->
             IO.puts("   [Program] #{truncate(program_json, 80)}")
 
+            # Increment run counter when program is generated
+            run_tracked_usage = increment_run_count(new_usage)
+
             # Execute the program with native memory support
             case PtcRunner.Json.run(program_json,
                    context: datasets,
@@ -321,7 +324,7 @@ defmodule PtcDemo.Agent do
                   model,
                   new_context,
                   datasets,
-                  new_usage,
+                  run_tracked_usage,
                   remaining - 1,
                   new_last_exec,
                   new_memory
@@ -341,7 +344,7 @@ defmodule PtcDemo.Agent do
                   model,
                   new_context,
                   datasets,
-                  new_usage,
+                  run_tracked_usage,
                   remaining - 1,
                   last_exec,
                   memory
@@ -573,11 +576,18 @@ defmodule PtcDemo.Agent do
 
   # --- Usage Tracking Helpers ---
 
+  defp estimate_system_prompt_tokens(prompt) when is_binary(prompt) do
+    # Rough approximation: ~4 characters per token on average
+    div(String.length(prompt), 4)
+  end
+
   defp empty_usage do
     %{
       input_tokens: 0,
       output_tokens: 0,
       total_tokens: 0,
+      system_prompt_tokens: estimate_system_prompt_tokens(system_prompt(:schema)),
+      total_runs: 0,
       total_cost: 0.0,
       requests: 0
     }
@@ -593,9 +603,15 @@ defmodule PtcDemo.Agent do
       input_tokens: acc.input_tokens + normalized.input_tokens,
       output_tokens: acc.output_tokens + normalized.output_tokens,
       total_tokens: acc.total_tokens + normalized.total_tokens,
+      system_prompt_tokens: acc.system_prompt_tokens,
+      total_runs: acc.total_runs,
       total_cost: acc.total_cost + normalized.total_cost,
       requests: acc.requests + 1
     }
+  end
+
+  defp increment_run_count(usage) do
+    %{usage | total_runs: usage.total_runs + 1}
   end
 
   defp normalize_usage(usage) when is_map(usage) do

--- a/demo/lib/ptc_demo/test_runner/report.ex
+++ b/demo/lib/ptc_demo/test_runner/report.ex
@@ -68,6 +68,10 @@ defmodule PtcDemo.TestRunner.Report do
     | Total Attempts | #{summary.total_attempts} |
     | Avg Attempts/Test | #{if summary.total > 0, do: Float.round(summary.total_attempts / summary.total, 2), else: 0.0} |
     | Duration | #{Base.format_duration(summary.duration_ms)} |
+    | Total Runs | #{summary.stats.total_runs} |
+    | System Prompt Tokens | #{summary.stats.system_prompt_tokens} |
+    | Input Tokens | #{summary.stats.input_tokens} |
+    | Output Tokens | #{summary.stats.output_tokens} |
     | Total Tokens | #{summary.stats.total_tokens} |
     | Cost | #{Base.format_cost(summary.stats.total_cost)} |
 


### PR DESCRIPTION
## Summary

Implemented enhanced statistics tracking for the demo test runner report, including:
- System prompt tokens estimation (~4 chars per token)
- Total program runs count (incremented when programs are generated)
- Input/output tokens breakdown in the summary table
- Cost fallback calculation using ModelRegistry when API doesn't provide cost

## Changes

**demo/lib/ptc_demo/agent.ex & lisp_agent.ex:**
- Extended `empty_usage/0` to include `system_prompt_tokens` and `total_runs` fields
- Added `estimate_system_prompt_tokens/1` helper function
- Added `increment_run_count/1` to track program generations separately
- Updated agent loop to call `increment_run_count` when programs are generated

**demo/lib/ptc_demo/test_runner/base.ex:**
- Added `apply_cost_fallback/2` function to calculate cost from tokens when provider returns nil/0
- Integrated cost fallback logic into `build_summary/5`

**demo/lib/ptc_demo/test_runner/report.ex:**
- Enhanced markdown summary table with new metrics:
  - Total Runs
  - System Prompt Tokens
  - Input Tokens
  - Output Tokens
  - (existing) Total Tokens
  - (existing) Cost

## Testing

- All existing tests pass: 1126 tests, 0 failures
- Verified with `mix lisp --test --report` - report now includes all new stats
- Precommit checks pass (format, compile, credo)

Closes #246

🤖 Generated with [Claude Code](https://claude.com/claude-code)