### PR TITLE
refactor(prompts): extract @extract_prompt_content to shared PromptLoader module

### DIFF
--- a/lib/ptc_runner/lisp/language_spec.ex
+++ b/lib/ptc_runner/lisp/language_spec.ex
@@ -102,22 +102,7 @@ defmodule PtcRunner.Lisp.LanguageSpec do
       |> String.to_atom()
 
     file_content = File.read!(path)
-
-    {header, content} =
-      case String.split(file_content, "<!-- PTC_PROMPT_START -->") do
-        [before, after_start] ->
-          trimmed_content =
-            case String.split(after_start, "<!-- PTC_PROMPT_END -->") do
-              [prompt_text, _after_end] -> String.trim(prompt_text)
-              _ -> String.trim(after_start)
-            end
-
-          {before, trimmed_content}
-
-        _ ->
-          {file_content, String.trim(file_content)}
-      end
-
+    {header, content} = PtcRunner.PromptLoader.extract_with_header(file_content)
     metadata = @parse_metadata.(header)
 
     {key, %{content: content, metadata: metadata, archived: archived}}

--- a/lib/ptc_runner/prompt_loader.ex
+++ b/lib/ptc_runner/prompt_loader.ex
@@ -1,0 +1,84 @@
+defmodule PtcRunner.PromptLoader do
+  @moduledoc """
+  Compile-time utilities for loading prompt templates from files.
+
+  Extracts content between `<!-- PTC_PROMPT_START -->` and `<!-- PTC_PROMPT_END -->` markers.
+  If markers are not found, returns the trimmed full content.
+
+  ## Examples
+
+      # Basic extraction
+      content = File.read!("priv/prompts/my-prompt.md")
+      prompt = PtcRunner.PromptLoader.extract_content(content)
+
+      # With header (for metadata parsing)
+      {header, content} = PtcRunner.PromptLoader.extract_with_header(content)
+  """
+
+  @start_marker "<!-- PTC_PROMPT_START -->"
+  @end_marker "<!-- PTC_PROMPT_END -->"
+
+  @doc """
+  Extract prompt content from file content string.
+
+  Returns content between markers, or trimmed full content if markers not found.
+
+  ## Examples
+
+      iex> PtcRunner.PromptLoader.extract_content("before<!-- PTC_PROMPT_START -->content<!-- PTC_PROMPT_END -->after")
+      "content"
+
+      iex> PtcRunner.PromptLoader.extract_content("<!-- PTC_PROMPT_START -->only start marker")
+      "only start marker"
+
+      iex> PtcRunner.PromptLoader.extract_content("  no markers  ")
+      "no markers"
+  """
+  @spec extract_content(String.t()) :: String.t()
+  def extract_content(file_content) do
+    case String.split(file_content, @start_marker) do
+      [_before, after_start] ->
+        case String.split(after_start, @end_marker) do
+          [prompt_text, _after_end] -> String.trim(prompt_text)
+          _ -> String.trim(after_start)
+        end
+
+      _ ->
+        String.trim(file_content)
+    end
+  end
+
+  @doc """
+  Extract prompt content with metadata header.
+
+  Returns `{header, content}` tuple where header is text before the start marker.
+  Used by `LanguageSpec` for version metadata parsing.
+
+  ## Examples
+
+      iex> PtcRunner.PromptLoader.extract_with_header("header<!-- PTC_PROMPT_START -->content<!-- PTC_PROMPT_END -->after")
+      {"header", "content"}
+
+      iex> PtcRunner.PromptLoader.extract_with_header("header<!-- PTC_PROMPT_START -->only start")
+      {"header", "only start"}
+
+      iex> PtcRunner.PromptLoader.extract_with_header("  no markers  ")
+      {"  no markers  ", "no markers"}
+  """
+  @spec extract_with_header(String.t()) :: {String.t(), String.t()}
+  def extract_with_header(file_content) do
+    case String.split(file_content, @start_marker) do
+      [before, after_start] ->
+        content =
+          case String.split(after_start, @end_marker) do
+            [prompt_text, _after_end] -> String.trim(prompt_text)
+            _ -> String.trim(after_start)
+          end
+
+        {before, content}
+
+      _ ->
+        {file_content, String.trim(file_content)}
+    end
+  end
+end

--- a/lib/ptc_runner/sub_agent/loop/json_mode.ex
+++ b/lib/ptc_runner/sub_agent/loop/json_mode.ex
@@ -44,31 +44,17 @@ defmodule PtcRunner.SubAgent.Loop.JsonMode do
   @external_resource @json_user_file
   @external_resource @json_error_file
 
-  # Extract content between PTC_PROMPT_START and PTC_PROMPT_END markers
-  @extract_prompt_content fn file_content ->
-    case String.split(file_content, "<!-- PTC_PROMPT_START -->") do
-      [_before, after_start] ->
-        case String.split(after_start, "<!-- PTC_PROMPT_END -->") do
-          [prompt_text, _after_end] -> String.trim(prompt_text)
-          _ -> String.trim(after_start)
-        end
-
-      _ ->
-        String.trim(file_content)
-    end
-  end
-
   @json_system_prompt @json_system_file
                       |> File.read!()
