### PR TITLE
refactor(mcp): extract shared McpTestHelpers module (#928)

### DIFF
--- a/mcp_server/test/ptc_runner_mcp/agentic_mcp_call_test.exs
+++ b/mcp_server/test/ptc_runner_mcp/agentic_mcp_call_test.exs
@@ -1,6 +1,8 @@
 defmodule PtcRunnerMcp.AgenticMcpCallTest do
   use ExUnit.Case, async: false
 
+  import PtcRunnerMcp.McpTestHelpers, only: [stop_existing_registry: 1]
+
   alias PtcRunner.Lisp.ExecutionError
   alias PtcRunnerMcp.Agentic.{Ledger, McpCall}
   alias PtcRunnerMcp.{AggregatorConfig, Limits}
@@ -11,13 +13,15 @@ defmodule PtcRunnerMcp.AgenticMcpCallTest do
   @registry_name PtcRunnerMcp.Upstream.Registry
 
   setup do
-    stop_existing_registry()
+    Fake.stop("alpha")
+    stop_existing_registry(@registry_name)
     Catalog.clear_frozen()
     AggregatorConfig.set(AggregatorConfig.defaults())
     Limits.set(Limits.defaults())
 
     on_exit(fn ->
-      stop_existing_registry()
+      Fake.stop("alpha")
+      stop_existing_registry(@registry_name)
       Catalog.clear_frozen()
       AggregatorConfig.set(AggregatorConfig.defaults())
       Limits.set(Limits.defaults())
@@ -278,24 +282,5 @@ defmodule PtcRunnerMcp.AgenticMcpCallTest do
           {name, {schema, fun}}
         end)
     }
-  end
-
-  defp stop_existing_registry do
-    Fake.stop("alpha")
-
-    case Process.whereis(@registry_name) do
-      nil ->
-        :ok
-
-      pid ->
-        ref = Process.monitor(pid)
-        Process.exit(pid, :kill)
-
-        receive do
-          {:DOWN, ^ref, :process, ^pid, _} -> :ok
-        after
-          1_000 -> :ok
-        end
-    end
   end
 end

