### PR TITLE
feat: Add JSON mode prompt templates

### DIFF
--- a/priv/prompts/json-error.md
+++ b/priv/prompts/json-error.md
@@ -1,0 +1,21 @@
+# JSON Mode Error Feedback
+
+Error feedback for JSON validation failures.
+
+<!-- version: 1 -->
+<!-- date: 2026-01-16 -->
+<!-- changes: Initial version -->
+
+<!-- PTC_PROMPT_START -->
+
+Your response was not valid JSON or didn't match the expected format.
+
+Error: {{error_message}}
+
+Your response was:
+{{invalid_response}}
+
+Please return valid JSON matching this format:
+{{expected_format}}
+
+<!-- PTC_PROMPT_END -->

--- a/priv/prompts/json-system.md
+++ b/priv/prompts/json-system.md
@@ -1,0 +1,15 @@
+# JSON Mode System Prompt
+
+System prompt for JSON output mode.
+
+<!-- version: 1 -->
+<!-- date: 2026-01-16 -->
+<!-- changes: Initial version -->
+
+<!-- PTC_PROMPT_START -->
+
+You are a helpful assistant that returns structured JSON responses.
+
+Return ONLY valid JSON matching the expected format. No explanation, no markdown code blocks, just the JSON object.
+
+<!-- PTC_PROMPT_END -->

--- a/priv/prompts/json-user.md
+++ b/priv/prompts/json-user.md
@@ -1,0 +1,29 @@
+# JSON Mode User Message Template
+
+User message template for JSON output mode.
+
+<!-- version: 1 -->
+<!-- date: 2026-01-16 -->
+<!-- changes: Initial version -->
+
+<!-- PTC_PROMPT_START -->
+
+# Data
+
+{{data_section}}
+
+# Task
+
+{{task}}
+
+# Expected Output
+
+Return a JSON object with these fields:
+{{field_descriptions}}
+
+Example format:
+```json
+{{example_output}}
+```
+
+<!-- PTC_PROMPT_END -->


### PR DESCRIPTION
## Summary

- Add `json-system.md` - minimal system prompt for JSON mode (no PTC-Lisp spec)
- Add `json-user.md` - user message template with data, task, and expected output sections
- Add `json-error.md` - error feedback template for validation retries

## Details

These templates follow the existing `priv/prompts/` format with:
- Metadata headers (version, date, changes)
- Content markers (`<!-- PTC_PROMPT_START/END -->`)
- Naming convention: `json-*.md` (matching `lisp-*.md` pattern)

Placeholders for template substitution:
- **User template**: `{{data_section}}`, `{{task}}`, `{{field_descriptions}}`, `{{example_output}}`
- **Error template**: `{{error_message}}`, `{{invalid_response}}`, `{{expected_format}}`

## Test plan

- [x] Templates compile without errors (`mix compile --force`)
- [x] All precommit checks pass
- Template loading and placeholder substitution will be tested in #684 (execution loop)

Closes #683

🤖 Generated with [Claude Code](https://claude.com/claude-code)