### PR TITLE
refactor: rename Lisp.Prompts to Lisp.LanguageSpec

### DIFF
--- a/demo/lib/ptc_demo/prompts.ex
+++ b/demo/lib/ptc_demo/prompts.ex
@@ -2,7 +2,7 @@ defmodule PtcDemo.Prompts do
   @moduledoc """
   Prompt profiles for testing different LLM instruction styles.
 
-  This module delegates to `PtcRunner.Lisp.Prompts` for standard prompts.
+  This module delegates to `PtcRunner.Lisp.LanguageSpec` for standard language specs.
 
   Different prompts can be useful for:
   - Testing model capabilities with varying levels of detail
@@ -29,7 +29,7 @@ defmodule PtcDemo.Prompts do
       PtcDemo.Prompts.list()
   """
 
-  alias PtcRunner.Lisp.Prompts, as: LibPrompts
+  alias PtcRunner.Lisp.LanguageSpec, as: LibLanguageSpec
 
   @doc """
   Get a prompt profile by name.
@@ -54,7 +54,7 @@ defmodule PtcDemo.Prompts do
 
   # Delegate standard prompts to the library
   def get(profile) when profile in [:single_shot, :multi_turn, :base, :addon_memory] do
-    LibPrompts.get(profile)
+    LibLanguageSpec.get(profile)
   end
 
   @doc """
@@ -129,7 +129,7 @@ defmodule PtcDemo.Prompts do
 
   """
   @spec version(atom()) :: pos_integer()
-  def version(profile), do: LibPrompts.version(profile)
+  def version(profile), do: LibLanguageSpec.version(profile)
 
   @doc """
   Get metadata for a prompt profile.
@@ -144,7 +144,7 @@ defmodule PtcDemo.Prompts do
 
   """
   @spec metadata(atom()) :: map()
-  def metadata(profile), do: LibPrompts.metadata(profile)
+  def metadata(profile), do: LibLanguageSpec.metadata(profile)
 
   @doc """
   Check if a prompt profile is archived.
@@ -156,7 +156,7 @@ defmodule PtcDemo.Prompts do
 
   """
   @spec archived?(atom()) :: boolean()
-  def archived?(profile), do: LibPrompts.archived?(profile)
+  def archived?(profile), do: LibLanguageSpec.archived?(profile)
 
   @doc """
   List only current (non-archived) prompt profiles.
@@ -170,6 +170,6 @@ defmodule PtcDemo.Prompts do
   """
   @spec list_current() :: [atom()]
   def list_current do
-    LibPrompts.list_current()
+    LibLanguageSpec.list_current()
   end
 end

--- a/docs/guides/subagent-prompts.md
+++ b/docs/guides/subagent-prompts.md
@@ -78,9 +78,9 @@ SubAgent.new(
   system_prompt: %{
     language_spec: fn ctx ->
       if ctx.turn == 1 do
-        PtcRunner.Lisp.Prompts.get(:single_shot)
+        PtcRunner.Lisp.LanguageSpec.get(:single_shot)
       else
-        PtcRunner.Lisp.Prompts.get(:multi_turn)
+        PtcRunner.Lisp.LanguageSpec.get(:multi_turn)
       end
     end
   }
@@ -103,7 +103,7 @@ Different models may need different prompt styles:
 ```elixir
 defmodule MyApp.Prompts do
   def language_spec_for_model(ctx) do
-    base = PtcRunner.Lisp.Prompts.get(:single_shot)
+    base = PtcRunner.Lisp.LanguageSpec.get(:single_shot)
 
     case ctx.model do
       :gemini ->
@@ -147,11 +147,11 @@ Build on top of library prompts:
 
 ```elixir
 defmodule MyApp.Prompts do
-  alias PtcRunner.Lisp.Prompts
+  alias PtcRunner.Lisp.LanguageSpec
 
   def with_domain_context do
     """