--- a/mcp_server/test/ptc_runner_mcp/agentic_payload_metrics_test.exs
+++ b/mcp_server/test/ptc_runner_mcp/agentic_payload_metrics_test.exs
@@ -10,6 +10,8 @@ defmodule PtcRunnerMcp.AgenticPayloadMetricsTest do
   """
   use ExUnit.Case, async: false
 
+  import PtcRunnerMcp.McpTestHelpers, only: [stop_existing_registry: 1]
+
   alias PtcRunnerMcp.Agentic.Planner
   alias PtcRunnerMcp.{AgenticConfig, AggregatorConfig, Limits, Tools}
   alias PtcRunnerMcp.Upstream.Catalog
@@ -102,7 +104,7 @@ defmodule PtcRunnerMcp.AgenticPayloadMetricsTest do
   end
 
   setup do
-    stop_existing_registry()
+    stop_existing_registry(@registry_name)
     Catalog.clear_frozen()
     AgenticConfig.set(AgenticConfig.defaults())
     AggregatorConfig.set(AggregatorConfig.defaults())
@@ -112,7 +114,7 @@ defmodule PtcRunnerMcp.AgenticPayloadMetricsTest do
     original_llm_adapter = Application.get_env(:ptc_runner, :llm_adapter)
 
     on_exit(fn ->
-      stop_existing_registry()
+      stop_existing_registry(@registry_name)
       Catalog.clear_frozen()
       AgenticConfig.set(AgenticConfig.defaults())
       AggregatorConfig.set(AggregatorConfig.defaults())
@@ -134,23 +136,6 @@ defmodule PtcRunnerMcp.AgenticPayloadMetricsTest do
 
   defp restore(app, key, nil), do: Application.delete_env(app, key)
   defp restore(app, key, value), do: Application.put_env(app, key, value)
-
-  defp stop_existing_registry do
-    case Process.whereis(@registry_name) do
-      nil ->
-        :ok
-
-      pid ->
-        ref = Process.monitor(pid)
-        Process.exit(pid, :kill)
-
-        receive do
-          {:DOWN, ^ref, :process, ^pid, _} -> :ok
-        after
-          1_000 -> :ok
-        end
-    end
-  end
 
   defp tools_config(tools) do
     %{tools: Map.new(tools, fn {n, fun} -> {n, {%{name: n, input_schema: %{}}, fun}} end)}

--- a/mcp_server/test/ptc_runner_mcp/agentic_test.exs
+++ b/mcp_server/test/ptc_runner_mcp/agentic_test.exs
@@ -1,6 +1,8 @@
 defmodule PtcRunnerMcp.AgenticTest do
   use ExUnit.Case, async: false
 
+  import PtcRunnerMcp.McpTestHelpers, only: [stop_existing_registry: 1]
+
   alias PtcRunnerMcp.{
     AgenticConfig,
     AggregatorConfig,
@@ -82,7 +84,7 @@ defmodule PtcRunnerMcp.AgenticTest do
   end
 
   setup do
-    stop_existing_registry()
+    stop_existing_registry(@registry_name)
     Catalog.clear_frozen()
     AgenticConfig.set(AgenticConfig.defaults())
     AggregatorConfig.set(AggregatorConfig.defaults())
@@ -93,7 +95,7 @@ defmodule PtcRunnerMcp.AgenticTest do
     original_trace = TraceConfig.get()
 
     on_exit(fn ->
-      stop_existing_registry()
+      stop_existing_registry(@registry_name)
       Catalog.clear_frozen()
       AgenticConfig.set(AgenticConfig.defaults())
       AggregatorConfig.set(AggregatorConfig.defaults())
@@ -697,21 +699,4 @@ defmodule PtcRunnerMcp.AgenticTest do
 
   defp restore_ptc_env(key, nil), do: Elixir.Application.delete_env(:ptc_runner, key)
   defp restore_ptc_env(key, value), do: Elixir.Application.put_env(:ptc_runner, key, value)
-
-  defp stop_existing_registry do
-    case Process.whereis(@registry_name) do
-      nil ->
-        :ok
-
-      pid ->
-        ref = Process.monitor(pid)
-        Process.exit(pid, :kill)
-
-        receive do
-          {:DOWN, ^ref, :process, ^pid, _} -> :ok
-        after
-          1_000 -> :ok
-        end
-    end
-  end
 end

--- a/mcp_server/test/ptc_runner_mcp/aggregator_auto_decode_test.exs
+++ b/mcp_server/test/ptc_runner_mcp/aggregator_auto_decode_test.exs
@@ -40,13 +40,15 @@ defmodule PtcRunnerMcp.AggregatorAutoDecodeTest do
 
   use ExUnit.Case, async: false
 
+  import PtcRunnerMcp.McpTestHelpers, only: [stop_existing_registry: 1]
+
   alias PtcRunnerMcp.{Limits, Tools}
   alias PtcRunnerMcp.Upstream.Registry
 
   @registry_name PtcRunnerMcp.Upstream.Registry
 
   setup do
-    stop_existing_registry()
+    stop_existing_registry(@registry_name)
 
     {:ok, _pid} = Registry.start_link(name: @registry_name)
     Limits.set(Limits.defaults())
@@ -68,28 +70,11 @@ defmodule PtcRunnerMcp.AggregatorAutoDecodeTest do
 
     on_exit(fn ->
       :telemetry.detach(handler_id)
-      stop_existing_registry()
+      stop_existing_registry(@registry_name)
       Limits.set(Limits.defaults())
     end)
 
     :ok
-  end
-
-  defp stop_existing_registry do
-    case Process.whereis(@registry_name) do
-      nil ->
-        :ok
-
-      pid ->
-        ref = Process.monitor(pid)
-        Process.exit(pid, :kill)
-
-        receive do
-          {:DOWN, ^ref, :process, ^pid, _} -> :ok
-        after
-          1_000 -> :ok
-        end
-    end
   end
 
   defp tools_config(tools) do

--- a/mcp_server/test/ptc_runner_mcp/aggregator_is_error_test.exs
+++ b/mcp_server/test/ptc_runner_mcp/aggregator_is_error_test.exs
@@ -26,40 +26,25 @@ defmodule PtcRunnerMcp.AggregatorIsErrorTest do
 
   use ExUnit.Case, async: false
 
+  import PtcRunnerMcp.McpTestHelpers, only: [stop_existing_registry: 1]
+
   alias PtcRunnerMcp.{Limits, Tools}
   alias PtcRunnerMcp.Upstream.Registry
 
   @registry_name PtcRunnerMcp.Upstream.Registry
 
   setup do
-    stop_existing_registry()
+    stop_existing_registry(@registry_name)
 
     {:ok, _pid} = Registry.start_link(name: @registry_name)
     Limits.set(Limits.defaults())
 
     on_exit(fn ->
-      stop_existing_registry()
+      stop_existing_registry(@registry_name)
       Limits.set(Limits.defaults())
     end)
 
     :ok
-  end
-
-  defp stop_existing_registry do
-    case Process.whereis(@registry_name) do
-      nil ->
-        :ok
-
-      pid ->
-        ref = Process.monitor(pid)
-        Process.exit(pid, :kill)
-
-        receive do
-          {:DOWN, ^ref, :process, ^pid, _} -> :ok
-        after
-          1_000 -> :ok
-        end
-    end
   end
 
   defp tools_config(tools) do

--- a/mcp_server/test/ptc_runner_mcp/aggregator_phase1a_test.exs
+++ b/mcp_server/test/ptc_runner_mcp/aggregator_phase1a_test.exs
@@ -17,42 +17,27 @@ defmodule PtcRunnerMcp.AggregatorPhase1aTest do
   """
   use ExUnit.Case, async: false
 
