### PR TITLE
feat: add generate_static/2 alias for generate_system/2

### DIFF
--- a/lib/ptc_runner/sub_agent/system_prompt.ex
+++ b/lib/ptc_runner/sub_agent/system_prompt.ex
@@ -118,6 +118,8 @@ defmodule PtcRunner.SubAgent.SystemPrompt do
   Returns only the language reference and output format - these sections rarely
   change across different questions and benefit from prompt caching.
 
+  This function has an alias `generate_static/2` for semantic clarity.
+
   ## Options
 
   - `:resolution_context` - Map with turn/model/memory/messages for language_spec callbacks
@@ -150,6 +152,14 @@ defmodule PtcRunner.SubAgent.SystemPrompt do
     # Apply truncation if prompt_limit is set
     truncate_if_needed(customized_prompt, agent.prompt_limit)
   end
+
+  @doc """
+  Alias for `generate_system/2` for semantic clarity.
+
+  See `generate_system/2` for documentation.
+  """
+  @spec generate_static(SubAgent.t(), keyword()) :: String.t()
+  def generate_static(agent, opts \\ []), do: generate_system(agent, opts)
 
   @doc """
   Generate dynamic context sections (prepended to user message).

--- a/test/ptc_runner/sub_agent/prompt_generate_system_test.exs
+++ b/test/ptc_runner/sub_agent/prompt_generate_system_test.exs
@@ -78,4 +78,12 @@ defmodule PtcRunner.SubAgent.PromptGenerateSystemTest do
       assert String.ends_with?(system, ">>")
     end
   end
+
+  describe "generate_static/2" do
+    test "is an alias for generate_system/2" do
+      agent = SubAgent.new(prompt: "Test task", tools: %{"search" => fn _ -> [] end})
+
+      assert SystemPrompt.generate_static(agent) == SystemPrompt.generate_system(agent)
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- Adds `generate_static/2` as an alias for `generate_system/2` for semantic clarity
- Updates documentation to cross-reference the alias
- Adds test verifying the alias produces identical output

Closes #623

## Test plan
- [x] New test verifies `generate_static/2` produces identical output to `generate_system/2`
- [x] All existing tests continue to pass
- [x] `mix precommit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)