### PR TITLE
Fix nil-as-empty-collection semantics for count, reduce, assoc

### DIFF
--- a/lib/ptc_runner/lisp/runtime/collection.ex
+++ b/lib/ptc_runner/lisp/runtime/collection.ex
@@ -516,6 +516,7 @@ defmodule PtcRunner.Lisp.Runtime.Collection do
   # Count
   # ============================================================
 
+  def count(nil), do: 0
   def count(%MapSet{} = set), do: MapSet.size(set)
   def count(coll) when is_binary(coll), do: String.length(coll)
   def count(coll) when is_list(coll) or is_map(coll), do: Enum.count(coll)
@@ -564,6 +565,8 @@ defmodule PtcRunner.Lisp.Runtime.Collection do
   # ============================================================
 
   # reduce with 2 args: (reduce f coll) - uses first element as initial value
+  def reduce(_f, nil), do: nil
+
   def reduce(f, coll) when is_list(coll) do
     case coll do
       [] -> nil
@@ -596,6 +599,8 @@ defmodule PtcRunner.Lisp.Runtime.Collection do
   end
 
   # reduce with 3 args: (reduce f init coll)
+  def reduce(_f, init, nil), do: init
+
   def reduce(f, init, coll) when is_list(coll) do
     Enum.reduce(coll, init, fn elem, acc -> Callable.call(f, [acc, elem]) end)
   end

--- a/lib/ptc_runner/lisp/runtime/map_ops.ex
+++ b/lib/ptc_runner/lisp/runtime/map_ops.ex
@@ -100,6 +100,10 @@ defmodule PtcRunner.Lisp.Runtime.MapOps do
       iex> PtcRunner.Lisp.Runtime.MapOps.assoc_variadic([%{}, :a, 1, :b, 2, :c, 3])
       %{a: 1, b: 2, c: 3}
   """
+  def assoc_variadic([nil | pairs]) when rem(length(pairs), 2) == 0 do
+    assoc_variadic([%{} | pairs])
+  end
+
   def assoc_variadic([m | pairs]) when is_map(m) and rem(length(pairs), 2) == 0 do
     pairs
     |> Enum.chunk_every(2)
@@ -127,6 +131,7 @@ defmodule PtcRunner.Lisp.Runtime.MapOps do
   end
 
   # Keep the 3-arg version for direct calls
+  def assoc(nil, k, v), do: %{k => v}
   def assoc(m, k, v) when is_map(m), do: Map.put(m, k, v)
 
   # List support - Clojure allows index == length for appending

--- a/test/ptc_runner/lisp/integration/collection_ops_test.exs
+++ b/test/ptc_runner/lisp/integration/collection_ops_test.exs
@@ -2610,4 +2610,35 @@ defmodule PtcRunner.Lisp.Integration.CollectionOpsTest do
       assert hd(result) |> length() == 2
     end
   end
+
+  # ============================================================
+  # Nil-as-empty-collection semantics (Clojure conformance)
+  # ============================================================
+
+  describe "nil collection semantics" do
+    test "count of nil returns 0" do
+      {:ok, %Step{return: result}} = Lisp.run(~S|(count nil)|)
+      assert result == 0
+    end
+
+    test "reduce 3-arity with nil collection returns init" do
+      {:ok, %Step{return: result}} = Lisp.run(~S|(reduce + 0 nil)|)
+      assert result == 0
+    end
+
+    test "reduce 2-arity with nil collection returns nil" do
+      {:ok, %Step{return: result}} = Lisp.run(~S|(reduce + nil)|)
+      assert result == nil
+    end
+
+    test "assoc on nil treats it as empty map" do
+      {:ok, %Step{return: result}} = Lisp.run(~S|(assoc nil :a 1)|)
+      assert result == %{a: 1}
+    end
+
+    test "assoc variadic on nil treats it as empty map" do
+      {:ok, %Step{return: result}} = Lisp.run(~S|(assoc nil :a 1 :b 2)|)
+      assert result == %{a: 1, b: 2}
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- Add nil clauses to `count`, `reduce` (2-arity and 3-arity), `assoc`, and `assoc_variadic` for Clojure conformance
- `(count nil)` → 0, `(reduce f nil)` → nil, `(reduce f init nil)` → init, `(assoc nil :a 1)` → `{:a 1}`
- Add integration tests covering all nil collection edge cases

Closes #861

## Test plan

- [x] All 5 nil-handling acceptance criteria verified with integration tests
- [x] All 4236 existing tests pass (0 failures)
- [x] Pre-commit checks pass (format, compile, credo, spec validation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)