### PR TITLE
feat: update Debug API to read from step.turns with new options

### DIFF
--- a/lib/ptc_runner/sub_agent.ex
+++ b/lib/ptc_runner/sub_agent.ex
@@ -327,10 +327,8 @@ defmodule PtcRunner.SubAgent do
   - `llm` - Required. LLM callback function `(map() -> {:ok, String.t()} | {:error, term()})` or atom
   - `llm_registry` - Map of atom to LLM callback for atom-based LLM references (default: %{})
   - `context` - Map of input data (default: %{})
-  - `debug` - Enable debug mode (default: false). When enabled, trace entries store exact message contents:
-    - `llm_response` - The assistant message (LLM output, stored as-is)
-    - `llm_feedback` - The user message (execution feedback, after truncation)
-    Use `SubAgent.Debug.print_trace(step, messages: true)` to view the conversation.
+  - `debug` - Deprecated, no longer needed. Turn structs always capture `raw_response`.
+    Use `SubAgent.Debug.print_trace(step, raw: true)` to view full LLM output.
   - `trace` - Trace collection mode (default: true):
     - `true` - Always collect trace in Step
     - `false` - Never collect trace

--- a/lib/ptc_runner/sub_agent/debug.ex
+++ b/lib/ptc_runner/sub_agent/debug.ex
@@ -5,37 +5,29 @@ defmodule PtcRunner.SubAgent.Debug do
   Provides functions to pretty-print execution traces and agent chains,
   making it easier to understand what happened during agent execution.
 
-  ## Debug Option
+  ## Raw Response
 
-  Enable debug mode via the `:debug` option on `SubAgent.run/2`:
+  Turn structs always capture `raw_response` (the full LLM output including reasoning).
+  Use `print_trace(step, raw: true)` to include this in the output.
 
-      {:ok, step} = SubAgent.run(agent, llm: llm, debug: true)
+  ## View Modes
 
-  When debug mode is enabled, trace entries store the exact message contents:
-  - `llm_response` - The assistant message (LLM output, stored as-is)
-  - `llm_feedback` - The user message (execution feedback, after truncation)
-
-  These are exactly what's in the messages array sent to the LLM.
-  Use `print_trace(step, messages: true)` to view this data.
-
-  ## Trace Option
-
-  Control trace collection via the `:trace` option:
-
-  | Value | Behavior |
-  |-------|----------|
-  | `true` (default) | Always collect trace |
-  | `false` | Never collect trace |
-  | `:on_error` | Only include trace on failure |
+  | View | Description |
+  |------|-------------|
+  | `:turns` (default) | Show programs + results from Turn structs |
+  | `:compressed` | Show what the LLM sees (compressed format) |
 
   ## Examples
 
       # Default compact view
-      {:ok, step} = SubAgent.run(agent, llm: llm, debug: true)
+      {:ok, step} = SubAgent.run(agent, llm: llm)
       SubAgent.Debug.print_trace(step)
 
-      # Show full LLM messages (requires debug: true)
-      SubAgent.Debug.print_trace(step, messages: true)
+      # Include raw LLM response (reasoning)
+      SubAgent.Debug.print_trace(step, raw: true)
+
+      # Show compressed view (what LLM sees)
+      SubAgent.Debug.print_trace(step, view: :compressed)
 
       # Print agent chain
       SubAgent.Debug.print_chain([step1, step2, step3])
@@ -44,6 +36,8 @@ defmodule PtcRunner.SubAgent.Debug do
 
   alias PtcRunner.Lisp.Format
   alias PtcRunner.Step
+  alias PtcRunner.SubAgent.Compression.SingleUserCoalesced
+  alias PtcRunner.Turn
 
   @box_width 60
 
@@ -57,9 +51,9 @@ defmodule PtcRunner.SubAgent.Debug do
 
   - `step` - A `%Step{}` struct with trace data
   - `opts` - Keyword list of options:
-    - `messages: true` - Show full LLM response and feedback (requires `debug: true` during execution)
-    - `system: true` - Show the system prompt in each turn (default: `false` when `messages: true`)
-    - `usage: true` - Show token usage summary after the trace
+    - `view` - `:turns` (default) or `:compressed` - perspective to render
+    - `raw` - Include `raw_response` in turns view (default: `false`)
+    - `usage` - Show token usage summary after the trace (default: `false`)
 
   ## Examples
 
