### PR TITLE
feat(lisp): add mapcat function for map-and-flatten operations

### DIFF
--- a/docs/ptc-lisp-specification.md
+++ b/docs/ptc-lisp-specification.md
@@ -1260,6 +1260,7 @@ This design eliminates the need to manually convert JSON responses to atom-keyed
 | `map` | `(map f coll)` | Apply f to each item |
 | `map` | `(map f c1 c2)` | Apply f to pairs from c1, c2 |
 | `map` | `(map f c1 c2 c3)` | Apply f to triples |
+| `mapcat` | `(mapcat f coll)` | Apply f to each item, concatenate results |
 | `pmap` | `(pmap f coll)` | Apply f to each item in parallel |
 | `pcalls` | `(pcalls f1 f2 ...)` | Execute thunks in parallel |
 | `mapv` | `(mapv f coll)` | Like map, returns vector |
@@ -1271,6 +1272,7 @@ This design eliminates the need to manually convert JSON responses to atom-keyed
 
 ```clojure
 (map :name users)                    ; extract :name from each
+(mapcat (fn [x] [x (* x 2)]) [1 2 3])  ; => [1 2 2 4 3 6] (map + flatten)
 (pmap :name users)                   ; same, but parallel execution
 (pcalls #(tool/get-user) #(tool/get-stats))  ; parallel heterogeneous calls
 (mapv :name users)                   ; same, ensures vector
@@ -1285,6 +1287,11 @@ This design eliminates the need to manually convert JSON responses to atom-keyed
 
 ;; 3-collection map requires explicit closure for variadic ops
 (map (fn [a b c] (+ a b c)) [1 2] [10 20] [100 200])  ; => [111 222]
+
+;; mapcat - apply function and concatenate results (flat_map)
+(mapcat (fn [x] (range 0 x)) [2 3 1])   ; => [0 1 0 1 2 0]
+(mapcat identity [[1 2] [3 4] [5]])     ; => [1 2 3 4 5] (flatten one level)
+(mapcat (fn [x] (if (> x 0) [x] [])) [-1 2 -3 4])  ; => [2 4] (filter + flatten)
 ```
 
 **Limitation:** Variadic builtins (`+`, `*`, `str`) don't work directly with 3-collection map—use explicit closures. See [#668](https://github.com/andreasronge/ptc_runner/issues/668).

--- a/lib/ptc_runner/lisp/env.ex
+++ b/lib/ptc_runner/lisp/env.ex
@@ -215,6 +215,7 @@ defmodule PtcRunner.Lisp.Env do
       {:map, {:multi_arity, :map, {&Runtime.map/2, &Runtime.map/3, &Runtime.map/4}}},
       {:mapv, {:multi_arity, :mapv, {&Runtime.mapv/2, &Runtime.mapv/3, &Runtime.mapv/4}}},
       {:"map-indexed", {:normal, &Runtime.map_indexed/2}},
+      {:mapcat, {:normal, &Runtime.mapcat/2}},
       {:pluck, {:normal, &Runtime.pluck/2}},
       {:sort, {:multi_arity, :sort, {&Runtime.sort/1, &Runtime.sort/2}}},
       # sort-by: 2-arity (key, coll) or 3-arity (key, comparator, coll)

--- a/lib/ptc_runner/lisp/runtime.ex
+++ b/lib/ptc_runner/lisp/runtime.ex
@@ -46,6 +46,7 @@ defmodule PtcRunner.Lisp.Runtime do
   defdelegate mapv(f, coll), to: Collection
   defdelegate mapv(f, coll1, coll2), to: Collection
   defdelegate mapv(f, coll1, coll2, coll3), to: Collection
+  defdelegate mapcat(f, coll), to: Collection
   defdelegate map_indexed(f, coll), to: Collection
   defdelegate pluck(key, coll), to: Collection
   defdelegate sort(coll), to: Collection


### PR DESCRIPTION
## Summary

- Implements Clojure-style `mapcat` function that applies a function to each element of a collection and concatenates the results into a flat list
- Works with lists, strings (graphemes), sets, and maps
- Supports keywords as extractors for nested lists (e.g., `(mapcat :tags posts)`)

## Examples

```clojure
(mapcat (fn [x] [x (* x 2)]) [1 2 3])  ; => [1 2 2 4 3 6]
(mapcat :tags posts)                   ; flatten nested tags
(mapcat identity [[1 2] [3]])          ; => [1 2 3]
(mapcat (fn [x] (range 0 x)) [2 3 1])  ; => [0 1 0 1 2 0]
```

## Test plan

- [x] Basic mapcat with vector-returning function
- [x] Mapcat with range
- [x] Mapcat with identity (flatten one level)
- [x] Mapcat with empty/nil collections
- [x] Mapcat with function returning empty vectors (filter behavior)
- [x] Mapcat with keyword extracts nested values
- [x] Mapcat with anonymous function creating pairs
- [x] Mapcat in threading macros
- [x] Mapcat with closure capturing scope
- [x] Mapcat on strings (graphemes)
- [x] Mapcat on sets
- [x] Mapcat on maps with key-value pairs
- [x] Practical example: flatten nested tags

Closes #770

🤖 Generated with [Claude Code](https://claude.com/claude-code)