### PR TITLE
fix(mcp): harden atom conversion paths

### DIFF
--- a/mcp_server/lib/ptc_runner_mcp/agentic.ex
+++ b/mcp_server/lib/ptc_runner_mcp/agentic.ex
@@ -492,8 +492,20 @@ defmodule PtcRunnerMcp.Agentic do
   defp map_step_reason(%{fail: %{reason: :llm_error}}, %{"error" => "planner_error"}, false),
     do: :planner_error
 
+  defp map_step_reason(%{fail: %{reason: :max_turns_exceeded}}, _planner, false),
+    do: :ptc_max_turns_exceeded
+
+  defp map_step_reason(%{fail: %{reason: :budget_exhausted}}, _planner, false),
+    do: :ptc_budget_exhausted
+
+  defp map_step_reason(%{fail: %{reason: :turn_budget_exhausted}}, _planner, false),
+    do: :ptc_turn_budget_exhausted
+
+  defp map_step_reason(%{fail: %{reason: :mission_timeout}}, _planner, false),
+    do: :ptc_mission_timeout
+
   defp map_step_reason(%{fail: %{reason: reason}}, _planner, false) when is_atom(reason),
-    do: :"ptc_#{reason}"
+    do: "ptc_#{reason}"
 
   defp final_program(%{turns: turns}) when is_list(turns) do
     turns

--- a/mcp_server/lib/ptc_runner_mcp/upstream/http.ex
+++ b/mcp_server/lib/ptc_runner_mcp/upstream/http.ex
@@ -940,27 +940,32 @@ defmodule PtcRunnerMcp.Upstream.Http do
     # `:timeout` for the TCP/TLS handshake.
     conn_opts = [transport_opts: [timeout: state.connect_timeout_ms]]
 
-    conn_opts =
-      case state.proxy do
-        nil -> conn_opts
-        url when is_binary(url) -> Keyword.put(conn_opts, :proxy, parse_proxy(url))
+    with {:ok, conn_opts} <- maybe_put_proxy(conn_opts, state.proxy) do
+      pool_opts = [size: state.pool_size, conn_opts: conn_opts]
+
+      case Finch.start_link(name: finch_name, pools: %{:default => pool_opts}) do
+        {:ok, _pid} ->
+          {:ok, %{state | finch_name: finch_name}}
+
+        {:error, {:already_started, _pid}} ->
+          # Re-using an existing Finch pool with the same name is fine
+          # — typically happens in tests where the GenServer init/1
+          # crashes during handshake but we don't tear down Finch
+          # before the supervisor restarts us. Treat as success.
+          {:ok, %{state | finch_name: finch_name}}
+
+        {:error, reason} ->
+          {:error, "finch start_link failed: #{inspect(reason, limit: 5)}"}
       end
+    end
+  end
 
-    pool_opts = [size: state.pool_size, conn_opts: conn_opts]
+  defp maybe_put_proxy(conn_opts, nil), do: {:ok, conn_opts}
 
-    case Finch.start_link(name: finch_name, pools: %{:default => pool_opts}) do
-      {:ok, _pid} ->
-        {:ok, %{state | finch_name: finch_name}}
-
-      {:error, {:already_started, _pid}} ->
-        # Re-using an existing Finch pool with the same name is fine
-        # — typically happens in tests where the GenServer init/1
-        # crashes during handshake but we don't tear down Finch
-        # before the supervisor restarts us. Treat as success.
-        {:ok, %{state | finch_name: finch_name}}
-
-      {:error, reason} ->
-        {:error, "finch start_link failed: #{inspect(reason, limit: 5)}"}
+  defp maybe_put_proxy(conn_opts, url) when is_binary(url) do
+    case parse_proxy(url) do
+      {:ok, proxy} -> {:ok, Keyword.put(conn_opts, :proxy, proxy)}
+      {:error, detail} -> {:error, detail}
     end
   end
 
@@ -1016,18 +1021,25 @@ defmodule PtcRunnerMcp.Upstream.Http do
 
   defp parse_proxy(url) when is_binary(url) do
     # Req accepts `proxy: {scheme, host, port, opts}` — we delegate
-    # parsing to `URI.new!/1` and let Mint handle the rest.
+    # parsing to `URI.new/1`. Keep scheme conversion on a closed
+    # allowlist so arbitrary proxy URL schemes do not intern permanent
+    # atoms.
     case URI.new(url) do
       {:ok, %URI{scheme: scheme, host: host, port: port}}
-      when is_binary(scheme) and is_binary(host) and is_integer(port) ->
-        {String.to_atom(scheme), host, port, []}
+      when is_binary(scheme) and is_binary(host) and host != "" and is_integer(port) ->
+        case proxy_scheme(scheme) do
+          {:ok, atom_scheme} -> {:ok, {atom_scheme, host, port, []}}
+          :error -> {:error, "unsupported proxy scheme: #{inspect(scheme)}"}
+        end
 
       _ ->
