### PR TITLE
fix(validator): close alias-key bypass in closed_map + add closed_map to JsonHandler

### DIFF
--- a/lib/ptc_runner/sub_agent/loop/json_handler.ex
+++ b/lib/ptc_runner/sub_agent/loop/json_handler.ex
@@ -123,6 +123,9 @@ defmodule PtcRunner.SubAgent.Loop.JsonHandler do
 
   @doc "Atomize value based on expected type."
   @spec atomize_value(term(), term()) :: term()
+  def atomize_value(map, {:closed_map, fields}) when is_map(map),
+    do: atomize_value(map, {:map, fields})
+
   def atomize_value(map, {:map, fields}) when is_map(map) do
     field_types = Map.new(fields)
 

--- a/lib/ptc_runner/sub_agent/signature/validator.ex
+++ b/lib/ptc_runner/sub_agent/signature/validator.ex
@@ -141,19 +141,8 @@ defmodule PtcRunner.SubAgent.Signature.Validator do
   # ============================================================
 
   defp validate_map_fields(data, fields, path) do
-    Enum.flat_map(fields, fn {field_name, field_type} ->
-      case get_field(data, field_name) do
-        {:ok, _key, value} ->
-          validate_type(value, field_type, path ++ [field_name])
-
-        :missing ->
-          if optional?(field_type) do
-            []
-          else
-            [error_at(path ++ [field_name], "expected field, got nil")]
-          end
-      end
-    end)
+    {errors, _consumed} = validate_map_fields_tracking(data, fields, path)
+    errors
   end
 
   # Like validate_map_fields/3 but also returns the set of consumed data keys

--- a/lib/ptc_runner/sub_agent/signature/validator.ex
+++ b/lib/ptc_runner/sub_agent/signature/validator.ex
@@ -129,7 +129,8 @@ defmodule PtcRunner.SubAgent.Signature.Validator do
   # error, so fields the caller explicitly excluded can't leak through.
   defp validate_type(data, {:closed_map, fields}, path) do
     if is_map(data) do
-      validate_map_fields(data, fields, path) ++ validate_no_extra_fields(data, fields, path)
+      {field_errors, consumed_keys} = validate_map_fields_tracking(data, fields, path)
+      field_errors ++ validate_no_extra_fields(data, consumed_keys, path)
     else
       [error_at(path, "expected map, got #{type_name(data)}")]
     end
@@ -142,11 +143,10 @@ defmodule PtcRunner.SubAgent.Signature.Validator do
   defp validate_map_fields(data, fields, path) do
     Enum.flat_map(fields, fn {field_name, field_type} ->
       case get_field(data, field_name) do
-        {:ok, value} ->
+        {:ok, _key, value} ->
           validate_type(value, field_type, path ++ [field_name])
 
         :missing ->
-          # Check if field is optional
           if optional?(field_type) do
             []
           else
@@ -156,19 +156,33 @@ defmodule PtcRunner.SubAgent.Signature.Validator do
     end)
   end
 
-  # Compare data keys against declared field names, normalizing both sides
-  # (atom→string, hyphen→underscore) so a Clojure-style `:user-id` data key
-  # still counts as covering a declared `"user_id"` field. Anything left over
-  # is an undeclared field.
-  defp validate_no_extra_fields(data, fields, path) do
-    declared =
-      fields
-      |> Enum.map(fn {name, _type} -> KeyNormalizer.normalize_key(name) end)
-      |> MapSet.new()
+  # Like validate_map_fields/3 but also returns the set of consumed data keys
+  # so validate_no_extra_fields can flag unconsumed ones directly.
+  defp validate_map_fields_tracking(data, fields, path) do
+    {errors, consumed} =
+      Enum.reduce(fields, {[], MapSet.new()}, fn {field_name, field_type}, {errs, keys} ->
+        case get_field(data, field_name) do
+          {:ok, matched_key, value} ->
+            field_errors = validate_type(value, field_type, path ++ [field_name])
+            {errs ++ field_errors, MapSet.put(keys, matched_key)}
 
+          :missing ->
+            if optional?(field_type) do
+              {errs, keys}
+            else
+              {errs ++ [error_at(path ++ [field_name], "expected field, got nil")], keys}
+            end
+        end
+      end)
+
+    {errors, consumed}
+  end
+
+  # Flag every data key that was not consumed by a declared field.
+  defp validate_no_extra_fields(data, consumed_keys, path) do
     data
     |> Map.keys()
