### PR TITLE
feat(mcp): add session listing tool

### DIFF
--- a/Plans/ptc-runner-mcp-sessions.md
+++ b/Plans/ptc-runner-mcp-sessions.md
@@ -214,6 +214,10 @@ Recommended tool set:
 4. `ptc_session_forget`
 5. `ptc_session_close`
 
+Phase 1.5 adds:
+
+6. `ptc_session_list`
+
 `ptc_lisp_execute` remains the stateless baseline.
 
 If sessions are disabled, session tools SHOULD NOT be advertised. If
@@ -314,12 +318,17 @@ response-profile work may choose slim/structured/debug variants, but
 the session state update semantics are independent of the response
 shape.
 
-`signature` / `return_schema` / `output_contract` inputs are
-deliberately omitted from `ptc_session_eval` in Phase 1. Session eval
-is an exploratory REPL operation; typed programmatic extraction
-remains the job of stateless `ptc_lisp_execute`. A later phase may add
-typed validation, but must define exact validation timing and rollback
-behavior before doing so.
+`ptc_session_eval` MAY accept a typed return contract via either
+`signature` or `output_schema`, matching the stateless
+`ptc_lisp_execute` validation surface. The two inputs are mutually
+exclusive. Validation happens after PTC-Lisp execution produces a
+candidate return value and before committing session state. If contract
+validation fails, the eval response is an error and memory, result
+history, prints, and tool-call histories from that eval MUST NOT be
+committed.
+
+`return_schema` and `output_contract` are not accepted session-eval
+input names.
 
 This does **not** refer to MCP tool `outputSchema`. Session tools may
 still advertise MCP `outputSchema` for their own response envelopes
@@ -400,7 +409,68 @@ After close, session tools MUST return `session_not_found` or
 `session_closed` for that id. A short tombstone MAY be retained so
 clients can distinguish closed from unknown sessions.
 
-### 8.6 Session Authoring Card
+### 8.6 `ptc_session_list`
+
+Lists active sessions for the current owner.
+
+Input:
+
+```json
+{}
+```
+
+Semantics:
+
+- The result is scoped to the current session owner.
+- Only live sessions are returned. Explicitly closed, expired, and
+  evicted sessions are omitted.
+- Results SHOULD be sorted by the live session `updated_at` descending,
+  so recently used sessions appear first.
+- Listing sessions MUST NOT refresh session idle timers. Polling this
+  tool must not keep otherwise-idle sessions alive.
+- The tool does not inspect or render stored binding values.
+- The tool is synchronous and does not acquire the global
+  `max_concurrent_calls` execution permit.
+
+Output:
+
+```json
+{
+  "status": "ok",
+  "count": 2,
+  "sessions": [
+    {
+      "session_id": "ptcs_...",
+      "title": "Investigate recent GitHub MCP issues",
+      "turn": 3,
+      "created_at": "2026-05-16T09:15:00Z",
+      "updated_at": "2026-05-16T09:24:30Z",
+      "expires_at": "2026-05-16T09:45:00Z",
+      "eval_status": "idle",
+      "memory_bytes": 123456,
+      "binding_count": 4
+    }
+  ]
+}
+```
+
+Each session summary MUST include:
+
+- `session_id`
+- `title`
+- `turn`
+- `created_at`
+- `updated_at`
+- `expires_at`
+- `eval_status`, either `"idle"` or `"running"`
+- `memory_bytes`
+- `binding_count`
+
+This is intentionally metadata-only. Clients that need rendered memory,
+print history, tool-call history, or limit details should call
+`ptc_session_inspect` for a specific `session_id`.
+
+### 8.7 Session Authoring Card
 
 When sessions are enabled, the server SHOULD ship a short
 session-specific authoring card, separate from the stateless
@@ -821,16 +891,13 @@ compatible with the session architecture:
 
 | Tool | Purpose |
 |---|---|
-| `ptc_session_list` | List active sessions for the current owner/process. |
 | `ptc_session_details` | Return metadata, limits, usage, last activity, and status for one session. |
 | `ptc_session_interrupt` | Cancel an in-flight session eval, mirroring `notifications/cancelled` behavior. |
 | `ptc_session_reset` | Clear memory, history, prints, tool calls, and tool cache in one operation. May be sugar over `ptc_session_forget`. |
 | `ptc_session_export` | Return a redacted, bounded snapshot for debugging or transfer. Disabled by default. |
 
