### PR TITLE
feat(loop): accept last expression as return value on budget exhaustion

### DIFF
--- a/test/ptc_runner/sub_agent/loop_collect_messages_test.exs
+++ b/test/ptc_runner/sub_agent/loop_collect_messages_test.exs
@@ -78,9 +78,12 @@ defmodule PtcRunner.SubAgent.LoopCollectMessagesTest do
     end
 
     test "error path (max_turns exceeded) collects messages" do
-      agent = test_agent(max_turns: 2)
+      # Uses a signature that the expression result doesn't match, preventing
+      # the fallback recovery from triggering (fallback validates against signature)
+      agent = test_agent(max_turns: 2, signature: "{result :string}")
 
       llm = fn _ ->
+        # Returns integer, doesn't match {result :string} signature
         {:ok, "```clojure\n(+ 1 2)\n```"}
       end
 

--- a/test/ptc_runner/sub_agent/loop_return_retries_test.exs
+++ b/test/ptc_runner/sub_agent/loop_return_retries_test.exs
@@ -338,11 +338,15 @@ defmodule PtcRunner.SubAgent.LoopReturnRetriesTest do
       # Bug scenario: LLM ignores must-return warning and returns expression
       # instead of calling (return ...). With return_retries > 0, the loop
       # should properly decrement retry_turns_remaining and terminate.
+      #
+      # Uses a signature that the expression result doesn't match, preventing
+      # the fallback recovery from triggering (fallback validates against signature)
       agent =
         SubAgent.new(
           prompt: "Return a value",
           max_turns: 1,
-          return_retries: 2
+          return_retries: 2,
+          signature: "{result :string}"
         )
 
       turn_counter = :counters.new(1, [:atomics])
@@ -352,6 +356,7 @@ defmodule PtcRunner.SubAgent.LoopReturnRetriesTest do
         :counters.put(turn_counter, 1, turn)
 
         # Always return expression without (return ...) - ignoring must-return
+        # Returns integer, doesn't match {result :string} signature
         {:ok, "```clojure\n(+ 1 #{turn})\n```"}
       end
 


### PR DESCRIPTION
## Summary

- Implements fallback mechanism to recover valid expression results when budget is exhausted
- Searches for the most recent successful turn with non-nil result
- Normalizes keys from Clojure-style hyphens to Elixir-style underscores
- Validates against the agent's signature before accepting
- Uses turn.memory from the successful turn for memory consistency
- Adds `fallback_used: true` to step.usage for observability

## Test plan

- [x] Normal fallback (valid result matches signature)
- [x] Validation failure (result doesn't match signature)
- [x] No successful turns (all turns failed)
- [x] Nil result skipped (println returns nil)
- [x] Key normalization (hyphenated keys converted)
- [x] Memory consistency (uses turn.memory)
- [x] Metadata marking (fallback_used present)
- [x] Explicit return still works normally (no fallback triggered)
- [x] Fallback works with return_retries > 0

Closes #744

🤖 Generated with [Claude Code](https://claude.com/claude-code)