### PR TITLE
fix: resolve quick-fix review issues

### DIFF
--- a/lib/ptc_runner/lisp/closure_capture.ex
+++ b/lib/ptc_runner/lisp/closure_capture.ex
@@ -1,0 +1,126 @@
+defmodule PtcRunner.Lisp.ClosureCapture do
+  @moduledoc """
+  Scope-aware helpers for determining which names a closure body references.
+  """
+
+  alias PtcRunner.Lisp.CoreAST
+
+  # Collects the free `{:var, _}` names in a CoreAST subtree, normalized to
+  # strings. Known binding forms are handled with their lexical scope; any
+  # unrecognized tuple/list/map is still recursed into so a future AST node
+  # cannot silently cause a referenced var to be missed.
+  @spec referenced_vars(term(), CoreAST.fn_params(), [CoreAST.name()]) :: MapSet.t(String.t())
+  def referenced_vars(ast, params, extra_bound_names \\ []) do
+    initial_bound =
+      params
+      |> bound_names_from_params()
+      |> MapSet.union(normalize_name_set(extra_bound_names))
+
+    collect_free_var_refs(ast, MapSet.new(), initial_bound)
+  end
+
+  defp collect_free_var_refs({:var, name}, acc, bound) do
+    name = to_string(name)
+
+    if MapSet.member?(bound, name) do
+      acc
+    else
+      MapSet.put(acc, name)
+    end
+  end
+
+  defp collect_free_var_refs({:let, bindings, body}, acc, bound) do
+    collect_free_refs_in_bindings(bindings, body, acc, bound)
+  end
+
+  defp collect_free_var_refs({:loop, bindings, body}, acc, bound) do
+    collect_free_refs_in_bindings(bindings, body, acc, bound)
+  end
+
+  defp collect_free_var_refs({:fn, params, body}, acc, bound) do
+    collect_free_var_refs(body, acc, MapSet.union(bound, bound_names_from_params(params)))
+  end
+
+  defp collect_free_var_refs({:fn, name, params, body}, acc, bound) do
+    inner_bound =
+      bound
+      |> MapSet.union(bound_names_from_params(params))
+      |> MapSet.put(to_string(name))
+
+    collect_free_var_refs(body, acc, inner_bound)
+  end
+
+  defp collect_free_var_refs(tuple, acc, bound) when is_tuple(tuple) do
+    collect_free_var_refs(Tuple.to_list(tuple), acc, bound)
+  end
+
+  defp collect_free_var_refs(list, acc, bound) when is_list(list) do
+    Enum.reduce(list, acc, &collect_free_var_refs(&1, &2, bound))
+  end
+
+  defp collect_free_var_refs(map, acc, bound) when is_map(map) and not is_struct(map) do
+    Enum.reduce(map, acc, fn {k, v}, inner ->
+      v
+      |> collect_free_var_refs(collect_free_var_refs(k, inner, bound), bound)
+    end)
+  end
+
+  defp collect_free_var_refs(_other, acc, _bound), do: acc
+
+  defp collect_free_refs_in_bindings(bindings, body, acc, bound) do
+    {acc, bound} =
+      Enum.reduce(bindings, {acc, bound}, fn {:binding, pattern, value_ast},
+                                             {inner_acc, inner_bound} ->
+        inner_acc = collect_free_var_refs(value_ast, inner_acc, inner_bound)
+        inner_bound = MapSet.union(inner_bound, bound_names_from_pattern(pattern))
+        {inner_acc, inner_bound}
+      end)
+
+    collect_free_var_refs(body, acc, bound)
+  end
+
+  defp bound_names_from_params(params) when is_list(params) do
+    params
+    |> Enum.flat_map(&names_from_pattern/1)
+    |> normalize_name_set()
+  end
+
+  defp bound_names_from_params({:variadic, leading, rest_pattern}) do
+    (Enum.flat_map(leading, &names_from_pattern/1) ++ names_from_pattern(rest_pattern))
+    |> normalize_name_set()
+  end
+
+  defp bound_names_from_pattern(pattern) do
+    pattern
+    |> names_from_pattern()
+    |> normalize_name_set()
+  end
+
+  defp names_from_pattern({:var, name}), do: [name]
+  defp names_from_pattern({:destructure, {:keys, keys, _defaults}}), do: keys
+
+  defp names_from_pattern({:destructure, {:map, keys, renames, _defaults}}) do
+    keys ++
+      Enum.flat_map(renames, fn {target_pattern, _source_key} ->
+        names_from_pattern(target_pattern)
+      end)
+  end
+
+  defp names_from_pattern({:destructure, {:as, name, inner}}),
+    do: [name | names_from_pattern(inner)]
+
+  defp names_from_pattern({:destructure, {:seq, patterns}}),
+    do: Enum.flat_map(patterns, &names_from_pattern/1)
+
+  defp names_from_pattern({:destructure, {:seq_rest, leading, rest}}) do
+    Enum.flat_map(leading, &names_from_pattern/1) ++ names_from_pattern(rest)
+  end
+
+  defp names_from_pattern(_other), do: []
+
+  defp normalize_name_set(names) do
+    names
+    |> Enum.map(&to_string/1)
+    |> MapSet.new()
+  end
+end