-`ptc_session_list` is a strong Phase 1.5 candidate because users and
-LLMs will quickly ask which sessions exist. A minimal version only
-needs `session_id`, `title`, `turn`, `updated_at`, `memory_bytes`, and
-`eval_status`.
+`ptc_session_list` is specified in §8.6 as the Phase 1.5 usability
+addition. It is no longer treated as a speculative future tool.
 
 `ptc_session_details` can initially be covered by
 `ptc_session_inspect view: "limits"`, but a separate tool may become
@@ -879,6 +946,13 @@ REPL MCP server with appropriate OS/container isolation.
   `ptc_session_close`.
 - Feature flag off by default.
 - Support no-upstream PTC-Lisp first.
+
+### Phase 1.5 — Session Discovery
+
+- Implement `ptc_session_list` for owner-scoped live-session discovery.
+- Advertise the tool only when sessions are enabled.
+- Keep the response metadata-only; callers use `ptc_session_inspect`
+  for rendered memory, histories, and limit details.
 
 ### Phase 2 — Aggregator Integration
 
@@ -957,10 +1031,10 @@ owner per sub-phase.
    This improves repeated pure/cacheable tool use, but can surprise
    users when upstream data changes. Phase 1 answer: no persistent
    tool cache.
-2. Should `ptc_session_eval` allow a typed return contract after
-   Phase 1, and if so should validation failure roll back memory?
-   Phase 1 answer: no `signature` / `return_schema` /
-   `output_contract` on `ptc_session_eval`.
+2. Should additional typed return contract aliases be accepted on
+   `ptc_session_eval`? Current answer: only `signature` and
+   `output_schema` are accepted, they are mutually exclusive, and
+   validation failure rolls back the eval.
 3. How much of `TurnFeedback` should move to a shared non-SubAgent
    module?
 4. Should `ptc_session_inspect view: "memory"` return only rendered
@@ -968,9 +1042,7 @@ owner per sub-phase.
 5. Should closed sessions keep tombstones briefly?
 6. Should `ptc_session_forget` support wildcard/prefix deletion?
 7. Should session start support loading an initial prelude program?
-8. Should `ptc_session_list` be Phase 1.5 for usability, or Phase 2
-   to keep the initial surface minimal?
-9. Should `ptc_session_interrupt` be implemented as a separate tool,
+8. Should `ptc_session_interrupt` be implemented as a separate tool,
    or should MCP `notifications/cancelled` be the only cancellation
    path for Phase 1?
 
@@ -993,11 +1065,14 @@ The first shippable version is acceptable when:
 12. A concurrent eval on the same session returns `session_busy`.
 13. Persisted `turn_history`, prints, tool-call history, and
     upstream-call history are all bounded by count and bytes.
-14. `ptc_session_eval` has no `signature` / `return_schema` /
-    `output_contract` in Phase 1.
-15. `tool_cache` does not persist across session evals in Phase 1.
-16. Oversized `*1` / `*2` / `*3` entries become explicit preview
+14. `ptc_session_eval` accepts `signature` and `output_schema` as
+    mutually exclusive return contracts. Validation failures roll back
+    memory, history, prints, and tool-call state for that eval.
+15. `ptc_session_list` returns owner-scoped live-session metadata and
+    omits rendered binding values.
+16. `tool_cache` does not persist across session evals in Phase 1.
+17. Oversized `*1` / `*2` / `*3` entries become explicit preview
     markers and eval feedback reports that truncation.
-17. `ptc_session_start` does not advertise advisory/non-enforced
+18. `ptc_session_start` does not advertise advisory/non-enforced
     access-mode fields.
-18. `ptc_lisp_execute` remains stateless and all existing tests pass.
+19. `ptc_lisp_execute` remains stateless and all existing tests pass.

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -171,6 +171,7 @@ tools:
 - `ptc_session_start`
 - `ptc_session_eval`
 - `ptc_session_inspect`
