### PR TITLE
feat(mcp): mode-aware catalog description rendering

### DIFF
--- a/mcp_server/lib/ptc_runner_mcp/catalog_description.ex
+++ b/mcp_server/lib/ptc_runner_mcp/catalog_description.ex
@@ -1,0 +1,268 @@
+defmodule PtcRunnerMcp.CatalogDescription do
+  @moduledoc """
+  Mode-aware catalog description rendering for the `ptc_lisp_execute`
+  MCP tool description.
+
+  Per `Plans/ptc-runner-mcp-catalog-exposure.md` §5-§6, the catalog
+  section of the tool description varies based on `catalog_mode`
+  (auto|inline|lazy), upstream catalog availability, and size
+  thresholds. This module resolves the effective mode and renders the
+  appropriate description fragment.
+
+  The existing `Upstream.Catalog` module retains its rendering for the
+  detailed per-tool signature format. This module produces the §6.2
+  compact inline format and §6.3 lazy format, which are structurally
+  different (one-line-per-tool summaries vs. discovery instructions).
+  """
+
+  alias PtcRunnerMcp.CatalogConfig
+  alias PtcRunnerMcp.Upstream.Catalog, as: UpstreamCatalog
+
+  @type snapshot_entry :: %{
+          required(:name) => String.t(),
+          required(:tools) => [map()] | nil,
+          optional(:impl) => module() | nil,
+          optional(:metadata) => map()
+        }
+
+  @doc """
+  Returns the catalog description fragment for the `ptc_lisp_execute`
+  tool description, or `nil` if no catalog should be rendered.
+
+  Reads the frozen snapshot and config, resolves the effective mode,
+  and renders the appropriate description.
+  """
+  @spec render() :: String.t() | nil
+  def render do
+    entries = UpstreamCatalog.frozen_snapshot()
+
+    case entries do
+      [] -> nil
+      _ -> render_for_entries(entries, CatalogConfig.get())
+    end
+  end
+
+  @doc """
+  Renders the catalog description for explicit entries and config.
+
+  Used directly by tests to exercise rendering without persistent_term.
+  """
+  @spec render_for_entries([snapshot_entry()], CatalogConfig.t()) :: String.t() | nil
+  def render_for_entries([], _config), do: nil
+
+  def render_for_entries(entries, config) do
+    case resolve_mode(entries, config) do
+      {:inline, warnings} ->
+        render_inline(entries, warnings)
+
+      :lazy ->
+        render_lazy(entries)
+    end
+  end
+
+  @doc """
+  Resolves the effective catalog mode from entries and config.
+
+  Returns `{:inline, warnings}` or `:lazy`. Warnings is a list of
+  server names whose catalogs are unknown (only populated when forced
+  inline encounters unknown catalogs).
+  """
+  @spec resolve_mode([snapshot_entry()], CatalogConfig.t()) ::
+          {:inline, [String.t()]} | :lazy
+  def resolve_mode(entries, config) do
+    case config.catalog_mode do
+      :lazy ->
+        :lazy
+
+      :inline ->
+        unknown = unknown_servers(entries)
+
+        {:inline, unknown}
+
+      :auto ->
+        resolve_auto(entries, config)
+    end
+  end
+
+  defp resolve_auto(entries, config) do
+    if has_unknown_catalogs?(entries) do
+      :lazy
+    else
+      total_tools = count_tools(entries)
+
+      if total_tools > config.catalog_inline_max_tools do
+        :lazy
+      else
+        inline_text = render_inline_body(entries)
+
+        if String.length(inline_text) > config.catalog_inline_max_chars do
+          :lazy
+        else
+          {:inline, []}
+        end
+      end
+    end
+  end
+
+  # -- Inline rendering (§6.2) --
+
+  defp render_inline(entries, []) do
+    render_inline_body(entries)
+  end
+
+  defp render_inline(entries, unknown_servers) do
+    body = render_inline_body(entries)
+    warnings = render_unknown_warnings(unknown_servers)
+    discovery = render_discovery_block()
+
+    body <> "\n\n" <> warnings <> "\n\n" <> discovery
+  end
+
+  defp render_inline_body(entries) do
+    server_blocks =
+      entries
+      |> Enum.sort_by(& &1.name)
+      |> Enum.map_join("\n", &render_inline_server/1)
+
+    "Configured upstream MCP servers:\n" <> server_blocks
+  end
+
+  defp render_inline_server(%{name: name, tools: nil} = entry) do
+    desc = server_description(entry)
+    "- #{name}: #{desc}Catalog loads on first use."
+  end
+
+  defp render_inline_server(%{name: name, tools: []} = entry) do
+    desc = server_description(entry)
+    "- #{name}: #{desc}0 tools."
+  end
+
+  defp render_inline_server(%{name: name, tools: tools} = entry) when is_list(tools) do
+    desc = server_description(entry)
+    capabilities = server_capabilities(entry)
+    tool_count = length(tools)
+
+    header = "- #{name}: #{desc}#{tool_count} tools.#{capabilities}"
+
+    tool_lines = Enum.map_join(tools, "\n", &render_inline_tool/1)
+
+    header <> "\n  Tools:\n" <> tool_lines
+  end
+
+  defp render_inline_tool(tool) do
+    name = tool_field(tool, :name, "unknown")
+    description = tool_field(tool, :description, "")
+    desc_part = if description == "", do: "", else: " #{compact_description(description)}"
+    "  - #{name}:#{desc_part}"
+  end
+
+  # -- Lazy rendering (§6.3) --
+
+  defp render_lazy(entries) do
+    server_lines =
+      entries
+      |> Enum.sort_by(& &1.name)
+      |> Enum.map_join("\n", &render_lazy_server/1)
+
+    "Configured upstream MCP servers:\n" <>
+      server_lines <>
+      "\n\n" <>
+      render_discovery_block()
+  end
+
+  defp render_lazy_server(%{name: name, tools: nil} = entry) do
+    desc = server_description(entry)
+    "- #{name}: #{desc}Catalog loads on first use."
+  end
+
+  defp render_lazy_server(%{name: name, tools: []} = entry) do
+    desc = server_description(entry)
+    "- #{name}: #{desc}0 tools."
+  end
+
+  defp render_lazy_server(%{name: name, tools: tools} = entry) when is_list(tools) do
+    desc = server_description(entry)
+    capabilities = server_capabilities(entry)
+    tool_count = length(tools)
+    "- #{name}: #{desc}#{tool_count} tools.#{capabilities}"
+  end
+
+  # -- Shared helpers --
+
+  defp server_description(%{metadata: %{description: desc}})
+       when is_binary(desc) and desc != "" do
+    compact_description(desc) <> ". "
+  end
+
+  defp server_description(%{metadata: %{"description" => desc}})
+       when is_binary(desc) and desc != "" do
+    compact_description(desc) <> ". "
+  end
+
+  defp server_description(_), do: ""
+
+  defp server_capabilities(%{metadata: %{capabilities: caps}})
+       when is_list(caps) and caps != [] do
+    " " <> Enum.join(caps, ", ") <> "."
+  end
+
+  defp server_capabilities(%{metadata: %{"capabilities" => caps}})
+       when is_list(caps) and caps != [] do
+    " " <> Enum.join(caps, ", ") <> "."
+  end
+
+  defp server_capabilities(_), do: ""
+
+  defp compact_description(text) when is_binary(text) do
+    text
+    |> String.replace(~r/\s+/, " ")
+    |> String.trim()
+  end
+
+  defp render_unknown_warnings(servers) do
+    lines = Enum.map_join(servers, "\n", &"Warning: catalog for \"#{&1}\" not loaded yet.")
+    lines
+  end
+
+  defp render_discovery_block do
+    """
+    Use catalog/search-tools inside the PTC-Lisp program to find relevant \
+    upstream tools. If search reports an unloaded server-level match, call \
+    catalog/list-tools or catalog/describe-tool for that server to load its \
+    catalog. Use catalog/describe-tool before calling unfamiliar tools. Then \
+    call upstream tools with tool/mcp-call.
+
+    (catalog/search-tools "query" {:limit 8})
+    (catalog/list-tools "server-name" {:limit 20})
+    (catalog/describe-tool "server-name" "tool-name")
+    (tool/mcp-call {:server "server-name" :tool "tool-name" :args {...}})\
+    """
+  end
+
+  defp has_unknown_catalogs?(entries) do
+    Enum.any?(entries, fn entry -> entry.tools == nil end)
+  end
+
+  defp unknown_servers(entries) do
+    entries
+    |> Enum.filter(fn entry -> entry.tools == nil end)
+    |> Enum.map(& &1.name)
+    |> Enum.sort()
+  end
+
+  defp count_tools(entries) do
+    Enum.reduce(entries, 0, fn entry, acc ->
+      case entry.tools do
+        nil -> acc
+        tools when is_list(tools) -> acc + length(tools)
+      end
+    end)
+  end
+
+  defp tool_field(tool, key, default) do
+    case tool do
+      %{^key => v} -> v
+      _ -> Map.get(tool, to_string(key), default)
+    end
+  end
+end