+  import PtcRunnerMcp.McpTestHelpers, only: [stop_existing_registry: 1]
+
   alias PtcRunnerMcp.{AggregatorConfig, Limits, Tools, UpstreamCalls}
   alias PtcRunnerMcp.Upstream.Registry
 
   @registry_name PtcRunnerMcp.Upstream.Registry
 
   setup do
-    stop_existing_registry()
+    stop_existing_registry(@registry_name)
 
     {:ok, _pid} = Registry.start_link(name: @registry_name)
     Limits.set(Limits.defaults())
     AggregatorConfig.set(AggregatorConfig.defaults())
 
     on_exit(fn ->
-      stop_existing_registry()
+      stop_existing_registry(@registry_name)
       Limits.set(Limits.defaults())
       AggregatorConfig.set(AggregatorConfig.defaults())
     end)
 
     :ok
-  end
-
-  defp stop_existing_registry do
-    case Process.whereis(@registry_name) do
-      nil ->
-        :ok
-
-      pid ->
-        ref = Process.monitor(pid)
-        Process.exit(pid, :kill)
-
-        receive do
-          {:DOWN, ^ref, :process, ^pid, _} -> :ok
-        after
-          1_000 -> :ok
-        end
-    end
   end
 
   defp tools_config(tools) do

--- a/mcp_server/test/ptc_runner_mcp/aggregator_phase1b_test.exs
+++ b/mcp_server/test/ptc_runner_mcp/aggregator_phase1b_test.exs
@@ -19,40 +19,25 @@ defmodule PtcRunnerMcp.AggregatorPhase1bTest do
   """
   use ExUnit.Case, async: false
 
+  import PtcRunnerMcp.McpTestHelpers, only: [stop_existing_registry: 1]
+
   alias PtcRunnerMcp.{Limits, Tools}
   alias PtcRunnerMcp.Upstream.Registry
 
   @registry_name PtcRunnerMcp.Upstream.Registry
 
   setup do
-    stop_existing_registry()
+    stop_existing_registry(@registry_name)
 
     {:ok, _pid} = Registry.start_link(name: @registry_name)
     Limits.set(Limits.defaults())
 
     on_exit(fn ->
-      stop_existing_registry()
+      stop_existing_registry(@registry_name)
       Limits.set(Limits.defaults())
     end)
 
     :ok
-  end
-
-  defp stop_existing_registry do
-    case Process.whereis(@registry_name) do
-      nil ->
-        :ok
-
-      pid ->
-        ref = Process.monitor(pid)
-        Process.exit(pid, :kill)
-
-        receive do
-          {:DOWN, ^ref, :process, ^pid, _} -> :ok
-        after
-          1_000 -> :ok
-        end
-    end
   end
 
   describe "cross-name concurrency (§12.3.3 mandatory DoD)" do

--- a/mcp_server/test/ptc_runner_mcp/catalog_builtins_test.exs
+++ b/mcp_server/test/ptc_runner_mcp/catalog_builtins_test.exs
@@ -8,40 +8,25 @@ defmodule PtcRunnerMcp.CatalogBuiltinsTest do
   """
   use ExUnit.Case, async: false
 
