### PR TITLE
feat: migrate demo to new message history API

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -652,7 +652,7 @@ The key insight: **2500 records stay in BEAM memory, never touching LLM context.
 mix lisp --debug --prompt=multi_turn
 ```
 
-After an error, use `SubAgent.Debug.print_trace(step, messages: true)` to see:
+After an error, use `SubAgent.Debug.print_trace(step, raw: true)` to see:
 - The full LLM response (before code extraction)
 - What feedback was sent back to the LLM
 - How truncation affected the data


### PR DESCRIPTION
## Summary
- Update `SubAgent.new()` to use `mission:` instead of `prompt:`
- Replace `step.trace` with `step.turns` for Turn struct access
- Update `print_trace()` calls to use `raw:` instead of `messages:`
- Update README.md documentation for new API

## Test plan
- [x] All tests pass (`mix format --check-formatted && mix compile --warnings-as-errors && mix test`)
- [ ] E2E tests pass (`mix test --include e2e` - requires OPENROUTER_API_KEY)

Closes #628

🤖 Generated with [Claude Code](https://claude.com/claude-code)