--- a/mcp_server/lib/ptc_runner_mcp/tools.ex
+++ b/mcp_server/lib/ptc_runner_mcp/tools.ex
@@ -44,7 +44,7 @@ defmodule PtcRunnerMcp.Tools do
   }
 
   alias PtcRunnerMcp.AggregatorConfig
-  alias PtcRunnerMcp.Upstream.Catalog, as: UpstreamCatalog
+  alias PtcRunnerMcp.CatalogDescription
   alias PtcRunnerMcp.Upstream.Registry, as: UpstreamRegistry
 
   @tool_name "ptc_lisp_execute"
@@ -445,30 +445,12 @@ defmodule PtcRunnerMcp.Tools do
     |> maybe_put_output_schema(output_schema_for(capability_profile, response_profile))
   end
 
-  # §12.5: read the FROZEN catalog from `:persistent_term`. The
-  # Phase 0 `:mcp_no_tools` fixture is byte-equal-protected by
-  # `tools_phase0_test.exs` — that profile MUST keep `catalog: nil`
-  # so the v1 tool_entry snapshot is unchanged.
-  #
-  # The catalog string is rendered ONCE at boot (in
-  # `Upstream.Supervisor.start_link/1` after `eager_start_upstreams/1`)
-  # and stored via `Catalog.freeze/1`. This satisfies §12.5's
-  # "rebuilt only on PtcRunner restart" contract: post-boot upstream
-  # crashes, recoveries, and `put_fake/2` calls do NOT change the
-  # catalog text the calling LLM sees.
-  #
-  # `Catalog.frozen/0` returns `""` when no catalog has been frozen
-  # (non-aggregator mode, or a boot path where the supervisor was
-  # never started). `advertised_description/2` already maps `""` to
-  # "no catalog block", so the description still renders cleanly.
+  # §5/§6: mode-aware catalog description. The frozen snapshot
+  # (populated at boot by Upstream.Supervisor) is read by
+  # CatalogDescription, which resolves the effective mode (auto,
+  # inline, lazy) and renders the appropriate description fragment.
   defp catalog_for(:mcp_no_tools), do: nil
