### PR TITLE
fix(lisp): stop atom growth from source names

### DIFF
--- a/lib/ptc_runner/lisp.ex
+++ b/lib/ptc_runner/lisp.ex
@@ -33,6 +33,8 @@ defmodule PtcRunner.Lisp do
   alias PtcRunner.Lisp.{Analyze, DataKeys, Env, Eval, ExecutionError, Parser, SymbolCounter}
   alias PtcRunner.Lisp.Eval.Context, as: EvalContext
   alias PtcRunner.Lisp.Eval.Helpers
+  alias PtcRunner.Lisp.Format.Var
+  alias PtcRunner.Lisp.Keyword, as: LispKeyword
   alias PtcRunner.Step
   alias PtcRunner.SubAgent.Signature
   alias PtcRunner.Tool
@@ -657,9 +659,9 @@ defmodule PtcRunner.Lisp do
     cleaned_pmap_calls = Enum.map(reversed_pmap_calls, &Map.delete(&1, :child_steps))
 
     %Step{
-      return: round_floats(value, precision),
+      return: value |> externalize_lisp_values() |> round_floats(precision),
       fail: nil,
-      memory: ctx.user_ns,
+      memory: externalize_memory(ctx.user_ns),
       journal: ctx.journal,
       summaries: ctx.summaries,
       tool_cache: ctx.tool_cache,
@@ -700,6 +702,56 @@ defmodule PtcRunner.Lisp do
   end
 
   defp round_floats(value, _precision), do: value
+
+  defp externalize_lisp_values(%LispKeyword{name: name} = keyword) do
+    existing_atom_or(name, keyword)
+  end
+
+  defp externalize_lisp_values(%Var{name: name} = var) when is_binary(name) do
+    %{var | name: existing_atom_or(name, name)}
+  end
+
+  defp externalize_lisp_values({:__ptc_return__, inner}) do
+    {:__ptc_return__, externalize_lisp_values(inner)}
+  end
+
+  defp externalize_lisp_values({:__ptc_fail__, inner}) do
+    {:__ptc_fail__, externalize_lisp_values(inner)}
+  end
+
+  defp externalize_lisp_values(value) when is_list(value) do
+    Enum.map(value, &externalize_lisp_values/1)
+  end
+
+  defp externalize_lisp_values(value) when is_map(value) and not is_struct(value) do
+    Map.new(value, fn {k, v} ->
+      {externalize_map_key(k), externalize_lisp_values(v)}
+    end)
+  end
+
+  defp externalize_lisp_values(value), do: value
+
+  defp externalize_memory(memory) when is_map(memory) do
+    Map.new(memory, fn {k, v} ->
+      {externalize_memory_key(k), externalize_lisp_values(v)}
+    end)
+  end
+
+  defp externalize_map_key(%LispKeyword{name: name}), do: existing_atom_or(name, name)
+  defp externalize_map_key(other), do: other
+
+  defp externalize_memory_key(%LispKeyword{name: name} = keyword),
+    do: existing_atom_or(name, keyword)
+
+  defp externalize_memory_key(name) when is_binary(name), do: existing_atom_or(name, name)
+  defp externalize_memory_key(other), do: other
+
+  defp existing_atom_or(name, fallback) when is_binary(name) do
+    case safe_to_existing_atom(name) do
+      {:ok, atom} -> atom
+      :error -> fallback
+    end
+  end
 
   # Check if symbol count exceeds limit
   defp check_symbol_limit(ast, max_symbols, memory, journal) do
@@ -945,7 +997,7 @@ defmodule PtcRunner.Lisp do
     name_str = to_string(name)
 
     # Skip interop method names (e.g., .toString) — validity checked at runtime
-    if String.starts_with?(name_str, ".") or Env.builtin?(name) or MapSet.member?(scope, name) do
+    if String.starts_with?(name_str, ".") or Env.builtin?(name) or scope_member?(scope, name) do
       []
     else
       [name_str]
@@ -1165,6 +1217,21 @@ defmodule PtcRunner.Lisp do
   end
 
   defp pattern_vars(_other), do: []
+
+  defp scope_member?(scope, name) do
+    MapSet.member?(scope, name) or
+      (is_binary(name) and
+         case safe_to_existing_atom(name) do
+           {:ok, atom} -> MapSet.member?(scope, atom)
+           :error -> false
+         end)
+  end
+
+  defp safe_to_existing_atom(name) do
+    {:ok, String.to_existing_atom(name)}
+  rescue
+    ArgumentError -> :error
+  end
 
   # Format errors from parse/analyze for validate/1
   defp format_validate_error({:parse_error, msg}), do: "Parse error: #{msg}"

--- a/lib/ptc_runner/lisp/analyze.ex
+++ b/lib/ptc_runner/lisp/analyze.ex
@@ -214,7 +214,8 @@ defmodule PtcRunner.Lisp.Analyze do
   defp do_analyze({:shadowed_local, name}, _tail?), do: {:ok, {:var, name}}
 
   # Var reader syntax: #'name produces {:var, name} from the parser
-  defp do_analyze({:var, name}, _tail?) when is_atom(name), do: {:ok, {:var, name}}
+  defp do_analyze({:var, name}, _tail?) when is_atom(name) or is_binary(name),
+    do: {:ok, {:var, name}}
 
   defp do_analyze({:ns_symbol, :data, key}, _tail?), do: {:ok, {:data, key}}
 
@@ -655,7 +656,8 @@ defmodule PtcRunner.Lisp.Analyze do
   # ============================================================
 
   # Named fn: (fn name [params] body ...)
-  defp analyze_fn([{:symbol, name}, params_ast, first_body | rest_body]) when is_atom(name) do
+  defp analyze_fn([{:symbol, name}, params_ast, first_body | rest_body])
+       when is_atom(name) or is_binary(name) do
     body_asts = [first_body | rest_body]
 
     with {:ok, params} <- analyze_fn_params(params_ast) do

--- a/lib/ptc_runner/lisp/analyze/patterns.ex
+++ b/lib/ptc_runner/lisp/analyze/patterns.ex
@@ -129,7 +129,7 @@ defmodule PtcRunner.Lisp.Analyze.Patterns do
       has_defaults = not Enum.empty?(defaults)
 
       # Convert :strs names into renames with string source keys
-      strs_as_renames = Enum.map(strs, fn name -> {{:var, name}, Atom.to_string(name)} end)
+      strs_as_renames = Enum.map(strs, fn name -> {{:var, name}, to_string(name)} end)
       all_renames = renames ++ strs_as_renames
 
       if has_keys || has_strs || has_renames || has_defaults do

--- a/lib/ptc_runner/lisp/analyze/short_fn.ex
+++ b/lib/ptc_runner/lisp/analyze/short_fn.ex
@@ -7,6 +7,7 @@ defmodule PtcRunner.Lisp.Analyze.ShortFn do
   """
 
   alias PtcRunner.Lisp.Analyze
+  alias PtcRunner.Lisp.SourceAtoms
 
   @doc """
   Desugars short function syntax into a transformed AST.
@@ -163,13 +164,13 @@ defmodule PtcRunner.Lisp.Analyze.ShortFn do
 
   defp generate_params({:variadic, n}) do
     leading =
-      if n > 0, do: Enum.map(1..n, fn i -> {:symbol, String.to_atom("p#{i}")} end), else: []
+      if n > 0, do: Enum.map(1..n, fn i -> {:symbol, SourceAtoms.intern("p#{i}")} end), else: []
 
     leading ++ [{:symbol, :&}, {:symbol, :rest}]
   end
 
   defp generate_params(arity) when arity > 0 do
-    Enum.map(1..arity, fn i -> {:symbol, String.to_atom("p#{i}")} end)
+    Enum.map(1..arity, fn i -> {:symbol, SourceAtoms.intern("p#{i}")} end)
   end
 
   # ============================================================
@@ -182,7 +183,7 @@ defmodule PtcRunner.Lisp.Analyze.ShortFn do
     Enum.map(asts, &transform_body(&1, placeholders))
   end
 
-  defp transform_body({:symbol, name}, _placeholders) when is_atom(name) do
+  defp transform_body({:symbol, name}, _placeholders) when is_atom(name) or is_binary(name) do
     name_str = to_string(name)
 
     case Analyze.placeholder?(name) do
@@ -227,7 +228,7 @@ defmodule PtcRunner.Lisp.Analyze.ShortFn do
     case name_str do
       "%" -> :p1
       "%&" -> :rest
-      "%" <> num_str -> String.to_atom("p#{num_str}")
+      "%" <> num_str -> SourceAtoms.intern("p#{num_str}")
     end
   end
 end

--- a/lib/ptc_runner/lisp/ast.ex
+++ b/lib/ptc_runner/lisp/ast.ex
@@ -1,25 +1,29 @@
 defmodule PtcRunner.Lisp.AST do
   @moduledoc "AST node types for PTC-Lisp"
 
+  alias PtcRunner.Lisp.SourceAtoms
+
+  @type name :: atom() | String.t()
+
   # Literals
   @type t ::
           nil
           | boolean()
           | number()
           | {:string, String.t()}
-          | {:keyword, atom()}
+          | {:keyword, name()}
           # Collections
           | {:vector, [t()]}
           | {:map, [{t(), t()}]}
           | {:set, [t()]}
           # Symbols
-          | {:symbol, atom()}
-          | {:ns_symbol, atom(), atom()}
+          | {:symbol, name()}
+          | {:ns_symbol, name(), name()}
           # Calls
           | {:list, [t()]}
 
   @doc "Create a keyword node"
-  def keyword(name) when is_binary(name), do: {:keyword, String.to_atom(name)}
+  def keyword(name) when is_binary(name), do: {:keyword, SourceAtoms.intern(name)}
 
   @doc "Create a symbol node"
   def symbol(name) when is_binary(name) do
@@ -37,18 +41,18 @@ defmodule PtcRunner.Lisp.AST do
       _ ->
         case String.split(name, "/", parts: 2) do
           [name] ->
-            {:symbol, String.to_atom(name)}
+            {:symbol, SourceAtoms.intern(name)}
 
           ["", _] ->
             # Handles "/" operator (division) - empty namespace means not a namespaced symbol
-            {:symbol, String.to_atom(name)}
+            {:symbol, SourceAtoms.intern(name)}
 
           [ns, key] when ns != "" and key != "" ->
-            {:ns_symbol, String.to_atom(ns), String.to_atom(key)}
+            {:ns_symbol, SourceAtoms.intern(ns), SourceAtoms.intern(key)}
 
           _ ->
             # Fallback for edge cases
-            {:symbol, String.to_atom(name)}
+            {:symbol, SourceAtoms.intern(name)}
         end
     end
   end

--- a/lib/ptc_runner/lisp/clojure_validator.ex
+++ b/lib/ptc_runner/lisp/clojure_validator.ex
@@ -25,6 +25,9 @@ defmodule PtcRunner.Lisp.ClojureValidator do
   @default_timeout 5_000
   @local_bb_path "_build/tools/bb"
 
+  alias PtcRunner.Lisp.Keyword, as: LispKeyword
+  alias PtcRunner.Lisp.SourceAtoms
+
   @doc """
   Check if Babashka is available.
 
@@ -277,7 +280,7 @@ defmodule PtcRunner.Lisp.ClojureValidator do
 
       # Keyword
       String.starts_with?(str, ":") ->
-        str |> String.slice(1..-1//1) |> String.to_atom()
+        str |> String.slice(1..-1//1) |> keyword_value()
 
       # String (quoted)
       String.starts_with?(str, "\"") and String.ends_with?(str, "\"") ->
@@ -333,7 +336,7 @@ defmodule PtcRunner.Lisp.ClojureValidator do
     Map.new(value, fn {k, v} ->
       key =
         if is_binary(k) and String.starts_with?(k, ":") do
-          k |> String.slice(1..-1//1) |> String.to_atom()
+          k |> String.slice(1..-1//1) |> keyword_value()
         else
           k
         end
@@ -386,6 +389,8 @@ defmodule PtcRunner.Lisp.ClojureValidator do
     Atom.to_string(value)
   end
 
+  defp normalize_value(%LispKeyword{name: name}), do: name
+
   defp normalize_value(value), do: value
 
   # Convert Elixir value to EDN string
@@ -399,6 +404,8 @@ defmodule PtcRunner.Lisp.ClojureValidator do
   defp to_edn(a) when is_atom(a) do
     ":" <> Atom.to_string(a)
   end
+
+  defp to_edn(%LispKeyword{name: name}), do: ":" <> name
 
   defp to_edn(list) when is_list(list) do
     items = Enum.map_join(list, " ", &to_edn/1)
@@ -417,6 +424,13 @@ defmodule PtcRunner.Lisp.ClojureValidator do
       end)
 
     "{#{items}}"
+  end
+
+  defp keyword_value(name) when is_binary(name) do
+    case SourceAtoms.intern(name) do
+      atom when is_atom(atom) -> atom
+      binary when is_binary(binary) -> LispKeyword.new(binary)
+    end
   end
 
   # PTC-specific function stubs for Clojure

--- a/lib/ptc_runner/lisp/core_ast.ex
+++ b/lib/ptc_runner/lisp/core_ast.ex
@@ -13,12 +13,14 @@ defmodule PtcRunner.Lisp.CoreAST do
   ```
   """
 
+  @type name :: atom() | String.t()
+
   @type literal ::
           nil
           | boolean()
           | number()
           | {:string, String.t()}
-          | {:keyword, atom()}
+          | {:keyword, name()}
 
   @type fn_params :: [pattern()] | {:variadic, [pattern()], pattern()}
 
@@ -29,8 +31,8 @@ defmodule PtcRunner.Lisp.CoreAST do
           | {:map, [{t(), t()}]}
           | {:set, [t()]}
           # Variables and namespace access
-          | {:var, atom()}
-          | {:data, atom()}
+          | {:var, name()}
+          | {:data, name()}
           # Function call: f(args...)
           | {:call, t(), [t()]}
           # Let bindings: (let [p1 v1 p2 v2 ...] body)
@@ -39,7 +41,7 @@ defmodule PtcRunner.Lisp.CoreAST do
           | {:if, t(), t(), t()}
           # Anonymous function (optionally named for self-recursion)
           | {:fn, fn_params(), t()}
-          | {:fn, atom(), fn_params(), t()}
+          | {:fn, name(), fn_params(), t()}
           # Sequential evaluation (special forms, not calls)
           | {:do, [t()]}
           # Short-circuit logic (special forms, not calls)
@@ -55,11 +57,11 @@ defmodule PtcRunner.Lisp.CoreAST do
           | {:step_done, t(), t()}
           | {:task_reset, t()}
           # Tool invocation via tool/ namespace: (tool/name args...)
-          | {:tool_call, atom(), [t()]}
+          | {:tool_call, name(), [t()]}
           # Define binding in user namespace: (def name value) with optional metadata
-          | {:def, atom(), t(), map()}
+          | {:def, name(), t(), map()}
           # Idempotent define: (defonce name value) — no-op if already bound
-          | {:defonce, atom(), t(), map()}
+          | {:defonce, name(), t(), map()}
           # Tail recursion: loop and recur
           | {:loop, [binding()], t()}
           | {:recur, [t()]}
@@ -67,10 +69,10 @@ defmodule PtcRunner.Lisp.CoreAST do
   @type binding :: {:binding, pattern(), t()}
 
   @type pattern ::
-          {:var, atom()}
-          | {:destructure, {:keys, [atom()], keyword()}}
-          | {:destructure, {:map, [atom()], [{pattern(), term()}], keyword()}}
-          | {:destructure, {:as, atom(), pattern()}}
+          {:var, name()}
+          | {:destructure, {:keys, [name()], keyword()}}
+          | {:destructure, {:map, [name()], [{pattern(), term()}], keyword()}}
+          | {:destructure, {:as, name(), pattern()}}
           | {:destructure, {:seq, [pattern()]}}
           # Rest pattern: [a b & rest] binds rest to remaining elements
           | {:destructure, {:seq_rest, [pattern()], pattern()}}

--- a/lib/ptc_runner/lisp/core_to_source.ex
+++ b/lib/ptc_runner/lisp/core_to_source.ex
@@ -14,6 +14,7 @@ defmodule PtcRunner.Lisp.CoreToSource do
   """
 
   alias PtcRunner.Lisp.Formatter
+  alias PtcRunner.Lisp.Keyword, as: LispKeyword
 
   @doc """
   Convert a Core AST node to a PTC-Lisp source string.
@@ -63,7 +64,7 @@ defmodule PtcRunner.Lisp.CoreToSource do
   end
 
   # Variables and data access
-  def format({:var, name}), do: Atom.to_string(name)
+  def format({:var, name}), do: to_string(name)
   def format({:data, key}), do: "data/#{key}"
 
   # Collections
@@ -274,11 +275,18 @@ defmodule PtcRunner.Lisp.CoreToSource do
     {non_closures, closures} =
       Enum.split_with(entries, fn {_k, v} -> !match?({:closure, _, _, _, _, _}, v) end)
 
-    ns_keys = MapSet.new(Enum.map(entries, fn {k, _} -> k end))
+    ns_keys = MapSet.new(Enum.map(entries, fn {k, _} -> source_name(k) end))
+
     # Build dependency graph: closure -> set of namespace keys it references
     deps =
       Map.new(closures, fn {k, {:closure, _params, body, _env, _h, _m}} ->
-        {k, collect_var_refs(body) |> MapSet.intersection(ns_keys) |> MapSet.delete(k)}
+        refs =
+          body
+          |> collect_var_refs()
+          |> Enum.map(&source_name/1)
+          |> MapSet.new()
+
+        {k, refs |> MapSet.intersection(ns_keys) |> MapSet.delete(source_name(k))}
       end)
 
     sorted_closures = topo_sort(closures, deps, [], MapSet.new())
@@ -300,10 +308,15 @@ defmodule PtcRunner.Lisp.CoreToSource do
         Enum.reverse(acc) ++ remaining
 
       _ ->
-        new_visited = Enum.reduce(ready, visited, fn {k, _}, vs -> MapSet.put(vs, k) end)
+        new_visited =
+          Enum.reduce(ready, visited, fn {k, _}, vs -> MapSet.put(vs, source_name(k)) end)
+
         topo_sort(blocked, deps, Enum.reverse(ready) ++ acc, new_visited)
     end
   end
+
+  defp source_name(name) when is_atom(name), do: Atom.to_string(name)
+  defp source_name(name) when is_binary(name), do: name
 
   defp collect_var_refs(ast, acc \\ MapSet.new())
   defp collect_var_refs({:var, name}, acc), do: MapSet.put(acc, name)
@@ -393,6 +406,10 @@ defmodule PtcRunner.Lisp.CoreToSource do
     String.starts_with?(name, "_") or String.starts_with?(name, "__ptc_")
   end
 
+  defp internal_key?(key) when is_binary(key) do
+    String.starts_with?(key, "_") or String.starts_with?(key, "__ptc_")
+  end
+
   defp internal_key?(_), do: false
 
   # --- Helpers ---
@@ -415,10 +432,10 @@ defmodule PtcRunner.Lisp.CoreToSource do
     end
   end
 
-  defp format_pattern({:var, name}), do: Atom.to_string(name)
+  defp format_pattern({:var, name}), do: to_string(name)
 
   defp format_pattern({:destructure, {:keys, keys, defaults}}) do
-    keys_str = Enum.map_join(keys, " ", &Atom.to_string/1)
+    keys_str = Enum.map_join(keys, " ", &to_string/1)
 
     case defaults do
       [] ->
@@ -467,6 +484,7 @@ defmodule PtcRunner.Lisp.CoreToSource do
   # Runtime map keys: strings stay as strings, atoms become keywords
   defp format_map_key(k) when is_binary(k), do: ~s("#{escape_string(k)}")
   defp format_map_key(k) when is_atom(k), do: ":#{k}"
+  defp format_map_key(%LispKeyword{name: name}), do: ":#{name}"
   defp format_map_key(k), do: format(k)
 
   defp escape_string(s) do

--- a/lib/ptc_runner/lisp/data_keys.ex
+++ b/lib/ptc_runner/lisp/data_keys.ex
@@ -76,7 +76,9 @@ defmodule PtcRunner.Lisp.DataKeys do
 
   # Data access - the target of our extraction
   defp do_extract({:data, key}, acc) when is_atom(key), do: MapSet.put(acc, key)
-  defp do_extract({:data, key}, acc) when is_binary(key), do: MapSet.put(acc, key)
+
+  defp do_extract({:data, key}, acc) when is_binary(key),
+    do: MapSet.put(acc, existing_atom_or(key))
 
   # Lists - recurse into each element
   defp do_extract(list, acc) when is_list(list) do
@@ -99,4 +101,10 @@ defmodule PtcRunner.Lisp.DataKeys do
 
   # Primitives and structs - no data access
   defp do_extract(_other, acc), do: acc
+
+  defp existing_atom_or(key) do
+    String.to_existing_atom(key)
+  rescue
+    ArgumentError -> key
+  end
 end

--- a/lib/ptc_runner/lisp/eval.ex
+++ b/lib/ptc_runner/lisp/eval.ex
@@ -810,7 +810,9 @@ defmodule PtcRunner.Lisp.Eval do
   # - Prevent atom memory leaks from LLM-generated keywords
   # - Match JSON conventions (like Phoenix params)
   defp build_args_map([], _tool_name), do: {:ok, %{}}
-  defp build_args_map([arg], _tool_name) when is_map(arg), do: {:ok, stringify_keys(arg)}
+
+  defp build_args_map([arg], _tool_name) when is_map(arg) and not is_struct(arg),
+    do: {:ok, stringify_keys(arg)}
 
   defp build_args_map(args, tool_name) do
     if keyword_style_args?(args) do
@@ -854,12 +856,15 @@ defmodule PtcRunner.Lisp.Eval do
 
   # Recursively convert map keys to strings (for tool boundary).
   # Handles nested maps and lists to ensure full protection against atom leaks.
-  defp stringify_keys(map) when is_map(map) do
+  defp stringify_keys(map) when is_map(map) and not is_struct(map) do
     Map.new(map, fn {k, v} -> {stringify_key(k), stringify_value(v)} end)
   end
 
   # Recursively stringify values (for nested maps/lists in tool args)
-  defp stringify_value(map) when is_map(map), do: stringify_keys(map)
+  defp stringify_value(%LispKeyword{name: name}), do: existing_atom_or(name, name)
+
+  defp stringify_value(map) when is_map(map) and not is_struct(map), do: stringify_keys(map)
+
   defp stringify_value(list) when is_list(list), do: Enum.map(list, &stringify_value/1)
   defp stringify_value(other), do: other
 
@@ -1469,6 +1474,13 @@ defmodule PtcRunner.Lisp.Eval do
   defp keyword_runtime?(%LispKeyword{}), do: true
   defp keyword_runtime?(atom) when is_atom(atom), do: not is_nil(atom) and not is_boolean(atom)
   defp keyword_runtime?(_), do: false
+
+  defp existing_atom_or(name, fallback) when is_binary(name) do
+    case safe_to_existing_atom(name) do
+      {:ok, atom} -> atom
+      :error -> fallback
+    end
+  end
 
   defp legacy_var_present?(map, name) when is_map(map) and is_binary(name) do
     case safe_to_existing_atom(name) do

--- a/lib/ptc_runner/lisp/eval.ex
+++ b/lib/ptc_runner/lisp/eval.ex
@@ -23,6 +23,7 @@ defmodule PtcRunner.Lisp.Eval do
   alias PtcRunner.Lisp.Eval.Context, as: EvalContext
   alias PtcRunner.Lisp.ExecutionError
   alias PtcRunner.Lisp.Format.Var
+  alias PtcRunner.Lisp.Keyword, as: LispKeyword
   alias PtcRunner.Lisp.Runtime.Callable
   alias PtcRunner.SubAgent.KeyNormalizer
   alias PtcRunner.TraceContext
@@ -143,7 +144,10 @@ defmodule PtcRunner.Lisp.Eval do
     do: {:ok, n, eval_ctx}
 
   defp do_eval({:string, s}, %EvalContext{} = eval_ctx), do: {:ok, s, eval_ctx}
-  defp do_eval({:keyword, k}, %EvalContext{} = eval_ctx), do: {:ok, k, eval_ctx}
+
+  defp do_eval({:keyword, k}, %EvalContext{} = eval_ctx),
+    do: {:ok, keyword_value(k), eval_ctx}
+
   defp do_eval({:literal, v}, %EvalContext{} = eval_ctx), do: {:ok, v, eval_ctx}
   defp do_eval(a, %EvalContext{} = eval_ctx) when is_atom(a), do: {:ok, a, eval_ctx}
 
@@ -186,40 +190,13 @@ defmodule PtcRunner.Lisp.Eval do
   # env contains both builtins and let bindings; locals tracks let-bound names.
   # user_ns (def) shadows builtins but not let bindings.
   defp do_eval({:var, name}, %EvalContext{user_ns: user_ns, env: env, locals: locals} = eval_ctx) do
-    cond do
-      # Let/fn binding (explicitly tracked as local)
-      MapSet.member?(locals, name) ->
-        {:ok, Map.get(env, name), eval_ctx}
-
-      # User namespace (def/defn) — shadows builtins
-      Map.has_key?(user_ns, name) ->
-        {:ok, Map.get(user_ns, name), eval_ctx}
-
-      # Builtin (from env or Env.initial fallback)
-      Map.has_key?(env, name) ->
-        case Map.get(env, name) do
-          {:constant, value} -> {:ok, value, eval_ctx}
-          other -> {:ok, other, eval_ctx}
-        end
-
-      Env.builtin?(name) ->
-        case Map.get(Env.initial(), name) do
-          {:constant, value} -> {:ok, value, eval_ctx}
-          other -> {:ok, other, eval_ctx}
-        end
-
-      true ->
-        name_str = to_string(name)
-
-        if String.starts_with?(name_str, ".") do
-          available =
-            Env.builtins_by_category(:interop)
-            |> Enum.map_join(", ", &to_string/1)
-
-          {:error, {:unsupported_method, name_str, available}}
-        else
-          {:error, {:unbound_var, name}}
-        end
+    with :error <- resolve_local(name, locals, env, eval_ctx),
+         :error <- resolve_user_ns(name, user_ns, eval_ctx),
+         :error <- resolve_env(name, env, eval_ctx),
+         :error <- resolve_builtin(name, eval_ctx),
+         :error <- resolve_legacy_user_ns(name, user_ns, eval_ctx),
+         :error <- resolve_legacy_env(name, env, eval_ctx) do
+      unresolved_var(name)
     end
   end
 
@@ -264,7 +241,7 @@ defmodule PtcRunner.Lisp.Eval do
   # Binds name only if not already defined in user_ns.
   # Value expression is NOT evaluated when name is already bound.
   defp do_eval({:defonce, name, value_ast, opts}, %EvalContext{user_ns: user_ns} = eval_ctx) do
-    if Map.has_key?(user_ns, name) do
+    if Map.has_key?(user_ns, name) or (is_binary(name) and legacy_var_present?(user_ns, name)) do
       {:ok, %Var{name: name}, eval_ctx}
     else
       with {:ok, value, eval_ctx2} <- do_eval(value_ast, eval_ctx) do
@@ -453,7 +430,7 @@ defmodule PtcRunner.Lisp.Eval do
     with {:ok, fn_val, eval_ctx1} <- do_eval(fn_ast, eval_ctx),
          {:ok, coll_val, eval_ctx2} <- do_eval(coll_ast, eval_ctx1) do
       # Consistency check: keywords don't work with single hash-map in map/pmap
-      if is_atom(fn_val) and not is_boolean(fn_val) and is_map(coll_val) and
+      if keyword_runtime?(fn_val) and is_map(coll_val) and
            not is_struct(coll_val) do
         {:error,
          {:type_error, "pmap: keyword accessor requires a list of maps, got a single map",
@@ -727,8 +704,8 @@ defmodule PtcRunner.Lisp.Eval do
         # Convert args list to map for tool executor
         case build_args_map(arg_vals, tool_name) do
           {:ok, args_map} ->
-            # Convert atom to string for backward compatibility with tool_exec
-            tool_name_str = Atom.to_string(tool_name)
+            # Convert to string for backward compatibility with tool_exec
+            tool_name_str = to_string(tool_name)
             # Check if this tool has caching enabled
             cacheable? = get_in(eval_ctx2.tools_meta, [tool_name_str, :cache]) == true
             record_tool_call(tool_name_str, args_map, tool_exec, eval_ctx2, cacheable?)
@@ -745,6 +722,66 @@ defmodule PtcRunner.Lisp.Eval do
   # ============================================================
   # Evaluation helpers
   # ============================================================
+
+  defp resolve_local(name, locals, env, eval_ctx) do
+    if MapSet.member?(locals, name), do: {:ok, Map.get(env, name), eval_ctx}, else: :error
+  end
+
+  defp resolve_user_ns(name, user_ns, eval_ctx) do
+    if Map.has_key?(user_ns, name), do: {:ok, Map.get(user_ns, name), eval_ctx}, else: :error
+  end
+
+  defp resolve_env(name, env, eval_ctx) do
+    case Map.fetch(env, name) do
+      {:ok, value} -> {:ok, unwrap_constant(value), eval_ctx}
+      :error -> :error
+    end
+  end
+
+  defp resolve_builtin(name, eval_ctx) do
+    if Env.builtin?(name) do
+      {:ok, unwrap_constant(Map.get(Env.initial(), name)), eval_ctx}
+    else
+      :error
+    end
+  end
+
+  defp resolve_legacy_user_ns(name, user_ns, eval_ctx) do
+    with true <- is_binary(name),
+         {:ok, atom} <- safe_to_existing_atom(name),
+         {:ok, value} <- Map.fetch(user_ns, atom) do
+      {:ok, value, eval_ctx}
+    else
+      _ -> :error
+    end
+  end
+
+  defp resolve_legacy_env(name, env, eval_ctx) do
+    with true <- is_binary(name),
+         {:ok, atom} <- safe_to_existing_atom(name),
+         {:ok, value} <- Map.fetch(env, atom) do
+      {:ok, unwrap_constant(value), eval_ctx}
+    else
+      _ -> :error
+    end
+  end
+
+  defp unwrap_constant({:constant, value}), do: value
+  defp unwrap_constant(other), do: other
+
+  defp unresolved_var(name) do
+    name_str = to_string(name)
+
+    if String.starts_with?(name_str, ".") do
+      available =
+        Env.builtins_by_category(:interop)
+        |> Enum.map_join(", ", &to_string/1)
+
+      {:error, {:unsupported_method, name_str, available}}
+    else
+      {:error, {:unbound_var, name}}
+    end
+  end
 
   # Truthiness check for conditional / short-circuit forms.
   # Only `nil` and `false` are falsy; every other value is truthy.
@@ -798,11 +835,11 @@ defmodule PtcRunner.Lisp.Eval do
   end
 
   # Check if args list is keyword-style: [:key1, val1, :key2, val2, ...]
-  # Must have even length and odd positions (0, 2, 4...) must be atoms
+  # Must have even length and odd positions (0, 2, 4...) must be keywords
   defp keyword_style_args?(args) when rem(length(args), 2) == 0 do
     args
     |> Enum.chunk_every(2)
-    |> Enum.all?(fn [k, _v] -> is_atom(k) end)
+    |> Enum.all?(fn [k, _v] -> keyword_runtime?(k) end)
   end
 
   defp keyword_style_args?(_), do: false
@@ -827,6 +864,7 @@ defmodule PtcRunner.Lisp.Eval do
   defp stringify_value(other), do: other
 
   defp stringify_key(k) when is_atom(k), do: KeyNormalizer.normalize_key(k)
+  defp stringify_key(%LispKeyword{name: name}), do: KeyNormalizer.normalize_key(name)
   defp stringify_key(k) when is_binary(k), do: KeyNormalizer.normalize_key(k)
   defp stringify_key(k), do: inspect(k)
 
@@ -1167,6 +1205,10 @@ defmodule PtcRunner.Lisp.Eval do
     fn m -> flex_get(m, k) end
   end
 
+  defp value_to_erlang_fn(%LispKeyword{} = k, %EvalContext{}) do
+    fn m -> flex_get(m, k) end
+  end
+
   defp value_to_erlang_fn(value, %EvalContext{} = eval_ctx) do
     Apply.closure_to_fun(value, eval_ctx, &do_eval/2)
   end
@@ -1419,5 +1461,25 @@ defmodule PtcRunner.Lisp.Eval do
       0 -> base
       _ -> Map.put(base, :captured_locals, locals)
     end
+  end
+
+  defp keyword_value(name) when is_atom(name), do: name
+  defp keyword_value(name) when is_binary(name), do: LispKeyword.new(name)
+
+  defp keyword_runtime?(%LispKeyword{}), do: true
+  defp keyword_runtime?(atom) when is_atom(atom), do: not is_nil(atom) and not is_boolean(atom)
+  defp keyword_runtime?(_), do: false
+
+  defp legacy_var_present?(map, name) when is_map(map) and is_binary(name) do
+    case safe_to_existing_atom(name) do
+      {:ok, atom} -> Map.has_key?(map, atom)
+      :error -> false
+    end
+  end
+
+  defp safe_to_existing_atom(name) do
+    {:ok, String.to_existing_atom(name)}
+  rescue
+    ArgumentError -> :error
   end
 end

--- a/lib/ptc_runner/lisp/eval/apply.ex
+++ b/lib/ptc_runner/lisp/eval/apply.ex
@@ -19,6 +19,7 @@ defmodule PtcRunner.Lisp.Eval.Apply do
   alias PtcRunner.Lisp.Eval.Patterns
   alias PtcRunner.Lisp.ExecutionError
   alias PtcRunner.Lisp.Format
+  alias PtcRunner.Lisp.Keyword, as: LispKeyword
   alias PtcRunner.Lisp.Runtime.Math
   alias PtcRunner.SubAgent.Namespace.TypeVocabulary
 
@@ -37,32 +38,11 @@ defmodule PtcRunner.Lisp.Eval.Apply do
 
   # Keyword as function: (:key map) → Map.get(map, :key)
   defp do_apply_fun(k, args, %EvalContext{} = eval_ctx, _do_eval_fn) when is_atom(k) do
-    case args do
-      [m] when is_map(m) ->
-        {:ok, flex_get(m, k), eval_ctx}
+    apply_keyword(k, args, eval_ctx)
+  end
 
-      [m, default] when is_map(m) ->
-        case flex_fetch(m, k) do
-          {:ok, val} -> {:ok, val, eval_ctx}
-          :error -> {:ok, default, eval_ctx}
-        end
-
-      [nil] ->
-        {:ok, nil, eval_ctx}
-
-      [nil, default] ->
-        {:ok, default, eval_ctx}
-
-      # Clojure returns nil for keyword lookup on non-map types: (:key "string") → nil
-      [_] ->
-        {:ok, nil, eval_ctx}
-
-      [_, default] ->
-        {:ok, default, eval_ctx}
-
-      _ ->
-        {:error, {:invalid_keyword_call, k, args}}
-    end
+  defp do_apply_fun(%LispKeyword{} = k, args, %EvalContext{} = eval_ctx, _do_eval_fn) do
+    apply_keyword(k, args, eval_ctx)
   end
 
   # Set as function: (#{1 2 3} x) → checks membership, returns element or nil
@@ -326,6 +306,35 @@ defmodule PtcRunner.Lisp.Eval.Apply do
   # Fallback: not callable
   defp do_apply_fun(other, _args, %EvalContext{}, _do_eval_fn) do
     {:error, {:not_callable, other}}
+  end
+
+  defp apply_keyword(k, args, %EvalContext{} = eval_ctx) do
+    case args do
+      [m] when is_map(m) ->
+        {:ok, flex_get(m, k), eval_ctx}
+
+      [m, default] when is_map(m) ->
+        case flex_fetch(m, k) do
+          {:ok, val} -> {:ok, val, eval_ctx}
+          :error -> {:ok, default, eval_ctx}
+        end
+
+      [nil] ->
+        {:ok, nil, eval_ctx}
+
+      [nil, default] ->
+        {:ok, default, eval_ctx}
+
+      # Clojure returns nil for keyword lookup on non-map types: (:key "string") → nil
+      [_] ->
+        {:ok, nil, eval_ctx}
+
+      [_, default] ->
+        {:ok, default, eval_ctx}
+
+      _ ->
+        {:error, {:invalid_keyword_call, k, args}}
+    end
   end
 
   defp check_arity({:variadic, leading, _rest}, args) do

--- a/lib/ptc_runner/lisp/eval/helpers.ex
+++ b/lib/ptc_runner/lisp/eval/helpers.ex
@@ -82,8 +82,10 @@ defmodule PtcRunner.Lisp.Eval.Helpers do
 
   # (get key map) / (get-in path map) — collection must come first. A keyword
   # or string first arg with a map second arg is almost always swapped.
-  defp specific_type_error(name, [k, %{} = _m] = args)
-       when name in [:get, :get_in] and (is_atom(k) or is_binary(k) or is_list(k)) do
+  defp specific_type_error(name, [k, %{} = m] = args)
+       when name in [:get, :get_in] and not is_struct(m) and
+              (is_atom(k) or is_binary(k) or is_list(k) or
+                 is_struct(k, PtcRunner.Lisp.Keyword)) do
     {:ok,
      {:type_error,
       "#{display_name(name)} expects the collection first, e.g. (#{display_name(name)} map key) — " <>

--- a/lib/ptc_runner/lisp/eval/patterns.ex
+++ b/lib/ptc_runner/lisp/eval/patterns.ex
@@ -21,12 +21,12 @@ defmodule PtcRunner.Lisp.Eval.Patterns do
   end
 
   def match_pattern({:destructure, {:keys, keys, defaults}}, value)
-      when is_map(value) or is_nil(value) do
+      when (is_map(value) and not is_struct(value)) or is_nil(value) do
     value = value || %{}
 
     bindings =
       Enum.reduce(keys, %{}, fn key, acc ->
-        default = Keyword.get(defaults, key)
+        default = default_for(defaults, key)
 
         val =
           case flex_fetch(value, key) do
@@ -45,12 +45,12 @@ defmodule PtcRunner.Lisp.Eval.Patterns do
   end
 
   def match_pattern({:destructure, {:map, keys, renames, defaults}}, value)
-      when is_map(value) or is_nil(value) do
+      when (is_map(value) and not is_struct(value)) or is_nil(value) do
     value = value || %{}
     # First extract keys
     keys_bindings =
       Enum.reduce(keys, %{}, fn key, acc ->
-        default = Keyword.get(defaults, key)
+        default = default_for(defaults, key)
 
         val =
           case flex_fetch(value, key) do
@@ -68,7 +68,7 @@ defmodule PtcRunner.Lisp.Eval.Patterns do
         # or we just pass nil and let the inner pattern handle its own defaults.
         default =
           case pattern do
-            {:var, name} -> Keyword.get(defaults, name)
+            {:var, name} -> default_for(defaults, name)
             _ -> nil
           end
 
@@ -192,5 +192,12 @@ defmodule PtcRunner.Lisp.Eval.Patterns do
     list
     |> Enum.chunk_every(2)
     |> Enum.into(%{}, fn [k, v] -> {k, v} end)
+  end
+
+  defp default_for(defaults, key) when is_list(defaults) do
+    case List.keyfind(defaults, key, 0) do
+      {^key, value} -> value
+      nil -> nil
+    end
   end
 end

--- a/lib/ptc_runner/lisp/format.ex
+++ b/lib/ptc_runner/lisp/format.ex
@@ -50,6 +50,8 @@ defmodule PtcRunner.Lisp.Format do
     end
   end
 
+  alias PtcRunner.Lisp.Keyword, as: LispKeyword
+
   @doc """
   Format a Lisp value as a string for display.
 
@@ -168,6 +170,7 @@ defmodule PtcRunner.Lisp.Format do
 
   defp format_clojure(s, opts) when is_binary(s), do: format_clojure_string(s, opts)
   defp format_clojure(a, _opts) when is_atom(a), do: {":#{a}", false}
+  defp format_clojure(%LispKeyword{name: name}, _opts), do: {":#{name}", false}
 
   defp format_clojure(%Fn{params: params}, _opts), do: {"#fn[#{params}]", false}
   defp format_clojure(%Builtin{}, _opts), do: {"#<builtin>", false}
@@ -322,6 +325,7 @@ defmodule PtcRunner.Lisp.Format do
 
   # Format map keys - atoms as keywords, strings as strings
   defp format_clojure_key(k) when is_atom(k), do: ":#{k}"
+  defp format_clojure_key(%LispKeyword{name: name}), do: ":#{name}"
   defp format_clojure_key(k) when is_binary(k), do: inspect(k)
 
   defp format_clojure_key(k) do
@@ -376,7 +380,7 @@ defmodule PtcRunner.Lisp.Format do
   defp sanitize({:collect, fun}) when is_function(fun), do: %Fn{params: "..."}
 
   # Var references - convert to Var struct for display
-  defp sanitize({:var, name}) when is_atom(name), do: %Var{name: name}
+  defp sanitize({:var, name}) when is_atom(name) or is_binary(name), do: %Var{name: name}
 
   # Pass through wrapper structs unchanged (they're already sanitized)
   defp sanitize(%Var{} = v), do: v
@@ -406,7 +410,7 @@ defmodule PtcRunner.Lisp.Format do
   defp sanitize(value), do: value
 
   # Extract parameter name from pattern AST
-  defp extract_param_name({:var, name}), do: Atom.to_string(name)
+  defp extract_param_name({:var, name}), do: Kernel.to_string(name)
   defp extract_param_name({:destructure, _}), do: "_"
   defp extract_param_name(_), do: "_"
 end

--- a/lib/ptc_runner/lisp/formatter.ex
+++ b/lib/ptc_runner/lisp/formatter.ex
@@ -25,7 +25,7 @@ defmodule PtcRunner.Lisp.Formatter do
 
   def format({:string, s}), do: ~s("#{escape_string(s)}")
   def format({:keyword, k}), do: ":#{k}"
-  def format({:symbol, name}), do: Atom.to_string(name)
+  def format({:symbol, name}), do: to_string(name)
   def format({:ns_symbol, ns, key}), do: "#{ns}/#{key}"
 
   def format({:vector, elems}) do

--- a/lib/ptc_runner/lisp/keyword.ex
+++ b/lib/ptc_runner/lisp/keyword.ex
@@ -1,0 +1,29 @@
+defmodule PtcRunner.Lisp.Keyword do
+  @moduledoc """
+  Runtime representation for PTC-Lisp keywords that are not in the bounded atom vocabulary.
+
+  Existing atom-backed keywords remain atoms for compatibility. New source keywords use this
+  struct so user input cannot grow the BEAM atom table while keywords stay distinct from strings.
+  """
+
+  defstruct [:name]
+
+  @type t :: %__MODULE__{name: String.t()}
+
+  @spec new(String.t()) :: t()
+  def new(name) when is_binary(name), do: %__MODULE__{name: name}
+
+  @spec name(atom() | t()) :: String.t()
+  def name(%__MODULE__{name: name}), do: name
+  def name(atom) when is_atom(atom), do: Atom.to_string(atom)
+
+  @spec keyword?(term()) :: boolean()
+  def keyword?(%__MODULE__{}), do: true
+
+  def keyword?(atom) when is_atom(atom),
+    do:
+      not is_nil(atom) and not is_boolean(atom) and
+        atom not in [:infinity, :negative_infinity, :nan]
+
+  def keyword?(_), do: false
+end

--- a/lib/ptc_runner/lisp/parser_helpers.ex
+++ b/lib/ptc_runner/lisp/parser_helpers.ex
@@ -2,6 +2,7 @@ defmodule PtcRunner.Lisp.ParserHelpers do
   @moduledoc "Helper functions for parser reductions"
 
   alias PtcRunner.Lisp.AST
+  alias PtcRunner.Lisp.SourceAtoms
 
   # ============================================================
   # Number parsing
@@ -48,11 +49,11 @@ defmodule PtcRunner.Lisp.ParserHelpers do
   # Keyword/Symbol building
   # ============================================================
 
-  def build_keyword([name]), do: {:keyword, String.to_atom(name)}
+  def build_keyword([name]), do: {:keyword, SourceAtoms.intern(name)}
 
   def build_var(parts) do
     name = Enum.join(parts)
-    {:var, String.to_atom(name)}
+    {:var, SourceAtoms.intern(name)}
   end
 
   def build_symbol(parts) do

--- a/lib/ptc_runner/lisp/runtime/callable.ex
+++ b/lib/ptc_runner/lisp/runtime/callable.ex
@@ -16,15 +16,28 @@ defmodule PtcRunner.Lisp.Runtime.Callable do
       (map range [1 2 3])              ;; multi_arity - now works
   """
 
-  alias PtcRunner.Lisp.Runtime.Math
-
+  alias PtcRunner.Lisp.Keyword, as: LispKeyword
   alias PtcRunner.Lisp.Runtime.FlexAccess
+  alias PtcRunner.Lisp.Runtime.Math
 
   # Guard: true keywords (atoms that aren't nil, true, or false)
   defguardp is_keyword(k) when is_atom(k) and k != nil and k != true and k != false
 
   @spec call(term(), [term()]) :: term()
   def call(f, args) when is_function(f), do: apply(f, args)
+
+  def call(%LispKeyword{} = k, [m]) when is_map(m), do: FlexAccess.flex_get(m, k)
+  def call(%LispKeyword{}, [nil]), do: nil
+  def call(%LispKeyword{}, [_]), do: nil
+
+  def call(%LispKeyword{} = k, [m, default]) when is_map(m) do
+    case FlexAccess.flex_fetch(m, k) do
+      {:ok, val} -> val
+      :error -> default
+    end
+  end
+
+  def call(%LispKeyword{}, [nil, default]), do: default
 
   # Keyword as function: (:key map) → map lookup
   def call(k, [m]) when is_keyword(k) and is_map(m), do: FlexAccess.flex_get(m, k)

--- a/lib/ptc_runner/lisp/runtime/collection.ex
+++ b/lib/ptc_runner/lisp/runtime/collection.ex
@@ -527,12 +527,14 @@ defmodule PtcRunner.Lisp.Runtime.Collection do
   def count(nil), do: 0
   def count(%MapSet{} = set), do: MapSet.size(set)
   def count(coll) when is_binary(coll), do: String.length(coll)
-  def count(coll) when is_list(coll) or is_map(coll), do: Enum.count(coll)
+  def count(coll) when is_list(coll), do: Enum.count(coll)
+  def count(coll) when is_map(coll) and not is_struct(coll), do: Enum.count(coll)
 
   def empty?(nil), do: true
   def empty?(%MapSet{} = set), do: MapSet.size(set) == 0
   def empty?(coll) when is_binary(coll), do: coll == ""
-  def empty?(coll) when is_list(coll) or is_map(coll), do: Enum.empty?(coll)
+  def empty?(coll) when is_list(coll), do: Enum.empty?(coll)
+  def empty?(coll) when is_map(coll) and not is_struct(coll), do: Enum.empty?(coll)
 
   def not_empty(coll) do
     if seq(coll), do: coll, else: nil
@@ -559,7 +561,7 @@ defmodule PtcRunner.Lisp.Runtime.Collection do
     end
   end
 
-  def seq(m) when is_map(m) do
+  def seq(m) when is_map(m) and not is_struct(m) do
     case Enum.empty?(m) do
       true -> nil
       false -> Enum.map(m, fn {k, v} -> [k, v] end)
@@ -897,15 +899,11 @@ defmodule PtcRunner.Lisp.Runtime.Collection do
 
   def contains?(%MapSet{} = set, val), do: MapSet.member?(set, val)
 
-  def contains?(coll, key) when is_map(coll) do
-    cond do
-      Map.has_key?(coll, key) -> true
-      is_atom(key) -> Map.has_key?(coll, to_string(key))
-      is_binary(key) -> Map.has_key?(coll, String.to_existing_atom(key))
-      true -> false
+  def contains?(coll, key) when is_map(coll) and not is_struct(coll) do
+    case FlexAccess.flex_fetch(coll, key) do
+      {:ok, _value} -> true
+      :error -> false
     end
-  rescue
-    ArgumentError -> false
   end
 
   def contains?(coll, val) when is_list(coll), do: val in coll

--- a/lib/ptc_runner/lisp/runtime/collection.ex
+++ b/lib/ptc_runner/lisp/runtime/collection.ex
@@ -12,6 +12,7 @@ defmodule PtcRunner.Lisp.Runtime.Collection do
   """
 
   alias PtcRunner.Lisp.Eval.Helpers
+  alias PtcRunner.Lisp.Keyword, as: LispKeyword
   alias PtcRunner.Lisp.Runtime.Callable
   alias PtcRunner.Lisp.Runtime.Collection.Normalize
   alias PtcRunner.Lisp.Runtime.Collection.Select
@@ -414,6 +415,9 @@ defmodule PtcRunner.Lisp.Runtime.Collection do
 
   # Keyword on string: keyword access on graphemes always nil → nothing passes
   def split_with(pred, coll) when is_atom(pred) and is_binary(coll),
+    do: [[], Normalize.graphemes(coll)]
+
+  def split_with(%LispKeyword{}, coll) when is_binary(coll),
     do: [[], Normalize.graphemes(coll)]
 
   def split_with(pred, coll) do

--- a/lib/ptc_runner/lisp/runtime/collection/normalize.ex
+++ b/lib/ptc_runner/lisp/runtime/collection/normalize.ex
@@ -7,6 +7,7 @@ defmodule PtcRunner.Lisp.Runtime.Collection.Normalize do
   """
 
   alias PtcRunner.Lisp.Eval.Helpers
+  alias PtcRunner.Lisp.Keyword, as: LispKeyword
   alias PtcRunner.Lisp.Runtime.Callable
   alias PtcRunner.Lisp.Runtime.FlexAccess
 
@@ -53,6 +54,12 @@ defmodule PtcRunner.Lisp.Runtime.Collection.Normalize do
   def normalize_pred(key, :value) when is_atom(key),
     do: fn item -> FlexAccess.flex_get(item, key) end
 
+  def normalize_pred(%LispKeyword{} = key, :truthy),
+    do: fn item -> !!FlexAccess.flex_get(item, key) end
+
+  def normalize_pred(%LispKeyword{} = key, :value),
+    do: fn item -> FlexAccess.flex_get(item, key) end
+
   def normalize_pred(%MapSet{} = set, _mode),
     do: fn item -> if MapSet.member?(set, item), do: item, else: nil end
 
@@ -69,6 +76,9 @@ defmodule PtcRunner.Lisp.Runtime.Collection.Normalize do
   vector error message ("function or key" vs "predicate").
   """
   def normalize_keyfn(key) when is_atom(key),
+    do: fn item -> FlexAccess.flex_get(item, key) end
+
+  def normalize_keyfn(%LispKeyword{} = key),
     do: fn item -> FlexAccess.flex_get(item, key) end
 
   def normalize_keyfn(%MapSet{} = set),

--- a/lib/ptc_runner/lisp/runtime/collection/select.ex
+++ b/lib/ptc_runner/lisp/runtime/collection/select.ex
@@ -7,12 +7,14 @@ defmodule PtcRunner.Lisp.Runtime.Collection.Select do
   delegating predicate/collection normalization to `Collection.Normalize`.
   """
 
+  alias PtcRunner.Lisp.Keyword, as: LispKeyword
   alias PtcRunner.Lisp.Runtime.Collection.Normalize
 
   # ── filter ──────────────────────────────────────────────────────────
 
   # Keyword on string graphemes: keyword access always returns nil → empty
   def filter(pred, coll) when is_atom(pred) and is_binary(coll), do: []
+  def filter(%LispKeyword{}, coll) when is_binary(coll), do: []
 
   def filter(pred, coll) when is_map(coll) and not is_struct(coll) do
     pred_fn = Normalize.normalize_pred(pred, :truthy)
@@ -27,6 +29,7 @@ defmodule PtcRunner.Lisp.Runtime.Collection.Select do
 
   # Keyword on string: always falsy, so nothing is removed
   def remove(pred, coll) when is_atom(pred) and is_binary(coll), do: Normalize.graphemes(coll)
+  def remove(%LispKeyword{}, coll) when is_binary(coll), do: Normalize.graphemes(coll)
 
   def remove(pred, coll) when is_map(coll) and not is_struct(coll) do
     pred_fn = Normalize.normalize_pred(pred, :truthy)
@@ -41,6 +44,7 @@ defmodule PtcRunner.Lisp.Runtime.Collection.Select do
 
   # Keyword on string: always nil
   def find(pred, coll) when is_atom(pred) and is_binary(coll), do: nil
+  def find(%LispKeyword{}, coll) when is_binary(coll), do: nil
 
   def find(pred, coll) when is_map(coll) and not is_struct(coll) do
     pred_fn = Normalize.normalize_pred(pred, :truthy)

--- a/lib/ptc_runner/lisp/runtime/collection/transform.ex
+++ b/lib/ptc_runner/lisp/runtime/collection/transform.ex
@@ -7,6 +7,7 @@ defmodule PtcRunner.Lisp.Runtime.Collection.Transform do
   delegating normalization to `Collection.Normalize`.
   """
 
+  alias PtcRunner.Lisp.Keyword, as: LispKeyword
   alias PtcRunner.Lisp.Runtime.Callable
   alias PtcRunner.Lisp.Runtime.Collection.Normalize
   alias PtcRunner.Lisp.Runtime.FlexAccess
@@ -15,6 +16,9 @@ defmodule PtcRunner.Lisp.Runtime.Collection.Transform do
 
   # Keyword on string: flex_get on graphemes always returns nil
   def map(f, coll) when is_atom(f) and is_binary(coll),
+    do: Enum.map(Normalize.graphemes(coll), fn _ -> nil end)
+
+  def map(%LispKeyword{}, coll) when is_binary(coll),
     do: Enum.map(Normalize.graphemes(coll), fn _ -> nil end)
 
   def map(f, coll) when is_map(coll) and not is_struct(coll) do
@@ -78,6 +82,16 @@ defmodule PtcRunner.Lisp.Runtime.Collection.Transform do
     end)
   end
 
+  def mapcat(%LispKeyword{} = key, coll) when is_list(coll) do
+    Enum.flat_map(coll, fn item ->
+      case FlexAccess.flex_get(item, key) do
+        nil -> []
+        val when is_list(val) -> val
+        val -> [val]
+      end
+    end)
+  end
+
   def mapcat(f, coll) when is_map(coll) and not is_struct(coll) do
     Enum.flat_map(coll, fn {k, v} -> Callable.call(f, [[k, v]]) end)
   end
@@ -94,6 +108,7 @@ defmodule PtcRunner.Lisp.Runtime.Collection.Transform do
 
   # Keyword on string: always nil, so keep returns empty
   def keep(f, coll) when is_atom(f) and is_binary(coll), do: []
+  def keep(%LispKeyword{}, coll) when is_binary(coll), do: []
 
   def keep(f, coll) when is_map(coll) and not is_struct(coll) do
     keyfn = Normalize.normalize_keyfn(f)

--- a/lib/ptc_runner/lisp/runtime/flex_access.ex
+++ b/lib/ptc_runner/lisp/runtime/flex_access.ex
@@ -13,12 +13,21 @@ defmodule PtcRunner.Lisp.Runtime.FlexAccess do
   3. Hyphen↔underscore normalized variant (`:turn-summaries` → `:turn_summaries`, `"turn_summaries"`)
   """
 
+  alias PtcRunner.Lisp.Keyword, as: LispKeyword
+
   @doc """
   Flexible key access: try atom/string and hyphen/underscore variants of the key.
   Returns the value if found, nil if missing.
   Use this for simple lookups where you don't need to distinguish between nil values and missing keys.
   """
   def flex_get(%MapSet{}, _key), do: nil
+
+  def flex_get(map, %LispKeyword{name: name} = key) when is_map(map) do
+    case Map.fetch(map, key) do
+      {:ok, value} -> value
+      :error -> flex_get_keyword_name(map, name)
+    end
+  end
 
   def flex_get(map, key) when is_map(map) and is_atom(key) do
     case Map.fetch(map, key) do
@@ -29,8 +38,14 @@ defmodule PtcRunner.Lisp.Runtime.FlexAccess do
         str = to_string(key)
 
         case Map.fetch(map, str) do
-          {:ok, value} -> value
-          :error -> get_normalized(map, str, :atom)
+          {:ok, value} ->
+            value
+
+          :error ->
+            case Map.fetch(map, LispKeyword.new(str)) do
+              {:ok, value} -> value
+              :error -> get_normalized(map, str, :atom)
+            end
         end
     end
   end
@@ -50,8 +65,14 @@ defmodule PtcRunner.Lisp.Runtime.FlexAccess do
           end
 
         case result do
-          {:ok, value} -> value
-          :error -> get_normalized(map, key, :string)
+          {:ok, value} ->
+            value
+
+          :error ->
+            case Map.fetch(map, LispKeyword.new(key)) do
+              {:ok, value} -> value
+              :error -> get_normalized(map, key, :string)
+            end
         end
     end
   end
@@ -75,6 +96,13 @@ defmodule PtcRunner.Lisp.Runtime.FlexAccess do
   """
   def flex_fetch(%MapSet{}, _key), do: :error
 
+  def flex_fetch(map, %LispKeyword{name: name} = key) when is_map(map) do
+    case Map.fetch(map, key) do
+      {:ok, _} = ok -> ok
+      :error -> flex_fetch_keyword_name(map, name)
+    end
+  end
+
   def flex_fetch(map, key) when is_map(map) and is_atom(key) do
     case Map.fetch(map, key) do
       {:ok, _} = ok ->
@@ -84,8 +112,14 @@ defmodule PtcRunner.Lisp.Runtime.FlexAccess do
         str = to_string(key)
 
         case Map.fetch(map, str) do
-          {:ok, _} = ok -> ok
-          :error -> fetch_normalized(map, str, :atom)
+          {:ok, _} = ok ->
+            ok
+
+          :error ->
+            case Map.fetch(map, LispKeyword.new(str)) do
+              {:ok, _} = ok -> ok
+              :error -> fetch_normalized(map, str, :atom)
+            end
         end
     end
   end
@@ -104,8 +138,14 @@ defmodule PtcRunner.Lisp.Runtime.FlexAccess do
           end
 
         case result do
-          {:ok, _} = ok -> ok
-          :error -> fetch_normalized(map, key, :string)
+          {:ok, _} = ok ->
+            ok
+
+          :error ->
+            case Map.fetch(map, LispKeyword.new(key)) do
+              {:ok, _} = ok -> ok
+              :error -> fetch_normalized(map, key, :string)
+            end
         end
     end
   end
@@ -339,6 +379,34 @@ defmodule PtcRunner.Lisp.Runtime.FlexAccess do
         rescue
           ArgumentError -> :error
         end
+    end
+  end
+
+  defp flex_get_keyword_name(map, name) do
+    case fetch_keyword_name(map, name) do
+      {:ok, value} -> value
+      :error -> get_normalized(map, name, :atom)
+    end
+  end
+
+  defp flex_fetch_keyword_name(map, name) do
+    case fetch_keyword_name(map, name) do
+      {:ok, _} = ok -> ok
+      :error -> fetch_normalized(map, name, :atom)
+    end
+  end
+
+  defp fetch_keyword_name(map, name) do
+    result =
+      try do
+        Map.fetch(map, String.to_existing_atom(name))
+      rescue
+        ArgumentError -> :error
+      end
+
+    case result do
+      {:ok, _} = ok -> ok
+      :error -> Map.fetch(map, name)
     end
   end
 

--- a/lib/ptc_runner/lisp/runtime/flex_access.ex
+++ b/lib/ptc_runner/lisp/runtime/flex_access.ex
@@ -21,15 +21,16 @@ defmodule PtcRunner.Lisp.Runtime.FlexAccess do
   Use this for simple lookups where you don't need to distinguish between nil values and missing keys.
   """
   def flex_get(%MapSet{}, _key), do: nil
+  def flex_get(%LispKeyword{}, _key), do: nil
 
-  def flex_get(map, %LispKeyword{name: name} = key) when is_map(map) do
+  def flex_get(map, %LispKeyword{name: name} = key) when is_map(map) and not is_struct(map) do
     case Map.fetch(map, key) do
       {:ok, value} -> value
       :error -> flex_get_keyword_name(map, name)
     end
   end
 
-  def flex_get(map, key) when is_map(map) and is_atom(key) do
+  def flex_get(map, key) when is_map(map) and not is_struct(map) and is_atom(key) do
     case Map.fetch(map, key) do
       {:ok, value} ->
         value
@@ -50,7 +51,7 @@ defmodule PtcRunner.Lisp.Runtime.FlexAccess do
     end
   end
 
-  def flex_get(map, key) when is_map(map) and is_binary(key) do
+  def flex_get(map, key) when is_map(map) and not is_struct(map) and is_binary(key) do
     case Map.fetch(map, key) do
       {:ok, value} ->
         value
@@ -78,8 +79,11 @@ defmodule PtcRunner.Lisp.Runtime.FlexAccess do
   end
 
   def flex_get(nil, path) when is_list(path), do: nil
-  def flex_get(map, path) when is_map(map) and is_list(path), do: flex_get_in(map, path)
-  def flex_get(map, key) when is_map(map), do: Map.get(map, key)
+
+  def flex_get(map, path) when is_map(map) and not is_struct(map) and is_list(path),
+    do: flex_get_in(map, path)
+
+  def flex_get(map, key) when is_map(map) and not is_struct(map), do: Map.get(map, key)
 
   # List index support - only non-negative integers
   def flex_get(list, key) when is_list(list) and is_integer(key) and key >= 0,
@@ -95,15 +99,16 @@ defmodule PtcRunner.Lisp.Runtime.FlexAccess do
   Use this when you need to distinguish between nil values and missing keys.
   """
   def flex_fetch(%MapSet{}, _key), do: :error
+  def flex_fetch(%LispKeyword{}, _key), do: :error
 
-  def flex_fetch(map, %LispKeyword{name: name} = key) when is_map(map) do
+  def flex_fetch(map, %LispKeyword{name: name} = key) when is_map(map) and not is_struct(map) do
     case Map.fetch(map, key) do
       {:ok, _} = ok -> ok
       :error -> flex_fetch_keyword_name(map, name)
     end
   end
 
-  def flex_fetch(map, key) when is_map(map) and is_atom(key) do
+  def flex_fetch(map, key) when is_map(map) and not is_struct(map) and is_atom(key) do
     case Map.fetch(map, key) do
       {:ok, _} = ok ->
         ok
@@ -124,7 +129,7 @@ defmodule PtcRunner.Lisp.Runtime.FlexAccess do
     end
   end
 
-  def flex_fetch(map, key) when is_map(map) and is_binary(key) do
+  def flex_fetch(map, key) when is_map(map) and not is_struct(map) and is_binary(key) do
     case Map.fetch(map, key) do
       {:ok, _} = ok ->
         ok
@@ -151,8 +156,11 @@ defmodule PtcRunner.Lisp.Runtime.FlexAccess do
   end
 
   def flex_fetch(nil, path) when is_list(path), do: :error
-  def flex_fetch(map, path) when is_map(map) and is_list(path), do: flex_fetch_in(map, path)
-  def flex_fetch(map, key) when is_map(map), do: Map.fetch(map, key)
+
+  def flex_fetch(map, path) when is_map(map) and not is_struct(map) and is_list(path),
+    do: flex_fetch_in(map, path)
+
+  def flex_fetch(map, key) when is_map(map) and not is_struct(map), do: Map.fetch(map, key)
 
   # List index support - single traversal using sentinel
   def flex_fetch(list, key) when is_list(list) and is_integer(key) and key >= 0 do

--- a/lib/ptc_runner/lisp/runtime/map_ops.ex
+++ b/lib/ptc_runner/lisp/runtime/map_ops.ex
@@ -37,11 +37,11 @@ defmodule PtcRunner.Lisp.Runtime.MapOps do
     |> Enum.into(%{}, fn [k, v] -> {k, v} end)
   end
 
-  def get(m, k) when is_map(m), do: FlexAccess.flex_get(m, k)
+  def get(m, k) when is_map(m) and not is_struct(m), do: FlexAccess.flex_get(m, k)
   def get(l, k) when is_list(l), do: FlexAccess.flex_get(l, k)
   def get(nil, _k), do: nil
 
-  def get(m, k, default) when is_map(m) do
+  def get(m, k, default) when is_map(m) and not is_struct(m) do
     cond do
       Map.has_key?(m, k) ->
         Map.get(m, k)
@@ -71,10 +71,10 @@ defmodule PtcRunner.Lisp.Runtime.MapOps do
 
   def get(nil, _k, default), do: default
 
-  def get_in(m, path) when is_map(m), do: FlexAccess.flex_get_in(m, path)
+  def get_in(m, path) when is_map(m) and not is_struct(m), do: FlexAccess.flex_get_in(m, path)
   def get_in(l, path) when is_list(l), do: FlexAccess.flex_get_in(l, path)
 
-  def get_in(m, path, default) when is_map(m) do
+  def get_in(m, path, default) when is_map(m) and not is_struct(m) do
     case FlexAccess.flex_get_in(m, path) do
       nil -> default
       val -> val

--- a/lib/ptc_runner/lisp/runtime/map_ops.ex
+++ b/lib/ptc_runner/lisp/runtime/map_ops.ex
@@ -42,23 +42,9 @@ defmodule PtcRunner.Lisp.Runtime.MapOps do
   def get(nil, _k), do: nil
 
   def get(m, k, default) when is_map(m) and not is_struct(m) do
-    cond do
-      Map.has_key?(m, k) ->
-        Map.get(m, k)
-
-      is_atom(k) and Map.has_key?(m, to_string(k)) ->
-        Map.get(m, to_string(k))
-
-      is_binary(k) ->
-        try do
-          atom_key = String.to_existing_atom(k)
-          if Map.has_key?(m, atom_key), do: Map.get(m, atom_key), else: default
-        rescue
-          ArgumentError -> default
-        end
-
-      true ->
-        default
+    case FlexAccess.flex_fetch(m, k) do
+      {:ok, value} -> value
+      :error -> default
     end
   end
 

--- a/lib/ptc_runner/lisp/runtime/math.ex
+++ b/lib/ptc_runner/lisp/runtime/math.ex
@@ -8,6 +8,7 @@ defmodule PtcRunner.Lisp.Runtime.Math do
 
   alias PtcRunner.Lisp.Eval.Helpers
   alias PtcRunner.Lisp.ExecutionError
+  alias PtcRunner.Lisp.Keyword, as: LispKeyword
   alias PtcRunner.Lisp.Runtime.SpecialValues
 
   def add(args) when is_list(args) do
@@ -395,7 +396,16 @@ defmodule PtcRunner.Lisp.Runtime.Math do
   def not_eq(x, y), do: not eq(x, y)
 
   def eq(x, y) do
-    if SpecialValues.nan?(x) or SpecialValues.nan?(y), do: false, else: x == y
+    cond do
+      SpecialValues.nan?(x) or SpecialValues.nan?(y) ->
+        false
+
+      LispKeyword.keyword?(x) and LispKeyword.keyword?(y) ->
+        LispKeyword.name(x) == LispKeyword.name(y)
+
+      true ->
+        x == y
+    end
   end
 
   def lt(x, y) do

--- a/lib/ptc_runner/lisp/runtime/predicates.ex
+++ b/lib/ptc_runner/lisp/runtime/predicates.ex
@@ -251,7 +251,7 @@ defmodule PtcRunner.Lisp.Runtime.Predicates do
 
   def regex?(x), do: is_tuple(x) and elem(x, 0) == :re_mp
 
-  def map?(x), do: is_map(x) and not is_struct(x, MapSet)
+  def map?(x), do: is_map(x) and not is_struct(x)
 
   # coll? returns true for all collections: vectors, maps, and sets
   def coll?(x) when is_list(x), do: true
@@ -275,7 +275,7 @@ defmodule PtcRunner.Lisp.Runtime.Predicates do
   # counted? - all types where count works (collection.ex)
   def counted?(x) when is_list(x), do: true
   def counted?(%MapSet{}), do: true
-  def counted?(x) when is_map(x), do: true
+  def counted?(x) when is_map(x) and not is_struct(x), do: true
   def counted?(x) when is_binary(x), do: true
   def counted?(_), do: false
 
@@ -296,7 +296,7 @@ defmodule PtcRunner.Lisp.Runtime.Predicates do
   def seqable?(nil), do: true
   def seqable?(x) when is_list(x), do: true
   def seqable?(%MapSet{}), do: true
-  def seqable?(x) when is_map(x), do: true
+  def seqable?(x) when is_map(x) and not is_struct(x), do: true
   def seqable?(x) when is_binary(x), do: true
   def seqable?(_), do: false
 
@@ -409,7 +409,7 @@ defmodule PtcRunner.Lisp.Runtime.Predicates do
   def vec(coll) when is_list(coll), do: coll
   def vec(%MapSet{} = set), do: MapSet.to_list(set)
   def vec(s) when is_binary(s), do: String.graphemes(s)
-  def vec(m) when is_map(m), do: Enum.map(m, fn {k, v} -> [k, v] end)
+  def vec(m) when is_map(m) and not is_struct(m), do: Enum.map(m, fn {k, v} -> [k, v] end)
 
   # ============================================================
   # Numeric Predicates

--- a/lib/ptc_runner/lisp/runtime/predicates.ex
+++ b/lib/ptc_runner/lisp/runtime/predicates.ex
@@ -46,7 +46,9 @@ defmodule PtcRunner.Lisp.Runtime.Predicates do
       iex> f.(5)
       6
   """
+  alias PtcRunner.Lisp.Keyword, as: LispKeyword
   alias PtcRunner.Lisp.Runtime.Callable
+  alias PtcRunner.Lisp.SourceAtoms
 
   # Plain 1-arity function
   def fnil(f, default) when is_function(f, 1) do
@@ -240,8 +242,7 @@ defmodule PtcRunner.Lisp.Runtime.Predicates do
 
   def string?(x), do: is_binary(x)
 
-  def keyword?(x),
-    do: is_atom(x) and not is_nil(x) and not is_boolean(x) and not SpecialValues.special?(x)
+  def keyword?(x), do: LispKeyword.keyword?(x) and not SpecialValues.special?(x)
 
   def vector?(x), do: is_list(x)
   def char?(x), do: is_binary(x) and String.length(x) == 1
@@ -255,7 +256,7 @@ defmodule PtcRunner.Lisp.Runtime.Predicates do
   # coll? returns true for all collections: vectors, maps, and sets
   def coll?(x) when is_list(x), do: true
   def coll?(%MapSet{}), do: true
-  def coll?(x) when is_map(x), do: true
+  def coll?(x) when is_map(x) and not is_struct(x), do: true
   def coll?(_), do: false
 
   # sequential? returns true for ordered collections (vectors in PTC-Lisp)
@@ -305,6 +306,7 @@ defmodule PtcRunner.Lisp.Runtime.Predicates do
   # like mapv/group-by because Callable.call/2 doesn't dispatch on them.
   # Wrap in a lambda: (mapv #(my-map %) coll)
   def ifn?(%MapSet{}), do: true
+  def ifn?(%LispKeyword{}), do: true
   def ifn?(x) when is_map(x) and not is_struct(x), do: true
   def ifn?(x) when is_atom(x) and not is_nil(x) and not is_boolean(x), do: type_of(x) != :number
   def ifn?(x), do: type_of(x) == :function
@@ -325,6 +327,7 @@ defmodule PtcRunner.Lisp.Runtime.Predicates do
   def type_of(x) when is_binary(x), do: :string
   def type_of(x) when is_list(x), do: :vector
   def type_of(%MapSet{}), do: :set
+  def type_of(%LispKeyword{}), do: :keyword
 
   def type_of(x) when is_atom(x) do
     if SpecialValues.special?(x), do: :number, else: :keyword
@@ -340,7 +343,7 @@ defmodule PtcRunner.Lisp.Runtime.Predicates do
     end
   end
 
-  def type_of(x) when is_map(x), do: :map
+  def type_of(x) when is_map(x) and not is_struct(x), do: :map
   def type_of(x) when is_function(x), do: :function
   def type_of(_), do: :unknown
 
@@ -380,25 +383,21 @@ defmodule PtcRunner.Lisp.Runtime.Predicates do
     end
   end
 
+  def keyword(%LispKeyword{} = k), do: k
+
   def keyword(s) when is_binary(s) do
     unless Regex.match?(@keyword_pattern, s) do
       raise ArgumentError, "invalid keyword name: #{inspect(s)}"
     end
 
-    case safe_to_existing_atom(s) do
-      {:ok, atom} -> atom
-      :error -> raise ArgumentError, "keyword not found: #{inspect(s)}"
+    case SourceAtoms.intern(s) do
+      atom when is_atom(atom) -> atom
+      name when is_binary(name) -> LispKeyword.new(name)
     end
   end
 
   def keyword(x) do
     raise ArgumentError, "cannot coerce to keyword: #{inspect(x)}"
-  end
-
-  defp safe_to_existing_atom(s) do
-    {:ok, String.to_existing_atom(s)}
-  rescue
-    ArgumentError -> :error
   end
 
   @doc "Convert collection to set"

--- a/lib/ptc_runner/lisp/runtime/string.ex
+++ b/lib/ptc_runner/lisp/runtime/string.ex
@@ -6,6 +6,7 @@ defmodule PtcRunner.Lisp.Runtime.String do
   """
 
   alias PtcRunner.Lisp.Format
+  alias PtcRunner.Lisp.Keyword, as: LispKeyword
 
   @doc """
   Convert zero or more values to string and concatenate.
@@ -43,6 +44,7 @@ defmodule PtcRunner.Lisp.Runtime.String do
   def to_str(:negative_infinity), do: "-Infinity"
   def to_str(:nan), do: "NaN"
   def to_str(atom) when is_atom(atom), do: inspect(atom)
+  def to_str(%LispKeyword{name: name}), do: ":" <> name
 
   # Temporal structs: render as ISO 8601 so `(java.util.Date. (str dt))` works
   # and the LLM never sees the Elixir sigil form. Must precede the generic map
@@ -712,6 +714,8 @@ defmodule PtcRunner.Lisp.Runtime.String do
       Atom.to_string(k)
     end
   end
+
+  def name(%LispKeyword{name: name}), do: name
 
   def name(x) do
     raise ArgumentError, "name not supported on: #{inspect(x)}"

--- a/lib/ptc_runner/lisp/source_atoms.ex
+++ b/lib/ptc_runner/lisp/source_atoms.ex
@@ -129,6 +129,7 @@ defmodule PtcRunner.Lisp.SourceAtoms do
   # Verified via `rg ':"[a-z-]+"' lib/ptc_runner/lisp/analyze.ex`.
   @qualified_keys ~w(
     summary remaining list-servers list-tools describe-tool search-tools
+    parse-string generate-string text json
     re-pattern
   )a
 

--- a/lib/ptc_runner/lisp/spec_validator/parser.ex
+++ b/lib/ptc_runner/lisp/spec_validator/parser.ex
@@ -40,6 +40,9 @@ defmodule PtcRunner.Lisp.SpecValidator.Parser do
       }
   """
 
+  alias PtcRunner.Lisp.Keyword, as: LispKeyword
+  alias PtcRunner.Lisp.SourceAtoms
+
   alias PtcRunner.Lisp.Format
 
   @doc """
@@ -613,7 +616,7 @@ defmodule PtcRunner.Lisp.SpecValidator.Parser do
   # Parse keywords
   defp parse_keyword(str) do
     keyword_name = String.slice(str, 1..-1//1)
-    {:ok, String.to_atom(keyword_name)}
+    {:ok, keyword_value(keyword_name)}
   end
 
   # Parse vars like #'name (optionally followed by comments)
@@ -621,7 +624,14 @@ defmodule PtcRunner.Lisp.SpecValidator.Parser do
     # Only take the part until the first space
     var_part = str |> String.split(" ") |> hd()
     var_name = String.slice(var_part, 2..-1//1)
-    {:ok, %Format.Var{name: String.to_atom(var_name)}}
+    {:ok, %Format.Var{name: SourceAtoms.intern(var_name)}}
+  end
+
+  defp keyword_value(name) do
+    case SourceAtoms.intern(name) do
+      atom when is_atom(atom) -> atom
+      binary when is_binary(binary) -> LispKeyword.new(binary)
+    end
   end
 
   # Unescape string literals

--- a/lib/ptc_runner/sub_agent/debug.ex
+++ b/lib/ptc_runner/sub_agent/debug.ex
@@ -748,7 +748,7 @@ defmodule PtcRunner.SubAgent.Debug do
         print_box_footer()
 
       :error ->
-        available = sections |> Map.keys() |> Enum.sort()
+        available = sections |> Map.keys() |> Enum.sort_by(&to_string/1)
 
         IO.puts(
           "\n#{ansi(:yellow)}Unknown section :#{key} for turn #{turn_number}.#{ansi(:reset)}"
@@ -806,7 +806,7 @@ defmodule PtcRunner.SubAgent.Debug do
         |> String.replace(~r/[^a-z0-9]+/, "_")
         |> String.trim_leading("_")
         |> String.trim_trailing("_")
-        |> String.to_atom()
+        |> existing_atom_or_string()
 
       key ->
         key
@@ -814,6 +814,12 @@ defmodule PtcRunner.SubAgent.Debug do
   end
 
   defp xml_tag_to_key(tag_name) do
-    Map.get(@xml_tag_to_key, tag_name, String.to_atom(tag_name))
+    Map.get(@xml_tag_to_key, tag_name, existing_atom_or_string(tag_name))
+  end
+
+  defp existing_atom_or_string(name) do
+    String.to_existing_atom(name)
+  rescue
+    ArgumentError -> name
   end
 end

--- a/lib/ptc_runner/sub_agent/loop/text_mode.ex
+++ b/lib/ptc_runner/sub_agent/loop/text_mode.ex
@@ -2203,7 +2203,7 @@ defmodule PtcRunner.SubAgent.Loop.TextMode do
   defp format_type_description({:map, fields}, field_descriptions) do
     Enum.map_join(fields, "\n", fn {name, type} ->
       type_str = format_type_name(type)
-      desc = Map.get(field_descriptions, String.to_atom(name), "")
+      desc = field_description(field_descriptions, name)
       desc_part = if desc != "", do: " - #{desc}", else: ""
       "- `#{name}` (#{type_str})#{desc_part}"
     end)
@@ -2215,6 +2215,25 @@ defmodule PtcRunner.SubAgent.Loop.TextMode do
 
   defp format_type_description(type, _field_descriptions) do
     "(#{format_type_name(type)})"
+  end
+
+  defp field_description(field_descriptions, name) do
+    case Map.fetch(field_descriptions, name) do
+      {:ok, desc} ->
+        desc
+
+      :error ->
+        case existing_atom(name) do
+          {:ok, atom} -> Map.get(field_descriptions, atom, "")
+          :error -> ""
+        end
+    end
+  end
+
+  defp existing_atom(name) do
+    {:ok, String.to_existing_atom(name)}
+  rescue
+    ArgumentError -> :error
   end
 
   defp format_type_name(:string), do: "string"

--- a/lib/ptc_runner/sub_agent/namespace/type_vocabulary.ex
+++ b/lib/ptc_runner/sub_agent/namespace/type_vocabulary.ex
@@ -1,6 +1,8 @@
 defmodule PtcRunner.SubAgent.Namespace.TypeVocabulary do
   @moduledoc "Converts Elixir values to human-readable type labels."
 
+  alias PtcRunner.Lisp.Keyword, as: LispKeyword
+
   @doc """
   Returns a type label for any value.
 
@@ -65,7 +67,8 @@ defmodule PtcRunner.SubAgent.Namespace.TypeVocabulary do
   def type_of(%NaiveDateTime{}), do: "datetime"
   def type_of(%Date{}), do: "date"
   def type_of(%Time{}), do: "time"
-  def type_of(map) when is_map(map), do: "map[#{map_size(map)}]"
+  def type_of(%LispKeyword{}), do: "keyword"
+  def type_of(map) when is_map(map) and not is_struct(map), do: "map[#{map_size(map)}]"
   def type_of(s) when is_binary(s), do: "string"
   def type_of(n) when is_integer(n), do: "integer"
   def type_of(f) when is_float(f), do: "float"

--- a/lib/ptc_runner/sub_agent/signature/validator.ex
+++ b/lib/ptc_runner/sub_agent/signature/validator.ex
@@ -5,6 +5,7 @@ defmodule PtcRunner.SubAgent.Signature.Validator do
   Provides strict validation with path-based error reporting.
   """
 
+  alias PtcRunner.Lisp.Keyword, as: LispKeyword
   alias PtcRunner.SubAgent.KeyNormalizer
 
   @type validation_error :: %{
@@ -63,7 +64,7 @@ defmodule PtcRunner.SubAgent.Signature.Validator do
   end
 
   defp validate_type(data, :keyword, path) do
-    if is_atom(data) do
+    if is_atom(data) or match?(%LispKeyword{}, data) do
       []
     else
       [error_at(path, "expected keyword, got #{type_name(data)}")]
@@ -71,7 +72,7 @@ defmodule PtcRunner.SubAgent.Signature.Validator do
   end
 
   defp validate_type(data, :map, path) do
-    if is_map(data) do
+    if plain_map?(data) do
       []
     else
       [error_at(path, "expected map, got #{type_name(data)}")]
@@ -117,7 +118,7 @@ defmodule PtcRunner.SubAgent.Signature.Validator do
 
   # Map types with field validation
   defp validate_type(data, {:map, fields}, path) do
-    if is_map(data) do
+    if plain_map?(data) do
       validate_map_fields(data, fields, path)
     else
       [error_at(path, "expected map, got #{type_name(data)}")]
@@ -128,7 +129,7 @@ defmodule PtcRunner.SubAgent.Signature.Validator do
   # declared field is validated as usual *and* any undeclared key is an
   # error, so fields the caller explicitly excluded can't leak through.
   defp validate_type(data, {:closed_map, fields}, path) do
-    if is_map(data) do
+    if plain_map?(data) do
       {field_errors, consumed_keys} = validate_map_fields_tracking(data, fields, path)
       field_errors ++ validate_no_extra_fields(data, consumed_keys, path)
     else
@@ -181,6 +182,7 @@ defmodule PtcRunner.SubAgent.Signature.Validator do
     end)
   end
 
+  defp path_segment(%LispKeyword{name: name}), do: name
   defp path_segment(key) when is_binary(key) or is_atom(key), do: to_string(key)
   defp path_segment(key), do: inspect(key)
 
@@ -189,7 +191,7 @@ defmodule PtcRunner.SubAgent.Signature.Validator do
   # or normalized `:user_id` / `"user_id"`). PTC-Lisp keyword-keyed maps reach
   # the validator with hyphenated atom keys; Elixir-side tools typically use
   # underscored atom or string keys.
-  defp get_field(data, field_name) when is_map(data) do
+  defp get_field(data, field_name) when is_map(data) and not is_struct(data) do
     normalized = KeyNormalizer.normalize_key(field_name)
 
     candidates =
@@ -217,7 +219,17 @@ defmodule PtcRunner.SubAgent.Signature.Validator do
         result
 
       :missing ->
-        if Map.has_key?(data, key), do: {:ok, key, Map.get(data, key)}, else: :missing
+        cond do
+          Map.has_key?(data, key) ->
+            {:ok, key, Map.get(data, key)}
+
+          Map.has_key?(data, %LispKeyword{name: key}) ->
+            keyword = %LispKeyword{name: key}
+            {:ok, keyword, Map.get(data, keyword)}
+
+          true ->
+            :missing
+        end
     end
   end
 
@@ -237,12 +249,15 @@ defmodule PtcRunner.SubAgent.Signature.Validator do
   defp optional?({:optional, _type}), do: true
   defp optional?(_), do: false
 
+  defp plain_map?(data), do: is_map(data) and not is_struct(data)
+
   defp type_name(data) when is_binary(data), do: "string"
   defp type_name(data) when is_integer(data) and not is_boolean(data), do: "int"
   defp type_name(data) when is_float(data), do: "float"
   defp type_name(data) when is_boolean(data), do: "bool"
   defp type_name(data) when is_atom(data), do: "keyword"
-  defp type_name(data) when is_map(data), do: "map"
+  defp type_name(%LispKeyword{}), do: "keyword"
+  defp type_name(data) when is_map(data) and not is_struct(data), do: "map"
   defp type_name(data) when is_list(data), do: "list"
   defp type_name(data), do: inspect(data)
 

--- a/test/ptc_runner/lisp/lisp_integration_test.exs
+++ b/test/ptc_runner/lisp/lisp_integration_test.exs
@@ -597,6 +597,33 @@ defmodule PtcRunner.Lisp.IntegrationTest do
       assert [tool_call] = step.tool_calls
       assert tool_call.args == %{"url" => "http://example.com"}
     end
+
+    test "novel keyword values in tool args are externalized without struct enumeration" do
+      tools = %{
+        "echo" => fn args -> args end
+      }
+
+      source = ~S|(tool/echo {:kind :novel-runtime-keyword})|
+
+      {:ok, step} = Lisp.run(source, tools: tools)
+
+      assert [tool_call] = step.tool_calls
+      assert tool_call.args == %{"kind" => "novel-runtime-keyword"}
+      assert step.return == %{"kind" => "novel-runtime-keyword"}
+    end
+
+    test "single novel keyword arg keeps the named-args validation error" do
+      tools = %{
+        "echo" => fn args -> args end
+      }
+
+      source = ~S|(tool/echo :novel-runtime-keyword)|
+
+      assert {:error, %{fail: %{reason: :invalid_tool_args, message: msg}}} =
+               Lisp.run(source, tools: tools)
+
+      assert msg =~ "Tool calls require named arguments"
+    end
   end
 
   describe "tool_calls preserved across closure calls" do

--- a/test/ptc_runner/lisp/parser_test.exs
+++ b/test/ptc_runner/lisp/parser_test.exs
@@ -33,9 +33,9 @@ defmodule PtcRunner.Lisp.ParserTest do
 
     test "keywords" do
       assert {:ok, {:keyword, :name}} = Parser.parse(":name")
-      assert {:ok, {:keyword, :user_id}} = Parser.parse(":user_id")
+      assert {:ok, {:keyword, "user_id"}} = Parser.parse(":user_id")
       assert {:ok, {:keyword, :empty?}} = Parser.parse(":empty?")
-      assert {:ok, {:keyword, :valid!}} = Parser.parse(":valid!")
+      assert {:ok, {:keyword, "valid!"}} = Parser.parse(":valid!")
     end
 
     test "keywords with operator characters (Clojure conformance)" do
@@ -82,9 +82,9 @@ defmodule PtcRunner.Lisp.ParserTest do
     end
 
     test "namespaced symbols" do
-      assert {:ok, {:ns_symbol, :data, :input}} = Parser.parse("data/input")
-      assert {:ok, {:ns_symbol, :tool, :search}} = Parser.parse("tool/search")
-      assert {:ok, {:ns_symbol, :foo, :bar}} = Parser.parse("foo/bar")
+      assert {:ok, {:ns_symbol, :data, "input"}} = Parser.parse("data/input")
+      assert {:ok, {:ns_symbol, :tool, "search"}} = Parser.parse("tool/search")
+      assert {:ok, {:ns_symbol, "foo", "bar"}} = Parser.parse("foo/bar")
     end
 
     test "Clojure-style namespaced symbols with dots" do
@@ -95,8 +95,8 @@ defmodule PtcRunner.Lisp.ParserTest do
 
     test "nil/true/false don't match as prefixes" do
       # "nilly" should be a symbol, not nil + "ly"
-      assert {:ok, {:symbol, :nilly}} = Parser.parse("nilly")
-      assert {:ok, {:symbol, :truthy}} = Parser.parse("truthy")
+      assert {:ok, {:symbol, "nilly"}} = Parser.parse("nilly")
+      assert {:ok, {:symbol, "truthy"}} = Parser.parse("truthy")
     end
   end
 
@@ -119,7 +119,7 @@ defmodule PtcRunner.Lisp.ParserTest do
     end
 
     test "map with entries" do
-      assert {:ok, {:map, [{{:keyword, :a}, 1}, {{:keyword, :b}, 2}]}} =
+      assert {:ok, {:map, [{{:keyword, "a"}, 1}, {{:keyword, "b"}, 2}]}} =
                Parser.parse("{:a 1 :b 2}")
     end
 
@@ -132,8 +132,8 @@ defmodule PtcRunner.Lisp.ParserTest do
               {:list,
                [
                  {:symbol, :filter},
-                 {:list, [{:symbol, :=}, {:keyword, :active}, true]},
-                 {:symbol, :users}
+                 {:list, [{:symbol, :=}, {:keyword, "active"}, true]},
+                 {:symbol, "users"}
                ]}} = Parser.parse("(filter (= :active true) users)")
     end
 
@@ -149,7 +149,7 @@ defmodule PtcRunner.Lisp.ParserTest do
 
     test "set with keywords" do
       set_kw = "#" <> "{:a :b}"
-      assert {:ok, {:set, [{:keyword, :a}, {:keyword, :b}]}} = Parser.parse(set_kw)
+      assert {:ok, {:set, [{:keyword, "a"}, {:keyword, "b"}]}} = Parser.parse(set_kw)
     end
 
     test "nested set" do
@@ -170,13 +170,13 @@ defmodule PtcRunner.Lisp.ParserTest do
     test "set containing map" do
       set_map = "#" <> "{:a {:b 1}}"
 
-      assert {:ok, {:set, [{:keyword, :a}, {:map, [{{:keyword, :b}, 1}]}]}} =
+      assert {:ok, {:set, [{:keyword, "a"}, {:map, [{{:keyword, "b"}, 1}]}]}} =
                Parser.parse(set_map)
     end
 
     test "set with mixed types" do
       set_mixed = "#" <> "{:a \"b\" 3}"
-      assert {:ok, {:set, [{:keyword, :a}, {:string, "b"}, 3]}} = Parser.parse(set_mixed)
+      assert {:ok, {:set, [{:keyword, "a"}, {:string, "b"}, 3]}} = Parser.parse(set_mixed)
     end
   end
 
@@ -198,13 +198,13 @@ defmodule PtcRunner.Lisp.ParserTest do
 
     test "semicolon after keyword starts a comment" do
       # ; after :foo starts a comment, swallowing :bar on the same line
-      assert {:ok, {:keyword, :foo}} =
+      assert {:ok, {:keyword, "foo"}} =
                Parser.parse(":foo; :bar eaten by comment")
     end
 
     test "semicolon mid-vector eats rest of line" do
       # :baz on next line is still parsed, but :bar is comment
-      assert {:ok, {:vector, [{:keyword, :foo}, {:keyword, :baz}]}} =
+      assert {:ok, {:vector, [{:keyword, "foo"}, {:keyword, "baz"}]}} =
                Parser.parse("[:foo; :bar comment\n:baz]")
     end
   end
@@ -218,7 +218,7 @@ defmodule PtcRunner.Lisp.ParserTest do
            (take 10))
       """
 
-      assert {:ok, {:list, [{:symbol, :"->>"}, {:ns_symbol, :data, :products} | _]}} =
+      assert {:ok, {:list, [{:symbol, :"->>"}, {:ns_symbol, :data, "products"} | _]}} =
                Parser.parse(source)
     end
 
@@ -245,7 +245,8 @@ defmodule PtcRunner.Lisp.ParserTest do
     test "namespaced keywords are not supported" do
       # Spec: "no namespaced keywords like :foo/bar"
       # Parses as two separate tokens: :foo and /bar (a symbol)
-      assert {:ok, {:program, [{:keyword, :foo}, {:symbol, :"/bar"}]}} = Parser.parse(":foo/bar")
+      assert {:ok, {:program, [{:keyword, "foo"}, {:symbol, "/bar"}]}} =
+               Parser.parse(":foo/bar")
     end
 
     test "quoted lists are rejected" do
@@ -292,7 +293,7 @@ defmodule PtcRunner.Lisp.ParserTest do
   describe "numeric edge cases" do
     test "leading decimal point parses as symbol (for .method interop)" do
       # .5 is parsed as symbol because . can start method-call symbols like .getTime
-      assert {:ok, {:symbol, :".5"}} = Parser.parse(".5")
+      assert {:ok, {:symbol, ".5"}} = Parser.parse(".5")
     end
 
     test "trailing decimal point splits into number and dot symbol" do
@@ -320,7 +321,7 @@ defmodule PtcRunner.Lisp.ParserTest do
 
     test "positive sign on numbers" do
       # +5 parses as symbol, not number
-      assert {:ok, {:symbol, :"+5"}} = Parser.parse("+5")
+      assert {:ok, {:symbol, "+5"}} = Parser.parse("+5")
     end
   end
 
@@ -334,11 +335,11 @@ defmodule PtcRunner.Lisp.ParserTest do
     end
 
     test "false-positive is a symbol not false" do
-      assert {:ok, {:symbol, :"false-positive"}} = Parser.parse("false-positive")
+      assert {:ok, {:symbol, "false-positive"}} = Parser.parse("false-positive")
     end
 
     test "nilly is a symbol not nil" do
-      assert {:ok, {:symbol, :nilly}} = Parser.parse("nilly")
+      assert {:ok, {:symbol, "nilly"}} = Parser.parse("nilly")
     end
   end
 
@@ -366,23 +367,23 @@ defmodule PtcRunner.Lisp.ParserTest do
 
   describe "var reader syntax #'" do
     test "simple var" do
-      assert {:ok, {:var, :x}} = Parser.parse("#'x")
+      assert {:ok, {:var, "x"}} = Parser.parse("#'x")
     end
 
     test "var with question mark" do
-      assert {:ok, {:var, :suspicious?}} = Parser.parse("#'suspicious?")
+      assert {:ok, {:var, "suspicious?"}} = Parser.parse("#'suspicious?")
     end
 
     test "var with bang" do
-      assert {:ok, {:var, :save!}} = Parser.parse("#'save!")
+      assert {:ok, {:var, "save!"}} = Parser.parse("#'save!")
     end
 
     test "var with underscore" do
-      assert {:ok, {:var, :my_var}} = Parser.parse("#'my_var")
+      assert {:ok, {:var, "my_var"}} = Parser.parse("#'my_var")
     end
 
     test "var with hyphen" do
-      assert {:ok, {:var, :"my-var"}} = Parser.parse("#'my-var")
+      assert {:ok, {:var, "my-var"}} = Parser.parse("#'my-var")
     end
 
     test "var with trailing apostrophe" do
@@ -391,11 +392,11 @@ defmodule PtcRunner.Lisp.ParserTest do
     end
 
     test "var in collection" do
-      assert {:ok, {:vector, [{:var, :x}, {:var, :y}]}} = Parser.parse("[#'x #'y]")
+      assert {:ok, {:vector, [{:var, "x"}, {:var, "y"}]}} = Parser.parse("[#'x #'y]")
     end
 
     test "var in map value" do
-      assert {:ok, {:map, [{{:keyword, :result}, {:var, :foo}}]}} =
+      assert {:ok, {:map, [{{:keyword, "result"}, {:var, "foo"}}]}} =
                Parser.parse("{:result #'foo}")
     end
 
@@ -414,25 +415,25 @@ defmodule PtcRunner.Lisp.ParserTest do
     end
 
     test "short function with single placeholder" do
-      assert {:ok, {:short_fn, [{:symbol, :%}]}} = Parser.parse("#(%)")
+      assert {:ok, {:short_fn, [{:symbol, "%"}]}} = Parser.parse("#(%)")
     end
 
     test "short function with arithmetic" do
-      assert {:ok, {:short_fn, [{:symbol, :+}, {:symbol, :%}, 1]}} = Parser.parse("#(+ % 1)")
+      assert {:ok, {:short_fn, [{:symbol, :+}, {:symbol, "%"}, 1]}} = Parser.parse("#(+ % 1)")
     end
 
     test "short function with numeric placeholders" do
-      assert {:ok, {:short_fn, [{:symbol, :+}, {:symbol, :"%1"}, {:symbol, :"%2"}]}} =
+      assert {:ok, {:short_fn, [{:symbol, :+}, {:symbol, "%1"}, {:symbol, "%2"}]}} =
                Parser.parse("#(+ %1 %2)")
     end
 
     test "short function with multiple uses of same placeholder" do
-      assert {:ok, {:short_fn, [{:symbol, :*}, {:symbol, :%}, {:symbol, :%}]}} =
+      assert {:ok, {:short_fn, [{:symbol, :*}, {:symbol, "%"}, {:symbol, "%"}]}} =
                Parser.parse("#(* % %)")
     end
 
     test "short function with whitespace and formatting" do
-      assert {:ok, {:short_fn, [{:symbol, :+}, {:symbol, :%}, 1]}} =
+      assert {:ok, {:short_fn, [{:symbol, :+}, {:symbol, "%"}, 1]}} =
                Parser.parse("#(  +  %  1  )")
     end
 
@@ -441,7 +442,7 @@ defmodule PtcRunner.Lisp.ParserTest do
               {:list,
                [
                  {:symbol, :filter},
-                 {:short_fn, [{:symbol, :>}, {:symbol, :%}, 10]},
+                 {:short_fn, [{:symbol, :>}, {:symbol, "%"}, 10]},
                  {:vector, [5, 15]}
                ]}} = Parser.parse("(filter #(> % 10) [5 15])")
     end
@@ -451,16 +452,16 @@ defmodule PtcRunner.Lisp.ParserTest do
     end
 
     test "placeholder symbols parse outside #()" do
-      assert {:ok, {:symbol, :%}} = Parser.parse("%")
-      assert {:ok, {:symbol, :"%1"}} = Parser.parse("%1")
-      assert {:ok, {:symbol, :"%2"}} = Parser.parse("%2")
+      assert {:ok, {:symbol, "%"}} = Parser.parse("%")
+      assert {:ok, {:symbol, "%1"}} = Parser.parse("%1")
+      assert {:ok, {:symbol, "%2"}} = Parser.parse("%2")
     end
   end
 
   describe "multiple top-level expressions" do
     test "single expression returns unwrapped (backward compatible)" do
       assert {:ok, 42} = Parser.parse("42")
-      assert {:ok, {:symbol, :x}} = Parser.parse("x")
+      assert {:ok, {:symbol, "x"}} = Parser.parse("x")
     end
 
     test "multiple expressions return {:program, list}" do

--- a/test/ptc_runner/lisp/runtime/name_keyword_test.exs
+++ b/test/ptc_runner/lisp/runtime/name_keyword_test.exs
@@ -94,4 +94,38 @@ defmodule PtcRunner.Lisp.Runtime.NameKeywordTest do
       assert run!(~s|(keyword? (keyword "zzxxyywwnotexist"))|) == true
     end
   end
+
+  describe "non-atom keyword runtime behavior" do
+    test "novel source keywords are scalar keywords, not maps or collections" do
+      assert run!(~s|(keyword? :novel-runtime-keyword)|) == true
+      assert run!(~s|(map? :novel-runtime-keyword)|) == false
+      assert run!(~s|(coll? :novel-runtime-keyword)|) == false
+      assert run!(~s|(counted? :novel-runtime-keyword)|) == false
+      assert run!(~s|(seqable? :novel-runtime-keyword)|) == false
+    end
+
+    test "novel source keywords do not expose struct fields through keyword lookup" do
+      assert run!(~s|(:name :novel-runtime-keyword)|) == nil
+    end
+
+    test "novel source keywords use flexible lookup consistently" do
+      ctx = %{"m" => %{"novel-runtime-keyword" => 1}}
+
+      assert {:ok, %{return: 1}} =
+               PtcRunner.Lisp.run(~s|(:novel-runtime-keyword data/m)|, context: ctx)
+
+      assert {:ok, %{return: 1}} =
+               PtcRunner.Lisp.run(~s|(get data/m :novel-runtime-keyword)|, context: ctx)
+
+      assert {:ok, %{return: 1}} =
+               PtcRunner.Lisp.run(~s|(get data/m :novel-runtime-keyword :missing)|,
+                 context: ctx
+               )
+
+      assert {:ok, %{return: true}} =
+               PtcRunner.Lisp.run(~s|(contains? data/m :novel-runtime-keyword)|,
+                 context: ctx
+               )
+    end
+  end
 end

--- a/test/ptc_runner/lisp/runtime/name_keyword_test.exs
+++ b/test/ptc_runner/lisp/runtime/name_keyword_test.exs
@@ -89,12 +89,9 @@ defmodule PtcRunner.Lisp.Runtime.NameKeywordTest do
       assert step.fail.message =~ "cannot coerce special value"
     end
 
-    test "unknown atom string raises error" do
-      # A string that passes validation but has no existing atom
-      assert {:error, step} =
-               PtcRunner.Lisp.run(~s|(keyword "zzxxyywwnotexist")|, context: %{})
-
-      assert step.fail.message =~ "keyword not found"
+    test "unknown atom string becomes a non-atom keyword" do
+      assert run!(~s|(name (keyword "zzxxyywwnotexist"))|) == "zzxxyywwnotexist"
+      assert run!(~s|(keyword? (keyword "zzxxyywwnotexist"))|) == true
     end
   end
 end

--- a/test/ptc_runner/lisp/source_atoms_test.exs
+++ b/test/ptc_runner/lisp/source_atoms_test.exs
@@ -166,6 +166,10 @@ defmodule PtcRunner.Lisp.SourceAtomsTest do
       :"list-tools",
       :"describe-tool",
       :"search-tools",
+      :"parse-string",
+      :"generate-string",
+      :text,
+      :json,
       :"re-pattern"
     ]
 

--- a/test/ptc_runner/lisp/turn_history_test.exs
+++ b/test/ptc_runner/lisp/turn_history_test.exs
@@ -23,9 +23,9 @@ defmodule PtcRunner.Lisp.TurnHistoryTest do
     end
 
     test "other *N symbols parse as regular symbols" do
-      assert AST.symbol("*4") == {:symbol, :"*4"}
-      assert AST.symbol("*0") == {:symbol, :"*0"}
-      assert AST.symbol("*foo") == {:symbol, :"*foo"}
+      assert AST.symbol("*4") == {:symbol, "*4"}
+      assert AST.symbol("*0") == {:symbol, "*0"}
+      assert AST.symbol("*foo") == {:symbol, "*foo"}
     end
   end
 

--- a/test/soak/atom_leak_soak_test.exs
+++ b/test/soak/atom_leak_soak_test.exs
@@ -7,12 +7,12 @@ defmodule PtcRunner.AtomLeakSoakTest do
 
   This is the regression test for [#953](https://github.com/andreasronge/ptc_runner/issues/953).
 
-  PTC-Lisp's parser currently interns every var, symbol, and keyword
-  name via `String.to_atom/1` (see `lib/ptc_runner/lisp/parser_helpers.ex`,
-  `lib/ptc_runner/lisp/ast.ex`), so this test is **expected to fail
-  on the pre-fix code**. After the audited call sites switch to
-  `String.to_existing_atom/1` (or move to binary keys), the rate
-  should drop to ~0 atoms/iter.
+  PTC-Lisp used to intern every var, symbol, and keyword name via
+  `String.to_atom/1` (see `lib/ptc_runner/lisp/parser_helpers.ex`,
+  `lib/ptc_runner/lisp/ast.ex`). The parser now keeps only the bounded
+  `SourceAtoms` vocabulary as atoms and leaves unbounded source names
+  as binaries, so the steady-state atom growth rate should stay at
+  ~0 atoms/iter.
 
   ## Why three programs
 
@@ -37,14 +37,7 @@ defmodule PtcRunner.AtomLeakSoakTest do
   alias PtcRunner.Lisp
   alias PtcRunner.TestSupport.MemorySoak
 
-  # Tagged `:skip` because this regression test currently fails — it
-  # reproduces the leak described in
-  # https://github.com/andreasronge/ptc_runner/issues/953. Run
-  # explicitly with `mix test --include skip --include soak
-  # test/soak/atom_leak_soak_test.exs` to reproduce.
-  # Remove the `:skip` tag once #953 is fixed.
   @moduletag :soak
-  @moduletag :skip
   @moduletag timeout: :infinity
 
   setup do

--- a/test/support/lisp_generators_test.exs
+++ b/test/support/lisp_generators_test.exs
@@ -2,7 +2,7 @@ defmodule PtcRunner.TestSupport.LispGeneratorsTest do
   use ExUnit.Case, async: true
   use ExUnitProperties
 
-  alias PtcRunner.Lisp.{Formatter, Parser}
+  alias PtcRunner.Lisp.{Formatter, Parser, SourceAtoms}
   alias PtcRunner.Step
   alias PtcRunner.TestSupport.LispGenerators, as: Gen
 
@@ -14,7 +14,9 @@ defmodule PtcRunner.TestSupport.LispGeneratorsTest do
 
         case Parser.parse(source) do
           {:ok, parsed} ->
-            assert ast_equivalent?(ast, parsed),
+            expected = normalize_source_names(ast)
+
+            assert ast_equivalent?(expected, parsed),
                    "Roundtrip failed:\nOriginal: #{inspect(ast)}\nSource: #{source}\nParsed: #{inspect(parsed)}"
 
           {:error, reason} ->
@@ -57,6 +59,39 @@ defmodule PtcRunner.TestSupport.LispGeneratorsTest do
   end
 
   # Helpers
+
+  defp normalize_source_names({tag, name})
+       when tag in [:symbol, :keyword, :var] and (is_atom(name) or is_binary(name)) do
+    {tag, normalize_source_name(name)}
+  end
+
+  defp normalize_source_names({:ns_symbol, ns, name}) do
+    {:ns_symbol, normalize_source_name(ns), normalize_source_name(name)}
+  end
+
+  defp normalize_source_names({:map, entries}) do
+    {:map,
+     Enum.map(entries, fn {key, value} ->
+       {normalize_source_names(key), normalize_source_names(value)}
+     end)}
+  end
+
+  defp normalize_source_names({tag, children})
+       when tag in [:list, :vector, :set, :program, :short_fn] and is_list(children) do
+    {tag, Enum.map(children, &normalize_source_names/1)}
+  end
+
+  defp normalize_source_names(other), do: other
+
+  defp normalize_source_name(name) when is_atom(name) do
+    name
+    |> Atom.to_string()
+    |> SourceAtoms.intern()
+  end
+
+  defp normalize_source_name(name) when is_binary(name) do
+    SourceAtoms.intern(name)
+  end
 
   defp ast_equivalent?(a, b) when is_float(a) and is_float(b) do
     abs(a - b) < 1.0e-9


### PR DESCRIPTION
## Summary
- Replace unbounded PTC-Lisp parser atom interning with a bounded `SourceAtoms` vocabulary.
- Add runtime keyword values for user-authored keywords that are not safe bounded atoms.
- Update eval, formatting, collection access, MCP/sub-agent compatibility, and parser/property tests for binary source names.
- Unskip and update the atom-leak soak regression for #953.

Closes #953.

## Verification
- `mix format --check-formatted`
- `mix credo --strict`
- `mix test`
- `PTC_SOAK_ITERATIONS=50 mix test --only soak test/soak/atom_leak_soak_test.exs`
- `cd mcp_server && mix test`
- Pre-commit hook: format, compile --warnings-as-errors, Credo, scoped tests
- Pre-push hook: root tests + dialyzer, mcp_server tests + dialyzer, ptc_viewer tests

## Atom soak result
The #953 soak now reports steady-state `+0` atom growth (`0.0/iter`) for novel vars, novel namespace symbols, and novel keywords after the first iteration warmup.