-    #{Prompts.get(:single_shot)}
+    #{LanguageSpec.get(:single_shot)}
 
     ## Domain Context
 
@@ -228,4 +228,4 @@ IO.puts(preview.user)    # Expanded user prompt
 - [Core Concepts](subagent-concepts.md) - Context, memory, and firewalls
 - [Advanced Topics](subagent-advanced.md) - System prompt structure details
 - `PtcRunner.SubAgent.SystemPrompt` - API reference for prompt generation
-- `PtcRunner.Lisp.Prompts` - Available prompt profiles
+- `PtcRunner.Lisp.LanguageSpec` - Available language spec profiles

--- a/docs/ptc_agents/specification.md
+++ b/docs/ptc_agents/specification.md
@@ -1014,7 +1014,7 @@ Developers can customize the system prompt via the `system_prompt` field. This e
 | Form | Description |
 |------|-------------|
 | `String.t()` | Custom language specification string (used as-is) |
-| `atom()` | Resolved via `PtcRunner.Lisp.Prompts.get!/1` (e.g., `:minimal`, `:default`) |
+| `atom()` | Resolved via `PtcRunner.Lisp.LanguageSpec.get!/1` (e.g., `:minimal`, `:default`) |
 | `fn ctx -> String.t()` | Callback called per-turn with context map |
 
 **Callback context (for function form):**
@@ -1057,8 +1057,8 @@ SubAgent.new(
   signature: "(data :map) -> {result :map}",
   system_prompt: %{
     language_spec: fn ctx ->
-      alias PtcRunner.Lisp.Prompts
-      if ctx.turn > 1, do: Prompts.get(:multi_turn), else: Prompts.get(:minimal)
+      alias PtcRunner.Lisp.LanguageSpec
+      if ctx.turn > 1, do: LanguageSpec.get(:multi_turn), else: LanguageSpec.get(:minimal)
     end
   }
 )

--- a/lib/ptc_runner/lisp/language_spec.ex
+++ b/lib/ptc_runner/lisp/language_spec.ex
@@ -1,11 +1,11 @@
-defmodule PtcRunner.Lisp.Prompts do
+defmodule PtcRunner.Lisp.LanguageSpec do
   @moduledoc """
-  Prompt loader for PTC-Lisp language references.
+  Language specification loader for PTC-Lisp.
 
-  Loads prompt snippets from `priv/prompts/` directory at compile time and
+  Loads language spec snippets from `priv/prompts/` directory at compile time and
   provides compositions for common use cases.
 
-  ## Available Prompts
+  ## Available Specs
 
   | Key | Description |
   |-----|-------------|
@@ -22,7 +22,7 @@ defmodule PtcRunner.Lisp.Prompts do
 
   ## Version Metadata
 
-  Prompt files can include optional metadata headers:
+  Spec files can include optional metadata headers:
 
       <!-- version: 2 -->
       <!-- date: 2025-01-15 -->
@@ -33,18 +33,18 @@ defmodule PtcRunner.Lisp.Prompts do
   ## Usage
 
       # For single-turn queries
-      PtcRunner.Lisp.Prompts.get(:single_shot)
+      PtcRunner.Lisp.LanguageSpec.get(:single_shot)
 
       # For multi-turn conversations
-      PtcRunner.Lisp.Prompts.get(:multi_turn)
+      PtcRunner.Lisp.LanguageSpec.get(:multi_turn)
 
       # Raw snippets for custom compositions
-      PtcRunner.Lisp.Prompts.get(:base) <> my_custom_addon
+      PtcRunner.Lisp.LanguageSpec.get(:base) <> my_custom_addon
 
       # Use in SubAgent
       SubAgent.new(
         prompt: "...",
-        system_prompt: %{language_spec: PtcRunner.Lisp.Prompts.get(:single_shot)}
+        system_prompt: %{language_spec: PtcRunner.Lisp.LanguageSpec.get(:single_shot)}
       )
   """
 
