### PR TITLE
feat: Filter hidden fields from LLM-visible output

### DIFF
--- a/lib/ptc_runner/sub_agent/namespace/execution_history.ex
+++ b/lib/ptc_runner/sub_agent/namespace/execution_history.ex
@@ -9,6 +9,8 @@ defmodule PtcRunner.SubAgent.Namespace.ExecutionHistory do
   Returns `;; No tool calls made` for empty list, otherwise formatted list
   with header and entries.
 
+  Hidden fields (keys starting with `_`) in arguments are replaced with `[Hidden]`.
+
   ## Examples
 
       iex> PtcRunner.SubAgent.Namespace.ExecutionHistory.render_tool_calls([], 20)
@@ -17,6 +19,10 @@ defmodule PtcRunner.SubAgent.Namespace.ExecutionHistory do
       iex> call = %{name: "search", args: %{query: "hello"}}
       iex> PtcRunner.SubAgent.Namespace.ExecutionHistory.render_tool_calls([call], 20)
       ";; Tool calls made:\\n;   search({:query \\"hello\\"})"
+
+      iex> call = %{name: "search", args: %{query: "test", _token: "secret123"}}
+      iex> PtcRunner.SubAgent.Namespace.ExecutionHistory.render_tool_calls([call], 20)
+      ";; Tool calls made:\\n;   search({:_token \\"[Hidden]\\" :query \\"test\\"})"
   """
   @spec render_tool_calls([map()], non_neg_integer()) :: String.t()
   def render_tool_calls([], _limit), do: ";; No tool calls made"
@@ -27,12 +33,28 @@ defmodule PtcRunner.SubAgent.Namespace.ExecutionHistory do
 
     lines =
       Enum.map(calls_to_render, fn %{name: name, args: args} ->
-        {args_str, _truncated} = Format.to_clojure(args, limit: 3, printable_limit: 60)
+        filtered_args = filter_hidden_args(args)
+        {args_str, _truncated} = Format.to_clojure(filtered_args, limit: 3, printable_limit: 60)
         ";   #{name}(#{args_str})"
       end)
 
     [";; Tool calls made:" | lines] |> Enum.join("\n")
   end
+
+  # Replace values for hidden keys (underscore prefix) with [Hidden] marker
+  defp filter_hidden_args(args) when is_map(args) do
+    Map.new(args, fn {key, value} ->
+      key_str = to_string(key)
+
+      if String.starts_with?(key_str, "_") do
+        {key, "[Hidden]"}
+      else
+        {key, value}
+      end
+    end)
+  end
+
+  defp filter_hidden_args(args), do: args
 
   @doc """
   Render println output from successful turns.

--- a/lib/ptc_runner/sub_agent/namespace/user.ex
+++ b/lib/ptc_runner/sub_agent/namespace/user.ex
@@ -46,6 +46,9 @@ defmodule PtcRunner.SubAgent.Namespace.User do
 
       iex> PtcRunner.SubAgent.Namespace.User.render(%{total: 42}, has_println: true)
       ";; === user/ (your prelude) ===\\ntotal                         ; = integer"
+
+      iex> PtcRunner.SubAgent.Namespace.User.render(%{_secret: "token123"}, [])
+      ";; === user/ (your prelude) ===\\n_secret                       ; = string, [Hidden]"
   """
   @spec render(map(), keyword()) :: String.t() | nil
   def render(memory, _opts) when map_size(memory) == 0, do: nil
@@ -151,6 +154,7 @@ defmodule PtcRunner.SubAgent.Namespace.User do
   defp get_return_type(_), do: nil
 
   # Format values: name ; = type with optional sample
+  # Hidden values (names starting with `_`) show [Hidden] instead of sample
   defp format_values(values, opts) do
     has_println = Keyword.get(opts, :has_println, false)
 
@@ -159,12 +163,18 @@ defmodule PtcRunner.SubAgent.Namespace.User do
       name_str = Atom.to_string(name)
       # Pad name to 30 chars for alignment
       padded_name = String.pad_trailing(name_str, 30)
+      is_hidden = String.starts_with?(name_str, "_")
 
-      if has_println do
-        "#{padded_name}; = #{type_label}"
-      else
-        sample = format_sample(value, opts)
-        "#{padded_name}; = #{type_label}, sample: #{sample}"
+      cond do
+        is_hidden ->
+          "#{padded_name}; = #{type_label}, [Hidden]"
+
+        has_println ->
+          "#{padded_name}; = #{type_label}"
+
+        true ->
+          sample = format_sample(value, opts)
+          "#{padded_name}; = #{type_label}, sample: #{sample}"
       end
     end)
   end

--- a/test/ptc_runner/sub_agent/namespace/user_test.exs
+++ b/test/ptc_runner/sub_agent/namespace/user_test.exs
@@ -175,5 +175,44 @@ defmodule PtcRunner.SubAgent.Namespace.UserTest do
       assert Enum.at(lines, 3) =~ "items"
       assert Enum.at(lines, 4) =~ "total"
     end
+
+    test "hides value with underscore-prefixed name" do
+      result = User.render(%{_secret: "token123"}, [])
+
+      # Type should be shown, but not the sample value
+      assert result =~ "_secret"
+      assert result =~ "; = string, [Hidden]"
+      refute result =~ "token123"
+      refute result =~ "sample:"
+    end
+
+    test "hides multiple underscore-prefixed values" do
+      result = User.render(%{_key: "abc", _token: 42, visible: "data"}, [])
+
+      assert result =~ "_key"
+      assert result =~ "; = string, [Hidden]"
+      assert result =~ "_token"
+      # _token is integer, should show type but [Hidden]
+      assert result =~ "; = integer, [Hidden]"
+      # visible should show sample
+      assert result =~ "visible"
+      assert result =~ "sample: \"data\""
+      # Hidden values should not appear
+      refute result =~ "abc"
+      refute result =~ " 42"
+    end
+
+    test "hides underscore-prefixed values even with has_println true" do
+      result = User.render(%{_secret: "token", normal: 5}, has_println: true)
+
+      # Hidden value shows [Hidden] regardless of has_println
+      assert result =~ "_secret"
+      assert result =~ "; = string, [Hidden]"
+      # Normal value should not show sample (has_println behavior)
+      assert result =~ "normal"
+      assert result =~ "; = integer"
+      refute result =~ "sample:"
+      refute result =~ "token"
+    end
   end
 end


### PR DESCRIPTION
## Summary

- Filter hidden keys (underscore prefix) in tool call arguments - shows `"[Hidden]"` instead of actual value
- Filter hidden values in user namespace - shows `[Hidden]` instead of sample value
- Existing `data/` namespace hidden field behavior unchanged

This ensures sensitive data marked with underscore prefix stays hidden across all LLM-visible output paths, not just the initial context data.

## Files Changed

- `lib/ptc_runner/sub_agent/namespace/execution_history.ex` - Added `filter_hidden_args/1` helper to replace hidden arg values
- `lib/ptc_runner/sub_agent/namespace/user.ex` - Added underscore prefix check in `format_values/2`
- Tests added for both paths

## Test plan

- [x] Tests pass for tool call args with hidden fields
- [x] Tests pass for user namespace with hidden values
- [x] Existing data namespace tests pass (unchanged behavior)
- [x] `mix precommit` passes

Closes #675

🤖 Generated with [Claude Code](https://claude.com/claude-code)