@@ -68,9 +62,12 @@ defmodule PtcRunner.SubAgent.Debug do
       iex> PtcRunner.SubAgent.Debug.print_trace(step)
       :ok
 
-      # Show full LLM messages (requires debug: true during execution)
-      iex> {:ok, step} = PtcRunner.SubAgent.run(agent, llm: llm, debug: true)
-      iex> PtcRunner.SubAgent.Debug.print_trace(step, messages: true)
+      # Include raw LLM response
+      iex> PtcRunner.SubAgent.Debug.print_trace(step, raw: true)
+      :ok
+
+      # Show compressed view
+      iex> PtcRunner.SubAgent.Debug.print_trace(step, view: :compressed)
       :ok
 
       # Show token usage
@@ -81,25 +78,58 @@ defmodule PtcRunner.SubAgent.Debug do
   @spec print_trace(Step.t(), keyword()) :: :ok
   def print_trace(step, opts \\ [])
 
-  def print_trace(%Step{trace: nil}, _opts) do
+  # Handle nil turns - fall back to trace for backward compatibility
+  def print_trace(%Step{turns: nil, trace: nil}, _opts) do
     IO.puts("No trace available (trace disabled or not yet executed)")
     :ok
   end
 
-  def print_trace(%Step{trace: []}, _opts) do
+  def print_trace(%Step{turns: nil, trace: trace} = step, opts) when is_list(trace) do
+    # Backward compatibility: use trace if turns not available
+    print_trace_from_trace(step, opts)
+  end
+
+  def print_trace(%Step{turns: []}, _opts) do
     IO.puts("Empty trace")
     :ok
   end
 
-  def print_trace(%Step{trace: trace, usage: usage}, opts) when is_list(trace) do
-    show_messages = Keyword.get(opts, :messages, false)
+  def print_trace(%Step{turns: turns, usage: usage} = step, opts) when is_list(turns) do
+    view = Keyword.get(opts, :view, :turns)
     show_usage = Keyword.get(opts, :usage, false)
 
-    if show_messages do
-      Enum.each(trace, &print_turn_with_messages(&1, opts))
-    else
-      Enum.each(trace, &print_turn/1)
+    case view do
+      :turns ->
+        show_raw = Keyword.get(opts, :raw, false)
+        Enum.each(turns, &print_turn(&1, show_raw))
+
+      :compressed ->
+        print_compressed_view(step)
     end
+
+    if show_usage and usage do
+      print_usage_summary(usage)
+    end
+
+    :ok
+  end
+
+  # Backward compatibility: handle old trace format
+  defp print_trace_from_trace(%Step{trace: nil}, _opts) do
+    IO.puts("No trace available (trace disabled or not yet executed)")
+    :ok
+  end
+
+  defp print_trace_from_trace(%Step{trace: []}, _opts) do
+    IO.puts("Empty trace")
+    :ok
+  end
+
+  defp print_trace_from_trace(%Step{trace: trace, usage: usage}, opts) when is_list(trace) do
+    show_raw = Keyword.get(opts, :raw, false)
+    show_usage = Keyword.get(opts, :usage, false)
+
+    Enum.each(trace, &print_legacy_turn(&1, show_raw))
 
     if show_usage and usage do
       print_usage_summary(usage)
@@ -132,7 +162,7 @@ defmodule PtcRunner.SubAgent.Debug do
     label = " Agent Chain "
 
     IO.puts(
-      "\n#{ansi(:cyan)}┌─#{label}#{String.duplicate("─", @box_width - 3 - String.length(label))}┐#{ansi(:reset)}"
+      "\n#{ansi(:cyan)}+-#{label}#{String.duplicate("-", @box_width - 3 - String.length(label))}+#{ansi(:reset)}"
     )
 
     steps
@@ -141,42 +171,55 @@ defmodule PtcRunner.SubAgent.Debug do
       print_chain_step(step, index, length(steps))
     end)
 
-    IO.puts("#{ansi(:cyan)}└#{String.duplicate("─", @box_width - 2)}┘#{ansi(:reset)}\n")
+    IO.puts("#{ansi(:cyan)}+#{String.duplicate("-", @box_width - 2)}+#{ansi(:reset)}\n")
 
     :ok
   end
 
   # ============================================================