--- a/lib/ptc_runner/lisp/eval.ex
+++ b/lib/ptc_runner/lisp/eval.ex
@@ -17,6 +17,7 @@ defmodule PtcRunner.Lisp.Eval do
 
   require Logger
 
+  alias PtcRunner.Lisp.ClosureCapture
   alias PtcRunner.Lisp.CoreAST
   alias PtcRunner.Lisp.Env
   alias PtcRunner.Lisp.Eval.{Apply, Patterns}
@@ -1449,7 +1450,7 @@ defmodule PtcRunner.Lisp.Eval do
     # session's TTL. The collector is scope-aware so params, named-fn self
     # bindings, and inner let/fn/loop bindings don't cause an unrelated outer
     # value with the same name to be captured.
-    referenced = referenced_vars(body, params, extra_bound_names)
+    referenced = ClosureCapture.referenced_vars(body, params, extra_bound_names)
 
     # Keep an entry only if the body references it AND it is EITHER:
     #   * a key in `locals` (let/fn-param, possibly shadowing a builtin like
@@ -1498,125 +1499,6 @@ defmodule PtcRunner.Lisp.Eval do
       {:ok, atom} -> [name, atom]
       :error -> [name]
     end
-  end
-
-  # Collects the free `{:var, _}` names in a CoreAST subtree, normalized to
-  # strings. Known binding forms are handled with their lexical scope; any
-  # unrecognized tuple/list/map is still recursed into so a future AST node
-  # cannot silently cause a referenced var to be missed.
-  @spec referenced_vars(term(), CoreAST.fn_params(), [CoreAST.name()]) :: MapSet.t(String.t())
-  defp referenced_vars(ast, params, extra_bound_names) do
-    initial_bound =
-      params
-      |> bound_names_from_params()
-      |> MapSet.union(normalize_name_set(extra_bound_names))
-
-    collect_free_var_refs(ast, MapSet.new(), initial_bound)
-  end
-
-  defp collect_free_var_refs({:var, name}, acc, bound) do
-    name = to_string(name)
-
-    if MapSet.member?(bound, name) do
-      acc
-    else
-      MapSet.put(acc, name)
-    end
-  end
-
-  defp collect_free_var_refs({:let, bindings, body}, acc, bound) do
-    collect_free_refs_in_bindings(bindings, body, acc, bound)
-  end
-
-  defp collect_free_var_refs({:loop, bindings, body}, acc, bound) do
-    collect_free_refs_in_bindings(bindings, body, acc, bound)
-  end
-
-  defp collect_free_var_refs({:fn, params, body}, acc, bound) do
-    collect_free_var_refs(body, acc, MapSet.union(bound, bound_names_from_params(params)))
-  end
-
-  defp collect_free_var_refs({:fn, name, params, body}, acc, bound) do
-    inner_bound =
-      bound
-      |> MapSet.union(bound_names_from_params(params))
-      |> MapSet.put(to_string(name))
-
-    collect_free_var_refs(body, acc, inner_bound)
-  end
-
-  defp collect_free_var_refs(tuple, acc, bound) when is_tuple(tuple) do
-    collect_free_var_refs(Tuple.to_list(tuple), acc, bound)
-  end
-
-  defp collect_free_var_refs(list, acc, bound) when is_list(list) do
-    Enum.reduce(list, acc, &collect_free_var_refs(&1, &2, bound))
-  end
-
-  defp collect_free_var_refs(map, acc, bound) when is_map(map) and not is_struct(map) do
-    Enum.reduce(map, acc, fn {k, v}, inner ->
-      v
-      |> collect_free_var_refs(collect_free_var_refs(k, inner, bound), bound)
-    end)
-  end
-
-  defp collect_free_var_refs(_other, acc, _bound), do: acc
-
-  defp collect_free_refs_in_bindings(bindings, body, acc, bound) do
-    {acc, bound} =
-      Enum.reduce(bindings, {acc, bound}, fn {:binding, pattern, value_ast},
-                                             {inner_acc, inner_bound} ->
-        inner_acc = collect_free_var_refs(value_ast, inner_acc, inner_bound)
-        inner_bound = MapSet.union(inner_bound, bound_names_from_pattern(pattern))
-        {inner_acc, inner_bound}
-      end)
-
-    collect_free_var_refs(body, acc, bound)
-  end
-
-  defp bound_names_from_params(params) when is_list(params) do
-    params
-    |> Enum.flat_map(&names_from_pattern/1)
-    |> normalize_name_set()
-  end
-
-  defp bound_names_from_params({:variadic, leading, rest_pattern}) do
-    (Enum.flat_map(leading, &names_from_pattern/1) ++ names_from_pattern(rest_pattern))
-    |> normalize_name_set()
-  end
-
-  defp bound_names_from_pattern(pattern) do
-    pattern
-    |> names_from_pattern()
-    |> normalize_name_set()
-  end
-
-  defp names_from_pattern({:var, name}), do: [name]
-  defp names_from_pattern({:destructure, {:keys, keys, _defaults}}), do: keys
-
-  defp names_from_pattern({:destructure, {:map, keys, renames, _defaults}}) do
-    keys ++
-      Enum.flat_map(renames, fn {target_pattern, _source_key} ->
-        names_from_pattern(target_pattern)
-      end)
-  end
-
-  defp names_from_pattern({:destructure, {:as, name, inner}}),
-    do: [name | names_from_pattern(inner)]
-
-  defp names_from_pattern({:destructure, {:seq, patterns}}),
-    do: Enum.flat_map(patterns, &names_from_pattern/1)
-
-  defp names_from_pattern({:destructure, {:seq_rest, leading, rest}}) do
-    Enum.flat_map(leading, &names_from_pattern/1) ++ names_from_pattern(rest)
-  end
-
-  defp names_from_pattern(_other), do: []
-
-  defp normalize_name_set(names) do
-    names
-    |> Enum.map(&to_string/1)
-    |> MapSet.new()
   end
 
   # Only embed captured_locals in meta when non-empty — keeps closure size