+  import PtcRunnerMcp.McpTestHelpers, only: [stop_existing_registry: 1]
+
   alias PtcRunnerMcp.{CatalogBuiltins, CatalogConfig, UpstreamCalls}
   alias PtcRunnerMcp.Upstream.Registry
 
   @registry_name PtcRunnerMcp.CatalogBuiltinsTestRegistry
 
   setup do
-    stop_existing_registry()
+    stop_existing_registry(@registry_name)
 
     {:ok, _pid} = Registry.start_link(name: @registry_name)
     CatalogConfig.set(CatalogConfig.defaults())
 
     on_exit(fn ->
-      stop_existing_registry()
+      stop_existing_registry(@registry_name)
       CatalogConfig.set(CatalogConfig.defaults())
     end)
 
     :ok
-  end
-
-  defp stop_existing_registry do
-    case Process.whereis(@registry_name) do
-      nil ->
-        :ok
-
-      pid ->
-        ref = Process.monitor(pid)
-        Process.exit(pid, :kill)
-
-        receive do
-          {:DOWN, ^ref, :process, ^pid, _} -> :ok
-        after
-          1_000 -> :ok
-        end
-    end
   end
 
   defp tools_config(tools) do

--- a/mcp_server/test/ptc_runner_mcp/catalog_integration_test.exs
+++ b/mcp_server/test/ptc_runner_mcp/catalog_integration_test.exs
@@ -16,13 +16,15 @@ defmodule PtcRunnerMcp.CatalogIntegrationTest do
   """
   use ExUnit.Case, async: false
 
+  import PtcRunnerMcp.McpTestHelpers, only: [stop_existing_registry: 1]
+
   alias PtcRunnerMcp.{AggregatorConfig, CatalogConfig, Limits, Tools}
   alias PtcRunnerMcp.Upstream.{Catalog, Registry}
 
   @registry_name PtcRunnerMcp.Upstream.Registry
 
   setup do
-    stop_existing_registry()
+    stop_existing_registry(@registry_name)
 
     {:ok, _pid} = Registry.start_link(name: @registry_name)
     Limits.set(Limits.defaults())
@@ -30,7 +32,7 @@ defmodule PtcRunnerMcp.CatalogIntegrationTest do
     CatalogConfig.set(CatalogConfig.defaults())
 
     on_exit(fn ->
-      stop_existing_registry()
+      stop_existing_registry(@registry_name)
       Limits.set(Limits.defaults())
       AggregatorConfig.set(AggregatorConfig.defaults())
       CatalogConfig.set(CatalogConfig.defaults())
@@ -222,23 +224,6 @@ defmodule PtcRunnerMcp.CatalogIntegrationTest do
   # ============================================================
   # Helpers
   # ============================================================
-
-  defp stop_existing_registry do
-    case Process.whereis(@registry_name) do
-      nil ->
-        :ok
-
-      pid ->
-        ref = Process.monitor(pid)
-        Process.exit(pid, :kill)
-
-        receive do
-          {:DOWN, ^ref, :process, ^pid, _} -> :ok
-        after
-          1_000 -> :ok
-        end
-    end
-  end
 
   defp put_fake_with_tools(name, count, description, capabilities, opts \\ []) do
     handler_fn =

--- a/mcp_server/test/ptc_runner_mcp/limits_phase1a_test.exs
+++ b/mcp_server/test/ptc_runner_mcp/limits_phase1a_test.exs
@@ -13,6 +13,8 @@ defmodule PtcRunnerMcp.LimitsPhase1aTest do
   """
   use ExUnit.Case, async: false
 