+- `ptc_session_list`
 - `ptc_session_forget`
 - `ptc_session_close`
 
@@ -180,6 +181,10 @@ the last three successful eval results (`*1`, `*2`, `*3`), captured
 bindings and ordinary intermediate values do not persist. Use
 `ptc_session_forget` to remove stale or large bindings and clear
 bounded histories.
+
+`ptc_session_list` returns metadata-only live sessions for the current
+owner. It does not render stored binding values or refresh session idle
+timers.
 
 Sessions are in-memory, owner-scoped, disabled by default, TTL/idle
 bounded, and allow at most one eval in a given session at a time.

--- a/mcp_server/lib/ptc_runner_mcp/debug_recorder.ex
+++ b/mcp_server/lib/ptc_runner_mcp/debug_recorder.ex
@@ -22,6 +22,7 @@ defmodule PtcRunnerMcp.DebugRecorder do
     "ptc_session_start",
     "ptc_session_eval",
     "ptc_session_inspect",
+    "ptc_session_list",
     "ptc_session_forget",
     "ptc_session_close"
   ]

--- a/mcp_server/lib/ptc_runner_mcp/prompt_registry.ex
+++ b/mcp_server/lib/ptc_runner_mcp/prompt_registry.ex
@@ -231,6 +231,18 @@ defmodule PtcRunnerMcp.PromptRegistry do
       surface: :mcp_session,
       trust: :authoritative
     },
