### PR TITLE
fix: batch quick-fixes (4 issues)

### DIFF
--- a/lib/ptc_runner/lisp/eval/apply.ex
+++ b/lib/ptc_runner/lisp/eval/apply.ex
@@ -352,7 +352,7 @@ defmodule PtcRunner.Lisp.Eval.Apply do
   """
   @spec closure_to_fun(term(), EvalContext.t(), (term(), EvalContext.t() -> term())) :: term()
   def closure_to_fun(
-        {:closure, patterns, body, closure_env, closure_turn_history, metadata} = closure,
+        {:closure, patterns, body, closure_env, _closure_turn_history, metadata} = closure,
         %EvalContext{} = eval_context,
         do_eval_fn
       ) do
@@ -383,7 +383,6 @@ defmodule PtcRunner.Lisp.Eval.Apply do
               body,
               closure_env,
               eval_context,
-              closure_turn_history,
               metadata,
               do_eval_fn
             )
@@ -397,7 +396,6 @@ defmodule PtcRunner.Lisp.Eval.Apply do
               body,
               closure_env,
               eval_context,
-              closure_turn_history,
               metadata,
               do_eval_fn
             )
@@ -411,7 +409,6 @@ defmodule PtcRunner.Lisp.Eval.Apply do
               body,
               closure_env,
               eval_context,
-              closure_turn_history,
               metadata,
               do_eval_fn
             )
@@ -425,7 +422,6 @@ defmodule PtcRunner.Lisp.Eval.Apply do
               body,
               closure_env,
               eval_context,
-              closure_turn_history,
               metadata,
               do_eval_fn
             )
@@ -473,7 +469,6 @@ defmodule PtcRunner.Lisp.Eval.Apply do
               body,
               closure_env,
               eval_context,
-              closure_turn_history,
               metadata,
               do_eval_fn
             )
@@ -487,7 +482,6 @@ defmodule PtcRunner.Lisp.Eval.Apply do
               body,
               closure_env,
               eval_context,
-              closure_turn_history,
               metadata,
               do_eval_fn
             )
@@ -590,7 +584,6 @@ defmodule PtcRunner.Lisp.Eval.Apply do
          body,
          closure_env,
          %EvalContext{} = eval_context,
-         _closure_turn_history,
          metadata,
          do_eval_fn
        ) do

--- a/lib/ptc_runner/lisp/runtime/map_ops.ex
+++ b/lib/ptc_runner/lisp/runtime/map_ops.ex
@@ -23,21 +23,13 @@ defmodule PtcRunner.Lisp.Runtime.MapOps do
       iex> PtcRunner.Lisp.Runtime.MapOps.hash_map([:a, 1, :b, 2])
       %{a: 1, b: 2}
   """
-  def array_map(args) when is_list(args) do
+  def array_map(args) when is_list(args), do: build_map(args, "array-map")
+  def hash_map(args) when is_list(args), do: build_map(args, "hash-map")
+
+  defp build_map(args, name) do
     if rem(length(args), 2) != 0 do
       raise ExecutionError,
-        message: "array-map requires an even number of arguments, got #{length(args)}"
-    end
-
-    args
-    |> Enum.chunk_every(2)
-    |> Enum.into(%{}, fn [k, v] -> {k, v} end)
-  end
-
-  def hash_map(args) when is_list(args) do
-    if rem(length(args), 2) != 0 do
-      raise ExecutionError,
-        message: "hash-map requires an even number of arguments, got #{length(args)}"
+        message: "#{name} requires an even number of arguments, got #{length(args)}"
     end
 
     args

--- a/lib/ptc_runner/sub_agent/loop/turn_feedback.ex
+++ b/lib/ptc_runner/sub_agent/loop/turn_feedback.ex
@@ -441,11 +441,13 @@ defmodule PtcRunner.SubAgent.Loop.TurnFeedback do
     end
   end
 
-  defp truncate_prints(str, max_chars) when byte_size(str) > max_chars do
-    {String.slice(str, 0, max_chars), true}
+  defp truncate_prints(str, max_chars) do
+    if String.length(str) > max_chars do
+      {String.slice(str, 0, max_chars), true}
+    else
+      {str, false}
+    end
   end
-
-  defp truncate_prints(str, _max_chars), do: {str, false}
 
   # Return only vars that are new or changed compared to previous turn
   defp changed_vars(prev_memory, current_memory) do

--- a/mcp_server/test/integration/real_filesystem_test.exs
+++ b/mcp_server/test/integration/real_filesystem_test.exs
@@ -64,6 +64,8 @@ defmodule PtcRunnerMcp.Integration.RealFilesystemTest do
 
   use ExUnit.Case, async: false
 
+  import PtcRunnerMcp.McpTestHelpers, only: [stop_existing_registry: 2]
+
   alias PtcRunnerMcp.{Limits, Tools}
   alias PtcRunnerMcp.Upstream.{Connection, Registry, Stdio}
 
@@ -384,7 +386,7 @@ defmodule PtcRunnerMcp.Integration.RealFilesystemTest do
     stdio_monitor = monitor_existing_stdio(@upstream_name)
 
     stop_existing_connection(@upstream_name)
-    kill_named_genserver(@registry_name)
+    stop_existing_registry(@registry_name, 5_000)
 
     wait_for_stdio_down(stdio_monitor)
   end
@@ -419,23 +421,6 @@ defmodule PtcRunnerMcp.Integration.RealFilesystemTest do
           # terminate/2 -> Port.close + Stdio.Names release).
           Connection.stop(conn_pid)
       end
-    end
-  end
-
-  defp kill_named_genserver(name) do
-    case Process.whereis(name) do
-      nil ->
-        :ok
-
-      pid ->
-        ref = Process.monitor(pid)
-        Process.exit(pid, :kill)
-
-        receive do
-          {:DOWN, ^ref, :process, ^pid, _} -> :ok
-        after
-          5_000 -> :ok
-        end
     end
   end
 


### PR DESCRIPTION
## Summary
Batch fix for quick-fix issues flagged in PR reviews.

## Issues Fixed
- Closes #950: fix byte_size guard in truncate_prints for multi-byte char consistency
- Closes #946: Remove dead closure_turn_history parameter threading in closure_to_fun
- Closes #943: DRY up array_map/hash_map body duplication in map_ops.ex
- Closes #936: Replace kill_named_genserver/1 with stop_existing_registry/2 in real_filesystem_test.exs

## Issues Skipped
- #938: Already fixed in commit `55244312` (fix(lisp): preserve catalog ops across recur) — `recur_effects/1` and `restore_recur_effects/2` in `eval/context.ex` already include `catalog_ops`.

## Changes
- `turn_feedback.ex`: Replaced `byte_size(str) > max_chars` guard with `String.length(str) > max_chars` check inside function body (guard context doesn't allow `String.length/1`)
- `eval/apply.ex`: Removed dead `closure_turn_history` parameter from `closure_to_fun` destructuring and all 6 `eval_closure_args` call sites, and from the `eval_closure_args` function head
- `runtime/map_ops.ex`: Extracted shared `build_map/2` private helper; `array_map/1` and `hash_map/1` now delegate to it with their respective function name for the error message
- `real_filesystem_test.exs`: Imported `stop_existing_registry/2` from `McpTestHelpers`, replaced `kill_named_genserver/1` call with `stop_existing_registry(@registry_name, 5_000)`, removed the now-redundant `kill_named_genserver/1` private helper

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)