### PR TITLE
perf(pre-push): tracked hook + docs-only short-circuit (Phase 0+1 of phased plan)

### DIFF
--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -9,6 +9,8 @@ the per-clone `.git/hooks/` directory). Today there is one:
   pushed and dirty path matches the strict allow-list documented in
   `Plans/pre-push-perf.md` §"Phase 1".
 
+> **Note:** The docs-only short-circuit requires Python 3 (`python3` on `PATH`). Without it the hook degrades gracefully to the full gate with no error, so contributors without Python 3 will simply never see the <0.5 s fast path.
+
 ## One-time setup per clone
 
 After cloning (or in any existing clone), point git at this directory:

--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -1,0 +1,82 @@
+# Tracked git hooks
+
+This directory holds the repo's git hooks as tracked files (rather than
+the per-clone `.git/hooks/` directory). Today there is one:
+
+- `pre-push` — runs `mix test --exclude clojure` and `mix dialyzer` for
+  each top-level Mix project (`.`, `mcp_server`, `ptc_viewer`), with a
+  docs-only short-circuit at the top that skips the gate when every
+  pushed and dirty path matches the strict allow-list documented in
+  `Plans/pre-push-perf.md` §"Phase 1".
+
+## One-time setup per clone
+
+After cloning (or in any existing clone), point git at this directory:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+Verify with:
+
+```bash
+git config --get core.hooksPath
+# → .githooks
+```
+
+This is per-clone (it lives in `.git/config`), so each contributor
+runs it once. Linked worktrees inherit the parent clone's setting —
+no extra step there.
+
+## Override: skip the docs-only short-circuit
+
+Set `FORCE_FULL_PRE_PUSH=1` to always run the full test/dialyzer gate,
+even when the diff is docs-only:
+
+```bash
+FORCE_FULL_PRE_PUSH=1 git push
+```
+
+Useful when you've changed a docs file that's read at runtime or
+doctested (the deny list catches the well-known cases, but the
+override is the explicit lever when you want belt-and-suspenders).
+
+## Gotcha: fresh clones need `mix deps.compile`
+
+A freshly cloned worktree (or a clone that's never run `mix compile`)
+will fail the mock-server tests during the gate with:
+
+```
+subprocess exited during handshake (status=1)
+```
+
+This is because `mcp_server`'s mock-server tests spawn helpers via
+`mix run --no-start --no-compile`, which does **not** side-load
+dependencies like `Jason`. The deps must be pre-compiled.
+
+Fix once after cloning:
+
+```bash
+mix deps.get
+mix deps.compile      # ← critical; `deps.get` alone is not enough
+(cd mcp_server && mix deps.get && mix deps.compile)
+(cd ptc_viewer && mix deps.get && mix deps.compile)
+```
+
+After that the hook (and `mix test`) work normally.
+
+## Allow-list summary
+
+Pushed/dirty paths matching these regexes are docs-only-eligible:
+
+- `^Plans/.*\.md$`
+- `^CHANGELOG\.md$`
+- `^LICENSES/MIT\.txt$`
+- `^\.gitignore$`
+- `^\.githooks/README\.md$`
+
+Everything else (including `README.md`, `docs/**.md`,
+`priv/prompts/**.md`, `usage-rules*.md`, all source code, configs,
+fixtures) falls through to the full gate. See
+`Plans/pre-push-perf.md` §"Phase 1" for the verified list of
+runtime-read / doctested markdown that the deny side protects.

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,327 @@
+#!/bin/bash
+# Pre-push hook — tracked under .githooks/ so it lives with the repo.
+#
+# Behavior:
+#   1. Docs-only short-circuit: if every file in the *combined* set
+#      (committed-diff against the remote + dirty worktree) matches the
+#      strict allow-list below, skip the test/dialyzer gate and exit 0.
+#   2. Otherwise: run `mix test --exclude clojure` and `mix dialyzer`
+#      for each top-level Mix project (".", "mcp_server", "ptc_viewer"),
+#      preserving the existing pre-push behavior.
+#
+# Override:
+#   FORCE_FULL_PRE_PUSH=1 git push  → always run the full gate, even if
+#   the docs-only check would have allowed a skip.
+#
+# Stdin contract (githooks(5)):
+#   <local-ref> <local-sha> <remote-ref> <remote-sha>\n  (one per ref)
+#
+# See Plans/pre-push-perf.md §"Phase 1" for design rationale, including
+# the allow-list / deny-list and the worktree-clean requirement.
+
+set -e
+
+# ----------------------------------------------------------------------
+# Step 1: Docs-only short-circuit (unless FORCE_FULL_PRE_PUSH=1).
+# ----------------------------------------------------------------------
+
+# Read stdin once. Pre-push hooks get ref tuples on stdin; if we don't
+# capture before invoking python we'd lose them. An empty stdin (e.g.
+# manual invocation with no piped input) is treated as "no committed
+# changes" and falls through to the dirty-worktree check.
+REFS_INPUT="$(cat || true)"
+
+if [ -z "${FORCE_FULL_PRE_PUSH:-}" ]; then
+  SHORT_CIRCUIT_RESULT=0
+  # Write the python helper to a temp file so its stdin stays free
+  # for the pushed-ref tuples. Piping the heredoc into `python3 -`
+  # would consume stdin with the script itself.
+  PY_TMP="$(mktemp -t pre-push-docs-only.XXXXXX.py)"
+  trap 'rm -f "$PY_TMP"' EXIT
+  cat > "$PY_TMP" <<'PYEOF'
+import os
+import re
+import subprocess
+import sys
+
+# Exit codes returned to the bash wrapper:
+#   0 → docs-only, skip the full gate.
+#   2 → not docs-only (or empty), run the full gate.
+#   1 → unexpected error; fail-safe by running the full gate.
+SKIP = 0
+RUN_FULL = 2
+
+# Strict allow-list (exact regexes against repo-relative paths).
+ALLOW_PATTERNS = [
+    re.compile(r"^Plans/.*\.md$"),
+    re.compile(r"^CHANGELOG\.md$"),
+    re.compile(r"^LICENSES/MIT\.txt$"),
+    re.compile(r"^\.gitignore$"),
+    re.compile(r"^\.githooks/README\.md$"),
+]
+
+
+def is_allowed(path):
+    return any(p.match(path) for p in ALLOW_PATTERNS)
+
+
+def run(args, **kwargs):
+    """Run a git command, returning (stdout_bytes, returncode)."""
+    proc = subprocess.run(
+        args,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        **kwargs,
+    )
+    return proc.stdout, proc.returncode
+
+
+def committed_paths(local_sha, remote_sha):
+    """Return the set of file paths changed in commits being pushed.
+
+    Handles the all-zeros remote-sha case (first push of a new branch)
+    by falling back to `origin/main..local_sha`. If `origin/main` does
+    not exist either, fall back to listing every commit reachable from
+    local_sha — conservative, but correct (we'd rather over-include and
+    run the full gate than under-include and skip it).
+    """
+    paths = set()
+
+    if set(remote_sha) == {"0"}:
+        # First push of this branch.
+        for base in ("origin/main", "origin/HEAD"):
+            _, rc = run(["git", "rev-parse", "--verify", base])
+            if rc == 0:
+                rev_range = f"{base}..{local_sha}"
+                break
+        else:
+            # No suitable upstream; fall back to all commits reachable.
+            rev_range = local_sha
+    else:
+        rev_range = f"{remote_sha}..{local_sha}"
+
+    out, rc = run(["git", "rev-list", rev_range])
+    if rc != 0:
+        # Range invalid (e.g., remote-sha not present locally). Be
+        # conservative: force full gate.
+        return None
+
+    commits = [c for c in out.decode().split("\n") if c]
+    if not commits:
+        return paths
+
+    # Use diff-tree per commit. Cheap and deterministic; avoids issues
+    # with merge commits and `--combined`.
+    for c in commits:
+        out, rc = run(
+            ["git", "diff-tree", "-r", "--name-only", "--no-commit-id", c]
+        )
+        if rc != 0:
+            return None
+        for line in out.decode().split("\n"):
+            line = line.strip()
+            if line:
+                paths.add(line)
+
+    return paths
+
+
+def dirty_paths():
+    """Return the set of dirty paths in the worktree, rename-aware.
+
+    Uses porcelain v1 with NUL delimiters so paths with spaces, quotes,
+    and renames are parsed safely. Both old and new paths of a rename
+    enter the dirty set — a rename `Plans/a.md → README.md` cannot
+    evade the deny by appearing only as a "new" path.
+    """
+    out, rc = run(
+        [
+            "git",
+            "status",
+            "--porcelain=v1",
+            "-z",
+            "--untracked-files=normal",
+        ]
+    )
+    if rc != 0:
+        return None
+
+    # Split on NUL, drop trailing empty.
+    fields = out.split(b"\x00")
+    if fields and fields[-1] == b"":
+        fields = fields[:-1]
+
+    paths = set()
+    i = 0
+    while i < len(fields):
+        entry = fields[i]
+        if not entry:
+            i += 1
+            continue
+        if len(entry) < 3:
+            i += 1
+            continue
+        status = entry[:2].decode()
+        path = entry[3:].decode()
+        # Porcelain v1 puts index status in column 0 and worktree
+        # status in column 1. Renames/copies can appear in either
+        # column ("R " staged, " R" unstaged-detected, "RR" both).
+        # When either column is R/C, the next NUL-record holds the
+        # *old* path.
+        if status[0] in "RC" or status[1] in "RC":
+            paths.add(path)  # new path
+            if i + 1 < len(fields):
+                paths.add(fields[i + 1].decode())  # old path
+            i += 2
+        else:
+            paths.add(path)
+            i += 1
+
+    return paths
+
+
+def main():
+    refs_input = sys.stdin.read()
+
+    committed = set()
+    if refs_input.strip():
+        for line in refs_input.split("\n"):
+            line = line.strip()
+            if not line:
+                continue
+            parts = line.split()
+            if len(parts) != 4:
+                # Malformed input — fail safe.
+                return RUN_FULL
+            _local_ref, local_sha, _remote_ref, remote_sha = parts
+            # Deletion: local_sha all zeros, nothing to push.
+            if set(local_sha) == {"0"}:
+                continue
+            paths = committed_paths(local_sha, remote_sha)
+            if paths is None:
+                return RUN_FULL
+            committed |= paths
+
+    dirty = dirty_paths()
+    if dirty is None:
+        return RUN_FULL
+
+    combined = committed | dirty
+
+    # Empty combined set → nothing to push *and* clean worktree.
+    # That can happen on a re-push of an already-pushed sha. Treat as
+    # docs-only-eligible: there's literally nothing to test.
+    non_allowed = [p for p in combined if not is_allowed(p)]
+
+    if non_allowed:
+        return RUN_FULL
+
+    return SKIP
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception as e:  # noqa: BLE001
+        # Anything unexpected → fail safe (run the full gate).
+        sys.stderr.write(f"pre-push docs-only check errored: {e}\n")
+        sys.exit(RUN_FULL)
+PYEOF
+
+  set +e
+  printf '%s' "$REFS_INPUT" | /usr/bin/env python3 "$PY_TMP"
+  SHORT_CIRCUIT_RESULT=$?
+  set -e
+  rm -f "$PY_TMP"
+  trap - EXIT
+
+  case "$SHORT_CIRCUIT_RESULT" in
+    0)
+      echo "📝 Docs-only push, skipping test/dialyzer gate (override: FORCE_FULL_PRE_PUSH=1)"
+      exit 0
+      ;;
+    2)
+      : # Fall through to the full gate.
+      ;;
+    *)
+      # Unexpected python failure — fail safe by running the full gate.
+      echo "⚠️  Docs-only check failed unexpectedly (exit=$SHORT_CIRCUIT_RESULT); running full gate."
+      ;;
+  esac
+fi
+
+# ----------------------------------------------------------------------
+# Step 2: Existing per-project test + dialyzer gate (unchanged behavior).
+# ----------------------------------------------------------------------
+
+echo "🔍 Running pre-push checks..."
+
+START_TIME=$(date +%s)
+
+PROJECTS=("." "mcp_server" "ptc_viewer")
+
+project_has_dep() {
+  local proj="$1" dep="$2"
+  grep -qE "\\{:${dep}," "${proj}/mix.exs" 2>/dev/null
+}
+
+run_project_gates() {
+  local proj="$1"
+  local label
+
+  if [ "$proj" = "." ]; then
+    label="root (:ptc_runner)"
+  else
+    label="$proj/"
+    [ -d "$proj" ] || return 0
+  fi
+
+  echo ""
+  echo "📦 Project: $label"
+
+  pushd "$proj" > /dev/null
+
+  echo "  ⏳ Running full test suite..."
+  if ! mix test --exclude clojure 2>&1; then
+    echo "  ❌ Tests failed in $label. Run: (cd $proj && mix test)"
+    popd > /dev/null
+    exit 1
+  fi
+  echo "  ✅ Tests passed"
+
+  # CWD is the project dir (we are inside `pushd "$proj"`), so check
+  # `./mix.exs` rather than `$proj/mix.exs`. Passing `$proj` here would
+  # resolve to `mcp_server/mcp_server/mix.exs` and silently skip
+  # dialyzer for non-root projects.
+  if project_has_dep "." "dialyxir"; then
+    echo "  ⏳ Running dialyzer (this may take a moment)..."
+    DIALYZER_OUTPUT=$(mix dialyzer 2>&1) || DIALYZER_EXIT=$?
+    DIALYZER_EXIT=${DIALYZER_EXIT:-0}
+
+    if [ "$DIALYZER_EXIT" -ne 0 ]; then
+      echo "  ❌ Dialyzer found errors in $label:"
+      echo "$DIALYZER_OUTPUT"
+      echo ""
+      echo "  Run: (cd $proj && mix dialyzer)"
+      popd > /dev/null
+      exit 1
+    fi
+    echo "  ✅ Dialyzer passed"
+    unset DIALYZER_EXIT
+  else
+    echo "  ⏭️  Dialyzer not declared in ${label}mix.exs"
+  fi
+
+  popd > /dev/null
+}
+
+for proj in "${PROJECTS[@]}"; do
+  run_project_gates "$proj"
+done
+
+END_TIME=$(date +%s)
+ELAPSED=$((END_TIME - START_TIME))
+
+echo ""
+echo "✅ All pre-push checks passed in ${ELAPSED}s"
+echo ""

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -79,14 +79,24 @@ def run(args, **kwargs):
 def committed_paths(local_sha, remote_sha):
     """Return the set of file paths changed in commits being pushed.
 
-    Handles the all-zeros remote-sha case (first push of a new branch)
-    by falling back to `origin/main..local_sha`. If `origin/main` does
-    not exist either, fall back to listing every commit reachable from
-    local_sha — conservative, but correct (we'd rather over-include and
-    run the full gate than under-include and skip it).
-    """
-    paths = set()
+    Uses the cumulative range diff `<base>..<local_sha>` rather than
+    iterating commits with `git diff-tree`. Per-commit diff-tree
+    silently emits nothing for merge commits unless `-m` is passed,
+    which can let a merge whose conflict resolution changes source
+    files slip past the docs-only check while every non-merge commit
+    in the range only touches allow-listed paths. The cumulative
+    range diff (`git diff A..B`) reflects merge-resolution changes
+    naturally because it compares tree B to tree A directly.
 