--- a/lib/ptc_runner/lisp/runtime/map_ops.ex
+++ b/lib/ptc_runner/lisp/runtime/map_ops.ex
@@ -13,6 +13,22 @@ defmodule PtcRunner.Lisp.Runtime.MapOps do
   @doc """
   Creates a map from alternating key-value pairs.
 
+  Equivalent to Clojure's `array-map`. PTC-Lisp currently uses the same
+  unordered runtime map representation as `hash-map`.
+
+  ## Examples
+
+      iex> PtcRunner.Lisp.Runtime.MapOps.array_map([])
+      %{}
+
+      iex> PtcRunner.Lisp.Runtime.MapOps.array_map([:a, 1, :b, 2])
+      %{a: 1, b: 2}
+  """
+  def array_map(args) when is_list(args), do: build_map(args, "array-map")
+
+  @doc """
+  Creates a map from alternating key-value pairs.
+
   Equivalent to Clojure's `hash-map`. Requires an even number of arguments.
 
   ## Examples
@@ -23,7 +39,6 @@ defmodule PtcRunner.Lisp.Runtime.MapOps do
       iex> PtcRunner.Lisp.Runtime.MapOps.hash_map([:a, 1, :b, 2])
       %{a: 1, b: 2}
   """
-  def array_map(args) when is_list(args), do: build_map(args, "array-map")
   def hash_map(args) when is_list(args), do: build_map(args, "hash-map")
 
   defp build_map(args, name) do

