### PR TITLE
refactor(turn): use params map for optional fields in Turn constructors

### DIFF
--- a/lib/ptc_runner/sub_agent/loop/metrics.ex
+++ b/lib/ptc_runner/sub_agent/loop/metrics.ex
@@ -229,28 +229,17 @@ defmodule PtcRunner.SubAgent.Loop.Metrics do
         }
       end)
 
+    params = %{
+      prints: prints,
+      tool_calls: simplified_tool_calls,
+      memory: memory,
+      messages: messages
+    }
+
     if success? do
-      Turn.success(
-        state.turn,
-        raw_response,
-        program,
-        result,
-        prints,
-        simplified_tool_calls,
-        memory,
-        messages
-      )
+      Turn.success(state.turn, raw_response, program, result, params)
     else
-      Turn.failure(
-        state.turn,
-        raw_response,
-        program,
-        result,
-        prints,
-        simplified_tool_calls,
-        memory,
-        messages
-      )
+      Turn.failure(state.turn, raw_response, program, result, params)
     end
   end
 end

--- a/test/ptc_runner/sub_agent/debug_test.exs
+++ b/test/ptc_runner/sub_agent/debug_test.exs
@@ -283,7 +283,7 @@ defmodule PtcRunner.SubAgent.DebugTest do
   describe "Debug.print_trace/2 with turns" do
     test "prints trace for successful execution" do
       turns = [
-        Turn.success(1, "```clojure\n(+ 1 2)\n```", "(+ 1 2)", 3, [], [], %{})
+        Turn.success(1, "```clojure\n(+ 1 2)\n```", "(+ 1 2)", 3)
       ]
 
       step = %Step{
@@ -335,10 +335,7 @@ defmodule PtcRunner.SubAgent.DebugTest do
           1,
           "Some reasoning here\n\n```clojure\n(+ 1 2)\n```",
           "(+ 1 2)",
-          3,
-          [],
-          [],
-          %{}
+          3
         )
       ]
 
@@ -369,10 +366,7 @@ defmodule PtcRunner.SubAgent.DebugTest do
           1,
           "Some reasoning here\n\n```clojure\n(+ 1 2)\n```",
           "(+ 1 2)",
-          3,
-          [],
-          [],
-          %{}
+          3
         )
       ]
 
