### PR TITLE
fix(format): consistent compact truncation hints with char-based signals

### DIFF
--- a/lib/ptc_runner/lisp/eval/context.ex
+++ b/lib/ptc_runner/lisp/eval/context.ex
@@ -234,9 +234,11 @@ defmodule PtcRunner.Lisp.Eval.Context do
   """
   @spec append_print(t(), String.t()) :: t()
   def append_print(%__MODULE__{prints: prints, max_print_length: max_len} = context, message) do
+    total = String.length(message)
+
     truncated =
-      if String.length(message) > max_len do
-        String.slice(message, 0, max_len) <> "..."
+      if total > max_len do
+        String.slice(message, 0, max_len) <> "... (#{max_len}/#{total} chars)"
       else
         message
       end

--- a/lib/ptc_runner/lisp/format.ex
+++ b/lib/ptc_runner/lisp/format.ex
@@ -99,7 +99,7 @@ defmodule PtcRunner.Lisp.Format do
   ## Options
 
   - `:limit` - Maximum items to show in collections (default: :infinity)
-  - `:printable_limit` - Maximum string bytes to show (default: :infinity)
+  - `:printable_limit` - Maximum string chars to show (default: :infinity)
 
   ## Examples
 
@@ -131,10 +131,10 @@ defmodule PtcRunner.Lisp.Format do
       {"[{:a 1} {:b 2}]", false}
 
       iex> PtcRunner.Lisp.Format.to_clojure([1, 2, 3, 4, 5], limit: 2)
-      {"[1 2 ...] (5 items, showing first 2)", true}
+      {"[1 2 ...] (2/5)", true}
 
       iex> PtcRunner.Lisp.Format.to_clojure("very long string here", printable_limit: 10)
-      {~s("very long ..."), true}
+      {~s("very long ...") <> " (10/21 chars)", true}
 
       iex> {str, _} = PtcRunner.Lisp.Format.to_clojure(%{title: "Hello", _body: "secret"})
       iex> str
@@ -191,8 +191,9 @@ defmodule PtcRunner.Lisp.Format do
     formatted = Enum.join(formatted_items, " ")
 
     if set_truncated do
+      shown = length(to_show)
       total = MapSet.size(set)
-      {"\#{#{formatted} ...} (#{total} items, showing first #{limit})", true}
+      {"\#{#{formatted} ...} (#{shown}/#{total})", true}
     else
       {"\#{#{formatted}}", any_child_truncated}
     end
@@ -232,8 +233,9 @@ defmodule PtcRunner.Lisp.Format do
     formatted = Enum.join(formatted_items, " ")
 
     if list_truncated do
+      shown = length(items)
       total = length(list)
-      {"[#{formatted} ...] (#{total} items, showing first #{limit})", true}
+      {"[#{formatted} ...] (#{shown}/#{total})", true}
     else
       {"[#{formatted}]", any_child_truncated}
     end
@@ -299,7 +301,9 @@ defmodule PtcRunner.Lisp.Format do
     formatted = Enum.join(formatted_items, " ")
 
     if map_truncated do
-      {"{#{formatted} ...}", true}
+      shown = length(items)
+      total = length(entries)
+      {"{#{formatted} ...} (#{shown}/#{total})", true}
     else
       {"{#{formatted}}", any_child_truncated}
     end
@@ -333,11 +337,14 @@ defmodule PtcRunner.Lisp.Format do
       :infinity ->
         {inspect(s), false}
 
-      n when byte_size(s) > n ->
-        {inspect(String.slice(s, 0, n) <> "..."), true}
+      n when is_integer(n) ->
+        total = String.length(s)
 
-      _ ->
-        {inspect(s), false}
+        if total > n do
+          {inspect(String.slice(s, 0, n) <> "...") <> " (#{n}/#{total} chars)", true}
+        else
+          {inspect(s), false}
+        end
     end
   end
 

--- a/lib/ptc_runner/sub_agent/loop/turn_feedback.ex
+++ b/lib/ptc_runner/sub_agent/loop/turn_feedback.ex
@@ -233,7 +233,7 @@ defmodule PtcRunner.SubAgent.Loop.TurnFeedback do
 
     prints_with_hint =
       if prints_truncated? do
-        prints_output <> "\n... (truncated, print specific fields instead)"
+        prints_output <> "\n... (truncated at #{max_chars} chars; print specific fields instead)"
       else
         prints_output
       end
@@ -349,13 +349,7 @@ defmodule PtcRunner.SubAgent.Loop.TurnFeedback do
   defp format_result_preview_unconditional(lisp_step, preview_max) do
     if lisp_step.return != nil and not var?(lisp_step.return) do
       {text, was_truncated?} = truncate_value(lisp_step.return, preview_max)
-
-      hint =
-        if was_truncated?,
-          do: "\n... (truncated, use println on specific fields)",
-          else: ""
-
-      {"user=> #{text}#{hint}", was_truncated?}
+      {"user=> #{text}", was_truncated?}
     else
       {nil, false}
     end
@@ -397,7 +391,7 @@ defmodule PtcRunner.SubAgent.Loop.TurnFeedback do
 
         hint =
           if any_truncated?,
-            do: "\n;; (truncated, use println on specific fields)",
+            do: "\n;; (truncated at #{preview_max} chars; use println on specific fields)",
             else: ""
 
         stored_hint_text = Enum.join(lines, "\n") <> hint
@@ -455,12 +449,14 @@ defmodule PtcRunner.SubAgent.Loop.TurnFeedback do
   end
 
   # Format a value as Clojure EDN and truncate for preview.
-  # Returns {text, was_truncated?}.
+  # Preserves inner Format.to_clojure hints when the outer cap does not cut;
+  # replaces with an outer cap hint when it does.
   defp truncate_value(value, max_len) do
     {str, format_truncated?} = Format.to_clojure(value, limit: 50)
 
     if String.length(str) > max_len do
-      {String.slice(str, 0, max_len) <> " ...", true}
+      {String.slice(str, 0, max_len) <>
+         " ... (truncated at #{max_len} chars; use println on specific fields)", true}
     else
       {str, format_truncated?}
     end

--- a/test/ptc_runner/lisp/format_test.exs
+++ b/test/ptc_runner/lisp/format_test.exs
@@ -211,7 +211,7 @@ defmodule PtcRunner.Lisp.FormatTest do
       assert result =~ ":a"
       assert result =~ ":b"
       assert result =~ ":c"
-      refute result =~ "entries, showing"
+      refute result =~ "..."
     end
   end
 
@@ -282,6 +282,59 @@ defmodule PtcRunner.Lisp.FormatTest do
       assert result =~ "\"id\" 1"
       refute result =~ "_secret"
       refute result =~ "hidden"
+    end
+  end
+
+  describe "to_clojure/2 compact (shown/total) hints" do
+    test "lists use compact hint format" do
+      {result, true} = Format.to_clojure([1, 2, 3, 4, 5], limit: 2)
+      assert result == "[1 2 ...] (2/5)"
+    end
+
+    test "sets use compact hint format" do
+      set = MapSet.new([1, 2, 3, 4, 5])
+      {result, true} = Format.to_clojure(set, limit: 2)
+      assert result =~ "...} (2/5)"
+    end
+
+    test "maps use compact hint format with count after hidden filtering" do
+      map = %{a: 1, b: 2, c: 3, d: 4, e: 5}
+      {result, true} = Format.to_clojure(map, limit: 2)
+      assert result =~ "...} (2/5)"
+    end
+
+    test "map total excludes hidden fields" do
+      map = %{a: 1, b: 2, _secret: "hidden", _token: "also-hidden"}
+      {result, true} = Format.to_clojure(map, limit: 1)
+      assert result =~ "(1/2)"
+      refute result =~ "_secret"
+      refute result =~ "_token"
+    end
+  end
+
+  describe "to_clojure/2 string truncation hints" do
+    test "shows char-based hint when truncated" do
+      {result, true} = Format.to_clojure("hello world", printable_limit: 5)
+      assert result =~ "(5/11 chars)"
+    end
+
+    test "no hint when string fits within limit" do
+      {result, false} = Format.to_clojure("short", printable_limit: 100)
+      assert result == ~s("short")
+      refute result =~ "chars"
+    end
+
+    test "uses String.length not byte_size for guard" do
+      # Multi-byte chars: "héllo" is 5 chars but 6 bytes
+      {result, false} = Format.to_clojure("héllo", printable_limit: 5)
+      assert result == ~s("héllo")
+      refute result =~ "chars"
+    end
+
+    test "truncates multi-byte string correctly by chars" do
+      # "aaaa héllo" is 10 chars; limit to 5 should truncate
+      {result, true} = Format.to_clojure("aaaa héllo", printable_limit: 5)
+      assert result =~ "(5/10 chars)"
     end
   end
 

--- a/test/ptc_runner/lisp/println_test.exs
+++ b/test/ptc_runner/lisp/println_test.exs
@@ -102,9 +102,8 @@ defmodule PtcRunner.Lisp.PrintlnTest do
 
     {:ok, step} = Lisp.run(source)
     [output] = step.prints
-    assert String.length(output) == 2003
-    assert String.ends_with?(output, "...")
     assert String.starts_with?(output, "xxx")
+    assert output =~ "... (2000/2500 chars)"
   end
 
   test "multiple long println calls each truncated independently" do
@@ -120,13 +119,11 @@ defmodule PtcRunner.Lisp.PrintlnTest do
     assert length(step.prints) == 2
 
     [first, second] = step.prints
-    assert String.length(first) == 2003
     assert String.starts_with?(first, "aaa")
-    assert String.ends_with?(first, "...")
+    assert first =~ "... (2000/2100 chars)"
 
-    assert String.length(second) == 2003
     assert String.starts_with?(second, "bbb")
-    assert String.ends_with?(second, "...")
+    assert second =~ "... (2000/2100 chars)"
   end
 
   test "println respects configurable max_print_length option" do
@@ -139,9 +136,8 @@ defmodule PtcRunner.Lisp.PrintlnTest do
     # Custom limit of 100 characters
     {:ok, step} = Lisp.run(source, max_print_length: 100)
     [output] = step.prints
-    assert String.length(output) == 103
-    assert String.ends_with?(output, "...")
     assert String.starts_with?(output, "yyy")
+    assert output =~ "... (100/200 chars)"
   end
 
   test "max_print_length propagates into defn calls" do
@@ -155,11 +151,8 @@ defmodule PtcRunner.Lisp.PrintlnTest do
     # Custom limit of 100 characters should be respected inside defn
     {:ok, step} = Lisp.run(source, max_print_length: 100)
     [output] = step.prints
-
-    assert String.length(output) == 103,
-           "expected 103 (100 + '...'), got #{String.length(output)}"
-
-    assert String.ends_with?(output, "...")
+    assert String.starts_with?(output, "zzz")
+    assert output =~ "... (100/200 chars)"
   end
 
   test "max_print_length propagates into closure calls" do
@@ -172,11 +165,8 @@ defmodule PtcRunner.Lisp.PrintlnTest do
 
     {:ok, step} = Lisp.run(source, max_print_length: 100)
     [output] = step.prints
-
-    assert String.length(output) == 103,
-           "expected 103 (100 + '...'), got #{String.length(output)}"
-
-    assert String.ends_with?(output, "...")
+    assert String.starts_with?(output, "www")
+    assert output =~ "... (100/200 chars)"
   end
 
   describe "char list detection (take on string)" do

--- a/test/ptc_runner/sub_agent/loop_turn_feedback_test.exs
+++ b/test/ptc_runner/sub_agent/loop_turn_feedback_test.exs
@@ -616,7 +616,7 @@ defmodule PtcRunner.SubAgent.LoopTurnFeedbackTest do
       result = TurnFeedback.execution_feedback(agent, state, lisp_step)
 
       assert result.truncated == true
-      assert result.result =~ "... (truncated, use println on specific fields)"
+      assert result.result =~ "truncated at 10 chars; use println on specific fields"
       # Sanity: this case isn't being detected via prints/memory channels.
       assert result.memory.truncated == false
     end
@@ -639,6 +639,87 @@ defmodule PtcRunner.SubAgent.LoopTurnFeedbackTest do
       assert result.memory.truncated == false
       assert result.result =~ "user=> 42"
       refute result.result =~ "truncated"
+    end
+
+    test "outer cap hint shows the actual budget value" do
+      agent =
+        SubAgent.new(
+          prompt: "task",
+          tools: %{},
+          max_turns: 3,
+          format_options: [preview_max_chars: 15]
+        )
+
+      state = build_state()
+      big_list = Enum.to_list(1..200)
+      lisp_step = build_lisp_step(return: big_list)
+
+      result = TurnFeedback.execution_feedback(agent, state, lisp_step)
+
+      assert result.truncated == true
+      assert result.result =~ "truncated at 15 chars"
+    end
+
+    test "inner Format.to_clojure hints survive when outer cap does not cut" do
+      agent =
+        SubAgent.new(
+          prompt: "task",
+          tools: %{},
+          max_turns: 3,
+          format_options: [preview_max_chars: 500]
+        )
+
+      state = build_state()
+      # A list that Format.to_clojure truncates at limit:50 but fits in 500 chars
+      long_list = Enum.to_list(1..100)
+      lisp_step = build_lisp_step(return: long_list)
+
+      result = TurnFeedback.execution_feedback(agent, state, lisp_step)
+
+      # Inner hint from Format.to_clojure should survive (compact shown/total)
+      assert result.result =~ "(50/100)"
+      # Outer cap hint should NOT appear since the formatted string fits
+      refute result.result =~ "truncated at"
+    end
+
+    test "outer cap replaces inner hint when it must cut" do
+      agent =
+        SubAgent.new(
+          prompt: "task",
+          tools: %{},
+          max_turns: 3,
+          format_options: [preview_max_chars: 20]
+        )
+
+      state = build_state()
+      long_list = Enum.to_list(1..100)
+      lisp_step = build_lisp_step(return: long_list)
+
+      result = TurnFeedback.execution_feedback(agent, state, lisp_step)
+
+      assert result.truncated == true
+      # Outer cap hint should appear with the actual budget
+      assert result.result =~ "truncated at 20 chars"
+    end
+
+    test "memory truncation hint shows the actual budget" do
+      agent =
+        SubAgent.new(
+          prompt: "task",
+          tools: %{},
+          max_turns: 3,
+          format_options: [preview_max_chars: 15]
+        )
+
+      state = build_state()
+      big_list = Enum.to_list(1..200)
+
+      lisp_step = build_lisp_step(return: nil, memory: %{huge: big_list})
+
+      result = TurnFeedback.execution_feedback(agent, state, lisp_step)
+
+      assert result.memory.truncated == true
+      assert result.feedback =~ "truncated at 15 chars"
     end
 
     test "stored_keys is empty list when memory is empty" do

--- a/test/ptc_runner/sub_agent/namespace/data_test.exs
+++ b/test/ptc_runner/sub_agent/namespace/data_test.exs
@@ -60,7 +60,7 @@ defmodule PtcRunner.SubAgent.Namespace.DataTest do
       assert result =~ "data/items"
       assert result =~ "list[10]"
       # Should be truncated due to limit: 3
-      assert result =~ "[1 2 3 ...] (10 items, showing first 3)"
+      assert result =~ "[1 2 3 ...] (3/10)"
     end
 
     test "sorts entries alphabetically" do

--- a/test/ptc_runner/sub_agent/namespace/execution_history_test.exs
+++ b/test/ptc_runner/sub_agent/namespace/execution_history_test.exs
@@ -59,7 +59,6 @@ defmodule PtcRunner.SubAgent.Namespace.ExecutionHistoryTest do
       # Should show truncation indicator from Format.to_clojure
       assert result =~ ";   analyze"
       assert result =~ "..."
-      assert result =~ "10 items"
     end
 
     test "ignores extra fields in tool call maps" do

--- a/test/ptc_runner/sub_agent/namespace/user_test.exs
+++ b/test/ptc_runner/sub_agent/namespace/user_test.exs
@@ -109,7 +109,7 @@ defmodule PtcRunner.SubAgent.Namespace.UserTest do
 
       assert result =~ "items"
       assert result =~ "list[5]"
-      assert result =~ "sample: [1 2 3 ...] (5 items, showing first 3)"
+      assert result =~ "sample: [1 2 3 ...] (3/5)"
     end
 
     test "renders value with map type" do


### PR DESCRIPTION
## Summary

- **Lists/sets/maps**: Use compact `(shown/total)` hints instead of verbose `(N items, showing first M)` — e.g., `[1 2 3 ...] (3/10)` instead of `[1 2 3 ...] (10 items, showing first 3)`
- **Map totals**: Computed after hidden-field filtering so `(1/2)` doesn't leak that hidden keys exist
- **Strings**: Char-based length hint when truncated — e.g., `"very long..." (10/21 chars)`
- **byte/char mismatch fix**: `format_clojure_string/2` guard now uses `String.length/1` instead of `byte_size/1`, matching the char-based `String.slice` truncation
- **`append_print/2`**: Shows `(shown/total chars)` instead of bare `...` — e.g., `... (2000/2500 chars)`
- **Outer `truncate_value`**: Shows actual cap value with actionable guidance — e.g., `... (truncated at 250 chars; use println on specific fields)`
- **Inner hint preservation**: `Format.to_clojure` hints survive unless the outer cap must cut, in which case the outer cap hint replaces them

Closes #947

## Test plan

- [x] Existing list/set format test assertions updated for compact `(shown/total)` format
- [x] New tests for map `(shown/total)` hint with hidden-field filtering
- [x] New tests for string char-based truncation hints (including multi-byte chars)
- [x] New tests for outer cap showing actual budget value
- [x] New tests for inner hint survival when outer cap doesn't cut
- [x] New tests for outer cap replacing inner hint when it must cut
- [x] New tests for memory truncation hint showing actual budget
- [x] println tests updated for `(shown/total chars)` format
- [x] `mix precommit` passes (format + compile + credo + spec + tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)