### PR TITLE
feat(mcp): add output_schema JSON Schema input argument

### DIFF
--- a/lib/ptc_runner/sub_agent/signature.ex
+++ b/lib/ptc_runner/sub_agent/signature.ex
@@ -19,11 +19,11 @@ defmodule PtcRunner.SubAgent.Signature do
 
   ## Examples
 
-      iex> {:ok, sig} = Signature.parse("(name :string) -> {greeting :string}")
+      iex> {:ok, sig} = PtcRunner.SubAgent.Signature.parse("(name :string) -> {greeting :string}")
       iex> sig
       {:signature, [{"name", :string}], {:map, [{"greeting", :string}]}}
 
-      iex> {:ok, sig} = Signature.parse("{count :int}")
+      iex> {:ok, sig} = PtcRunner.SubAgent.Signature.parse("{count :int}")
       iex> sig
       {:signature, [], {:map, [{"count", :int}]}}
 
@@ -66,17 +66,17 @@ defmodule PtcRunner.SubAgent.Signature do
 
   ## Examples
 
-      iex> Signature.parse("(id :int) -> {name :string}")
+      iex> PtcRunner.SubAgent.Signature.parse("(id :int) -> {name :string}")
       {:ok, {:signature, [{"id", :int}], {:map, [{"name", :string}]}}}
 
-      iex> Signature.parse("() -> :string")
+      iex> PtcRunner.SubAgent.Signature.parse("() -> :string")
       {:ok, {:signature, [], :string}}
 
-      iex> Signature.parse("{count :int}")
+      iex> PtcRunner.SubAgent.Signature.parse("{count :int}")
       {:ok, {:signature, [], {:map, [{"count", :int}]}}}
 
-      iex> Signature.parse("invalid")
-      {:error, "..."}
+      iex> match?({:error, _}, PtcRunner.SubAgent.Signature.parse("invalid"))
+      true
   """
   @spec parse(String.t()) :: {:ok, signature()} | {:error, String.t()}
   def parse(input) when is_binary(input) do
@@ -94,12 +94,12 @@ defmodule PtcRunner.SubAgent.Signature do
 
   ## Examples
 
-      iex> {:ok, sig} = Signature.parse("() -> {count :int, items [:string]}")
-      iex> Signature.validate(sig, %{count: 5, items: ["a", "b"]})
+      iex> {:ok, sig} = PtcRunner.SubAgent.Signature.parse("() -> {count :int, items [:string]}")
+      iex> PtcRunner.SubAgent.Signature.validate(sig, %{count: 5, items: ["a", "b"]})
       :ok
 
-      iex> {:ok, sig} = Signature.parse("() -> :int")
-      iex> Signature.validate(sig, "not an int")
+      iex> {:ok, sig} = PtcRunner.SubAgent.Signature.parse("() -> :int")
+      iex> PtcRunner.SubAgent.Signature.validate(sig, "not an int")
       {:error, [%{path: [], message: "expected int, got string"}]}
   """
   @spec validate(signature(), term()) :: :ok | {:error, [validation_error()]}

--- a/lib/ptc_runner/sub_agent/signature.ex
+++ b/lib/ptc_runner/sub_agent/signature.ex
@@ -197,6 +197,123 @@ defmodule PtcRunner.SubAgent.Signature do
   def returns_list?({:signature, _params, {:list, _}}), do: true
   def returns_list?(_), do: false
 
+  @supported_scalar_keys MapSet.new(~w(type description))
+  @supported_array_keys MapSet.new(~w(type description items))
+  @supported_object_keys MapSet.new(~w(type description properties required additionalProperties))
+
+  @doc """
+  Convert a JSON Schema subset map to a PTC signature return type.
+
+  Inverse of `type_to_json_schema/1`. Supports scalar types (`string`,
+  `integer`, `number`, `boolean`), `array` with `items`, and `object`
+  with `properties`/`required`. Unsupported JSON Schema features
+  (combinators, `$ref`, `enum`, `pattern`, etc.) return `{:error, reason}`.
+
+  ## Examples
+
+      iex> PtcRunner.SubAgent.Signature.from_json_schema(%{"type" => "integer"})
+      {:ok, :int}
+
+      iex> PtcRunner.SubAgent.Signature.from_json_schema(%{"type" => "array", "items" => %{"type" => "string"}})
+      {:ok, {:list, :string}}
+
+      iex> PtcRunner.SubAgent.Signature.from_json_schema(%{"type" => "object", "properties" => %{"count" => %{"type" => "integer"}}, "required" => ["count"]})
+      {:ok, {:map, [{"count", :int}]}}
+
+      iex> PtcRunner.SubAgent.Signature.from_json_schema(%{"type" => "object", "properties" => %{"name" => %{"type" => "string"}}})
+      {:ok, {:map, [{"name", {:optional, :string}}]}}
+
+  """
+  @spec from_json_schema(map()) :: {:ok, type()} | {:error, String.t()}
+  def from_json_schema(%{"type" => "string"} = s), do: check_scalar_keys(s, :string)
+  def from_json_schema(%{"type" => "integer"} = s), do: check_scalar_keys(s, :int)
+  def from_json_schema(%{"type" => "number"} = s), do: check_scalar_keys(s, :float)
+  def from_json_schema(%{"type" => "boolean"} = s), do: check_scalar_keys(s, :bool)
+  def from_json_schema(%{"type" => "array"} = s), do: convert_array_schema(s)
+  def from_json_schema(%{"type" => "object"} = s), do: convert_object_schema(s)
+
+  def from_json_schema(%{"type" => type}) when is_binary(type),
+    do: {:error, "unsupported type: #{inspect(type)}"}
+
+  def from_json_schema(schema) when is_map(schema),
+    do: {:error, "schema must have a \"type\" key"}
+
+  def from_json_schema(other),
+    do: {:error, "schema must be a JSON object, got #{inspect(other)}"}
+
+  defp check_scalar_keys(schema, type) do
+    case check_unsupported_keys(schema, @supported_scalar_keys) do
+      :ok -> {:ok, type}
+      error -> error
+    end
+  end
+
+  defp convert_array_schema(schema) do
+    with :ok <- check_unsupported_keys(schema, @supported_array_keys) do
+      case Map.fetch(schema, "items") do
+        {:ok, items} when is_map(items) ->
+          case from_json_schema(items) do
+            {:ok, inner} -> {:ok, {:list, inner}}
+            error -> error
+          end
+
+        {:ok, _} ->
+          {:error, "array \"items\" must be a JSON object"}
+
+        :error ->
+          {:error, "array type requires an \"items\" key"}
+      end
+    end
+  end
+
+  defp convert_object_schema(schema) do
+    with :ok <- check_unsupported_keys(schema, @supported_object_keys) do
+      case Map.fetch(schema, "properties") do
+        {:ok, properties} when is_map(properties) ->
+          required = Map.get(schema, "required", [])
+          convert_object_fields(properties, required)
+
+        {:ok, _} ->
+          {:error, "object \"properties\" must be a JSON object"}
+
+        :error ->
+          {:ok, :map}
+      end
+    end
+  end
+
+  defp convert_object_fields(properties, required) when is_list(required) do
+    properties
+    |> Enum.sort_by(&elem(&1, 0))
+    |> Enum.reduce_while({:ok, []}, fn {name, sub_schema}, {:ok, acc} ->
+      case from_json_schema(sub_schema) do
+        {:ok, type} ->
+          field_type = if name in required, do: type, else: {:optional, type}
+          {:cont, {:ok, [{name, field_type} | acc]}}
+
+        {:error, reason} ->
+          {:halt, {:error, "property #{inspect(name)}: #{reason}"}}
+      end
+    end)
+    |> case do
+      {:ok, fields} -> {:ok, {:map, Enum.reverse(fields)}}
+      {:error, _} = err -> err
+    end
+  end
+
+  defp convert_object_fields(_properties, _required),
+    do: {:error, "\"required\" must be an array of strings"}
+
+  defp check_unsupported_keys(schema, allowed) do
+    extra = schema |> Map.keys() |> Enum.reject(&MapSet.member?(allowed, &1))
+
+    if extra == [] do
+      :ok
+    else
+      {:error, "unsupported JSON Schema key(s): #{Enum.join(Enum.sort(extra), ", ")}"}
+    end
+  end
+
   @doc false
   @spec type_to_json_schema(type()) :: map()
   def type_to_json_schema(:string), do: %{"type" => "string"}

