### PR TITLE
docs: sync system prompt spec with implementation

### DIFF
--- a/docs/ptc_agents/system-prompt-template.md
+++ b/docs/ptc_agents/system-prompt-template.md
@@ -108,14 +108,14 @@ Generated from `context` and `context_signature`:
 
 Available in `ctx/`:
 
-| Key | Type | Description |
-|-----|------|-------------|
-| `ctx/user_id` | `:int` | The user's ID |
-| `ctx/emails` | `[{id :int, subject :string}]` | List of email objects |
-| `ctx/_token` | `:string` | [Firewalled] Auth token |
+| Key | Type | Sample |
+|-----|------|--------|
+| `ctx/user_id` | `:int` | `123` |
+| `ctx/emails` | `[{id :int, subject :string}]` | `[{id: 1, subject: "Hello"}, ...]` (5 items) |
+| `ctx/_token` | `:string` | [Hidden] |
 
-Note: Firewalled fields (prefixed with `_`) are available in your program
-but hidden from conversation history.
+Note: Firewalled fields (prefixed with `_`) show `[Hidden]` in the Sample column
+but are available in your program at runtime.
 ```
 
 **Generation Logic:**


### PR DESCRIPTION
## Summary

- Update Data Inventory table header from "Description" to "Sample" to match actual implementation
- Update example values to show runtime samples instead of static descriptions
- Update firewalled field notation from "[Firewalled]" to "[Hidden]"

## Context

This addresses documentation drift identified in PR #430 review. The implementation in `PtcRunner.SubAgent.Prompt.generate_data_inventory/2` uses "Sample" column with actual runtime values, which is more useful to the LLM.

## Related

- Originated from: #430 (review comment)
- Follow-up issue created: #433 (tool_catalog support)

🤖 Generated with [Claude Code](https://claude.com/claude-code)