### PR TITLE
perf(lisp): avoid builtin scan during closure capture

### DIFF
--- a/lib/ptc_runner/lisp/eval.ex
+++ b/lib/ptc_runner/lisp/eval.ex
@@ -1460,12 +1460,11 @@ defmodule PtcRunner.Lisp.Eval do
     # call time via the Env.builtin? fallback in (:var ...). This is the
     # whole point of the optimization — each closure would otherwise drag
     # the full ~18 KB builtin map (and every unused sibling binding) around.
-    keep? = fn key ->
-      MapSet.member?(referenced, to_string(key)) and
-        (MapSet.member?(locals, key) or not Map.has_key?(initial, key))
-    end
-
-    captured_env = :maps.filter(fn key, _value -> keep?.(key) end, env)
+    captured_env =
+      referenced
+      |> Enum.reduce(%{}, fn name, acc ->
+        capture_referenced_binding(name, env, locals, initial, acc)
+      end)
 
     # Narrow `locals` (stored in meta as `:captured_locals`) to the same
     # referenced set so it stays consistent with `captured_env` — every
@@ -1473,11 +1472,32 @@ defmodule PtcRunner.Lisp.Eval do
     # include caller-injected env keys: promoting them would invert the
     # documented precedence (locals > user_ns > env).
     captured_locals =
-      locals
-      |> Enum.filter(&MapSet.member?(referenced, to_string(&1)))
+      captured_env
+      |> Map.keys()
+      |> Enum.filter(&MapSet.member?(locals, &1))
       |> MapSet.new()
 
     {captured_env, captured_locals}
+  end
+
+  defp capture_referenced_binding(name, env, locals, initial, acc) do
+    name
+    |> referenced_env_keys()
+    |> Enum.reduce(acc, fn key, inner_acc ->
+      with {:ok, value} <- Map.fetch(env, key),
+           true <- MapSet.member?(locals, key) or not Map.has_key?(initial, key) do
+        Map.put(inner_acc, key, value)
+      else
+        _ -> inner_acc
+      end
+    end)
+  end
+
+  defp referenced_env_keys(name) when is_binary(name) do
+    case safe_to_existing_atom(name) do
+      {:ok, atom} -> [name, atom]
+      :error -> [name]
+    end
   end
 
   # Collects the free `{:var, _}` names in a CoreAST subtree, normalized to

--- a/test/ptc_runner/lisp/closure_capture_test.exs
+++ b/test/ptc_runner/lisp/closure_capture_test.exs
@@ -177,6 +177,21 @@ defmodule PtcRunner.Lisp.ClosureCaptureTest do
       assert {:ok, :from_user_ns, ^user_ns} =
                Eval.eval(ast, %{}, user_ns, env, fn _, _ -> nil end)
     end
+
+    test "caller-injected env entries are captured for string and atom keys" do
+      alias PtcRunner.Lisp.Eval
+
+      string_ast = {:call, {:fn, [], {:var, "external"}}, []}
+      atom_ast = {:call, {:fn, [], {:var, :external}}, []}
+
+      assert {:ok, :from_string_env, %{}} =
+               Eval.eval(string_ast, %{}, %{}, %{"external" => :from_string_env}, fn _, _ ->
+                 nil
+               end)
+
+      assert {:ok, :from_atom_env, %{}} =
+               Eval.eval(atom_ast, %{}, %{}, %{external: :from_atom_env}, fn _, _ -> nil end)
+    end
   end
 
   describe "memory footprint" do


### PR DESCRIPTION
## Summary\n- Fixes #967 by walking the small referenced-var set when capturing closure env entries instead of filtering/stringifying the full env.\n- Preserves lexical local shadowing, builtin fallback behavior, and caller-injected env capture for both string and atom keys.\n- Adds regression coverage for caller-injected env key capture.\n\n## Verification\n- mix test test/ptc_runner/lisp/closure_capture_test.exs\n- mix test test/ptc_runner/lisp/sci_conformance_test.exs test/ptc_runner/lisp/lisp_integration_test.exs --max-failures 1\n- mix test --max-failures 1\n- mix run bench/lisp_throughput.exs\n- mix run bench/lisp_profile.exs\n- pre-push hook passed: root tests + dialyzer, mcp_server tests + dialyzer, ptc_viewer tests\n\n## Review\n- Independent high-effort Codex review run twice; final review found no material issues.\n\n## Benchmark Notes\n- collection HOFs: ~17.61K ips\n- closure + apply: ~25.73K ips\n- tprof shows closure capture no longer scans the full builtin map per closure.