-
-  defp catalog_for(:mcp_aggregator) do
-    case UpstreamCatalog.frozen() do
-      "" -> nil
-      str when is_binary(str) -> str
-    end
-  end
+  defp catalog_for(:mcp_aggregator), do: CatalogDescription.render()
 
   @doc "Handle a `tools/list` request."
   @spec list() :: map()

--- a/mcp_server/test/ptc_runner_mcp/catalog_description_test.exs
+++ b/mcp_server/test/ptc_runner_mcp/catalog_description_test.exs
@@ -1,0 +1,354 @@
+defmodule PtcRunnerMcp.CatalogDescriptionTest do
+  @moduledoc """
+  Tests for mode-aware catalog description rendering.
+
+  Spec: `Plans/ptc-runner-mcp-catalog-exposure.md` §5-§6.
+
+  Covers the 8 scenarios from issue #910:
+  1. Small fully-known fleet → auto chooses inline
+  2. Large fleet (>40 tools) → auto chooses lazy
+  3. Fleet with unknown catalog → auto chooses lazy
+  4. Fleet with rendered >12k chars → auto chooses lazy
+  5. Any fleet, mode=inline → forced inline
+  6. Any fleet, mode=lazy → forced lazy
+  7. Forced inline with unknown catalogs → inline + warnings + discovery
+  8. Zero upstreams → no catalog section (nil)
+  """
+  use ExUnit.Case, async: true
+
+  alias PtcRunnerMcp.CatalogDescription
+
+  defp make_tools(count) do
+    Enum.map(1..count, fn i ->
+      %{
+        name: "tool_#{i}",
+        description: "Description for tool #{i}.",
+        input_schema: %{
+          "type" => "object",
+          "properties" => %{"arg" => %{"type" => "string"}},
+          "required" => ["arg"]
+        }
+      }
+    end)
+  end
+
+  defp small_fleet do
+    [
+      %{
+        name: "github",
+        tools: make_tools(8),
+        impl: PtcRunnerMcp.Upstream.Stdio,
+        metadata: %{
+          description: "GitHub MCP server",
+          capabilities: ["issues", "pull requests"]
+        }
+      },
+      %{
+        name: "filesystem",
+        tools: make_tools(7),
+        impl: PtcRunnerMcp.Upstream.Stdio,
+        metadata: %{
+          description: "Filesystem MCP server",
+          capabilities: ["files", "directories"]
+        }
+      }
+    ]
+  end
+
+  defp large_fleet do
+    [
+      %{
+        name: "github",
+        tools: make_tools(25),
+        impl: PtcRunnerMcp.Upstream.Stdio,
+        metadata: %{description: "GitHub MCP server", capabilities: ["issues"]}
+      },
+      %{
+        name: "linear",
+        tools: make_tools(20),
+        impl: PtcRunnerMcp.Upstream.Http,
+        metadata: %{description: "Linear issue tracker", capabilities: ["issues", "projects"]}
+      }
+    ]
+  end
+
+  defp fleet_with_unknown do
+    [
+      %{
+        name: "github",
+        tools: make_tools(8),
+        impl: PtcRunnerMcp.Upstream.Stdio,
+        metadata: %{description: "GitHub MCP server", capabilities: ["issues"]}
+      },
+      %{
+        name: "linear",
+        tools: nil,
+        impl: PtcRunnerMcp.Upstream.Http,
+        metadata: %{description: "Linear issue tracker", capabilities: ["issues"]}
+      }
+    ]
+  end
+
+  defp default_config, do: PtcRunnerMcp.CatalogConfig.defaults()
+
+  describe "render_for_entries/2 — scenario table" do
+    test "scenario 1: small fully-known fleet, auto → inline" do
+      result = CatalogDescription.render_for_entries(small_fleet(), default_config())
+
+      assert result =~ "Configured upstream MCP servers:"
+      assert result =~ "- filesystem:"
+      assert result =~ "- github:"
+      assert result =~ "Tools:"
+      assert result =~ "- tool_1:"
+      refute result =~ "catalog/search-tools"
+    end
+
+    test "scenario 2: large fleet (>40 tools), auto → lazy" do
+      result = CatalogDescription.render_for_entries(large_fleet(), default_config())
+
+      assert result =~ "Configured upstream MCP servers:"
+      assert result =~ "- github:"
+      assert result =~ "25 tools."
+      assert result =~ "- linear:"
+      assert result =~ "20 tools."
+      refute result =~ "Tools:"
+      assert result =~ "catalog/search-tools"
+      assert result =~ "catalog/list-tools"
+      assert result =~ "catalog/describe-tool"
+    end
+
+    test "scenario 3: fleet with unknown catalog, auto → lazy" do
+      result = CatalogDescription.render_for_entries(fleet_with_unknown(), default_config())
+
+      assert result =~ "Configured upstream MCP servers:"
+      assert result =~ "Catalog loads on first use."
+      refute result =~ "Tools:"
+      assert result =~ "catalog/search-tools"
+    end
+
+    test "scenario 4: fleet with rendered >12k chars, auto → lazy" do
+      verbose_fleet = [
+        %{
+          name: "big_server",
+          tools: make_tools(35),
+          impl: PtcRunnerMcp.Upstream.Stdio,
+          metadata: %{
+            description: String.duplicate("A verbose description. ", 50),
+            capabilities: Enum.map(1..20, &"cap_#{&1}")
+          }
+        }
+      ]
+
+      config = %{default_config() | catalog_inline_max_chars: 500}
+      result = CatalogDescription.render_for_entries(verbose_fleet, config)
+
+      refute result =~ "Tools:"
+      assert result =~ "catalog/search-tools"
+    end
+
+    test "scenario 5: any fleet, mode=inline → forced inline" do
+      config = %{default_config() | catalog_mode: :inline}
+      result = CatalogDescription.render_for_entries(large_fleet(), config)
+
+      assert result =~ "Tools:"
+      assert result =~ "- tool_1:"
+      refute result =~ "catalog/search-tools"
+    end
+
+    test "scenario 6: any fleet, mode=lazy → forced lazy" do
+      config = %{default_config() | catalog_mode: :lazy}
+      result = CatalogDescription.render_for_entries(small_fleet(), config)
+
+      refute result =~ "Tools:"
+      assert result =~ "catalog/search-tools"
+      assert result =~ "8 tools."
+      assert result =~ "7 tools."
+    end
+
+    test "scenario 7: forced inline with unknown catalogs → warnings + discovery" do
+      config = %{default_config() | catalog_mode: :inline}
+      result = CatalogDescription.render_for_entries(fleet_with_unknown(), config)
+
+      assert result =~ "Tools:"
+      assert result =~ "- tool_1:"
+      assert result =~ ~s(Warning: catalog for "linear" not loaded yet.)
+      assert result =~ "Catalog loads on first use."
+      assert result =~ "catalog/search-tools"
+      assert result =~ "catalog/describe-tool"
+    end
+
+    test "scenario 8: zero upstreams → nil" do
+      assert CatalogDescription.render_for_entries([], default_config()) == nil
+    end
+  end
+
+  describe "resolve_mode/2" do
+    test "auto with all known and under thresholds → inline" do
+      assert {:inline, []} = CatalogDescription.resolve_mode(small_fleet(), default_config())
+    end
+
+    test "auto with unknown catalog → lazy" do
+      assert :lazy = CatalogDescription.resolve_mode(fleet_with_unknown(), default_config())
+    end
+
+    test "auto with too many tools → lazy" do
+      assert :lazy = CatalogDescription.resolve_mode(large_fleet(), default_config())
+    end
+
+    test "auto with too many chars → lazy" do
+      config = %{default_config() | catalog_inline_max_chars: 10}
+      assert :lazy = CatalogDescription.resolve_mode(small_fleet(), config)
+    end
+
+    test "forced inline always returns inline" do
+      config = %{default_config() | catalog_mode: :inline}
+      assert {:inline, []} = CatalogDescription.resolve_mode(small_fleet(), config)
+    end
+
+    test "forced inline with unknown catalogs returns warning servers" do
+      config = %{default_config() | catalog_mode: :inline}
+      assert {:inline, ["linear"]} = CatalogDescription.resolve_mode(fleet_with_unknown(), config)
+    end
+
+    test "forced lazy always returns lazy" do
+      config = %{default_config() | catalog_mode: :lazy}
+      assert :lazy = CatalogDescription.resolve_mode(small_fleet(), config)
+    end
+  end
+
+  describe "inline rendering format (§6.2)" do
+    test "includes server description and capabilities from metadata" do
+      result = CatalogDescription.render_for_entries(small_fleet(), default_config())
+
+      assert result =~ "- github: GitHub MCP server. 8 tools. issues, pull requests."
+      assert result =~ "- filesystem: Filesystem MCP server. 7 tools. files, directories."
+    end
+
+    test "entries are sorted by server name" do
+      entries = [
+        %{name: "zulu", tools: [%{name: "t1", description: "d"}], metadata: %{}},
+        %{name: "alpha", tools: [%{name: "t2", description: "d"}], metadata: %{}}
+      ]
+
+      result = CatalogDescription.render_for_entries(entries, default_config())
+      alpha_pos = :binary.match(result, "alpha") |> elem(0)
+      zulu_pos = :binary.match(result, "zulu") |> elem(0)
+      assert alpha_pos < zulu_pos
+    end
+
+    test "tool entries include name and description" do
+      entries = [
+        %{
+          name: "srv",
+          tools: [
+            %{name: "do_thing", description: "Does something useful."},
+            %{name: "no_desc", description: ""}
+          ],
+          metadata: %{}
+        }
+      ]
+
+      result = CatalogDescription.render_for_entries(entries, default_config())
+      assert result =~ "  - do_thing: Does something useful."
+      assert result =~ "  - no_desc:"
+      refute result =~ "  - no_desc: "
+    end
+
+    test "known empty tools renders 0 tools" do
+      entries = [%{name: "empty", tools: [], metadata: %{}}]
+      result = CatalogDescription.render_for_entries(entries, default_config())
+      assert result =~ "- empty: 0 tools."
+    end
+  end
+
+  describe "lazy rendering format (§6.3)" do
+    test "includes discovery syntax examples" do
+      config = %{default_config() | catalog_mode: :lazy}
+      result = CatalogDescription.render_for_entries(small_fleet(), config)
+
+      assert result =~ ~s|(catalog/search-tools "query" {:limit 8})|
+      assert result =~ ~s|(catalog/list-tools "server-name" {:limit 20})|
+      assert result =~ ~s|(catalog/describe-tool "server-name" "tool-name")|
+      assert result =~ ~s|(tool/mcp-call {:server "server-name" :tool "tool-name" :args {...}})|
+    end
+
+    test "does not list individual tools" do
+      config = %{default_config() | catalog_mode: :lazy}
+      result = CatalogDescription.render_for_entries(small_fleet(), config)
+
+      refute result =~ "tool_1"
+      refute result =~ "Tools:"
+    end
+
+    test "unknown server shows catalog loads on first use" do
+      config = %{default_config() | catalog_mode: :lazy}
+      result = CatalogDescription.render_for_entries(fleet_with_unknown(), config)
+
+      assert result =~ "- linear: Linear issue tracker. Catalog loads on first use."
+    end
+  end
+
+  describe "metadata handling" do
+    test "uses operator description when present" do
+      entries = [
+        %{
+          name: "srv",
+          tools: make_tools(3),
+          metadata: %{description: "Custom operator description"}
+        }
+      ]
+
+      result = CatalogDescription.render_for_entries(entries, default_config())
+      assert result =~ "Custom operator description"
+    end
+
+    test "handles string-keyed metadata" do
+      entries = [
+        %{
+          name: "srv",
+          tools: make_tools(3),
+          metadata: %{"description" => "String keyed desc", "capabilities" => ["cap1"]}
+        }
+      ]
+
+      result = CatalogDescription.render_for_entries(entries, default_config())
+      assert result =~ "String keyed desc"
+      assert result =~ "cap1."
+    end
+
+    test "renders cleanly without metadata" do
+      entries = [%{name: "bare", tools: make_tools(2)}]
+      result = CatalogDescription.render_for_entries(entries, default_config())
+      assert result =~ "- bare: 2 tools."
+    end
+
+    test "renders cleanly with empty metadata" do
+      entries = [%{name: "bare", tools: make_tools(2), metadata: %{}}]
+      result = CatalogDescription.render_for_entries(entries, default_config())
+      assert result =~ "- bare: 2 tools."
+    end
+  end
+
+  describe "threshold behavior" do
+    test "auto stays inline at exactly the tool threshold" do
+      entries = [%{name: "srv", tools: make_tools(40), metadata: %{}}]
+      assert {:inline, []} = CatalogDescription.resolve_mode(entries, default_config())
+    end
+
+    test "auto switches to lazy at tool threshold + 1" do
+      entries = [%{name: "srv", tools: make_tools(41), metadata: %{}}]
+      assert :lazy = CatalogDescription.resolve_mode(entries, default_config())
+    end
+
+    test "auto respects custom thresholds" do
+      entries = [%{name: "srv", tools: make_tools(5), metadata: %{}}]
+      config = %{default_config() | catalog_inline_max_tools: 3}
+      assert :lazy = CatalogDescription.resolve_mode(entries, config)
+    end
+
+    test "unknown catalog is not counted as zero tools in auto" do
+      entries = [%{name: "srv", tools: nil, metadata: %{}}]
+      assert :lazy = CatalogDescription.resolve_mode(entries, default_config())
+    end
+  end
+end