@@ -162,11 +162,11 @@ defmodule PtcRunner.Lisp.Prompts do
 
   ## Examples
 
-      iex> prompt = PtcRunner.Lisp.Prompts.get(:single_shot)
+      iex> prompt = PtcRunner.Lisp.LanguageSpec.get(:single_shot)
       iex> is_binary(prompt)
       true
 
-      iex> prompt = PtcRunner.Lisp.Prompts.get(:multi_turn)
+      iex> prompt = PtcRunner.Lisp.LanguageSpec.get(:multi_turn)
       iex> String.contains?(prompt, "State Persistence")
       true
 
@@ -202,7 +202,7 @@ defmodule PtcRunner.Lisp.Prompts do
 
   ## Examples
 
-      iex> prompt = PtcRunner.Lisp.Prompts.get!(:single_shot)
+      iex> prompt = PtcRunner.Lisp.LanguageSpec.get!(:single_shot)
       iex> is_binary(prompt)
       true
 
@@ -245,7 +245,7 @@ defmodule PtcRunner.Lisp.Prompts do
 
   ## Examples
 
-      iex> meta = PtcRunner.Lisp.Prompts.metadata(:base)
+      iex> meta = PtcRunner.Lisp.LanguageSpec.metadata(:base)
       iex> is_map(meta)
       true
 
@@ -272,7 +272,7 @@ defmodule PtcRunner.Lisp.Prompts do
 
   ## Examples
 
-      iex> PtcRunner.Lisp.Prompts.archived?(:single_shot)
+      iex> PtcRunner.Lisp.LanguageSpec.archived?(:single_shot)
       false
 
   """
@@ -297,7 +297,7 @@ defmodule PtcRunner.Lisp.Prompts do
 
   ## Examples
 
-      iex> keys = PtcRunner.Lisp.Prompts.list()
+      iex> keys = PtcRunner.Lisp.LanguageSpec.list()
       iex> :single_shot in keys
       true
       iex> :multi_turn in keys
@@ -316,7 +316,7 @@ defmodule PtcRunner.Lisp.Prompts do
 
   ## Examples
 
-      iex> keys = PtcRunner.Lisp.Prompts.list_current()
+      iex> keys = PtcRunner.Lisp.LanguageSpec.list_current()
       iex> :single_shot in keys
       true
       iex> :base in keys
@@ -343,7 +343,7 @@ defmodule PtcRunner.Lisp.Prompts do
 
   ## Examples
 
-      iex> list = PtcRunner.Lisp.Prompts.list_with_descriptions()
+      iex> list = PtcRunner.Lisp.LanguageSpec.list_with_descriptions()
       iex> Enum.any?(list, fn {k, _} -> k == :single_shot end)
       true
 

--- a/lib/ptc_runner/sub_agent.ex
+++ b/lib/ptc_runner/sub_agent.ex
@@ -90,7 +90,7 @@ defmodule PtcRunner.SubAgent do
 
   Can be:
   - String: used as-is
-  - Atom: resolved via `PtcRunner.Lisp.Prompts.get!/1` (e.g., `:minimal`, `:default`)
+  - Atom: resolved via `PtcRunner.Lisp.LanguageSpec.get!/1` (e.g., `:minimal`, `:default`)
   - Function: callback receiving context map with `:turn`, `:model`, `:memory`, `:messages`
   """
   @type language_spec :: String.t() | atom() | (map() -> String.t())

--- a/lib/ptc_runner/sub_agent/system_prompt.ex
+++ b/lib/ptc_runner/sub_agent/system_prompt.ex
@@ -29,7 +29,7 @@ defmodule PtcRunner.SubAgent.SystemPrompt do
   ## Language Spec
 
   The `:language_spec` option can be:
-  - **Atom** - Resolved via `PtcRunner.Lisp.Prompts.get!/1`
+  - **Atom** - Resolved via `PtcRunner.Lisp.LanguageSpec.get!/1`
   - **String** - Used as-is
   - **Callback** - `fn ctx -> "prompt" end`
 
