### PR TITLE
refactor(loop): extract shared validate_program/1 into PtcToolProtocol

### DIFF
--- a/lib/ptc_runner/ptc_tool_protocol.ex
+++ b/lib/ptc_runner/ptc_tool_protocol.ex
@@ -343,6 +343,50 @@ defmodule PtcRunner.PtcToolProtocol do
   def lisp_run(source, opts \\ []), do: Lisp.run(source, opts)
 
   @doc """
+  Validate the `program` argument of a `ptc_lisp_execute` invocation.
+
+  Shared across the in-process `:tool_call` and text-mode loop branches
+  so the wire-format error wording for an absent, mistyped, or empty
+  `program` stays in lockstep with the rest of the protocol surface.
+
+  Returns `{:ok, program}` for a non-empty binary, or
+  `{:error, :args_error, message}` describing the violation.
+
+  ## Examples
+
+      iex> PtcRunner.PtcToolProtocol.validate_program("(+ 1 2)")
+      {:ok, "(+ 1 2)"}
+
+      iex> PtcRunner.PtcToolProtocol.validate_program(nil)
+      {:error, :args_error, "ptc_lisp_execute requires a non-empty `program` string argument."}
+
+      iex> PtcRunner.PtcToolProtocol.validate_program(42)
+      {:error, :args_error, "ptc_lisp_execute `program` must be a string, got 42."}
+
+      iex> PtcRunner.PtcToolProtocol.validate_program("   ")
+      {:error, :args_error, "ptc_lisp_execute `program` must be a non-empty string."}
+  """
+  @spec validate_program(term()) ::
+          {:ok, String.t()} | {:error, :args_error, String.t()}
+  def validate_program(nil),
+    do:
+      {:error, :args_error,
+       "ptc_lisp_execute requires a non-empty `program` string argument."}
+
+  def validate_program(program) when not is_binary(program),
+    do:
+      {:error, :args_error,
+       "ptc_lisp_execute `program` must be a string, got #{inspect(program)}."}
+
+  def validate_program(program) when is_binary(program) do
+    if String.trim(program) == "" do
+      {:error, :args_error, "ptc_lisp_execute `program` must be a non-empty string."}
+    else
+      {:ok, program}
+    end
+  end
+
+  @doc """
   Delegates to `PtcRunner.SubAgent.Loop.JsonHandler.atomize_value/2`.
 
   Used by surfaces that need to coerce a raw JSON value into the

--- a/lib/ptc_runner/ptc_tool_protocol.ex
+++ b/lib/ptc_runner/ptc_tool_protocol.ex
@@ -369,9 +369,7 @@ defmodule PtcRunner.PtcToolProtocol do
   @spec validate_program(term()) ::
           {:ok, String.t()} | {:error, :args_error, String.t()}
   def validate_program(nil),
-    do:
-      {:error, :args_error,
-       "ptc_lisp_execute requires a non-empty `program` string argument."}
+    do: {:error, :args_error, "ptc_lisp_execute requires a non-empty `program` string argument."}
 
   def validate_program(program) when not is_binary(program),
     do:

--- a/lib/ptc_runner/sub_agent/loop/ptc_tool_call.ex
+++ b/lib/ptc_runner/sub_agent/loop/ptc_tool_call.ex
@@ -1075,23 +1075,7 @@ defmodule PtcRunner.SubAgent.Loop.PtcToolCall do
       args = Map.get(call, :args) || Map.get(call, "args")
       program = if is_map(args), do: Map.get(args, "program") || Map.get(args, :program)
 
-      validate_program(program)
-    end
-  end
-
-  defp validate_program(nil) do
-    {:error, :args_error, "ptc_lisp_execute requires a non-empty `program` string argument."}
-  end
-
-  defp validate_program(program) when not is_binary(program) do
-    {:error, :args_error, "ptc_lisp_execute `program` must be a string, got #{inspect(program)}."}
-  end
-
-  defp validate_program(program) when is_binary(program) do
-    if String.trim(program) == "" do
-      {:error, :args_error, "ptc_lisp_execute `program` must be a non-empty string."}
-    else
-      {:ok, program}
+      PtcToolProtocol.validate_program(program)
     end
   end
 

--- a/lib/ptc_runner/sub_agent/loop/text_mode.ex
+++ b/lib/ptc_runner/sub_agent/loop/text_mode.ex
@@ -1423,26 +1423,10 @@ defmodule PtcRunner.SubAgent.Loop.TextMode do
 
   defp extract_program(%{args: args}) when is_map(args) do
     program = Map.get(args, "program") || Map.get(args, :program)
-    validate_program(program)
+    PtcToolProtocol.validate_program(program)
   end
 
-  defp extract_program(_), do: validate_program(nil)
-
-  defp validate_program(nil),
-    do: {:error, :args_error, "ptc_lisp_execute requires a non-empty `program` string argument."}
-
-  defp validate_program(program) when not is_binary(program),
-    do:
-      {:error, :args_error,
-       "ptc_lisp_execute `program` must be a string, got #{inspect(program)}."}
-
-  defp validate_program(program) when is_binary(program) do
-    if String.trim(program) == "" do
-      {:error, :args_error, "ptc_lisp_execute `program` must be a non-empty string."}
-    else
-      {:ok, program}
-    end
-  end
+  defp extract_program(_), do: PtcToolProtocol.validate_program(nil)
 
   defp execute_single_tool(tool_name, tool_args, state) do
     start = System.monotonic_time(:millisecond)


### PR DESCRIPTION
Both Loop.PtcToolCall and Loop.TextMode carried byte-identical
validate_program/1 clauses for the ptc_lisp_execute `program`
argument. Move the helper to PtcToolProtocol — already the wire-format
source of truth for the tool — so the error wording stays in lockstep
across the in-process tool-call and text-mode branches.