### PR TITLE
feat: rename SubAgent.prompt to SubAgent.mission

### DIFF
--- a/docs/guides/subagent-getting-started.md
+++ b/docs/guides/subagent-getting-started.md
@@ -300,7 +300,7 @@ For reusable agents, create the struct separately:
 ```elixir
 # Define once
 product_finder = PtcRunner.SubAgent.new(
-  prompt: "Find the most expensive product",
+  mission: "Find the most expensive product",
   signature: "{name :string, price :float}",
   tools: product_tools,
   max_turns: 5
@@ -318,7 +318,7 @@ SubAgents support additional optional fields for documentation and output contro
 
 ```elixir
 PtcRunner.SubAgent.new(
-  prompt: "Find products matching {{query}}",
+  mission: "Find products matching {{query}}",
   signature: "(query :string) -> [{name :string, price :float}]",
   tools: product_tools,
 

--- a/lib/ptc_runner/sub_agent/loop.ex
+++ b/lib/ptc_runner/sub_agent/loop.ex
@@ -196,8 +196,8 @@ defmodule PtcRunner.SubAgent.Loop do
     calculated_deadline =
       run_opts.mission_deadline || calculate_mission_deadline(agent.mission_timeout)
 
-    # Expand template in prompt (mission)
-    expanded_prompt = expand_template(agent.prompt, run_opts.context)
+    # Expand template in mission
+    expanded_prompt = expand_template(agent.mission, run_opts.context)
 
     # Build first user message with dynamic context prepended
     # This includes data inventory, tool schemas, expected output, plus the mission

--- a/lib/ptc_runner/sub_agent/system_prompt.ex
+++ b/lib/ptc_runner/sub_agent/system_prompt.ex
@@ -397,7 +397,7 @@ defmodule PtcRunner.SubAgent.SystemPrompt do
 
     expected_output = Output.generate(context_signature, agent.field_descriptions)
 
-    mission = expand_mission(agent.prompt, context)
+    mission = expand_mission(agent.mission, context)
 
     # Combine all sections
     # language_ref contains role, rules, and language reference from priv/prompts/

--- a/test/ptc_runner/sub_agent/new_test.exs
+++ b/test/ptc_runner/sub_agent/new_test.exs
@@ -55,16 +55,16 @@ defmodule PtcRunner.SubAgent.NewTest do
       assert agent.tools == %{}
     end
 
-    test "raises when prompt is missing" do
-      assert_raise ArgumentError, "prompt is required", fn ->
+    test "raises when mission is missing" do
+      assert_raise ArgumentError, "mission is required", fn ->
         SubAgent.new(tools: %{})
       end
 
-      assert_raise ArgumentError, "prompt is required", fn ->
+      assert_raise ArgumentError, "mission is required", fn ->
         SubAgent.new([])
       end
 
-      assert_raise ArgumentError, "prompt is required", fn ->
+      assert_raise ArgumentError, "mission is required", fn ->
         SubAgent.new(max_turns: 10)
       end
     end


### PR DESCRIPTION
## Summary

- Add `mission` field as primary field for SubAgent task description
- Keep `prompt` field for backward compatibility (normalized to `mission` internally)
- Validator accepts both `mission:` and `prompt:` options
- Internal code now uses `agent.mission`
- Update documentation to show `mission:` as primary option

## Context

This change aligns with existing naming conventions:
- `MissionExpander` module already uses "mission" naming
- `mission_timeout` field already exists
- Compression layer already expects `mission:` option

The dual-field strategy enables gradual migration without breaking existing code.

## Test plan

- [x] All existing tests pass with `prompt:` (backward compat)
- [x] New doctests verify `mission:` works correctly
- [x] Error messages updated to reference "mission"
- [x] Documentation examples use `mission:` as primary

Closes #627

🤖 Generated with [Claude Code](https://claude.com/claude-code)