--- a/mcp_server/test/ptc_runner_mcp/tools_phase3_test.exs
+++ b/mcp_server/test/ptc_runner_mcp/tools_phase3_test.exs
@@ -62,21 +62,19 @@ defmodule PtcRunnerMcp.ToolsPhase3Test do
       assert is_pid(pid)
       {:ok, _} = Connection.ensure_started(pid)
 
-      # Production boot freezes the catalog after eager-start; tests
-      # do the same explicitly because they bypass the full supervisor.
+      # Production boot freezes both the rendered string and the
+      # structured snapshot; tests do the same explicitly because
+      # they bypass the full supervisor.
+      snapshot = Catalog.snapshot(@registry_name)
       :ok = Catalog.freeze(Catalog.render(@registry_name))
+      :ok = Catalog.freeze_snapshot(snapshot)
 
       entry = Tools.tool_entry()
       description = entry["description"]
 
       assert is_binary(description)
-      assert description =~ "alpha:"
-      assert description =~ "ping(msg: string) -> :unknown_content - Ping the upstream"
-
-      assert String.trim_trailing(description)
-             |> String.ends_with?(
-               "alpha:\n  ping(msg: string) -> :unknown_content - Ping the upstream"
-             )
+      assert description =~ "- alpha:"
+      assert description =~ "- ping: Ping the upstream"
     end
 
     test "aggregator-mode tool_entry uses the aggregator outputSchema/annotations" do