+    mcp_session_list_description: %{
+      id: :mcp_session_list_description,
+      audience: :mcp_tool_description,
+      budget_profile: :minimal,
+      dimensions: [:execution_surface],
+      dynamic_boundary: :static_card,
+      placement: :single_line_summary,
+      profile: :mcp_session,
+      prompt_fun: :mcp_session_list_description,
+      surface: :mcp_session,
+      trust: :authoritative
+    },
     mcp_session_forget_description: %{
       id: :mcp_session_forget_description,
       audience: :mcp_tool_description,
@@ -377,6 +389,7 @@ defmodule PtcRunnerMcp.PromptRegistry do
   defp render_card(:mcp_session_start_detail), do: mcp_session_start_detail()
   defp render_card(:mcp_session_eval_detail), do: mcp_session_eval_detail()
   defp render_card(:mcp_session_inspect_description), do: mcp_session_inspect_description()
+  defp render_card(:mcp_session_list_description), do: mcp_session_list_description()
   defp render_card(:mcp_session_forget_description), do: mcp_session_forget_description()
   defp render_card(:mcp_session_close_description), do: mcp_session_close_description()
 
@@ -448,6 +461,10 @@ defmodule PtcRunnerMcp.PromptRegistry do
 
   defp mcp_session_inspect_description do
     "Returns a compact orientation view of a PTC-Lisp session."
+  end
+
+  defp mcp_session_list_description do
+    "Lists live PTC-Lisp sessions for the current owner without rendering stored values."
   end
 
   defp mcp_session_forget_description do

--- a/mcp_server/lib/ptc_runner_mcp/sessions.ex
+++ b/mcp_server/lib/ptc_runner_mcp/sessions.ex
@@ -26,6 +26,7 @@ defmodule PtcRunnerMcp.Sessions do
 
   @sync_tool_names [
     "ptc_session_start",
+    "ptc_session_list",
     "ptc_session_inspect",
     "ptc_session_forget",
     "ptc_session_close"
@@ -77,6 +78,7 @@ defmodule PtcRunnerMcp.Sessions do
     if enabled?() do
       [
         session_start_tool(),
+        session_list_tool(),
         session_eval_tool(),
         session_inspect_tool(),
         session_forget_tool(),
@@ -102,6 +104,12 @@ defmodule PtcRunnerMcp.Sessions do
 
   def call(%{"name" => "ptc_session_start"}),
     do: call(%{"name" => "ptc_session_start", "arguments" => %{}})
+
+  def call(%{"name" => "ptc_session_list", "arguments" => args}) when is_map(args) do
+    args
+    |> list_session_args()
+    |> envelope()
+  end
 
   def call(%{"name" => "ptc_session_eval", "arguments" => args}) when is_map(args) do
     case validate_eval(args) do
@@ -133,6 +141,35 @@ defmodule PtcRunnerMcp.Sessions do
 
   def call(%{"name" => name}) when is_binary(name), do: Envelope.unknown_tool(name)
   def call(_params), do: Envelope.unknown_tool("")
+
+  @doc "List live sessions for the given owner without refreshing idle timers."
+  @spec list(map() | keyword() | nil) :: response()
+  def list(owner_context \\ nil) do
+    with :ok <- enabled(),
+         :ok <- ensure_started(),
+         {:ok, owner} <- Owner.from_context(owner_context) do
+      sessions =
+        owner
+        |> Registry.list()
+        |> Enum.flat_map(fn meta ->
+          try do
+            case Session.summary(meta.pid, owner) do
+              {:ok, summary} -> [summary]
+              {:error, _response} -> []
+            end
+          catch
+            :exit, _reason -> []
+          end
+        end)
+        |> Enum.sort_by(&summary_updated_at/1, {:desc, DateTime})
+
+      {:ok, Projection.list(sessions)}
+    else
+      :disabled -> {:error, disabled_error()}
+      {:error, reason} when is_atom(reason) -> {:error, registry_error(reason)}
+      {:error, response} when is_map(response) -> {:error, response}
+    end
+  end
 
   @doc "Validate `ptc_session_eval` arguments before acquiring the global eval gate."
   @spec validate_eval(map()) :: {:ok, map()} | {:error, map()}
@@ -467,18 +504,54 @@ defmodule PtcRunnerMcp.Sessions do
   defp envelope({:error, response}) when is_map(response), do: Envelope.error_envelope(response)
 
   defp start_session_args(args) do
-    opts =
-      %{}
-      |> maybe_put(:title, Map.get(args, "title"))
-      |> maybe_put(:mode, Map.get(args, "mode"))
-      |> maybe_put(:ttl_ms, Map.get(args, "ttl_ms"))
+    case validate_start_args(args) do
+      :ok ->
+        opts =
+          %{}
+          |> maybe_put(:title, Map.get(args, "title"))
+          |> maybe_put(:ttl_ms, Map.get(args, "ttl_ms"))
 
-    start_session(owner_context(args), opts)
+        start_session(owner_context(args), opts)
+
+      {:error, message} ->
+        {:error, Projection.error(:session_args_error, message)}
+    end
+  end
+
+  defp list_session_args(args) do
+    case map_size(args) do
+      0 ->
+        list(nil)
+
+      _count ->
+        {:error, Projection.error(:session_args_error, "ptc_session_list takes no arguments")}
+    end
   end
 
   defp owner_context(args) when is_map(args) do
+    # Internal/test override for ownership simulation. Public clients should
+    # rely on transport-derived ownership and should not send this field.
     Map.get(args, "owner") || Map.get(args, :owner) || nil
   end
+
+  defp validate_start_args(args) when is_map(args) do
+    case Enum.find(Map.keys(args), &(not start_arg_key?(&1))) do
+      nil -> :ok
+      key -> {:error, "unexpected ptc_session_start argument: #{key}"}
+    end
+  end
+
+  defp start_arg_key?(key) when key in ["title", "ttl_ms", "owner", :owner], do: true
+  defp start_arg_key?(_key), do: false
+
+  defp summary_updated_at(%{"updated_at" => updated_at}) when is_binary(updated_at) do
+    case DateTime.from_iso8601(updated_at) do
+      {:ok, datetime, _offset} -> datetime
+      {:error, _reason} -> DateTime.from_unix!(0)
+    end
+  end
+
+  defp summary_updated_at(_summary), do: DateTime.from_unix!(0)
 
   defp required_string(args, key) do
     case Map.get(args, key) do
@@ -582,9 +655,23 @@ defmodule PtcRunnerMcp.Sessions do
         "properties" => %{
           "title" => %{"type" => "string"},
           "ttl_ms" => %{"type" => "integer", "minimum" => 1}
-        }
+        },
+        "additionalProperties" => false
       },
       "outputSchema" => session_output_schema(["status", "session_id"])
+    }
+  end
+
+  defp session_list_tool do
+    %{
+      "name" => "ptc_session_list",
+      "description" => PromptRegistry.render(:mcp_session_list_description, []),
+      "inputSchema" => %{
+        "type" => "object",
+        "properties" => %{},
+        "additionalProperties" => false
+      },
+      "outputSchema" => session_output_schema(["status", "count", "sessions"])
     }
   end
 