-    |> Enum.reject(fn key -> MapSet.member?(declared, KeyNormalizer.normalize_key(key)) end)
+    |> Enum.reject(&MapSet.member?(consumed_keys, &1))
     |> Enum.sort_by(&inspect/1)
     |> Enum.map(fn key ->
       error_at(
@@ -198,7 +212,7 @@ defmodule PtcRunner.SubAgent.Signature.Validator do
 
     Enum.reduce_while(candidates, :missing, fn key, _acc ->
       case try_key(data, key) do
-        {:ok, _} = result -> {:halt, result}
+        {:ok, _matched_key, _value} = result -> {:halt, result}
         :missing -> {:cont, :missing}
       end
     end)
@@ -208,20 +222,19 @@ defmodule PtcRunner.SubAgent.Signature.Validator do
     :missing
   end
 
-  # Look up a string key by trying it both as a string and as an existing atom.
   defp try_key(data, key) when is_binary(key) do
     case try_existing_atom_key(data, key) do
-      {:ok, _} = result ->
+      {:ok, _matched_key, _value} = result ->
         result
 
       :missing ->
-        if Map.has_key?(data, key), do: {:ok, Map.get(data, key)}, else: :missing
+        if Map.has_key?(data, key), do: {:ok, key, Map.get(data, key)}, else: :missing
     end
   end
 
   defp try_existing_atom_key(data, field_name) do
     atom_key = String.to_existing_atom(field_name)
-    if Map.has_key?(data, atom_key), do: {:ok, Map.get(data, atom_key)}, else: :missing
+    if Map.has_key?(data, atom_key), do: {:ok, atom_key, Map.get(data, atom_key)}, else: :missing
   rescue
     ArgumentError -> :missing
   end

--- a/test/ptc_runner/sub_agent/signature/validator_test.exs
+++ b/test/ptc_runner/sub_agent/signature/validator_test.exs
@@ -346,6 +346,17 @@ defmodule PtcRunner.SubAgent.Signature.ValidatorTest do
                  {:map, [{"at", :datetime}]}
                )
     end
+
+    test ":datetime inside closed_map gets coercion via JsonHandler.atomize_value" do
+      alias PtcRunner.SubAgent.Loop.JsonHandler
+
+      iso = "2026-05-03T09:14:00Z"
+      schema = {:closed_map, [{"at", :datetime}]}
+
+      atomized = JsonHandler.atomize_value(%{"at" => iso}, schema)
+      assert %{at: %DateTime{}} = atomized
+      assert :ok = Validator.validate(atomized, schema)
+    end
   end
 
   describe "validate/2 - closed maps" do
@@ -392,6 +403,22 @@ defmodule PtcRunner.SubAgent.Signature.ValidatorTest do
                  %{"user" => %{"name" => "A", "extra" => 1}},
                  {:closed_map, [{"user", {:closed_map, [{"name", :string}]}}]}
                )
+    end
+
+    test "rejects alias key alongside canonical key (bypass via dual keys)" do
+      data = %{"user_id" => 1, "user-id" => "bad"}
+      schema = {:closed_map, [{"user_id", :int}]}
+
+      assert {:error, errors} = Validator.validate(data, schema)
+      assert Enum.any?(errors, &(&1.message =~ "unexpected field"))
+    end
+
+    test "rejects atom alias key alongside string canonical key" do
+      data = %{"user_id" => 1, :"user-id" => "bad"}
+      schema = {:closed_map, [{"user_id", :int}]}
+
+      assert {:error, errors} = Validator.validate(data, schema)
+      assert Enum.any?(errors, &(&1.message =~ "unexpected field"))
     end
   end
 end


### PR DESCRIPTION
## Summary
- **P1**: Fix alias-key bypass in `closed_map` validation — when data contained both a canonical key (`"user_id"`) and its hyphenated alias (`"user-id"`), the alias was neither type-checked nor flagged as extra. Now tracks which data key each declared field consumed and flags unconsumed keys directly.
- **P2**: Add missing `{:closed_map, fields}` clause to `JsonHandler.atomize_value/2` — type-driven coercion (e.g. ISO-8601 → `%DateTime{}`) was lost inside closed maps. Delegates to the existing `{:map, fields}` clause, matching the pattern used in `renderer.ex`, `signature.ex`, and `coercion.ex`.
- 3 regression tests covering the exact shapes from the issue

Closes #932

## Test plan
- [x] `mix precommit` passes (all 4927 tests + 200 demo tests)
- [x] New test: dual-key bypass with string alias is rejected
- [x] New test: dual-key bypass with atom alias is rejected
- [x] New test: `:datetime` inside `{:closed_map, ...}` gets ISO-8601 → `%DateTime{}` coercion
- [x] All existing closed_map and validator tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Fix Automation State
<!-- fix-state: {"attempts":2} -->
Fix attempts: 2/3