+  import PtcRunnerMcp.McpTestHelpers, only: [stop_existing_registry: 1]
+
   alias PtcRunnerMcp.{Application, Limits, Tools}
   alias PtcRunnerMcp.Upstream.Registry
 
@@ -151,9 +153,9 @@ defmodule PtcRunnerMcp.LimitsPhase1aTest do
 
   describe "upstream_call_timeout_ms is consumed by the executor" do
     setup do
-      stop_existing_registry()
+      stop_existing_registry(@registry_name)
       {:ok, _pid} = Registry.start_link(name: @registry_name)
-      on_exit(fn -> stop_existing_registry() end)
+      on_exit(fn -> stop_existing_registry(@registry_name) end)
       :ok
     end
 
@@ -185,9 +187,9 @@ defmodule PtcRunnerMcp.LimitsPhase1aTest do
 
   describe "max_upstream_response_bytes is consumed by the executor" do
     setup do
-      stop_existing_registry()
+      stop_existing_registry(@registry_name)
       {:ok, _pid} = Registry.start_link(name: @registry_name)
-      on_exit(fn -> stop_existing_registry() end)
+      on_exit(fn -> stop_existing_registry(@registry_name) end)
       :ok
     end
 
@@ -219,9 +221,9 @@ defmodule PtcRunnerMcp.LimitsPhase1aTest do
 
   describe "max_upstream_calls_per_program is consumed by the executor" do
     setup do
-      stop_existing_registry()
+      stop_existing_registry(@registry_name)
       {:ok, _pid} = Registry.start_link(name: @registry_name)
-      on_exit(fn -> stop_existing_registry() end)
+      on_exit(fn -> stop_existing_registry(@registry_name) end)
       :ok
     end
 
@@ -257,23 +259,6 @@ defmodule PtcRunnerMcp.LimitsPhase1aTest do
 
       assert ok_count == 2
       assert cap_count == 2
-    end
-  end
-
-  defp stop_existing_registry do
-    case Process.whereis(@registry_name) do
-      nil ->
-        :ok
-
-      pid ->
-        ref = Process.monitor(pid)
-        Process.exit(pid, :kill)
-
-        receive do
-          {:DOWN, ^ref, :process, ^pid, _} -> :ok
-        after
-          1_000 -> :ok
-        end
     end
   end
 end

--- a/mcp_server/test/ptc_runner_mcp/payload_reduction_test.exs
+++ b/mcp_server/test/ptc_runner_mcp/payload_reduction_test.exs
@@ -9,41 +9,26 @@ defmodule PtcRunnerMcp.PayloadReductionTest do
   """
   use ExUnit.Case, async: false
 
+  import PtcRunnerMcp.McpTestHelpers, only: [stop_existing_registry: 1]
+
   alias PtcRunnerMcp.{AggregatorConfig, Limits, Tools}
   alias PtcRunnerMcp.Upstream.Registry
 
   @registry_name PtcRunnerMcp.Upstream.Registry
 
   setup do
-    stop_existing_registry()
+    stop_existing_registry(@registry_name)
     {:ok, _pid} = Registry.start_link(name: @registry_name)
     Limits.set(Limits.defaults())
     AggregatorConfig.set(AggregatorConfig.defaults())
 
     on_exit(fn ->
-      stop_existing_registry()
+      stop_existing_registry(@registry_name)
       Limits.set(Limits.defaults())
       AggregatorConfig.set(AggregatorConfig.defaults())
     end)
 
     :ok
-  end
-
-  defp stop_existing_registry do
-    case Process.whereis(@registry_name) do
-      nil ->
-        :ok
-
-      pid ->
-        ref = Process.monitor(pid)
-        Process.exit(pid, :kill)
-
-        receive do
-          {:DOWN, ^ref, :process, ^pid, _} -> :ok
-        after
-          1_000 -> :ok
-        end
-    end
   end
 
   defp tools_config(tools) do

--- a/mcp_server/test/ptc_runner_mcp/telemetry_phase1a_test.exs
+++ b/mcp_server/test/ptc_runner_mcp/telemetry_phase1a_test.exs
@@ -14,13 +14,15 @@ defmodule PtcRunnerMcp.TelemetryPhase1aTest do
   """
   use ExUnit.Case, async: false
 