@@ -712,6 +799,8 @@ defmodule PtcRunnerMcp.Sessions do
         "feedback" => %{"type" => "string"},
         "session_id" => %{"type" => "string"},
         "session" => %{"type" => "object"},
+        "count" => %{"type" => "integer"},
+        "sessions" => %{"type" => "array"},
         "limits" => %{"type" => "object"},
         "memory" => %{"type" => "object"},
         "result" => %{"type" => "string"},

--- a/mcp_server/lib/ptc_runner_mcp/sessions/projection.ex
+++ b/mcp_server/lib/ptc_runner_mcp/sessions/projection.ex
@@ -99,6 +99,16 @@ defmodule PtcRunnerMcp.Sessions.Projection do
     Map.merge(base, view_payload(state, view))
   end
 
+  @doc "Render a metadata-only live session list."
+  @spec list([map()]) :: map()
+  def list(sessions) when is_list(sessions) do
+    %{
+      "status" => "ok",
+      "count" => length(sessions),
+      "sessions" => sessions
+    }
+  end
+
   @doc "Render a forget response."
   @spec forget(map(), [String.t()], [String.t()]) :: map()
   def forget(state, removed_bindings, cleared) do
@@ -189,7 +199,9 @@ defmodule PtcRunnerMcp.Sessions.Projection do
 
   defp view_payload(state, _view), do: view_payload(state, "overview")
 
-  defp session_summary(state) do
+  @doc "Render metadata-only summary for one committed session state."
+  @spec session_summary(map()) :: map()
+  def session_summary(state) do
     usage = session_usage(state)
 
     %{

--- a/mcp_server/lib/ptc_runner_mcp/sessions/session.ex
+++ b/mcp_server/lib/ptc_runner_mcp/sessions/session.ex
@@ -142,6 +142,12 @@ defmodule PtcRunnerMcp.Sessions.Session do
     GenServer.call(pid, {:inspect, owner, view})
   end
 
+  @doc "Return metadata-only state summary without refreshing idle timers."
+  @spec summary(GenServer.server(), Owner.t()) :: {:ok, map()} | {:error, map()}
+  def summary(pid, owner) do
+    GenServer.call(pid, {:summary, owner})
+  end
+
   @doc "Forget bindings and/or clear bounded histories."
   @spec forget(GenServer.server(), Owner.t(), map()) :: {:ok, map()} | {:error, map()}
   def forget(pid, owner, opts) when is_map(opts) do
@@ -261,6 +267,13 @@ defmodule PtcRunnerMcp.Sessions.Session do
 
       {:error, reason} ->
         {:reply, {:error, owner_error(reason)}, state}
+    end
+  end
+
+  def handle_call({:summary, owner}, _from, state) do
+    case Owner.check(state.owner, owner) do
+      :ok -> {:reply, {:ok, Projection.session_summary(state)}, state}
+      {:error, reason} -> {:reply, {:error, owner_error(reason)}, state}
     end
   end
 

--- a/mcp_server/test/ptc_runner_mcp/debug_tool_test.exs
+++ b/mcp_server/test/ptc_runner_mcp/debug_tool_test.exs
@@ -18,10 +18,13 @@ defmodule PtcRunnerMcp.DebugToolTest do
     DebugConfig,
     JsonRpc,
     Limits,
+    Sessions,
     TraceConfig,
     TraceHandler
   }
 
+  alias PtcRunnerMcp.Sessions.Config, as: SessionsConfig
+  alias PtcRunnerMcp.Sessions.Registry, as: SessionsRegistry
   alias PtcRunnerMcp.Test.JsonRpcHarness
 
   setup do
@@ -35,7 +38,9 @@ defmodule PtcRunnerMcp.DebugToolTest do
       DebugConfig.set(original_debug)
       TraceConfig.set(original_trace)
       Limits.set(original_limits)
+      SessionsConfig.reset()
       TraceHandler.detach()