@@ -148,12 +146,14 @@ defmodule PtcRunnerMcp.ToolsPhase3Test do
       # The "frozen at boot" snapshot captures cached_tools=nil for this
       # case — the eager-start branch failed and we still froze.
       :ok = UpstreamRegistry.put_fake("beta", %{tools: %{}}, @registry_name)
+      snapshot = Catalog.snapshot(@registry_name)
       :ok = Catalog.freeze(Catalog.render(@registry_name))
+      :ok = Catalog.freeze_snapshot(snapshot)
 
       entry = Tools.tool_entry()
       description = entry["description"]
 
-      assert description =~ "beta:\n  (unavailable at startup)"
+      assert description =~ "Catalog loads on first use."
     end
   end
 
@@ -168,11 +168,13 @@ defmodule PtcRunnerMcp.ToolsPhase3Test do
       {:ok, _} = Connection.ensure_started(pid_a)
       {:ok, _} = Connection.ensure_started(pid_b)
 
+      catalog_snapshot = Catalog.snapshot(@registry_name)
       :ok = Catalog.freeze(Catalog.render(@registry_name))
+      :ok = Catalog.freeze_snapshot(catalog_snapshot)
 
       snapshot = Tools.tool_entry()["description"]
-      assert snapshot =~ "alpha:"
-      assert snapshot =~ "beta:"
+      assert snapshot =~ "- alpha:"
+      assert snapshot =~ "- beta:"
 
       # Kill the underlying impl pid for `beta`. Pre-fix: the live
       # `Catalog.render` path would observe `cached_tools = nil` for


