### PR TITLE
feat: Improve signature documentation and error messages

### DIFF
--- a/test/ptc_runner/sub_agent/signature_test.exs
+++ b/test/ptc_runner/sub_agent/signature_test.exs
@@ -202,6 +202,21 @@ defmodule PtcRunner.SubAgent.SignatureTest do
                Enum.at(err.path, 0) == "results" and Enum.at(err.path, 1) == 0
              end)
     end
+
+    test "invalid type in signature includes hint about valid types" do
+      {:error, message} = Signature.parse("(pending :list) -> :bool")
+
+      assert message =~ "Hint: Valid types are"
+      assert message =~ ":string"
+      assert message =~ ":int"
+      assert message =~ "[:type]"
+    end
+
+    test "other invalid types also include hint" do
+      {:error, message} = Signature.parse("(items :array) -> :bool")
+
+      assert message =~ "Hint: Valid types are"
+    end
   end
 
   describe "to_json_schema/1" do


### PR DESCRIPTION
## Summary

- Add hint about valid types when parser encounters invalid type names like `:list` or `:array`
- Add "String Keys at Tool Boundary" section to docs explaining tool key conventions  
- Add "Invalid Type Names (Common Mistakes)" subsection documenting common type guesses
- Add test cases for improved error messages

## Test plan

- [x] Verified parser produces helpful hint for `:list` and `:array` invalid types
- [x] Test cases added for improved error messages
- [x] `mix precommit` passes (format, credo, dialyzer, tests)

Closes #713

🤖 Generated with [Claude Code](https://claude.com/claude-code)