--- a/lib/ptc_runner/sub_agent/signature.ex
+++ b/lib/ptc_runner/sub_agent/signature.ex
@@ -49,6 +49,7 @@ defmodule PtcRunner.SubAgent.Signature do
           | {:optional, type()}
           | {:list, type()}
           | {:map, [field()]}
+          | {:closed_map, [field()]}
 
   @type field :: {String.t(), type()}
 
@@ -197,17 +198,24 @@ defmodule PtcRunner.SubAgent.Signature do
   def returns_list?({:signature, _params, {:list, _}}), do: true
   def returns_list?(_), do: false
 
-  @supported_scalar_keys MapSet.new(~w(type description))
-  @supported_array_keys MapSet.new(~w(type description items))
-  @supported_object_keys MapSet.new(~w(type description properties required additionalProperties))
+  @supported_scalar_keys ~w(type description)
+  @supported_array_keys ~w(type description items)
+  @supported_object_keys ~w(type description properties required additionalProperties)
 
   @doc """
   Convert a JSON Schema subset map to a PTC signature return type.
 
   Inverse of `type_to_json_schema/1`. Supports scalar types (`string`,
   `integer`, `number`, `boolean`), `array` with `items`, and `object`
-  with `properties`/`required`. Unsupported JSON Schema features
-  (combinators, `$ref`, `enum`, `pattern`, etc.) return `{:error, reason}`.
+  with `properties`/`required`/`additionalProperties`. Unsupported JSON
+  Schema features (combinators, `$ref`, `enum`, `pattern`, etc.) return
+  `{:error, reason}`.
+
+  `additionalProperties: false` produces a closed map (`{:closed_map, ...}`)
+  whose validation rejects undeclared fields. `additionalProperties: true`
+  (or its absence) produces an open `{:map, ...}` that tolerates extras.
+  Every `required` entry must be a string naming a declared property,
+  otherwise an `{:error, reason}` is returned.
 
   ## Examples
 
@@ -222,6 +230,12 @@ defmodule PtcRunner.SubAgent.Signature do
 
       iex> PtcRunner.SubAgent.Signature.from_json_schema(%{"type" => "object", "properties" => %{"name" => %{"type" => "string"}}})
       {:ok, {:map, [{"name", {:optional, :string}}]}}
+
+      iex> PtcRunner.SubAgent.Signature.from_json_schema(%{"type" => "object", "properties" => %{"x" => %{"type" => "integer"}}, "required" => ["x"], "additionalProperties" => false})
+      {:ok, {:closed_map, [{"x", :int}]}}
+
+      iex> match?({:error, _}, PtcRunner.SubAgent.Signature.from_json_schema(%{"type" => "object", "properties" => %{}, "required" => ["missing"]}))
+      true
 
   """
   @spec from_json_schema(map()) :: {:ok, type()} | {:error, String.t()}
@@ -267,22 +281,70 @@ defmodule PtcRunner.SubAgent.Signature do
   end
 
   defp convert_object_schema(schema) do
-    with :ok <- check_unsupported_keys(schema, @supported_object_keys) do
+    with :ok <- check_unsupported_keys(schema, @supported_object_keys),
+         {:ok, mode} <- additional_properties_mode(schema) do
+      required = Map.get(schema, "required", [])
+
       case Map.fetch(schema, "properties") do
         {:ok, properties} when is_map(properties) ->
-          required = Map.get(schema, "required", [])
-          convert_object_fields(properties, required)
+          with :ok <- validate_required_entries(required, properties) do
+            convert_object_fields(properties, required, mode)
+          end
 
         {:ok, _} ->
           {:error, "object \"properties\" must be a JSON object"}
 
         :error ->
-          {:ok, :map}
+          with :ok <- validate_required_entries(required, %{}) do
+            {:ok, empty_object_type(mode)}
+          end
       end
     end
   end
 
