### PR TITLE
fix(lisp): closures capture only referenced free vars (#961)

### DIFF
--- a/lib/ptc_runner/lisp/eval.ex
+++ b/lib/ptc_runner/lisp/eval.ex
@@ -378,14 +378,14 @@ defmodule PtcRunner.Lisp.Eval do
     # references. Builtins are resolved at call time via the Env.builtin?
     # fallback in (:var ...), so carrying them in the closure would inflate
     # session memory by ~18 KB per closure.
-    {captured_env, captured_locals} = capture_lexical_scope(eval_ctx, body)
+    {captured_env, captured_locals} = capture_lexical_scope(eval_ctx, params, body)
     meta = locals_meta(captured_locals, %{})
     {:ok, {:closure, params, body, captured_env, [], meta}, eval_ctx}
   end
 
   # Named fn: (fn name [params] body) — name is bound inside body for self-recursion
   defp do_eval({:fn, name, params, body}, %EvalContext{} = eval_ctx) do
-    {captured_env, captured_locals} = capture_lexical_scope(eval_ctx, body)
+    {captured_env, captured_locals} = capture_lexical_scope(eval_ctx, params, body, [name])
     meta = locals_meta(captured_locals, %{fn_name: name})
     {:ok, {:closure, params, body, captured_env, [], meta}, eval_ctx}
   end
@@ -1434,18 +1434,22 @@ defmodule PtcRunner.Lisp.Eval do
   # Closure capture helpers
   # ============================================================
 
-  defp capture_lexical_scope(%EvalContext{env: env, locals: locals}, body) do
+  defp capture_lexical_scope(
+         %EvalContext{env: env, locals: locals},
+         params,
+         body,
+         extra_bound_names \\ []
+       ) do
     initial = Env.initial()
 
     # Names the closure body can actually reference (issue #961). A closure
     # captures its whole enclosing lexical scope, so a `(fn [] 42)` defined
     # next to a large `let` binding would otherwise pin that binding for the
     # closure's entire lifetime — and in a long-lived session, for the
-    # session's TTL. `referenced_vars/1` over-approximates: it collects every
-    # `{:var, _}` occurrence in the body (including names re-bound by an inner
-    # scope and nested-fn params), so the result is always a safe superset of
-    # the true free-variable set — it can never drop a binding the body needs.
-    referenced = referenced_vars(body)
+    # session's TTL. The collector is scope-aware so params, named-fn self
+    # bindings, and inner let/fn/loop bindings don't cause an unrelated outer
+    # value with the same name to be captured.
+    referenced = referenced_vars(body, params, extra_bound_names)
 
     # Keep an entry only if the body references it AND it is EITHER:
     #   * a key in `locals` (let/fn-param, possibly shadowing a builtin like
@@ -1476,28 +1480,124 @@ defmodule PtcRunner.Lisp.Eval do
     {captured_env, captured_locals}
   end
 
-  # Collects the names of every `{:var, _}` reference anywhere in a CoreAST
-  # subtree, normalized to strings. A deliberately total structural walk —
-  # any unrecognized tuple/list/map is recursed into rather than skipped — so
-  # a future AST node cannot silently cause a referenced var to be missed.
-  @spec referenced_vars(term()) :: MapSet.t(String.t())
-  defp referenced_vars(ast), do: collect_var_refs(ast, MapSet.new())
+  # Collects the free `{:var, _}` names in a CoreAST subtree, normalized to
+  # strings. Known binding forms are handled with their lexical scope; any
+  # unrecognized tuple/list/map is still recursed into so a future AST node
+  # cannot silently cause a referenced var to be missed.
+  @spec referenced_vars(term(), CoreAST.fn_params(), [CoreAST.name()]) :: MapSet.t(String.t())
+  defp referenced_vars(ast, params, extra_bound_names) do
+    initial_bound =
+      params
+      |> bound_names_from_params()
+      |> MapSet.union(normalize_name_set(extra_bound_names))
 
-  defp collect_var_refs({:var, name}, acc), do: MapSet.put(acc, to_string(name))
-
-  defp collect_var_refs(tuple, acc) when is_tuple(tuple) do
-    collect_var_refs(Tuple.to_list(tuple), acc)
+    collect_free_var_refs(ast, MapSet.new(), initial_bound)
   end
 
-  defp collect_var_refs(list, acc) when is_list(list) do
-    Enum.reduce(list, acc, &collect_var_refs/2)
+  defp collect_free_var_refs({:var, name}, acc, bound) do
+    name = to_string(name)
+
+    if MapSet.member?(bound, name) do
+      acc
+    else
+      MapSet.put(acc, name)
+    end
   end
 
-  defp collect_var_refs(map, acc) when is_map(map) and not is_struct(map) do
-    Enum.reduce(map, acc, fn {k, v}, inner -> collect_var_refs(v, collect_var_refs(k, inner)) end)
+  defp collect_free_var_refs({:let, bindings, body}, acc, bound) do
+    collect_free_refs_in_bindings(bindings, body, acc, bound)
   end
 
-  defp collect_var_refs(_other, acc), do: acc
+  defp collect_free_var_refs({:loop, bindings, body}, acc, bound) do
+    collect_free_refs_in_bindings(bindings, body, acc, bound)
+  end
+
+  defp collect_free_var_refs({:fn, params, body}, acc, bound) do
+    collect_free_var_refs(body, acc, MapSet.union(bound, bound_names_from_params(params)))
+  end
+
+  defp collect_free_var_refs({:fn, name, params, body}, acc, bound) do
+    inner_bound =
+      bound
+      |> MapSet.union(bound_names_from_params(params))
+      |> MapSet.put(to_string(name))
+
+    collect_free_var_refs(body, acc, inner_bound)
+  end
+
+  defp collect_free_var_refs(tuple, acc, bound) when is_tuple(tuple) do
+    collect_free_var_refs(Tuple.to_list(tuple), acc, bound)
+  end
+
+  defp collect_free_var_refs(list, acc, bound) when is_list(list) do
+    Enum.reduce(list, acc, &collect_free_var_refs(&1, &2, bound))
+  end
+
+  defp collect_free_var_refs(map, acc, bound) when is_map(map) and not is_struct(map) do
+    Enum.reduce(map, acc, fn {k, v}, inner ->
+      v
+      |> collect_free_var_refs(collect_free_var_refs(k, inner, bound), bound)
+    end)
+  end
+
+  defp collect_free_var_refs(_other, acc, _bound), do: acc
+
+  defp collect_free_refs_in_bindings(bindings, body, acc, bound) do
+    {acc, bound} =
+      Enum.reduce(bindings, {acc, bound}, fn {:binding, pattern, value_ast},
+                                             {inner_acc, inner_bound} ->
+        inner_acc = collect_free_var_refs(value_ast, inner_acc, inner_bound)
+        inner_bound = MapSet.union(inner_bound, bound_names_from_pattern(pattern))
+        {inner_acc, inner_bound}
+      end)
+
+    collect_free_var_refs(body, acc, bound)
+  end
+
+  defp bound_names_from_params(params) when is_list(params) do
+    params
+    |> Enum.flat_map(&names_from_pattern/1)
+    |> normalize_name_set()
+  end
+
+  defp bound_names_from_params({:variadic, leading, rest_pattern}) do
+    (Enum.flat_map(leading, &names_from_pattern/1) ++ names_from_pattern(rest_pattern))
+    |> normalize_name_set()
+  end
+
+  defp bound_names_from_pattern(pattern) do
+    pattern
+    |> names_from_pattern()
+    |> normalize_name_set()
+  end
+
+  defp names_from_pattern({:var, name}), do: [name]
+  defp names_from_pattern({:destructure, {:keys, keys, _defaults}}), do: keys
+
+  defp names_from_pattern({:destructure, {:map, keys, renames, _defaults}}) do
+    keys ++
+      Enum.flat_map(renames, fn {target_pattern, _source_key} ->
+        names_from_pattern(target_pattern)
+      end)
+  end
+
+  defp names_from_pattern({:destructure, {:as, name, inner}}),
+    do: [name | names_from_pattern(inner)]
+
+  defp names_from_pattern({:destructure, {:seq, patterns}}),
+    do: Enum.flat_map(patterns, &names_from_pattern/1)
+
+  defp names_from_pattern({:destructure, {:seq_rest, leading, rest}}) do
+    Enum.flat_map(leading, &names_from_pattern/1) ++ names_from_pattern(rest)
+  end
+
+  defp names_from_pattern(_other), do: []
+
+  defp normalize_name_set(names) do
+    names
+    |> Enum.map(&to_string/1)
+    |> MapSet.new()
+  end
 
   # Only embed captured_locals in meta when non-empty — keeps closure size
   # tiny for top-level (defn ...) without enclosing scope.

--- a/lib/ptc_runner/lisp/eval.ex
+++ b/lib/ptc_runner/lisp/eval.ex
@@ -374,17 +374,18 @@ defmodule PtcRunner.Lisp.Eval do
   defp do_eval({:fn, params, body}, %EvalContext{} = eval_ctx) do
     # Capture only the *user-visible* slice of the env — let/fn-param locals
     # plus any caller-injected env entries (anything that isn't in the
-    # canonical builtin set). Builtins are resolved at call time via the
-    # Env.builtin? fallback in (:var ...), so carrying them in the closure
-    # would inflate session memory by ~18 KB per closure.
-    {captured_env, captured_locals} = capture_lexical_scope(eval_ctx)
+    # canonical builtin set), further narrowed to names the body actually
+    # references. Builtins are resolved at call time via the Env.builtin?
+    # fallback in (:var ...), so carrying them in the closure would inflate
+    # session memory by ~18 KB per closure.
+    {captured_env, captured_locals} = capture_lexical_scope(eval_ctx, body)
     meta = locals_meta(captured_locals, %{})
     {:ok, {:closure, params, body, captured_env, [], meta}, eval_ctx}
   end
 
   # Named fn: (fn name [params] body) — name is bound inside body for self-recursion
   defp do_eval({:fn, name, params, body}, %EvalContext{} = eval_ctx) do
-    {captured_env, captured_locals} = capture_lexical_scope(eval_ctx)
+    {captured_env, captured_locals} = capture_lexical_scope(eval_ctx, body)
     meta = locals_meta(captured_locals, %{fn_name: name})
     {:ok, {:closure, params, body, captured_env, [], meta}, eval_ctx}
   end
@@ -1433,31 +1434,70 @@ defmodule PtcRunner.Lisp.Eval do
   # Closure capture helpers
   # ============================================================
 
-  defp capture_lexical_scope(%EvalContext{env: env, locals: locals}) do
+  defp capture_lexical_scope(%EvalContext{env: env, locals: locals}, body) do
     initial = Env.initial()
 
-    # Keep an entry if EITHER:
-    #   * its key is in `locals` (let/fn-param, possibly shadowing a builtin
-    #     like `count` — must preserve so the shadow survives in the closure)
-    #   * its key isn't a builtin at all (caller-injected env entries, e.g.
-    #     test harness pre-populating env)
+    # Names the closure body can actually reference (issue #961). A closure
+    # captures its whole enclosing lexical scope, so a `(fn [] 42)` defined
+    # next to a large `let` binding would otherwise pin that binding for the
+    # closure's entire lifetime — and in a long-lived session, for the
+    # session's TTL. `referenced_vars/1` over-approximates: it collects every
+    # `{:var, _}` occurrence in the body (including names re-bound by an inner
+    # scope and nested-fn params), so the result is always a safe superset of
+    # the true free-variable set — it can never drop a binding the body needs.
+    referenced = referenced_vars(body)
+
+    # Keep an entry only if the body references it AND it is EITHER:
+    #   * a key in `locals` (let/fn-param, possibly shadowing a builtin like
+    #     `count` — must preserve so the shadow survives in the closure)
+    #   * not a builtin at all (caller-injected env entries, e.g. a test
+    #     harness pre-populating env)
     # Builtins that the user didn't shadow are stripped; they resolve at
     # call time via the Env.builtin? fallback in (:var ...). This is the
     # whole point of the optimization — each closure would otherwise drag
-    # the full ~18 KB builtin map around.
-    captured_env =
-      :maps.filter(
-        fn key, _value ->
-          MapSet.member?(locals, key) or not Map.has_key?(initial, key)
-        end,
-        env
-      )
+    # the full ~18 KB builtin map (and every unused sibling binding) around.
+    keep? = fn key ->
+      MapSet.member?(referenced, to_string(key)) and
+        (MapSet.member?(locals, key) or not Map.has_key?(initial, key))
+    end
 
-    # `locals` is NOT widened to include caller-injected env keys —
-    # promoting them would invert the documented precedence
-    # (locals > user_ns > env). They stay accessible via the env path.
-    {captured_env, locals}
+    captured_env = :maps.filter(fn key, _value -> keep?.(key) end, env)
+
+    # Narrow `locals` (stored in meta as `:captured_locals`) to the same
+    # referenced set so it stays consistent with `captured_env` — every
+    # captured local still has an env entry. `locals` is NOT widened to
+    # include caller-injected env keys: promoting them would invert the
+    # documented precedence (locals > user_ns > env).
+    captured_locals =
+      locals
+      |> Enum.filter(&MapSet.member?(referenced, to_string(&1)))
+      |> MapSet.new()
+
+    {captured_env, captured_locals}
   end
+
+  # Collects the names of every `{:var, _}` reference anywhere in a CoreAST
+  # subtree, normalized to strings. A deliberately total structural walk —
+  # any unrecognized tuple/list/map is recursed into rather than skipped — so
+  # a future AST node cannot silently cause a referenced var to be missed.
+  @spec referenced_vars(term()) :: MapSet.t(String.t())
+  defp referenced_vars(ast), do: collect_var_refs(ast, MapSet.new())
+
+  defp collect_var_refs({:var, name}, acc), do: MapSet.put(acc, to_string(name))
+
+  defp collect_var_refs(tuple, acc) when is_tuple(tuple) do
+    collect_var_refs(Tuple.to_list(tuple), acc)
+  end
+
+  defp collect_var_refs(list, acc) when is_list(list) do
+    Enum.reduce(list, acc, &collect_var_refs/2)
+  end
+
+  defp collect_var_refs(map, acc) when is_map(map) and not is_struct(map) do
+    Enum.reduce(map, acc, fn {k, v}, inner -> collect_var_refs(v, collect_var_refs(k, inner)) end)
+  end
+
+  defp collect_var_refs(_other, acc), do: acc
 
   # Only embed captured_locals in meta when non-empty — keeps closure size
   # tiny for top-level (defn ...) without enclosing scope.

--- a/test/ptc_runner/lisp/closure_capture_test.exs
+++ b/test/ptc_runner/lisp/closure_capture_test.exs
@@ -236,6 +236,48 @@ defmodule PtcRunner.Lisp.ClosureCaptureTest do
       assert next.return == 105
     end
 
+    test "closure param does not capture an outer binding with the same name (#961)" do
+      src = """
+      (def f
+        (let [n (apply str (range 0 5000))]
+          (fn [n] n)))
+      """
+
+      {:ok, step} = Lisp.run(src, profile: :mcp_no_tools, mode: :multi_turn)
+
+      {:closure, _params, _body, captured_env, _history, _meta} =
+        Map.get(step.memory, "f") || Map.fetch!(step.memory, :f)
+
+      assert captured_env == %{}
+
+      {:ok, next} =
+        Lisp.run("(f 123)", profile: :mcp_no_tools, mode: :multi_turn, memory: step.memory)
+
+      assert next.return == 123
+      assert :erlang.external_size(step.memory) < 2_000
+    end
+
+    test "inner let binding does not capture an outer binding with the same name (#961)" do
+      src = """
+      (def f
+        (let [x (apply str (range 0 5000))]
+          (fn [] (let [x 2] x))))
+      """
+
+      {:ok, step} = Lisp.run(src, profile: :mcp_no_tools, mode: :multi_turn)
+
+      {:closure, _params, _body, captured_env, _history, _meta} =
+        Map.get(step.memory, "f") || Map.fetch!(step.memory, :f)
+
+      assert captured_env == %{}
+
+      {:ok, next} =
+        Lisp.run("(f)", profile: :mcp_no_tools, mode: :multi_turn, memory: step.memory)
+
+      assert next.return == 2
+      assert :erlang.external_size(step.memory) < 2_000
+    end
+
     test "closures do not retain prior turn history in session memory" do
       large_history_entry = String.duplicate("x", 100_000)
 

--- a/test/ptc_runner/lisp/closure_capture_test.exs
+++ b/test/ptc_runner/lisp/closure_capture_test.exs
@@ -196,6 +196,46 @@ defmodule PtcRunner.Lisp.ClosureCaptureTest do
              "expected defn memory < 2000 bytes, got #{memory_size}"
     end
 
+    test "closure does not capture a sibling let binding it never references (#961)" do
+      src = """
+      (def f
+        (let [unused-big (apply str (range 0 5000))
+              also-unused 7]
+          (fn [] 42)))
+      """
+
+      {:ok, step} = Lisp.run(src, profile: :mcp_no_tools, mode: :multi_turn)
+      {:closure, _params, _body, captured_env, _history, _meta} = step.memory[:f]
+
+      # The body is the literal `42` — it references nothing, so neither
+      # the 5k-char `unused-big` nor `also-unused` should be pinned.
+      assert captured_env == %{}
+
+      assert :erlang.external_size(step.memory) < 2_000,
+             "closure pinned an unused sibling binding: #{:erlang.external_size(step.memory)} bytes"
+    end
+
+    test "closure still captures the sibling binding its body references (#961)" do
+      src = """
+      (def adder
+        (let [base 100
+              unused-big (apply str (range 0 5000))]
+          (fn [n] (+ n base))))
+      """
+
+      {:ok, step} = Lisp.run(src, profile: :mcp_no_tools, mode: :multi_turn)
+      {:closure, _params, _body, captured_env, _history, _meta} = step.memory[:adder]
+
+      # `base` is referenced and must survive; `unused-big` must not.
+      assert Map.keys(captured_env) == ["base"] or Map.keys(captured_env) == [:base]
+
+      # The captured closure remains callable in a later turn.
+      {:ok, next} =
+        Lisp.run("(adder 5)", profile: :mcp_no_tools, mode: :multi_turn, memory: step.memory)
+
+      assert next.return == 105
+    end
+
     test "closures do not retain prior turn history in session memory" do
       large_history_entry = String.duplicate("x", 100_000)
 


### PR DESCRIPTION
## Summary

Fixes #961. PTC-Lisp closures captured their entire enclosing lexical scope instead of just the variables their body can actually reach. A `(fn [] 42)` defined next to a large `let` binding pinned that binding for the closure lifetime, and in a long-lived MCP session, for the session TTL.

Found while soak-probing complex closure programs across many turns as a follow-up to the #953 atom-leak work.

## Change

`Eval.capture_lexical_scope/4` now receives the closure params and body, computes a scope-aware free-variable set, and keeps only matching env/locals entries.

The collector understands closure params, named-function self bindings, sequential `let`/`loop` bindings, and nested functions. Unknown tuple/list/map nodes are still recursively scanned as a conservative fallback so future AST nodes do not silently drop needed captures.

## Effect

```clojure
(let [unused (apply str (range 0 5000))
      f (fn [] 42)]
  f)
```

returns a 26-byte closure instead of a 19 KB closure.

The follow-up review commit also prevents shadowing cases from retaining large outer values, for example `(let [n big] (fn [n] n))` and `(let [x big] (fn [] (let [x 2] x)))`.

## Verification

- `mix test` - 4947 tests, 0 failures
- `mix test test/ptc_runner/lisp --max-failures 1` - 2581 tests plus doctests, 0 failures
- `mix test test/ptc_runner/lisp/closure_capture_test.exs` - 20 tests, 0 failures
- `mix format --check-formatted lib/ptc_runner/lisp/eval.ex test/ptc_runner/lisp/closure_capture_test.exs`
- Git pre-push hook - root tests + dialyzer, `mcp_server/` tests + dialyzer, and `ptc_viewer/` tests all passed
- Standalone `mix precommit` still fails in spec validation on existing keyword/checksum drift unrelated to this closure patch
