### PR TITLE
fix(mcp): batch quick-fixes for 3 catalog issues (#921, #922, #925)

### DIFF
--- a/mcp_server/lib/ptc_runner_mcp/catalog_builtins.ex
+++ b/mcp_server/lib/ptc_runner_mcp/catalog_builtins.ex
@@ -84,7 +84,7 @@ defmodule PtcRunnerMcp.CatalogBuiltins do
     opts = parse_list_tools_opts(rest)
 
     with :ok <- validate_list_tools_opts(opts),
-         :ok <- check_configured(registry, server) do
+         :ok <- check_configured(registry, server, "catalog/list-tools") do
       do_list_tools(server, opts, call_context, registry, catalog_config)
     end
   end
@@ -92,7 +92,7 @@ defmodule PtcRunnerMcp.CatalogBuiltins do
   defp dispatch(:describe_tool, [server, tool], call_context, registry, catalog_config) do
     with :ok <- validate_string_arg(server, "catalog/describe-tool", "server"),
          :ok <- validate_string_arg(tool, "catalog/describe-tool", "tool"),
-         :ok <- check_configured(registry, server) do
+         :ok <- check_configured(registry, server, "catalog/describe-tool") do
       do_describe_tool(server, tool, call_context, registry, catalog_config)
     end
   end
@@ -378,17 +378,7 @@ defmodule PtcRunnerMcp.CatalogBuiltins do
   # Option parsing and validation
   # ----------------------------------------------------------------
 
-  defp parse_list_tools_opts([]), do: %{}
-
-  defp parse_list_tools_opts([opts]) when is_map(opts) do
-    Map.new(opts, fn
-      {k, v} when is_atom(k) -> {k, v}
-      {k, v} when is_binary(k) -> {safe_to_atom(k), v}
-      kv -> kv
-    end)
-  end
-
-  defp parse_list_tools_opts(_), do: %{}
+  defp parse_list_tools_opts(rest), do: parse_catalog_opts(rest)
 
   defp validate_list_tools_opts(opts) do
     limit = Map.get(opts, :limit, 50)
@@ -408,9 +398,11 @@ defmodule PtcRunnerMcp.CatalogBuiltins do
     end
   end
 
-  defp parse_search_tools_opts([]), do: %{}
+  defp parse_search_tools_opts(rest), do: parse_catalog_opts(rest)
 
-  defp parse_search_tools_opts([opts]) when is_map(opts) do
+  defp parse_catalog_opts([]), do: %{}
+
+  defp parse_catalog_opts([opts]) when is_map(opts) do
     Map.new(opts, fn
       {k, v} when is_atom(k) -> {k, v}
       {k, v} when is_binary(k) -> {safe_to_atom(k), v}
@@ -418,7 +410,7 @@ defmodule PtcRunnerMcp.CatalogBuiltins do
     end)
   end
 
-  defp parse_search_tools_opts(_), do: %{}
+  defp parse_catalog_opts(_), do: %{}
 
   defp validate_search_tools_opts(opts) do
     limit = Map.get(opts, :limit, 8)
@@ -455,8 +447,8 @@ defmodule PtcRunnerMcp.CatalogBuiltins do
     end
   end
 
-  defp check_configured(registry, server) do
-    with :ok <- validate_string_arg(server, "catalog/list-tools", "server") do
+  defp check_configured(registry, server, form) do
+    with :ok <- validate_string_arg(server, form, "server") do
       if Registry.configured?(server, registry) do
         :ok
       else
@@ -526,7 +518,12 @@ defmodule PtcRunnerMcp.CatalogBuiltins do
   # ----------------------------------------------------------------
 
   defp all_server_info(registry) do
-    routings = GenServer.call(registry, :all_routings)
+    routings =
+      try do
+        GenServer.call(registry, :all_routings)
+      catch
+        :exit, _ -> %{}
+      end
 
     routings
     |> Enum.map(fn {name, routing} ->


### PR DESCRIPTION
Batch fix for three quick-fix issues in `mcp_server/lib/ptc_runner_mcp/catalog_builtins.ex`. Single file, ~16/19 line diff, no public-API change.

## Changes

### #921 — `check_configured/2` hardcoded form name
`check_configured` called `validate_string_arg(server, "catalog/list-tools", "server")` with a literal form name, so error messages from the `:describe_tool` dispatch path were wrong. The helper now takes an explicit `form` argument; both `:list_tools` and `:describe_tool` pass their own form name.

### #922 — `all_server_info/1` missing defensive try/catch
The helper called `GenServer.call(registry, :all_routings)` unguarded. The sibling helper `Catalog.configured_entries/1` already wraps the identical call in `try { … } catch :exit, _ -> %{} end` to stay safe during shutdown / registry restarts. Adopted the same pattern — falls back to an empty list cleanly.

### #925 — duplicated option parsers
`parse_search_tools_opts/1` (`:411-421`) and `parse_list_tools_opts/1` (`:381-391`) were character-identical. Extracted a shared `parse_catalog_opts/1`; both named helpers now delegate to it. Callsites unchanged.

## Verification

- `mix format` clean
- `mix compile --warnings-as-errors` clean
- `mix credo --strict lib/ptc_runner_mcp/catalog_builtins.ex` → no issues
- All 5 catalog test files pass: `catalog_builtins_test`, `catalog_config_test`, `catalog_description_test`, `catalog_integration_test`, `catalog_test` → **139 tests, 0 failures**
- pre-push hook: root + viewer test suites pass
- The 13 unrelated stdio/Phase1b failures in `mcp_server/test/ptc_runner_mcp/upstream_stdio_phase1b_test.exs` are **pre-existing on `main`** (verified by stashing this change and re-running). Their root cause is the `mock_server.exs` subprocess script failing with `Jason is not available`. Out of scope.

Closes #921
Closes #922
Closes #925

🤖 Generated with [Claude Code](https://claude.com/claude-code)