--- a/mcp_server/test/soak/many_turns_soak_test.exs
+++ b/mcp_server/test/soak/many_turns_soak_test.exs
@@ -33,31 +33,20 @@ defmodule PtcRunnerMcp.ManyTurnsSoakTest do
   """
   use ExUnit.Case, async: false
 
-  alias PtcRunnerMcp.{ConcurrencyGate, Sessions, Tools}
-  alias PtcRunnerMcp.Sessions.Config, as: SessionsConfig
   alias PtcRunnerMcp.Sessions.Registry, as: SessionsRegistry
   alias PtcRunnerMcp.TestSupport.MemorySoak
+  alias PtcRunnerMcp.TestSupport.SoakHelpers
 
   @moduletag :soak
   @moduletag timeout: :infinity
 
   setup do
-    stop_sessions_processes()
-    SessionsConfig.set(%{enabled: true})
-    ConcurrencyGate.reset()
-    assert :ok = Sessions.ensure_started()
-
-    on_exit(fn ->
-      stop_sessions_processes()
-      SessionsConfig.reset()
-      ConcurrencyGate.reset()
-    end)
-
+    SoakHelpers.setup_sessions()
     {:ok, iters: MemorySoak.iteration_count()}
   end
 
   test "stateless turns don't grow the session GenServer", %{iters: iters} do
-    session_id = start_session()
+    session_id = SoakHelpers.start_session()
     session_pid = session_pid!(session_id)
 
     before_session = process_memory(session_pid)
@@ -65,7 +54,7 @@ defmodule PtcRunnerMcp.ManyTurnsSoakTest do
     IO.puts("BEFORE (stateless turns, n=#{iters}):\n#{MemorySoak.format(before)}")
 
     MemorySoak.loop(iters, fn _phase ->
-      eval_ok!(session_id, "(+ 1 2)")
+      SoakHelpers.eval_ok!(session_id, "(+ 1 2)")
     end)
 
     after_session = process_memory(session_pid)
@@ -86,11 +75,11 @@ defmodule PtcRunnerMcp.ManyTurnsSoakTest do
     MemorySoak.assert_flat!(before, aft, :binary, tolerance_pct: 100)
     MemorySoak.assert_atoms_per_iter!(before, aft, iters)
 
-    close_session!(session_id)
+    SoakHelpers.close_session!(session_id)
   end
 
   test "writes that accumulate user-namespace state grow linearly", %{iters: iters} do
-    session_id = start_session()
+    session_id = SoakHelpers.start_session()
     session_pid = session_pid!(session_id)
 
     before_session = process_memory(session_pid)
@@ -103,7 +92,7 @@ defmodule PtcRunnerMcp.ManyTurnsSoakTest do
     # per entry, give or take).
     MemorySoak.loop(iters, fn {_phase, i} ->
       program = "(def x_#{i} (str \"value-\" #{i}))"
-      eval_ok!(session_id, program)
+      SoakHelpers.eval_ok!(session_id, program)
     end)
 
     after_session = process_memory(session_pid)
@@ -128,33 +117,7 @@ defmodule PtcRunnerMcp.ManyTurnsSoakTest do
     # input somewhere in the eval path.
     MemorySoak.assert_atoms_per_iter!(before, aft, iters)
 
-    close_session!(session_id)
-  end
-
-  defp start_session do
-    %{"structuredContent" => sc} =
-      Tools.call(%{"name" => "ptc_session_start", "arguments" => %{}})
-
-    sc["session_id"]
-  end
-
-  defp eval_ok!(session_id, program) do
-    response =
-      Tools.call(%{
-        "name" => "ptc_session_eval",
-        "arguments" => %{"session_id" => session_id, "program" => program}
-      })
-
-    sc = response["structuredContent"]
-    assert sc["status"] == "ok", "eval failed: #{inspect(sc)}"
-    sc
-  end
-
-  defp close_session!(session_id) do
-    Tools.call(%{
-      "name" => "ptc_session_close",
-      "arguments" => %{"session_id" => session_id}
-    })
+    SoakHelpers.close_session!(session_id)
   end
 
   defp session_pid!(session_id) do
@@ -167,25 +130,5 @@ defmodule PtcRunnerMcp.ManyTurnsSoakTest do
       {:memory, m} -> m
       nil -> 0
     end
-  end
-
-  defp stop_sessions_processes do
-    stop_if_alive(SessionsRegistry)
-    stop_if_alive(PtcRunnerMcp.Sessions.Supervisor)
-  end
-
-  defp stop_if_alive(name) do
-    case Process.whereis(name) do
-      nil -> :ok
-      pid -> stop_process(pid)
-    end
-  end
-
-  defp stop_process(pid) do
-    if Process.alive?(pid) do
-      GenServer.stop(pid, :normal, 5_000)
-    end
-  catch
-    :exit, _ -> :ok
   end
 end

--- a/mcp_server/test/soak/mcp_stdio_soak_test.exs
+++ b/mcp_server/test/soak/mcp_stdio_soak_test.exs
@@ -41,93 +41,86 @@ defmodule PtcRunnerMcp.McpStdioSoakTest do
   use ExUnit.Case, async: false
 
   alias PtcRunnerMcp.Test.ReleaseRunner
-  alias PtcRunnerMcp.TestSupport.MemorySoak
 
   @moduletag :soak
   @moduletag timeout: :infinity
 
-  setup_all do
-    if ReleaseRunner.release_built?() do
-      {:ok, skip: nil}
-    else
-      {:ok,
-       skip:
-         "release binary missing — run `MIX_ENV=prod mix release --overwrite` first " <>
-           "(expected at #{ReleaseRunner.release_bin()})"}
-    end
-  end
+  @release_skip_reason "release binary missing - run `MIX_ENV=prod mix release --overwrite` first " <>
+                         "(expected at #{ReleaseRunner.release_bin()})"
 
-  test "stdio stateless eval loop returns ok for every request", %{skip: skip} do
-    if skip do
-      IO.puts("\n[SKIP] #{skip}")
-      assert true
-    else
+  if ReleaseRunner.release_built?() do
+    alias PtcRunnerMcp.TestSupport.MemorySoak
+
+    test "stdio stateless eval loop returns ok for every request" do
       run_stdio_soak()
     end
-  end
 
-  defp run_stdio_soak do
-    iters = MemorySoak.iteration_count()
+    defp run_stdio_soak do
+      iters = MemorySoak.iteration_count()
 
-    # Build the wire script: init -> N stateless eval calls -> exit.
-    {frames, total_requests} = build_frames(iters)
+      # Build the wire script: init -> N stateless eval calls -> exit.
+      {frames, total_requests} = build_frames(iters)
 
-    started_at = System.monotonic_time(:millisecond)
+      started_at = System.monotonic_time(:millisecond)
 
-    {:ok, replies, status, stderr} =
-      ReleaseRunner.run_session(frames,
-        timeout_ms: max(iters * 50, 60_000),
-        env: [
-          # Disable any noisy telemetry sinks the soak doesn't care about.
-          {"PTC_RUNNER_MCP_LOG_LEVEL", "error"}
-        ]
-      )
+      {:ok, replies, status, stderr} =
+        ReleaseRunner.run_session(frames,
+          timeout_ms: max(iters * 50, 60_000),
+          env: [
+            # Disable any noisy telemetry sinks the soak doesn't care about.
+            {"PTC_RUNNER_MCP_LOG_LEVEL", "error"}
+          ]
+        )
 
-    elapsed_ms = System.monotonic_time(:millisecond) - started_at
+      elapsed_ms = System.monotonic_time(:millisecond) - started_at
 
-    assert status in [0, :normal], """
-    Release exited abnormally: status=#{inspect(status)}
-    stderr (last 2 KB):
-    #{String.slice(stderr, max(byte_size(stderr) - 2048, 0), 2048)}
-    """
+      assert status in [0, :normal], """
+      Release exited abnormally: status=#{inspect(status)}
+      stderr (last 2 KB):
+      #{String.slice(stderr, max(byte_size(stderr) - 2048, 0), 2048)}
+      """
 
-    # Every `ptc_lisp_execute` reply should be `status: "ok"`. We grep
-    # `structuredContent.status` on the bodies — only call-result frames
-    # have it.
-    bad =
-      replies
-      |> Enum.filter(&match?(%{"result" => %{"structuredContent" => _}}, &1))
-      |> Enum.reject(fn frame ->
-        get_in(frame, ["result", "structuredContent", "status"]) == "ok"
-      end)
+      # Every `ptc_lisp_execute` reply should be `status: "ok"`. We grep
+      # `structuredContent.status` on the bodies — only call-result frames
+      # have it.
+      bad =
+        replies
+        |> Enum.filter(&match?(%{"result" => %{"structuredContent" => _}}, &1))
+        |> Enum.reject(fn frame ->
+          get_in(frame, ["result", "structuredContent", "status"]) == "ok"
+        end)
 
-    assert bad == [],
-           "#{length(bad)} eval call(s) returned non-OK status. " <>
-             "First failure:\n#{inspect(Enum.at(bad, 0), pretty: true, limit: :infinity)}"
+      assert bad == [],
+             "#{length(bad)} eval call(s) returned non-OK status. " <>
+               "First failure:\n#{inspect(Enum.at(bad, 0), pretty: true, limit: :infinity)}"
 
-    IO.puts("""
-    Stdio soak:
-      iterations:  #{iters}
-      requests:    #{total_requests}
-      elapsed_ms:  #{elapsed_ms}
-      replies:     #{length(replies)}
-      per-iter ms: #{Float.round(elapsed_ms / max(iters, 1), 2)}
-    """)
-  end
+      IO.puts("""
+      Stdio soak:
+        iterations:  #{iters}
+        requests:    #{total_requests}
+        elapsed_ms:  #{elapsed_ms}
+        replies:     #{length(replies)}
+        per-iter ms: #{Float.round(elapsed_ms / max(iters, 1), 2)}
+      """)
+    end
 
-  # ---------------------------------------------------------------------
-  # Frame construction
-  # ---------------------------------------------------------------------
+    # ---------------------------------------------------------------------
+    # Frame construction
+    # ---------------------------------------------------------------------
 
-  defp build_frames(iters) do
-    eval_frames =
-      Enum.map(1..iters, fn i ->
-        ReleaseRunner.tools_call_request(i + 1, "ptc_lisp_execute", %{
-          "program" => "(+ 1 2 3)"
-        })
-      end)
+    defp build_frames(iters) do
+      eval_frames =
+        Enum.map(1..iters, fn i ->
+          ReleaseRunner.tools_call_request(i + 1, "ptc_lisp_execute", %{
+            "program" => "(+ 1 2 3)"
+          })
+        end)
 
-    frames = [ReleaseRunner.init_request(1), ReleaseRunner.initialized_notif() | eval_frames]
-    {frames ++ [ReleaseRunner.exit_notif()], iters + 1}
+      frames = [ReleaseRunner.init_request(1), ReleaseRunner.initialized_notif() | eval_frames]
+      {frames ++ [ReleaseRunner.exit_notif()], iters + 1}
+    end
+  else
+    @tag skip: @release_skip_reason
+    test "stdio stateless eval loop returns ok for every request"
   end
 end

--- a/mcp_server/test/soak/session_churn_soak_test.exs
+++ b/mcp_server/test/soak/session_churn_soak_test.exs
@@ -32,26 +32,15 @@ defmodule PtcRunnerMcp.SessionChurnSoakTest do
   """
   use ExUnit.Case, async: false
 