@@ -49,7 +49,7 @@ defmodule PtcRunner.SubAgent.SystemPrompt do
 
   require Logger
 
-  alias PtcRunner.Lisp.Prompts
+  alias PtcRunner.Lisp.LanguageSpec
   alias PtcRunner.SubAgent
   alias PtcRunner.SubAgent.MissionExpander
   alias PtcRunner.SubAgent.Signature
@@ -226,7 +226,7 @@ defmodule PtcRunner.SubAgent.SystemPrompt do
   def resolve_language_spec(spec, _context) when is_binary(spec), do: spec
 
   def resolve_language_spec(spec, _context) when is_atom(spec) do
-    Prompts.get!(spec)
+    LanguageSpec.get!(spec)
   end
 
   def resolve_language_spec(spec, context) when is_function(spec, 1) do
@@ -427,7 +427,7 @@ defmodule PtcRunner.SubAgent.SystemPrompt do
         }
 
       _ ->
-        {Prompts.get(default_spec), @output_format}
+        {LanguageSpec.get(default_spec), @output_format}
     end
   end
 

--- a/test/ptc_runner/lisp/language_spec_test.exs
+++ b/test/ptc_runner/lisp/language_spec_test.exs
@@ -1,84 +1,84 @@
-defmodule PtcRunner.Lisp.PromptsTest do
+defmodule PtcRunner.Lisp.LanguageSpecTest do
   use ExUnit.Case, async: true
 
-  alias PtcRunner.Lisp.Prompts
+  alias PtcRunner.Lisp.LanguageSpec
 
-  doctest Prompts
+  doctest LanguageSpec
 
   describe "get/1" do
     test "returns single_shot prompt (base + single_shot addon)" do
-      prompt = Prompts.get(:single_shot)
+      prompt = LanguageSpec.get(:single_shot)
       assert is_binary(prompt)
       assert String.contains?(prompt, "PTC-Lisp")
       assert String.contains?(prompt, "Single-Shot")
     end
 
     test "returns multi_turn prompt (base + multi_turn addon)" do
-      prompt = Prompts.get(:multi_turn)
+      prompt = LanguageSpec.get(:multi_turn)
       assert is_binary(prompt)
       assert String.contains?(prompt, "PTC-Lisp")
       assert String.contains?(prompt, "Multi-Turn")
       # multi_turn is longer than single_shot
-      assert String.length(prompt) > String.length(Prompts.get(:single_shot))
+      assert String.length(prompt) > String.length(LanguageSpec.get(:single_shot))
     end
 
     test "returns base snippet" do
-      prompt = Prompts.get(:base)
+      prompt = LanguageSpec.get(:base)
       assert is_binary(prompt)
       assert String.contains?(prompt, "PTC-Lisp")
     end
 
     test "returns addon_single_shot snippet" do
-      prompt = Prompts.get(:addon_single_shot)
+      prompt = LanguageSpec.get(:addon_single_shot)
       assert is_binary(prompt)
       assert String.contains?(prompt, "Single-Shot")
     end
 
     test "returns addon_multi_turn snippet" do
-      prompt = Prompts.get(:addon_multi_turn)
+      prompt = LanguageSpec.get(:addon_multi_turn)
       assert is_binary(prompt)
       assert String.contains?(prompt, "State Persistence")
     end
 
     test "returns nil for unknown prompt" do
-      assert Prompts.get(:nonexistent) == nil
+      assert LanguageSpec.get(:nonexistent) == nil
     end
   end
 
   describe "get!/1" do
     test "returns prompt for valid key" do
-      prompt = Prompts.get!(:single_shot)
+      prompt = LanguageSpec.get!(:single_shot)
       assert is_binary(prompt)
     end
 
     test "raises for unknown prompt" do
       assert_raise ArgumentError, ~r/Unknown prompt: :nonexistent/, fn ->
