### PR TITLE
fix: batch quick-fixes (4 issues)

### DIFF
--- a/mcp_server/lib/ptc_runner_mcp/catalog_description.ex
+++ b/mcp_server/lib/ptc_runner_mcp/catalog_description.ex
@@ -127,27 +127,13 @@ defmodule PtcRunnerMcp.CatalogDescription do
     "Configured upstream MCP servers:\n" <> server_blocks
   end
 
-  defp render_inline_server(%{name: name, tools: nil} = entry) do
-    desc = server_description(entry)
-    "- #{name}: #{desc}Catalog loads on first use."
-  end
-
-  defp render_inline_server(%{name: name, tools: []} = entry) do
-    desc = server_description(entry)
-    "- #{name}: #{desc}0 tools."
-  end
-
-  defp render_inline_server(%{name: name, tools: tools} = entry) when is_list(tools) do
-    desc = server_description(entry)
-    capabilities = server_capabilities(entry)
-    tool_count = length(tools)
-
-    header = "- #{name}: #{desc}#{tool_count} tools.#{capabilities}"
-
+  defp render_inline_server(%{tools: tools} = entry) when is_list(tools) and tools != [] do
+    header = render_server_header(entry)
     tool_lines = Enum.map_join(tools, "\n", &render_inline_tool/1)
-
     header <> "\n  Tools:\n" <> tool_lines
   end
+
+  defp render_inline_server(entry), do: render_server_header(entry)
 
   defp render_inline_tool(tool) do
     name = tool_field(tool, :name, "unknown")
@@ -170,17 +156,19 @@ defmodule PtcRunnerMcp.CatalogDescription do
       render_discovery_block()
   end
 
-  defp render_lazy_server(%{name: name, tools: nil} = entry) do
+  defp render_lazy_server(entry), do: render_server_header(entry)
+
+  defp render_server_header(%{name: name, tools: nil} = entry) do
     desc = server_description(entry)
     "- #{name}: #{desc}Catalog loads on first use."
   end
 
-  defp render_lazy_server(%{name: name, tools: []} = entry) do
+  defp render_server_header(%{name: name, tools: []} = entry) do
     desc = server_description(entry)
     "- #{name}: #{desc}0 tools."
   end
 
-  defp render_lazy_server(%{name: name, tools: tools} = entry) when is_list(tools) do
+  defp render_server_header(%{name: name, tools: tools} = entry) when is_list(tools) do
     desc = server_description(entry)
     capabilities = server_capabilities(entry)
     tool_count = length(tools)

--- a/mcp_server/lib/ptc_runner_mcp/tools.ex
+++ b/mcp_server/lib/ptc_runner_mcp/tools.ex
@@ -954,8 +954,17 @@ defmodule PtcRunnerMcp.Tools do
 
   # Mutual exclusivity gate: if both `output_schema` and `signature`
   # are supplied, reject before either is parsed.
+  # `signature: "any"` normalizes to nil in validate_signature/1, so it
+  # must not trigger this gate — treat it as absent here too.
   defp validate_output_contract(args) do
-    sig_present = match?({:ok, v} when not is_nil(v), Map.fetch(args, "signature"))
+    sig_present =
+      case Map.fetch(args, "signature") do
+        {:ok, nil} -> false
+        {:ok, v} when is_binary(v) -> String.trim(v) != "any"
+        {:ok, _} -> true
+        :error -> false
+      end
+
     schema_present = match?({:ok, v} when not is_nil(v), Map.fetch(args, "output_schema"))
 
     cond do

--- a/mcp_server/test/ptc_runner_mcp/application_phase1b_test.exs
+++ b/mcp_server/test/ptc_runner_mcp/application_phase1b_test.exs
@@ -180,7 +180,7 @@ defmodule PtcRunnerMcp.ApplicationPhase1bTest do
       assert output[:env] == %{"GITHUB_TOKEN" => "abc", "FOO" => "bar"}
     end
 
-    test "preserves :handshake_timeout_ms (codex [P2] #2 regression)" do
+    test "preserves :handshake_timeout_ms (codex [P2] #2 regression)", %{tmp_dir: tmp_dir} do
       # Codex review of `0f6c1cd` flagged that
       # `:handshake_timeout_ms` was missing from the whitelist —
       # `Upstream.Stdio` reads `Map.get(config, :handshake_timeout_ms, 10_000)`
@@ -205,24 +205,18 @@ defmodule PtcRunnerMcp.ApplicationPhase1bTest do
 
       # And the full JSON-load path also preserves it (sanity floor:
       # the boundary normalize is invoked by `parse_upstreams_body/2`).