+  import PtcRunnerMcp.McpTestHelpers, only: [stop_existing_registry: 1]
+
   alias PtcRunnerMcp.{Limits, Tools}
   alias PtcRunnerMcp.Upstream.Registry
 
   @registry_name PtcRunnerMcp.Upstream.Registry
 
   setup do
-    stop_existing_registry()
+    stop_existing_registry(@registry_name)
     {:ok, _pid} = Registry.start_link(name: @registry_name)
     Limits.set(Limits.defaults())
 
@@ -44,7 +46,7 @@ defmodule PtcRunnerMcp.TelemetryPhase1aTest do
 
     on_exit(fn ->
       :telemetry.detach(handler_id)
-      stop_existing_registry()
+      stop_existing_registry(@registry_name)
       Limits.set(Limits.defaults())
     end)
 
@@ -209,23 +211,6 @@ defmodule PtcRunnerMcp.TelemetryPhase1aTest do
 
       assert_receive {:telemetry, [:ptc_runner_mcp, :upstream, :call, :start], _, start_meta}
       assert start_meta.request_id == nil
-    end
-  end
-
-  defp stop_existing_registry do
-    case Process.whereis(@registry_name) do
-      nil ->
-        :ok
-
-      pid ->
-        ref = Process.monitor(pid)
-        Process.exit(pid, :kill)
-
-        receive do
-          {:DOWN, ^ref, :process, ^pid, _} -> :ok
-        after
-          1_000 -> :ok
-        end
     end
   end
 end