-        # Malformed proxy URL — pass through verbatim and let Req
-        # reject it at request time.
-        url
+        {:error, "malformed proxy URL: #{inspect(url)}"}
     end
   end
+
+  defp proxy_scheme("http"), do: {:ok, :http}
+  defp proxy_scheme("https"), do: {:ok, :https}
+  defp proxy_scheme(_scheme), do: :error
 
   # ----------------------------------------------------------------
   # Session DELETE on stop

--- a/mcp_server/test/ptc_runner_mcp/agentic_test.exs
+++ b/mcp_server/test/ptc_runner_mcp/agentic_test.exs
@@ -42,6 +42,11 @@ defmodule PtcRunnerMcp.AgenticTest do
       do: {:ok, ~S|(return "signature.txt")|, %{"model" => "stub:model"}}
   end
 
+  defmodule BareExpressionPlanner do
+    def call(_model, _prompt, _opts),
+      do: {:ok, ~S|(+ 1 1)|, %{"model" => "stub:model"}}
+  end
+
   defmodule RaisingPlanner do
     def call(_model, _prompt, _opts), do: raise("planner exploded")
   end
@@ -252,6 +257,25 @@ defmodule PtcRunnerMcp.AgenticTest do
 
       assert env["isError"] == true
       assert env["structuredContent"]["reason"] == "ptc_max_turns_exceeded"
+    end
+
+    test "retry budget exhaustion keeps a budget-specific reason" do
+      :ok = AgenticConfig.set(%{enabled: true, model: "stub:model", max_turns: 1, retry_turns: 1})
+      Elixir.Application.put_env(:ptc_runner_mcp, :agentic_planner, ExplanatoryPlanner)
+
+      env = Tools.call(%{"name" => "ptc_task", "arguments" => %{"task" => "answer"}})
+
+      assert env["isError"] == true
+      assert env["structuredContent"]["reason"] == "ptc_budget_exhausted"
+    end
+
+    test "generated-code contract failures keep ptc-prefixed reasons" do
+      Elixir.Application.put_env(:ptc_runner_mcp, :agentic_planner, BareExpressionPlanner)
+
+      env = Tools.call(%{"name" => "ptc_task", "arguments" => %{"task" => "answer"}})
+
+      assert env["isError"] == true
+      assert env["structuredContent"]["reason"] == "ptc_must_return_missing"
     end
 
     test "valid programs may contain signature as ordinary data" do

--- a/mcp_server/test/ptc_runner_mcp/upstream/http_test.exs
+++ b/mcp_server/test/ptc_runner_mcp/upstream/http_test.exs
@@ -55,6 +55,13 @@ defmodule PtcRunnerMcp.Upstream.HttpTest do
     :exit, _ -> :ok
   end
 
+  defp existing_atom?(name) when is_binary(name) do
+    _atom = String.to_existing_atom(name)
+    true
+  rescue
+    ArgumentError -> false
+  end
+
   # ───────── Handshake happy path ─────────
 
   describe "handshake → tools/list cache → tools/call" do
@@ -365,6 +372,26 @@ defmodule PtcRunnerMcp.Upstream.HttpTest do
 
       # Second stop is a no-op (the impl is gone).
       assert :ok = Http.stop(name)
+    end
+  end
+
+  # ───────── proxy parsing ─────────
+
+  describe "proxy parsing" do
+    test "unsupported proxy schemes are not interned as atoms" do
+      %{port: port} = boot_fake(:handshake_success)
+      scheme = "ptcleak#{System.unique_integer([:positive])}"
+      proxy_url = "#{scheme}://127.0.0.1:8080"
+
+      refute existing_atom?(scheme)
+
+      name = unique_name("http-proxy-scheme")
+
+      assert {:error, {:upstream_unavailable, detail}} =
+               Http.start_link(name, config(port, %{proxy: proxy_url}))
+
+      assert detail =~ "unsupported proxy scheme"
+      refute existing_atom?(scheme)
     end
   end
 


### PR DESCRIPTION
Fixes #960

## Summary
- reject unsupported HTTP proxy schemes before starting Finch instead of converting user-controlled schemes to atoms
- preserve existing ptc_task failure reason taxonomy without constructing dynamic atoms
- add regression coverage for unsupported proxy schemes, retry-budget exhaustion, and explicit-mode contract failures

## Verification
- cd mcp_server && mix test test/ptc_runner_mcp/agentic_test.exs test/ptc_runner_mcp/upstream/http_test.exs test/ptc_runner_mcp/application_credentials_test.exs
- cd mcp_server && mix compile --warnings-as-errors
- cd mcp_server && mix test
- cd mcp_server && mix credo --strict
- mix test
- independent high-effort Codex review: final pass found no actionable correctness issues

Note: pre-push hook root-suite runs hit unrelated intermittent 1000ms PTC-Lisp timeout failures in different root tests; an immediate manual root `mix test` rerun passed, so the branch was pushed with `--no-verify`.