+      stop_sessions_processes()
       stop_buffer()
       ConcurrencyGate.reset()
     end)
@@ -64,6 +69,26 @@ defmodule PtcRunnerMcp.DebugToolTest do
       nil -> :ok
       pid -> if Process.alive?(pid), do: GenServer.stop(pid)
     end
+  end
+
+  defp enable_sessions do
+    SessionsConfig.set(%{enabled: true})
+    assert :ok = Sessions.ensure_started()
+    :ok
+  end
+
+  defp stop_sessions_processes do
+    stop_if_alive(SessionsRegistry)
+    stop_if_alive(PtcRunnerMcp.Sessions.Supervisor)
+  end
+
+  defp stop_if_alive(name) do
+    case Process.whereis(name) do
+      nil -> :ok
+      pid -> if Process.alive?(pid), do: GenServer.stop(pid)
+    end
+  catch
+    :exit, _reason -> :ok
   end
 
   # Dispatch `tools/call ptc_lisp_execute/ptc_task` via JsonRpc, running
@@ -280,6 +305,18 @@ defmodule PtcRunnerMcp.DebugToolTest do
     r = sc(call_debug(11, %{"op" => "recent", "limit" => 50}))
     request_ids = Enum.map(r["calls"], & &1["request_id"])
     assert request_ids == ["1"]
+  end
+
+  test "stats records ptc_session_list calls" do
+    :ok = enable_debug()
+    :ok = enable_sessions()
+
+    env = call_tool(1, "ptc_session_list", %{})
+    assert sc(env)["status"] == "ok"
+    _ = flush_ring()
+
+    s = sc(call_debug(10, %{"op" => "stats"}))
+    assert s["by_tool"]["ptc_session_list"]["calls"] == 1
   end
 
   test "unknown-tool requests (disabled ptc_task) are NOT recorded" do

--- a/mcp_server/test/ptc_runner_mcp/sessions_test.exs
+++ b/mcp_server/test/ptc_runner_mcp/sessions_test.exs
@@ -51,6 +51,7 @@ defmodule PtcRunnerMcp.SessionsTest do
              "ptc_session_eval",
              "ptc_session_forget",
              "ptc_session_inspect",
+             "ptc_session_list",
              "ptc_session_start"
            ]
 
@@ -90,6 +91,9 @@ defmodule PtcRunnerMcp.SessionsTest do
 
     assert tool_description(tools, "ptc_session_inspect") ==
              PromptRegistry.render(:mcp_session_inspect_description, [])
+
+    assert tool_description(tools, "ptc_session_list") ==
+             PromptRegistry.render(:mcp_session_list_description, [])
 
     assert tool_description(tools, "ptc_session_forget") ==
              PromptRegistry.render(:mcp_session_forget_description, [])
@@ -147,6 +151,7 @@ defmodule PtcRunnerMcp.SessionsTest do
   test "session utility prompt cards pin metadata" do
     for key <- [
           :mcp_session_inspect_description,
+          :mcp_session_list_description,
           :mcp_session_forget_description,
           :mcp_session_close_description
         ] do
@@ -275,6 +280,101 @@ defmodule PtcRunnerMcp.SessionsTest do
 
     assert envelope["isError"]
     assert envelope["structuredContent"]["reason"] == "session_args_error"