-        Prompts.get!(:nonexistent)
+        LanguageSpec.get!(:nonexistent)
       end
     end
   end
 
   describe "compositions" do
     test "single_shot equals base + addon_single_shot" do
-      base = Prompts.get(:base)
-      addon = Prompts.get(:addon_single_shot)
+      base = LanguageSpec.get(:base)
+      addon = LanguageSpec.get(:addon_single_shot)
       expected = base <> "\n\n" <> addon
 
-      assert Prompts.get(:single_shot) == expected
+      assert LanguageSpec.get(:single_shot) == expected
     end
 
     test "multi_turn equals base + addon_multi_turn" do
-      base = Prompts.get(:base)
-      addon = Prompts.get(:addon_multi_turn)
+      base = LanguageSpec.get(:base)
+      addon = LanguageSpec.get(:addon_multi_turn)
       expected = base <> "\n\n" <> addon
 
-      assert Prompts.get(:multi_turn) == expected
+      assert LanguageSpec.get(:multi_turn) == expected
     end
   end
 
   describe "list/0" do
     test "returns list of available prompts" do
-      keys = Prompts.list()
+      keys = LanguageSpec.list()
       assert :single_shot in keys
       assert :multi_turn in keys
       assert :base in keys
@@ -89,7 +89,7 @@ defmodule PtcRunner.Lisp.PromptsTest do
 
   describe "list_with_descriptions/0" do
     test "returns list of {key, description} tuples" do
-      items = Prompts.list_with_descriptions()
+      items = LanguageSpec.list_with_descriptions()
       assert is_list(items)
 
       # Check structure
@@ -106,64 +106,64 @@ defmodule PtcRunner.Lisp.PromptsTest do
 
   describe "version/1" do
     test "returns a positive integer for base" do
-      version = Prompts.version(:base)
+      version = LanguageSpec.version(:base)
       assert is_integer(version)
       assert version >= 1
     end
 
     test "compositions return the same version as their base snippet" do
-      base_v = Prompts.version(:base)
-      assert Prompts.version(:single_shot) == base_v
-      assert Prompts.version(:multi_turn) == base_v
+      base_v = LanguageSpec.version(:base)
+      assert LanguageSpec.version(:single_shot) == base_v
+      assert LanguageSpec.version(:multi_turn) == base_v
     end
 
     test "raises for unknown prompt" do
       assert_raise ArgumentError, ~r/Unknown prompt: :nonexistent/, fn ->
-        Prompts.version(:nonexistent)
+        LanguageSpec.version(:nonexistent)
       end
     end
   end
 
   describe "metadata/1" do
     test "returns metadata for single_shot (from base)" do
-      meta = Prompts.metadata(:single_shot)
+      meta = LanguageSpec.metadata(:single_shot)
       assert is_map(meta)
     end
 
     test "returns metadata for base" do
-      meta = Prompts.metadata(:base)
+      meta = LanguageSpec.metadata(:base)
       assert is_map(meta)
     end
 
     test "raises for unknown prompt" do
       assert_raise ArgumentError, ~r/Unknown prompt: :nonexistent/, fn ->
-        Prompts.metadata(:nonexistent)
+        LanguageSpec.metadata(:nonexistent)
       end
     end
   end
 
   describe "archived?/1" do
     test "returns false for compositions" do
-      refute Prompts.archived?(:single_shot)
-      refute Prompts.archived?(:multi_turn)
+      refute LanguageSpec.archived?(:single_shot)
+      refute LanguageSpec.archived?(:multi_turn)
     end
 
     test "returns false for current snippets" do
-      refute Prompts.archived?(:base)
-      refute Prompts.archived?(:addon_single_shot)
-      refute Prompts.archived?(:addon_multi_turn)
+      refute LanguageSpec.archived?(:base)
+      refute LanguageSpec.archived?(:addon_single_shot)
+      refute LanguageSpec.archived?(:addon_multi_turn)
     end
 
     test "raises for unknown prompt" do
       assert_raise ArgumentError, ~r/Unknown prompt: :nonexistent/, fn ->