-                      |> @extract_prompt_content.()
+                      |> PtcRunner.PromptLoader.extract_content()
 
   @json_user_template @json_user_file
                       |> File.read!()
-                      |> @extract_prompt_content.()
+                      |> PtcRunner.PromptLoader.extract_content()
 
   @json_error_template @json_error_file
                        |> File.read!()
-                       |> @extract_prompt_content.()
+                       |> PtcRunner.PromptLoader.extract_content()
 
   @doc """
   Generate a preview of the JSON mode prompts.

--- a/lib/ptc_runner/sub_agent/loop/turn_feedback.ex
+++ b/lib/ptc_runner/sub_agent/loop/turn_feedback.ex
@@ -22,29 +22,13 @@ defmodule PtcRunner.SubAgent.Loop.TurnFeedback do
   @external_resource @must_return_warning_path
   @external_resource @retry_feedback_path
 
-  # Extract content between PTC_PROMPT_START and PTC_PROMPT_END markers
-  @extract_prompt_content fn file_content ->
-    case String.split(file_content, "<!-- PTC_PROMPT_START -->") do
-      [_before, after_start] ->
-        case String.split(after_start, "<!-- PTC_PROMPT_END -->") do
-          [prompt_text, _after_end] -> String.trim(prompt_text)
-          _ -> String.trim(after_start)
-        end
+  @must_return_warning_template @must_return_warning_path
+                                |> File.read!()
+                                |> PtcRunner.PromptLoader.extract_content()
 
-      _ ->
-        String.trim(file_content)
-    end
-  end
-
-  @must_return_warning_template (fn ->
-                                   content = File.read!(@must_return_warning_path)
-                                   @extract_prompt_content.(content)
-                                 end).()
-
-  @retry_feedback_template (fn ->
-                              content = File.read!(@retry_feedback_path)
-                              @extract_prompt_content.(content)
-                            end).()
+  @retry_feedback_template @retry_feedback_path
+                           |> File.read!()
+                           |> PtcRunner.PromptLoader.extract_content()
 
   @doc """
   Append turn progress info to a feedback message.

--- a/test/ptc_runner/prompt_loader_test.exs
+++ b/test/ptc_runner/prompt_loader_test.exs
@@ -1,0 +1,78 @@
+defmodule PtcRunner.PromptLoaderTest do
+  use ExUnit.Case, async: true
+
+  doctest PtcRunner.PromptLoader
+
+  alias PtcRunner.PromptLoader
+
+  describe "extract_content/1" do
+    test "extracts content between markers" do
+      input = """
+      <!-- metadata here -->
+      <!-- PTC_PROMPT_START -->
+      This is the prompt content.
+      Multiple lines supported.
+      <!-- PTC_PROMPT_END -->
+      <!-- after content -->
+      """
+
+      assert PromptLoader.extract_content(input) ==
+               "This is the prompt content.\nMultiple lines supported."
+    end
+
+    test "handles only start marker (no end marker)" do
+      input = """
+      before
+      <!-- PTC_PROMPT_START -->
+      prompt content here
+      """
+
+      assert PromptLoader.extract_content(input) == "prompt content here"
+    end
+
+    test "returns trimmed content when no markers present" do
+      input = "  just plain content  \n\n"
+      assert PromptLoader.extract_content(input) == "just plain content"
+    end
+
+    test "handles empty content between markers" do
+      input = "before<!-- PTC_PROMPT_START --><!-- PTC_PROMPT_END -->after"
+      assert PromptLoader.extract_content(input) == ""
+    end
+  end
+
+  describe "extract_with_header/1" do
+    test "returns header and content as tuple" do
+      input = """
+      <!-- version: 2 -->
+      <!-- date: 2025-01-15 -->
+      <!-- PTC_PROMPT_START -->
+      The prompt content.
+      <!-- PTC_PROMPT_END -->
+      after
+      """
+
+      {header, content} = PromptLoader.extract_with_header(input)
+
+      assert header =~ "version: 2"
+      assert header =~ "date: 2025-01-15"
+      assert content == "The prompt content."
+    end
+
+    test "returns original as header when no markers" do
+      input = "no markers here"
+      {header, content} = PromptLoader.extract_with_header(input)
+
+      assert header == "no markers here"
+      assert content == "no markers here"
+    end
+
+    test "handles only start marker (no end)" do
+      input = "header text<!-- PTC_PROMPT_START -->content"
+      {header, content} = PromptLoader.extract_with_header(input)
+
+      assert header == "header text"
+      assert content == "content"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Created `PtcRunner.PromptLoader` module to centralize prompt content extraction between `<!-- PTC_PROMPT_START -->` and `<!-- PTC_PROMPT_END -->` markers
- Removed duplicate `@extract_prompt_content` anonymous function from `JsonMode` and `TurnFeedback`
- Replaced inline extraction logic in `LanguageSpec` with `PromptLoader.extract_with_header/1`
- Added unit tests and doctests for the new module

## Test plan

- [x] All 3860+ existing tests pass (verified with `mix precommit`)
- [x] New doctests cover basic extraction scenarios
- [x] New unit tests cover edge cases (empty content, missing markers, header extraction)

Closes #733

🤖 Generated with [Claude Code](https://claude.com/claude-code)