--- a/mcp_server/test/ptc_runner_mcp/tools_phase3_test.exs
+++ b/mcp_server/test/ptc_runner_mcp/tools_phase3_test.exs
@@ -22,6 +22,8 @@ defmodule PtcRunnerMcp.ToolsPhase3Test do
   """
   use ExUnit.Case, async: false
 
+  import PtcRunnerMcp.McpTestHelpers, only: [stop_existing_registry: 1]
+
   alias PtcRunnerMcp.{AggregatorConfig, Tools}
   alias PtcRunnerMcp.Upstream.Catalog
   alias PtcRunnerMcp.Upstream.Connection
@@ -31,11 +33,11 @@ defmodule PtcRunnerMcp.ToolsPhase3Test do
   @fixture_path Path.expand("../fixtures/tool_entry_v1.json", __DIR__)
 
   setup do
-    stop_existing_registry()
+    stop_existing_registry(@registry_name)
     Catalog.clear_frozen()
 
     on_exit(fn ->
-      stop_existing_registry()
+      stop_existing_registry(@registry_name)
       Catalog.clear_frozen()
       AggregatorConfig.set(AggregatorConfig.defaults())
     end)
@@ -249,23 +251,6 @@ defmodule PtcRunnerMcp.ToolsPhase3Test do
       end
     else
       :ok
-    end
-  end
-
-  defp stop_existing_registry do
-    case Process.whereis(@registry_name) do
-      nil ->
-        :ok
-
-      pid ->
-        ref = Process.monitor(pid)
-        Process.exit(pid, :kill)
-
-        receive do
-          {:DOWN, ^ref, :process, ^pid, _} -> :ok
-        after
-          1_000 -> :ok
-        end
     end
   end
 end

--- a/mcp_server/test/support/mcp_test_helpers.ex
+++ b/mcp_server/test/support/mcp_test_helpers.ex
@@ -1,0 +1,51 @@
+defmodule PtcRunnerMcp.McpTestHelpers do
+  @moduledoc """
+  Shared helpers for `PtcRunnerMcp` tests.
+
+  Extracted (issue #928) to consolidate the `stop_existing_registry`
+  helper that was previously copy-pasted across ~13 test files. Each
+  test file historically defined its own private `defp` clone of the
+  same kill-and-monitor pattern keyed off a `@registry_name` module
+  attribute.
+
+  ## When to use this module versus inline cleanup
+
+  Most aggregator/catalog/agentic tests use a single named
+  `Upstream.Registry` GenServer per test module, so a single call to
+  `stop_existing_registry/2` in a `setup` block (or before
+  `start_supervised!/2`) is enough.
+
+  Tests that own additional resources (stdio subprocesses, fake
+  upstream pids, Finch supervision trees, etc.) should call those
+  cleanup helpers first and then call `stop_existing_registry/2`.
+  See `test/integration/real_filesystem_test.exs` for an example that
+  composes a different shutdown sequence.
+  """
+
+  @doc """
+  Kill the named registry GenServer if it is running, waiting up to
+  `timeout` ms for the process to exit.
+
+  Returns `:ok` whether the registry was running or not. Idempotent.
+  """
+  @spec stop_existing_registry(atom() | pid(), non_neg_integer()) :: :ok
+  def stop_existing_registry(registry_name, timeout \\ 1_000)
+
+  def stop_existing_registry(registry_name, timeout) when is_atom(registry_name) do
+    case Process.whereis(registry_name) do
+      nil -> :ok
+      pid -> stop_existing_registry(pid, timeout)
+    end
+  end
+
+  def stop_existing_registry(pid, timeout) when is_pid(pid) do
+    ref = Process.monitor(pid)
+    Process.exit(pid, :kill)
+
+    receive do
+      {:DOWN, ^ref, :process, ^pid, _} -> :ok
+    after
+      timeout -> :ok
+    end
+  end
+end


### PR DESCRIPTION
Replaces 13 character-identical `defp stop_existing_registry` copies in `mcp_server/test/` with a single shared helper.

## What changes

**New module** — `test/support/mcp_test_helpers.ex`:

```elixir
defmodule PtcRunnerMcp.McpTestHelpers do
  @spec stop_existing_registry(atom() | pid(), non_neg_integer()) :: :ok
  def stop_existing_registry(registry_name, timeout \\ 1_000)
  # ...
end
```

The single function takes an atom name (resolved via `Process.whereis/1`) or a pid directly. `test/support/` is already compiled in the test env (`mix.exs:64`), so no test_helper.exs change needed.

**Migrated 13 files**:
- 12 standard-pattern files now `import PtcRunnerMcp.McpTestHelpers, only: [stop_existing_registry: 1]` and call `stop_existing_registry(@registry_name)`
- `agentic_mcp_call_test.exs` had a slightly different variant that prefixed `Fake.stop(\"alpha\")` inside the local defp. The prefix moved up to the call sites (in `setup` + `on_exit`); behaviour identical.

**Untouched** — `test/integration/real_filesystem_test.exs` composes a fundamentally different stdio-aware cleanup sequence; its variant is referenced in the new module's `@moduledoc` so future readers know why it diverges.

## Diff

`14 files changed, 109 insertions(+), 253 deletions(-)` — net **−144 lines**.

## Verification

- All 183 tests across the migrated files pass (`--seed 0` deterministic run)
- `mix format` clean
- `mix credo --strict` clean (2026 mods/funs, zero issues)
- `mix compile --warnings-as-errors` clean

One initial run hit a pre-existing `:already_started` race between aggregator-phase1a and -phase1b under random seed; re-running with `--seed 0` or in smaller groupings is consistently green. Not introduced by this PR — same registry naming pattern as before, just less duplicated.

Closes #928

🤖 Generated with [Claude Code](https://claude.com/claude-code)