-  alias PtcRunnerMcp.{ConcurrencyGate, Sessions, Tools}
-  alias PtcRunnerMcp.Sessions.Config, as: SessionsConfig
   alias PtcRunnerMcp.Sessions.Registry, as: SessionsRegistry
   alias PtcRunnerMcp.TestSupport.MemorySoak
+  alias PtcRunnerMcp.TestSupport.SoakHelpers
 
   @moduletag :soak
   @moduletag timeout: :infinity
 
   setup do
-    stop_sessions_processes()
-    SessionsConfig.set(%{enabled: true, max_sessions: 10_000})
-    ConcurrencyGate.reset()
-    assert :ok = Sessions.ensure_started()
-
-    on_exit(fn ->
-      stop_sessions_processes()
-      SessionsConfig.reset()
-      ConcurrencyGate.reset()
-    end)
-
+    SoakHelpers.setup_sessions(%{enabled: true, max_sessions: 10_000})
     {:ok, iters: MemorySoak.iteration_count()}
   end
 
@@ -60,9 +49,9 @@ defmodule PtcRunnerMcp.SessionChurnSoakTest do
     IO.puts("BEFORE (churn, n=#{iters}):\n#{MemorySoak.format(before)}")
 
     MemorySoak.loop(iters, fn _phase ->
-      session_id = start_session()
-      eval_ok!(session_id, "(+ 1 2 3)")
-      close_session!(session_id)
+      session_id = SoakHelpers.start_session()
+      SoakHelpers.eval_ok!(session_id, "(+ 1 2 3)")
+      SoakHelpers.close_session!(session_id)
     end)
 
     flush_registry()
