### PR TITLE
feat(budget): add introspection and callback for RLM patterns (#761)

### DIFF
--- a/lib/ptc_runner/lisp.ex
+++ b/lib/ptc_runner/lisp.ex
@@ -52,6 +52,7 @@ defmodule PtcRunner.Lisp do
     - `:max_symbols` - Max unique symbols/keywords allowed (default: 10_000)
     - `:max_print_length` - Max characters per `println` call (default: 2000)
     - `:filter_context` - Filter context to only include accessed data keys (default: true)
+    - `:budget` - Budget info map for `(budget/remaining)` introspection (default: nil)
 
   ## Return Value
 
@@ -136,6 +137,7 @@ defmodule PtcRunner.Lisp do
     turn_history = Keyword.get(opts, :turn_history, [])
     max_print_length = Keyword.get(opts, :max_print_length)
     filter_context = Keyword.get(opts, :filter_context, true)
+    budget = Keyword.get(opts, :budget)
 
     # Normalize tools to Tool structs
     with {:ok, normalized_tools} <- normalize_tools(raw_tools),
@@ -176,7 +178,8 @@ defmodule PtcRunner.Lisp do
         max_symbols: max_symbols,
         turn_history: turn_history,
         max_print_length: max_print_length,
-        filter_context: filter_context
+        filter_context: filter_context,
+        budget: budget
       }
 
       execute_program(source, opts)
@@ -203,7 +206,8 @@ defmodule PtcRunner.Lisp do
       max_symbols: max_symbols,
       turn_history: turn_history,
       max_print_length: max_print_length,
-      filter_context: filter_context
+      filter_context: filter_context,
+      budget: budget
     } = opts
 
     with {:ok, raw_ast} <- Parser.parse(source),
@@ -216,8 +220,10 @@ defmodule PtcRunner.Lisp do
       # Build Context for sandbox (turn_history passed for completeness, used via eval_fn)
       context = PtcRunner.Context.new(filtered_ctx, memory, normalized_tools, turn_history)
 
-      # Build eval options (only include max_print_length if set)
-      eval_opts = if max_print_length, do: [max_print_length: max_print_length], else: []
+      # Build eval options (only include options if set)
+      eval_opts =
+        [max_print_length: max_print_length, budget: budget]
+        |> Enum.reject(fn {_k, v} -> is_nil(v) end)
 
       # Wrapper to adapt Lisp eval signature to sandbox's expected (ast, context) -> result
       eval_fn = fn _ast, sandbox_context ->

--- a/lib/ptc_runner/lisp/eval.ex
+++ b/lib/ptc_runner/lisp/eval.ex
@@ -88,6 +88,15 @@ defmodule PtcRunner.Lisp.Eval do
   end
 
   # ============================================================
+  # Budget introspection: (budget/remaining)
+  # ============================================================
+
+  # Returns the budget info map, or empty map if running standalone (not in SubAgent loop)
+  defp do_eval({:budget_remaining}, %EvalContext{budget: budget} = eval_ctx) do
+    {:ok, budget || %{}, eval_ctx}
+  end
+
+  # ============================================================
   # Literals
   # ============================================================
 

--- a/lib/ptc_runner/lisp/eval/context.ex
+++ b/lib/ptc_runner/lisp/eval/context.ex
@@ -26,6 +26,7 @@ defmodule PtcRunner.Lisp.Eval.Context do
     :env,
     :tool_exec,
     :turn_history,
+    :budget,
     iteration_count: 0,
     loop_limit: 1000,
     max_print_length: @default_print_length,
@@ -59,6 +60,7 @@ defmodule PtcRunner.Lisp.Eval.Context do
           env: map(),
           tool_exec: (String.t(), map() -> term()),
           turn_history: list(),
+          budget: map() | nil,
           iteration_count: integer(),
           loop_limit: integer(),
           max_print_length: pos_integer(),
