### PR TITLE
feat: wire compression strategy into SubAgent

### DIFF
--- a/lib/ptc_runner/sub_agent.ex
+++ b/lib/ptc_runner/sub_agent.ex
@@ -35,6 +35,7 @@ defmodule PtcRunner.SubAgent do
   - `context_descriptions` - map() | nil, descriptions for context variables (keys are field names)
   - `format_options` - keyword list controlling output truncation (see `t:format_options/0`)
   - `float_precision` - non_neg_integer(), decimal places for floats in results and context (default: 2)
+  - `compression` - compression_opts(), compression strategy for turn history (default: nil)
 
   ## Tool Resolution
 
@@ -131,6 +132,19 @@ defmodule PtcRunner.SubAgent do
   @type llm_registry :: %{atom() => llm_callback()}
 
   @typedoc """
+  Compression strategy configuration.
+
+  Can be:
+  - `nil` or `false` - Compression disabled (default)
+  - `true` - Use default strategy (`SingleUserCoalesced`) with default options
+  - `Module` - Use custom strategy module with default options
+  - `{Module, opts}` - Use custom strategy module with custom options
+
+  See `PtcRunner.SubAgent.Compression` for details.
+  """
+  @type compression_opts :: nil | false | true | module() | {module(), keyword()}
+
+  @typedoc """
   Output format options for truncation and display.
 
   Fields:
@@ -168,7 +182,8 @@ defmodule PtcRunner.SubAgent do
           field_descriptions: map() | nil,
           context_descriptions: map() | nil,
           format_options: format_options(),
-          float_precision: non_neg_integer()
+          float_precision: non_neg_integer(),
+          compression: compression_opts()
         }
 
   alias PtcRunner.SubAgent.LLMResolver
@@ -195,6 +210,7 @@ defmodule PtcRunner.SubAgent do
     :description,
     :field_descriptions,
     :context_descriptions,
+    :compression,
     tools: %{},
     max_turns: 5,
     memory_limit: 1_048_576,
@@ -240,6 +256,7 @@ defmodule PtcRunner.SubAgent do
   - `context_descriptions` - Map of context variable names to descriptions (shown in Data Inventory)
   - `format_options` - Keyword list controlling output truncation (merged with defaults)
   - `float_precision` - Non-negative integer for decimal places in floats (default: 2)
+  - `compression` - Compression strategy for turn history (see `t:compression_opts/0`)
 
   ## Returns
 


### PR DESCRIPTION
## Summary

- Add `compression` field to SubAgent struct enabling history compression strategies
- Wire compression into Loop module for multi-turn agents
- Skip compression for single-shot mode (`max_turns: 1`) per SS-001

## Changes

### SubAgent struct (`lib/ptc_runner/sub_agent.ex`)
- Add `compression` field with `compression_opts` type
- Document in @moduledoc and `new/1` options

### Loop module (`lib/ptc_runner/sub_agent/loop.ex`)
- Add `build_llm_messages/3` to choose between compressed/uncompressed modes
- Add `build_compressed_messages/5` to render turns using the strategy
- Integration with existing message building flow

### Tests (`test/ptc_runner/sub_agent/loop_test.exs`)
- `compression: nil` uses uncompressed messages
- `compression: true` uses SingleUserCoalesced on turn > 1
- `compression: {Strategy, opts}` passes custom options
- `compression: false` disables compression
- Single-shot mode skips compression (SS-001)
- Compressed view includes turns indicator and execution history

## API

```elixir
# Disabled (default)
SubAgent.new(mission: "Task", compression: nil)

# Enable with default strategy
SubAgent.new(mission: "Task", compression: true)

# Custom strategy with options
SubAgent.new(mission: "Task", compression: {SingleUserCoalesced, println_limit: 10})
```

## Test plan

- [x] Unit tests verify compression option normalization
- [x] Integration tests verify compressed message format
- [x] All existing tests pass (`mix precommit` green)

Closes #632

🤖 Generated with [Claude Code](https://claude.com/claude-code)