-      tmp_dir =
-        Path.join(System.tmp_dir!(), "phase1b-hs-#{System.unique_integer([:positive])}")
-
-      File.mkdir_p!(tmp_dir)
-      on_exit(fn -> File.rm_rf(tmp_dir) end)
-      cfg_path = Path.join(tmp_dir, "upstreams.json")
-
-      File.write!(
-        cfg_path,
-        Jason.encode!(%{
-          "upstreams" => %{
-            "slow" => %{
-              "command" => "npx",
-              "handshake_timeout_ms" => 30_000
+      cfg_path =
+        write_config(
+          tmp_dir,
+          Jason.encode!(%{
+            "upstreams" => %{
+              "slow" => %{
+                "command" => "npx",
+                "handshake_timeout_ms" => 30_000
+              }
             }
-          }
-        })
-      )
+          })
+        )
 
       args_map = PtcRunnerMcp.Application.parse_args(["--upstreams-config", cfg_path])
 
@@ -251,27 +245,21 @@ defmodule PtcRunnerMcp.ApplicationPhase1bTest do
   end
 
   describe "upstream metadata preservation (§6.1.1)" do
-    test "stdio entry preserves description and capabilities in metadata" do
-      json =
-        Jason.encode!(%{
-          "upstreams" => %{
-            "github" => %{
-              "command" => "npx",
-              "args" => ["-y", "@modelcontextprotocol/server-github"],
-              "description" => "GitHub MCP server",
-              "capabilities" => ["issues", "pull_requests"]
+    test "stdio entry preserves description and capabilities in metadata", %{tmp_dir: tmp_dir} do
+      cfg_path =
+        write_config(
+          tmp_dir,
+          Jason.encode!(%{
+            "upstreams" => %{
+              "github" => %{
+                "command" => "npx",
+                "args" => ["-y", "@modelcontextprotocol/server-github"],
+                "description" => "GitHub MCP server",
+                "capabilities" => ["issues", "pull_requests"]
+              }
             }
-          }
-        })
-
-      tmp_dir =
-        Path.join(System.tmp_dir!(), "phase1b-meta-#{System.unique_integer([:positive])}")
-
-      File.mkdir_p!(tmp_dir)
-      on_exit(fn -> File.rm_rf(tmp_dir) end)
-
-      cfg_path = Path.join(tmp_dir, "upstreams.json")
-      File.write!(cfg_path, json)
+          })
+        )
 
       args_map = PtcRunnerMcp.Application.parse_args(["--upstreams-config", cfg_path])
       [entry] = PtcRunnerMcp.Application.load_upstreams_config(args_map)
@@ -286,24 +274,18 @@ defmodule PtcRunnerMcp.ApplicationPhase1bTest do
       refute Map.has_key?(entry.config, "description")
     end
 
-    test "metadata defaults to empty map when not provided" do
-      json =
-        Jason.encode!(%{
-          "upstreams" => %{
-            "bare" => %{
-              "command" => "npx"
+    test "metadata defaults to empty map when not provided", %{tmp_dir: tmp_dir} do
+      cfg_path =
+        write_config(
+          tmp_dir,
+          Jason.encode!(%{
+            "upstreams" => %{
+              "bare" => %{
+                "command" => "npx"
+              }
             }
-          }
-        })
-
-      tmp_dir =
-        Path.join(System.tmp_dir!(), "phase1b-nometa-#{System.unique_integer([:positive])}")
-
-      File.mkdir_p!(tmp_dir)
-      on_exit(fn -> File.rm_rf(tmp_dir) end)
-
-      cfg_path = Path.join(tmp_dir, "upstreams.json")
-      File.write!(cfg_path, json)
+          })
+        )
 
       args_map = PtcRunnerMcp.Application.parse_args(["--upstreams-config", cfg_path])
       [entry] = PtcRunnerMcp.Application.load_upstreams_config(args_map)
@@ -311,31 +293,54 @@ defmodule PtcRunnerMcp.ApplicationPhase1bTest do
       assert entry.metadata == %{}
     end
 
-    test "partial metadata (description only) preserves what's present" do
-      json =
-        Jason.encode!(%{
-          "upstreams" => %{
-            "linear" => %{
-              "command" => "npx",
-              "description" => "Linear tracker"
+    test "partial metadata (description only) preserves what's present", %{tmp_dir: tmp_dir} do
+      cfg_path =
+        write_config(
+          tmp_dir,
+          Jason.encode!(%{
+            "upstreams" => %{
+              "linear" => %{
+                "command" => "npx",
+                "description" => "Linear tracker"
+              }
             }
-          }
-        })
-
-      tmp_dir =
-        Path.join(System.tmp_dir!(), "phase1b-partial-#{System.unique_integer([:positive])}")
-
-      File.mkdir_p!(tmp_dir)
-      on_exit(fn -> File.rm_rf(tmp_dir) end)
-
-      cfg_path = Path.join(tmp_dir, "upstreams.json")
-      File.write!(cfg_path, json)
+          })
+        )
 
       args_map = PtcRunnerMcp.Application.parse_args(["--upstreams-config", cfg_path])
       [entry] = PtcRunnerMcp.Application.load_upstreams_config(args_map)
 
       assert entry.metadata == %{description: "Linear tracker"}
       refute Map.has_key?(entry.metadata, :capabilities)
+    end
+
+    test "http entry preserves description and capabilities in metadata", %{tmp_dir: tmp_dir} do
+      cfg_path =
+        write_config(
+          tmp_dir,
+          Jason.encode!(%{
+            "upstreams" => %{
+              "example" => %{
+                "transport" => "http",
+                "url" => "https://api.example.test",
+                "description" => "Example HTTP server",
+                "capabilities" => ["search", "files"]
+              }
+            }
+          })
+        )
+
+      args_map = PtcRunnerMcp.Application.parse_args(["--upstreams-config", cfg_path])
+      [entry] = PtcRunnerMcp.Application.load_upstreams_config(args_map)
+
+      assert entry.metadata == %{
+               description: "Example HTTP server",
+               capabilities: ["search", "files"]
+             }
+
+      assert entry.config[:url] == "https://api.example.test"
+      refute Map.has_key?(entry.config, :description)
+      refute Map.has_key?(entry.config, "description")
     end
   end
 

--- a/mcp_server/test/ptc_runner_mcp/output_schema_arg_test.exs
+++ b/mcp_server/test/ptc_runner_mcp/output_schema_arg_test.exs
@@ -153,6 +153,22 @@ defmodule PtcRunnerMcp.OutputSchemaArgTest do
       assert env["isError"] == false
       assert env["structuredContent"]["validated"] == %{"count" => 1}
     end
+
+    test ~S|signature: "any" with output_schema is accepted ("any" means absent)| do
+      env =
+        call(%{
+          "program" => "{:count 1}",
+          "output_schema" => %{
+            "type" => "object",
+            "properties" => %{"count" => %{"type" => "integer"}},
+            "required" => ["count"]
+          },
+          "signature" => "any"
+        })
+
+      assert env["isError"] == false
+      assert env["structuredContent"]["validated"] == %{"count" => 1}
+    end
   end
 
   describe "successful schema → validated field" do


### PR DESCRIPTION
## Summary
Batch fix for quick-fix issues from recent PR reviews.

## Issues Fixed
- Closes #907: `signature: "any"` + `output_schema` mutual exclusivity edge case
- Closes #915: Add HTTP upstream metadata test for `parse_http_upstream/3`
- Closes #916: Clean up repeated `tmp_dir` setup in metadata tests
- Closes #918: Extract shared server header helper in `CatalogDescription`

## Issues Skipped
- #921 and #922: Both reference `catalog_builtins.ex` which only exists on the unmerged PR #919 branch (`claude/911-catalog-namespace-builtins`). These should be fixed when that branch is merged.

## Changes

**#907 — `tools.ex`**: `validate_output_contract/1` was checking `sig_present` using a simple nil-check, which treated `signature: "any"` as present. But `validate_signature/1` normalizes `"any"` to `{:ok, nil}` (absent). Fixed the presence check to exclude `"any"` values using the same `String.trim/1` logic. Added a regression test in `output_schema_arg_test.exs`.

**#915 — `application_phase1b_test.exs`**: Added `"http entry preserves description and capabilities in metadata"` test to the existing `upstream metadata preservation` describe block, completing coverage for the HTTP path of `extract_upstream_metadata/1`.

**#916 — `application_phase1b_test.exs`**: Refactored the 3 new metadata tests and the `handshake_timeout_ms` test to accept `%{tmp_dir: tmp_dir}` from the existing `setup` block and use the `write_config/2` helper instead of creating their own inline tmp directories.

**#918 — `catalog_description.ex`**: Extracted `render_server_header/1` (3 clauses: nil/empty/list tools) to replace the 6 duplicated clauses across `render_inline_server/1` and `render_lazy_server/1`. The lazy path now delegates entirely to `render_server_header/1`; the inline path calls it and appends the tool listing for non-empty tool lists.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)