@@ -74,32 +63,6 @@ defmodule PtcRunnerMcp.SessionChurnSoakTest do
     MemorySoak.assert_flat!(before, aft, :total, tolerance_pct: 30)
     MemorySoak.assert_flat!(before, aft, :binary, tolerance_pct: 50)
     MemorySoak.assert_atoms_per_iter!(before, aft, iters)
-  end
-
-  defp start_session do
-    %{"structuredContent" => sc} =
-      Tools.call(%{"name" => "ptc_session_start", "arguments" => %{}})
-
-    sc["session_id"]
-  end
-
-  defp eval_ok!(session_id, program) do
-    response =
-      Tools.call(%{
-        "name" => "ptc_session_eval",
-        "arguments" => %{"session_id" => session_id, "program" => program}
-      })
-
-    sc = response["structuredContent"]
-    assert sc["status"] == "ok", "eval failed: #{inspect(sc)}"
-    sc
-  end
-
-  defp close_session!(session_id) do
-    Tools.call(%{
-      "name" => "ptc_session_close",
-      "arguments" => %{"session_id" => session_id}
-    })
   end
 
   # `ptc_session_close` makes the Session GenServer reply then `:stop`
@@ -115,25 +78,5 @@ defmodule PtcRunnerMcp.SessionChurnSoakTest do
     end
 
     :ok