-  # Private Helpers
+  # Private Helpers - Turn-based (new format)
   # ============================================================
 
-  defp print_turn(turn_entry) do
-    turn_num = Map.get(turn_entry, :turn, 0)
-    program = Map.get(turn_entry, :program, "")
-    result = Map.get(turn_entry, :result, nil)
-    tool_calls = Map.get(turn_entry, :tool_calls, [])
-    prints = Map.get(turn_entry, :prints, [])
-
-    header = " Turn #{turn_num} "
+  defp print_turn(%Turn{} = turn, show_raw) do
+    header = " Turn #{turn.number} "
 
     IO.puts(
-      "\n#{ansi(:cyan)}┌─#{header}#{String.duplicate("─", @box_width - 3 - String.length(header))}┐#{ansi(:reset)}"
+      "\n#{ansi(:cyan)}+-#{header}#{String.duplicate("-", @box_width - 3 - String.length(header))}+#{ansi(:reset)}"
     )
 
-    IO.puts("#{ansi(:cyan)}│#{ansi(:reset)} #{ansi(:bold)}Program:#{ansi(:reset)}")
+    # Print raw response (reasoning) if requested
+    if show_raw and turn.raw_response do
+      IO.puts("#{ansi(:cyan)}|#{ansi(:reset)} #{ansi(:bold)}Raw Response:#{ansi(:reset)}")
 
-    # Print program with indentation
-    program
-    |> String.split("\n")
-    |> Enum.each(fn line ->
-      IO.puts("#{ansi(:cyan)}│#{ansi(:reset)}   #{truncate_line(line, 80)}")
-    end)
+      turn.raw_response
+      |> String.split("\n")
+      |> Enum.each(fn line ->
+        IO.puts(
+          "#{ansi(:cyan)}|#{ansi(:reset)}   #{ansi(:dim)}#{truncate_line(line, 80)}#{ansi(:reset)}"
+        )
+      end)
+
+      IO.puts("#{ansi(:cyan)}|#{ansi(:reset)}")
+    end
+
+    # Print program
+    IO.puts("#{ansi(:cyan)}|#{ansi(:reset)} #{ansi(:bold)}Program:#{ansi(:reset)}")
+
+    if turn.program do
+      turn.program
+      |> String.split("\n")
+      |> Enum.each(fn line ->
+        IO.puts("#{ansi(:cyan)}|#{ansi(:reset)}   #{truncate_line(line, 80)}")
+      end)
+    else
+      IO.puts("#{ansi(:cyan)}|#{ansi(:reset)}   #{ansi(:dim)}(parsing failed)#{ansi(:reset)}")
+    end
 
     # Print tool calls if any
-    unless Enum.empty?(tool_calls) do
-      IO.puts("#{ansi(:cyan)}│#{ansi(:reset)} #{ansi(:bold)}Tools:#{ansi(:reset)}")
+    unless Enum.empty?(turn.tool_calls) do
+      IO.puts("#{ansi(:cyan)}|#{ansi(:reset)} #{ansi(:bold)}Tools:#{ansi(:reset)}")
 