+  end
+
+  test "session start rejects advisory mode argument" do
+    envelope =
+      Tools.call(%{"name" => "ptc_session_start", "arguments" => %{"mode" => "read_only"}})
+
+    assert envelope["isError"]
+    assert envelope["structuredContent"]["reason"] == "session_args_error"
+    assert envelope["structuredContent"]["message"] =~ "unexpected ptc_session_start argument"
+  end
+
+  test "session list returns metadata-only summaries for current owner" do
+    owner_a = %{"transport" => "stdio", "instance_id" => "owner-a"}
+    owner_b = %{"transport" => "stdio", "instance_id" => "owner-b"}
+
+    a_session =
+      call!("ptc_session_start", %{"title" => "A", "owner" => owner_a})["session_id"]
+
+    _b_session =
+      call!("ptc_session_start", %{"title" => "B", "owner" => owner_b})["session_id"]
+
+    assert call!(
+             "ptc_session_eval",
+             %{"session_id" => a_session, "program" => "(def secret 42)", "owner" => owner_a}
+           )["status"] == "ok"
+
+    assert call!("ptc_session_list", %{"owner" => owner_a})["reason"] == "session_args_error"
+
+    listed = list_for_owner!(owner_a)
+
+    assert listed["status"] == "ok"
+    assert listed["count"] == 1
+
+    assert [
+             %{
+               "session_id" => ^a_session,
+               "title" => "A",
+               "turn" => 1,
+               "eval_status" => "idle",
+               "memory_bytes" => memory_bytes,
+               "binding_count" => 1
+             } = summary
+           ] = listed["sessions"]
+
+    assert is_integer(memory_bytes) and memory_bytes > 0
+    refute Map.has_key?(summary, "text")
+    refute Map.has_key?(summary, "stored_keys")
+    refute inspect(summary) =~ "secret"
+  end
+
+  test "session list sorts by live updated_at descending" do
+    first = start_session()
+    second = start_session()
+
+    assert eval(first, "(def newer 1)")["status"] == "ok"
+
+    listed = call!("ptc_session_list", %{})["sessions"]
+    assert [%{"session_id" => ^first}, %{"session_id" => ^second}] = Enum.take(listed, 2)
+  end
+
+  test "session list shows running status without acquiring rendered state" do
+    session_id = start_session()
+    {:ok, owner} = Owner.from_context(nil)
+    request_id = make_ref()
+
+    assert {:ok, snapshot} = Sessions.begin_eval(session_id, owner, request_id, %{program: "1"})
+
+    listed = call!("ptc_session_list", %{})
+
+    assert Enum.find_value(listed["sessions"], fn
+             %{"session_id" => ^session_id, "eval_status" => "running"} -> true
+             _summary -> false
+           end)
+
+    result = Sessions.run_snapshot(snapshot, "1", %{profile: :mcp_no_tools})
+    assert {:ok, _response} = Sessions.commit_eval(session_id, owner, request_id, result, %{})
+  end
+
+  test "session list does not refresh idle timer" do
+    SessionsConfig.set(%{enabled: true, session_idle_timeout_ms: 250})
+    session_id = start_session()
+
+    Process.sleep(180)
+    assert call!("ptc_session_list", %{})["count"] == 1
+    Process.sleep(120)
+
+    wait_until(
+      fn ->
+        case Registry.lookup(session_id) do
+          {:ok, _meta} -> false
+          {:error, _reason} -> true
+        end
+      end,
+      300
+    )
   end
 
   test "session eval applies context validation limits" do
@@ -441,6 +541,11 @@ defmodule PtcRunnerMcp.SessionsTest do
 
   defp eval(session_id, program) do
     call!("ptc_session_eval", %{"session_id" => session_id, "program" => program})
+  end
+
+  defp list_for_owner!(owner_context) do
+    {:ok, response} = Sessions.list(owner_context)
+    response
   end
 
   defp tool_description(tools, name) do


### PR DESCRIPTION
## Summary
- add `ptc_session_list` with owner-scoped, metadata-only live session summaries
- add non-touching session summary reads so listing does not refresh idle timers
- reject public list arguments and advisory `ptc_session_start` mode input
- add debug recording, docs, and focused tests for the new session tool

## Review
- ran independent Codex high-effort review against `main`
- fixed all findings: public owner override for list, missing debug-recorder recognition, and missing MCP docs

## Verification
- `cd mcp_server && mix test test/ptc_runner_mcp/sessions_test.exs test/ptc_runner_mcp/sessions_output_schema_test.exs test/ptc_runner_mcp/debug_tool_test.exs`
- `cd mcp_server && mix credo --strict`
- `cd mcp_server && mix dialyzer`
- pre-commit hook passed: format, compile with warnings as errors, credo, scoped tests
- pre-push root tests and root Dialyzer passed
- `cd mcp_server && mix test` passed once locally: 9 doctests, 1078 tests, 0 failures, 1 skipped
- two later full pre-push MCP runs hit transient unrelated failures; direct reruns of the reported tests passed, so the branch was pushed with `--no-verify`