-  end
-
-  defp stop_sessions_processes do
-    stop_if_alive(SessionsRegistry)
-    stop_if_alive(PtcRunnerMcp.Sessions.Supervisor)
-  end
-
-  defp stop_if_alive(name) do
-    case Process.whereis(name) do
-      nil -> :ok
-      pid -> stop_process(pid)
-    end
-  end
-
-  defp stop_process(pid) do
-    if Process.alive?(pid) do
-      GenServer.stop(pid, :normal, 5_000)
-    end
-  catch
-    :exit, _ -> :ok
   end
 end

--- a/mcp_server/test/support/soak_helpers.ex
+++ b/mcp_server/test/support/soak_helpers.ex
@@ -1,0 +1,73 @@
+defmodule PtcRunnerMcp.TestSupport.SoakHelpers do
+  @moduledoc """
+  Shared helpers for MCP soak tests.
+  """
+
+  import ExUnit.Assertions
+  import ExUnit.Callbacks
+
+  alias PtcRunnerMcp.{ConcurrencyGate, Sessions, Tools}
+  alias PtcRunnerMcp.Sessions.Config, as: SessionsConfig
+  alias PtcRunnerMcp.Sessions.Registry, as: SessionsRegistry
+
+  def setup_sessions(config \\ %{enabled: true}) do
+    stop_sessions_processes()
+    SessionsConfig.set(config)
+    ConcurrencyGate.reset()
+    assert :ok = Sessions.ensure_started()
+
+    on_exit(fn ->
+      stop_sessions_processes()
+      SessionsConfig.reset()
+      ConcurrencyGate.reset()
+    end)
+
+    :ok
+  end
+
+  def start_session do
+    %{"structuredContent" => sc} =
+      Tools.call(%{"name" => "ptc_session_start", "arguments" => %{}})
+
+    sc["session_id"]
+  end
+
+  def eval_ok!(session_id, program) do
+    response =
+      Tools.call(%{
+        "name" => "ptc_session_eval",
+        "arguments" => %{"session_id" => session_id, "program" => program}
+      })
+
+    sc = response["structuredContent"]
+    assert sc["status"] == "ok", "eval failed: #{inspect(sc)}"
+    sc
+  end
+
+  def close_session!(session_id) do
+    Tools.call(%{
+      "name" => "ptc_session_close",
+      "arguments" => %{"session_id" => session_id}
+    })
+  end
+
+  def stop_sessions_processes do
+    stop_if_alive(SessionsRegistry)
+    stop_if_alive(PtcRunnerMcp.Sessions.Supervisor)
+  end
+
+  defp stop_if_alive(name) do
+    case Process.whereis(name) do
+      nil -> :ok
+      pid -> stop_process(pid)
+    end
+  end
+
+  defp stop_process(pid) do
+    if Process.alive?(pid) do
+      GenServer.stop(pid, :normal, 5_000)
+    end
+  catch
+    :exit, _ -> :ok
+  end
+end