-      Enum.each(tool_calls, fn call ->
+      Enum.each(turn.tool_calls, fn call ->
         tool_name = Map.get(call, :name, "unknown")
         tool_args = Map.get(call, :args, %{})
         tool_result = Map.get(call, :result, nil)
@@ -185,96 +228,138 @@ defmodule PtcRunner.SubAgent.Debug do
         result_str = format_compact(tool_result)
 
         IO.puts(
-          "#{ansi(:cyan)}│#{ansi(:reset)}   #{ansi(:green)}→#{ansi(:reset)} #{tool_name}(#{args_str})"
+          "#{ansi(:cyan)}|#{ansi(:reset)}   #{ansi(:green)}->#{ansi(:reset)} #{tool_name}(#{args_str})"
         )
 
         IO.puts(
-          "#{ansi(:cyan)}│#{ansi(:reset)}     #{ansi(:green)}←#{ansi(:reset)} #{result_str}"
+          "#{ansi(:cyan)}|#{ansi(:reset)}     #{ansi(:green)}<-#{ansi(:reset)} #{result_str}"
         )
       end)
     end
 
     # Print println output if any
-    unless Enum.empty?(prints) do
-      IO.puts("#{ansi(:cyan)}│#{ansi(:reset)} #{ansi(:bold)}Output:#{ansi(:reset)}")
+    unless Enum.empty?(turn.prints) do
+      IO.puts("#{ansi(:cyan)}|#{ansi(:reset)} #{ansi(:bold)}Output:#{ansi(:reset)}")
 
-      Enum.each(prints, fn line ->
+      Enum.each(turn.prints, fn line ->
         IO.puts(
-          "#{ansi(:cyan)}│#{ansi(:reset)}   #{ansi(:yellow)}#{truncate_line(line, 80)}#{ansi(:reset)}"
+          "#{ansi(:cyan)}|#{ansi(:reset)}   #{ansi(:yellow)}#{truncate_line(line, 80)}#{ansi(:reset)}"
         )
       end)
     end
 
     # Print result
-    IO.puts("#{ansi(:cyan)}│#{ansi(:reset)} #{ansi(:bold)}Result:#{ansi(:reset)}")
-    result_lines = format_result(result)
+    IO.puts("#{ansi(:cyan)}|#{ansi(:reset)} #{ansi(:bold)}Result:#{ansi(:reset)}")
+    result_lines = format_result(turn.result)
 
     Enum.each(result_lines, fn line ->
-      IO.puts("#{ansi(:cyan)}│#{ansi(:reset)}   #{truncate_line(line, 80)}")
+      IO.puts("#{ansi(:cyan)}|#{ansi(:reset)}   #{truncate_line(line, 80)}")
     end)
 
-    IO.puts("#{ansi(:cyan)}└#{String.duplicate("─", @box_width - 2)}┘#{ansi(:reset)}")
+    IO.puts("#{ansi(:cyan)}+#{String.duplicate("-", @box_width - 2)}+#{ansi(:reset)}")
   end
 
-  # Print turn with full LLM messages (for messages: true option)
-  defp print_turn_with_messages(turn_entry, opts) do
+  # Print compressed view using SingleUserCoalesced compression
+  defp print_compressed_view(%Step{turns: turns, memory: memory}) do
+    header = " Compressed View "
+
+    IO.puts(
+      "\n#{ansi(:cyan)}+-#{header}#{String.duplicate("-", @box_width - 3 - String.length(header))}+#{ansi(:reset)}"
+    )
+
+    # Use compression strategy to render what LLM would see
+    messages =
+      SingleUserCoalesced.to_messages(turns, memory,
+        system_prompt: "(system prompt omitted)",
+        mission: "(mission)",
+        tools: %{},
+        data: %{},
+        turns_left: 0
+      )
+
+    # Print each message
+    Enum.each(messages, fn msg ->
+      role_color = if msg.role == :system, do: :dim, else: :yellow
+
+      IO.puts("#{ansi(:cyan)}|#{ansi(:reset)} #{ansi(:bold)}[#{msg.role}]#{ansi(:reset)}")
+
+      msg.content
+      |> String.split("\n")
+      |> Enum.each(fn line ->
+        IO.puts("#{ansi(:cyan)}|#{ansi(:reset)}   #{ansi(role_color)}#{line}#{ansi(:reset)}")
+      end)
+
+      IO.puts("#{ansi(:cyan)}|#{ansi(:reset)}")
+    end)
+
+    IO.puts("#{ansi(:cyan)}+#{String.duplicate("-", @box_width - 2)}+#{ansi(:reset)}")
+  end
+
+  # ============================================================
+  # Private Helpers - Legacy trace format (backward compat)
+  # ============================================================
+
+  defp print_legacy_turn(turn_entry, show_raw) do
     turn_num = Map.get(turn_entry, :turn, 0)
     program = Map.get(turn_entry, :program, "")
-    reasoning = Map.get(turn_entry, :reasoning)
     result = Map.get(turn_entry, :result, nil)
     tool_calls = Map.get(turn_entry, :tool_calls, [])
     prints = Map.get(turn_entry, :prints, [])
-    llm_feedback = Map.get(turn_entry, :llm_feedback)
+    llm_response = Map.get(turn_entry, :llm_response)
+    reasoning = Map.get(turn_entry, :reasoning)
 
     header = " Turn #{turn_num} "
-    system_prompt = Map.get(turn_entry, :system_prompt)
-    show_system = Keyword.get(opts, :system, false)
 
     IO.puts(
-      "\n#{ansi(:cyan)}┌─#{header}#{String.duplicate("─", @box_width - 3 - String.length(header))}┐#{ansi(:reset)}"
+      "\n#{ansi(:cyan)}+-#{header}#{String.duplicate("-", @box_width - 3 - String.length(header))}+#{ansi(:reset)}"
     )
 
-    # Print System Prompt
-    if show_system and system_prompt do
-      IO.puts("#{ansi(:cyan)}│#{ansi(:reset)} #{ansi(:bold)}System Prompt:#{ansi(:reset)}")
+    # Print raw response/reasoning if requested and available
+    if show_raw do
+      cond do
+        llm_response ->
+          IO.puts("#{ansi(:cyan)}|#{ansi(:reset)} #{ansi(:bold)}Raw Response:#{ansi(:reset)}")
 
-      system_prompt
-      |> String.split("\n")
-      |> Enum.each(fn line ->
-        IO.puts("#{ansi(:cyan)}│#{ansi(:reset)}   #{ansi(:dim)}#{line}#{ansi(:reset)}")
-      end)
+          llm_response
+          |> String.split("\n")
+          |> Enum.each(fn line ->
+            IO.puts(
+              "#{ansi(:cyan)}|#{ansi(:reset)}   #{ansi(:dim)}#{truncate_line(line, 80)}#{ansi(:reset)}"
+            )
+          end)
 
-      IO.puts("#{ansi(:cyan)}│#{ansi(:reset)}")
+          IO.puts("#{ansi(:cyan)}|#{ansi(:reset)}")
+
+        reasoning ->
+          IO.puts("#{ansi(:cyan)}|#{ansi(:reset)} #{ansi(:bold)}Reasoning:#{ansi(:reset)}")
+
+          reasoning
+          |> String.split("\n")
+          |> Enum.each(fn line ->
+            IO.puts(
+              "#{ansi(:cyan)}|#{ansi(:reset)}   #{ansi(:dim)}#{truncate_line(line, 80)}#{ansi(:reset)}"
+            )
+          end)
+
+          IO.puts("#{ansi(:cyan)}|#{ansi(:reset)}")
+
+        true ->
+          :ok
+      end
     end
 
-    # Print reasoning (everything except the code block)
-    IO.puts("#{ansi(:cyan)}│#{ansi(:reset)} #{ansi(:bold)}Reasoning:#{ansi(:reset)}")
+    IO.puts("#{ansi(:cyan)}|#{ansi(:reset)} #{ansi(:bold)}Program:#{ansi(:reset)}")
 
-    if reasoning do
-      reasoning
-      |> String.split("\n")
-      |> Enum.each(fn line ->
-        IO.puts("#{ansi(:cyan)}│#{ansi(:reset)}   #{ansi(:dim)}#{line}#{ansi(:reset)}")
-      end)
-    else
-      IO.puts("#{ansi(:cyan)}│#{ansi(:reset)}   #{ansi(:dim)}(none)#{ansi(:reset)}")
-    end
-
-    IO.puts("#{ansi(:cyan)}│#{ansi(:reset)}")
-
-    # Print extracted program
-    IO.puts("#{ansi(:cyan)}│#{ansi(:reset)} #{ansi(:bold)}Program:#{ansi(:reset)}")
-
+    # Print program with indentation
     program
     |> String.split("\n")
     |> Enum.each(fn line ->
-      IO.puts("#{ansi(:cyan)}│#{ansi(:reset)}   #{ansi(:green)}#{line}#{ansi(:reset)}")
+      IO.puts("#{ansi(:cyan)}|#{ansi(:reset)}   #{truncate_line(line, 80)}")
     end)
 
     # Print tool calls if any
     unless Enum.empty?(tool_calls) do
-      IO.puts("#{ansi(:cyan)}│#{ansi(:reset)}")
-      IO.puts("#{ansi(:cyan)}│#{ansi(:reset)} #{ansi(:bold)}Tools:#{ansi(:reset)}")
+      IO.puts("#{ansi(:cyan)}|#{ansi(:reset)} #{ansi(:bold)}Tools:#{ansi(:reset)}")
 
       Enum.each(tool_calls, fn call ->
         tool_name = Map.get(call, :name, "unknown")
@@ -285,94 +370,85 @@ defmodule PtcRunner.SubAgent.Debug do
         result_str = format_compact(tool_result)
 
         IO.puts(
-          "#{ansi(:cyan)}│#{ansi(:reset)}   #{ansi(:green)}→#{ansi(:reset)} #{tool_name}(#{args_str})"
+          "#{ansi(:cyan)}|#{ansi(:reset)}   #{ansi(:green)}->#{ansi(:reset)} #{tool_name}(#{args_str})"
         )
 
         IO.puts(
-          "#{ansi(:cyan)}│#{ansi(:reset)}     #{ansi(:green)}←#{ansi(:reset)} #{result_str}"
+          "#{ansi(:cyan)}|#{ansi(:reset)}     #{ansi(:green)}<-#{ansi(:reset)} #{result_str}"
         )
       end)
     end
 
     # Print println output if any
     unless Enum.empty?(prints) do
-      IO.puts("#{ansi(:cyan)}│#{ansi(:reset)}")
-      IO.puts("#{ansi(:cyan)}│#{ansi(:reset)} #{ansi(:bold)}Output:#{ansi(:reset)}")
+      IO.puts("#{ansi(:cyan)}|#{ansi(:reset)} #{ansi(:bold)}Output:#{ansi(:reset)}")
 
       Enum.each(prints, fn line ->
         IO.puts(
-          "#{ansi(:cyan)}│#{ansi(:reset)}   #{ansi(:yellow)}#{truncate_line(line, 80)}#{ansi(:reset)}"
+          "#{ansi(:cyan)}|#{ansi(:reset)}   #{ansi(:yellow)}#{truncate_line(line, 80)}#{ansi(:reset)}"
         )
       end)
     end
 
-    IO.puts("#{ansi(:cyan)}│#{ansi(:reset)}")
+    # Print result
+    IO.puts("#{ansi(:cyan)}|#{ansi(:reset)} #{ansi(:bold)}Result:#{ansi(:reset)}")
+    result_lines = format_result(result)
 
-    # Print result (full, not truncated)
-    IO.puts("#{ansi(:cyan)}│#{ansi(:reset)} #{ansi(:bold)}Result:#{ansi(:reset)}")
-    result_str = Format.to_string(result, pretty: true, limit: :infinity)
-
-    result_str
-    |> String.split("\n")
-    |> Enum.each(fn line ->
-      IO.puts("#{ansi(:cyan)}│#{ansi(:reset)}   #{line}")
+    Enum.each(result_lines, fn line ->
+      IO.puts("#{ansi(:cyan)}|#{ansi(:reset)}   #{truncate_line(line, 80)}")
     end)
 
-    IO.puts("#{ansi(:cyan)}│#{ansi(:reset)}")
-
-    # Print feedback to LLM (user message in messages array - truncated)
-    IO.puts(
-      "#{ansi(:cyan)}│#{ansi(:reset)} #{ansi(:bold)}User Message (feedback, truncated):#{ansi(:reset)}"
-    )
-
-    if llm_feedback do
-      llm_feedback
-      |> String.split("\n")
-      |> Enum.each(fn line ->
-        IO.puts("#{ansi(:cyan)}│#{ansi(:reset)}   #{ansi(:yellow)}#{line}#{ansi(:reset)}")
-      end)
-    else
-      IO.puts("#{ansi(:cyan)}│#{ansi(:reset)}   #{ansi(:dim)}(none - final turn)#{ansi(:reset)}")
-    end
-
-    IO.puts("#{ansi(:cyan)}└#{String.duplicate("─", @box_width - 2)}┘#{ansi(:reset)}")
+    IO.puts("#{ansi(:cyan)}+#{String.duplicate("-", @box_width - 2)}+#{ansi(:reset)}")
   end
+
+  # ============================================================
+  # Private Helpers - Chain
+  # ============================================================
 
   defp print_chain_step(step, index, total) do
     status =
       case step.fail do
-        nil -> ansi(:green) <> "✓" <> ansi(:reset)
-        _fail -> ansi(:red) <> "✗" <> ansi(:reset)
+        nil -> ansi(:green) <> "ok" <> ansi(:reset)
+        _fail -> ansi(:red) <> "X" <> ansi(:reset)
       end
 
-    turns = if step.trace, do: length(step.trace), else: 0
+    turns = get_turn_count(step)
     duration_ms = get_in(step.usage, [:duration_ms]) || 0
 
-    IO.puts("#{ansi(:cyan)}│#{ansi(:reset)}")
-    IO.puts("#{ansi(:cyan)}│#{ansi(:reset)} #{status} Step #{index}/#{total}")
+    IO.puts("#{ansi(:cyan)}|#{ansi(:reset)}")
+    IO.puts("#{ansi(:cyan)}|#{ansi(:reset)} #{status} Step #{index}/#{total}")
 
     if step.fail do
       reason = step.fail.reason
       message = step.fail.message
-      IO.puts("#{ansi(:cyan)}│#{ansi(:reset)}   #{ansi(:red)}Error:#{ansi(:reset)} #{reason}")
-      IO.puts("#{ansi(:cyan)}│#{ansi(:reset)}   #{ansi(:red)}Message:#{ansi(:reset)} #{message}")
+      IO.puts("#{ansi(:cyan)}|#{ansi(:reset)}   #{ansi(:red)}Error:#{ansi(:reset)} #{reason}")
+      IO.puts("#{ansi(:cyan)}|#{ansi(:reset)}   #{ansi(:red)}Message:#{ansi(:reset)} #{message}")
     else
       return_preview = format_compact(step.return)
 
       IO.puts(
-        "#{ansi(:cyan)}│#{ansi(:reset)}   #{ansi(:bold)}Return:#{ansi(:reset)} #{return_preview}"
+        "#{ansi(:cyan)}|#{ansi(:reset)}   #{ansi(:bold)}Return:#{ansi(:reset)} #{return_preview}"
       )
     end
 
     IO.puts(
-      "#{ansi(:cyan)}│#{ansi(:reset)}   #{ansi(:dim)}Turns:#{ansi(:reset)} #{turns} | #{ansi(:dim)}Duration:#{ansi(:reset)} #{duration_ms}ms"
+      "#{ansi(:cyan)}|#{ansi(:reset)}   #{ansi(:dim)}Turns:#{ansi(:reset)} #{turns} | #{ansi(:dim)}Duration:#{ansi(:reset)} #{duration_ms}ms"
     )
 
     # Add arrow between steps (except for last step)
     if index < total do
-      IO.puts("#{ansi(:cyan)}│#{ansi(:reset)}   #{ansi(:dim)}↓#{ansi(:reset)}")
+      IO.puts("#{ansi(:cyan)}|#{ansi(:reset)}   #{ansi(:dim)}v#{ansi(:reset)}")
     end
   end
+
+  # Get turn count from either turns or trace
+  defp get_turn_count(%Step{turns: turns}) when is_list(turns), do: length(turns)
+  defp get_turn_count(%Step{trace: trace}) when is_list(trace), do: length(trace)
+  defp get_turn_count(_step), do: 0
+
+  # ============================================================
+  # Private Helpers - Formatting
+  # ============================================================
 
   # Format result for display
   defp format_result(result) when is_binary(result) do
@@ -477,42 +553,42 @@ defmodule PtcRunner.SubAgent.Debug do
     header = " Usage "
 
     IO.puts(
-      "\n#{ansi(:cyan)}┌─#{header}#{String.duplicate("─", @box_width - 3 - String.length(header))}┐#{ansi(:reset)}"
+      "\n#{ansi(:cyan)}+-#{header}#{String.duplicate("-", @box_width - 3 - String.length(header))}+#{ansi(:reset)}"
     )
 
     if usage[:input_tokens] do
       IO.puts(
-        "#{ansi(:cyan)}│#{ansi(:reset)}   Input tokens:  #{format_number(usage.input_tokens)}"
+        "#{ansi(:cyan)}|#{ansi(:reset)}   Input tokens:  #{format_number(usage.input_tokens)}"
       )
     end
 
     if usage[:output_tokens] do
       IO.puts(
-        "#{ansi(:cyan)}│#{ansi(:reset)}   Output tokens: #{format_number(usage.output_tokens)}"
+        "#{ansi(:cyan)}|#{ansi(:reset)}   Output tokens: #{format_number(usage.output_tokens)}"
       )
     end
 
     if usage[:total_tokens] do
       IO.puts(
-        "#{ansi(:cyan)}│#{ansi(:reset)}   Total tokens:  #{format_number(usage.total_tokens)}"
+        "#{ansi(:cyan)}|#{ansi(:reset)}   Total tokens:  #{format_number(usage.total_tokens)}"
       )
     end
 
     if usage[:system_prompt_tokens] && usage.system_prompt_tokens > 0 do
       IO.puts(
-        "#{ansi(:cyan)}│#{ansi(:reset)}   System prompt: #{format_number(usage.system_prompt_tokens)} #{ansi(:dim)}(est.)#{ansi(:reset)}"
+        "#{ansi(:cyan)}|#{ansi(:reset)}   System prompt: #{format_number(usage.system_prompt_tokens)} #{ansi(:dim)}(est.)#{ansi(:reset)}"
       )
     end
 
     if usage[:duration_ms] do
-      IO.puts("#{ansi(:cyan)}│#{ansi(:reset)}   Duration:      #{usage.duration_ms}ms")
+      IO.puts("#{ansi(:cyan)}|#{ansi(:reset)}   Duration:      #{usage.duration_ms}ms")
     end
 
     if usage[:turns] do
-      IO.puts("#{ansi(:cyan)}│#{ansi(:reset)}   Turns:         #{usage.turns}")
+      IO.puts("#{ansi(:cyan)}|#{ansi(:reset)}   Turns:         #{usage.turns}")
     end
 
-    IO.puts("#{ansi(:cyan)}└#{String.duplicate("─", @box_width - 2)}┘#{ansi(:reset)}")
+    IO.puts("#{ansi(:cyan)}+#{String.duplicate("-", @box_width - 2)}+#{ansi(:reset)}")
   end
 
   # Format number with thousand separators

--- a/lib/ptc_runner/sub_agent/loop.ex
+++ b/lib/ptc_runner/sub_agent/loop.ex
@@ -87,10 +87,8 @@ defmodule PtcRunner.SubAgent.Loop do
     - `cache` - Enable prompt caching (default: false). When true, the LLM callback receives
       `cache: true` in its input map. The callback should pass this to the provider to enable
       caching of system prompts for cost savings on multi-turn agents.
-    - `debug` - Enable debug mode (default: false). When enabled, trace entries store exact message contents:
-      - `llm_response` - The assistant message (LLM output, stored as-is)
-      - `llm_feedback` - The user message (execution feedback, after truncation)
-      Use `SubAgent.Debug.print_trace(step, messages: true)` to view the conversation.
+    - `debug` - Deprecated, no longer needed. Turn structs always capture `raw_response`.
+      Use `SubAgent.Debug.print_trace(step, raw: true)` to view full LLM output.
     - `trace` - Trace filtering: true (always), false (never), :on_error (only on failure) (default: true)
     - `collect_messages` - Capture full conversation history in Step.messages (default: false).
       When enabled, messages are in OpenAI format: `[%{role: :system | :user | :assistant, content: String.t()}]`


### PR DESCRIPTION
## Summary

- Update Debug.print_trace to read from `step.turns` (Turn structs) instead of `step.trace`
- Replace `messages:`/`system:` options with `raw:`/`view:` options (simpler, orthogonal)
- Add `view: :compressed` option to show what the LLM sees
- Deprecate `debug:` option since `raw_response` is always captured in Turn structs
- Maintain backward compatibility: falls back to `trace` if `turns` is nil

## Changes

### New API

| Option | Values | Description |
|--------|--------|-------------|
| `view` | `:turns` (default), `:compressed` | Perspective to render |
| `raw` | `boolean` | Include `raw_response` in turns view |
| `usage` | `boolean` | Add token statistics |

### Removed Options (Breaking)

- `messages:` - replaced by `raw:` option
- `system:` - no longer relevant (system prompt is static)

### Deprecated

- `debug:` option on SubAgent.run - no longer needed since Turn always captures `raw_response`

## Test plan

- [x] Existing debug tests updated to use new API
- [x] Tests for `raw: true` showing `raw_response` from Turn structs
- [x] Tests for `view: :compressed` using Compression module
- [x] Tests for backward compatibility with legacy `trace` format
- [x] All tests pass with `mix precommit`

Closes #626

🤖 Generated with [Claude Code](https://claude.com/claude-code)