@@ -392,7 +386,7 @@ defmodule PtcRunner.SubAgent.DebugTest do
 
     test "view: :compressed shows compressed format" do
       turns = [
-        Turn.success(1, "```clojure\n(+ 1 2)\n```", "(+ 1 2)", 3, [], [], %{})
+        Turn.success(1, "```clojure\n(+ 1 2)\n```", "(+ 1 2)", 3)
       ]
 
       step = %Step{
@@ -459,7 +453,7 @@ defmodule PtcRunner.SubAgent.DebugTest do
 
     test "usage: true shows token stats" do
       turns = [
-        Turn.success(1, "```clojure\n(+ 1 2)\n```", "(+ 1 2)", 3, [], [], %{})
+        Turn.success(1, "```clojure\n(+ 1 2)\n```", "(+ 1 2)", 3)
       ]
 
       step = %Step{
@@ -485,8 +479,8 @@ defmodule PtcRunner.SubAgent.DebugTest do
 
     test "usage: true shows memory and system prompt ratio" do
       turns = [
-        Turn.success(1, "```clojure\n(+ 1 2)\n```", "(+ 1 2)", 3, [], [], %{}),
-        Turn.success(2, "```clojure\n(+ 3 4)\n```", "(+ 3 4)", 7, [], [], %{})
+        Turn.success(1, "```clojure\n(+ 1 2)\n```", "(+ 1 2)", 3),
+        Turn.success(2, "```clojure\n(+ 3 4)\n```", "(+ 3 4)", 7)
       ]
 
       step = %Step{
@@ -523,7 +517,7 @@ defmodule PtcRunner.SubAgent.DebugTest do
       long_program = String.duplicate("(+ 1 2) ", 50)
 
       turns = [
-        Turn.success(1, "```clojure\n#{long_program}\n```", long_program, 3, [], [], %{})
+        Turn.success(1, "```clojure\n#{long_program}\n```", long_program, 3)
       ]
 
       step = %Step{
@@ -548,7 +542,7 @@ defmodule PtcRunner.SubAgent.DebugTest do
         return: %{value: 10},
         fail: nil,
         memory: %{},
-        turns: [Turn.success(1, "(+ 5 5)", "(+ 5 5)", 10, [], [], %{})],
+        turns: [Turn.success(1, "(+ 5 5)", "(+ 5 5)", 10)],
         usage: %{duration_ms: 50, memory_bytes: 0}
       }
 
@@ -556,7 +550,7 @@ defmodule PtcRunner.SubAgent.DebugTest do
         return: %{value: 20},
         fail: nil,
         memory: %{},
-        turns: [Turn.success(1, "(* data/value 2)", "(* data/value 2)", 20, [], [], %{})],
+        turns: [Turn.success(1, "(* data/value 2)", "(* data/value 2)", 20)],
         usage: %{duration_ms: 75, memory_bytes: 0}
       }
 
@@ -736,21 +730,19 @@ defmodule PtcRunner.SubAgent.DebugTest do
           "```clojure\n(tool/search \"foo\")\n```",
           "(tool/search \"foo\")",
           %{},
-          [],
-          [%{name: "search", args: %{query: "foo"}, result: ["result1"]}],
-          %{}
+          %{tool_calls: [%{name: "search", args: %{query: "foo"}, result: ["result1"]}]}
         ),
         Turn.success(
           2,
           "```clojure\n(tool/search \"bar\")\n```",
           "(tool/search \"bar\")",
           %{},
-          [],
-          [
-            %{name: "search", args: %{query: "bar"}, result: ["result2"]},
-            %{name: "fetch", args: %{url: "http://example.com"}, result: "html"}
-          ],
-          %{}
+          %{
+            tool_calls: [
+              %{name: "search", args: %{query: "bar"}, result: ["result2"]},
+              %{name: "fetch", args: %{url: "http://example.com"}, result: "html"}
+            ]
+          }
         )
       ]
 
@@ -784,9 +776,7 @@ defmodule PtcRunner.SubAgent.DebugTest do
           "...",
           "...",
           %{},
-          [],
-          [%{name: "process", args: %{query: "test", limit: 10}, result: "ok"}],
-          %{}
+          %{tool_calls: [%{name: "process", args: %{query: "test", limit: 10}, result: "ok"}]}
         )
       ]
 
@@ -810,7 +800,7 @@ defmodule PtcRunner.SubAgent.DebugTest do
 
     test "usage: true does not show tool section when no tools called" do
       turns = [
-        Turn.success(1, "```clojure\n(+ 1 2)\n```", "(+ 1 2)", 3, [], [], %{})
+        Turn.success(1, "```clojure\n(+ 1 2)\n```", "(+ 1 2)", 3)
       ]
 
       step = %Step{


### PR DESCRIPTION
## Summary

- Reduce `Turn.success` and `Turn.failure` arity from 8 to 5 by grouping optional fields into a params map
- Optional fields (prints, tool_calls, memory, messages) now passed via a map parameter with defaults
- Updates `metrics.ex` (only production caller) and all test files

## Motivation

- Current functions have 8 positional arguments, hitting Credo's max arity limit
- Issue #720 needs to add a `type` field, which would exceed the limit
- Using a params map is more maintainable and extensible

## API Change

Before:
```elixir
Turn.success(number, raw_response, program, result, prints, tool_calls, memory, messages \\ nil)
```

After:
```elixir
Turn.success(number, raw_response, program, result, params \\ %{})
# params: %{prints: [], tool_calls: [], memory: %{}, messages: nil}
```

## Test plan

- [x] All existing tests pass with updated call sites
- [x] Added tests for default values when params not provided
- [x] `mix precommit` passes (formatting, credo, dialyzer, tests)

Closes #721

🤖 Generated with [Claude Code](https://claude.com/claude-code)