--- a/test/ptc_runner/lisp/closure_capture_test.exs
+++ b/test/ptc_runner/lisp/closure_capture_test.exs
@@ -11,10 +11,57 @@ defmodule PtcRunner.Lisp.ClosureCaptureTest do
   use ExUnit.Case, async: true
 
   alias PtcRunner.Lisp
+  alias PtcRunner.Lisp.ClosureCapture
 
   defp run!(src) do
     case Lisp.run(src, profile: :mcp_no_tools, mode: :multi_turn) do
       {:ok, step} -> step.return
+    end
+  end
+
+  describe "referenced_vars/3" do
+    test "excludes function params and extra bound names" do
+      ast =
+        {:call, {:var, :+},
+         [
+           {:var, :x},
+           {:var, :outer},
+           {:var, :self}
+         ]}
+
+      assert ClosureCapture.referenced_vars(ast, [{:var, :x}], [:self]) ==
+               MapSet.new(["+", "outer"])
+    end
+
+    test "handles sequential let binding scope" do
+      ast =
+        {:let,
+         [
+           {:binding, {:var, :x}, {:var, :outer}},
+           {:binding, {:var, :y}, {:call, {:var, :inc}, [{:var, :x}]}}
+         ], {:call, {:var, :+}, [{:var, :x}, {:var, :y}, {:var, :z}]}}
+
+      assert ClosureCapture.referenced_vars(ast, [], []) ==
+               MapSet.new(["outer", "inc", "+", "z"])
+    end
+
+    test "treats inner function params and names as locally bound" do
+      ast =
+        {:fn, :walk, [{:var, :node}],
+         {:call, {:var, :map}, [{:var, :walk}, {:var, :node}, {:var, :roots}]}}
+
+      assert ClosureCapture.referenced_vars(ast, [], []) == MapSet.new(["map", "roots"])
+    end
+
+    test "collects destructuring pattern names as bound" do
+      ast =
+        {:let,
+         [
+           {:binding, {:destructure, {:map, [:keep], [{{:var, :renamed}, :source}], []}},
+            {:var, :input}}
+         ], {:vector, [{:var, :keep}, {:var, :renamed}, {:var, :outside}]}}
+
+      assert ClosureCapture.referenced_vars(ast, [], []) == MapSet.new(["input", "outside"])
     end
   end
 


### PR DESCRIPTION
## Summary
- Extract closure-capture free-var walking into `PtcRunner.Lisp.ClosureCapture` with direct unit coverage.
- Split the misplaced `array-map` / `hash-map` docs in `MapOps`.
- Extract shared MCP soak session helpers and replace the stdio soak pass-as-skip branch with an ExUnit skip.
- Confirmed `catalog_ops` recur preservation for #938 is already present on `main` with regression coverage in `test/catalog_builtins_test.exs`.

Closes #965
Closes #958
Closes #956
Closes #952
Closes #938

## Verification
- `mix test test/catalog_builtins_test.exs`
- `mix test test/ptc_runner/lisp/closure_capture_test.exs test/ptc_runner/lisp/eval_functions_test.exs`
- `PTC_SOAK_ITERATIONS=3 mix test --include soak test/soak/session_churn_soak_test.exs` from `mcp_server/`
- `PTC_SOAK_ITERATIONS=3 mix test --include soak test/soak/many_turns_soak_test.exs` from `mcp_server/`
- `PTC_SOAK_ITERATIONS=3 mix test --include soak test/soak/mcp_stdio_soak_test.exs` from `mcp_server/` (skipped cleanly because release binary is absent)
- `mix format --check-formatted` in root and `mcp_server/`
- `git diff --check`
- Commit hook passed root + mcp_server format, warnings-as-errors compile, Credo, and scoped tests
- Pre-push root full suite and Dialyzer passed; mcp_server full suite hit an unrelated ordering-sensitive pmap duration assertion in `test/ptc_runner_mcp/aggregator_phase1a_test.exs:615`, and the isolated rerun of that test passed.