-  defp convert_object_fields(properties, required) when is_list(required) do
+  # `additionalProperties` controls whether undeclared fields survive
+  # validation. We only honour the boolean form of the keyword; the
+  # schema-valued form (`additionalProperties: {...}`) is rejected as
+  # unsupported so it can never be silently dropped.
+  defp additional_properties_mode(schema) do
+    case Map.fetch(schema, "additionalProperties") do
+      :error ->
+        {:ok, :open}
+
+      {:ok, true} ->
+        {:ok, :open}
+
+      {:ok, false} ->
+        {:ok, :closed}
+
+      {:ok, other} ->
+        {:error, ~s|"additionalProperties" must be true or false, got #{inspect(other)}|}
+    end
+  end
+
+  defp empty_object_type(:closed), do: {:closed_map, []}
+  defp empty_object_type(:open), do: :map
+
+  defp validate_required_entries(required, _properties) when not is_list(required),
+    do: {:error, ~s|"required" must be an array of strings|}
+
+  defp validate_required_entries(required, properties) do
+    declared = Map.keys(properties)
+
+    Enum.reduce_while(required, :ok, fn
+      entry, :ok when is_binary(entry) ->
+        if entry in declared do
+          {:cont, :ok}
+        else
+          {:halt, {:error, ~s|"required" entry #{inspect(entry)} is not a declared property|}}
+        end
+
+      entry, :ok ->
+        {:halt, {:error, ~s|"required" entries must be strings, got #{inspect(entry)}|}}
+    end)
+  end
+
+  defp convert_object_fields(properties, required, mode) do
     properties
     |> Enum.sort_by(&elem(&1, 0))
     |> Enum.reduce_while({:ok, []}, fn {name, sub_schema}, {:ok, acc} ->
@@ -296,16 +358,16 @@ defmodule PtcRunner.SubAgent.Signature do
       end
     end)
     |> case do
-      {:ok, fields} -> {:ok, {:map, Enum.reverse(fields)}}
+      {:ok, fields} -> {:ok, build_object_type(mode, Enum.reverse(fields))}
       {:error, _} = err -> err
     end
   end
 
-  defp convert_object_fields(_properties, _required),
-    do: {:error, "\"required\" must be an array of strings"}
+  defp build_object_type(:closed, fields), do: {:closed_map, fields}
+  defp build_object_type(:open, fields), do: {:map, fields}
 
   defp check_unsupported_keys(schema, allowed) do
-    extra = schema |> Map.keys() |> Enum.reject(&MapSet.member?(allowed, &1))
+    extra = schema |> Map.keys() |> Enum.reject(&Enum.member?(allowed, &1))
 
     if extra == [] do
       :ok
@@ -361,6 +423,11 @@ defmodule PtcRunner.SubAgent.Signature do
       "additionalProperties" => false
     }
   end
+
+  # Closed maps already advertise `additionalProperties: false` via the
+  # `{:map, ...}` branch above — the only difference is enforcement at
+  # validation time, which the JSON Schema can't express any further.
+  def type_to_json_schema({:closed_map, fields}), do: type_to_json_schema({:map, fields})
 
   @doc false
   @spec unwrap_optional(type()) :: {type(), boolean()}

--- a/lib/ptc_runner/sub_agent/signature/coercion.ex
+++ b/lib/ptc_runner/sub_agent/signature/coercion.ex
@@ -275,6 +275,26 @@ defmodule PtcRunner.SubAgent.Signature.Coercion do
     {:error, "cannot coerce to map"}
   end
 
+  # Closed maps reject undeclared keys. `coerce_map` already drops anything
+  # not declared, so a non-empty difference between the input keys and the
+  # coerced keys means the caller passed fields the schema excluded.
+  defp coerce_impl(value, {:closed_map, fields}) when is_map(value) do
+    with {:ok, coerced, warnings} <- coerce_map(value, fields, %{}, []) do
+      case Map.keys(value) -- Map.keys(coerced) do
+        [] ->
+          {:ok, coerced, warnings}
+
+        extra ->
+          {:error,
+           "unexpected field(s): #{Enum.map_join(Enum.sort_by(extra, &inspect/1), ", ", &inspect/1)}"}
+      end
+    end
+  end
+
+  defp coerce_impl(_value, {:closed_map, _fields}) do
+    {:error, "cannot coerce to map"}
+  end
+
   # Catch-all for unknown types
   defp coerce_impl(_value, _type) do
     {:error, "unsupported type"}

--- a/lib/ptc_runner/sub_agent/signature/renderer.ex
+++ b/lib/ptc_runner/sub_agent/signature/renderer.ex
@@ -117,4 +117,8 @@ defmodule PtcRunner.SubAgent.Signature.Renderer do
 
     "{#{fields_str}}"
   end
+
+  # The PTC signature DSL has no closed-map syntax; render it like a plain
+  # map (the "closed" semantics only affect validation, not display).
+  def render_type({:closed_map, fields}, opts), do: render_type({:map, fields}, opts)
 end

--- a/lib/ptc_runner/sub_agent/signature/validator.ex
+++ b/lib/ptc_runner/sub_agent/signature/validator.ex
@@ -124,6 +124,17 @@ defmodule PtcRunner.SubAgent.Signature.Validator do
     end
   end
 
+  # Closed maps (from a JSON Schema `additionalProperties: false`): every
+  # declared field is validated as usual *and* any undeclared key is an
+  # error, so fields the caller explicitly excluded can't leak through.
+  defp validate_type(data, {:closed_map, fields}, path) do
+    if is_map(data) do
+      validate_map_fields(data, fields, path) ++ validate_no_extra_fields(data, fields, path)
+    else
+      [error_at(path, "expected map, got #{type_name(data)}")]
+    end
+  end
+
   # ============================================================
   # Map Field Validation
   # ============================================================
@@ -144,6 +155,31 @@ defmodule PtcRunner.SubAgent.Signature.Validator do
       end
     end)
   end
+
+  # Compare data keys against declared field names, normalizing both sides
+  # (atom→string, hyphen→underscore) so a Clojure-style `:user-id` data key
+  # still counts as covering a declared `"user_id"` field. Anything left over
+  # is an undeclared field.
+  defp validate_no_extra_fields(data, fields, path) do
+    declared =
+      fields
+      |> Enum.map(fn {name, _type} -> KeyNormalizer.normalize_key(name) end)
+      |> MapSet.new()
+
+    data
+    |> Map.keys()
+    |> Enum.reject(fn key -> MapSet.member?(declared, KeyNormalizer.normalize_key(key)) end)
+    |> Enum.sort_by(&inspect/1)
+    |> Enum.map(fn key ->
+      error_at(
+        path ++ [path_segment(key)],
+        "unexpected field — schema disallows additional properties"
+      )
+    end)
+  end
+
+  defp path_segment(key) when is_binary(key) or is_atom(key), do: to_string(key)
+  defp path_segment(key), do: inspect(key)
 
   # Try several key forms so signature field names match regardless of which
   # convention the data uses (Clojure-style `:user-id`, JSON-style `"user-id"`,

--- a/mcp_server/lib/ptc_runner_mcp/tools.ex
+++ b/mcp_server/lib/ptc_runner_mcp/tools.ex
@@ -27,6 +27,7 @@ defmodule PtcRunnerMcp.Tools do
   """
 
   alias PtcRunner.PtcToolProtocol
+  alias PtcRunner.SubAgent.Signature
 
   alias PtcRunnerMcp.{
     Agentic,
@@ -482,7 +483,7 @@ defmodule PtcRunnerMcp.Tools do
   def validate(args) when is_map(args) do
     with {:ok, program} <- validate_program(args),
          {:ok, context} <- validate_context(args),
-         {:ok, parsed_signature} <- validate_signature(args) do
+         {:ok, parsed_signature} <- validate_output_contract(args) do
       {:ok, program, context, parsed_signature}
     else
       {:error, message} -> {:error, Envelope.render_error(:args_error, message)}
@@ -851,6 +852,41 @@ defmodule PtcRunnerMcp.Tools do
     end
   end
 
+  # Mutual exclusivity gate: if both `output_schema` and `signature`
+  # are supplied, reject before either is parsed.
+  defp validate_output_contract(args) do
+    sig_present = match?({:ok, v} when not is_nil(v), Map.fetch(args, "signature"))
+    schema_present = match?({:ok, v} when not is_nil(v), Map.fetch(args, "output_schema"))
+
+    cond do
+      sig_present and schema_present ->
+        {:error,
+         "arguments `output_schema` and `signature` are mutually exclusive — provide one or neither"}
+
+      schema_present ->
+        validate_output_schema(args)
+
+      true ->
+        validate_signature(args)
+    end
+  end
+
+  defp validate_output_schema(args) do
+    case Map.fetch(args, "output_schema") do
+      {:ok, value} when not is_map(value) or is_struct(value) ->
+        {:error, "argument `output_schema` must be a JSON object, got #{type_label(value)}"}
+
+      {:ok, value} ->
+        case Signature.from_json_schema(value) do
+          {:ok, return_type} -> {:ok, {:signature, [], return_type}}
+          {:error, reason} -> {:error, "argument `output_schema` is invalid: #{reason}"}
+        end
+
+      :error ->
+        {:ok, nil}
+    end
+  end
+
   defp type_label(v) when is_struct(v), do: "struct"
   defp type_label(v) when is_map(v), do: "object"
   defp type_label(v) when is_list(v), do: "array"
@@ -875,6 +911,10 @@ defmodule PtcRunnerMcp.Tools do
               "Keys are strings; values are JSON-encodable.",
           "additionalProperties" => true
         },
+        "output_schema" => %{
+          "type" => "object",
+          "description" => output_schema_description_for(profile)
+        },
         "signature" => %{
           "type" => "string",
           "description" => signature_description_for(profile)
@@ -884,15 +924,29 @@ defmodule PtcRunnerMcp.Tools do
     }
   end
 
+  defp output_schema_description_for(:mcp_no_tools) do
+    ~s|Optional JSON Schema for return validation. The response carries a structured | <>
+      ~s|`validated` JSON value when supplied. Supported types: string, integer, number, | <>
+      ~s|boolean, array (with items), object (with properties/required). | <>
+      ~s|Example: {"type": "object", "properties": {"count": {"type": "integer"}}, | <>
+      ~s|"required": ["count"]}. Mutually exclusive with `signature`.|
+  end
+
+  defp output_schema_description_for(:mcp_aggregator) do
+    "Optional JSON Schema for return validation. Omit for exploratory upstream calls. " <>
+      "Supported types: string, integer, number, boolean, array (with items), " <>
+      "object (with properties/required). Mutually exclusive with `signature`."
+  end
+
   defp signature_description_for(:mcp_no_tools) do
-    "Optional PTC signature for return validation, e.g. '() -> {count :int}'. " <>
-      "The '() ->' prefix is shorthand-optional — a bare type like '{count :int}' " <>
-      "is equivalent and accepted. See docs/signature-syntax.md."
+    "Advanced/legacy. PTC signature syntax for return validation, e.g. " <>
+      "'() -> {count :int}'. Prefer `output_schema` (JSON Schema) for typed output. " <>
+      "Mutually exclusive with `output_schema`."
   end
 
   defp signature_description_for(:mcp_aggregator) do
-    "Usually omit in aggregator mode. Do not pass for exploratory upstream calls. " <>
-      "Only use when the user explicitly needs validated output and you know the exact " <>
-      "PTC signature syntax, e.g. '() -> {count :int}'."
+    "Advanced/legacy. Usually omit in aggregator mode. Prefer `output_schema` for " <>
+      "typed output. Only use when you know the exact PTC signature syntax, " <>
+      "e.g. '() -> {count :int}'. Mutually exclusive with `output_schema`."
   end
 end

--- a/mcp_server/priv/mcp_aggregator_authoring_card.md
+++ b/mcp_server/priv/mcp_aggregator_authoring_card.md
@@ -57,7 +57,7 @@ Programs that don't care about the distinction can treat `:json-null` as truthy 
 - Unwrap upstream results before filtering: use `(mcp/json r)` for JSON payloads and `(mcp/text r)` for text.
 - Return compact maps/vectors, not full upstream envelopes. Use `map`, `filter`, `take`, and selected fields.
 - Keep returned strings short; long previews truncate. Prefer fewer items/fields over `println`.
-- Do not pass `signature` in exploratory aggregator calls. Omit it unless the user explicitly needs validated output and you know the exact PTC signature syntax.
+- For typed output, use `output_schema` (JSON Schema) instead of `signature`. Omit both for exploratory aggregator calls.
 
 ## Response envelope
 

--- a/mcp_server/priv/mcp_authoring_card.md
+++ b/mcp_server/priv/mcp_authoring_card.md
@@ -5,7 +5,8 @@ PTC-Lisp is a deterministic, sandboxed subset of Clojure with a small Java-inter
 ## Non-obvious bits
 
 - **`context` keys are bound under the `data/` namespace.** Pass `{"records": [...]}`, reference as `data/records` inside the program. There is no `context` binding.
-- **`signature`** is a return-type schema, e.g. `() -> {count :int}` or `() -> [{name :string, score :int}]`. Supplying it makes the response carry a structured `validated` JSON value — the only path for a caller to receive programmatic data. Without it, the response only contains an LLM-readable preview.
+- **`output_schema`** is a JSON Schema for the return type. Supplying it makes the response carry a structured `validated` JSON value — the only path for a caller to receive programmatic data. Without it, the response only contains an LLM-readable preview. Supported types: `string`, `integer`, `number`, `boolean`, `array` (with `items`), `object` (with `properties`/`required`).
+- **`signature`** (advanced/legacy) is the PTC-internal return-type syntax, e.g. `() -> {count :int}`. Prefer `output_schema` above. Mutually exclusive with `output_schema`.
 - **`(fail v)`** terminates with an error value when you want to surface a domain failure to the caller.
 - **JSON**: `(json/parse-string s)` / `(json/generate-string v)` are available; `nil` on failure.
 
@@ -21,8 +22,8 @@ If you reach for something that isn't there, the response will say so clearly �
 ## Example
 
 ```
-;; context:   {"orders": [{"total": 12}, {"total": 7}, {"total": 33}]}
-;; signature: "() -> {count :int, sum :int}"
+;; context:       {"orders": [{"total": 12}, {"total": 7}, {"total": 33}]}
+;; output_schema: {"type": "object", "properties": {"count": {"type": "integer"}, "sum": {"type": "integer"}}, "required": ["count", "sum"]}
 (let [big (filter #(> (get % "total") 10) data/orders)]
   {:count (count big)
    :sum   (reduce + (map #(get % "total") big))})

--- a/mcp_server/test/fixtures/tool_entry_v1.json
+++ b/mcp_server/test/fixtures/tool_entry_v1.json
@@ -5,7 +5,7 @@
     "openWorldHint": false,
     "readOnlyHint": true
   },
-  "description": "Execute a PTC-Lisp program in PtcRunner's sandbox. Use this for deterministic computation, filtering, aggregation, or multi-step data transformation. No app tools are available inside the program. Pass external data via the `context` argument; each invocation is independent — there is no memory of prior calls.\n\n# PTC-Lisp authoring\n\nPTC-Lisp is a deterministic, sandboxed subset of Clojure with a small Java-interop surface (Date/Time + String methods). A program is one or more top-level expressions; the last expression's value is the result.\n\n## Non-obvious bits\n\n- **`context` keys are bound under the `data/` namespace.** Pass `{\"records\": [...]}`, reference as `data/records` inside the program. There is no `context` binding.\n- **`signature`** is a return-type schema, e.g. `() -> {count :int}` or `() -> [{name :string, score :int}]`. Supplying it makes the response carry a structured `validated` JSON value — the only path for a caller to receive programmatic data. Without it, the response only contains an LLM-readable preview.\n- **`(fail v)`** terminates with an error value when you want to surface a domain failure to the caller.\n- **JSON**: `(json/parse-string s)` / `(json/generate-string v)` are available; `nil` on failure.\n\n## Restrictions\n\n- No mutable state: `atom`, `swap!`, `reset!`, `@deref` are absent — use `reduce` / `map` / `filter`.\n- No I/O except `println`. No filesystem, no network. No general Java interop.\n- No state across calls — each invocation is independent.\n- 1 s wall-clock, 10 MB memory, 64 KB program, 4 MB context.\n\nIf you reach for something that isn't there, the response will say so clearly — adjust and retry.\n\n## Example\n\n```\n;; context:   {\"orders\": [{\"total\": 12}, {\"total\": 7}, {\"total\": 33}]}\n;; signature: \"() -> {count :int, sum :int}\"\n(let [big (filter #(> (get % \"total\") 10) data/orders)]\n  {:count (count big)\n   :sum   (reduce + (map #(get % \"total\") big))})\n```\n\nFull reference: https://hexdocs.pm/ptc_runner.\n",
+  "description": "Execute a PTC-Lisp program in PtcRunner's sandbox. Use this for deterministic computation, filtering, aggregation, or multi-step data transformation. No app tools are available inside the program. Pass external data via the `context` argument; each invocation is independent — there is no memory of prior calls.\n\n# PTC-Lisp authoring\n\nPTC-Lisp is a deterministic, sandboxed subset of Clojure with a small Java-interop surface (Date/Time + String methods). A program is one or more top-level expressions; the last expression's value is the result.\n\n## Non-obvious bits\n\n- **`context` keys are bound under the `data/` namespace.** Pass `{\"records\": [...]}`, reference as `data/records` inside the program. There is no `context` binding.\n- **`output_schema`** is a JSON Schema for the return type. Supplying it makes the response carry a structured `validated` JSON value — the only path for a caller to receive programmatic data. Without it, the response only contains an LLM-readable preview. Supported types: `string`, `integer`, `number`, `boolean`, `array` (with `items`), `object` (with `properties`/`required`).\n- **`signature`** (advanced/legacy) is the PTC-internal return-type syntax, e.g. `() -> {count :int}`. Prefer `output_schema` above. Mutually exclusive with `output_schema`.\n- **`(fail v)`** terminates with an error value when you want to surface a domain failure to the caller.\n- **JSON**: `(json/parse-string s)` / `(json/generate-string v)` are available; `nil` on failure.\n\n## Restrictions\n\n- No mutable state: `atom`, `swap!`, `reset!`, `@deref` are absent — use `reduce` / `map` / `filter`.\n- No I/O except `println`. No filesystem, no network. No general Java interop.\n- No state across calls — each invocation is independent.\n- 1 s wall-clock, 10 MB memory, 64 KB program, 4 MB context.\n\nIf you reach for something that isn't there, the response will say so clearly — adjust and retry.\n\n## Example\n\n```\n;; context:       {\"orders\": [{\"total\": 12}, {\"total\": 7}, {\"total\": 33}]}\n;; output_schema: {\"type\": \"object\", \"properties\": {\"count\": {\"type\": \"integer\"}, \"sum\": {\"type\": \"integer\"}}, \"required\": [\"count\", \"sum\"]}\n(let [big (filter #(> (get % \"total\") 10) data/orders)]\n  {:count (count big)\n   :sum   (reduce + (map #(get % \"total\") big))})\n```\n\nFull reference: https://hexdocs.pm/ptc_runner.\n",
   "inputSchema": {
     "properties": {
       "context": {
@@ -13,12 +13,16 @@
         "description": "Optional map of named values bound under data/ in the program. Keys are strings; values are JSON-encodable.",
         "type": "object"
       },
+      "output_schema": {
+        "description": "Optional JSON Schema for return validation. The response carries a structured `validated` JSON value when supplied. Supported types: string, integer, number, boolean, array (with items), object (with properties/required). Example: {\"type\": \"object\", \"properties\": {\"count\": {\"type\": \"integer\"}}, \"required\": [\"count\"]}. Mutually exclusive with `signature`.",
+        "type": "object"
+      },
       "program": {
         "description": "PTC-Lisp source code. Must be non-empty after trimming whitespace.",
         "type": "string"
       },
       "signature": {
-        "description": "Optional PTC signature for return validation, e.g. '() -> {count :int}'. The '() ->' prefix is shorthand-optional — a bare type like '{count :int}' is equivalent and accepted. See docs/signature-syntax.md.",
+        "description": "Advanced/legacy. PTC signature syntax for return validation, e.g. '() -> {count :int}'. Prefer `output_schema` (JSON Schema) for typed output. Mutually exclusive with `output_schema`.",
         "type": "string"
       }
     },
@@ -102,3 +106,4 @@
     "type": "object"
   }
 }
+

--- a/mcp_server/test/ptc_runner_mcp/aggregator_phase1a_test.exs
+++ b/mcp_server/test/ptc_runner_mcp/aggregator_phase1a_test.exs
@@ -678,7 +678,7 @@ defmodule PtcRunnerMcp.AggregatorPhase1aTest do
       assert desc =~ "upstream_calls"
       assert desc =~ "Authoring rules"
       assert desc =~ "Unwrap upstream results before filtering"
-      assert desc =~ "Do not pass `signature` in exploratory aggregator calls"
+      assert desc =~ "use `output_schema` (JSON Schema) instead of `signature`"
     end
 
     test "annotations match §8.2 (destructiveHint: true, readOnlyHint: false)" do

--- a/mcp_server/test/ptc_runner_mcp/output_schema_arg_test.exs
+++ b/mcp_server/test/ptc_runner_mcp/output_schema_arg_test.exs
@@ -1,0 +1,395 @@
+defmodule PtcRunnerMcp.OutputSchemaArgTest do
+  @moduledoc """
+  Coverage for the `output_schema` argument of
+  `tools/call name: "ptc_lisp_execute"`.
+
+  Covers:
+
+    * Successful JSON Schema → validated field in response
+    * Validation failure (type mismatch) → `validation_error`
+    * Unsupported JSON Schema features → `args_error`
+    * Mutual exclusivity with `signature`
+    * Scalar, array, and nested object schemas
+  """
+  use ExUnit.Case, async: false
+
+  alias PtcRunnerMcp.{ConcurrencyGate, Limits, Tools}
+
+  setup do
+    Limits.set(Limits.defaults())
+    ConcurrencyGate.reset()
+    :ok
+  end
+
+  defp call(args) do
+    Tools.call(%{"name" => "ptc_lisp_execute", "arguments" => args})
+  end
+
+  describe "output_schema shape validation" do
+    test "non-object output_schema returns args_error" do
+      env = call(%{"program" => "1", "output_schema" => "not an object"})
+
+      assert env["isError"] == true
+      sc = env["structuredContent"]
+      assert sc["reason"] == "args_error"
+      assert sc["message"] =~ "output_schema"
+    end
+
+    test "missing type key returns args_error" do
+      env = call(%{"program" => "1", "output_schema" => %{"properties" => %{}}})
+
+      assert env["isError"] == true
+      sc = env["structuredContent"]
+      assert sc["reason"] == "args_error"
+      assert sc["message"] =~ "output_schema"
+      assert sc["message"] =~ "type"
+    end
+
+    test "unsupported type returns args_error" do
+      env = call(%{"program" => "1", "output_schema" => %{"type" => "null"}})
+
+      assert env["isError"] == true
+      sc = env["structuredContent"]
+      assert sc["reason"] == "args_error"
+      assert sc["message"] =~ "unsupported type"
+    end
+
+    test "unsupported JSON Schema key returns args_error listing the key" do
+      env =
+        call(%{
+          "program" => "1",
+          "output_schema" => %{"type" => "integer", "minimum" => 0}
+        })
+
+      assert env["isError"] == true
+      sc = env["structuredContent"]
+      assert sc["reason"] == "args_error"
+      assert sc["message"] =~ "minimum"
+    end
+
+    test "$ref is rejected" do
+      env =
+        call(%{
+          "program" => "1",
+          "output_schema" => %{"type" => "object", "$ref" => "#/definitions/Foo"}
+        })
+
+      assert env["isError"] == true
+      assert env["structuredContent"]["reason"] == "args_error"
+    end
+
+    test "oneOf combinator is rejected" do
+      env =
+        call(%{
+          "program" => "1",
+          "output_schema" => %{
+            "type" => "object",
+            "oneOf" => [%{"type" => "string"}, %{"type" => "integer"}]
+          }
+        })
+
+      assert env["isError"] == true
+      assert env["structuredContent"]["reason"] == "args_error"
+    end
+
+    test "array without items is rejected" do
+      env = call(%{"program" => "1", "output_schema" => %{"type" => "array"}})
+
+      assert env["isError"] == true
+      sc = env["structuredContent"]
+      assert sc["reason"] == "args_error"
+      assert sc["message"] =~ "items"
+    end
+
+    test "consumes no permit on validation failure" do
+      call(%{"program" => "1", "output_schema" => %{"type" => "null"}})
+      assert ConcurrencyGate.in_flight() == 0
+    end
+  end
+
+  describe "mutual exclusivity with signature" do
+    test "both output_schema and signature present returns args_error" do
+      env =
+        call(%{
+          "program" => "{:count 1}",
+          "output_schema" => %{
+            "type" => "object",
+            "properties" => %{"count" => %{"type" => "integer"}},
+            "required" => ["count"]
+          },
+          "signature" => "() -> {count :int}"
+        })
+
+      assert env["isError"] == true
+      sc = env["structuredContent"]
+      assert sc["reason"] == "args_error"
+      assert sc["message"] =~ "mutually exclusive"
+    end
+
+    test "output_schema with null signature is accepted (null = absent)" do
+      env =
+        call(%{
+          "program" => "{:count 1}",
+          "output_schema" => %{
+            "type" => "object",
+            "properties" => %{"count" => %{"type" => "integer"}},
+            "required" => ["count"]
+          },
+          "signature" => nil
+        })
+
+      assert env["isError"] == false
+      assert env["structuredContent"]["validated"] == %{"count" => 1}
+    end
+
+    test "null output_schema falls through to signature" do
+      env =
+        call(%{
+          "program" => "{:count 1}",
+          "output_schema" => nil,
+          "signature" => "() -> {count :int}"
+        })
+
+      assert env["isError"] == false
+      assert env["structuredContent"]["validated"] == %{"count" => 1}
+    end
+  end
+
+  describe "successful schema → validated field" do
+    test "object schema with required fields" do
+      env =
+        call(%{
+          "program" => "{:count (+ 1 2 3 4) :label \"test\"}",
+          "output_schema" => %{
+            "type" => "object",
+            "properties" => %{
+              "count" => %{"type" => "integer"},
+              "label" => %{"type" => "string"}
+            },
+            "required" => ["count", "label"]
+          }
+        })
+
+      assert env["isError"] == false
+      sc = env["structuredContent"]
+      assert sc["status"] == "ok"
+      assert sc["validated"] == %{"count" => 10, "label" => "test"}
+    end
+
+    test "scalar integer schema" do
+      env =
+        call(%{
+          "program" => "(+ 1 2)",
+          "output_schema" => %{"type" => "integer"}
+        })
+
+      assert env["isError"] == false
+      assert env["structuredContent"]["validated"] == 3
+    end
+
+    test "scalar string schema" do
+      env =
+        call(%{
+          "program" => ~s|"hello"|,
+          "output_schema" => %{"type" => "string"}
+        })
+
+      assert env["isError"] == false
+      assert env["structuredContent"]["validated"] == "hello"
+    end
+
+    test "scalar boolean schema" do
+      env =
+        call(%{
+          "program" => "true",
+          "output_schema" => %{"type" => "boolean"}
+        })
+
+      assert env["isError"] == false
+      assert env["structuredContent"]["validated"] == true
+    end
+
+    test "scalar number schema" do
+      env =
+        call(%{
+          "program" => "3.14",
+          "output_schema" => %{"type" => "number"}
+        })
+
+      assert env["isError"] == false
+      assert env["structuredContent"]["validated"] == 3.14
+    end
+
+    test "array of integers schema" do
+      env =
+        call(%{
+          "program" => "[1 2 3]",
+          "output_schema" => %{
+            "type" => "array",
+            "items" => %{"type" => "integer"}
+          }
+        })
+
+      assert env["isError"] == false
+      assert env["structuredContent"]["validated"] == [1, 2, 3]
+    end
+
+    test "nested object schema" do
+      env =
+        call(%{
+          "program" => "{:user {:name \"Alice\" :age 30}}",
+          "output_schema" => %{
+            "type" => "object",
+            "properties" => %{
+              "user" => %{
+                "type" => "object",
+                "properties" => %{
+                  "name" => %{"type" => "string"},
+                  "age" => %{"type" => "integer"}
+                },
+                "required" => ["name", "age"]
+              }
+            },
+            "required" => ["user"]
+          }
+        })
+
+      assert env["isError"] == false
+      sc = env["structuredContent"]
+      assert sc["validated"] == %{"user" => %{"name" => "Alice", "age" => 30}}
+    end
+
+    test "object with optional fields — missing field omitted from validated" do
+      env =
+        call(%{
+          "program" => "{:count 5}",
+          "output_schema" => %{
+            "type" => "object",
+            "properties" => %{
+              "count" => %{"type" => "integer"},
+              "label" => %{"type" => "string"}
+            },
+            "required" => ["count"]
+          }
+        })
+
+      assert env["isError"] == false
+      sc = env["structuredContent"]
+      assert sc["validated"]["count"] == 5
+    end
+
+    test "empty properties → empty map validated" do
+      env =
+        call(%{
+          "program" => "{}",
+          "output_schema" => %{
+            "type" => "object",
+            "properties" => %{}
+          }
+        })
+
+      assert env["isError"] == false
+      assert env["structuredContent"]["validated"] == %{}
+    end
+
+    test "cross-language smoke: filter+reduce over data/orders" do
+      program = """
+      (let [big (filter #(> (get % "total") 10) data/orders)]
+        {:count (count big) :sum (reduce + (map #(get % "total") big))})
+      """
+
+      env =
+        call(%{
+          "program" => program,
+          "context" => %{
+            "orders" => [
+              %{"total" => 12},
+              %{"total" => 7},
+              %{"total" => 33}
+            ]
+          },
+          "output_schema" => %{
+            "type" => "object",
+            "properties" => %{
+              "count" => %{"type" => "integer"},
+              "sum" => %{"type" => "integer"}
+            },
+            "required" => ["count", "sum"]
+          }
+        })
+
+      assert env["isError"] == false
+      sc = env["structuredContent"]
+      assert sc["status"] == "ok"
+      assert sc["validated"] == %{"count" => 2, "sum" => 45}
+    end
+  end
+
+  describe "schema mismatch → validation_error" do
+    test "string return when schema expects integer" do
+      env =
+        call(%{
+          "program" => ~s|"hello"|,
+          "output_schema" => %{"type" => "integer"}
+        })
+
+      assert env["isError"] == true
+      sc = env["structuredContent"]
+      assert sc["status"] == "error"
+      assert sc["reason"] == "validation_error"
+      assert is_binary(sc["message"])
+    end
+
+    test "wrong-typed field surfaces validation_error" do
+      env =
+        call(%{
+          "program" => ~s|{:count "not a number"}|,
+          "output_schema" => %{
+            "type" => "object",
+            "properties" => %{"count" => %{"type" => "integer"}},
+            "required" => ["count"]
+          }
+        })
+
+      assert env["isError"] == true
+      assert env["structuredContent"]["reason"] == "validation_error"
+    end
+
+    test "missing required field surfaces validation_error" do
+      env =
+        call(%{
+          "program" => ~s|{:name "Alice"}|,
+          "output_schema" => %{
+            "type" => "object",
+            "properties" => %{
+              "name" => %{"type" => "string"},
+              "age" => %{"type" => "integer"}
+            },
+            "required" => ["name", "age"]
+          }
+        })
+
+      assert env["isError"] == true
+      assert env["structuredContent"]["reason"] == "validation_error"
+    end
+  end
+
+  describe "description anchors" do
+    test "output_schema description mentions JSON Schema" do
+      %{"tools" => [tool]} = Tools.list()
+      desc = tool["inputSchema"]["properties"]["output_schema"]["description"]
+      assert desc =~ "JSON Schema"
+    end
+
+    test "signature description marks it as advanced/legacy" do
+      %{"tools" => [tool]} = Tools.list()
+      desc = tool["inputSchema"]["properties"]["signature"]["description"]
+      assert desc =~ "Advanced/legacy"
+    end
+
+    test "authoring card mentions output_schema" do
+      card = Tools.authoring_card()
+      assert card =~ "output_schema"
+    end
+  end
+end

--- a/mcp_server/test/ptc_runner_mcp/output_schema_arg_test.exs
+++ b/mcp_server/test/ptc_runner_mcp/output_schema_arg_test.exs
@@ -372,6 +372,107 @@ defmodule PtcRunnerMcp.OutputSchemaArgTest do
       assert env["isError"] == true
       assert env["structuredContent"]["reason"] == "validation_error"
     end
+
+    test "additionalProperties: false rejects an undeclared field" do
+      env =
+        call(%{
+          "program" => ~s|{:x 1 :extra 2}|,
+          "output_schema" => %{
+            "type" => "object",
+            "properties" => %{"x" => %{"type" => "integer"}},
+            "required" => ["x"],
+            "additionalProperties" => false
+          }
+        })
+
+      assert env["isError"] == true
+      sc = env["structuredContent"]
+      assert sc["reason"] == "validation_error"
+      assert sc["message"] =~ "unexpected field"
+    end
+
+    test "additionalProperties: false still accepts an exact match" do
+      env =
+        call(%{
+          "program" => ~s|{:x 1}|,
+          "output_schema" => %{
+            "type" => "object",
+            "properties" => %{"x" => %{"type" => "integer"}},
+            "required" => ["x"],
+            "additionalProperties" => false
+          }
+        })
+
+      assert env["isError"] == false
+      assert env["structuredContent"]["validated"] == %{"x" => 1}
+    end
+
+    test "absent additionalProperties tolerates extra fields" do
+      env =
+        call(%{
+          "program" => ~s|{:x 1 :extra 2}|,
+          "output_schema" => %{
+            "type" => "object",
+            "properties" => %{"x" => %{"type" => "integer"}},
+            "required" => ["x"]
+          }
+        })
+
+      assert env["isError"] == false
+      assert env["structuredContent"]["validated"] == %{"x" => 1, "extra" => 2}
+    end
+  end
+
+  describe "required validation" do
+    test "required entry not declared as a property is an args_error" do
+      env =
+        call(%{
+          "program" => "1",
+          "output_schema" => %{
+            "type" => "object",
+            "properties" => %{"x" => %{"type" => "integer"}},
+            "required" => ["missing"]
+          }
+        })
+
+      assert env["isError"] == true
+      sc = env["structuredContent"]
+      assert sc["reason"] == "args_error"
+      assert sc["message"] =~ "missing"
+    end
+
+    test "non-string required entry is an args_error" do
+      env =
+        call(%{
+          "program" => "1",
+          "output_schema" => %{
+            "type" => "object",
+            "properties" => %{"x" => %{"type" => "integer"}},
+            "required" => [123]
+          }
+        })
+
+      assert env["isError"] == true
+      sc = env["structuredContent"]
+      assert sc["reason"] == "args_error"
+    end
+
+    test "non-boolean additionalProperties is an args_error" do
+      env =
+        call(%{
+          "program" => "1",
+          "output_schema" => %{
+            "type" => "object",
+            "properties" => %{},
+            "additionalProperties" => %{"type" => "string"}
+          }
+        })
+
+      assert env["isError"] == true
+      sc = env["structuredContent"]
+      assert sc["reason"] == "args_error"
+      assert sc["message"] =~ "additionalProperties"
+    end
   end
 
   describe "description anchors" do

--- a/mcp_server/test/ptc_runner_mcp/tools_phase3_test.exs
+++ b/mcp_server/test/ptc_runner_mcp/tools_phase3_test.exs
@@ -118,7 +118,7 @@ defmodule PtcRunnerMcp.ToolsPhase3Test do
         |> get_in(["inputSchema", "properties", "signature", "description"])
 
       assert description =~ "Usually omit in aggregator mode"
-      assert description =~ "Do not pass for exploratory upstream calls"
+      assert description =~ "Advanced/legacy"
       refute description =~ "shorthand-optional"
     end
 

--- a/mcp_server/test/ptc_runner_mcp/tools_test.exs
+++ b/mcp_server/test/ptc_runner_mcp/tools_test.exs
@@ -19,7 +19,7 @@ defmodule PtcRunnerMcp.ToolsTest do
       assert ann["openWorldHint"] == false
     end
 
-    test "inputSchema has program required and context/signature optional" do
+    test "inputSchema has program required and context/output_schema/signature optional" do
       %{"tools" => [tool]} = Tools.list()
       schema = tool["inputSchema"]
 
@@ -27,6 +27,7 @@ defmodule PtcRunnerMcp.ToolsTest do
       assert schema["required"] == ["program"]
       assert Map.has_key?(schema["properties"], "program")
       assert Map.has_key?(schema["properties"], "context")
+      assert Map.has_key?(schema["properties"], "output_schema")
       assert Map.has_key?(schema["properties"], "signature")
     end
 

--- a/test/ptc_runner/sub_agent/signature/validator_test.exs
+++ b/test/ptc_runner/sub_agent/signature/validator_test.exs
@@ -347,4 +347,51 @@ defmodule PtcRunner.SubAgent.Signature.ValidatorTest do
                )
     end
   end
+
+  describe "validate/2 - closed maps" do
+    test "accepts a map with exactly the declared fields" do
+      assert :ok = Validator.validate(%{"x" => 1}, {:closed_map, [{"x", :int}]})
+    end
+
+    test "rejects an undeclared field" do
+      assert {:error, [%{path: ["extra"], message: msg}]} =
+               Validator.validate(%{"x" => 1, "extra" => 2}, {:closed_map, [{"x", :int}]})
+
+      assert msg =~ "unexpected field"
+    end
+
+    test "still reports declared-field type errors alongside extras" do
+      assert {:error, errors} =
+               Validator.validate(
+                 %{"x" => "nope", "extra" => 2},
+                 {:closed_map, [{"x", :int}]}
+               )
+
+      assert Enum.any?(errors, &(&1.path == ["x"] and &1.message =~ "expected int"))
+      assert Enum.any?(errors, &(&1.path == ["extra"] and &1.message =~ "unexpected field"))
+    end
+
+    test "missing optional fields are fine; missing required fields still fail" do
+      assert :ok = Validator.validate(%{}, {:closed_map, [{"x", {:optional, :int}}]})
+
+      assert {:error, [%{path: ["x"]}]} =
+               Validator.validate(%{}, {:closed_map, [{"x", :int}]})
+    end
+
+    test "treats hyphenated atom keys as covering underscored field names" do
+      assert :ok =
+               Validator.validate(
+                 %{:"user-id" => 1},
+                 {:closed_map, [{"user_id", :int}]}
+               )
+    end
+
+    test "enforces closedness for nested closed maps" do
+      assert {:error, [%{path: ["user", "extra"]}]} =
+               Validator.validate(
+                 %{"user" => %{"name" => "A", "extra" => 1}},
+                 {:closed_map, [{"user", {:closed_map, [{"name", :string}]}}]}
+               )
+    end
+  end
 end

--- a/test/ptc_runner/sub_agent/signature_test.exs
+++ b/test/ptc_runner/sub_agent/signature_test.exs
@@ -1,6 +1,8 @@
 defmodule PtcRunner.SubAgent.SignatureTest do
   use ExUnit.Case
 
+  doctest PtcRunner.SubAgent.Signature
+
   alias PtcRunner.SubAgent.Signature
 
   describe "parse/1" do

--- a/test/ptc_runner/sub_agent/signature_test.exs
+++ b/test/ptc_runner/sub_agent/signature_test.exs
@@ -344,4 +344,112 @@ defmodule PtcRunner.SubAgent.SignatureTest do
       assert schema["properties"]["who"] == %{"type" => "string"}
     end
   end
+
+  describe "from_json_schema/1 - additionalProperties" do
+    test "additionalProperties: false yields a closed map" do
+      assert {:ok, {:closed_map, [{"x", :int}]}} =
+               Signature.from_json_schema(%{
+                 "type" => "object",
+                 "properties" => %{"x" => %{"type" => "integer"}},
+                 "required" => ["x"],
+                 "additionalProperties" => false
+               })
+    end
+
+    test "additionalProperties: true yields an open map" do
+      assert {:ok, {:map, [{"x", :int}]}} =
+               Signature.from_json_schema(%{
+                 "type" => "object",
+                 "properties" => %{"x" => %{"type" => "integer"}},
+                 "required" => ["x"],
+                 "additionalProperties" => true
+               })
+    end
+
+    test "absent additionalProperties yields an open map" do
+      assert {:ok, {:map, [{"x", :int}]}} =
+               Signature.from_json_schema(%{
+                 "type" => "object",
+                 "properties" => %{"x" => %{"type" => "integer"}},
+                 "required" => ["x"]
+               })
+    end
+
+    test "additionalProperties: false with no properties is a closed empty object" do
+      assert {:ok, {:closed_map, []}} =
+               Signature.from_json_schema(%{"type" => "object", "additionalProperties" => false})
+    end
+
+    test "non-boolean additionalProperties is rejected" do
+      assert {:error, msg} =
+               Signature.from_json_schema(%{
+                 "type" => "object",
+                 "properties" => %{},
+                 "additionalProperties" => %{"type" => "string"}
+               })
+
+      assert msg =~ "additionalProperties"
+    end
+
+    test "closedness propagates to nested objects" do
+      assert {:ok, {:closed_map, [{"user", {:closed_map, [{"name", :string}]}}]}} =
+               Signature.from_json_schema(%{
+                 "type" => "object",
+                 "properties" => %{
+                   "user" => %{
+                     "type" => "object",
+                     "properties" => %{"name" => %{"type" => "string"}},
+                     "required" => ["name"],
+                     "additionalProperties" => false
+                   }
+                 },
+                 "required" => ["user"],
+                 "additionalProperties" => false
+               })
+    end
+  end
+
+  describe "from_json_schema/1 - required validation" do
+    test "rejects a required entry that is not a declared property" do
+      assert {:error, msg} =
+               Signature.from_json_schema(%{
+                 "type" => "object",
+                 "properties" => %{"x" => %{"type" => "integer"}},
+                 "required" => ["missing"]
+               })
+
+      assert msg =~ "missing"
+    end
+
+    test "rejects a non-string required entry" do
+      assert {:error, msg} =
+               Signature.from_json_schema(%{
+                 "type" => "object",
+                 "properties" => %{"x" => %{"type" => "integer"}},
+                 "required" => [123]
+               })
+
+      assert msg =~ "must be strings"
+    end
+
+    test "rejects required entries when no properties are declared" do
+      assert {:error, _} =
+               Signature.from_json_schema(%{
+                 "type" => "object",
+                 "properties" => %{},
+                 "required" => ["x"]
+               })
+    end
+
+    test "still rejects non-list required" do
+      assert {:error, msg} =
+               Signature.from_json_schema(%{
+                 "type" => "object",
+                 "properties" => %{"x" => %{"type" => "integer"}},
+                 "required" => "x"
+               })
+
+      assert msg =~ "array of strings"
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- Adds `output_schema` JSON Schema subset input argument to `ptc_lisp_execute`, enabling MCP client LLMs to specify typed output contracts using familiar JSON Schema syntax instead of the PTC-internal signature DSL
- Implements `Signature.from_json_schema/1` for JSON Schema → PTC type translation (string, integer, number, boolean, array/items, object/properties/required)
- Marks `signature` as advanced/legacy; authoring cards now recommend `output_schema` as the primary path for typed output

Closes #905

## Test plan

- [x] Successful schema validation (scalar, array, nested object) → `validated` field populated
- [x] Validation failure (type mismatch, missing required field) → `validation_error`
- [x] Unsupported schema features ($ref, oneOf, enum, minimum, etc.) → `args_error` with clear message
- [x] Mutual exclusivity: both `output_schema` and `signature` → `args_error`
- [x] Null values for either argument treated as absent
- [x] Cross-language smoke test (filter+reduce over data/orders with output_schema)
- [x] v1 fixture byte-equality (Phase 0 regression)
- [x] Aggregator-mode description anchors updated
- [x] `mix precommit` passes (format, compile, credo, spec, tests)
- [x] `mix test` in mcp_server: 895 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Fix Automation State
<!-- fix-state: {"attempts":3} -->
Fix attempts: 2/3
