### PR TITLE
MCP catalog exposure: integration tests and benchmarks

### DIFF
--- a/mcp_server/bench/catalog_bench.exs
+++ b/mcp_server/bench/catalog_bench.exs
@@ -7,6 +7,11 @@
 #
 # Spec: `Plans/ptc-runner-mcp-catalog-exposure.md` §13.
 #
+# §13 coverage:
+#   Covered here: description size (chars), rendering latency (median/p99).
+#   Deferred (require real model/API access): approximate token cost,
+#   first-shot program correctness, failure modes in lazy mode.
+#
 # Usage (from repo root):
 #
 #   mix run mcp_server/bench/catalog_bench.exs
@@ -51,7 +56,6 @@ defmodule CatalogBench.Helpers do
       %{
         name: "server_#{i}",
         tools: make_tools(count, "server_#{i}"),
-        impl: PtcRunnerMcp.Upstream.Stdio,
         metadata: %{
           description: "Test server #{i} for benchmarking catalog rendering",
           capabilities: ["capability_a", "capability_b"]

--- a/mcp_server/bench/catalog_bench.exs
+++ b/mcp_server/bench/catalog_bench.exs
@@ -1,0 +1,200 @@
+# Catalog exposure benchmark: description size and tools/list latency.
+#
+# Measures rendered description size (characters) and rendering latency
+# at 10, 30, 50, 100, and 200 tools for both inline and lazy modes.
+# Outputs a markdown table suitable for pasting into a PR comment to
+# justify or revise the default threshold values.
+#
+# Spec: `Plans/ptc-runner-mcp-catalog-exposure.md` §13.
+#
+# Usage (from repo root):
+#
+#   mix run mcp_server/bench/catalog_bench.exs
+#   mix run mcp_server/bench/catalog_bench.exs --runs=100
+#   mix run mcp_server/bench/catalog_bench.exs --out=catalog_bench_report.md
+
+{opts, _, _} =
+  OptionParser.parse(System.argv(),
+    strict: [runs: :integer, out: :string, help: :boolean],
+    aliases: [h: :help, n: :runs, o: :out]
+  )
+
+if Keyword.get(opts, :help, false) do
+  IO.puts("""
+  Usage:
+    mix run mcp_server/bench/catalog_bench.exs [options]
+
+  Options:
+    --runs=N     Number of iterations per measurement (default: 50)
+    --out=PATH   Write markdown report to file
+    -h, --help   Show this help
+  """)
+
+  System.halt(0)
+end
+
+runs = Keyword.get(opts, :runs, 50)
+out_path = Keyword.get(opts, :out)
+
+alias PtcRunnerMcp.{CatalogConfig, CatalogDescription}
+
+defmodule CatalogBench.Helpers do
+  @moduledoc false
+
+  def make_entries(tool_count, servers \\ 3) do
+    per_server = div(tool_count, servers)
+    remainder = rem(tool_count, servers)
+
+    Enum.map(1..servers, fn i ->
+      count = if i <= remainder, do: per_server + 1, else: per_server
+
+      %{
+        name: "server_#{i}",
+        tools: make_tools(count, "server_#{i}"),
+        impl: PtcRunnerMcp.Upstream.Stdio,
+        metadata: %{
+          description: "Test server #{i} for benchmarking catalog rendering",
+          capabilities: ["capability_a", "capability_b"]
+        }
+      }
+    end)
+  end
+
+  defp make_tools(count, server_name) do
+    Enum.map(1..max(count, 0), fn i ->
+      %{
+        name: "#{server_name}_tool_#{i}",
+        description:
+          "Performs operation #{i} on #{server_name} resources. " <>
+            "Accepts standard parameters and returns structured results.",
+        input_schema: %{
+          "type" => "object",
+          "properties" => %{
+            "query" => %{"type" => "string", "description" => "Search query"},
+            "limit" => %{"type" => "integer", "description" => "Max results"}
+          },
+          "required" => ["query"]
+        }
+      }
+    end)
+  end
+
+  def measure_us(fun, runs) do
+    times =
+      Enum.map(1..runs, fn _ ->
+        {time_us, _result} = :timer.tc(fun)
+        time_us
+      end)
+
+    sorted = Enum.sort(times)
+    median = Enum.at(sorted, div(length(sorted), 2))
+    p99 = Enum.at(sorted, trunc(length(sorted) * 0.99))
+    mean = div(Enum.sum(times), length(times))
+
+    %{median_us: median, p99_us: p99, mean_us: mean}
+  end
+end
+
+alias CatalogBench.Helpers
+
+tool_counts = [10, 30, 50, 100, 200]
+
+inline_config = Map.put(CatalogConfig.defaults(), :catalog_mode, :inline)
+lazy_config = Map.put(CatalogConfig.defaults(), :catalog_mode, :lazy)
+
+IO.puts("\nCatalog Exposure Benchmark (#{runs} runs per measurement)")
+IO.puts(String.duplicate("=", 60))
+
+results =
+  Enum.map(tool_counts, fn count ->
+    entries = Helpers.make_entries(count)
+
+    inline_text = CatalogDescription.render_for_entries(entries, inline_config)
+    lazy_text = CatalogDescription.render_for_entries(entries, lazy_config)
+
+    inline_chars = if inline_text, do: String.length(inline_text), else: 0
+    lazy_chars = if lazy_text, do: String.length(lazy_text), else: 0
+
+    inline_timing =
+      Helpers.measure_us(
+        fn -> CatalogDescription.render_for_entries(entries, inline_config) end,
+        runs
+      )
+
+    lazy_timing =
+      Helpers.measure_us(
+        fn -> CatalogDescription.render_for_entries(entries, lazy_config) end,
+        runs
+      )
+
+    auto_config = CatalogConfig.defaults()
+    auto_text = CatalogDescription.render_for_entries(entries, auto_config)
+
+    auto_mode =
+      if auto_text && String.contains?(auto_text, "catalog/search-tools"),
+        do: "lazy",
+        else: "inline"
+
+    %{
+      tools: count,
+      inline_chars: inline_chars,
+      lazy_chars: lazy_chars,
+      inline_median_us: inline_timing.median_us,
+      inline_p99_us: inline_timing.p99_us,
+      lazy_median_us: lazy_timing.median_us,
+      lazy_p99_us: lazy_timing.p99_us,
+      auto_mode: auto_mode
+    }
+  end)
+
+size_rows =
+  Enum.map_join(results, "\n", fn r ->
+    "| #{r.tools} | #{r.inline_chars} | #{r.lazy_chars} | #{r.auto_mode} |"
+  end)
+
+latency_rows =
+  Enum.map_join(results, "\n", fn r ->
+    "| #{r.tools} | #{r.inline_median_us} | #{r.inline_p99_us} | #{r.lazy_median_us} | #{r.lazy_p99_us} |"
+  end)
+
+threshold_rows =
+  Enum.map_join(results, "\n", fn r ->
+    threshold_note =
+      cond do
+        r.tools > 40 -> "Over tool threshold (#{r.tools} > 40)"
+        r.inline_chars > 12_000 -> "Over char threshold (#{r.inline_chars} > 12000)"
+        true -> "Under both thresholds"
+      end
+
+    "- **#{r.tools} tools**: #{threshold_note}. Auto selects **#{r.auto_mode}**. " <>
+      "Inline: #{r.inline_chars} chars, lazy: #{r.lazy_chars} chars."
+  end)
+
+report =
+  """
+  ## Catalog Description Size
+
+  | Tools | Inline (chars) | Lazy (chars) | Auto mode |
+  |------:|---------------:|-------------:|-----------|
+  #{size_rows}
+
+  ## Rendering Latency
+
+  | Tools | Inline median (µs) | Inline p99 (µs) | Lazy median (µs) | Lazy p99 (µs) |
+  |------:|--------------------:|----------------:|------------------:|---------------:|
+  #{latency_rows}
+
+  ## Threshold Analysis
+
+  Default thresholds: `catalog_inline_max_chars=12000`, `catalog_inline_max_tools=40`.
+
+  #{threshold_rows}
+  """
+  |> String.trim_leading()
+
+IO.puts(report)
+
+if out_path do
+  File.write!(out_path, report)
+  IO.puts("Report written to #{out_path}")
+end

--- a/mcp_server/test/ptc_runner_mcp/catalog_integration_test.exs
+++ b/mcp_server/test/ptc_runner_mcp/catalog_integration_test.exs
@@ -1,0 +1,338 @@
+defmodule PtcRunnerMcp.CatalogIntegrationTest do
+  @moduledoc """
+  Integration tests for size-aware MCP catalog exposure.
+
+  Spec: `Plans/ptc-runner-mcp-catalog-exposure.md` §12 integration tests.
+
+  These test the full pipeline — tools/list rendering or PTC-Lisp
+  execution — not individual modules. Each test starts its own
+  `Upstream.Registry` under the production name so `Tools` functions
+  find it, freezes a catalog snapshot for description rendering, and
+  cleans up on exit.
+
+  Tests 1–3: tools/list rendering (inline, lazy, unloaded).
+  Tests 4–6: PTC-Lisp execution flows (discovery, unloaded discovery,
+             direct call bypass).
+  """
+  use ExUnit.Case, async: false
+
+  alias PtcRunnerMcp.{AggregatorConfig, CatalogConfig, Limits, Tools}
+  alias PtcRunnerMcp.Upstream.{Catalog, Registry}
+
+  @registry_name PtcRunnerMcp.Upstream.Registry
+
+  setup do
+    stop_existing_registry()
+
+    {:ok, _pid} = Registry.start_link(name: @registry_name)
+    Limits.set(Limits.defaults())
+    AggregatorConfig.set(AggregatorConfig.defaults())
+    CatalogConfig.set(CatalogConfig.defaults())
+
+    on_exit(fn ->
+      stop_existing_registry()
+      Limits.set(Limits.defaults())
+      AggregatorConfig.set(AggregatorConfig.defaults())
+      CatalogConfig.set(CatalogConfig.defaults())
+      Catalog.clear_frozen()
+    end)
+
+    :ok
+  end
+
+  # ============================================================
+  # § 12 integration test 1: inline rendering in tools/list
+  # ============================================================
+
+  describe "inline rendering in tools/list" do
+    test "small fleet under both thresholds renders inline catalog" do
+      put_fake_with_tools("alpha", 3, "Alpha server", ["search"])
+      put_fake_with_tools("beta", 2, "Beta server", ["files"])
+
+      freeze_snapshot()
+
+      entry = Tools.tool_entry()
+      description = entry["description"]
+
+      assert description =~ "Configured upstream MCP servers:"
+      assert description =~ "alpha:"
+      assert description =~ "beta:"
+      assert description =~ "3 tools."
+      assert description =~ "2 tools."
+      assert description =~ "Tools:"
+      assert description =~ "tool_1:"
+      refute description =~ "catalog/search-tools"
+    end
+  end
+
+  # ============================================================
+  # § 12 integration test 2: lazy rendering in tools/list
+  # ============================================================
+
+  describe "lazy rendering in tools/list" do
+    test "large fleet over tool threshold renders lazy instructions" do
+      put_fake_with_tools("srv_a", 25, "Service A", [])
+      put_fake_with_tools("srv_b", 20, "Service B", [])
+
+      freeze_snapshot()
+
+      entry = Tools.tool_entry()
+      description = entry["description"]
+
+      assert description =~ "Configured upstream MCP servers:"
+      assert description =~ "srv_a:"
+      assert description =~ "srv_b:"
+      assert description =~ "catalog/search-tools"
+      assert description =~ "catalog/list-tools"
+      assert description =~ "catalog/describe-tool"
+      refute description =~ "  Tools:"
+    end
+  end
+
+  # ============================================================
+  # § 12 integration test 3: unloaded upstreams in tools/list
+  # ============================================================
+
+  describe "unloaded upstreams in tools/list" do
+    test "unloaded upstream fleet renders lazy instructions" do
+      put_fake_unloaded("gamma", "Gamma server")
+      put_fake_unloaded("delta", "Delta server")
+
+      freeze_snapshot_unloaded(["gamma", "delta"])
+
+      entry = Tools.tool_entry()
+      description = entry["description"]
+
+      assert description =~ "Configured upstream MCP servers:"
+      assert description =~ "gamma:"
+      assert description =~ "delta:"
+      assert description =~ "Catalog loads on first use."
+      assert description =~ "catalog/search-tools"
+      refute description =~ "  Tools:"
+    end
+  end
+
+  # ============================================================
+  # § 12 integration test 4: PTC-Lisp discovery flow
+  # ============================================================
+
+  describe "PTC-Lisp discovery flow" do
+    test "search → describe → mcp-call returns compact result" do
+      put_fake_with_tools("warehouse", 3, "Warehouse inventory", ["stock"],
+        handler: fn _tool_name ->
+          fn args, _opts -> {:ok, %{"count" => args["item_id"]}} end
+        end
+      )
+
+      {:ok, _} = Registry.ensure_started("warehouse")
+      freeze_snapshot()
+
+      env =
+        call(~S"""
+        (let [results (catalog/search-tools "warehouse" {:limit 5})
+              first_tool (get (first results) "tool")
+              server (get (first results) "server")
+              detail (catalog/describe-tool server first_tool)]
+          (tool/mcp-call {:server server
+                          :tool first_tool
+                          :args {:item_id "abc"}}))
+        """)
+
+      assert env["isError"] == false
+      assert structured(env)["status"] == "ok"
+      assert structured(env)["result"] =~ "abc"
+
+      upstream = upstream_calls(env)
+      assert length(upstream) == 1
+      [entry] = upstream
+      assert entry["server"] == "warehouse"
+      assert entry["status"] == "ok"
+    end
+  end
+
+  # ============================================================
+  # § 12 integration test 5: unloaded discovery flow
+  # ============================================================
+
+  describe "unloaded discovery flow" do
+    test "search server-level → list-tools → describe → mcp-call" do
+      put_fake_with_tools("analytics", 2, "Analytics platform", ["metrics"],
+        handler: fn tool_name ->
+          fn _args, _opts -> {:ok, %{"tool" => tool_name, "value" => 42}} end
+        end
+      )
+
+      freeze_snapshot_unloaded(["analytics"])
+
+      env =
+        call(~S"""
+        (let [search (catalog/search-tools "analytics" {:limit 5})
+              server (get (first search) "server")
+              tools (catalog/list-tools server {:limit 10})
+              first_tool (get (first tools) "tool")
+              detail (catalog/describe-tool server first_tool)]
+          (tool/mcp-call {:server server
+                          :tool first_tool
+                          :args {:query "test"}}))
+        """)
+
+      assert env["isError"] == false
+      assert structured(env)["status"] == "ok"
+      assert structured(env)["result"] =~ "42"
+
+      upstream = upstream_calls(env)
+      assert length(upstream) == 1
+      assert hd(upstream)["server"] == "analytics"
+    end
+  end
+
+  # ============================================================
+  # § 12 integration test 6: direct call in inline mode
+  # ============================================================
+
+  describe "direct call in inline mode" do
+    test "mcp-call works without catalog builtins in inline mode" do
+      put_fake_with_tools("storage", 2, "Storage backend", ["blobs"])
+
+      freeze_snapshot()
+
+      env =
+        call(~S"""
+        (tool/mcp-call {:server "storage"
+                        :tool "tool_1"
+                        :args {:key "myfile"}})
+        """)
+
+      assert env["isError"] == false
+      assert structured(env)["status"] == "ok"
+
+      upstream = upstream_calls(env)
+      assert length(upstream) == 1
+      assert hd(upstream)["server"] == "storage"
+      assert hd(upstream)["tool"] == "tool_1"
+      assert hd(upstream)["status"] == "ok"
+    end
+  end
+
+  # ============================================================
+  # Helpers
+  # ============================================================
+
+  defp stop_existing_registry do
+    case Process.whereis(@registry_name) do
+      nil ->
+        :ok
+
+      pid ->
+        ref = Process.monitor(pid)
+        Process.exit(pid, :kill)
+
+        receive do
+          {:DOWN, ^ref, :process, ^pid, _} -> :ok
+        after
+          1_000 -> :ok
+        end
+    end
+  end
+
+  defp put_fake_with_tools(name, count, description, capabilities, opts \\ []) do
+    handler_fn =
+      Keyword.get(opts, :handler, fn _tool_name ->
+        fn args, _opts -> {:ok, %{"result" => args}} end
+      end)
+
+    tool_schemas =
+      Enum.map(1..count, fn i ->
+        tool_name = "tool_#{i}"
+
+        %{
+          name: tool_name,
+          description: "Description for #{tool_name}.",
+          input_schema: %{
+            "type" => "object",
+            "properties" => %{"key" => %{"type" => "string"}},
+            "required" => []
+          }
+        }
+      end)
+
+    tools =
+      Map.new(tool_schemas, fn schema ->
+        {schema.name, {schema, handler_fn.(schema.name)}}
+      end)
+
+    metadata = %{description: description, capabilities: capabilities}
+    config = %{tools: tools, metadata: metadata}
+
+    :ok = Registry.put_fake(name, config, @registry_name)
+
+    register_fake_tracking(name, tool_schemas, metadata)
+  end
+
+  defp put_fake_unloaded(name, description) do
+    tool_schemas = [%{name: "placeholder", description: "Placeholder.", input_schema: %{}}]
+
+    config = %{
+      tools: %{
+        "placeholder" =>
+          {%{name: "placeholder", input_schema: %{}},
+           fn _args, _opts -> {:ok, %{"ok" => true}} end}
+      },
+      init_delay_ms: 0,
+      metadata: %{
+        description: description,
+        capabilities: []
+      }
+    }
+
+    :ok = Registry.put_fake(name, config, @registry_name)
+
+    metadata = %{description: description, capabilities: []}
+    register_fake_tracking(name, tool_schemas, metadata)
+  end
+
+  defp freeze_snapshot do
+    entries = build_loaded_snapshot()
+    Catalog.freeze_snapshot(entries)
+  end
+
+  defp freeze_snapshot_unloaded(server_names) do
+    loaded = build_loaded_snapshot()
+
+    entries =
+      Enum.map(server_names, fn name ->
+        case Enum.find(loaded, &(&1.name == name)) do
+          %{metadata: metadata} ->
+            %{name: name, tools: nil, metadata: metadata}
+
+          _ ->
+            %{name: name, tools: nil, metadata: %{}}
+        end
+      end)
+
+    Catalog.freeze_snapshot(entries)
+  end
+
+  defp build_loaded_snapshot do
+    Enum.map(registered_fakes(), fn {name, tools, metadata} ->
+      %{name: name, tools: tools, metadata: metadata}
+    end)
+  end
+
+  defp registered_fakes do
+    Process.get(:test_fakes, [])
+  end
+
+  defp register_fake_tracking(name, tools, metadata) do
+    fakes = Process.get(:test_fakes, [])
+    Process.put(:test_fakes, fakes ++ [{name, tools, metadata}])
+  end
+
+  defp call(program) do
+    Tools.call_with_gate(%{"program" => program})
+  end
+
+  defp structured(env), do: env["structuredContent"]
+
+  defp upstream_calls(env), do: structured(env)["upstream_calls"] || []
+end


### PR DESCRIPTION
## Summary

- Add 6 integration tests (spec §12) validating the full catalog exposure pipeline end-to-end
- Add benchmark script (spec §13) measuring description size and rendering latency at 10/30/50/100/200 tools

### Integration tests (`catalog_integration_test.exs`)

1. **Inline rendering in tools/list** — small fleet under both thresholds renders inline catalog with tool details
2. **Lazy rendering in tools/list** — large fleet over tool threshold renders lazy instructions with discovery builtins
3. **Unloaded upstreams in tools/list** — initially unloaded fleet renders lazy instructions
4. **PTC-Lisp discovery flow** — `catalog/search-tools` → `catalog/describe-tool` → `tool/mcp-call` pipeline
5. **Unloaded discovery flow** — search server-level match → `catalog/list-tools` → `catalog/describe-tool` → `tool/mcp-call`
6. **Direct call in inline mode** — `tool/mcp-call` works without catalog builtins

### Benchmark script (`catalog_bench.exs`)

Measures rendered description size (chars) and rendering latency (µs) at 10, 30, 50, 100, and 200 tools for inline vs lazy modes. Outputs a markdown table with threshold analysis to justify/revise the default values (`catalog_inline_max_chars=12000`, `catalog_inline_max_tools=40`).

Run: `mix run mcp_server/bench/catalog_bench.exs [--runs=N] [--out=PATH]`

Closes #913

## Test plan

- [x] All 6 integration tests pass (`mix test mcp_server/test/ptc_runner_mcp/catalog_integration_test.exs`)
- [x] All existing mcp_server tests pass (1009 tests, 0 failures)
- [x] All root tests pass (5305 tests, 0 failures)
- [x] Benchmark script runs and produces correct output
- [x] Format, credo, and compile checks pass

## Fix Automation State
<!-- fix-state: {"attempts":2} -->
Fix attempts: 2/3
