### PR TITLE
perf(precommit): faster precommit — drop forced recompile, split out dialyzer, parallelize spec validation

### DIFF
--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -1,0 +1,4 @@
+# Dialyzer warning filters. Keep empty unless a warning is a confirmed false
+# positive — each entry is either a regex string or a {file, warning} tuple.
+# `list_unused_filters: true` (mix.exs) flags entries here that no longer match.
+[]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,12 +30,13 @@ mix test                        # Run tests (--failed to re-run failures)
 mix format                      # Format code
 mix credo --strict              # Lint
 mix dialyzer                    # Type checking
-mix precommit                   # Run before pushing (format + compile + credo + dialyzer + test)
+mix precommit                   # Fast quality gate (format + compile + credo + schema + spec + tests)
+mix prepush                     # Slower checks before pushing (dialyzer + unused-deps check)
 ```
 
 Full quality check: `mix format --check-formatted && mix compile --warnings-as-errors && mix test`
 
-Always run `mix precommit` before `git push`. If it fails, fix all issues before pushing.
+Run `mix precommit` before committing and `mix prepush` before `git push`. If either fails, fix all issues before pushing. (CI also runs dialyzer and the unused-deps check on every PR.)
 
 ## Project Structure
 
@@ -92,7 +93,7 @@ Programs execute in isolated BEAM processes with timeout (1s) and memory limits 
 ### Code Quality
 
 - When fixing dialyzer or Credo issues, always re-run the tool after changes to verify the fix. Never assume fixes are correct without verification.
-- Run `mix precommit` to catch all issues before committing.
+- Run `mix precommit` to catch most issues before committing, and `mix prepush` (dialyzer) before pushing.
 
 ### Testing
 

--- a/lib/ptc_runner/lisp/spec_validator.ex
+++ b/lib/ptc_runner/lisp/spec_validator.ex
@@ -879,7 +879,8 @@ defmodule PtcRunner.Lisp.SpecValidator do
         end,
         ordered: true,
         timeout: 30_000,
-        max_concurrency: System.schedulers_online()
+        max_concurrency: System.schedulers_online(),
+        on_timeout: :kill_task
       )
       |> Enum.reduce(initial_results, &fold_example_result/2)
 

--- a/lib/ptc_runner/lisp/spec_validator.ex
+++ b/lib/ptc_runner/lisp/spec_validator.ex
@@ -869,38 +869,49 @@ defmodule PtcRunner.Lisp.SpecValidator do
       by_section: %{}
     }
 
-    validate_example_list(examples, initial_results)
-  end
+    # Each example runs in its own sandbox process, so they parallelize cleanly.
+    # Keep `ordered: true` so `failures` ordering is deterministic.
+    results =
+      examples
+      |> Task.async_stream(
+        fn {code, expected, section} ->
+          {validate_example(code, expected), code, expected, section}
+        end,
+        ordered: true,
+        timeout: 30_000,
+        max_concurrency: System.schedulers_online()
+      )
+      |> Enum.reduce(initial_results, &fold_example_result/2)
 
-  defp validate_example_list([], results) do
     {:ok, results}
   end
 
-  defp validate_example_list([{code, expected, section} | rest], results) do
-    case validate_example(code, expected) do
-      :ok ->
-        # Update section stats
-        by_section = update_section_stats(results.by_section, section, :pass)
+  defp fold_example_result({:ok, {:ok, _code, _expected, section}}, results) do
+    %{
+      results
+      | passed: results.passed + 1,
+        by_section: update_section_stats(results.by_section, section, :pass)
+    }
+  end
 
-        validate_example_list(rest, %{
-          results
-          | passed: results.passed + 1,
-            by_section: by_section
-        })
+  defp fold_example_result({:ok, {{:error, reason}, code, expected, section}}, results) do
+    %{
+      results
+      | failed: results.failed + 1,
+        failures: [{code, expected, reason, section} | results.failures],
+        by_section: update_section_stats(results.by_section, section, :fail)
+    }
+  end
 
-      {:error, reason} ->
-        failure = {code, expected, reason, section}
-
-        # Update section stats
-        by_section = update_section_stats(results.by_section, section, :fail)
-
-        validate_example_list(rest, %{
-          results
-          | failed: results.failed + 1,
-            failures: [failure | results.failures],
-            by_section: by_section
-        })
-    end
+  defp fold_example_result({:exit, reason}, results) do
+    %{
+      results
+      | failed: results.failed + 1,
+        failures: [
+          {"<task crashed>", nil, "Task exited: #{inspect(reason)}", "<unknown>"}
+          | results.failures
+        ]
+    }
   end
 
   defp update_section_stats(by_section, section, status) do

--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,9 @@ defmodule PtcRunner.MixProject do
       dialyzer: [
         plt_core_path: "priv/plts",
         plt_file: {:no_warn, "priv/plts/project.plt"},
-        plt_add_apps: [:ex_unit, :mix, :req, :req_llm]
+        plt_add_apps: [:ex_unit, :mix, :req, :req_llm],
+        ignore_warnings: ".dialyzer_ignore.exs",
+        list_unused_filters: true
       ]
     ]
   end
@@ -36,7 +38,7 @@ defmodule PtcRunner.MixProject do
 
   def cli do
     [
-      preferred_envs: [precommit: :test]
+      preferred_envs: [precommit: :test, prepush: :test]
     ]
   end
 
@@ -66,14 +68,19 @@ defmodule PtcRunner.MixProject do
     [
       precommit: [
         "format --check-formatted",
-        "compile --force --warnings-as-errors",
+        "compile --warnings-as-errors",
         "credo --strict",
-        "dialyzer",
         "schema.gen",
         "ptc.validate_spec",
         "test --warnings-as-errors",
         "cmd --cd demo mix test --color",
         "cmd --cd ptc_viewer mix test --color"
+      ],
+      # Slower checks kept out of the per-commit loop; run before pushing.
+      # CI runs dialyzer + the unused-deps check on every PR regardless.
+      prepush: [
+        "dialyzer",
+        "deps.unlock --check-unused"
       ],
       "schema.gen": [
         "run -e 'File.write!(\"priv/ptc_schema.json\", Jason.encode!(PtcRunner.Schema.to_json_schema(), pretty: true))'"


### PR DESCRIPTION
## Summary

Investigation into `mix precommit` performance, plus the low-risk wins it surfaced.

**Where the time went** (warm run ≈ 50s wall on a heavily-loaded machine):
| Step | Cost | Note |
|---|---|---|
| `compile --force --warnings-as-errors` | ~5–8s | full recompile of all 152 `.ex` files **every run**, even with zero changes |
| `credo --strict` | ~5s | fine |
| `dialyzer` | ~5s warm / **2–3 min on PLT rebuild** | the lurking cost whenever a dep changes |
| `ptc.validate_spec` | ~15s | 380 spec examples run serially |
| `test --warnings-as-errors` | ~15–20s | 4831 tests, already well-parallelized |
| demo / ptc_viewer tests | ~2s warm | (separate `_build`, cheap when warm) |

The alias already runs in a single BEAM process, so per-step VM-startup overhead was not a factor.

## Changes

- **Drop `--force` from the compile step.** Eliminates the ~5–8s full recompile on every run. `mix compile --warnings-as-errors` still surfaces warnings on changed files; CI's clean build remains the authoritative warnings-as-errors gate.
- **Move `dialyzer` (+ `deps.unlock --check-unused`) out of `precommit` into a new `mix prepush` alias.** Dialyzer is cheap when the PLT is warm but costs 2–3 min on a rebuild; CI runs it on every PR regardless. `precommit` stays the fast per-commit gate; `prepush` is the heavier pre-push check.
- **Parallelize `ptc.validate_spec`** with `Task.async_stream` (each example already runs in its own sandbox process). ~15s → ~3s standalone. Ordering of `failures`/`by_section` is preserved (`ordered: true`); task crashes/timeouts are now reported as failures rather than aborting the run.
- **Add an empty `.dialyzer_ignore.exs` + `list_unused_filters: true`** to silence dialyxir's "No :ignore_warnings opt specified" notice and prevent stale filters accumulating.
- **Update `CLAUDE.md`** to document the `precommit` / `prepush` split.

Net: `mix precommit` dropped from ~52s to ~32s in back-to-back runs here (both noisy — machine was at load ~50 on 10 cores), and no longer does a redundant full recompile.

## Considered but not done

- **Parallel runner for the whole alias** — concurrent `mix` processes contend on Mix's build lock during their compile-check phase, so the win is modest and the failure modes are flaky. Left as a sequential alias.
- **`schema.gen` as a check instead of regenerate** — it's cheap inside the shared BEAM; not worth the churn.

## Verification

- `mix precommit` → green (format, compile, credo, schema.gen, ptc.validate_spec 380/380, 4831 tests, demo 200 tests, ptc_viewer 9 tests)
- `mix prepush` → green (dialyzer passed, unused-deps check passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Fix Automation State
<!-- fix-state: {"attempts":2} -->
Fix attempts: 2/3