+    `--no-renames` decomposes renames into delete+add so both old
+    and new paths surface. The dirty-set parser already handles
+    rename-aware worktree state separately.
+
+    Handles the all-zeros remote-sha case (first push of a new
+    branch) by falling back to `origin/main..local_sha` or
+    `origin/HEAD..local_sha`. If neither exists, returns None to
+    force the full gate — conservative.
+    """
     if set(remote_sha) == {"0"}:
         # First push of this branch.
         for base in ("origin/main", "origin/HEAD"):
@@ -95,34 +105,24 @@ def committed_paths(local_sha, remote_sha):
                 rev_range = f"{base}..{local_sha}"
                 break
         else:
-            # No suitable upstream; fall back to all commits reachable.
-            rev_range = local_sha
+            # No suitable upstream; force full gate.
+            return None
     else:
         rev_range = f"{remote_sha}..{local_sha}"
 
-    out, rc = run(["git", "rev-list", rev_range])
+    out, rc = run(
+        ["git", "diff", "--name-only", "--no-renames", rev_range]
+    )
     if rc != 0:
-        # Range invalid (e.g., remote-sha not present locally). Be
-        # conservative: force full gate.
+        # Range invalid (e.g., remote-sha not present locally) or
+        # diff failed for any other reason. Be conservative.
         return None
 
-    commits = [c for c in out.decode().split("\n") if c]
-    if not commits:
-        return paths
-
-    # Use diff-tree per commit. Cheap and deterministic; avoids issues
-    # with merge commits and `--combined`.
-    for c in commits:
-        out, rc = run(
-            ["git", "diff-tree", "-r", "--name-only", "--no-commit-id", c]
-        )
-        if rc != 0:
-            return None
-        for line in out.decode().split("\n"):
-            line = line.strip()
-            if line:
-                paths.add(line)
-
+    paths = set()
+    for line in out.decode().split("\n"):
+        line = line.strip()
+        if line:
+            paths.add(line)
     return paths
 
 

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -39,7 +39,6 @@ if [ -z "${FORCE_FULL_PRE_PUSH:-}" ]; then
   PY_TMP="$(mktemp -t pre-push-docs-only.XXXXXX.py)"
   trap 'rm -f "$PY_TMP"' EXIT
   cat > "$PY_TMP" <<'PYEOF'
-import os
 import re
 import subprocess
 import sys

--- a/Plans/pre-push-perf.md
+++ b/Plans/pre-push-perf.md
@@ -60,6 +60,23 @@ re-reviewed by codex; 9 further issues found. All addressed:
   state is a per-test-spawn invariant; partially exempting it
   without a defined reset proof was incoherent.
 
+**Revision 3 (2026-05-09, post-codex re-re-review):** revision 2
+re-reviewed; 1× `[P1]` and 2× `[P2]` issues. All addressed:
+- Phase 1 rename parser corrected: `status[0] in "RC"` → check both
+  status columns. Porcelain v1 puts index status in column 0 and
+  worktree status in column 1; renames can appear in either, and
+  the previous parser missed unstaged-detected renames (` R`/` C`).
+- Phase 1 markdown-reader inventory expanded with
+  `lib/ptc_runner/prompt_loader.ex:11`, `usage-rules*.md` via
+  `test/usage_rules_test.exs`, and an
+  `lib/ptc_runner/lisp/registry.ex` `@external_resource`.
+- Phase 1 explicit deny list now includes `usage-rules.md` and
+  `usage-rules/*.md`.
+- Phase 3 made explicit: `mcp_server/mix.exs` has no `compilers:`
+  list and no `test` alias today. The plan now says creating one
+  is part of the work and recommends the `test` alias path with a
+  `Mix.Tasks.Compile.MockEscript` module as the default.
+
 ## Goal
 
 Reduce `git push origin main` wallclock from the current ~53 s while
@@ -153,11 +170,18 @@ allow-list-based docs-only gate can drop pure-docs pushes from
      `test/ptc_runner/lisp/spec_validator_test.exs:283`, by
      `lib/ptc_runner/lisp/spec_validator.ex:21`, and by
      `test/support/ptc_lisp_benchmark.ex:63`.
-   - `priv/prompts/*.md` files are read by
-     `lib/ptc_runner/prompts.ex:78`.
+   - `priv/prompts/*.md` files are read at compile time via
+     `@external_resource` chains in `lib/ptc_runner/prompts.ex:78`
+     (multiple files), and by direct `File.read!` in
+     `lib/ptc_runner/prompt_loader.ex:11`.
    - `mcp_server/priv/mcp_authoring_card.md` and
      `mcp_server/priv/mcp_aggregator_authoring_card.md` are read by
-     `mcp_server/lib/ptc_runner_mcp/tools.ex:50`.
+     `mcp_server/lib/ptc_runner_mcp/tools.ex:50` and `:63` via
+     `@external_resource`.
+   - `usage-rules.md` and `usage-rules/*.md` are read by
+     `test/usage_rules_test.exs:33`.
+   - `lib/ptc_runner/lisp/registry.ex:25` declares an
+     `@external_resource` on a registry markdown file.
    - `mcp_server/README.md` and `ptc_viewer/README.md` are *not*
      verified doctested today, but are conservatively denied (cheap
      defense; they may be added to a doctest target later).
@@ -202,8 +226,11 @@ allow-list-based docs-only gate can drop pure-docs pushes from
              continue
          status = entry[:2].decode()
          path = entry[3:].decode()
-         # Renames / copies: status is "R " or "C "; the next NUL-record is the old path.
-         if status[0] in "RC":
+         # Renames / copies. Porcelain v1 puts the index status in column 0
+         # and the worktree status in column 1. Renames can appear in either
+         # column ("R " for staged, " R" for unstaged-detected, "RR" for both).
+         # When either column is R/C, the next NUL-record holds the old path.
+         if status[0] in "RC" or status[1] in "RC":
              print(path)         # new path
              if i + 1 < len(buf):
                  print(buf[i + 1].decode())  # old path
@@ -229,6 +256,8 @@ allow-list-based docs-only gate can drop pure-docs pushes from
    **Explicit deny list** — verified read at runtime or doctested,
    *must* fall through to the full gate:
    - `^README\.md$` (doctested by `test/readme_test.exs`)
+   - `^usage-rules\.md$`, `^usage-rules/.*\.md$` (read by
+     `test/usage_rules_test.exs`)
    - `^docs/.*\.md$` (especially `docs/ptc-lisp-specification.md`)
    - `^priv/prompts/.*\.md$` (read by `lib/ptc_runner/prompts.ex`)
    - `^mcp_server/priv/.*\.md$` (read by
@@ -368,14 +397,35 @@ A. **Pre-compile mock_server to escript with deps bundled.** Static
    exec. **Build the artifact at compile time, not at test runtime
    — building inside `setup_all` or any test process re-introduces
    the mix/build-lock contention this phase exists to remove.**
-   Concrete options:
-   - A `compilers: [:mock_escript, ...]` entry in mcp_server's
-     `mix.exs` that depends on the `:elixir` compiler and builds
-     the escript before tests can start.
-   - A `mix.exs` task aliased into `test` so `mix test`
-     transparently builds first, then runs the suite.
-   - A static path under `mcp_server/test/support/_build/` checked
-     into the repo (rejected — escripts are platform-specific).
+
+   **Critical: the integration point doesn't exist yet.** Verified
+   2026-05-09: `mcp_server/mix.exs` has an `aliases/0` block with
+   only `precommit`, `mcp.start`, `mcp.run` — no `compilers:` list,
+   no `test` alias. Phase 3 must explicitly *create* whichever
+   integration point it picks. This is part of the work, not a
+   plug-in.
+
+   Concrete options (pick during execution):
+
+   1. **Add a `test` alias** in `mcp_server/mix.exs`:
+      ```elixir
+      defp aliases, do: [
+        precommit: [...existing...],
+        mcp.start: [...],
+        mcp.run: [...],
+        test: ["compile.mock_escript", "test"]   # NEW
+      ]
+      ```
+      Plus a small `Mix.Tasks.Compile.MockEscript` module in
+      `mcp_server/lib/mix/tasks/` that builds the escript only when
+      stale. Simplest. Recommended default.
+   2. **Add a `:mock_escript` entry to a `compilers:` list** in
+      `mcp_server/mix.exs`. Requires more boilerplate (the project
+      currently has no `compilers:` key, so Mix uses defaults; we'd
+      have to declare them all explicitly to add ours). Heavier;
+      only if option 1 turns out insufficient.
+   3. **Static path under `mcp_server/test/support/_build/`** —
+      rejected because escripts are platform-specific.
 B. **Replace `mix run`-port spawn with a Burrito-style standalone
    release** if deps are heavy. Bigger change; probably overkill.
 C. **Move tests that genuinely need a real subprocess to

--- a/Plans/pre-push-perf.md
+++ b/Plans/pre-push-perf.md
@@ -383,56 +383,156 @@ plus shell + mix-startup overhead).
 
 ### Approach
 
-1. **Measure first.** Before touching anything, run each project's
-   `mix test` and `mix dialyzer` concurrently in a scratch script and
-   measure wallclock vs sequential. If concurrent isn't actually
-   faster (e.g., they contend on the same `_build` symlink, hex
-   cache, or telemetry handlers), abort the phase before code lands.
-   Specifically watch for:
-   - `_build` lock contention between projects (each project has its
-     own `_build/dev` and `_build/test` directories — should be
-     fine, but verify with `lsof` or `fs_usage` while running).
-   - Hex cache contention (`mix deps.compile` writes to
-     `~/.hex/` — only an issue on a fresh clone, irrelevant once
-     deps are compiled).
-   - Telemetry / logger contention if processes write to the same
-     stderr/stdout (the hook captures combined output).
-2. **If measured win is ≥5 s on the test+dialyzer-bound path**,
-   refactor the hook to launch the three subproject loops as
-   background jobs and `wait` for all to finish. Capture each
-   project's output to a per-project temp file; on failure, dump the
-   relevant project's output and exit non-zero. On success, print
-   each project's `✅` summary in order.
-3. **Output ordering matters.** Sequential output is currently
-   readable — interleaved bg-job output is not. Buffer per-project
-   output to temp files; print them in deterministic order after all
-   jobs finish.
-4. **Failure semantics.** First failure cancels the others (or lets
-   them finish; pick one and document). Sequential's behavior is
-   "first failure aborts the rest"; concurrent's natural behavior
-   is "all run to completion, then report all failures." Pick "all
-   finish, report all failures" — strictly more useful for the
-   developer fixing things.
-5. **Update `.githooks/README.md`** with the new behavior + any
-   per-project temp-file paths a developer might want to inspect.
+1. **Measure first, with a precisely specified harness.** Before
+   touching the hook, write a scratch script that exactly mirrors the
+   intended runtime shape:
+
+   ```
+   for proj in . mcp_server ptc_viewer; do
+     ( cd "$proj" && mix test --exclude clojure && mix dialyzer ) &
+   done
+   wait
+   ```
+
+   Three background jobs, each doing test-then-dialyzer
+   sequentially **inside** the project. Not six fully-concurrent
+   commands. Compare against the current sequential loop on the
+   *same* machine, *same* load profile.
+
+   Required preconditions for the measurement to be meaningful:
+   - **Warm deps and PLT** for all three projects (`mix deps.compile`
+     and `mix dialyzer --plt` run once per project before timing).
+   - **Clean worktree** (no uncommitted changes touching tests,
+     no stale `_build` partial-compile state).
+   - **Phase21 flake fixed or excluded** from the timing test runs
+     (`fix/phase21-cascade-flake` PR must land first, or the timing
+     runs use `--exclude phase21_flake_tag`). Otherwise sporadic
+     test failures contaminate the measurement.
+   - **Quiet machine** — no other heavy tasks running during
+     timing. Use `time` repeatedly (≥5 runs each side) and report
+     median + p95.
+
+   If concurrent isn't faster on this harness, abort the phase
+   *before* refactoring the hook. Watch for these contention
+   sources during measurement:
+   - `_build` lock contention between projects (each has its own
+     `_build/{dev,test}` — should be fine; verify with `lsof` or
+     `fs_usage` while running).
+   - Hex cache contention (`~/.hex/` — only on fresh clones).
+   - CPU / scheduler saturation: 3 concurrent BEAM VMs can starve
+     each other on small machines. Median win on a 20-core box
+     might disappear on an 8-core box.
+   - Shared `System.tmp_dir!()` filename collisions if any tests
+     hardcode a path that collides across subprojects.
+   - Tests that mutate OS env via `System.put_env/2` — concurrent
+     mutation across BEAM VMs is fine (separate processes), but
+     concurrent mutation *within* the same VM (e.g., async tests
+     in the same project) was already a hazard. Confirm none cross
+     the VM boundary.
+   - Path-dep compile effects: if any of the three projects
+     `path:` to another at build time, parallel `mix test` may
+     trigger redundant or conflicting compile of the shared
+     source.
+
+2. **Decide whether to land based on a multi-criterion threshold,**
+   not a rigid ≥5 s rule:
+   - **Statistically repeatable positive median win** across the
+     ≥5 timing runs. Single-shot wins don't count.
+   - **No p95 regression.** If concurrent is faster on average
+     but tail-latency increases (e.g., one project occasionally
+     gets starved), the developer experience degrades.
+   - **Either** ≥5 s median improvement, **or** trivial
+     implementation (a 5-line refactor) with a stable smaller win.
+   - **No new flakes** introduced — concurrent execution must not
+     reveal a race that didn't exist sequentially.
+
+   If all four hold: land. Otherwise abort and document the
+   negative result so a future revision doesn't re-attempt this
+   phase blindly.
+
+3. **Refactor the hook to launch the three subproject loops as
+   background jobs and `wait` for all to finish.** Capture each
+   project's output to a per-project temp file via `mktemp`; clean
+   up on exit via `trap`.
+
+4. **Output semantics — decided.** The current hook streams full
+   command output as it runs. The new flow can't preserve that
+   without interleaving across projects. Choice (and rationale):
+   - **On failure:** dump the failing project's full captured
+     output, then any other failed projects' output, in
+     project-list order. Match the current hook's failure
+     verbosity.
+   - **On success:** print only each project's `✅` summary lines
+     (the same `Tests passed`, `Dialyzer passed` lines the
+     sequential hook prints), in project-list order. Drop the
+     verbose interleaved test output that's currently emitted.
+   - **`PRE_PUSH_VERBOSE=1` env var** opts back into full output
+     for debugging (dumps each project's full log even on success).
+
+   The success-path log loss is the actual behavior change; flag
+   it explicitly in the commit body and the README.
+
+5. **Failure semantics — decided.** Pick "all-finish + report-all"
+   over "first-failure-aborts-rest." Rationale: the developer
+   fixing pre-push failures benefits more from seeing every
+   project's failure in one cycle than from saving 10–20 s when
+   the hook would have aborted early. Document the trade in the
+   commit body. The exception: if a project's test run produces
+   destructive side effects (writing to shared dirs, mutating
+   OS-level state), abort early. None of the three projects do
+   this currently; verify before relying on it.
+
+6. **Match the current hook's project-list and dialyzer-skip
+   semantics exactly.** The new hook must:
+   - Process the same project list (`.`, `mcp_server`,
+     `ptc_viewer`) in the same order.
+   - Skip dialyzer for any project without `:dialyxir` declared
+     (matches the current `project_has_dep` check).
+   - Honor `FORCE_FULL_PRE_PUSH=1` and the docs-only short-circuit
+     from Phase 1 (no regression on the docs-only path —
+     verify by running the four Phase 1 acceptance cases against
+     the new hook).
+   - Exit non-zero on any project failure (preserve the existing
+     contract).
+
+7. **Update `.githooks/README.md`** with the new behavior, the
+   `PRE_PUSH_VERBOSE=1` opt-in, and any per-project temp-file
+   paths a developer might want to inspect during a failure.
 
 ### Acceptance
 
-- **Concurrent wallclock vs sequential, code-only push:** ≥5 s
-  drop. Measured before/after on the same machine, ideally same
-  load. Document the measurement.
-- **Output ordering preserved:** developer sees per-project
-  `✅`/`❌` summaries in the same order as today.
+- **Multi-criterion landing threshold (per Approach #2):**
+  - Statistically repeatable positive median win across ≥5 timing
+    runs each (sequential and concurrent).
+  - No p95 regression.
+  - Either ≥5 s median improvement, or trivial implementation
+    with a stable smaller win.
+  - No new flakes introduced.
+- **Output semantics — explicit:**
+  - On failure: full captured output of every failed project,
+    project-list order.
+  - On success: per-project `✅` summary lines only, project-list
+    order. Verbose stream available via `PRE_PUSH_VERBOSE=1`.
 - **Multi-failure case works:** if both root and `mcp_server` fail,
   both failure outputs are printed (not just the first).
 - **No false greens:** the hook still correctly exits non-zero on
   any subproject failure.
 - **No race condition between concurrent `mix dialyzer` runs.** If
   one is detected (PLT corruption, lock errors), the phase aborts
-  and the hook stays sequential.
+  and the hook stays sequential. Verify by 25 consecutive runs of
+  the new hook on a code-touching commit; any PLT lock error or
+  inconsistent dialyzer result reverts the phase.
+- **Project-list and dialyzer-skip semantics match the current
+  hook exactly.** Verify by inspecting each project's output: if
+  a project lacks `:dialyxir`, it must show `⏭️ Dialyzer not
+  declared`, identical to today.
+- **Phase 1 acceptance cases pass unchanged.** Re-run the four
+  Phase 1 acceptance cases (docs-only, source-touch, dirty-tree,
+  `FORCE_FULL_PRE_PUSH=1`) against the new hook. None should
+  regress.
 - **Worktree environment doc updated:** if the new flow needs any
-  new dependency (`mktemp`, `wait`, `xargs -P`), document any
-  unusual portability gotchas.
+  new dependency (`mktemp`, `wait`, `trap`), document any unusual
+  portability gotchas (e.g., bash 3.2 on stock macOS).
 
 ### Risk
 
@@ -440,15 +540,43 @@ plus shell + mix-startup overhead).
   fight over the dialyxir PLT cache. Mitigation: per-project
   `_build` already gives each its own PLT; verify before
   refactoring.
-- **Output interleaving** — debug-level test logs from one project
-  could swamp another. Mitigation: per-project temp files +
-  deterministic ordering at the end.
-- **Failure-mode regression** — if first-failure-wins behavior
-  matters to anyone, "all-run + report-all" is a behavior change.
-  Document it in the commit body.
-- **Test-port contention** — the three subprojects might fight over
-  ports / paths if any tests bind to fixed addresses. Phase 2's
-  hypothesis-test step exists specifically to surface this.
+- **CPU / scheduler saturation** — three concurrent BEAM VMs can
+  starve each other on small machines. A median win on a
+  20-core dev box might vanish on an 8-core CI machine or a
+  contention-heavy laptop. Mitigation: measurement step runs on
+  the typical target hardware before landing.
+- **Output interleaving** — addressed by capturing per-project
+  output to temp files and printing in deterministic order at the
+  end. Verbose-on-success path requires `PRE_PUSH_VERBOSE=1`.
+- **Loss of warning visibility on success** — current hook
+  streams full output; new hook hides it on green. A regression
+  in warning volume would be invisible until someone explicitly
+  ran `PRE_PUSH_VERBOSE=1`. Document the trade in the commit body.
+- **Failure-mode regression** — `all-run + report-all` is a
+  behavior change vs `first-failure-aborts`. Document it in the
+  commit body and README.
+- **Shared `System.tmp_dir!()` collisions** — if any tests
+  hardcode tmp paths that collide across subprojects, parallel
+  runs might race. Each project's tests today appear to use
+  per-test unique tmp dirs; verify by `rg -n 'tmp_dir!()'`
+  before refactoring.
+- **`System.put_env` cross-VM mutation** — irrelevant across BEAM
+  VM boundaries (separate processes), but worth confirming none
+  of the projects' tests assume cross-VM env state.
+- **Path-dep compile cross-talk** — if any of the three projects
+  declares another via `path:` and depends on its compiled
+  artifacts, parallel `mix test` may trigger redundant or
+  conflicting compile. Verify by inspecting each `mix.exs`'s
+  `deps` list before refactoring.
+- **Test-port contention** — the three subprojects might fight
+  over fixed-port bindings if any tests use `Bandit` /
+  `Cowboy` / similar with hardcoded ports. Phase 2's measurement
+  step surfaces this before code lands.
+- **Phase21 flake confounds the measurement.** Until the
+  separate `fix/phase21-cascade-flake` PR lands or the test is
+  tagged out of the timing runs, sporadic failures will skew
+  median + p95 numbers. Sequence the measurement step *after*
+  the flake fix.
 
 ### Estimated impact
 
@@ -549,6 +677,14 @@ file that flakes flips back with the failure mode recorded.
 > escript build + mix.exs alias) isn't justified. Codex consult:
 > "Do it only after measuring how much wallclock is actually
 > attributable to those subprocesses under the current hook."
+>
+> **Retirement criteria:** if post-Phase-2 re-profiling shows
+> that `mix run`-via-`Port.open` accounts for **<10% of remaining
+> pre-push wallclock** on code-touching pushes, or the lock-
+> contention warning ("Waiting for lock on the build directory")
+> doesn't appear across 25 consecutive `mix test` runs of
+> `mcp_server`, retire Phase 3 with a recorded rationale. If
+> ≥10% and the warning fires, ship Phase 3 as specified below.
 >
 > The original spec is preserved as-is below; the *go/no-go*
 > decision is gated on re-profiling.

--- a/Plans/pre-push-perf.md
+++ b/Plans/pre-push-perf.md
@@ -389,15 +389,25 @@ plus shell + mix-startup overhead).
 
    ```
    for proj in . mcp_server ptc_viewer; do
-     ( cd "$proj" && mix test --exclude clojure && mix dialyzer ) &
+     (
+       cd "$proj" && \
+       mix test --exclude clojure && \
+       if grep -qE '\{:dialyxir,' mix.exs; then mix dialyzer; fi
+     ) &
    done
    wait
    ```
 
-   Three background jobs, each doing test-then-dialyzer
-   sequentially **inside** the project. Not six fully-concurrent
-   commands. Compare against the current sequential loop on the
-   *same* machine, *same* load profile.
+   Three background jobs, each doing test-then-(conditionally)-
+   dialyzer sequentially **inside** the project. Not six
+   fully-concurrent commands. The dialyzer step is gated on the
+   presence of `:dialyxir` in the project's `mix.exs`, mirroring
+   the current hook's `project_has_dep` check
+   (`.githooks/pre-push:296`). `ptc_viewer/mix.exs` has no
+   `:dialyxir` dep today, so the harness skips dialyzer there —
+   exactly as the production hook does. Compare against the
+   current sequential loop on the *same* machine, *same* load
+   profile.
 
    Required preconditions for the measurement to be meaningful:
    - **Warm deps and PLT** for all three projects (`mix deps.compile`

--- a/Plans/pre-push-perf.md
+++ b/Plans/pre-push-perf.md
@@ -77,6 +77,54 @@ re-reviewed; 1× `[P1]` and 2× `[P2]` issues. All addressed:
   is part of the work and recommends the `test` alias path with a
   `Mix.Tasks.Compile.MockEscript` module as the default.
 
+**Revision 4 (2026-05-09, post-execution + codex consult):**
+Phase 2 hit a wall during execution and the plan needed a structural
+reframe. Codex consulted on what to do next; this revision encodes
+the response. Changes:
+- **Old Phase 2 (async-flips) RETIRED.** Hypothesis was falsified
+  during execution: of 25 default-path sync files, only 1 was safely
+  flippable. Three other candidates exposed real failure modes
+  under load (`stdio_test.exs` harness timeout, `stdio_lifecycle_test.exs`
+  monitor race, `stdio_latin1_test.exs` aggravated the phase21
+  flake). The other 21 files mutate `Application.put_env`, global
+  registries, `:persistent_term`, or telemetry — sync for real
+  reasons. The Phase 2 attempt is preserved in a stash; not
+  shipping. Codex: "documentation debt masquerading as progress."
+- **Old Phase 4 (subprocess fixture pooling) SHELVED.** Phase 2's
+  lessons demonstrated the suite has real global-state sensitivity;
+  pooling is invasive and likely to create hidden state coupling.
+  Shelved unless Phase 3 measurements prove subprocess startup
+  dominates and pooling is the only credible fix. Codex agreed.
+- **New Phase 2: parallel subproject checks.** The current hook
+  loops sequentially over root / `mcp_server` / `ptc_viewer`. Codex
+  flagged this as "probably the next thing to measure" — if the
+  three subprojects don't contend on build artifacts, parallel
+  execution could shave ~10–15 s off code-touching pushes for free.
+  Lower risk and higher leverage than the retired Phase 2.
+- **Phase 3 conditional on re-profiling.** Original baseline (53 s)
+  may not describe the decision problem after Phase 1 + new
+  Phase 2 land. Re-profile code-touching pushes before deciding
+  whether `mix run`-via-`Port.open` elimination is still worth it.
+- **Pre-existing flake escalated.** Phase 2's investigation
+  surfaced a flake in `upstream_supervisor_phase21_test.exs`
+  "DynSup restart-intensity cascade" that exists on `main`
+  (~1/8 runs on seed=24). Bit two of three recent pushes. Being
+  fixed on a separate branch (`fix/phase21-cascade-flake`) and a
+  separate PR; not part of this perf plan, but blocking confidence
+  in any timing measurement until it lands.
+
+## Status post-execution (2026-05-09)
+
+| Phase | Status | Notes |
+|---|---|---|
+| 0 | ✅ Shipped | Commit `7cdca33`. |
+| 1 | ✅ Shipped | Commits `144ef7a` (base) + `58cd523` (codex-fixup). PR #887. |
+| Old 2 (async-flips) | ❌ Retired | Hypothesis falsified. Stashed, not shipped. |
+| New 2 (parallel subprojects) | 🔜 Pending | Spec below. |
+| 3 (mix-via-port) | ⏸ Conditional | Re-profile after new Phase 2 first. |
+| Old 4 (pooling) | 🗄 Shelved | Phase 2 lessons make this not worth the risk. |
+| Side: phase21 flake | 🔧 In flight | Separate branch + PR. |
+
 ## Goal
 
 Reduce `git push origin main` wallclock from the current ~53 s while
@@ -118,21 +166,25 @@ Two structural facts drive the plan:
    directory (held by process 58521)" — tail-latency cliff inside the
    suite.
 
-## Sequencing rationale
+## Sequencing rationale (post-Revision 4)
 
-Phases run smallest-leverage-loss-on-failure first:
+Phases run smallest-leverage-loss-on-failure first. Old Phase 2 and
+old Phase 4 are retired/shelved per Revision 4; they remain in the
+doc below for archival reference.
 
-| # | Phase | Why this order |
-|---|---|---|
-| 0 | Drop unused test helpers | Pure cleanup unrelated to perf, but codex flagged it. Trivial. |
-| 1 | Conservative hook tracking + docs-only gate | Highest leverage for the recent docs-heavy commit pattern, low test-coverage risk *if* implemented conservatively. |
-| 2 | Flip safe `async: false` files in `mcp_server/test/` | Real perf win, low architectural risk if isolation is documented per file. |
-| 3 | Eliminate `mix run`-via-`Port.open` from default test paths | Removes lock-contention cliff. Surgical refactor. |
-| 4 | Pool upstream subprocess fixtures | Highest architectural risk — runs last so failure here is contained. |
+| # | Phase | Status | Why this order |
+|---|---|---|---|
+| 0 | Drop unused test helpers | ✅ Shipped | Pure cleanup. Trivial. |
+| 1 | Tracked hook + docs-only short-circuit | ✅ Shipped | Highest leverage for docs-heavy pushes. Conservative implementation kept test-coverage risk low. |
+| 2 (new) | Parallel subproject checks | Pending | Sequential per-project loop is the next obvious bottleneck once docs-only is solved. Cheap, structural. |
+| 3 | Eliminate `mix run`-via-`Port.open` | Conditional | Re-profile after new Phase 2 ships before deciding. |
+| Old 2 | Flip async:false files | Retired | Hypothesis falsified. See §"Old Phase 2 (RETIRED)" below. |
+| Old 4 | Pool subprocess fixtures | Shelved | Phase 2 lessons make this not worth the risk. See §"Old Phase 4 (SHELVED)" below. |
 
-Phase 0 is trivial and goes in without codex review. Phases 1–4 each
-get codex review before the next phase starts. Failed codex review →
-fixup commit on the same phase, re-review, repeat until pass.
+Phase 0 is trivial and went in without codex review. Phases 1, new
+2, and 3 each get codex review before the next phase starts. Failed
+codex review → fixup commit on the same phase, re-review, repeat
+until pass.
 
 ## Phase 0 — Drop unused test helpers
 
@@ -302,7 +354,127 @@ allow-list-based docs-only gate can drop pure-docs pushes from
 **Estimated impact:** ~50 s saved on docs-only pushes. Non-docs
 pushes unchanged.
 
-## Phase 2 — Flip safe `async: false` files in `mcp_server/test/`
+## Phase 2 (new) — Parallel subproject checks
+
+**Hypothesis:** the current hook loops sequentially over the three
+Mix subprojects (`.`, `mcp_server`, `ptc_viewer`), running
+`mix test` then `mix dialyzer` for each. Running them concurrently
+should shave wallclock from any push that doesn't take the
+docs-only short-circuit, which is now the common case for code
+changes. Codex flagged this as "probably the next thing to measure"
+after Phase 1.
+
+### What the current hook does
+
+In `.githooks/pre-push`, after the docs-only short-circuit:
+
+```
+for proj in . mcp_server ptc_viewer; do
+  pushd "$proj"
+  mix test --exclude clojure || exit 1
+  mix dialyzer || exit 1
+  popd
+done
+```
+
+Sequential. Total ~32 s across the three subprojects in the current
+baseline (8.7 + 23.3 + 0.1 for tests; 11.9 + 3.6 + 0 for dialyzer;
+plus shell + mix-startup overhead).
+
+### Approach
+
+1. **Measure first.** Before touching anything, run each project's
+   `mix test` and `mix dialyzer` concurrently in a scratch script and
+   measure wallclock vs sequential. If concurrent isn't actually
+   faster (e.g., they contend on the same `_build` symlink, hex
+   cache, or telemetry handlers), abort the phase before code lands.
+   Specifically watch for:
+   - `_build` lock contention between projects (each project has its
+     own `_build/dev` and `_build/test` directories — should be
+     fine, but verify with `lsof` or `fs_usage` while running).
+   - Hex cache contention (`mix deps.compile` writes to
+     `~/.hex/` — only an issue on a fresh clone, irrelevant once
+     deps are compiled).
+   - Telemetry / logger contention if processes write to the same
+     stderr/stdout (the hook captures combined output).
+2. **If measured win is ≥5 s on the test+dialyzer-bound path**,
+   refactor the hook to launch the three subproject loops as
+   background jobs and `wait` for all to finish. Capture each
+   project's output to a per-project temp file; on failure, dump the
+   relevant project's output and exit non-zero. On success, print
+   each project's `✅` summary in order.
+3. **Output ordering matters.** Sequential output is currently
+   readable — interleaved bg-job output is not. Buffer per-project
+   output to temp files; print them in deterministic order after all
+   jobs finish.
+4. **Failure semantics.** First failure cancels the others (or lets
+   them finish; pick one and document). Sequential's behavior is
+   "first failure aborts the rest"; concurrent's natural behavior
+   is "all run to completion, then report all failures." Pick "all
+   finish, report all failures" — strictly more useful for the
+   developer fixing things.
+5. **Update `.githooks/README.md`** with the new behavior + any
+   per-project temp-file paths a developer might want to inspect.
+
+### Acceptance
+
+- **Concurrent wallclock vs sequential, code-only push:** ≥5 s
+  drop. Measured before/after on the same machine, ideally same
+  load. Document the measurement.
+- **Output ordering preserved:** developer sees per-project
+  `✅`/`❌` summaries in the same order as today.
+- **Multi-failure case works:** if both root and `mcp_server` fail,
+  both failure outputs are printed (not just the first).
+- **No false greens:** the hook still correctly exits non-zero on
+  any subproject failure.
+- **No race condition between concurrent `mix dialyzer` runs.** If
+  one is detected (PLT corruption, lock errors), the phase aborts
+  and the hook stays sequential.
+- **Worktree environment doc updated:** if the new flow needs any
+  new dependency (`mktemp`, `wait`, `xargs -P`), document any
+  unusual portability gotchas.
+
+### Risk
+
+- **PLT contention** — three concurrent `mix dialyzer` runs may
+  fight over the dialyxir PLT cache. Mitigation: per-project
+  `_build` already gives each its own PLT; verify before
+  refactoring.
+- **Output interleaving** — debug-level test logs from one project
+  could swamp another. Mitigation: per-project temp files +
+  deterministic ordering at the end.
+- **Failure-mode regression** — if first-failure-wins behavior
+  matters to anyone, "all-run + report-all" is a behavior change.
+  Document it in the commit body.
+- **Test-port contention** — the three subprojects might fight over
+  ports / paths if any tests bind to fixed addresses. Phase 2's
+  hypothesis-test step exists specifically to surface this.
+
+### Estimated impact
+
+If the test+dialyzer paths can run in parallel: code-touching push
+wallclock drops from ~53 s to ~30–35 s. If only the test runs can
+parallelize but dialyzer can't (PLT contention): smaller win,
+maybe 5–8 s. If neither parallelizes cleanly: phase aborts before
+landing.
+
+This phase is the "measure twice, cut once" phase — the design
+*depends* on the measurement step actually showing a win.
+
+## Old Phase 2 (RETIRED) — Flip safe `async: false` files in `mcp_server/test/`
+
+> **Status: RETIRED** (per Revision 4). Hypothesis falsified during
+> execution: of 25 default-path sync files, only 1 was safely
+> flippable (`cancellation_phase1a_test.exs`). Three other plausible
+> candidates exposed real failure modes under load. The other 21
+> files mutate `Application.put_env`, global registries,
+> `:persistent_term`, or telemetry — sync for real reasons. The
+> Phase 2 attempt is preserved in a stash; not shipping. Codex
+> consult: "documentation debt masquerading as progress."
+>
+> Section preserved below for archival reference.
+
+
 
 **Hypothesis:** A material fraction of the 25 default-path sync
 files in `mcp_server/test/` are sync defensively, not because the
@@ -367,7 +539,21 @@ file that flakes flips back with the failure mode recorded.
 
 **Estimated impact:** mcp_server suite from 23 s → ~15–17 s.
 
-## Phase 3 — Eliminate `mix`-via-`Port.open` from default test paths
+## Phase 3 (CONDITIONAL) — Eliminate `mix`-via-`Port.open` from default test paths
+
+> **Status: CONDITIONAL** (per Revision 4). Re-profile after the
+> new Phase 2 (parallel subprojects) lands. Original Phase 3
+> rationale ("removes the lock-contention cliff") still holds for
+> code-touching pushes, but the absolute wallclock left to attack
+> may be small enough that the implementation cost (compile-time
+> escript build + mix.exs alias) isn't justified. Codex consult:
+> "Do it only after measuring how much wallclock is actually
+> attributable to those subprocesses under the current hook."
+>
+> The original spec is preserved as-is below; the *go/no-go*
+> decision is gated on re-profiling.
+
+
 
 **Hypothesis:** `mcp_server` mock-server tests open ports with
 `command: "mix"` and `args: ["run", "--no-start", "--no-compile",
@@ -470,7 +656,19 @@ done.
 **Estimated impact:** mcp_server suite from ~15–17 s → ~13–15 s,
 plus removal of the lock-contention tail-latency cliff.
 
-## Phase 4 — Pool upstream subprocess fixtures (architectural)
+## Old Phase 4 (SHELVED) — Pool upstream subprocess fixtures (architectural)
+
+> **Status: SHELVED** (per Revision 4). Old Phase 2's lessons
+> demonstrated the suite has real global-state sensitivity (only
+> 1/25 sync files was safely flippable; 3 candidates exposed real
+> races under load). Pooling fixtures is invasive and likely to
+> create hidden state coupling. Codex consult: "Keep it shelved
+> unless Phase 3 measurements prove subprocess startup dominates and
+> pooling is the only remaining credible fix."
+>
+> Section preserved below for archival reference.
+
+
 
 **Highest risk; runs last so failure is contained.**
 

--- a/Plans/pre-push-perf.md
+++ b/Plans/pre-push-perf.md
@@ -3,202 +3,406 @@
 ## Status
 
 **Active plan, executed on branch `perf/pre-push-bottlenecks` in
-worktree `../ptc_runner_perf`.** Each phase is committed
-independently; each phase is gated by a `codex review` pass before
-the next phase starts. Phases can be discarded individually if codex
-flags issues that aren't worth fixing.
+worktree `ptc_runner_perf`.** Each non-trivial phase is committed
+independently; each is gated by a `codex review` pass before the next
+phase starts. Phases can be discarded individually if codex flags
+issues that aren't worth fixing.
 
 Started: 2026-05-09. Branch base: `main` at `ab75ab9`.
+
+**Revision (2026-05-09, post-codex):** original plan reviewed by
+codex against actual repo state. Codex flagged 13 issues. All
+incorporated:
+- Baseline counts corrected (5 of 30 sync files are integration-only
+  and excluded by default).
+- Phase order changed to put the conservative hook gate first; it's
+  the highest leverage and lowest implementation risk *if* made
+  conservative enough.
+- Phase 2 mechanism corrected (`Port.open` with `command: "mix"`,
+  not `System.cmd("mix")`).
+- Phase 4 docs-only gate redesigned with allow-list + worktree-clean
+  check (README.md and docs/ptc-lisp-specification.md are read by
+  tests; the original regex would have skipped tests for edits that
+  do break them).
+- Acceptance criteria tightened across the board.
+- Phase 0 added for unrelated cleanup codex spotted.
+- Plan now says "current pre-push gate," not "full suite" — current
+  hook excludes `:clojure`, `:integration`, `:real_upstream` tags.
 
 ## Goal
 
 Reduce `git push origin main` wallclock from the current ~53 s while
-keeping the safety guarantees of the current pre-push hook (full test
-suite + dialyzer per project). The current breakdown was measured in
-the previous session:
+**preserving the safety guarantees of the current pre-push gate**.
+Out of scope: dropping safety (`--no-verify`, removing tests or
+dialyzer, lowering coverage).
+
+Note: "current pre-push gate" ≠ "full suite." The hook runs
+`mix test --exclude clojure`, and `mcp_server/test/test_helper.exs`
+further excludes `:integration` and `:real_upstream` tags. Anything
+new the plan introduces must compose with that exclusion model, not
+fight it.
+
+## Baseline (measured 2026-05-09)
 
 | Stage | Time | % | Notes |
 |---|---|---|---|
-| `mcp_server` test suite | **23.3 s** | **44%** | Biggest single item |
+| `mcp_server` test suite (default exclusions) | **23.3 s** | **44%** | Biggest item |
 | Root `:ptc_runner` dialyzer (warm PLT) | 11.9 s | 22% | |
 | Root `:ptc_runner` test suite | 8.7 s | 16% | 4,745 tests, healthy |
 | `mcp_server` dialyzer (warm PLT) | 3.6 s | 7% | |
 | `mix` startup × 5 + shell | ~5 s | 9% | Fixed |
 | `ptc_viewer` tests | 0.1 s | <1% | Negligible |
 
+Test-file async distribution in `mcp_server/test/`:
+
+- 44 `use ExUnit.Case` modules total.
+- **30** declare `async: false`, **14** declare `async: true`.
+- **5 of the 30 sync files live under `mcp_server/test/integration/`**
+  and are excluded from the default test run by
+  `mcp_server/test/test_helper.exs:14`. So the **default-path
+  opportunity is 25 sync files**, not 30.
+
 Two structural facts drive the plan:
 
-1. `mcp_server` has **30 sync test files vs 14 async** — majority sync.
+1. `mcp_server` has 25 default-path sync files vs 14 async — majority
+   sync.
 2. The recent pre-push run logged "Waiting for lock on the build
    directory (held by process 58521)" — tail-latency cliff inside the
    suite.
 
-Out of scope here: dropping safety (skipping tests, dialyzer-off,
-`--no-verify`). Every phase preserves the current correctness gate
-and is reversible.
+## Sequencing rationale
 
-## Phase 1 — Audit and flip safe `async: false` files in `mcp_server`
+Phases run smallest-leverage-loss-on-failure first:
 
-**Hypothesis:** A meaningful fraction of the 30 sync files in
-`mcp_server/test/` are sync defensively, not because the tests
-genuinely conflict on shared state. Flipping the safe ones to
-`async: true` lets ExUnit parallelize them up to `max_cases: 20`.
+| # | Phase | Why this order |
+|---|---|---|
+| 0 | Drop unused test helpers | Pure cleanup unrelated to perf, but codex flagged it. Trivial. |
+| 1 | Conservative hook tracking + docs-only gate | Highest leverage for the recent docs-heavy commit pattern, low test-coverage risk *if* implemented conservatively. |
+| 2 | Flip safe `async: false` files in `mcp_server/test/` | Real perf win, low architectural risk if isolation is documented per file. |
+| 3 | Eliminate `mix run`-via-`Port.open` from default test paths | Removes lock-contention cliff. Surgical refactor. |
+| 4 | Pool upstream subprocess fixtures | Highest architectural risk — runs last so failure here is contained. |
+
+Phase 0 is trivial and goes in without codex review. Phases 1–4 each
+get codex review before the next phase starts. Failed codex review →
+fixup commit on the same phase, re-review, repeat until pass.
+
+## Phase 0 — Drop unused test helpers
+
+**Trivial cleanup, no codex review needed.**
+
+`mcp_server/test/ptc_runner_mcp/upstream_supervisor_phase21_test.exs`
+defines `await_connection!/3` and `do_await_connection/3` (lines 289
+and 294) that are never called — dialyzer warns on both. Either
+remove them or wire them into the test that actually needs polling.
+Default action: remove. If a test surfaces that needs polling
+later, it can re-add.
+
+**Acceptance:** dialyzer warnings disappear; suite still passes.
+
+## Phase 1 — Conservative hook tracking + docs-only short-circuit
+
+**Hypothesis:** for the recent docs-heavy commit pattern, full
+test+dialyzer per push is wasted work. A conservative
+allow-list-based docs-only gate can drop pure-docs pushes from
+~53 s to <2 s without compromising safety.
+
+**Constraints surfaced by codex review:**
+
+1. The current hook is at `.git/hooks/pre-push` (in the *main* repo's
+   `.git`, not the worktree's). `.git` in a worktree is a *file*
+   pointing at the linked `.git/worktrees/<name>` dir, not a
+   directory. Hook moves must use
+   `git rev-parse --git-path hooks/pre-push` or the resolved hook
+   path, not literal paths.
+2. Several markdown files are read by tests:
+   - `README.md` is doctested by `test/readme_test.exs`.
+   - `docs/ptc-lisp-specification.md` is read by
+     `test/ptc_runner/lisp/spec_validator_test.exs` and by
+     `lib/ptc_runner/lisp/spec_validator.ex`.
+   - `mcp_server/README.md` is doctested in its own `:ptc_runner_mcp`
+     project.
+   - Other `*.md` files under `docs/`, `Plans/`, `mcp_server/`,
+     `ptc_viewer/` may also be referenced.
+3. The hook runs `mix test` against the **working tree**, not the
+   committed bytes. A docs-only short-circuit must verify
+   working-tree + index are clean (or only contain docs-allowed
+   paths), not just inspect committed diffs.
+4. Pre-push hooks receive ref updates on stdin (per
+   `githooks(5)` — the `<local-ref> <local-sha> <remote-ref>
+   <remote-sha>` lines). This is the correct way to enumerate
+   pushed refs, not `@{u}` guesses (which fail on first push of a
+   new branch).
 
 **Approach:**
 
-1. Enumerate every `async: false` file in `mcp_server/test/`.
-2. For each: classify the reason for sync. Common signals that
-   require sync:
-   - mutates `Application.put_env/3` for `:ptc_runner_mcp` config.
-   - registers globally-named processes (`:via {Registry, …}` is
-     fine; bare-name registration is not).
-   - touches singleton stdio state (`Stdio.Names`, `Upstream.Registry`).
-   - asserts on telemetry events with global handlers.
-3. For each file with no real reason, flip to `async: true`.
-4. Run `(cd mcp_server && mix test)` 5× back-to-back to catch races
-   that only surface under load. Anything that flakes flips back.
-5. Time the suite before/after to confirm the win.
+1. Move the hook to a tracked path: `.githooks/pre-push`. Make
+   executable. Set `git config core.hooksPath .githooks` once per
+   clone (document in README).
+2. At the top of the hook, before any `mix` invocations:
+   - Read pushed-ref tuples from stdin (per `githooks(5)`).
+   - For each tuple: enumerate commits with
+     `git rev-list <remote-sha>..<local-sha>` (or, if remote-sha is
+     all-zeros, use `<local-sha>` against `origin/main` or the
+     repo's default base).
+   - Take the union of files changed across all those commits via
+     `git diff-tree -r --name-only --no-commit-id`.
+   - Also enumerate dirty paths in the worktree:
+     `git status --porcelain --untracked-files=normal | awk '{print $2}'`.
+   - Combine both sets.
+3. Define a strict **docs-only allow-list** (paths that are *not*
+   read by tests):
+   - `^Plans/.*\.md$`
+   - `^CHANGELOG\.md$`
+   - `^.*\.txt$` (license, etc.)
+   - `^\.gitignore$`
+   - `^\.githooks/README\.md$` (the hook setup README, if added)
+   Anything else — including `README.md`, `docs/**/*.md`,
+   `mcp_server/README.md`, `mcp_server/docs/**/*.md` — falls through
+   to the full gate.
+4. If every file in the combined set matches the allow-list:
+   print `📝 Docs-only push, skipping test/dialyzer gate (override:
+   FORCE_FULL_PRE_PUSH=1)` and exit 0.
+5. Otherwise: run the existing per-project loop unchanged.
+6. Honor `FORCE_FULL_PRE_PUSH=1` env var: skip the short-circuit
+   even when the allow-list matches. Documented inline.
 
-**Acceptance:** mcp_server suite passes 5× consecutively under
-async, with measurable wall-clock reduction.
+**Acceptance:**
 
-**Risk:** New flakes from races that were previously masked by
-serialization. Mitigation: 5× repeat and revert any file that
-flakes. Codex review pass acts as the final gate.
+- Push of a `Plans/*.md`-only commit completes in <2 s.
+- Push touching `README.md`, `docs/ptc-lisp-specification.md`, or
+  `lib/**/*.ex` runs the full existing gate.
+- Push with allow-listed commits but a dirty worktree containing a
+  non-allow-listed path runs the full existing gate.
+- `FORCE_FULL_PRE_PUSH=1 git push` always runs the full gate.
+- Once-per-clone setup (`git config core.hooksPath .githooks`)
+  documented in README and verifiable via
+  `git config --get core.hooksPath`.
 
-**Estimated impact:** mcp_server suite from 23 s → ~12–15 s on a
-20-core box. ~8–11 s saved.
+**Risk:**
 
-## Phase 2 — Hunt and remove `mix` build-lock contention
+- Docs-only allow-list misses a file that *is* test-consumed → tests
+  silently skipped on edits that break them. Mitigation: explicit
+  allow-list (not deny-list); CI on push (separate from the local
+  hook) catches anything the local hook misses.
+- Hook-path resolution wrong on a worktree → gate doesn't fire.
+  Mitigation: shipping the hook as a tracked file under `.githooks/`
+  + `core.hooksPath` is the standard remediation; tested by running
+  the hook from this worktree as part of acceptance.
 
-**Hypothesis:** A specific test (or test setup) in `mcp_server/`
-shells out to `mix` (or to a fixture that itself runs `mix`),
-competing with the test runner's own build lock. The "Waiting for
-lock on the build directory" log line proves at least one such call
-exists. When it fires, it adds tail-latency that is invisible in the
-average but visible in the P99.
+**Estimated impact:** ~50 s saved on docs-only pushes. Non-docs
+pushes unchanged.
+
+## Phase 2 — Flip safe `async: false` files in `mcp_server/test/`
+
+**Hypothesis:** A material fraction of the 25 default-path sync
+files in `mcp_server/test/` are sync defensively, not because the
+tests genuinely conflict on shared state.
 
 **Approach:**
 
-1. Grep `mcp_server/test/` for `System.cmd("mix"`, `Mix.Task.run`,
-   `Mix.Shell`, and any wrapper calling `mix release` /
-   `mix compile`.
-2. Identify the call site(s).
-3. For each: replace the spawn with one of —
-   - a pre-built artifact resolved via test fixture path, or
-   - a direct module call (no subprocess), or
-   - a guard that skips the lock-contending path entirely when
-     running under `MIX_ENV=test`.
-4. Re-run the suite repeatedly to confirm the lock-wait warning
-   disappears.
+1. Enumerate every `async: false` file in `mcp_server/test/`
+   (excluding the 5 integration files — they're irrelevant to the
+   default-path baseline).
+2. For each file, classify the reason for sync. Real reasons:
+   - Mutates `Application.put_env/3` for `:ptc_runner_mcp` config
+     (e.g., `catalog_test.exs`, `log_test.exs`,
+     `trace_config_test.exs`).
+   - Registers globally-named processes outside the per-test
+     `Stdio.Names` Registry.
+   - Touches singleton state in `Upstream.Registry` or shared
+     `:persistent_term` keys.
+   - Asserts on telemetry events with global handlers and no
+     per-test-pid filter.
+3. **Per-file decision recorded inline** as a comment near the
+   `use ExUnit.Case` line, citing the specific shared-state
+   reference. Files with no real reason flip to `async: true`.
+4. Verify acceptance below before moving on.
 
-**Acceptance:** No "Waiting for lock on the build directory" logs
-across 10× consecutive `mix test` runs.
+**Acceptance:**
 
-**Risk:** Low — the call is almost certainly an over-engineered
-fixture. Replacing it with a static artifact is straightforward.
+- `mix test mcp_server/test/ --seed 0 --seed 1 --seed 2 … --seed 24`
+  (25 distinct seeds, scripted) all pass green. Catches scheduler
+  and ordering races the original "5× same seed" criterion missed.
+- `rg 'async:\s*false' mcp_server/test/ -l | wc -l` decreases
+  measurably (target: at least 8 files flipped).
+- For every file *not* flipped, a one-line comment explains why
+  sync is required (specific shared-state reference). No file is
+  left as `async: false` without a recorded reason.
+- mcp_server suite wallclock decreases by ≥3 s on a 20-core box.
 
-**Estimated impact:** Removes a 1–60 s tail-latency cliff. Average
-case may not move; worst case improves dramatically.
+**Risk:** New flakes from races previously masked by serialization.
+Mitigation: 25-seed sweep is much stronger than 5× same-seed; any
+file that flakes flips back with the failure mode recorded.
 
-## Phase 3 — Pool upstream subprocess fixtures in `mcp_server`
+**Estimated impact:** mcp_server suite from 23 s → ~15–17 s.
+
+## Phase 3 — Eliminate `mix`-via-`Port.open` from default test paths
+
+**Hypothesis:** `mcp_server` mock-server tests open ports with
+`command: "mix"` and `args: ["run", "--no-start", "--no-compile",
+mock_path, …]`. Each such port spawn invokes the elixir/mix
+launcher *and competes with the test runner's own build lock*. The
+"Waiting for lock on the build directory" log line in the recent
+pre-push run was caused by this pattern, not by `System.cmd("mix")`.
+
+**Concrete sites** (verified by codex on actual repo state):
+
+- `mcp_server/test/ptc_runner_mcp/upstream_stdio_phase1b_test.exs:40`
+- `mcp_server/test/ptc_runner_mcp/behaviour_conformance_test.exs:73`
+- `mcp_server/test/ptc_runner_mcp/application_phase1b_test.exs:64`
+- The wrapper shell script at
+  `mcp_server/test/ptc_runner_mcp/upstream_stdio_phase1b_test.exs:734`
+
+The mock server is `mcp_server/test/support/mock_server.exs:56`,
+which uses `Jason.encode!` — that's why it needs `mix run` for dep
+loading. Naively replacing it with a static escript is *not* trivial;
+deps must be available in the spawned interpreter.
+
+**Approach (options, pick during execution):**
+
+A. **Pre-compile mock_server to escript with deps bundled.** Static
+   artifact, no `mix run` needed. Spawn cost drops to a single
+   exec. Build the escript via a `mix.exs` task that runs once at
+   suite startup or as a `setup_all`.
+B. **Replace `mix run`-port spawn with a Burrito-style standalone
+   release** if deps are heavy. Bigger change; probably overkill.
+C. **Move tests that genuinely need a real subprocess to
+   `:integration` tag**, excluded from the default path. Trade-off:
+   default path no longer covers stdio-protocol behaviors against a
+   real subprocess. Probably unacceptable; flag if it's the only
+   viable path.
+
+Default plan: option A unless something prevents it.
+
+**Acceptance:**
+
+- `rg 'command:\s*"mix"' mcp_server/test mcp_server/lib`
+  returns zero hits in default-path test files (integration files
+  may keep them).
+- `rg 'exec mix' mcp_server/test mcp_server/lib` similarly clean.
+- The "Waiting for lock on the build directory" warning does not
+  appear across 10 consecutive `(cd mcp_server && mix test)` runs
+  with random seeds.
+- Behavioral coverage preserved: every test that previously launched
+  a `mix run` mock now launches the precompiled artifact and still
+  exercises the stdio handshake / tools/list / call paths it
+  exercised before. Verified by inspecting the test diff
+  before/after.
+- `mcp_server` suite wallclock drops further (estimated 2–4 s).
+
+**Risk:** Compiled-mock artifact diverges from `mix run` behavior
+in subtle ways (env loading, cwd, code path). Mitigation: same
+mock_server source, just compiled — behavior should match. Stress:
+run the suite 10× post-change with random seeds before declaring
+done.
+
+**Estimated impact:** mcp_server suite from ~15–17 s → ~13–15 s,
+plus removal of the lock-contention tail-latency cliff.
+
+## Phase 4 — Pool upstream subprocess fixtures (architectural)
+
+**Highest risk; runs last so failure is contained.**
 
 **Hypothesis:** Many `mcp_server` tests spawn their own upstream
-stdio subprocesses individually (visible in the run as
-`{:upstream_exited, …}` for unique names like `backoff-via-stdio-1641`,
-`call-crash-1800`, `parent-exit-6914`). Each spawn pays
-100–500 ms for binary load, handshake, and `tools/list`. Pooling /
-sharing fixtures across tests in a `describe` block amortizes the
-cost.
+stdio subprocesses individually (visible in run logs as unique
+names like `backoff-via-stdio-1641`, `call-crash-1800`,
+`parent-exit-6914`). Each spawn pays binary load + handshake +
+`tools/list`. Pooling fixtures across `describe` blocks amortizes
+the cost.
+
+**Invariants the per-test spawn pattern protects** (named explicitly,
+per codex):
+
+1. **Cached `tools/list` state** — each upstream caches its tools
+   on first call; tests asserting on cache miss / refresh need a
+   fresh process.
+2. **Backoff timer state** — reconnect/backoff tests assert on
+   timing windows that depend on a clean clock.
+3. **Parent-exit ordering** — tests like `parent-exit-6914`
+   verify that the upstream port closes when its parent BEAM
+   process dies. Pooled fixtures break this.
+4. **Crash-recovery behavior** — `call-crash-1800` asserts on
+   restart semantics; pool can't share a crashed process.
+5. **Env-driven mock behavior** — `application_phase1b_test.exs`
+   spawns mocks with per-test env vars (`MOCK_PROBE_PATH`, etc.).
+   Pool would have to reset env per checkout, which the mock
+   doesn't support.
+6. **Registry name uniqueness** — `Stdio.Names` Registry holds
+   concurrent instances by unique name. Pool would need a
+   reservation protocol.
+7. **Teardown ordering** — `on_exit` callbacks assume per-test
+   process; pool must keep this invariant or migrate tests to
+   `setup_all` teardown.
 
 **Approach:**
 
-1. Inventory upstream-spawning tests. Group by what kind of upstream
-   they need (echo, slow, big, crashing).
-2. For each kind: build a `setup_all` fixture that spawns one
-   upstream and registers it with a per-test alias. Tests that
-   genuinely need a fresh process (parent-exit, crash recovery,
-   handshake-timeout) keep their own spawn.
-3. Verify isolation guarantees — pooled upstreams must reset state
-   between tests, or tests must not depend on cross-test isolation.
-4. Re-run suite, time the delta.
+1. Inventory upstream-spawning tests. Group by upstream behavior
+   needed: echo, slow, big, crash, parent-exit, env-driven,
+   backoff.
+2. **Tests in groups 3–5 (parent-exit, crash, env-driven) keep
+   per-test spawn — non-negotiable.**
+3. **Tests in groups 1–2 (echo, slow) and 6 (clean backoff
+   start) are candidates for pooling**, *if* a per-checkout state
+   reset hook is added to the mock server (separate small
+   refactor).
+4. Build a `setup_all` fixture for the poolable groups that spawns
+   one upstream per `describe` and registers tests against it via
+   per-test alias.
+5. Verify isolation. The plan does not claim "passes under both
+   regimes" — the pooled fixtures *replace* per-test spawn for the
+   eligible groups. The criterion is: pool-eligible tests still
+   assert correctly when run in arbitrary order.
 
-**Acceptance:** Suite passes 5× under both pooled and per-test
-regimes; pooled-fixture tests don't see cross-test contamination.
+**Acceptance:**
 
-**Risk:** Highest of the four phases. Pooled fixtures hide subtle
-isolation bugs. Codex review here is most important.
+- Inventory document committed to `Plans/` listing every upstream
+  spawn site, classification, and pool-vs-per-test decision with
+  reason.
+- Pool-eligible tests pass under 25-seed sweep (same protocol as
+  Phase 2).
+- Suite still passes when each pool-eligible `describe` is run
+  alone (`mix test path/to/file.exs:LINE`).
+- mcp_server suite wallclock drops by another ≥3 s, or this phase
+  is reverted (it's the riskiest and not worth the architectural
+  complexity for a marginal win).
 
-**Estimated impact:** Hard to predict — depends on how many tests
-spawn vs. how many can share. Plausible 5–10 s further off
-mcp_server suite, but it could also be 1–2 s if most tests already
-share where they can.
+**Risk:** Highest of the four. Pooled fixtures hide subtle
+isolation bugs that only surface under specific ordering. Codex
+review for this phase is the most important — should explicitly
+challenge each invariant claim.
 
-## Phase 4 — Track the pre-push hook + docs-only gate
+**Estimated impact:** Hard to predict. Plausibly 3–5 s further
+savings; might be 1–2 s if most tests genuinely need per-test
+spawn (groups 3–5 may dominate).
 
-**Hypothesis:** The hook currently lives at `.git/hooks/pre-push`,
-which is not under version control. That makes hook changes
-unreviewable, unshareable, and undiscoverable. Tracking it (via
-`core.hooksPath`) plus adding a docs-only gate would skip the
-~15.5 s combined dialyzer cost and ~32 s combined test cost when no
-`lib/`, `mix.exs`, `mix.lock`, or `config/` files changed.
+## Codex review gating
 
-**Approach:**
+After each non-trivial phase commit:
 
-1. Move `.git/hooks/pre-push` into a tracked location:
-   `.githooks/pre-push`, `chmod +x`.
-2. Set `git config core.hooksPath .githooks` and document this in
-   the README (one-time per-clone setup).
-3. Add a path-aware short-circuit at the top of the hook:
-   - Compute the diff between the local ref and its upstream
-     (`git diff --name-only @{u}..HEAD`, or fall back to
-     `origin/main..HEAD` if no upstream).
-   - If every file matches `^(Plans/.*\.md|docs/.*\.md|.*README.*\.md|CHANGELOG\.md)$`,
-     print "📝 Docs-only push, skipping test/dialyzer gate" and exit 0.
-4. Document the escape hatch (env var `FORCE_FULL_PRE_PUSH=1`) in
-   the hook itself for the rare docs-only push that touches
-   doctest-bearing files.
+1. Run `codex review` against the phase commit.
+2. **`[P1]` findings → fixup commit on the same phase, re-review,
+   repeat until pass.** This is the hard gate.
+3. **`[P2]` findings → judgment call.** Fix if I agree, document
+   reasoning if I don't.
+4. Move to next phase only after `[P1]`-clean.
+5. The plan itself is also subject to review when changed
+   non-trivially. The original plan went through one review
+   (this revision is the result). Any future plan revision that
+   changes phase scope, acceptance criteria, or sequencing gets
+   re-reviewed.
 
-**Acceptance:** Docs-only push completes in <2 s; non-docs push
-runs the full suite as before; `FORCE_FULL_PRE_PUSH=1` overrides.
-
-**Risk:** Low. The gate is explicitly path-conservative — anything
-that could touch code falls through to the full suite.
-
-**Estimated impact:** Docs-only pushes drop from ~53 s to ~1–2 s.
-Non-docs pushes unchanged. This is the highest impact-to-effort
-ratio of the four phases for the workflow we just exercised.
-
-## Sequencing and codex review gates
-
-Run order: **1 → 2 → 3 → 4**, smallest-risk last because tracking
-the hook is purely additive (no test-coverage risk) but it does
-modify per-clone setup, so I'd rather not bundle it with any phase
-that could be reverted independently.
-
-After each phase:
-
-1. Commit the phase as a single commit with conventional message
-   (`perf(mcp_test): …`, `test(mcp): de-flake build-lock`, etc.).
-2. Invoke `codex review` against that commit's diff.
-3. If codex flags issues: fix in a fixup commit on the same phase,
-   re-review, repeat until pass. (Squash before merging back to
-   main.)
-4. Move to next phase only after codex pass.
-
-If a phase fails review and isn't worth fixing, the branch can drop
-that phase via `git rebase -i` and the remaining phases stand on
-their own.
+Phase 0 is trivial cleanup — skipped review per the user's "unless
+trivial" carve-out.
 
 ## Merge story
 
 When all phases land and review-pass:
 
 1. Squash phase commits into per-phase clean commits (one per
-   phase, not many fixups).
-2. Hand the worktree back to the user. They merge / fast-forward to
-   main when ready (or push the branch and review on GitHub if they
-   prefer that flow).
+   phase, no fixup churn in history).
+2. Worktree handed back to the user. They merge / fast-forward to
+   `main` when ready, or push the branch and review on GitHub if
+   they prefer that flow).
 
 This document is the source of truth for the work; commit-message
 bodies should reference the phase number rather than re-explaining

--- a/Plans/pre-push-perf.md
+++ b/Plans/pre-push-perf.md
@@ -10,7 +10,7 @@ issues that aren't worth fixing.
 
 Started: 2026-05-09. Branch base: `main` at `ab75ab9`.
 
-**Revision (2026-05-09, post-codex):** original plan reviewed by
+**Revision 1 (2026-05-09, post-codex):** original plan reviewed by
 codex against actual repo state. Codex flagged 13 issues. All
 incorporated:
 - Baseline counts corrected (5 of 30 sync files are integration-only
@@ -28,6 +28,37 @@ incorporated:
 - Phase 0 added for unrelated cleanup codex spotted.
 - Plan now says "current pre-push gate," not "full suite" — current
   hook excludes `:clojure`, `:integration`, `:real_upstream` tags.
+
+**Revision 2 (2026-05-09, post-codex re-review):** revision 1
+re-reviewed by codex; 9 further issues found. All addressed:
+- Phase 1 dirty-path enumeration switched from `awk '{print $2}'`
+  (broken on renames + paths with spaces) to `-z`-delimited
+  porcelain v1 with rename-aware Python parser; both old and new
+  paths of a rename go into the dirty set.
+- Phase 1 `^.*\.txt$` allow-list pattern narrowed to exact
+  `^LICENSES/MIT\.txt$` to avoid silently matching future
+  `priv/**.txt` or `test/support/**.txt` fixtures.
+- Phase 1 explicit deny list added with verified runtime-read
+  paths: `priv/prompts/*.md`,
+  `mcp_server/priv/{mcp_authoring_card,mcp_aggregator_authoring_card}.md`,
+  plus the previously-listed README and docs.
+- Phase 1 `mcp_server/README.md` doctested claim corrected — it
+  isn't doctested today, kept conservatively denied.
+- Phase 2 acceptance command rewritten as a `for` loop. Multiple
+  `--seed` flags in one `mix test` command don't produce 25 runs.
+- Phase 2 stress variant added with `--max-cases` × seed grid to
+  catch scheduler-density races, not just ordering races.
+- Phase 2 `async: false` count grep filters integration files.
+- Phase 3 default approach pinned to compile-time artifact build
+  (compiler entry or `mix.exs` alias on `test`). Building the
+  escript inside `setup_all` would re-introduce mix/build-lock
+  contention this phase exists to remove.
+- Phase 3 acceptance grep broadened to catch
+  `System.find_executable("mix")` and `exec mix` wrappers, not
+  just `command: "mix"`.
+- Phase 4 backoff tests removed from pooling candidates — backoff
+  state is a per-test-spawn invariant; partially exempting it
+  without a defined reset proof was incoherent.
 
 ## Goal
 
@@ -114,15 +145,24 @@ allow-list-based docs-only gate can drop pure-docs pushes from
    directory. Hook moves must use
    `git rev-parse --git-path hooks/pre-push` or the resolved hook
    path, not literal paths.
-2. Several markdown files are read by tests:
+2. Several markdown files are read at runtime or doctested. Verified
+   by grepping for `File.read`/`File.read!`/`@external_resource`
+   against `*.md` paths in the repo:
    - `README.md` is doctested by `test/readme_test.exs`.
    - `docs/ptc-lisp-specification.md` is read by
-     `test/ptc_runner/lisp/spec_validator_test.exs` and by
-     `lib/ptc_runner/lisp/spec_validator.ex`.
-   - `mcp_server/README.md` is doctested in its own `:ptc_runner_mcp`
-     project.
-   - Other `*.md` files under `docs/`, `Plans/`, `mcp_server/`,
-     `ptc_viewer/` may also be referenced.
+     `test/ptc_runner/lisp/spec_validator_test.exs:283`, by
+     `lib/ptc_runner/lisp/spec_validator.ex:21`, and by
+     `test/support/ptc_lisp_benchmark.ex:63`.
+   - `priv/prompts/*.md` files are read by
+     `lib/ptc_runner/prompts.ex:78`.
+   - `mcp_server/priv/mcp_authoring_card.md` and
+     `mcp_server/priv/mcp_aggregator_authoring_card.md` are read by
+     `mcp_server/lib/ptc_runner_mcp/tools.ex:50`.
+   - `mcp_server/README.md` and `ptc_viewer/README.md` are *not*
+     verified doctested today, but are conservatively denied (cheap
+     defense; they may be added to a doctest target later).
+   - All other `*.md` files under `docs/`, `mcp_server/docs/`,
+     `mcp_server/`, `ptc_viewer/` are conservatively denied.
 3. The hook runs `mix test` against the **working tree**, not the
    committed bytes. A docs-only short-circuit must verify
    working-tree + index are clean (or only contain docs-allowed
@@ -146,19 +186,61 @@ allow-list-based docs-only gate can drop pure-docs pushes from
      repo's default base).
    - Take the union of files changed across all those commits via
      `git diff-tree -r --name-only --no-commit-id`.
-   - Also enumerate dirty paths in the worktree:
-     `git status --porcelain --untracked-files=normal | awk '{print $2}'`.
-   - Combine both sets.
-3. Define a strict **docs-only allow-list** (paths that are *not*
-   read by tests):
+   - Enumerate dirty paths in the worktree using `-z`-delimited
+     porcelain output to handle paths with spaces, renames, and
+     copies safely:
+     ```bash
+     git status --porcelain=v1 -z --untracked-files=normal |
+       python3 -c '
+     import sys
+     buf = sys.stdin.buffer.read().split(b"\\0")
+     i = 0
+     while i < len(buf):
+         entry = buf[i]
+         if not entry:
+             i += 1
+             continue
+         status = entry[:2].decode()
+         path = entry[3:].decode()
+         # Renames / copies: status is "R " or "C "; the next NUL-record is the old path.
+         if status[0] in "RC":
+             print(path)         # new path
+             if i + 1 < len(buf):
+                 print(buf[i + 1].decode())  # old path
+             i += 2
+         else:
+             print(path)
+             i += 1'
+     ```
+     Both old and new paths of a rename go into the dirty-set so a
+     dirty rename `Plans/a.md → README.md` cannot evade the deny.
+   - Combine the committed-diff set and the dirty set.
+3. Define a strict **docs-only allow-list** (exact patterns, paths
+   that are *not* read by tests, runtime code, or doctests):
    - `^Plans/.*\.md$`
    - `^CHANGELOG\.md$`
-   - `^.*\.txt$` (license, etc.)
+   - `^LICENSES/MIT\.txt$`
    - `^\.gitignore$`
    - `^\.githooks/README\.md$` (the hook setup README, if added)
-   Anything else — including `README.md`, `docs/**/*.md`,
-   `mcp_server/README.md`, `mcp_server/docs/**/*.md` — falls through
-   to the full gate.
+   The previous draft used `^.*\.txt$` — too broad, would silently
+   match future `priv/**.txt` or `test/support/**.txt` fixtures.
+   Pin to the exact license path instead.
+
+   **Explicit deny list** — verified read at runtime or doctested,
+   *must* fall through to the full gate:
+   - `^README\.md$` (doctested by `test/readme_test.exs`)
+   - `^docs/.*\.md$` (especially `docs/ptc-lisp-specification.md`)
+   - `^priv/prompts/.*\.md$` (read by `lib/ptc_runner/prompts.ex`)
+   - `^mcp_server/priv/.*\.md$` (read by
+     `mcp_server/lib/ptc_runner_mcp/tools.ex`)
+   - `^mcp_server/README\.md$`, `^mcp_server/docs/.*\.md$`
+   - `^ptc_viewer/README\.md$`, `^ptc_viewer/docs/.*\.md$`
+   - All `lib/**`, `test/**`, `mcp_server/lib/**`,
+     `mcp_server/test/**`, `ptc_viewer/lib/**`,
+     `ptc_viewer/test/**`, `mix.exs`, `mix.lock`, `config/**`,
+     `priv/**` (anything not explicitly allow-listed).
+   The hook should be allow-list-positive: every file in the
+   combined set must match the allow-list, otherwise full gate.
 4. If every file in the combined set matches the allow-list:
    print `📝 Docs-only push, skipping test/dialyzer gate (override:
    FORCE_FULL_PRE_PUSH=1)` and exit 0.
@@ -220,11 +302,32 @@ tests genuinely conflict on shared state.
 
 **Acceptance:**
 
-- `mix test mcp_server/test/ --seed 0 --seed 1 --seed 2 … --seed 24`
-  (25 distinct seeds, scripted) all pass green. Catches scheduler
-  and ordering races the original "5× same seed" criterion missed.
-- `rg 'async:\s*false' mcp_server/test/ -l | wc -l` decreases
-  measurably (target: at least 8 files flipped).
+- 25-seed loop passes green (multiple `--seed` flags do *not* run
+  multiple suites — must be a loop):
+  ```bash
+  (cd mcp_server && \
+    for s in $(seq 0 24); do \
+      mix test --seed "$s" || { echo "FAIL seed=$s"; exit 1; } \
+    done)
+  ```
+- Stress variant — vary scheduler concurrency, not just ordering.
+  3 seeds × 3 `--max-cases` settings = 9 runs, all green:
+  ```bash
+  (cd mcp_server && \
+    for cases in 1 4 20; do \
+      for s in 0 7 13; do \
+        mix test --seed "$s" --max-cases "$cases" || \
+          { echo "FAIL seed=$s cases=$cases"; exit 1; } \
+      done \
+    done)
+  ```
+  Captures races that only surface at specific schedule densities
+  (low `--max-cases` exposes single-thread-only invariants; high
+  exposes contention).
+- `rg 'async:\s*false' mcp_server/test/ -l | grep -v '/integration/' | wc -l`
+  (excluding integration files, which Phase 2 doesn't touch)
+  decreases measurably from the baseline 25 — target: at least 8
+  files flipped.
 - For every file *not* flipped, a one-line comment explains why
   sync is required (specific shared-state reference). No file is
   left as `async: false` without a recorded reason.
@@ -262,8 +365,17 @@ deps must be available in the spawned interpreter.
 
 A. **Pre-compile mock_server to escript with deps bundled.** Static
    artifact, no `mix run` needed. Spawn cost drops to a single
-   exec. Build the escript via a `mix.exs` task that runs once at
-   suite startup or as a `setup_all`.
+   exec. **Build the artifact at compile time, not at test runtime
+   — building inside `setup_all` or any test process re-introduces
+   the mix/build-lock contention this phase exists to remove.**
+   Concrete options:
+   - A `compilers: [:mock_escript, ...]` entry in mcp_server's
+     `mix.exs` that depends on the `:elixir` compiler and builds
+     the escript before tests can start.
+   - A `mix.exs` task aliased into `test` so `mix test`
+     transparently builds first, then runs the suite.
+   - A static path under `mcp_server/test/support/_build/` checked
+     into the repo (rejected — escripts are platform-specific).
 B. **Replace `mix run`-port spawn with a Burrito-style standalone
    release** if deps are heavy. Bigger change; probably overkill.
 C. **Move tests that genuinely need a real subprocess to
@@ -272,17 +384,27 @@ C. **Move tests that genuinely need a real subprocess to
    real subprocess. Probably unacceptable; flag if it's the only
    viable path.
 
-Default plan: option A unless something prevents it.
+Default plan: option A with the compile-time build approach,
+unless something prevents it.
 
 **Acceptance:**
 
-- `rg 'command:\s*"mix"' mcp_server/test mcp_server/lib`
-  returns zero hits in default-path test files (integration files
-  may keep them).
-- `rg 'exec mix' mcp_server/test mcp_server/lib` similarly clean.
+- All forms of mix-via-port are gone from default test paths:
+  ```bash
+  rg --type elixir \
+    'command:\s*"mix"|command:\s*System\.find_executable\(.*"mix"\)|exec\s+mix' \
+    mcp_server/test mcp_server/lib | grep -v '/integration/'
+  ```
+  returns zero hits. Broadened from the previous draft to catch
+  `System.find_executable("mix")` and `exec mix` in wrapper
+  scripts.
+- The wrapper shell script at
+  `mcp_server/test/ptc_runner_mcp/upstream_stdio_phase1b_test.exs:734`
+  is updated to invoke the escript directly, not `mix run`.
 - The "Waiting for lock on the build directory" warning does not
   appear across 10 consecutive `(cd mcp_server && mix test)` runs
-  with random seeds.
+  with random seeds. (Necessary but not sufficient — the structural
+  grep above is the primary acceptance.)
 - Behavioral coverage preserved: every test that previously launched
   a `mix run` mock now launches the precompiled artifact and still
   exercises the stdio handshake / tools/list / call paths it
@@ -341,10 +463,14 @@ per codex):
    backoff.
 2. **Tests in groups 3–5 (parent-exit, crash, env-driven) keep
    per-test spawn — non-negotiable.**
-3. **Tests in groups 1–2 (echo, slow) and 6 (clean backoff
-   start) are candidates for pooling**, *if* a per-checkout state
-   reset hook is added to the mock server (separate small
-   refactor).
+3. **Tests in groups 1–2 (echo, slow) are candidates for pooling**,
+   *if* a per-checkout state reset hook is added to the mock server
+   (separate small refactor). Group 6 (backoff) is removed from the
+   pooling-candidate list — codex pointed out that listing backoff
+   state as a per-test-spawn invariant under §"Invariants" #2 and
+   then partially exempting it for pooling without defining the
+   reset proof is incoherent. Backoff tests keep per-test spawn
+   unless a future revision defines a verified reset protocol.
 4. Build a `setup_all` fixture for the poolable groups that spawns
    one upstream per `describe` and registers tests against it via
    per-test alias.
@@ -358,8 +484,9 @@ per codex):
 - Inventory document committed to `Plans/` listing every upstream
   spawn site, classification, and pool-vs-per-test decision with
   reason.
-- Pool-eligible tests pass under 25-seed sweep (same protocol as
-  Phase 2).
+- Pool-eligible tests pass under the 25-seed loop *and* the 9-run
+  scheduler-density stress (same protocol as Phase 2 — the loops,
+  not multiple `--seed` flags in one command).
 - Suite still passes when each pool-eligible `describe` is run
   alone (`mix test path/to/file.exs:LINE`).
 - mcp_server suite wallclock drops by another ≥3 s, or this phase

--- a/Plans/pre-push-perf.md
+++ b/Plans/pre-push-perf.md
@@ -1,0 +1,205 @@
+# Pre-Push Performance — Phased Plan
+
+## Status
+
+**Active plan, executed on branch `perf/pre-push-bottlenecks` in
+worktree `../ptc_runner_perf`.** Each phase is committed
+independently; each phase is gated by a `codex review` pass before
+the next phase starts. Phases can be discarded individually if codex
+flags issues that aren't worth fixing.
+
+Started: 2026-05-09. Branch base: `main` at `ab75ab9`.
+
+## Goal
+
+Reduce `git push origin main` wallclock from the current ~53 s while
+keeping the safety guarantees of the current pre-push hook (full test
+suite + dialyzer per project). The current breakdown was measured in
+the previous session:
+
+| Stage | Time | % | Notes |
+|---|---|---|---|
+| `mcp_server` test suite | **23.3 s** | **44%** | Biggest single item |
+| Root `:ptc_runner` dialyzer (warm PLT) | 11.9 s | 22% | |
+| Root `:ptc_runner` test suite | 8.7 s | 16% | 4,745 tests, healthy |
+| `mcp_server` dialyzer (warm PLT) | 3.6 s | 7% | |
+| `mix` startup × 5 + shell | ~5 s | 9% | Fixed |
+| `ptc_viewer` tests | 0.1 s | <1% | Negligible |
+
+Two structural facts drive the plan:
+
+1. `mcp_server` has **30 sync test files vs 14 async** — majority sync.
+2. The recent pre-push run logged "Waiting for lock on the build
+   directory (held by process 58521)" — tail-latency cliff inside the
+   suite.
+
+Out of scope here: dropping safety (skipping tests, dialyzer-off,
+`--no-verify`). Every phase preserves the current correctness gate
+and is reversible.
+
+## Phase 1 — Audit and flip safe `async: false` files in `mcp_server`
+
+**Hypothesis:** A meaningful fraction of the 30 sync files in
+`mcp_server/test/` are sync defensively, not because the tests
+genuinely conflict on shared state. Flipping the safe ones to
+`async: true` lets ExUnit parallelize them up to `max_cases: 20`.
+
+**Approach:**
+
+1. Enumerate every `async: false` file in `mcp_server/test/`.
+2. For each: classify the reason for sync. Common signals that
+   require sync:
+   - mutates `Application.put_env/3` for `:ptc_runner_mcp` config.
+   - registers globally-named processes (`:via {Registry, …}` is
+     fine; bare-name registration is not).
+   - touches singleton stdio state (`Stdio.Names`, `Upstream.Registry`).
+   - asserts on telemetry events with global handlers.
+3. For each file with no real reason, flip to `async: true`.
+4. Run `(cd mcp_server && mix test)` 5× back-to-back to catch races
+   that only surface under load. Anything that flakes flips back.
+5. Time the suite before/after to confirm the win.
+
+**Acceptance:** mcp_server suite passes 5× consecutively under
+async, with measurable wall-clock reduction.
+
+**Risk:** New flakes from races that were previously masked by
+serialization. Mitigation: 5× repeat and revert any file that
+flakes. Codex review pass acts as the final gate.
+
+**Estimated impact:** mcp_server suite from 23 s → ~12–15 s on a
+20-core box. ~8–11 s saved.
+
+## Phase 2 — Hunt and remove `mix` build-lock contention
+
+**Hypothesis:** A specific test (or test setup) in `mcp_server/`
+shells out to `mix` (or to a fixture that itself runs `mix`),
+competing with the test runner's own build lock. The "Waiting for
+lock on the build directory" log line proves at least one such call
+exists. When it fires, it adds tail-latency that is invisible in the
+average but visible in the P99.
+
+**Approach:**
+
+1. Grep `mcp_server/test/` for `System.cmd("mix"`, `Mix.Task.run`,
+   `Mix.Shell`, and any wrapper calling `mix release` /
+   `mix compile`.
+2. Identify the call site(s).
+3. For each: replace the spawn with one of —
+   - a pre-built artifact resolved via test fixture path, or
+   - a direct module call (no subprocess), or
+   - a guard that skips the lock-contending path entirely when
+     running under `MIX_ENV=test`.
+4. Re-run the suite repeatedly to confirm the lock-wait warning
+   disappears.
+
+**Acceptance:** No "Waiting for lock on the build directory" logs
+across 10× consecutive `mix test` runs.
+
+**Risk:** Low — the call is almost certainly an over-engineered
+fixture. Replacing it with a static artifact is straightforward.
+
+**Estimated impact:** Removes a 1–60 s tail-latency cliff. Average
+case may not move; worst case improves dramatically.
+
+## Phase 3 — Pool upstream subprocess fixtures in `mcp_server`
+
+**Hypothesis:** Many `mcp_server` tests spawn their own upstream
+stdio subprocesses individually (visible in the run as
+`{:upstream_exited, …}` for unique names like `backoff-via-stdio-1641`,
+`call-crash-1800`, `parent-exit-6914`). Each spawn pays
+100–500 ms for binary load, handshake, and `tools/list`. Pooling /
+sharing fixtures across tests in a `describe` block amortizes the
+cost.
+
+**Approach:**
+
+1. Inventory upstream-spawning tests. Group by what kind of upstream
+   they need (echo, slow, big, crashing).
+2. For each kind: build a `setup_all` fixture that spawns one
+   upstream and registers it with a per-test alias. Tests that
+   genuinely need a fresh process (parent-exit, crash recovery,
+   handshake-timeout) keep their own spawn.
+3. Verify isolation guarantees — pooled upstreams must reset state
+   between tests, or tests must not depend on cross-test isolation.
+4. Re-run suite, time the delta.
+
+**Acceptance:** Suite passes 5× under both pooled and per-test
+regimes; pooled-fixture tests don't see cross-test contamination.
+
+**Risk:** Highest of the four phases. Pooled fixtures hide subtle
+isolation bugs. Codex review here is most important.
+
+**Estimated impact:** Hard to predict — depends on how many tests
+spawn vs. how many can share. Plausible 5–10 s further off
+mcp_server suite, but it could also be 1–2 s if most tests already
+share where they can.
+
+## Phase 4 — Track the pre-push hook + docs-only gate
+
+**Hypothesis:** The hook currently lives at `.git/hooks/pre-push`,
+which is not under version control. That makes hook changes
+unreviewable, unshareable, and undiscoverable. Tracking it (via
+`core.hooksPath`) plus adding a docs-only gate would skip the
+~15.5 s combined dialyzer cost and ~32 s combined test cost when no
+`lib/`, `mix.exs`, `mix.lock`, or `config/` files changed.
+
+**Approach:**
+
+1. Move `.git/hooks/pre-push` into a tracked location:
+   `.githooks/pre-push`, `chmod +x`.
+2. Set `git config core.hooksPath .githooks` and document this in
+   the README (one-time per-clone setup).
+3. Add a path-aware short-circuit at the top of the hook:
+   - Compute the diff between the local ref and its upstream
+     (`git diff --name-only @{u}..HEAD`, or fall back to
+     `origin/main..HEAD` if no upstream).
+   - If every file matches `^(Plans/.*\.md|docs/.*\.md|.*README.*\.md|CHANGELOG\.md)$`,
+     print "📝 Docs-only push, skipping test/dialyzer gate" and exit 0.
+4. Document the escape hatch (env var `FORCE_FULL_PRE_PUSH=1`) in
+   the hook itself for the rare docs-only push that touches
+   doctest-bearing files.
+
+**Acceptance:** Docs-only push completes in <2 s; non-docs push
+runs the full suite as before; `FORCE_FULL_PRE_PUSH=1` overrides.
+
+**Risk:** Low. The gate is explicitly path-conservative — anything
+that could touch code falls through to the full suite.
+
+**Estimated impact:** Docs-only pushes drop from ~53 s to ~1–2 s.
+Non-docs pushes unchanged. This is the highest impact-to-effort
+ratio of the four phases for the workflow we just exercised.
+
+## Sequencing and codex review gates
+
+Run order: **1 → 2 → 3 → 4**, smallest-risk last because tracking
+the hook is purely additive (no test-coverage risk) but it does
+modify per-clone setup, so I'd rather not bundle it with any phase
+that could be reverted independently.
+
+After each phase:
+
+1. Commit the phase as a single commit with conventional message
+   (`perf(mcp_test): …`, `test(mcp): de-flake build-lock`, etc.).
+2. Invoke `codex review` against that commit's diff.
+3. If codex flags issues: fix in a fixup commit on the same phase,
+   re-review, repeat until pass. (Squash before merging back to
+   main.)
+4. Move to next phase only after codex pass.
+
+If a phase fails review and isn't worth fixing, the branch can drop
+that phase via `git rebase -i` and the remaining phases stand on
+their own.
+
+## Merge story
+
+When all phases land and review-pass:
+
+1. Squash phase commits into per-phase clean commits (one per
+   phase, not many fixups).
+2. Hand the worktree back to the user. They merge / fast-forward to
+   main when ready (or push the branch and review on GitHub if they
+   prefer that flow).
+
+This document is the source of truth for the work; commit-message
+bodies should reference the phase number rather than re-explaining
+the rationale.

--- a/Plans/pre-push-perf.md
+++ b/Plans/pre-push-perf.md
@@ -172,16 +172,15 @@ allow-list-based docs-only gate can drop pure-docs pushes from
      `test/support/ptc_lisp_benchmark.ex:63`.
    - `priv/prompts/*.md` files are read at compile time via
      `@external_resource` chains in `lib/ptc_runner/prompts.ex:78`
-     (multiple files), and by direct `File.read!` in
-     `lib/ptc_runner/prompt_loader.ex:11`.
+     (multiple files; the canonical reader). The moduledoc example
+     in `lib/ptc_runner/prompt_loader.ex:11` is illustrative, not
+     a live read site.
    - `mcp_server/priv/mcp_authoring_card.md` and
      `mcp_server/priv/mcp_aggregator_authoring_card.md` are read by
      `mcp_server/lib/ptc_runner_mcp/tools.ex:50` and `:63` via
      `@external_resource`.
    - `usage-rules.md` and `usage-rules/*.md` are read by
      `test/usage_rules_test.exs:33`.
-   - `lib/ptc_runner/lisp/registry.ex:25` declares an
-     `@external_resource` on a registry markdown file.
    - `mcp_server/README.md` and `ptc_viewer/README.md` are *not*
      verified doctested today, but are conservatively denied (cheap
      defense; they may be added to a doctest target later).

--- a/mcp_server/test/ptc_runner_mcp/upstream_supervisor_phase21_test.exs
+++ b/mcp_server/test/ptc_runner_mcp/upstream_supervisor_phase21_test.exs
@@ -286,30 +286,6 @@ defmodule PtcRunnerMcp.UpstreamSupervisorPhase21Test do
     end
   end
 
-  defp await_connection!(upstream, reg_name, timeout_ms) do
-    deadline = System.monotonic_time(:millisecond) + timeout_ms
-    do_await_connection(upstream, reg_name, deadline)
-  end
-
-  defp do_await_connection(upstream, reg_name, deadline) do
-    case UpstreamRegistry.connection_for(upstream, reg_name) do
-      pid when is_pid(pid) ->
-        pid
-
-      _ ->
-        if System.monotonic_time(:millisecond) >= deadline do
-          flunk("Connection for #{upstream} never reappeared after Registry restart")
-        else
-          receive do
-          after
-            10 -> :ok
-          end
-
-          do_await_connection(upstream, reg_name, deadline)
-        end
-    end
-  end
-
   # Atomically poll for a Connection that simultaneously satisfies
   # all four conditions:
   #   (a) Registry resolves the upstream to a pid,


### PR DESCRIPTION
## Summary

Phase 0 + Phase 1 of a 4-phase plan to reduce `git push origin main`
wallclock from ~53 s. Plan went through 4 codex review rounds before
implementation; each phase commit was codex-reviewed independently.

- **Phase 0** — Drop unused `await_connection!/3` and `do_await_connection/3`
  helpers (dialyzer-flagged dead code, no perf coupling).
- **Phase 1** — Track the pre-push hook at `.githooks/pre-push` and add
  a docs-only short-circuit. Pure-docs pushes (`Plans/*.md`,
  `CHANGELOG.md`, etc.) skip the test+dialyzer gate and exit in <0.5 s.
  Anything that touches `lib/`, `test/`, `README.md`, doctested docs,
  or `priv/**` runs the full gate. `FORCE_FULL_PRE_PUSH=1` overrides.

Phases 2–4 (async-flips, mix-via-port elimination, subprocess fixture
pooling) are specified in the plan and executed separately.

## What's in the diff

- `Plans/pre-push-perf.md` — phased plan (5 commits: initial + 3 codex-
  review revisions + 1 cosmetic fixup).
- `mcp_server/test/ptc_runner_mcp/upstream_supervisor_phase21_test.exs`
  — Phase 0 dead-code removal.
- `.githooks/pre-push` — Phase 1 tracked hook with docs-only short-
  circuit and rename-aware dirty-path parser. Phase 1 fixup addressed
  a codex-flagged merge-commit edge case (per-commit `diff-tree`
  silently emits zero paths for merge commits without `-m`; replaced
  with cumulative `git diff --name-only --no-renames <base>..<local>`).
- `.githooks/README.md` — per-clone setup (`git config core.hooksPath
  .githooks`) + override hatch + worktree gotcha (`mix deps.compile`
  needed in fresh clones for `mix run --no-start --no-compile` mock
  servers to find Jason).

## Codex review trail

Plan: 13 → 9 → 3 → 2 (cosmetic) → PLAN READY.
Phase 1: P2 finding (merge-commit blind spot) → fixup commit `58cd523`
→ "I did not find a discrete correctness issue introduced by this
patch."

## Test plan

- [x] `mix test` passes in all three projects (root, mcp_server,
      ptc_viewer) under the existing pre-push hook.
- [x] Phase 0 acceptance: dialyzer warnings on the unused helpers
      gone; suite still passes (384 tests, 0 failures).
- [x] Phase 1 acceptance #1: `Plans/*.md`-only commit completes
      docs-only short-circuit in 0.306–0.47 s.
- [x] Phase 1 acceptance #2: `README.md`, `docs/ptc-lisp-spec.md`, and
      `lib/**/*.ex` edits all fall through to the full gate.
- [x] Phase 1 acceptance #3: dirty worktree containing a
      non-allow-listed path forces full gate even when committed
      changes are docs-only.
- [x] Phase 1 acceptance #4: `FORCE_FULL_PRE_PUSH=1` always runs
      the full gate.
- [x] Synthetic merge-commit regression: a merge whose conflict
      resolution introduces a non-docs file now correctly flips the
      hook to the full gate (previously slipped past).

## Known limitations / follow-ups

- The new hook only fires after a per-clone
  `git config core.hooksPath .githooks` (documented in
  `.githooks/README.md`). The existing `.git/hooks/pre-push` continues
  to work until then.
- Phase 2 (async-flips in mcp_server tests) ran into a falsified
  hypothesis — most sync files turn out to be sync for real reasons
  (mutating `Application.put_env`, global registries,
  `:persistent_term`). The Engineer agent surfaced a pre-existing
  flake in `upstream_supervisor_phase21_test.exs` (~1/8 on seed=24)
  that's worth fixing on its own. The Phase 2 attempt
  (1 safe flip + 24 documented sync-reason comments) is stashed
  pending direction.
- Phases 3–4 (mix-via-Port.open elimination, subprocess fixture
  pooling) are unstarted and specified in the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Fix Automation State
<!-- fix-state: {"attempts":3} -->
Fix attempts: 2/3