### PR DESCRIPTION
## Summary

- Add `CatalogDescription` module that resolves the effective catalog mode (auto/inline/lazy) and renders the appropriate `ptc_lisp_execute` tool description fragment per spec §5-§6
- Replace the single-path `Catalog.frozen()` injection in `Tools.catalog_for/1` with mode-aware `CatalogDescription.render/0`
- Update `tools_phase3_test.exs` to freeze both rendered string and structured snapshot, matching the new rendering format

## Details

**Mode resolution** (`resolve_mode/2`):
- `auto`: chooses inline only when all catalogs are known AND rendered text is under `catalog_inline_max_chars` AND total tools are under `catalog_inline_max_tools`; otherwise lazy
- `inline`: always inline, with warnings + discovery examples if any catalogs are unknown
- `lazy`: always lazy

**Inline format** (§6.2): compact one-line-per-tool with server description, tool count, capabilities from operator metadata

**Lazy format** (§6.3): server list with metadata + `catalog/search-tools`, `catalog/list-tools`, `catalog/describe-tool` syntax examples

Closes #910

## Test plan

- [x] 30 new tests in `catalog_description_test.exs` covering all 8 scenarios from the issue table
- [x] Updated 3 existing `tools_phase3_test.exs` tests to match new rendering format
- [x] Full mcp_server test suite passes (967 tests, 0 failures)
- [x] Full root project test suite passes (4894 tests, 0 failures)
- [x] Credo strict passes in both projects
- [x] Format check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)