-        Prompts.archived?(:nonexistent)
+        LanguageSpec.archived?(:nonexistent)
       end
     end
   end
 
   describe "list_current/0" do
     test "returns list of current (non-archived) prompts" do
-      keys = Prompts.list_current()
+      keys = LanguageSpec.list_current()
       assert :single_shot in keys
       assert :multi_turn in keys
       assert :base in keys
@@ -172,8 +172,8 @@ defmodule PtcRunner.Lisp.PromptsTest do
     end
 
     test "list_current is subset of list" do
-      all_keys = Prompts.list()
-      current_keys = Prompts.list_current()
+      all_keys = LanguageSpec.list()
+      current_keys = LanguageSpec.list_current()
 
       for key <- current_keys do
         assert key in all_keys

--- a/test/ptc_runner/lisp/schema_test.exs
+++ b/test/ptc_runner/lisp/schema_test.exs
@@ -1,17 +1,17 @@
 defmodule PtcRunner.Lisp.SchemaTest do
   use ExUnit.Case, async: true
 
-  alias PtcRunner.Lisp.Prompts
+  alias PtcRunner.Lisp.LanguageSpec
 
   describe "multi_turn prompt" do
     test "returns non-empty string" do
-      prompt = Prompts.get(:multi_turn)
+      prompt = LanguageSpec.get(:multi_turn)
       assert is_binary(prompt)
       assert String.length(prompt) > 500
     end
 
     test "documents PTC extensions" do
-      prompt = Prompts.get(:multi_turn)
+      prompt = LanguageSpec.get(:multi_turn)
       # Predicate builders
       assert prompt =~ "where"
       assert prompt =~ "all-of"
@@ -22,26 +22,26 @@ defmodule PtcRunner.Lisp.SchemaTest do
     end
 
     test "documents context access" do
-      prompt = Prompts.get(:multi_turn)
+      prompt = LanguageSpec.get(:multi_turn)
       assert prompt =~ "ctx/"
     end
 
     test "documents restrictions" do
-      prompt = Prompts.get(:multi_turn)
+      prompt = LanguageSpec.get(:multi_turn)
       # Key restrictions LLMs need to know
       assert prompt =~ "if" and prompt =~ "else"
       assert prompt =~ "range"
     end
 
     test "documents common mistakes" do
-      prompt = Prompts.get(:multi_turn)
+      prompt = LanguageSpec.get(:multi_turn)
       # Table with wrong/right patterns
       assert prompt =~ "Wrong"
       assert prompt =~ "Right"
     end
 
     test "documents state persistence for multi-turn" do
-      prompt = Prompts.get(:multi_turn)
+      prompt = LanguageSpec.get(:multi_turn)
       assert prompt =~ "def"
       assert prompt =~ ~r/\*1|\*2|\*3/
     end
@@ -49,7 +49,7 @@ defmodule PtcRunner.Lisp.SchemaTest do
 
   describe "single_shot prompt" do
     test "does not include multi-turn memory docs" do
-      prompt = Prompts.get(:single_shot)
+      prompt = LanguageSpec.get(:single_shot)
       refute prompt =~ "*1"
       refute prompt =~ "Previous turn"
     end

--- a/test/ptc_runner/sub_agent/e2e_test.exs
+++ b/test/ptc_runner/sub_agent/e2e_test.exs
@@ -12,7 +12,7 @@ defmodule PtcRunner.SubAgent.E2ETest do
 
   @moduletag :e2e
 
-  alias PtcRunner.Lisp.Prompts
+  alias PtcRunner.Lisp.LanguageSpec
   alias PtcRunner.SubAgent
   alias PtcRunner.TestSupport.LispLLMClient
   alias PtcRunner.TestSupport.LLM
@@ -37,7 +37,7 @@ defmodule PtcRunner.SubAgent.E2ETest do
           signature: "() -> :int",
           max_turns: 1,
           # String override completely replaces generated prompt (no return/fail tools)
