### PR TITLE
feat: Add output: field to SubAgent struct

### DIFF
--- a/lib/ptc_runner/sub_agent.ex
+++ b/lib/ptc_runner/sub_agent.ex
@@ -139,6 +139,14 @@ defmodule PtcRunner.SubAgent do
   @type compression_opts :: nil | false | true | module() | {module(), keyword()}
 
   @typedoc """
+  Output mode for SubAgent execution.
+
+  - `:ptc_lisp` - Default. LLM generates PTC-Lisp code that is executed.
+  - `:json` - LLM generates JSON directly matching the signature's return type.
+  """
+  @type output_mode :: :ptc_lisp | :json
+
+  @typedoc """
   Output format options for truncation and display.
 
   Fields:
@@ -177,7 +185,8 @@ defmodule PtcRunner.SubAgent do
           context_descriptions: map() | nil,
           format_options: format_options(),
           float_precision: non_neg_integer(),
-          compression: compression_opts()
+          compression: compression_opts(),
+          output: output_mode()
         }
 
   alias PtcRunner.SubAgent.LLMResolver
@@ -210,7 +219,8 @@ defmodule PtcRunner.SubAgent do
     max_depth: 3,
     turn_budget: 20,
     format_options: @default_format_options,
-    float_precision: 2
+    float_precision: 2,
+    output: :ptc_lisp
   ]
 
   @doc "Returns the default format options."
@@ -399,7 +409,8 @@ defmodule PtcRunner.SubAgent do
         :field_descriptions,
         :context_descriptions,
         :format_options,
-        :float_precision
+        :float_precision,
+        :output
       ])
       |> Keyword.put(:prompt, mission)
 
@@ -424,7 +435,8 @@ defmodule PtcRunner.SubAgent do
         :field_descriptions,
         :context_descriptions,
         :format_options,
-        :float_precision
+        :float_precision,
+        :output
       ])
 
     run(agent, runtime_opts)

--- a/test/ptc_runner/sub_agent/validator_test.exs
+++ b/test/ptc_runner/sub_agent/validator_test.exs
@@ -1,0 +1,216 @@
+defmodule PtcRunner.SubAgent.ValidatorTest do
+  use ExUnit.Case, async: true
+
+  alias PtcRunner.SubAgent
+
+  describe "output validation" do
+    test "accepts :ptc_lisp output mode" do
+      agent = SubAgent.new(prompt: "Test", output: :ptc_lisp)
+      assert agent.output == :ptc_lisp
+    end
+
+    test "accepts :json output mode with signature" do
+      agent = SubAgent.new(prompt: "Test", output: :json, signature: "() -> {x :string}")
+      assert agent.output == :json
+    end
+
+    test "rejects invalid output mode atom" do
+      assert_raise ArgumentError, ~r/output must be :ptc_lisp or :json/, fn ->
+        SubAgent.new(prompt: "Test", output: :invalid)
+      end
+    end
+
+    test "defaults to :ptc_lisp when output not specified" do
+      agent = SubAgent.new(prompt: "Test")
+      assert agent.output == :ptc_lisp
+    end
+  end
+
+  describe "json mode constraints" do
+    test "rejects json mode with tools" do
+      assert_raise ArgumentError, "output: :json cannot be used with tools", fn ->
+        SubAgent.new(
+          prompt: "Test",
+          output: :json,
+          signature: "() -> {x :string}",
+          tools: %{foo: fn _ -> :ok end}
+        )
+      end
+    end
+
+    test "rejects json mode without signature" do
+      assert_raise ArgumentError, "output: :json requires a signature", fn ->
+        SubAgent.new(prompt: "Test", output: :json)
+      end
+    end
+
+    test "rejects json mode with compression: true" do
+      assert_raise ArgumentError, "output: :json cannot be used with compression", fn ->
+        SubAgent.new(
+          prompt: "Test",
+          output: :json,
+          signature: "() -> {x :string}",
+          compression: true
+        )
+      end
+    end
+
+    test "rejects json mode with compression module" do
+      assert_raise ArgumentError, "output: :json cannot be used with compression", fn ->
+        SubAgent.new(
+          prompt: "Test",
+          output: :json,
+          signature: "() -> {x :string}",
+          compression: SomeModule
+        )
+      end
+    end
+
+    test "accepts json mode with compression: nil" do
+      agent =
+        SubAgent.new(
+          prompt: "Test",
+          output: :json,
+          signature: "() -> {x :string}",
+          compression: nil
+        )
+
+      assert agent.output == :json
+    end
+
+    test "accepts json mode with compression: false" do
+      agent =
+        SubAgent.new(
+          prompt: "Test",
+          output: :json,
+          signature: "() -> {x :string}",
+          compression: false
+        )
+
+      assert agent.output == :json
+    end
+
+    test "rejects json mode with firewall field in signature" do
+      assert_raise ArgumentError,
+                   ~r/output: :json signature cannot have firewall fields \(_hidden\)/,
+                   fn ->
+                     SubAgent.new(
+                       prompt: "Test",
+                       output: :json,
+                       signature: "() -> {_hidden :string}"
+                     )
+                   end
+    end
+
+    test "rejects json mode with nested firewall field in signature" do
+      assert_raise ArgumentError,
+                   ~r/output: :json signature cannot have firewall fields \(_nested\)/,
+                   fn ->
+                     SubAgent.new(
+                       prompt: "Test",
+                       output: :json,
+                       signature: "() -> {x {_nested :int}}"
+                     )
+                   end
+    end
+
+    test "rejects json mode with firewall field in array element" do
+      assert_raise ArgumentError,
+                   ~r/output: :json signature cannot have firewall fields \(_secret\)/,
+                   fn ->
+                     SubAgent.new(
+                       prompt: "Test",
+                       output: :json,
+                       signature: "() -> {items [{name :string, _secret :string}]}"
+                     )
+                   end
+    end
+
+    test "accepts json mode with non-firewall nested fields" do
+      agent =
+        SubAgent.new(
+          prompt: "Test",
+          output: :json,
+          signature: "() -> {user {name :string, email :string}}"
+        )
+
+      assert agent.output == :json
+    end
+
+    test "accepts json mode with list of primitives" do
+      agent =
+        SubAgent.new(
+          prompt: "Test",
+          output: :json,
+          signature: "() -> {items [:string]}"
+        )
+
+      assert agent.output == :json
+    end
+
+    test "accepts json mode with optional fields (non-firewall)" do
+      agent =
+        SubAgent.new(
+          prompt: "Test",
+          output: :json,
+          signature: "() -> {name :string, nickname :string?}"
+        )
+
+      assert agent.output == :json
+    end
+
+    test "rejects json mode with firewall field inside optional map field" do
+      # Optional map field containing another map with firewall field
+      assert_raise ArgumentError,
+                   ~r/output: :json signature cannot have firewall fields \(_id\)/,
+                   fn ->
+                     SubAgent.new(
+                       prompt: "Test",
+                       output: :json,
+                       signature: "() -> {data {user :string, _id :int}}"
+                     )
+                   end
+    end
+  end
+
+  describe "ptc_lisp mode allows all features" do
+    test "ptc_lisp mode allows tools" do
+      agent =
+        SubAgent.new(
+          prompt: "Test",
+          output: :ptc_lisp,
+          tools: %{foo: fn _ -> :ok end}
+        )
+
+      assert agent.output == :ptc_lisp
+    end
+
+    test "ptc_lisp mode allows compression" do
+      agent =
+        SubAgent.new(
+          prompt: "Test",
+          output: :ptc_lisp,
+          compression: true
+        )
+
+      assert agent.output == :ptc_lisp
+    end
+
+    test "ptc_lisp mode allows firewall fields in signature" do
+      agent =
+        SubAgent.new(
+          prompt: "Test",
+          output: :ptc_lisp,
+          signature: "() -> {visible :string, _hidden :string}"
+        )
+
+      assert agent.output == :ptc_lisp
+    end
+
+    test "ptc_lisp mode allows no signature" do
+      agent = SubAgent.new(prompt: "Test", output: :ptc_lisp)
+      assert agent.output == :ptc_lisp
+      assert agent.signature == nil
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add `output:` field to SubAgent struct with type `output_mode :: :ptc_lisp | :json`
- Default is `:ptc_lisp` (existing behavior unchanged)
- JSON mode validation ensures proper constraints are met
- Recursive firewall field detection in signature output types

## Changes

- **lib/ptc_runner/sub_agent.ex**: Added `output` field to struct and type, added `output_mode` type, updated `run/2` string convenience form
- **lib/ptc_runner/sub_agent/validator.ex**: Added `validate_output!/1` with JSON mode constraint validation
- **test/ptc_runner/sub_agent/validator_test.exs**: New test file for output validation

## Test plan

- [x] Accepts `:ptc_lisp` output mode
- [x] Accepts `:json` output mode with signature
- [x] Rejects invalid output mode atom
- [x] Defaults to `:ptc_lisp` when output not specified
- [x] Rejects json mode with tools
- [x] Rejects json mode without signature
- [x] Rejects json mode with compression
- [x] Rejects json mode with firewall field in signature
- [x] Rejects json mode with nested firewall field in signature
- [x] Accepts json mode with non-firewall nested fields
- [x] ptc_lisp mode allows all features

Closes #680

🤖 Generated with [Claude Code](https://claude.com/claude-code)