### PR TITLE
feat: Add JSON parser for LLM responses

### DIFF
--- a/lib/ptc_runner/sub_agent/json_parser.ex
+++ b/lib/ptc_runner/sub_agent/json_parser.ex
@@ -1,0 +1,202 @@
+defmodule PtcRunner.SubAgent.JsonParser do
+  @moduledoc """
+  Extracts JSON from LLM responses, handling common formatting quirks.
+
+  LLMs often wrap JSON in markdown code blocks, add explanatory text,
+  or include trailing commentary. This module extracts the JSON content
+  following a priority order:
+
+  1. JSON in ```json code block
+  2. JSON in ``` code block (no language)
+  3. Raw JSON object (starts with `{`)
+  4. Raw JSON array (starts with `[`)
+
+  ## Examples
+
+      iex> PtcRunner.SubAgent.JsonParser.parse(~s|{"name": "Alice"}|)
+      {:ok, %{"name" => "Alice"}}
+
+      iex> PtcRunner.SubAgent.JsonParser.parse("```json\\n{\\"a\\": 1}\\n```")
+      {:ok, %{"a" => 1}}
+
+      iex> PtcRunner.SubAgent.JsonParser.parse("Here's the result: {\\"x\\": 5}")
+      {:ok, %{"x" => 5}}
+
+      iex> PtcRunner.SubAgent.JsonParser.parse("No JSON here")
+      {:error, :no_json_found}
+
+  """
+
+  @doc """
+  Parse JSON from an LLM response string.
+
+  Extracts JSON from code blocks or raw content, handling common LLM
+  formatting quirks like trailing text or explanation prefixes.
+
+  Returns `{:ok, term()}` with the parsed JSON data, or an error tuple.
+
+  ## Error Types
+
+  - `{:error, :no_json_found}` - No JSON structure detected in the response
+  - `{:error, :invalid_json}` - JSON was found but failed to parse
+
+  ## Examples
+
+      iex> PtcRunner.SubAgent.JsonParser.parse(~s|{"count": 42}|)
+      {:ok, %{"count" => 42}}
+
+      iex> PtcRunner.SubAgent.JsonParser.parse("[1, 2, 3]")
+      {:ok, [1, 2, 3]}
+
+      iex> PtcRunner.SubAgent.JsonParser.parse("```json\\n{\\"valid\\": true}\\n```")
+      {:ok, %{"valid" => true}}
+
+      iex> PtcRunner.SubAgent.JsonParser.parse("plain text")
+      {:error, :no_json_found}
+
+      iex> PtcRunner.SubAgent.JsonParser.parse("```json\\n{invalid}\\n```")
+      {:error, :invalid_json}
+
+  """
+  @spec parse(String.t()) :: {:ok, term()} | {:error, :no_json_found | :invalid_json}
+  def parse(response) when is_binary(response) do
+    case extract_json_code_block(response) do
+      {:ok, data} ->
+        {:ok, data}
+
+      {:error, :invalid_json} ->
+        # Code block found but JSON was malformed - don't fall through
+        {:error, :invalid_json}
+
+      {:error, _} ->
+        # No code block or empty - try raw JSON extraction
+        case extract_raw_json(response) do
+          {:ok, data} -> {:ok, data}
+          {:error, :invalid_json} -> {:error, :invalid_json}
+          {:error, _} -> {:error, :no_json_found}
+        end
+    end
+  end
+
+  # Extract JSON from ```json ... ``` or ``` ... ``` code blocks
+  defp extract_json_code_block(response) do
+    # Match ```json ... ``` or ``` ... ``` (no language tag)
+    regex = ~r/```(?:json)?\s*\n?([\s\S]*?)\n?```/
+
+    case Regex.run(regex, response) do
+      [_, json] ->
+        trimmed = String.trim(json)
+
+        if trimmed == "" do
+          {:error, :empty_code_block}
+        else
+          decode_json(trimmed)
+        end
+
+      nil ->
+        {:error, :no_code_block}
+    end
+  end
+
+  # Extract raw JSON object or array from the response
+  defp extract_raw_json(response) do
+    trimmed = String.trim(response)
+
+    cond do
+      String.starts_with?(trimmed, "{") -> extract_json_object(trimmed)
+      String.starts_with?(trimmed, "[") -> extract_json_array(trimmed)
+      # Try to find JSON embedded in the text (e.g., "Here's the result: {...}")
+      true -> find_embedded_json(response)
+    end
+  end
+
+  # Extract a JSON object by finding the matching closing brace
+  defp extract_json_object(text) do
+    case find_matching_bracket(text, ?{, ?}) do
+      {:ok, json_str} -> decode_json(json_str)
+      :error -> {:error, :no_json_found}
+    end
+  end
+
+  # Extract a JSON array by finding the matching closing bracket
+  defp extract_json_array(text) do
+    case find_matching_bracket(text, ?[, ?]) do
+      {:ok, json_str} -> decode_json(json_str)
+      :error -> {:error, :no_json_found}
+    end
+  end
+
+  # Find JSON embedded in text (preceded by explanatory text)
+  defp find_embedded_json(text) do
+    # Look for { or [ that might be JSON
+    case Regex.run(~r/[\{\[]/, text, return: :index) do
+      [{start, _}] ->
+        substring = String.slice(text, start..-1//1)
+
+        if String.starts_with?(substring, "{") do
+          extract_json_object(substring)
+        else
+          extract_json_array(substring)
+        end
+
+      nil ->
+        {:error, :no_json_found}
+    end
+  end
+
+  # Find the matching closing bracket, accounting for nesting and strings
+  defp find_matching_bracket(text, open_char, close_char) do
+    chars = String.to_charlist(text)
+    find_matching_bracket(chars, open_char, close_char, 0, false, false, [])
+  end
+
+  defp find_matching_bracket([], _open, _close, _depth, _in_string, _escaped, _acc) do
+    :error
+  end
+
+  defp find_matching_bracket([char | rest], open, close, depth, in_string, escaped, acc) do
+    cond do
+      # Handle escape sequences in strings
+      escaped ->
+        find_matching_bracket(rest, open, close, depth, in_string, false, [char | acc])
+
+      # Backslash starts escape sequence in strings
+      in_string and char == ?\\ ->
+        find_matching_bracket(rest, open, close, depth, in_string, true, [char | acc])
+
+      # Quote toggles string state
+      char == ?" ->
+        new_in_string = not in_string
+        find_matching_bracket(rest, open, close, depth, new_in_string, false, [char | acc])
+
+      # Opening bracket (not in string)
+      not in_string and char == open ->
+        new_depth = depth + 1
+        find_matching_bracket(rest, open, close, new_depth, in_string, false, [char | acc])
+
+      # Closing bracket (not in string)
+      not in_string and char == close ->
+        new_depth = depth - 1
+
+        if new_depth == 0 do
+          # Found matching bracket
+          result = [char | acc] |> Enum.reverse() |> List.to_string()
+          {:ok, result}
+        else
+          find_matching_bracket(rest, open, close, new_depth, in_string, false, [char | acc])
+        end
+
+      # Any other character
+      true ->
+        find_matching_bracket(rest, open, close, depth, in_string, false, [char | acc])
+    end
+  end
+
+  # Decode JSON string, converting Jason errors to our error format
+  defp decode_json(json_string) do
+    case Jason.decode(json_string) do
+      {:ok, data} -> {:ok, data}
+      {:error, _} -> {:error, :invalid_json}
+    end
+  end
+end

--- a/test/ptc_runner/sub_agent/json_parser_test.exs
+++ b/test/ptc_runner/sub_agent/json_parser_test.exs
@@ -1,0 +1,170 @@
+defmodule PtcRunner.SubAgent.JsonParserTest do
+  use ExUnit.Case
+
+  alias PtcRunner.SubAgent.JsonParser
+
+  doctest PtcRunner.SubAgent.JsonParser
+
+  describe "parse/1" do
+    test "extracts JSON from ```json code block" do
+      response = """
+      ```json
+      {"sentiment": "positive", "score": 0.95}
+      ```
+      """
+
+      assert {:ok, %{"sentiment" => "positive", "score" => 0.95}} = JsonParser.parse(response)
+    end
+
+    test "extracts JSON from ``` code block (no language)" do
+      response = """
+      ```
+      {"name": "Alice", "age": 30}
+      ```
+      """
+
+      assert {:ok, %{"name" => "Alice", "age" => 30}} = JsonParser.parse(response)
+    end
+
+    test "extracts raw JSON object" do
+      response = ~s|{"count": 42, "valid": true}|
+
+      assert {:ok, %{"count" => 42, "valid" => true}} = JsonParser.parse(response)
+    end
+
+    test "extracts raw JSON array" do
+      response = ~s|[1, 2, 3, "four"]|
+
+      assert {:ok, [1, 2, 3, "four"]} = JsonParser.parse(response)
+    end
+
+    test "handles trailing text after JSON" do
+      response = ~s|{"a": 1} Let me know if you need anything else!|
+
+      assert {:ok, %{"a" => 1}} = JsonParser.parse(response)
+    end
+
+    test "handles explanation prefix before JSON" do
+      response = """
+      Here's the result:
+      {"message": "hello"}
+      """
+
+      assert {:ok, %{"message" => "hello"}} = JsonParser.parse(response)
+    end
+
+    test "returns :no_json_found when no JSON present" do
+      response = "This is just plain text with no JSON content."
+
+      assert {:error, :no_json_found} = JsonParser.parse(response)
+    end
+
+    test "returns :invalid_json for malformed JSON" do
+      response = """
+      ```json
+      {"invalid": missing_quotes}
+      ```
+      """
+
+      assert {:error, :invalid_json} = JsonParser.parse(response)
+    end
+
+    test "handles nested JSON structures" do
+      response =
+        ~s|{"user": {"name": "Bob", "profile": {"bio": "Developer", "skills": ["elixir", "rust"]}}}|
+
+      assert {:ok, result} = JsonParser.parse(response)
+      assert result["user"]["name"] == "Bob"
+      assert result["user"]["profile"]["bio"] == "Developer"
+      assert result["user"]["profile"]["skills"] == ["elixir", "rust"]
+    end
+
+    test "handles JSON with escaped characters" do
+      response = ~s|{"message": "Hello \\"World\\"", "path": "C:\\\\Users\\\\test"}|
+
+      assert {:ok, result} = JsonParser.parse(response)
+      assert result["message"] == "Hello \"World\""
+      assert result["path"] == "C:\\Users\\test"
+    end
+
+    test "prefers code block over raw JSON when both present" do
+      response = """
+      Here's some raw json: {"raw": true}
+
+      ```json
+      {"from_block": true}
+      ```
+      """
+
+      assert {:ok, %{"from_block" => true}} = JsonParser.parse(response)
+    end
+
+    test "handles code block with extra whitespace" do
+      response = """
+      ```json
+
+        {"spaced": "out"}
+
+      ```
+      """
+
+      assert {:ok, %{"spaced" => "out"}} = JsonParser.parse(response)
+    end
+
+    test "handles empty code block" do
+      response = """
+      ```json
+      ```
+      """
+
+      # Should fall through to try raw JSON extraction
+      assert {:error, :no_json_found} = JsonParser.parse(response)
+    end
+
+    test "handles array in code block" do
+      response = """
+      ```json
+      ["item1", "item2", {"nested": true}]
+      ```
+      """
+
+      assert {:ok, ["item1", "item2", %{"nested" => true}]} = JsonParser.parse(response)
+    end
+
+    test "handles JSON with braces in strings" do
+      response = ~s|{"template": "Hello {name}!", "regex": "[a-z]{3}"}|
+
+      assert {:ok, result} = JsonParser.parse(response)
+      assert result["template"] == "Hello {name}!"
+      assert result["regex"] == "[a-z]{3}"
+    end
+
+    test "handles deeply nested arrays and objects" do
+      response = ~s|{"level1": [{"level2": [{"level3": {"value": 42}}]}]}|
+
+      assert {:ok, result} = JsonParser.parse(response)
+
+      assert get_in(result, ["level1", Access.at(0), "level2", Access.at(0), "level3", "value"]) ==
+               42
+    end
+
+    test "handles JSON with unicode characters" do
+      response = ~s|{"greeting": "Hello, \u4e16\u754c!", "emoji": "\u2764\ufe0f"}|
+
+      assert {:ok, result} = JsonParser.parse(response)
+      assert result["greeting"] == "Hello, \u4E16\u754C!"
+    end
+
+    test "handles raw array with trailing text" do
+      response = ~s|["a", "b", "c"] That's the list you requested.|
+
+      assert {:ok, ["a", "b", "c"]} = JsonParser.parse(response)
+    end
+
+    test "handles JSON embedded mid-sentence" do
+      response = ~s|The answer is {"result": "success"} as expected.|
+
+      assert {:ok, %{"result" => "success"}} = JsonParser.parse(response)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add `PtcRunner.SubAgent.JsonParser` module to extract JSON from LLM responses
- Handle common LLM formatting quirks (code blocks, trailing text, explanation prefixes)
- Support extraction priority: `json code block > code block > raw JSON object > raw JSON array
- Use bracket matching for correct handling of nested structures and escaped characters

## Implementation Details

The parser follows the extraction priority from the spec:
1. JSON in ` ```json ` code block
2. JSON in ` ``` ` code block (no language tag)
3. Raw JSON object (starts with `{`)
4. Raw JSON array (starts with `[`)

Key features:
- Proper bracket matching handles nested structures and JSON with braces in strings
- Distinguishes between `{:error, :no_json_found}` (no JSON detected) and `{:error, :invalid_json}` (JSON found but malformed)
- If a code block contains invalid JSON, returns `:invalid_json` immediately (doesn't fall through to raw extraction)

## Test plan

- [x] Extracts JSON from ` ```json ` code blocks
- [x] Extracts JSON from ` ``` ` code blocks (no language tag)
- [x] Extracts raw JSON objects starting with `{`
- [x] Extracts raw JSON arrays starting with `[`
- [x] Handles trailing text after JSON
- [x] Handles explanation prefix before JSON
- [x] Returns `{:error, :no_json_found}` when no JSON present
- [x] Returns `{:error, :invalid_json}` for malformed JSON
- [x] Handles nested JSON structures
- [x] Handles JSON with escaped characters
- [x] Handles JSON with braces in strings
- [x] Handles unicode characters

Closes #682

🤖 Generated with [Claude Code](https://claude.com/claude-code)