-          system_prompt: Prompts.get(@prompt_profile)
+          system_prompt: LanguageSpec.get(@prompt_profile)
         )
 
       assert {:ok, step} = SubAgent.run(agent, llm: llm_callback())
@@ -50,7 +50,7 @@ defmodule PtcRunner.SubAgent.E2ETest do
           prompt: "How many items are in ctx/items?",
           signature: "(items [:any]) -> :int",
           max_turns: 1,
-          system_prompt: Prompts.get(@prompt_profile)
+          system_prompt: LanguageSpec.get(@prompt_profile)
         )
 
       context = %{"items" => [1, 2, 3, 4, 5]}
@@ -65,7 +65,7 @@ defmodule PtcRunner.SubAgent.E2ETest do
           prompt: "What is the total of all :amount values in ctx/orders?",
           signature: "(orders [{:amount :int}]) -> :int",
           max_turns: 1,
-          system_prompt: Prompts.get(@prompt_profile)
+          system_prompt: LanguageSpec.get(@prompt_profile)
         )
 
       context = %{"orders" => [%{"amount" => 10}, %{"amount" => 20}, %{"amount" => 30}]}

--- a/test/support/lisp_llm_client.ex
+++ b/test/support/lisp_llm_client.ex
@@ -23,14 +23,14 @@ defmodule PtcRunner.TestSupport.LispLLMClient do
       PTC_TEST_MODEL=haiku mix test test/ptc_runner/lisp/e2e_test.exs --include e2e
   """
 
-  alias PtcRunner.Lisp.Prompts
+  alias PtcRunner.Lisp.LanguageSpec
   alias PtcRunner.TestSupport.LLM
   alias PtcRunner.TestSupport.LLMSupport
 
   @doc """
   Generates a PTC-Lisp program from a natural language task description.
 
-  Uses the compact `PtcRunner.Lisp.Prompts.get(:single_shot)` reference to guide
+  Uses the compact `PtcRunner.Lisp.LanguageSpec.get(:single_shot)` reference to guide
   the LLM in generating valid PTC-Lisp code.
 
   ## Arguments
@@ -46,7 +46,7 @@ defmodule PtcRunner.TestSupport.LispLLMClient do
     prompt = """
     You are generating a PTC-Lisp program for data transformation.
 
-    #{Prompts.get(:single_shot)}
+    #{LanguageSpec.get(:single_shot)}
 
     Available data (access via ctx/):
     - ctx/products - list of product maps with keys: name, price, category, in_stock

--- a/test/support/ptc_lisp_benchmark.ex
+++ b/test/support/ptc_lisp_benchmark.ex
@@ -23,7 +23,7 @@ defmodule PtcRunner.TestSupport.PtcLispBenchmark do
   Results are saved to `priv/ptc_lisp_benchmark/` with timestamp.
   """
 
-  alias PtcRunner.Lisp.Prompts
+  alias PtcRunner.Lisp.LanguageSpec
 
   @generator_models [
     "openrouter:google/gemini-2.5-flash",
@@ -48,7 +48,7 @@ defmodule PtcRunner.TestSupport.PtcLispBenchmark do
     """
     You are generating PTC-Lisp programs. PTC-Lisp is a minimal Clojure subset for data transformation.
 
-    #{Prompts.get(:single_shot)}
+    #{LanguageSpec.get(:single_shot)}
 
     IMPORTANT:
     - Respond with ONLY the PTC-Lisp code, no explanation or markdown formatting.


### PR DESCRIPTION
## Summary

Rename `Lisp.Prompts` module to `Lisp.LanguageSpec` to better reflect its purpose as the PTC-Lisp language reference specification.

Closes #625

## Changes

- Renamed `lib/ptc_runner/lisp/prompts.ex` → `lib/ptc_runner/lisp/language_spec.ex`
- Updated all references throughout codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)