@@ -72,6 +74,7 @@ defmodule PtcRunner.Lisp.Eval.Context do
   ## Options
 
   - `:max_print_length` - Max characters per `println` call (default: #{@default_print_length})
+  - `:budget` - Budget info map for `(budget/remaining)` introspection (default: nil)
 
   ## Examples
 
@@ -83,6 +86,10 @@ defmodule PtcRunner.Lisp.Eval.Context do
       iex> ctx.max_print_length
       500
 
+      iex> ctx = PtcRunner.Lisp.Eval.Context.new(%{}, %{}, %{}, fn _, _ -> nil end, [], budget: %{turns: 10})
+      iex> ctx.budget
+      %{turns: 10}
+
   """
   @spec new(map(), map(), map(), (String.t(), map() -> term()), list(), keyword()) :: t()
   def new(ctx, user_ns, env, tool_exec, turn_history, opts \\ []) do
@@ -93,6 +100,7 @@ defmodule PtcRunner.Lisp.Eval.Context do
       tool_exec: tool_exec,
       turn_history: turn_history,
       max_print_length: Keyword.get(opts, :max_print_length, @default_print_length),
+      budget: Keyword.get(opts, :budget),
       prints: [],
       tool_calls: []
     }

--- a/test/ptc_runner/lisp/budget_remaining_test.exs
+++ b/test/ptc_runner/lisp/budget_remaining_test.exs
@@ -1,0 +1,136 @@
+defmodule PtcRunner.Lisp.BudgetRemainingTest do
+  @moduledoc """
+  Tests for the (budget/remaining) primitive.
+
+  This primitive allows PTC-Lisp programs to query their remaining budget,
+  enabling intelligent resource allocation decisions in RLM patterns.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias PtcRunner.Lisp
+
+  describe "(budget/remaining)" do
+    test "returns budget map when budget is provided" do
+      budget = %{
+        turns: 15,
+        "work-turns": 10,
+        "retry-turns": 5,
+        depth: %{current: 1, max: 3},
+        tokens: %{
+          input: 5000,
+          output: 2000,
+          total: 7000,
+          "cache-creation": 1000,
+          "cache-read": 2000
+        },
+        "llm-requests": 3
+      }
+
+      {:ok, step} = Lisp.run("(budget/remaining)", budget: budget)
+
+      assert step.return == budget
+    end
+
+    test "returns empty map when running standalone (no SubAgent)" do
+      {:ok, step} = Lisp.run("(budget/remaining)")
+
+      assert step.return == %{}
+    end
+
+    test "budget map can be accessed with keywords" do
+      budget = %{
+        turns: 15,
+        "work-turns": 10
+      }
+
+      {:ok, step} = Lisp.run("(:turns (budget/remaining))", budget: budget)
+
+      assert step.return == 15
+    end
+
+    test "budget map can be used in conditional logic" do
+      budget = %{turns: 5}
+
+      {:ok, step} =
+        Lisp.run(
+          """
+          (if (< (:turns (budget/remaining)) 10)
+            :low-budget
+            :high-budget)
+          """,
+          budget: budget
+        )
+
+      # Note: PTC-Lisp uses hyphenated keywords (Clojure-style)
+      assert step.return == :"low-budget"
+    end
+
+    test "budget map with nil values returns empty map" do
+      {:ok, step} = Lisp.run("(budget/remaining)", budget: nil)
+
+      assert step.return == %{}
+    end
+
+    test "nested field access works on budget map" do
+      budget = %{
+        depth: %{current: 2, max: 5}
+      }
+
+      {:ok, step} =
+        Lisp.run(
+          """
+          (let [b (budget/remaining)]
+            (:current (:depth b)))
+          """,
+          budget: budget
+        )
+
+      assert step.return == 2
+    end
+
+    test "budget can be used to decide processing strategy" do
+      # Simulating an RLM pattern where agent chooses between batch and individual processing
+      low_budget = %{turns: 3}
+      high_budget = %{turns: 20}
+
+      code = """
+      (let [b (budget/remaining)
+            items [1 2 3 4 5]]
+        (if (< (:turns b) (count items))
+          :batch-mode
+          :individual-mode))
+      """
+
+      {:ok, low_step} = Lisp.run(code, budget: low_budget)
+      {:ok, high_step} = Lisp.run(code, budget: high_budget)
+
+      # Note: PTC-Lisp uses hyphenated keywords (Clojure-style)
+      assert low_step.return == :"batch-mode"
+      assert high_step.return == :"individual-mode"
+    end
+  end
+
+  describe "analyzer: budget namespace" do
+    test "parses budget/remaining correctly" do
+      {:ok, step} = Lisp.run("budget/remaining", budget: %{turns: 10})
+
+      assert step.return == %{turns: 10}
+    end
+
+    test "rejects unknown budget functions with helpful error" do
+      {:error, step} = Lisp.run("budget/other")
+
+      assert step.fail.reason == :invalid_form
+      assert step.fail.message =~ "Unknown budget function: budget/other"
+      assert step.fail.message =~ "Available: budget/remaining"
+    end
+
+    test "rejects budget/foo with helpful error" do
+      {:error, step} = Lisp.run("budget/foo")
+
+      assert step.fail.reason == :invalid_form
+      assert step.fail.message =~ "Unknown budget function: budget/foo"
+    end
+  end
+end

--- a/test/ptc_runner/sub_agent/budget_callback_test.exs
+++ b/test/ptc_runner/sub_agent/budget_callback_test.exs
@@ -1,0 +1,258 @@
+defmodule PtcRunner.SubAgent.BudgetCallbackTest do
+  @moduledoc """
+  Tests for budget callback functionality in SubAgent.
+
+  Budget callbacks allow operators to set hard limits with configurable behavior
+  when those limits are exceeded.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias PtcRunner.SubAgent
+
+  # Helper to create a mock LLM that returns valid code
+  defp make_llm(responses) when is_list(responses) do
+    agent = Agent.start_link(fn -> responses end) |> elem(1)
+
+    fn _input ->
+      response = Agent.get_and_update(agent, fn [h | t] -> {h, t ++ [h]} end)
+
+      {:ok,
+       %{
+         content: response,
+         tokens: %{input: 1000, output: 500}
+       }}
+    end
+  end
+
+  defp make_llm(response) when is_binary(response) do
+    fn _input ->
+      {:ok,
+       %{
+         content: response,
+         tokens: %{input: 1000, output: 500}
+       }}
+    end
+  end
+
+  describe "token_limit option" do
+    test "loop continues when under token limit" do
+      agent = SubAgent.new(prompt: "Test", max_turns: 2)
+
+      llm =
+        make_llm([
+          "(+ 1 1)",
+          "(return 42)"
+        ])
+
+      # High token limit should not trigger
+      {:ok, step} = SubAgent.run(agent, llm: llm, token_limit: 100_000)
+
+      assert step.return == 42
+    end
+
+    test "loop stops when token limit exceeded with on_budget_exceeded: :fail" do
+      agent = SubAgent.new(prompt: "Test", max_turns: 5)
+
+      # This LLM returns 1500 tokens per call (1000 input + 500 output)
+      # After 1 call: 1500 tokens total
+      llm =
+        make_llm([
+          "(+ 1 1)",
+          "(+ 2 2)",
+          "(return 42)"
+        ])
+
+      # Very low token limit - should trigger after first call
+      {:error, step} = SubAgent.run(agent, llm: llm, token_limit: 1000, on_budget_exceeded: :fail)
+
+      assert step.fail.reason == :budget_callback_exceeded
+      assert step.fail.message =~ "Budget exceeded"
+    end
+
+    test "loop stops with :return_partial and uses last successful expression" do
+      agent = SubAgent.new(prompt: "Test", max_turns: 5)
+
+      llm =
+        make_llm([
+          # First turn returns a valid value but doesn't call (return)
+          # Code must start with ( or be in a code block
+          "(identity {:computed 42})",
+          # Second turn - budget exceeded after this
+          "(identity {:computed 100})",
+          # Won't reach this
+          "(return 200)"
+        ])
+
+      # Token limit will trigger after second call (each call is 1500 tokens)
+      # After 2 calls: 3000 tokens total, which exceeds 2500 limit
+      {:ok, step} =
+        SubAgent.run(agent, llm: llm, token_limit: 2500, on_budget_exceeded: :return_partial)
+
+      # Should return the last successful expression result from turn 1
+      # (turn 2 result hasn't been recorded when budget check triggers)
+      assert step.return == %{"computed" => 42}
+      assert step.usage.fallback_used == true
+    end
+
+    test "returns error when :return_partial has no valid fallback" do
+      # Budget exceeded on first call means no previous result to fall back to
+      agent = SubAgent.new(prompt: "Test", max_turns: 3, tools: %{"noop" => fn _ -> :ok end})
+
+      llm =
+        make_llm([
+          "(+ 1 1)",
+          "(+ 2 2)"
+        ])
+
+      {:error, step} =
+        SubAgent.run(agent,
+          llm: llm,
+          token_limit: 100,
+          on_budget_exceeded: :return_partial
+        )
+
+      # Budget exceeded before any turn completed, so no fallback available
+      assert step.fail.reason == :budget_callback_exceeded
+    end
+  end
+
+  describe "budget callback function" do
+    test "callback receives usage map with token counts" do
+      agent = SubAgent.new(prompt: "Test", max_turns: 2)
+
+      received_usage = Agent.start_link(fn -> nil end) |> elem(1)
+
+      callback = fn usage ->
+        Agent.update(received_usage, fn _ -> usage end)
+        :continue
+      end
+
+      llm = make_llm("(return 42)")
+
+      {:ok, _step} = SubAgent.run(agent, llm: llm, budget: callback)
+
+      usage = Agent.get(received_usage, & &1)
+
+      assert is_map(usage)
+      assert Map.has_key?(usage, :total_tokens)
+      assert Map.has_key?(usage, :input_tokens)
+      assert Map.has_key?(usage, :output_tokens)
+      assert Map.has_key?(usage, :llm_requests)
+    end
+
+    test "callback returning :stop terminates loop" do
+      agent = SubAgent.new(prompt: "Test", max_turns: 5)
+
+      # Stop after first call
+      call_count = Agent.start_link(fn -> 0 end) |> elem(1)
+
+      callback = fn _usage ->
+        count = Agent.get_and_update(call_count, fn c -> {c, c + 1} end)
+        if count >= 1, do: :stop, else: :continue
+      end
+
+      llm =
+        make_llm([
+          "(+ 1 1)",
+          "(+ 2 2)",
+          "(return 42)"
+        ])
+
+      {:error, step} = SubAgent.run(agent, llm: llm, budget: callback)
+
+      # Should have stopped due to callback
+      assert step.fail.reason == :budget_callback_exceeded
+    end
+
+    test "callback returning :continue allows loop to proceed" do
+      agent = SubAgent.new(prompt: "Test", max_turns: 3)
+
+      callback = fn _usage -> :continue end
+
+      llm =
+        make_llm([
+          "(+ 1 1)",
+          "(return 42)"
+        ])
+
+      {:ok, step} = SubAgent.run(agent, llm: llm, budget: callback)
+
+      assert step.return == 42
+    end
+
+    test "callback takes precedence over token_limit" do
+      agent = SubAgent.new(prompt: "Test", max_turns: 5)
+
+      # Callback always continues, even with low token limit
+      callback = fn _usage -> :continue end
+
+      llm =
+        make_llm([
+          "(+ 1 1)",
+          "(return 42)"
+        ])
+
+      # Would normally trigger due to low limit
+      {:ok, step} = SubAgent.run(agent, llm: llm, token_limit: 100, budget: callback)
+
+      # But callback says continue, so it succeeds
+      assert step.return == 42
+    end
+
+    test "callback can use llm_requests to limit API calls" do
+      agent = SubAgent.new(prompt: "Test", max_turns: 10)
+
+      # Stop after 2 LLM requests
+      callback = fn usage ->
+        if usage.llm_requests >= 2, do: :stop, else: :continue
+      end
+
+      llm =
+        make_llm([
+          "(+ 1 1)",
+          "(+ 2 2)",
+          "(+ 3 3)",
+          "(return 42)"
+        ])
+
+      {:error, step} = SubAgent.run(agent, llm: llm, budget: callback)
+
+      assert step.fail.reason == :budget_callback_exceeded
+      # Should have stopped after 2 requests
+      assert step.usage.llm_requests == 2
+    end
+  end
+
+  describe "on_budget_exceeded option" do
+    test "defaults to :fail" do
+      agent = SubAgent.new(prompt: "Test", max_turns: 5)
+
+      llm =
+        make_llm([
+          "(+ 1 1)",
+          "(+ 2 2)"
+        ])
+
+      # Should fail by default
+      {:error, step} = SubAgent.run(agent, llm: llm, token_limit: 1000)
+
+      assert step.fail.reason == :budget_callback_exceeded
+    end
+
+    test ":fail returns error step" do
+      agent = SubAgent.new(prompt: "Test", max_turns: 5)
+
+      llm =
+        make_llm([
+          "(+ 1 1)",
+          "(+ 2 2)"
+        ])
+
+      {:error, step} = SubAgent.run(agent, llm: llm, token_limit: 1000, on_budget_exceeded: :fail)
+
+      assert step.fail.reason == :budget_callback_exceeded
+      assert step.fail.message =~ "Budget exceeded"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add `(budget/remaining)` primitive for PTC-Lisp budget introspection
- Add `token_limit`, `budget` callback, and `on_budget_exceeded` runtime options for hard budget enforcement
- Enable RLM agents to make intelligent resource allocation decisions

## Details

### Part 1: `(budget/remaining)` Primitive

Returns budget state map for agent introspection:

```clojure
{:turns 15
 :work-turns 10
 :retry-turns 5
 :depth {:current 1 :max 3}
 :tokens {:input 5000 :output 2000 :total 7000 :cache-creation 1000 :cache-read 2000}
 :llm-requests 3}
```

- Uses hyphenated keys (idiomatic PTC-Lisp/Clojure style)
- Returns empty map when running standalone (not in SubAgent loop)
- 1-based depth counting for intuitive reasoning

### Part 2: Budget Callback

Operator-level enforcement with configurable behavior:

```elixir
# Simple token limit
SubAgent.run(agent, llm: llm, token_limit: 100_000, on_budget_exceeded: :return_partial)

# Custom callback
SubAgent.run(agent, llm: llm,
  budget: fn usage ->
    cond do
      usage.total_tokens > 100_000 -> :stop
      usage.llm_requests > 50 -> :stop
      true -> :continue
    end
  end
)
```

- `token_limit` - Max total tokens before triggering
- `budget` - Custom callback receiving usage map (Elixir-style underscored keys)
- `on_budget_exceeded` - `:fail` (default) or `:return_partial`

## Test plan

- [x] Unit tests for `(budget/remaining)` primitive (10 tests)
- [x] Unit tests for budget callback functionality (11 tests)
- [x] Full test suite passes (3907 tests)
- [x] Credo strict mode passes
- [x] Dialyzer passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)