### PR TITLE
feat: Add LLMClient.generate_object/4

### DIFF
--- a/llm_client/lib/llm_client.ex
+++ b/llm_client/lib/llm_client.ex
@@ -35,6 +35,8 @@ defmodule LLMClient do
   # Provider functions
   defdelegate generate_text(model, messages, opts \\ []), to: LLMClient.Providers
   defdelegate generate_text!(model, messages, opts \\ []), to: LLMClient.Providers
+  defdelegate generate_object(model, messages, schema, opts \\ []), to: LLMClient.Providers
+  defdelegate generate_object!(model, messages, schema, opts \\ []), to: LLMClient.Providers
   defdelegate available?(model), to: LLMClient.Providers
   defdelegate requires_api_key?(model), to: LLMClient.Providers
 

--- a/llm_client/test/llm_client/providers_test.exs
+++ b/llm_client/test/llm_client/providers_test.exs
@@ -1,0 +1,29 @@
+defmodule LLMClient.ProvidersTest do
+  use ExUnit.Case, async: true
+
+  describe "generate_object/4" do
+    test "returns structured_output_not_supported for ollama" do
+      assert {:error, :structured_output_not_supported} =
+               LLMClient.generate_object("ollama:model", [], %{})
+    end
+
+    test "returns structured_output_not_supported for openai-compat" do
+      assert {:error, :structured_output_not_supported} =
+               LLMClient.generate_object("openai-compat:http://localhost|model", [], %{})
+    end
+  end
+
+  describe "generate_object!/4" do
+    test "raises for ollama" do
+      assert_raise RuntimeError, ~r/structured_output_not_supported/, fn ->
+        LLMClient.generate_object!("ollama:model", [], %{})
+      end
+    end
+
+    test "raises for openai-compat" do
+      assert_raise RuntimeError, ~r/structured_output_not_supported/, fn ->
+        LLMClient.generate_object!("openai-compat:http://localhost|model", [], %{})
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add `LLMClient.generate_object/4` for structured JSON output from cloud LLMs
- Add `generate_object!/4` raising variant
- Return `{:error, :structured_output_not_supported}` for local providers (Ollama, openai-compat)
- Reuse existing `apply_caching/3` for prompt caching support

## Test Plan

- [x] Unit tests for Ollama/openai-compat returning error
- [x] Unit tests for `generate_object!/4` raising on error
- [x] E2E test available (tagged `:e2e`) for manual verification with API key

Closes #685

🤖 Generated with [Claude Code](https://claude.com/claude-code)