### PR TITLE
feat(mcp): add streamable HTTP server

### DIFF
--- a/docs/mcp-debug.md
+++ b/docs/mcp-debug.md
@@ -10,7 +10,7 @@ For the broader MCP server overview see [mcp-server.md](mcp-server.md). For the 
 
 `ptc_debug` records every recognized-tool `tools/call` — `ptc_lisp_execute`, `ptc_task`, and all `ptc_session_*` tools when sessions are enabled — into a bounded in-memory ring (`--debug-ring-size`, default 500, FIFO eviction). Successes, `args_error` validation failures, and `busy` concurrency-gate rejections are all captured. `ptc_debug`'s own calls and unknown-tool requests are not recorded.
 
-The ring lives in process memory: it is lost on restart, and in a multi-client process it mixes records from all clients. Both facts are surfaced in every `stats` response (`debug_source`, `window`, `ring_count`).
+The ring lives in process memory: it is lost on restart, and in a multi-client process it mixes records from all clients. Both facts are surfaced in every `stats` response (`debug_source`, `window`, `ring_count`). In Streamable HTTP mode this means `ptc_debug` is suitable only when every bearer-token holder is in the same trust boundary; v1 does not partition the ring by HTTP session.
 
 ## Operations
 

--- a/docs/mcp-server-configuration.md
+++ b/docs/mcp-server-configuration.md
@@ -57,6 +57,40 @@ All configuration is read once at boot, either from a CLI flag or the equivalent
 | `--debug-ring-size` | `PTC_RUNNER_MCP_DEBUG_RING_SIZE` | `500` | In-memory ring-buffer capacity for `ptc_debug` (clamped to `[10, 5000]`). |
 | `--max-debug-response-bytes` | `PTC_RUNNER_MCP_MAX_DEBUG_RESPONSE_BYTES` | `65536` (64 KiB) | Hard cap on a single `ptc_debug` response (raised to a 4 KiB floor if set lower); oversized responses are truncated and flagged. |
 
+## Streamable HTTP flags
+
+HTTP mode is opt-in. Without `--http`, the release starts exactly as a
+stdio MCP server. With `--http`, the process starts a Streamable HTTP
+listener and does not attach stdio. See
+[`mcp-server-http-deployment.md`](mcp-server-http-deployment.md) for
+the deployment runbook.
+
+| Flag | Env var | Default | Meaning |
+|---|---|---|---|
+| `--http` | `PTC_RUNNER_MCP_HTTP` | `false` | Enable the HTTP listener. |
+| `--http-host` | `PTC_RUNNER_MCP_HTTP_HOST` | `127.0.0.1` | Bind IP address or `localhost`. Non-loopback binds require auth unless explicitly unsafe. |
+| `--http-port` | `PTC_RUNNER_MCP_HTTP_PORT` | `7332` | Bind port. |
+| `--http-path` | `PTC_RUNNER_MCP_HTTP_PATH` | `/mcp` | Streamable HTTP MCP endpoint. Must differ from `/health`, `/ready`, and `--http-metrics-path`. |
+| `--http-auth-token` | `PTC_RUNNER_MCP_HTTP_AUTH_TOKEN` | unset | Static bearer token. Must be at least 32 characters; generate it from a CSPRNG. |
+| `--http-disable-auth` | `PTC_RUNNER_MCP_HTTP_DISABLE_AUTH` | `false` | Disable bearer auth. Permitted on loopback with a warning; non-loopback also requires `--http-allow-unsafe-network`. |
+| `--http-allowed-origin` | `PTC_RUNNER_MCP_HTTP_ALLOWED_ORIGIN` | unset | Browser `Origin` allow-list. May be repeated or comma-separated. This is a DNS-rebinding check, not full CORS support. |
+| `--http-request-timeout-ms` | `PTC_RUNNER_MCP_HTTP_REQUEST_TIMEOUT_MS` | `15000` | HTTP request read timeout. |
+| `--http-shutdown-grace-ms` | `PTC_RUNNER_MCP_HTTP_SHUTDOWN_GRACE_MS` | `10000` | Application-stop drain window before in-flight workers are cancelled. |
+| `--http-max-body-bytes` | `PTC_RUNNER_MCP_HTTP_MAX_BODY_BYTES` | `--max-frame-bytes` | HTTP request body cap. |
+| `--http-session-ttl-ms` | `PTC_RUNNER_MCP_HTTP_SESSION_TTL_MS` | `3600000` | Absolute HTTP protocol-session lifetime. |
+| `--http-session-idle-timeout-ms` | `PTC_RUNNER_MCP_HTTP_SESSION_IDLE_TIMEOUT_MS` | `900000` | Idle timeout for HTTP protocol sessions. |
+| `--http-max-sessions` | `PTC_RUNNER_MCP_HTTP_MAX_SESSIONS` | `256` | Global HTTP protocol-session cap. |
+| `--http-max-sessions-per-owner` | `PTC_RUNNER_MCP_HTTP_MAX_SESSIONS_PER_OWNER` | `32` | Per-owner HTTP protocol-session cap. In single-token v1 every client shares one owner. |
+| `--http-max-in-flight-per-session` | `PTC_RUNNER_MCP_HTTP_MAX_IN_FLIGHT_PER_SESSION` | `4` | Non-queueing cap for executing requests in one HTTP protocol session. |
+| `--http-allow-unsafe-network` | `PTC_RUNNER_MCP_HTTP_ALLOW_UNSAFE_NETWORK` | `false` | Allows unauthenticated non-loopback bind only when paired with `--http-disable-auth`. |
+| `--http-metrics` | `PTC_RUNNER_MCP_HTTP_METRICS` | `false` | Reserved for the Prometheus endpoint follow-up; core telemetry is emitted regardless. |
+| `--http-metrics-path` | `PTC_RUNNER_MCP_HTTP_METRICS_PATH` | `/metrics` | Reserved metrics path; must not collide with HTTP control paths. |
+| `--http-instance-label` | `PTC_RUNNER_MCP_HTTP_INSTANCE_LABEL` | hostname | Stable instance label stamped into HTTP logs, telemetry, and trace metadata. |
+
+HTTP emits sanitized telemetry under `[:ptc_runner_mcp, :http, ...]`
+and logs request stop lines to stderr. Raw bearer tokens and raw
+`MCP-Session-Id` values are not logged.
+
 ## Response profiles
 
 `ptc_lisp_execute` renders its result according to a boot-time **response profile** (`--response-profile`). The default is **`slim`**: optimized for the model consuming the tool result, not for an operator reading a trace.

--- a/docs/mcp-server-http-deployment.md
+++ b/docs/mcp-server-http-deployment.md
@@ -1,0 +1,117 @@
+# MCP Streamable HTTP Deployment
+
+`ptc_runner_mcp` can run as an opt-in Streamable HTTP MCP server for
+private-network deployments. The HTTP mode is intended for a trusted
+agentic application or load balancer talking to one BEAM node over a
+small network boundary; stdio remains the default local-client mode.
+
+## Quick Start
+
+Generate a strong bearer token:
+
+```bash
+export PTC_RUNNER_MCP_HTTP_AUTH_TOKEN="$(openssl rand -base64 32)"
+```
+
+Start the release on loopback:
+
+```bash
+_build/prod/rel/ptc_runner_mcp/bin/ptc_runner_mcp start \
+  --http \
+  --http-auth-token "$PTC_RUNNER_MCP_HTTP_AUTH_TOKEN"
+```
+
+The MCP endpoint is `POST /mcp` on `127.0.0.1:7332` by default. In
+HTTP mode stdio is not attached.
+
+## Required Headers
+
+Every `/mcp` request needs:
+
+```http
+Authorization: Bearer <token>
+```
+
+The first request is `initialize` without an `MCP-Session-Id`. The
+response includes:
+
+```http
+MCP-Session-Id: <opaque id>
+```
+
+Subsequent POST and DELETE requests send that session id. Clients should
+also send `MCP-Protocol-Version`; if it is absent the server falls back
+to the version stored on the HTTP session.
+
+## Health And Readiness
+
+`GET /health` is liveness: it returns `200` while the process and
+listener are alive.
+
+`GET /ready` is load-balancer readiness: it returns `200` when the
+session registry is accepting work, and `503` when the node is draining
+or saturated.
+
+Both endpoints are unauthenticated and expose only process status. Keep
+them on a private network or restrict them at the load balancer.
+
+## Security Posture
+
+Use a private subnet, security group, firewall, or equivalent network
+boundary. The bearer token is the inner boundary, not the only boundary.
+
+TLS should terminate at the load balancer or edge proxy. If traffic from
+the proxy to the BEAM node is plaintext, anything able to observe that
+link can see the bearer token.
+
+Binding to a non-loopback address requires a token unless both
+`--http-disable-auth` and `--http-allow-unsafe-network` are set. That
+pair is for controlled tests only.
+
+The v1 auth model has one static token. All token holders are the same
+owner, so an `MCP-Session-Id` is a bearer capability inside that trust
+boundary. Session ids are random and are never logged raw.
+
+## Observability
+
+HTTP request logs are JSON lines on stderr. Each request log includes an
+instance label, `X-Request-Id`, method, path, status, duration, and
+hashed owner/session ids when known.
+
+The server emits sanitized telemetry under `[:ptc_runner_mcp, :http, ...]`
+for request start/stop, session create/close, auth failures, limit
+rejections, and cancellations.
+
+When `--trace-dir` is enabled, HTTP tool-call trace events include
+`owner_hash`, `mcp_session_hash`, and `transport_request_id` metadata.
+Trace payload policy is still controlled by `--trace-payloads`.
+
+Prometheus `/metrics` is not shipped in this PR. The config flags are
+reserved, but scraping support remains a follow-up.
+
+## Rolling Deploy Drain
+
+On application shutdown the registry enters drain mode, so `/ready`
+returns `503` and new `/mcp` POSTs receive a JSON-RPC `server draining`
+error. The process waits `--http-shutdown-grace-ms`, then cancels any
+remaining in-flight HTTP workers before exit.
+
+`DELETE /mcp` closes one protocol session immediately. Reaped or deleted
+sessions return `404` on later use.
+
+## Important Flags
+
+| Flag | Default | Meaning |
+|---|---:|---|
+| `--http` | `false` | Enable the HTTP listener. |
+| `--http-host` | `127.0.0.1` | Bind IP address or `localhost`. |
+| `--http-port` | `7332` | Bind port. |
+| `--http-path` | `/mcp` | MCP endpoint path. |
+| `--http-auth-token` | unset | Static bearer token; minimum 32 characters. |
+| `--http-allowed-origin` | unset | Exact allowed browser `Origin`; repeatable or comma-separated. |
+| `--http-max-sessions` | `256` | Global HTTP protocol-session cap. |
+| `--http-max-sessions-per-owner` | `32` | Per-owner protocol-session cap. |
+| `--http-max-in-flight-per-session` | `4` | Per-session executing request cap. |
+| `--http-session-ttl-ms` | `3600000` | Absolute protocol-session lifetime. |
+| `--http-session-idle-timeout-ms` | `900000` | Idle protocol-session timeout. |
+| `--http-instance-label` | hostname | Label stamped into HTTP logs/telemetry/traces. |

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -2,8 +2,10 @@
 
 `ptc_runner_mcp` is a long-running process that speaks
 [Model Context Protocol](https://modelcontextprotocol.io/) over stdio
-JSON-RPC and exposes `ptc_lisp_execute` to any MCP client (Claude
-Desktop, Cursor, Cline, Claude Code, MCP Inspector, …). The tool
+JSON-RPC by default, with an opt-in Streamable HTTP listener for
+private-network deployments. It exposes `ptc_lisp_execute` to MCP
+clients (Claude Desktop, Cursor, Cline, Claude Code, MCP Inspector,
+agentic applications, …). The tool
 accepts a PTC-Lisp program plus optional `context` and `output_schema`
 (or legacy `signature`), runs it in an isolated BEAM sandbox, and
 returns a structured result.
@@ -36,6 +38,8 @@ This document is the conceptual overview. For install + client
 configuration, see [`mcp_server/README.md`](../mcp_server/README.md);
 for every flag and environment variable, see
 [`docs/mcp-server-configuration.md`](mcp-server-configuration.md). For
+HTTP deployment, see
+[`docs/mcp-server-http-deployment.md`](mcp-server-http-deployment.md). For
 the PTC-Lisp language itself, see
 [`docs/ptc-lisp-specification.md`](ptc-lisp-specification.md).
 
@@ -100,12 +104,13 @@ cannot leak in the first place.
 
 ```
                        MCP client (Claude Desktop, Cursor, Cline, …)
-                                    │  stdio (NDJSON-framed JSON-RPC 2.0)
+                       or trusted private-network HTTP client
+                                    │  stdio NDJSON or Streamable HTTP
                                     ▼
                   ┌─────────────────────────────────────────┐
                   │              ptc_runner_mcp             │
                   │                                         │
-                  │   Stdio reader / writer                 │
+                  │   Stdio transport or HTTP session        │
                   │              │                          │
                   │              ▼                          │
                   │   JSON-RPC dispatcher                   │
@@ -138,8 +143,9 @@ cannot leak in the first place.
 
 Each `tools/call` request flows top-to-bottom:
 
-1. The stdio reader frames one NDJSON line and hands it to the JSON-RPC
-   dispatcher.
+1. The transport frames one JSON-RPC message and hands it to the
+   dispatcher. In stdio mode that is one NDJSON line; in HTTP mode it
+   is one `POST /mcp` body scoped by `MCP-Session-Id`.
 2. The dispatcher routes `tools/call` to a per-call worker after
    passing the concurrency semaphore (`max_concurrent_calls`,
    default 8). Excess calls return immediately with `reason: "busy"`
@@ -156,10 +162,27 @@ Each `tools/call` request flows top-to-bottom:
 5. The result flows back up: `PtcToolProtocol.render_success_from_step/2`
    builds the R22 success payload, or `render_error/3` builds the R23
    error payload. The MCP envelope (`isError`, `structuredContent`,
-   `content`) wraps it. The stdio writer ships one NDJSON frame back.
+   `content`) wraps it. The transport writes one response frame back.
 
 `notifications/cancelled` from the client kills the in-flight sandbox
-process. stdin EOF cancels every in-flight call and exits cleanly.
+process. stdin EOF cancels every stdio in-flight call and exits
+cleanly; HTTP `DELETE /mcp` closes one protocol session and cancels its
+in-flight work.
+
+## Streamable HTTP
+
+Start with `--http` to serve MCP over Streamable HTTP at `/mcp`
+(`127.0.0.1:7332` by default). `POST /mcp` accepts one JSON-RPC
+message. `GET /mcp` returns `405` until SSE/resumability support is
+added. `DELETE /mcp` terminates the protocol session named by
+`MCP-Session-Id`.
+
+HTTP mode is designed for private-network service deployment behind a
+TLS edge or load balancer. It requires a bearer token for non-loopback
+binds, validates browser `Origin` headers, exposes unauthenticated
+`/health` and `/ready`, and stamps request logs/telemetry/traces with
+hashed owner/session ids. See
+[`mcp-server-http-deployment.md`](mcp-server-http-deployment.md).
 
 ## Stateful Sessions
 

--- a/mcp_server/README.md
+++ b/mcp_server/README.md
@@ -6,7 +6,8 @@
 An [MCP](https://modelcontextprotocol.io/) server that exposes
 [PtcRunner](https://hex.pm/packages/ptc_runner)'s PTC-Lisp sandbox to any
 MCP client (Claude Desktop, Cursor, Cline, Claude Code, …) over stdio
-JSON-RPC. The default tool, `ptc_lisp_execute`, accepts a PTC-Lisp
+JSON-RPC, with an opt-in Streamable HTTP mode for private-network
+deployments. The default tool, `ptc_lisp_execute`, accepts a PTC-Lisp
 program plus optional `context` and `output_schema` (or legacy
 `signature`), runs it in an isolated BEAM process (1 s wall-clock,
 10 MB memory; 10 s / 100 MB in [aggregator mode](../docs/aggregator-mode.md)),
@@ -130,6 +131,28 @@ claude mcp add ptc-runner \
 To pass configuration flags through any of these clients, append them
 to the `args` array (e.g., `"args": ["start", "--max-frame-bytes", "8388608"]`).
 
+## Streamable HTTP mode
+
+HTTP mode is opt-in and intended for service deployments, not local
+desktop MCP client configs:
+
+```bash
+export PTC_RUNNER_MCP_HTTP_AUTH_TOKEN="$(openssl rand -base64 32)"
+_build/prod/rel/ptc_runner_mcp/bin/ptc_runner_mcp start \
+  --http \
+  --http-auth-token "$PTC_RUNNER_MCP_HTTP_AUTH_TOKEN"
+```
+
+The default endpoint is `POST /mcp` on `127.0.0.1:7332`. The first
+client request initializes an HTTP protocol session and receives an
+`MCP-Session-Id`; later POST/DELETE requests send that id. `GET /health`
+is liveness and `GET /ready` is load-balancer readiness.
+
+See [`docs/mcp-server-http-deployment.md`](../docs/mcp-server-http-deployment.md)
+for the private-network deployment runbook and
+[`docs/mcp-server-configuration.md#streamable-http-flags`](../docs/mcp-server-configuration.md#streamable-http-flags)
+for all HTTP flags.
+
 ## Features
 
 The server is one binary with several opt-in capabilities. Each links
@@ -144,6 +167,7 @@ to its own doc.
 | **Diagnostics** — `ptc_debug` for in-process telemetry rollups | off; `--debug-tool` | [`docs/mcp-debug.md`](../docs/mcp-debug.md) |
 | **Response profiles** — `slim` / `structured` / `debug` | `slim` | [`docs/mcp-server-configuration.md#response-profiles`](../docs/mcp-server-configuration.md#response-profiles) |
 | **Tracing** — per-call JSONL traces, viewable via `mix ptc.viewer` | off; `--trace-dir` | [`docs/mcp-server-configuration.md#tracing`](../docs/mcp-server-configuration.md#tracing) |
+| **Streamable HTTP** — private-network MCP endpoint with session ids, bearer auth, health/readiness, and HTTP telemetry | off; `--http` | [`docs/mcp-server-http-deployment.md`](../docs/mcp-server-http-deployment.md) |
 
 For every flag and environment variable, see
 [`docs/mcp-server-configuration.md`](../docs/mcp-server-configuration.md).
@@ -165,6 +189,7 @@ ptc_runner_mcp version    # print "ptc_runner_mcp <version>"
 
 - Conceptual overview: [`docs/mcp-server.md`](../docs/mcp-server.md)
 - Configuration reference: [`docs/mcp-server-configuration.md`](../docs/mcp-server-configuration.md)
+- HTTP deployment: [`docs/mcp-server-http-deployment.md`](../docs/mcp-server-http-deployment.md)
 - Aggregator mode: [`docs/aggregator-mode.md`](../docs/aggregator-mode.md)
 - Agentic mode (`ptc_task`): [`docs/agentic-mode.md`](../docs/agentic-mode.md)
 - Diagnostics (`ptc_debug`): [`docs/mcp-debug.md`](../docs/mcp-debug.md)

--- a/mcp_server/lib/ptc_runner_mcp/application.ex
+++ b/mcp_server/lib/ptc_runner_mcp/application.ex
@@ -58,6 +58,7 @@ defmodule PtcRunnerMcp.Application do
     TraceHandler
   }
 
+  alias PtcRunnerMcp.Http.{Config, Server, SessionRegistry}
   alias PtcRunnerMcp.Sessions.Config, as: SessionsConfig
 
   @impl Application
@@ -73,9 +74,11 @@ defmodule PtcRunnerMcp.Application do
     apply_agentic_config(args)
     apply_debug_config(args)
     apply_response_profile(args)
-    apply_sessions_config(args)
-    validate_agentic_boot!(upstreams)
     apply_limits(args, aggregator?: upstreams != [])
+    apply_sessions_config(args)
+    {:ok, http_config} = Config.resolve(args)
+    Application.put_env(:ptc_runner_mcp, :http_config, http_config)
+    validate_agentic_boot!(upstreams)
     apply_trace_config(args)
 
     if AgenticConfig.enabled?() and upstreams == [] do
@@ -94,10 +97,10 @@ defmodule PtcRunnerMcp.Application do
     # unique names. Returning an empty child list keeps the named ETS
     # redaction table free for test-owned `Credentials` instances.
     children =
-      if attach_stdio?() do
-        build_children(upstreams, bindings, args)
-      else
-        []
+      cond do
+        http_config.enabled -> build_http_children(upstreams, bindings, http_config)
+        attach_stdio?() -> build_children(upstreams, bindings, args)
+        true -> []
       end
 
     # `:rest_for_one` per `Plans/http-transport-credentials.md` §7.1.
@@ -128,6 +131,20 @@ defmodule PtcRunnerMcp.Application do
       aggregator_children(upstreams) ++
       session_children() ++
       stdio_children(args)
+  end
+
+  @doc false
+  @spec build_http_children([map()], %{String.t() => Credentials.Binding.t()}, map()) ::
+          [Supervisor.child_spec() | {module(), term()}]
+  def build_http_children(upstreams, bindings, http_config) do
+    [{Credentials, [bindings: bindings]}] ++
+      aggregator_children(upstreams) ++
+      session_children_for_http() ++
+      [
+        {SessionRegistry, [config: http_config]},
+        Server.child_spec(http_config)
+      ] ++
+      debug_children()
   end
 
   # ----------------------------------------------------------------
@@ -193,12 +210,42 @@ defmodule PtcRunnerMcp.Application do
           debug_tool: :boolean,
           debug_ring_size: :integer,
           max_debug_response_bytes: :integer,
-          response_profile: :string
+          response_profile: :string,
+          http: :boolean,
+          http_host: :string,
+          http_port: :integer,
+          http_path: :string,
+          http_auth_token: :string,
+          http_disable_auth: :boolean,
+          http_allowed_origin: [:string, :keep],
+          http_request_timeout_ms: :integer,
+          http_shutdown_grace_ms: :integer,
+          http_max_body_bytes: :integer,
+          http_session_ttl_ms: :integer,
+          http_session_idle_timeout_ms: :integer,
+          http_max_sessions: :integer,
+          http_max_sessions_per_owner: :integer,
+          http_max_in_flight_per_session: :integer,
+          http_allow_unsafe_network: :boolean,
+          http_metrics: :boolean,
+          http_metrics_path: :string,
+          http_instance_label: :string
         ]
       )
 
-    Map.new(opts)
+    opts_to_map(opts)
   end
+
+  defp opts_to_map(opts) do
+    {origins, rest} = Keyword.pop_values(opts, :http_allowed_origin)
+
+    rest
+    |> Map.new()
+    |> maybe_put_origins(origins)
+  end
+
+  defp maybe_put_origins(map, []), do: map
+  defp maybe_put_origins(map, origins), do: Map.put(map, :http_allowed_origin, origins)
 
   # Public-but-undocumented seam used by tests to verify CLI > env >
   # default precedence for non-limit aggregator behavior.
@@ -931,6 +978,10 @@ defmodule PtcRunnerMcp.Application do
     else
       []
     end
+  end
+
+  defp session_children_for_http do
+    Sessions.child_specs()
   end
 
   # Phase 1a: when at least one upstream is configured, start the

--- a/mcp_server/lib/ptc_runner_mcp/application.ex
+++ b/mcp_server/lib/ptc_runner_mcp/application.ex
@@ -58,7 +58,8 @@ defmodule PtcRunnerMcp.Application do
     TraceHandler
   }
 
-  alias PtcRunnerMcp.Http.{Config, Server, SessionRegistry}
+  alias PtcRunnerMcp.Http.{Config, Server}
+  alias PtcRunnerMcp.Http.SessionRegistry, as: HttpSessionRegistry
   alias PtcRunnerMcp.Sessions.Config, as: SessionsConfig
 
   @impl Application
@@ -111,6 +112,23 @@ defmodule PtcRunnerMcp.Application do
     Supervisor.start_link(children, opts)
   end
 
+  @impl Application
+  def prep_stop(state) do
+    case Application.get_env(:ptc_runner_mcp, :http_config) do
+      %{enabled: true, shutdown_grace_ms: grace_ms} ->
+        if Process.whereis(HttpSessionRegistry) do
+          _ = HttpSessionRegistry.begin_drain()
+          Process.sleep(grace_ms)
+          _ = HttpSessionRegistry.cancel_all(:shutdown)
+        end
+
+      _ ->
+        :ok
+    end
+
+    state
+  end
+
   # Compose the production supervisor child list. Public-but-undocumented
   # seam so tests can inspect ordering without running `start/2`.
   # Order matters for `:rest_for_one`: `Credentials` MUST come before
@@ -141,7 +159,7 @@ defmodule PtcRunnerMcp.Application do
       aggregator_children(upstreams) ++
       session_children_for_http() ++
       [
-        {SessionRegistry, [config: http_config]},
+        {HttpSessionRegistry, [config: http_config]},
         Server.child_spec(http_config)
       ] ++
       debug_children()

--- a/mcp_server/lib/ptc_runner_mcp/concurrency_gate.ex
+++ b/mcp_server/lib/ptc_runner_mcp/concurrency_gate.ex
@@ -16,6 +16,11 @@ defmodule PtcRunnerMcp.ConcurrencyGate do
   `:atomics.add_get/3`; if the post-increment value exceeds the cap,
   it decrements back and returns `:full`. `release/0` decrements.
 
+  HTTP workers can use tracked permits: the permit is acquired first,
+  then attached to the worker pid. A tiny monitor process releases the
+  permit exactly once if the worker exits before the owning session can
+  release it explicitly.
+
   This is intentionally lock-free and non-queueing: `:full` callers
   do NOT wait. Acquire is O(1) regardless of contention.
 
@@ -31,6 +36,7 @@ defmodule PtcRunnerMcp.ConcurrencyGate do
   alias PtcRunnerMcp.Limits
 
   @key {__MODULE__, :ref}
+  @type tracked_permit :: pid()
 
   @doc """
   Initialize the underlying atomics ref. Idempotent. Called once at
@@ -76,6 +82,38 @@ defmodule PtcRunnerMcp.ConcurrencyGate do
     end
   end
 
+  @doc """
+  Try to acquire a permit guarded by a monitor process.
+
+  The returned permit must either be attached to a worker via
+  `track_worker/2` or released with `release_tracked/1`. If the owner
+  process exits before a worker is attached, the guard releases the
+  permit. Once a worker is attached, the guard releases on either
+  explicit release or worker `:DOWN`.
+  """
+  @spec try_acquire_tracked(pos_integer(), pid()) :: {:ok, tracked_permit()} | :full
+  def try_acquire_tracked(cap, owner \\ self())
+      when is_integer(cap) and cap > 0 and is_pid(owner) do
+    case try_acquire(cap) do
+      :ok -> {:ok, spawn(fn -> permit_guard(owner) end)}
+      :full -> :full
+    end
+  end
+
+  @doc "Attach a tracked permit to the worker process that owns it."
+  @spec track_worker(tracked_permit(), pid()) :: :ok
+  def track_worker(permit, worker) when is_pid(permit) and is_pid(worker) do
+    send(permit, {:track_worker, worker})
+    :ok
+  end
+
+  @doc "Release a tracked permit before its worker exits."
+  @spec release_tracked(tracked_permit()) :: :ok
+  def release_tracked(permit) when is_pid(permit) do
+    send(permit, :release)
+    :ok
+  end
+
   @doc "Release one previously-acquired permit. Idempotent: never goes below 0."
   @spec release() :: :ok
   def release do
@@ -116,6 +154,34 @@ defmodule PtcRunnerMcp.ConcurrencyGate do
 
       ref ->
         ref
+    end
+  end
+
+  defp permit_guard(owner) do
+    owner_ref = Process.monitor(owner)
+
+    receive do
+      {:track_worker, worker} ->
+        Process.demonitor(owner_ref, [:flush])
+        worker_ref = Process.monitor(worker)
+        await_permit_release(worker_ref)
+
+      :release ->
+        release()
+
+      {:DOWN, ^owner_ref, :process, _pid, _reason} ->
+        release()
+    end
+  end
+
+  defp await_permit_release(worker_ref) do
+    receive do
+      :release ->
+        Process.demonitor(worker_ref, [:flush])
+        release()
+
+      {:DOWN, ^worker_ref, :process, _pid, _reason} ->
+        release()
     end
   end
 end

--- a/mcp_server/lib/ptc_runner_mcp/debug_recorder.ex
+++ b/mcp_server/lib/ptc_runner_mcp/debug_recorder.ex
@@ -132,7 +132,7 @@ defmodule PtcRunnerMcp.DebugRecorder do
       result_bytes: result_bytes(sc),
       prints_count: prints_count(sc),
       signature_present?: Map.has_key?(args, "signature") and not is_nil(args["signature"]),
-      protocol_version: protocol_version(),
+      protocol_version: Keyword.get(opts, :protocol_version, Version.primary()),
       upstream_calls: redacted_upstream_calls(sc),
       # `Plans/ptc-runner-mcp-payload-reduction.md` §4.5: copy the
       # envelope's `ptc_metrics` block verbatim (string-keyed) into the
@@ -257,12 +257,4 @@ defmodule PtcRunnerMcp.DebugRecorder do
 
   defp int_or_nil(v) when is_integer(v), do: v
   defp int_or_nil(_), do: nil
-
-  defp protocol_version do
-    Version.negotiated()
-  rescue
-    _ -> nil
-  catch
-    _, _ -> nil
-  end
 end

--- a/mcp_server/lib/ptc_runner_mcp/envelope.ex
+++ b/mcp_server/lib/ptc_runner_mcp/envelope.ex
@@ -53,6 +53,7 @@ defmodule PtcRunnerMcp.Envelope do
           | :busy
           | :unknown_tool
           | :shutting_down
+          | :cancelled
 
   @doc """
   Build the `unknown_tool` envelope for any `tools/call` whose
@@ -94,6 +95,12 @@ defmodule PtcRunnerMcp.Envelope do
       :shutting_down,
       "server is draining after shutdown; new tool calls are rejected"
     )
+  end
+
+  @doc "Build a cancelled envelope for HTTP request cancellation."
+  @spec cancelled(String.t()) :: t()
+  def cancelled(message) when is_binary(message) do
+    render_error(:cancelled, message)
   end
 
   @doc """
@@ -191,6 +198,19 @@ defmodule PtcRunnerMcp.Envelope do
     %{
       "status" => "error",
       "reason" => "shutting_down",
+      "message" => message,
+      "feedback" => feedback
+    }
+  end
+
+  def render_error_payload(:cancelled, message, opts) when is_binary(message) do
+    feedback =
+      Keyword.get(opts, :feedback) ||
+        "The request was cancelled before the tool call completed."
+
+    %{
+      "status" => "error",
+      "reason" => "cancelled",
       "message" => message,
       "feedback" => feedback
     }

--- a/mcp_server/lib/ptc_runner_mcp/http/auth.ex
+++ b/mcp_server/lib/ptc_runner_mcp/http/auth.ex
@@ -1,0 +1,40 @@
+defmodule PtcRunnerMcp.Http.Auth do
+  @moduledoc false
+
+  @www_authenticate "Bearer"
+
+  @type owner :: %{id: String.t(), hash: String.t()}
+
+  @spec authenticate(Plug.Conn.t(), map()) :: {:ok, owner()} | {:error, :missing | :invalid}
+  def authenticate(_conn, %{auth_disabled: true}) do
+    {:ok, owner_for("disabled")}
+  end
+
+  def authenticate(conn, %{auth_token: token}) when is_binary(token) do
+    with ["Bearer " <> presented] <- Plug.Conn.get_req_header(conn, "authorization"),
+         true <- constant_time_equal(presented, token) do
+      {:ok, owner_for(token)}
+    else
+      [] -> {:error, :missing}
+      _ -> {:error, :invalid}
+    end
+  end
+
+  def authenticate(_conn, _cfg), do: {:ok, owner_for("loopback-unauthenticated")}
+
+  @spec challenge(:missing | :invalid) :: {integer(), String.t()}
+  def challenge(:missing), do: {401, @www_authenticate}
+  def challenge(:invalid), do: {401, ~s(Bearer error="invalid_token")}
+
+  @spec owner_for(String.t()) :: owner()
+  def owner_for(value) when is_binary(value) do
+    hash = :crypto.hash(:sha256, value) |> Base.encode16(case: :lower)
+    %{id: hash, hash: String.slice(hash, 0, 16)}
+  end
+
+  defp constant_time_equal(a, b) when is_binary(a) and is_binary(b) do
+    Plug.Crypto.secure_compare(a, b)
+  rescue
+    _ -> false
+  end
+end

--- a/mcp_server/lib/ptc_runner_mcp/http/config.ex
+++ b/mcp_server/lib/ptc_runner_mcp/http/config.ex
@@ -1,0 +1,290 @@
+defmodule PtcRunnerMcp.Http.Config do
+  @moduledoc false
+
+  alias PtcRunnerMcp.{Limits, Log}
+
+  @default_host "127.0.0.1"
+  @default_port 7332
+  @default_path "/mcp"
+  @default_request_timeout_ms 15_000
+  @default_shutdown_grace_ms 10_000
+  @default_session_ttl_ms 3_600_000
+  @default_session_idle_timeout_ms 900_000
+  @default_max_sessions 256
+  @default_max_sessions_per_owner 32
+  @default_max_in_flight_per_session 4
+  @token_min_bytes 32
+
+  @type t :: %{
+          enabled: boolean(),
+          host: String.t(),
+          port: pos_integer(),
+          path: String.t(),
+          auth_token: String.t() | nil,
+          auth_disabled: boolean(),
+          allowed_origins: [String.t()],
+          request_timeout_ms: pos_integer(),
+          shutdown_grace_ms: pos_integer(),
+          max_body_bytes: pos_integer(),
+          session_ttl_ms: pos_integer(),
+          session_idle_timeout_ms: pos_integer(),
+          max_sessions: pos_integer(),
+          max_sessions_per_owner: pos_integer(),
+          max_in_flight_per_session: pos_integer(),
+          allow_unsafe_network: boolean(),
+          metrics?: boolean(),
+          metrics_path: String.t(),
+          instance_label: String.t()
+        }
+
+  @doc false
+  @spec resolve(map()) :: {:ok, t()} | {:error, String.t()}
+  def resolve(args) when is_map(args) do
+    cfg = %{
+      enabled: read_bool(args, :http, "PTC_RUNNER_MCP_HTTP", false),
+      host: read_string(args, :http_host, "PTC_RUNNER_MCP_HTTP_HOST", @default_host),
+      port: read_int(args, :http_port, "PTC_RUNNER_MCP_HTTP_PORT", @default_port),
+      path:
+        normalize_path(read_string(args, :http_path, "PTC_RUNNER_MCP_HTTP_PATH", @default_path)),
+      auth_token: read_optional_string(args, :http_auth_token, "PTC_RUNNER_MCP_HTTP_AUTH_TOKEN"),
+      auth_disabled:
+        read_bool(args, :http_disable_auth, "PTC_RUNNER_MCP_HTTP_DISABLE_AUTH", false),
+      allowed_origins:
+        read_list(args, :http_allowed_origin, "PTC_RUNNER_MCP_HTTP_ALLOWED_ORIGIN"),
+      request_timeout_ms:
+        read_int(
+          args,
+          :http_request_timeout_ms,
+          "PTC_RUNNER_MCP_HTTP_REQUEST_TIMEOUT_MS",
+          @default_request_timeout_ms
+        ),
+      shutdown_grace_ms:
+        read_int(
+          args,
+          :http_shutdown_grace_ms,
+          "PTC_RUNNER_MCP_HTTP_SHUTDOWN_GRACE_MS",
+          @default_shutdown_grace_ms
+        ),
+      max_body_bytes:
+        read_int(
+          args,
+          :http_max_body_bytes,
+          "PTC_RUNNER_MCP_HTTP_MAX_BODY_BYTES",
+          Limits.max_frame_bytes()
+        ),
+      session_ttl_ms:
+        read_int(
+          args,
+          :http_session_ttl_ms,
+          "PTC_RUNNER_MCP_HTTP_SESSION_TTL_MS",
+          @default_session_ttl_ms
+        ),
+      session_idle_timeout_ms:
+        read_int(
+          args,
+          :http_session_idle_timeout_ms,
+          "PTC_RUNNER_MCP_HTTP_SESSION_IDLE_TIMEOUT_MS",
+          @default_session_idle_timeout_ms
+        ),
+      max_sessions:
+        read_int(
+          args,
+          :http_max_sessions,
+          "PTC_RUNNER_MCP_HTTP_MAX_SESSIONS",
+          @default_max_sessions
+        ),
+      max_sessions_per_owner:
+        read_int(
+          args,
+          :http_max_sessions_per_owner,
+          "PTC_RUNNER_MCP_HTTP_MAX_SESSIONS_PER_OWNER",
+          @default_max_sessions_per_owner
+        ),
+      max_in_flight_per_session:
+        read_int(
+          args,
+          :http_max_in_flight_per_session,
+          "PTC_RUNNER_MCP_HTTP_MAX_IN_FLIGHT_PER_SESSION",
+          @default_max_in_flight_per_session
+        ),
+      allow_unsafe_network:
+        read_bool(
+          args,
+          :http_allow_unsafe_network,
+          "PTC_RUNNER_MCP_HTTP_ALLOW_UNSAFE_NETWORK",
+          false
+        ),
+      metrics?: read_bool(args, :http_metrics, "PTC_RUNNER_MCP_HTTP_METRICS", false),
+      metrics_path:
+        normalize_path(
+          read_string(args, :http_metrics_path, "PTC_RUNNER_MCP_HTTP_METRICS_PATH", "/metrics")
+        ),
+      instance_label:
+        read_string(args, :http_instance_label, "PTC_RUNNER_MCP_HTTP_INSTANCE_LABEL", hostname())
+    }
+
+    validate(cfg)
+  end
+
+  @doc false
+  @spec loopback_host?(String.t()) :: boolean()
+  def loopback_host?(host) when is_binary(host) do
+    case :inet.parse_address(to_charlist(host)) do
+      {:ok, {127, _, _, _}} -> true
+      {:ok, {0, 0, 0, 0, 0, 0, 0, 1}} -> true
+      _ -> host in ["localhost", "::1"]
+    end
+  end
+
+  @doc false
+  @spec token_min_bytes() :: pos_integer()
+  def token_min_bytes, do: @token_min_bytes
+
+  defp validate(%{enabled: false} = cfg), do: {:ok, cfg}
+
+  defp validate(cfg) do
+    with :ok <- validate_path_collisions(cfg),
+         :ok <- validate_auth(cfg) do
+      maybe_warn_single_token_caps(cfg)
+      {:ok, cfg}
+    end
+  end
+
+  defp validate_path_collisions(cfg) do
+    paths = [cfg.path, "/health", "/ready", cfg.metrics_path]
+
+    if Enum.uniq(paths) == paths do
+      :ok
+    else
+      {:error, "HTTP paths must be distinct"}
+    end
+  end
+
+  defp validate_auth(%{auth_token: token})
+       when is_binary(token) and byte_size(token) < @token_min_bytes do
+    {:error, "HTTP auth token must be at least #{@token_min_bytes} characters"}
+  end
+
+  defp validate_auth(%{auth_disabled: true, allow_unsafe_network: true}), do: :ok
+
+  defp validate_auth(%{auth_disabled: true, host: host}) when is_binary(host),
+    do: auth_disabled_loopback(host)
+
+  defp validate_auth(%{auth_token: token}) when is_binary(token), do: :ok
+
+  defp validate_auth(%{host: host}) do
+    if loopback_host?(host) do
+      :ok
+    else
+      {:error, "HTTP auth token is required for non-loopback binds"}
+    end
+  end
+
+  defp auth_disabled_loopback(host) do
+    if loopback_host?(host) do
+      Log.log(:warn, "http_auth_disabled_loopback")
+      :ok
+    else
+      {:error, "non-loopback unauthenticated HTTP requires --http-allow-unsafe-network"}
+    end
+  end
+
+  defp maybe_warn_single_token_caps(%{
+         auth_token: token,
+         max_sessions: max_sessions,
+         max_sessions_per_owner: max_per_owner
+       })
+       when is_binary(token) and max_per_owner < max_sessions do
+    Log.log(:warn, "http_single_token_owner_cap_below_global", %{
+      max_sessions: max_sessions,
+      max_sessions_per_owner: max_per_owner
+    })
+  end
+
+  defp maybe_warn_single_token_caps(_cfg), do: :ok
+
+  defp read_string(args, key, env, default) do
+    case env_or(args, key, env) do
+      nil -> default
+      value when is_binary(value) -> value
+      value -> to_string(value)
+    end
+  end
+
+  defp read_optional_string(args, key, env) do
+    case env_or(args, key, env) do
+      nil -> nil
+      "" -> nil
+      value when is_binary(value) -> value
+      value -> to_string(value)
+    end
+  end
+
+  defp read_int(args, key, env, default) do
+    case env_or(args, key, env) do
+      nil ->
+        default
+
+      n when is_integer(n) and n > 0 ->
+        n
+
+      value when is_binary(value) ->
+        case Integer.parse(value) do
+          {n, _} when n > 0 -> n
+          _ -> default
+        end
+
+      _ ->
+        default
+    end
+  end
+
+  defp read_bool(args, key, env, default) do
+    case env_or(args, key, env) do
+      nil -> default
+      value when is_boolean(value) -> value
+      value when is_binary(value) -> value |> String.downcase() |> String.trim() |> bool(default)
+      _ -> default
+    end
+  end
+
+  defp bool(value, _default) when value in ["1", "true", "yes", "on"], do: true
+  defp bool(value, _default) when value in ["0", "false", "no", "off"], do: false
+  defp bool(_value, default), do: default
+
+  defp read_list(args, key, env) do
+    values =
+      args
+      |> Map.get(key, [])
+      |> List.wrap()
+
+    env_values =
+      case System.get_env(env) do
+        nil -> []
+        "" -> []
+        raw -> String.split(raw, ",", trim: true)
+      end
+
+    (values ++ env_values)
+    |> Enum.map(&to_string/1)
+    |> Enum.flat_map(&String.split(&1, ",", trim: true))
+    |> Enum.map(&String.trim/1)
+    |> Enum.reject(&(&1 == ""))
+  end
+
+  defp env_or(args, key, env) do
+    case Map.fetch(args, key) do
+      {:ok, value} -> value
+      :error -> System.get_env(env)
+    end
+  end
+
+  defp normalize_path(path) when is_binary(path) do
+    if String.starts_with?(path, "/"), do: path, else: "/" <> path
+  end
+
+  defp hostname do
+    {:ok, name} = :inet.gethostname()
+    List.to_string(name)
+  end
+end

--- a/mcp_server/lib/ptc_runner_mcp/http/config.ex
+++ b/mcp_server/lib/ptc_runner_mcp/http/config.ex
@@ -143,10 +143,20 @@ defmodule PtcRunnerMcp.Http.Config do
   defp validate(%{enabled: false} = cfg), do: {:ok, cfg}
 
   defp validate(cfg) do
-    with :ok <- validate_path_collisions(cfg),
+    with :ok <- validate_bind_host(cfg.host),
+         :ok <- validate_path_collisions(cfg),
          :ok <- validate_auth(cfg) do
       maybe_warn_single_token_caps(cfg)
       {:ok, cfg}
+    end
+  end
+
+  defp validate_bind_host("localhost"), do: :ok
+
+  defp validate_bind_host(host) when is_binary(host) do
+    case :inet.parse_address(to_charlist(host)) do
+      {:ok, _ip} -> :ok
+      _ -> {:error, "HTTP host must be an IP address or localhost"}
     end
   end
 

--- a/mcp_server/lib/ptc_runner_mcp/http/origin.ex
+++ b/mcp_server/lib/ptc_runner_mcp/http/origin.ex
@@ -1,0 +1,60 @@
+defmodule PtcRunnerMcp.Http.Origin do
+  @moduledoc false
+
+  alias PtcRunnerMcp.Http.Config
+
+  @spec allowed?(Plug.Conn.t(), map()) :: boolean()
+  def allowed?(conn, cfg) do
+    case Plug.Conn.get_req_header(conn, "origin") do
+      [] -> true
+      [origin | _] -> allowed_origin?(origin, cfg)
+    end
+  end
+
+  @spec allowed_origin?(String.t(), map()) :: boolean()
+  def allowed_origin?(origin, cfg) when is_binary(origin) do
+    normalized = normalize(origin)
+    allowed = Enum.map(Map.get(cfg, :allowed_origins, []), &normalize/1)
+
+    cond do
+      normalized == nil ->
+        false
+
+      allowed != [] ->
+        normalized in allowed
+
+      Config.loopback_host?(Map.fetch!(cfg, :host)) ->
+        loopback_origin?(normalized)
+
+      true ->
+        false
+    end
+  end
+
+  defp loopback_origin?(origin) do
+    uri = URI.parse(origin)
+    uri.scheme in ["http", "https"] and Config.loopback_host?(uri.host || "")
+  end
+
+  defp normalize("null"), do: nil
+
+  defp normalize(origin) when is_binary(origin) do
+    uri = URI.parse(origin)
+
+    with scheme when scheme in ["http", "https"] <- lower(uri.scheme),
+         host when is_binary(host) <- lower(uri.host) do
+      port = normalized_port(scheme, uri.port)
+      scheme <> "://" <> host <> port
+    else
+      _ -> nil
+    end
+  end
+
+  defp lower(nil), do: nil
+  defp lower(value), do: String.downcase(value)
+
+  defp normalized_port("http", 80), do: ""
+  defp normalized_port("https", 443), do: ""
+  defp normalized_port(_scheme, nil), do: ""
+  defp normalized_port(_scheme, port), do: ":" <> Integer.to_string(port)
+end

--- a/mcp_server/lib/ptc_runner_mcp/http/plug_with_config.ex
+++ b/mcp_server/lib/ptc_runner_mcp/http/plug_with_config.ex
@@ -1,0 +1,13 @@
+defmodule PtcRunnerMcp.Http.PlugWithConfig do
+  @moduledoc false
+
+  alias PtcRunnerMcp.Http.Router
+
+  def init(config), do: config
+
+  def call(conn, config) do
+    conn
+    |> Plug.Conn.put_private(:ptc_http_config, config)
+    |> Router.call([])
+  end
+end

--- a/mcp_server/lib/ptc_runner_mcp/http/router.ex
+++ b/mcp_server/lib/ptc_runner_mcp/http/router.ex
@@ -1,0 +1,304 @@
+defmodule PtcRunnerMcp.Http.Router do
+  @moduledoc false
+
+  use Plug.Router
+
+  alias PtcRunnerMcp.Http.{Auth, Origin, Session, SessionRegistry}
+  alias PtcRunnerMcp.{JsonRpc, Limits, Version}
+
+  plug(:match)
+  plug(:dispatch)
+
+  get "/health" do
+    json(conn, 200, %{"status" => "ok"})
+  end
+
+  get "/ready" do
+    cfg = config(conn)
+
+    cond do
+      registry_down?() ->
+        json(conn, 503, %{"status" => "draining"})
+
+      SessionRegistry.draining?() ->
+        json(conn, 503, %{"status" => "draining"})
+
+      SessionRegistry.saturated?() ->
+        json(conn, 503, %{"status" => "saturated"})
+
+      true ->
+        json(conn, 200, %{"status" => "ready", "instance" => cfg.instance_label})
+    end
+  end
+
+  match _ do
+    cfg = config(conn)
+    request_id = request_id(conn)
+    conn = Plug.Conn.put_resp_header(conn, "x-request-id", request_id)
+
+    if conn.request_path == cfg.path do
+      route_mcp(conn, cfg)
+    else
+      Plug.Conn.send_resp(conn, 404, "not found")
+    end
+  end
+
+  defp route_mcp(%{method: "GET"} = conn, _cfg) do
+    conn
+    |> Plug.Conn.put_resp_header("allow", "POST, DELETE")
+    |> Plug.Conn.send_resp(405, "")
+  end
+
+  defp route_mcp(%{method: "DELETE"} = conn, cfg) do
+    with {:ok, owner} <- authenticate(conn, cfg),
+         {:ok, session_id} <- session_id(conn) do
+      case SessionRegistry.delete(session_id, owner) do
+        :ok -> Plug.Conn.send_resp(conn, 202, "")
+        {:error, :not_found} -> Plug.Conn.send_resp(conn, 404, "")
+      end
+    else
+      {:error, {:auth, reason}} -> auth_error(conn, reason)
+      {:error, :missing_session} -> Plug.Conn.send_resp(conn, 400, "missing MCP-Session-Id")
+      {:error, :origin} -> Plug.Conn.send_resp(conn, 403, "forbidden")
+    end
+  end
+
+  defp route_mcp(%{method: "POST"} = conn, cfg) do
+    with {:ok, owner} <- authenticate(conn, cfg),
+         {:ok, body, conn} <- read_body_capped(conn, cfg),
+         {:ok, decoded} <- decode_body(body) do
+      handle_post(conn, cfg, owner, decoded)
+    else
+      {:error, {:auth, reason}} ->
+        auth_error(conn, reason)
+
+      {:error, :origin} ->
+        Plug.Conn.send_resp(conn, 403, "forbidden")
+
+      {:error, :empty_body} ->
+        Plug.Conn.send_resp(conn, 400, "empty body")
+
+      {:error, :too_large} ->
+        Plug.Conn.send_resp(conn, 413, "payload too large")
+
+      {:error, :parse_error} ->
+        json(conn, 200, JsonRpc.dispatch({:error, :parse_error}) |> elem(1))
+    end
+  end
+
+  defp route_mcp(conn, _cfg) do
+    conn
+    |> Plug.Conn.put_resp_header("allow", "POST, DELETE")
+    |> Plug.Conn.send_resp(405, "")
+  end
+
+  defp handle_post(
+         conn,
+         _cfg,
+         owner,
+         %{"method" => "initialize", "id" => id} = frame
+       ) do
+    cond do
+      has_session_id?(conn) ->
+        Plug.Conn.send_resp(conn, 400, "initialize must not include MCP-Session-Id")
+
+      Map.get(frame, "jsonrpc") != "2.0" ->
+        json(conn, 200, invalid_request_reply(nil))
+
+      true ->
+        params = Map.get(frame, "params")
+        protocol_version = negotiate(params)
+
+        case SessionRegistry.create(owner, protocol_version) do
+          {:ok, meta} ->
+            case Session.request(meta.pid, frame) do
+              {:reply, reply} ->
+                conn
+                |> Plug.Conn.put_resp_header("mcp-session-id", meta.id)
+                |> json(200, reply)
+
+              :accepted ->
+                Plug.Conn.send_resp(conn, 202, "")
+            end
+
+          {:error, :max_sessions_per_owner} ->
+            json(conn, 429, server_error(id, "session owner limit exceeded"))
+
+          {:error, _} ->
+            json(conn, 503, server_error(id, "server saturated"))
+        end
+    end
+  end
+
+  defp handle_post(conn, _cfg, owner, %{"method" => _method} = frame) do
+    with {:ok, session_id} <- session_id(conn),
+         {:ok, meta} <- SessionRegistry.lookup(session_id, owner),
+         :ok <- protocol_version_ok(conn, meta.protocol_version) do
+      if Map.has_key?(frame, "id") do
+        case Session.request(meta.pid, frame) do
+          {:reply, reply} ->
+            json(conn, 200, reply)
+
+          :accepted ->
+            await_reply(conn, meta.pid, Map.get(frame, "id"), worker_await_timeout_ms(frame))
+        end
+      else
+        _ = Session.notify_or_response(meta.pid, frame)
+        Plug.Conn.send_resp(conn, 202, "")
+      end
+    else
+      {:error, :missing_session} ->
+        Plug.Conn.send_resp(conn, 400, "missing MCP-Session-Id")
+
+      {:error, :not_found} ->
+        Plug.Conn.send_resp(conn, 404, "")
+
+      {:error, :bad_protocol_version} ->
+        Plug.Conn.send_resp(conn, 400, "bad MCP-Protocol-Version")
+    end
+  end
+
+  defp handle_post(conn, _cfg, owner, %{"id" => _, "result" => _} = frame),
+    do: handle_response(conn, owner, frame)
+
+  defp handle_post(conn, _cfg, owner, %{"id" => _, "error" => _} = frame),
+    do: handle_response(conn, owner, frame)
+
+  defp handle_post(conn, _cfg, _owner, _decoded) do
+    json(conn, 200, invalid_request_reply(nil))
+  end
+
+  defp handle_response(conn, owner, frame) do
+    with {:ok, session_id} <- session_id(conn),
+         {:ok, meta} <- SessionRegistry.lookup(session_id, owner),
+         :ok <- protocol_version_ok(conn, meta.protocol_version) do
+      _ = Session.notify_or_response(meta.pid, frame)
+      Plug.Conn.send_resp(conn, 202, "")
+    else
+      {:error, :missing_session} ->
+        Plug.Conn.send_resp(conn, 400, "missing MCP-Session-Id")
+
+      {:error, :not_found} ->
+        Plug.Conn.send_resp(conn, 404, "")
+
+      {:error, :bad_protocol_version} ->
+        Plug.Conn.send_resp(conn, 400, "bad MCP-Protocol-Version")
+    end
+  end
+
+  defp await_reply(conn, session_pid, id, timeout_ms) do
+    receive do
+      {:ptc_http_reply, ^id, reply} -> json(conn, 200, reply)
+    after
+      timeout_ms ->
+        _ = Session.cancel(session_pid, id, :await_timeout)
+        json(conn, 200, server_error(id, "request timed out"))
+    end
+  end
+
+  defp authenticate(conn, cfg) do
+    if Origin.allowed?(conn, cfg) do
+      case Auth.authenticate(conn, cfg) do
+        {:ok, owner} -> {:ok, owner}
+        {:error, reason} -> {:error, {:auth, reason}}
+      end
+    else
+      {:error, :origin}
+    end
+  end
+
+  defp auth_error(conn, reason) do
+    {status, header} = Auth.challenge(reason)
+
+    conn
+    |> Plug.Conn.put_resp_header("www-authenticate", header)
+    |> Plug.Conn.send_resp(status, "")
+  end
+
+  defp read_body_capped(conn, cfg) do
+    case Plug.Conn.read_body(conn,
+           length: cfg.max_body_bytes,
+           read_length: min(cfg.max_body_bytes, 1_000_000)
+         ) do
+      {:ok, "", _conn} -> {:error, :empty_body}
+      {:ok, body, conn} -> {:ok, body, conn}
+      {:more, _partial, _conn} -> {:error, :too_large}
+      {:error, _} -> {:error, :parse_error}
+    end
+  end
+
+  defp decode_body(body) do
+    case Jason.decode(body) do
+      {:ok, value} when is_map(value) -> {:ok, value}
+      {:ok, _} -> {:ok, :invalid_request}
+      {:error, _} -> {:error, :parse_error}
+    end
+  end
+
+  defp session_id(conn) do
+    case Plug.Conn.get_req_header(conn, "mcp-session-id") do
+      [id | _] when id != "" -> {:ok, id}
+      _ -> {:error, :missing_session}
+    end
+  end
+
+  defp has_session_id?(conn), do: match?({:ok, _}, session_id(conn))
+
+  defp protocol_version_ok(conn, negotiated) do
+    case Plug.Conn.get_req_header(conn, "mcp-protocol-version") do
+      [] ->
+        :ok
+
+      [^negotiated | _] ->
+        :ok
+
+      [version | _] ->
+        if version in Version.supported(), do: :ok, else: {:error, :bad_protocol_version}
+    end
+  end
+
+  defp negotiate(params) do
+    requested =
+      case params do
+        %{"protocolVersion" => version} when is_binary(version) -> version
+        _ -> nil
+      end
+
+    Version.negotiate(requested)
+  end
+
+  defp worker_await_timeout_ms(%{"params" => %{"name" => "ptc_task"}}),
+    do: PtcRunnerMcp.AgenticConfig.get().task_timeout_ms + 1_000
+
+  defp worker_await_timeout_ms(_frame), do: Limits.program_timeout_ms() + 1_000
+
+  defp json(conn, status, body) do
+    conn
+    |> Plug.Conn.put_resp_content_type("application/json")
+    |> Plug.Conn.send_resp(status, Jason.encode!(body))
+  end
+
+  defp server_error(id, message) do
+    %{"jsonrpc" => "2.0", "id" => id, "error" => %{"code" => -32_000, "message" => message}}
+  end
+
+  defp invalid_request_reply(id) do
+    %{
+      "jsonrpc" => "2.0",
+      "id" => id,
+      "error" => %{"code" => -32_600, "message" => "Invalid Request"}
+    }
+  end
+
+  defp request_id(conn) do
+    case Plug.Conn.get_req_header(conn, "x-request-id") do
+      [id | _] when byte_size(id) <= 128 -> id
+      _ -> Base.url_encode64(:crypto.strong_rand_bytes(12), padding: false)
+    end
+  end
+
+  defp registry_down?, do: Process.whereis(SessionRegistry) == nil
+
+  defp config(conn),
+    do: conn.private[:ptc_http_config] || Application.fetch_env!(:ptc_runner_mcp, :http_config)
+end

--- a/mcp_server/lib/ptc_runner_mcp/http/router.ex
+++ b/mcp_server/lib/ptc_runner_mcp/http/router.ex
@@ -3,10 +3,11 @@ defmodule PtcRunnerMcp.Http.Router do
 
   use Plug.Router
 
-  alias PtcRunnerMcp.Http.{Auth, Origin, Session, SessionRegistry}
-  alias PtcRunnerMcp.{JsonRpc, Limits, Version}
+  alias PtcRunnerMcp.Http.{Auth, Origin, Session, SessionRegistry, Telemetry}
+  alias PtcRunnerMcp.{JsonRpc, Limits, Log, Version}
 
   plug(:match)
+  plug(:instrument_request)
   plug(:dispatch)
 
   get "/health" do
@@ -33,8 +34,6 @@ defmodule PtcRunnerMcp.Http.Router do
 
   match _ do
     cfg = config(conn)
-    request_id = request_id(conn)
-    conn = Plug.Conn.put_resp_header(conn, "x-request-id", request_id)
 
     if conn.request_path == cfg.path do
       route_mcp(conn, cfg)
@@ -52,6 +51,12 @@ defmodule PtcRunnerMcp.Http.Router do
   defp route_mcp(%{method: "DELETE"} = conn, cfg) do
     with {:ok, owner} <- authenticate(conn, cfg),
          {:ok, session_id} <- session_id(conn) do
+      conn =
+        put_http_private(conn,
+          owner_hash: owner.hash,
+          session_hash: Telemetry.hash_id(session_id)
+        )
+
       case SessionRegistry.delete(session_id, owner) do
         :ok -> Plug.Conn.send_resp(conn, 202, "")
         {:error, :not_found} -> Plug.Conn.send_resp(conn, 404, "")
@@ -67,7 +72,11 @@ defmodule PtcRunnerMcp.Http.Router do
     with {:ok, owner} <- authenticate(conn, cfg),
          {:ok, body, conn} <- read_body_capped(conn, cfg),
          {:ok, decoded} <- decode_body(body) do
-      handle_post(conn, cfg, owner, decoded)
+      if registry_draining?() do
+        json(conn, 503, server_error(frame_id(decoded), "server draining"))
+      else
+        handle_post(conn, cfg, owner, decoded)
+      end
     else
       {:error, {:auth, reason}} ->
         auth_error(conn, reason)
@@ -111,7 +120,9 @@ defmodule PtcRunnerMcp.Http.Router do
 
         case SessionRegistry.create(owner, protocol_version) do
           {:ok, meta} ->
-            case Session.request(meta.pid, frame) do
+            conn = put_session_private(conn, owner, meta)
+
+            case Session.request(meta.pid, frame, request_context(conn, owner, meta)) do
               {:reply, reply} ->
                 conn
                 |> Plug.Conn.put_resp_header("mcp-session-id", meta.id)
@@ -122,9 +133,11 @@ defmodule PtcRunnerMcp.Http.Router do
             end
 
           {:error, :max_sessions_per_owner} ->
+            conn = put_http_private(conn, owner_hash: owner.hash)
             json(conn, 429, server_error(id, "session owner limit exceeded"))
 
           {:error, _} ->
+            conn = put_http_private(conn, owner_hash: owner.hash)
             json(conn, 503, server_error(id, "server saturated"))
         end
     end
@@ -134,8 +147,10 @@ defmodule PtcRunnerMcp.Http.Router do
     with {:ok, session_id} <- session_id(conn),
          {:ok, meta} <- SessionRegistry.lookup(session_id, owner),
          :ok <- protocol_version_ok(conn, meta.protocol_version) do
+      conn = put_session_private(conn, owner, meta)
+
       if Map.has_key?(frame, "id") do
-        case Session.request(meta.pid, frame) do
+        case Session.request(meta.pid, frame, request_context(conn, owner, meta)) do
           {:reply, reply} ->
             json(conn, 200, reply)
 
@@ -172,6 +187,7 @@ defmodule PtcRunnerMcp.Http.Router do
     with {:ok, session_id} <- session_id(conn),
          {:ok, meta} <- SessionRegistry.lookup(session_id, owner),
          :ok <- protocol_version_ok(conn, meta.protocol_version) do
+      conn = put_session_private(conn, owner, meta)
       _ = Session.notify_or_response(meta.pid, frame)
       Plug.Conn.send_resp(conn, 202, "")
     else
@@ -199,8 +215,12 @@ defmodule PtcRunnerMcp.Http.Router do
   defp authenticate(conn, cfg) do
     if Origin.allowed?(conn, cfg) do
       case Auth.authenticate(conn, cfg) do
-        {:ok, owner} -> {:ok, owner}
-        {:error, reason} -> {:error, {:auth, reason}}
+        {:ok, owner} ->
+          {:ok, owner}
+
+        {:error, reason} ->
+          Telemetry.emit([:auth, :failure], %{count: 1}, base_meta(conn, cfg, %{reason: reason}))
+          {:error, {:auth, reason}}
       end
     else
       {:error, :origin}
@@ -252,8 +272,8 @@ defmodule PtcRunnerMcp.Http.Router do
       [^negotiated | _] ->
         :ok
 
-      [version | _] ->
-        if version in Version.supported(), do: :ok, else: {:error, :bad_protocol_version}
+      [_version | _] ->
+        {:error, :bad_protocol_version}
     end
   end
 
@@ -290,6 +310,93 @@ defmodule PtcRunnerMcp.Http.Router do
     }
   end
 
+  defp instrument_request(conn, _opts) do
+    cfg = config(conn)
+    request_id = request_id(conn)
+    start = System.monotonic_time()
+
+    conn =
+      conn
+      |> Plug.Conn.put_private(:ptc_http_request_id, request_id)
+      |> Plug.Conn.put_private(:ptc_http_started_at, start)
+      |> Plug.Conn.put_resp_header("x-request-id", request_id)
+
+    Telemetry.emit([:request, :start], %{system_time: System.system_time()}, base_meta(conn, cfg))
+
+    Plug.Conn.register_before_send(conn, fn conn ->
+      duration = System.monotonic_time() - start
+      duration_ms = System.convert_time_unit(duration, :native, :millisecond)
+
+      metadata =
+        base_meta(conn, cfg, %{status: conn.status, error_class: error_class(conn.status)})
+
+      Telemetry.emit([:request, :stop], %{duration: duration}, metadata)
+
+      Log.log(:info, "http_request_stop", %{
+        request_id: request_id,
+        instance: cfg.instance_label,
+        method: conn.method,
+        path: conn.request_path,
+        status: conn.status,
+        duration_ms: duration_ms,
+        owner_hash: conn.private[:ptc_http_owner_hash],
+        session_hash: conn.private[:ptc_http_session_hash],
+        error_class: error_class(conn.status)
+      })
+
+      conn
+    end)
+  end
+
+  defp put_session_private(conn, owner, meta) do
+    put_http_private(conn,
+      owner_hash: owner.hash,
+      session_hash: Telemetry.hash_id(meta.id),
+      protocol_version: meta.protocol_version
+    )
+  end
+
+  defp put_http_private(conn, opts) do
+    Enum.reduce(opts, conn, fn
+      {:owner_hash, value}, acc ->
+        Plug.Conn.put_private(acc, :ptc_http_owner_hash, value)
+
+      {:session_hash, value}, acc ->
+        Plug.Conn.put_private(acc, :ptc_http_session_hash, value)
+
+      {:protocol_version, value}, acc ->
+        Plug.Conn.put_private(acc, :ptc_http_protocol_version, value)
+    end)
+  end
+
+  defp request_context(conn, owner, meta) do
+    [
+      transport: :http,
+      transport_request_id: conn.private[:ptc_http_request_id],
+      owner_hash: owner.hash,
+      mcp_session_hash: Telemetry.hash_id(meta.id)
+    ]
+  end
+
+  defp base_meta(conn, cfg, extra \\ %{}) do
+    %{
+      instance: cfg.instance_label,
+      request_id: conn.private[:ptc_http_request_id],
+      method: conn.method,
+      path: conn.request_path,
+      owner_hash: conn.private[:ptc_http_owner_hash],
+      session_hash: conn.private[:ptc_http_session_hash]
+    }
+    |> Map.merge(extra)
+  end
+
+  defp frame_id(%{"id" => id}), do: id
+  defp frame_id(_), do: nil
+
+  defp error_class(status) when is_integer(status) and status >= 500, do: :server_error
+  defp error_class(status) when is_integer(status) and status >= 400, do: :client_error
+  defp error_class(_), do: nil
+
   defp request_id(conn) do
     case Plug.Conn.get_req_header(conn, "x-request-id") do
       [id | _] when byte_size(id) <= 128 -> id
@@ -298,6 +405,10 @@ defmodule PtcRunnerMcp.Http.Router do
   end
 
   defp registry_down?, do: Process.whereis(SessionRegistry) == nil
+
+  defp registry_draining? do
+    Process.whereis(SessionRegistry) != nil and SessionRegistry.draining?()
+  end
 
   defp config(conn),
     do: conn.private[:ptc_http_config] || Application.fetch_env!(:ptc_runner_mcp, :http_config)

--- a/mcp_server/lib/ptc_runner_mcp/http/server.ex
+++ b/mcp_server/lib/ptc_runner_mcp/http/server.ex
@@ -1,0 +1,36 @@
+defmodule PtcRunnerMcp.Http.Server do
+  @moduledoc false
+
+  alias PtcRunnerMcp.Http.Router
+
+  @spec child_spec(map()) :: {module(), keyword()}
+  def child_spec(config) do
+    plug = {__MODULE__.PlugWithConfig, config}
+
+    {Bandit,
+     plug: plug,
+     scheme: :http,
+     ip: parse_ip(config.host),
+     port: config.port,
+     thousand_island_options: [read_timeout: config.request_timeout_ms]}
+  end
+
+  defp parse_ip(host) do
+    case :inet.parse_address(to_charlist(host)) do
+      {:ok, ip} -> ip
+      _ -> {127, 0, 0, 1}
+    end
+  end
+
+  defmodule PlugWithConfig do
+    @moduledoc false
+
+    def init(config), do: config
+
+    def call(conn, config) do
+      conn
+      |> Plug.Conn.put_private(:ptc_http_config, config)
+      |> Router.call([])
+    end
+  end
+end

--- a/mcp_server/lib/ptc_runner_mcp/http/server.ex
+++ b/mcp_server/lib/ptc_runner_mcp/http/server.ex
@@ -1,11 +1,11 @@
 defmodule PtcRunnerMcp.Http.Server do
   @moduledoc false
 
-  alias PtcRunnerMcp.Http.Router
+  alias PtcRunnerMcp.Http.PlugWithConfig
 
   @spec child_spec(map()) :: {module(), keyword()}
   def child_spec(config) do
-    plug = {__MODULE__.PlugWithConfig, config}
+    plug = {PlugWithConfig, config}
 
     {Bandit,
      plug: plug,
@@ -19,18 +19,6 @@ defmodule PtcRunnerMcp.Http.Server do
     case :inet.parse_address(to_charlist(host)) do
       {:ok, ip} -> ip
       _ -> {127, 0, 0, 1}
-    end
-  end
-
-  defmodule PlugWithConfig do
-    @moduledoc false
-
-    def init(config), do: config
-
-    def call(conn, config) do
-      conn
-      |> Plug.Conn.put_private(:ptc_http_config, config)
-      |> Router.call([])
     end
   end
 end

--- a/mcp_server/lib/ptc_runner_mcp/http/session.ex
+++ b/mcp_server/lib/ptc_runner_mcp/http/session.ex
@@ -3,6 +3,8 @@ defmodule PtcRunnerMcp.Http.Session do
 
   use GenServer
 
+  alias PtcRunnerMcp.Http.Telemetry
+
   alias PtcRunnerMcp.{
     ConcurrencyGate,
     Envelope,
@@ -58,9 +60,9 @@ defmodule PtcRunnerMcp.Http.Session do
      }}
   end
 
-  @spec request(GenServer.server(), map(), timeout()) :: terminal()
-  def request(server, frame, timeout \\ 5_000) do
-    GenServer.call(server, {:request, frame, self()}, timeout)
+  @spec request(GenServer.server(), map(), keyword(), timeout()) :: terminal()
+  def request(server, frame, context \\ [], timeout \\ 5_000) do
+    GenServer.call(server, {:request, frame, self(), context}, timeout)
   end
 
   @spec notify_or_response(GenServer.server(), map(), timeout()) :: :accepted | {:reply, map()}
@@ -89,10 +91,10 @@ defmodule PtcRunnerMcp.Http.Session do
   end
 
   @impl GenServer
-  def handle_call({:request, frame, waiter}, _from, state) do
+  def handle_call({:request, frame, waiter, context}, _from, state) do
     state = touch(state)
 
-    case dispatch(frame, state) do
+    case dispatch(frame, state, context) do
       {:reply, reply, lifecycle} ->
         reply_with_lifecycle({:reply, reply}, state, lifecycle)
 
@@ -125,7 +127,7 @@ defmodule PtcRunnerMcp.Http.Session do
         {:reply, :accepted, state}
 
       false ->
-        case dispatch(frame, state) do
+        case dispatch(frame, state, []) do
           {:reply, _reply, lifecycle} ->
             reply_with_lifecycle(:accepted, state, lifecycle)
 
@@ -164,13 +166,14 @@ defmodule PtcRunnerMcp.Http.Session do
   @impl GenServer
   def handle_info({:async_reply, request_id, envelope}, state) do
     case Map.fetch(state.in_flight, request_id) do
-      {:ok, %{ref: ref, waiter: waiter}} ->
+      {:ok, %{ref: ref, waiter: waiter, waiter_ref: waiter_ref}} ->
         Log.log(:info, "tools_call_stop", %{
           request_id: request_id,
           is_error: Map.get(envelope, "isError")
         })
 
         Process.demonitor(ref, [:flush])
+        Process.demonitor(waiter_ref, [:flush])
         send(waiter, {:ptc_http_reply, request_id, success_reply(request_id, envelope)})
         {:noreply, state |> remove_in_flight(request_id) |> touch()}
 
@@ -179,7 +182,7 @@ defmodule PtcRunnerMcp.Http.Session do
     end
   end
 
-  def handle_info({:DOWN, _ref, :process, pid, reason}, state) do
+  def handle_info({:DOWN, ref, :process, pid, reason}, state) do
     case Map.fetch(state.workers, pid) do
       {:ok, request_id} ->
         reply =
@@ -194,7 +197,16 @@ defmodule PtcRunnerMcp.Http.Session do
         {:noreply, state |> remove_in_flight(request_id) |> touch()}
 
       :error ->
-        {:noreply, state}
+        case find_waiter_request(state, ref) do
+          nil ->
+            {:noreply, state}
+
+          request_id ->
+            {state, _cancelled?} =
+              cancel_request(state, request_id, :client_disconnect, reply?: false)
+
+            {:noreply, touch(state)}
+        end
     end
   end
 
@@ -204,12 +216,16 @@ defmodule PtcRunnerMcp.Http.Session do
     :ok
   end
 
-  defp dispatch(frame, state) do
+  defp dispatch(frame, state, context) do
     frame = maybe_put_http_owner(frame, state.id)
 
     JsonRpc.dispatch({:ok, frame},
       draining: state.draining,
-      protocol_version: state.protocol_version
+      protocol_version: state.protocol_version,
+      transport: Keyword.get(context, :transport, :http),
+      transport_request_id: Keyword.get(context, :transport_request_id),
+      owner_hash: Keyword.get(context, :owner_hash, state.owner_hash),
+      mcp_session_hash: Keyword.get(context, :mcp_session_hash)
     )
   end
 
@@ -220,6 +236,7 @@ defmodule PtcRunnerMcp.Http.Session do
         {:reply, duplicate_reply(request_id), state}
 
       map_size(state.in_flight) >= state.max_in_flight ->
+        Telemetry.emit([:limit, :rejected], %{count: 1}, telemetry_meta(state, :in_flight))
         envelope = Envelope.busy(state.max_in_flight)
         safe_invoke(on_busy, envelope)
         {:reply, success_reply(request_id, envelope), state}
@@ -230,6 +247,12 @@ defmodule PtcRunnerMcp.Http.Session do
             {:ok, spawn_worker(state, request_id, work_fn, on_discard, waiter)}
 
           :full ->
+            Telemetry.emit(
+              [:limit, :rejected],
+              %{count: 1},
+              telemetry_meta(state, :global_concurrency)
+            )
+
             envelope = Envelope.busy(Limits.max_concurrent_calls())
             safe_invoke(on_busy, envelope)
             {:reply, success_reply(request_id, envelope), state}
@@ -239,6 +262,7 @@ defmodule PtcRunnerMcp.Http.Session do
 
   defp spawn_worker(state, request_id, work_fn, on_discard, waiter) do
     parent = self()
+    waiter_ref = Process.monitor(waiter)
 
     {pid, ref} =
       spawn_monitor(fn ->
@@ -253,19 +277,24 @@ defmodule PtcRunnerMcp.Http.Session do
             pid: pid,
             ref: ref,
             waiter: waiter,
+            waiter_ref: waiter_ref,
             on_discard: on_discard
           }),
         workers: Map.put(state.workers, pid, request_id)
     }
   end
 
-  defp cancel_request(state, request_id, _reason) do
+  defp cancel_request(state, request_id, reason, opts \\ []) do
     case Map.fetch(state.in_flight, request_id) do
-      {:ok, %{pid: pid, ref: ref, waiter: waiter, on_discard: on_discard}} ->
+      {:ok, %{pid: pid, ref: ref, waiter: waiter}} ->
         Process.demonitor(ref, [:flush])
         Process.exit(pid, :kill)
-        safe_invoke(on_discard)
-        send(waiter, {:ptc_http_reply, request_id, cancelled_reply(request_id)})
+
+        if Keyword.get(opts, :reply?, true) do
+          send(waiter, {:ptc_http_reply, request_id, cancelled_reply(request_id)})
+        end
+
+        Telemetry.emit([:cancelled], %{count: 1}, telemetry_meta(state, reason))
         {remove_in_flight(state, request_id), true}
 
       :error ->
@@ -285,7 +314,8 @@ defmodule PtcRunnerMcp.Http.Session do
       {nil, _} ->
         state
 
-      {%{pid: pid, on_discard: on_discard}, in_flight} ->
+      {%{pid: pid, waiter_ref: waiter_ref, on_discard: on_discard}, in_flight} ->
+        Process.demonitor(waiter_ref, [:flush])
         safe_invoke(on_discard)
         ConcurrencyGate.release()
         %{state | in_flight: in_flight, workers: Map.delete(state.workers, pid)}
@@ -307,6 +337,13 @@ defmodule PtcRunnerMcp.Http.Session do
 
   defp touch(state), do: %{state | last_seen_mono: System.monotonic_time(:millisecond)}
 
+  defp find_waiter_request(state, waiter_ref) do
+    Enum.find_value(state.in_flight, fn
+      {request_id, %{waiter_ref: ^waiter_ref}} -> request_id
+      _ -> nil
+    end)
+  end
+
   defp classify_response(%{"method" => _}), do: false
   defp classify_response(%{"id" => _, "result" => _}), do: true
   defp classify_response(%{"id" => _, "error" => _}), do: true
@@ -318,7 +355,8 @@ defmodule PtcRunnerMcp.Http.Session do
 
     if is_map(args) and Sessions.tool_name?(Map.get(params, "name")) do
       owner = %{transport: :http, mcp_session_id: session_id}
-      put_in(frame, ["params", "arguments"], Map.put(args, :owner, owner))
+      args = args |> Map.drop(["owner", :owner]) |> Map.put(:owner, owner)
+      put_in(frame, ["params", "arguments"], args)
     else
       frame
     end
@@ -340,6 +378,15 @@ defmodule PtcRunnerMcp.Http.Session do
 
   defp cancelled_reply(id) do
     success_reply(id, Envelope.cancelled("cancelled"))
+  end
+
+  defp telemetry_meta(state, reason) do
+    %{
+      owner_hash: state.owner_hash,
+      session_hash: Telemetry.hash_id(state.id),
+      reason: reason,
+      limit_name: reason
+    }
   end
 
   defp safe_invoke(fun) when is_function(fun, 0) do

--- a/mcp_server/lib/ptc_runner_mcp/http/session.ex
+++ b/mcp_server/lib/ptc_runner_mcp/http/session.ex
@@ -242,9 +242,9 @@ defmodule PtcRunnerMcp.Http.Session do
         {:reply, success_reply(request_id, envelope), state}
 
       true ->
-        case ConcurrencyGate.try_acquire(Limits.max_concurrent_calls()) do
-          :ok ->
-            {:ok, spawn_worker(state, request_id, work_fn, on_discard, waiter)}
+        case ConcurrencyGate.try_acquire_tracked(Limits.max_concurrent_calls()) do
+          {:ok, permit} ->
+            {:ok, spawn_worker(state, request_id, work_fn, on_discard, waiter, permit)}
 
           :full ->
             Telemetry.emit(
@@ -260,7 +260,7 @@ defmodule PtcRunnerMcp.Http.Session do
     end
   end
 
-  defp spawn_worker(state, request_id, work_fn, on_discard, waiter) do
+  defp spawn_worker(state, request_id, work_fn, on_discard, waiter, permit) do
     parent = self()
     waiter_ref = Process.monitor(waiter)
 
@@ -270,6 +270,8 @@ defmodule PtcRunnerMcp.Http.Session do
         send(parent, {:async_reply, request_id, envelope})
       end)
 
+    :ok = ConcurrencyGate.track_worker(permit, pid)
+
     %{
       state
       | in_flight:
@@ -278,6 +280,7 @@ defmodule PtcRunnerMcp.Http.Session do
             ref: ref,
             waiter: waiter,
             waiter_ref: waiter_ref,
+            permit: permit,
             on_discard: on_discard
           }),
         workers: Map.put(state.workers, pid, request_id)
@@ -314,10 +317,10 @@ defmodule PtcRunnerMcp.Http.Session do
       {nil, _} ->
         state
 
-      {%{pid: pid, waiter_ref: waiter_ref, on_discard: on_discard}, in_flight} ->
+      {%{pid: pid, waiter_ref: waiter_ref, permit: permit, on_discard: on_discard}, in_flight} ->
         Process.demonitor(waiter_ref, [:flush])
         safe_invoke(on_discard)
-        ConcurrencyGate.release()
+        ConcurrencyGate.release_tracked(permit)
         %{state | in_flight: in_flight, workers: Map.delete(state.workers, pid)}
     end
   end

--- a/mcp_server/lib/ptc_runner_mcp/http/session.ex
+++ b/mcp_server/lib/ptc_runner_mcp/http/session.ex
@@ -1,0 +1,360 @@
+defmodule PtcRunnerMcp.Http.Session do
+  @moduledoc false
+
+  use GenServer
+
+  alias PtcRunnerMcp.{
+    ConcurrencyGate,
+    Envelope,
+    JsonRpc,
+    Limits,
+    Log,
+    Sessions,
+    Version
+  }
+
+  defstruct id: nil,
+            owner: nil,
+            owner_hash: nil,
+            protocol_version: Version.primary(),
+            max_in_flight: 4,
+            in_flight: %{},
+            workers: %{},
+            draining: false,
+            exited: false,
+            created_mono: 0,
+            last_seen_mono: 0
+
+  @type terminal :: {:reply, map()} | :accepted | {:error, term()}
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts)
+  end
+
+  @spec start(keyword()) :: GenServer.on_start()
+  def start(opts) do
+    GenServer.start(__MODULE__, opts)
+  end
+
+  @spec stop(GenServer.server(), term(), timeout()) :: :ok
+  def stop(server, reason \\ :normal, timeout \\ 5_000) do
+    GenServer.stop(server, reason, timeout)
+  end
+
+  @impl GenServer
+  def init(opts) do
+    now = System.monotonic_time(:millisecond)
+
+    {:ok,
+     %__MODULE__{
+       id: Keyword.fetch!(opts, :id),
+       owner: Keyword.fetch!(opts, :owner),
+       owner_hash: Keyword.fetch!(opts, :owner_hash),
+       protocol_version: Keyword.fetch!(opts, :protocol_version),
+       max_in_flight: Keyword.fetch!(opts, :max_in_flight),
+       created_mono: now,
+       last_seen_mono: now
+     }}
+  end
+
+  @spec request(GenServer.server(), map(), timeout()) :: terminal()
+  def request(server, frame, timeout \\ 5_000) do
+    GenServer.call(server, {:request, frame, self()}, timeout)
+  end
+
+  @spec notify_or_response(GenServer.server(), map(), timeout()) :: :accepted | {:reply, map()}
+  def notify_or_response(server, frame, timeout \\ 5_000) do
+    GenServer.call(server, {:notify_or_response, frame}, timeout)
+  end
+
+  @spec cancel_all(GenServer.server(), term()) :: :ok
+  def cancel_all(server, reason) do
+    GenServer.call(server, {:cancel_all, reason}, 5_000)
+  end
+
+  @spec cancel(GenServer.server(), term(), term()) :: :ok
+  def cancel(server, request_id, reason) do
+    GenServer.call(server, {:cancel, request_id, reason}, 5_000)
+  end
+
+  @spec idle?(GenServer.server(), non_neg_integer(), non_neg_integer()) :: boolean()
+  def idle?(server, now_mono, idle_timeout_ms) do
+    GenServer.call(server, {:idle?, now_mono, idle_timeout_ms}, 5_000)
+  end
+
+  @spec expired?(GenServer.server(), non_neg_integer(), non_neg_integer()) :: boolean()
+  def expired?(server, now_mono, ttl_ms) do
+    GenServer.call(server, {:expired?, now_mono, ttl_ms}, 5_000)
+  end
+
+  @impl GenServer
+  def handle_call({:request, frame, waiter}, _from, state) do
+    state = touch(state)
+
+    case dispatch(frame, state) do
+      {:reply, reply, lifecycle} ->
+        reply_with_lifecycle({:reply, reply}, state, lifecycle)
+
+      {:noreply, lifecycle} ->
+        reply_with_lifecycle(:accepted, state, lifecycle)
+
+      {:async_call, request_id, work_fn, on_busy, on_discard, lifecycle} ->
+        state = apply_lifecycle(state, lifecycle)
+
+        case start_async(state, request_id, work_fn, on_busy, on_discard, waiter) do
+          {:ok, state} -> {:reply, :accepted, state}
+          {:reply, reply, state} -> {:reply, {:reply, reply}, state}
+        end
+
+      {:cancel, request_id, lifecycle} ->
+        {state, _cancelled?} =
+          state
+          |> apply_lifecycle(lifecycle)
+          |> cancel_request(request_id, :client)
+
+        {:reply, :accepted, state}
+    end
+  end
+
+  def handle_call({:notify_or_response, frame}, _from, state) do
+    state = touch(state)
+
+    case classify_response(frame) do
+      true ->
+        {:reply, :accepted, state}
+
+      false ->
+        case dispatch(frame, state) do
+          {:reply, _reply, lifecycle} ->
+            reply_with_lifecycle(:accepted, state, lifecycle)
+
+          {:noreply, lifecycle} ->
+            reply_with_lifecycle(:accepted, state, lifecycle)
+
+          {:cancel, request_id, lifecycle} ->
+            {state, _} =
+              state
+              |> apply_lifecycle(lifecycle)
+              |> cancel_request(request_id, :client)
+
+            {:reply, :accepted, state}
+        end
+    end
+  end
+
+  def handle_call({:cancel_all, reason}, _from, state) do
+    {:reply, :ok, cancel_all_workers(state, reason)}
+  end
+
+  def handle_call({:cancel, request_id, reason}, _from, state) do
+    {state, _cancelled?} = cancel_request(state, request_id, reason)
+    {:reply, :ok, state}
+  end
+
+  def handle_call({:idle?, now, timeout_ms}, _from, state) do
+    idle? = map_size(state.in_flight) == 0 and now - state.last_seen_mono >= timeout_ms
+    {:reply, idle?, state}
+  end
+
+  def handle_call({:expired?, now, ttl_ms}, _from, state) do
+    {:reply, now - state.created_mono >= ttl_ms, state}
+  end
+
+  @impl GenServer
+  def handle_info({:async_reply, request_id, envelope}, state) do
+    case Map.fetch(state.in_flight, request_id) do
+      {:ok, %{ref: ref, waiter: waiter}} ->
+        Log.log(:info, "tools_call_stop", %{
+          request_id: request_id,
+          is_error: Map.get(envelope, "isError")
+        })
+
+        Process.demonitor(ref, [:flush])
+        send(waiter, {:ptc_http_reply, request_id, success_reply(request_id, envelope)})
+        {:noreply, state |> remove_in_flight(request_id) |> touch()}
+
+      :error ->
+        {:noreply, state}
+    end
+  end
+
+  def handle_info({:DOWN, _ref, :process, pid, reason}, state) do
+    case Map.fetch(state.workers, pid) do
+      {:ok, request_id} ->
+        reply =
+          case reason do
+            :killed -> cancelled_reply(request_id)
+            :normal -> cancelled_reply(request_id)
+            _ -> error_reply(request_id, -32_603, "Internal error")
+          end
+
+        waiter = get_in(state.in_flight, [request_id, :waiter])
+        if waiter, do: send(waiter, {:ptc_http_reply, request_id, reply})
+        {:noreply, state |> remove_in_flight(request_id) |> touch()}
+
+      :error ->
+        {:noreply, state}
+    end
+  end
+
+  @impl GenServer
+  def terminate(_reason, state) do
+    _ = cancel_all_workers(state, :terminate)
+    :ok
+  end
+
+  defp dispatch(frame, state) do
+    frame = maybe_put_http_owner(frame, state.id)
+
+    JsonRpc.dispatch({:ok, frame},
+      draining: state.draining,
+      protocol_version: state.protocol_version
+    )
+  end
+
+  defp start_async(state, request_id, work_fn, on_busy, on_discard, waiter) do
+    cond do
+      Map.has_key?(state.in_flight, request_id) ->
+        safe_invoke(on_discard)
+        {:reply, duplicate_reply(request_id), state}
+
+      map_size(state.in_flight) >= state.max_in_flight ->
+        envelope = Envelope.busy(state.max_in_flight)
+        safe_invoke(on_busy, envelope)
+        {:reply, success_reply(request_id, envelope), state}
+
+      true ->
+        case ConcurrencyGate.try_acquire(Limits.max_concurrent_calls()) do
+          :ok ->
+            {:ok, spawn_worker(state, request_id, work_fn, on_discard, waiter)}
+
+          :full ->
+            envelope = Envelope.busy(Limits.max_concurrent_calls())
+            safe_invoke(on_busy, envelope)
+            {:reply, success_reply(request_id, envelope), state}
+        end
+    end
+  end
+
+  defp spawn_worker(state, request_id, work_fn, on_discard, waiter) do
+    parent = self()
+
+    {pid, ref} =
+      spawn_monitor(fn ->
+        envelope = work_fn.()
+        send(parent, {:async_reply, request_id, envelope})
+      end)
+
+    %{
+      state
+      | in_flight:
+          Map.put(state.in_flight, request_id, %{
+            pid: pid,
+            ref: ref,
+            waiter: waiter,
+            on_discard: on_discard
+          }),
+        workers: Map.put(state.workers, pid, request_id)
+    }
+  end
+
+  defp cancel_request(state, request_id, _reason) do
+    case Map.fetch(state.in_flight, request_id) do
+      {:ok, %{pid: pid, ref: ref, waiter: waiter, on_discard: on_discard}} ->
+        Process.demonitor(ref, [:flush])
+        Process.exit(pid, :kill)
+        safe_invoke(on_discard)
+        send(waiter, {:ptc_http_reply, request_id, cancelled_reply(request_id)})
+        {remove_in_flight(state, request_id), true}
+
+      :error ->
+        {state, false}
+    end
+  end
+
+  defp cancel_all_workers(state, reason) do
+    Enum.reduce(Map.keys(state.in_flight), state, fn request_id, acc ->
+      {acc, _} = cancel_request(acc, request_id, reason)
+      acc
+    end)
+  end
+
+  defp remove_in_flight(state, request_id) do
+    case Map.pop(state.in_flight, request_id) do
+      {nil, _} ->
+        state
+
+      {%{pid: pid, on_discard: on_discard}, in_flight} ->
+        safe_invoke(on_discard)
+        ConcurrencyGate.release()
+        %{state | in_flight: in_flight, workers: Map.delete(state.workers, pid)}
+    end
+  end
+
+  defp apply_lifecycle(state, :continue), do: state
+  defp apply_lifecycle(state, :drain), do: %{state | draining: true}
+  defp apply_lifecycle(state, :exit), do: %{state | exited: true}
+
+  defp reply_with_lifecycle(reply, state, lifecycle) do
+    state = apply_lifecycle(state, lifecycle)
+
+    case lifecycle do
+      :exit -> {:stop, :normal, reply, state}
+      _ -> {:reply, reply, state}
+    end
+  end
+
+  defp touch(state), do: %{state | last_seen_mono: System.monotonic_time(:millisecond)}
+
+  defp classify_response(%{"method" => _}), do: false
+  defp classify_response(%{"id" => _, "result" => _}), do: true
+  defp classify_response(%{"id" => _, "error" => _}), do: true
+  defp classify_response(_), do: false
+
+  defp maybe_put_http_owner(%{"method" => "tools/call", "params" => params} = frame, session_id)
+       when is_map(params) do
+    args = Map.get(params, "arguments", %{})
+
+    if is_map(args) and Sessions.tool_name?(Map.get(params, "name")) do
+      owner = %{transport: :http, mcp_session_id: session_id}
+      put_in(frame, ["params", "arguments"], Map.put(args, :owner, owner))
+    else
+      frame
+    end
+  end
+
+  defp maybe_put_http_owner(frame, _session_id), do: frame
+
+  defp success_reply(id, result) when is_map(result) do
+    %{"jsonrpc" => "2.0", "id" => id, "result" => Map.delete(result, "__ptc_debug_structured")}
+  end
+
+  defp error_reply(id, code, message) do
+    %{"jsonrpc" => "2.0", "id" => id, "error" => %{"code" => code, "message" => message}}
+  end
+
+  defp duplicate_reply(id) do
+    error_reply(id, -32_600, "Invalid Request: id #{inspect(id)} is already in flight")
+  end
+
+  defp cancelled_reply(id) do
+    success_reply(id, Envelope.cancelled("cancelled"))
+  end
+
+  defp safe_invoke(fun) when is_function(fun, 0) do
+    fun.()
+  rescue
+    _ -> :ok
+  catch
+    _, _ -> :ok
+  end
+
+  defp safe_invoke(fun, arg) when is_function(fun, 1) do
+    fun.(arg)
+  rescue
+    _ -> :ok
+  catch
+    _, _ -> :ok
+  end
+end

--- a/mcp_server/lib/ptc_runner_mcp/http/session_registry.ex
+++ b/mcp_server/lib/ptc_runner_mcp/http/session_registry.ex
@@ -3,7 +3,7 @@ defmodule PtcRunnerMcp.Http.SessionRegistry do
 
   use GenServer
 
-  alias PtcRunnerMcp.Http.Session
+  alias PtcRunnerMcp.Http.{Session, Telemetry}
   alias PtcRunnerMcp.{Log, Sessions}
   alias PtcRunnerMcp.Sessions.Owner, as: PtcOwner
 
@@ -24,6 +24,7 @@ defmodule PtcRunnerMcp.Http.SessionRegistry do
 
   @impl GenServer
   def init(opts) do
+    Process.flag(:trap_exit, true)
     config = Keyword.fetch!(opts, :config)
     ref = Process.send_after(self(), :cleanup, @cleanup_interval_ms)
     {:ok, %__MODULE__{config: config, cleanup_ref: ref}}
@@ -60,6 +61,16 @@ defmodule PtcRunnerMcp.Http.SessionRegistry do
     GenServer.call(registry, :drain, 5_000)
   end
 
+  @spec begin_drain(GenServer.server()) :: :ok
+  def begin_drain(registry \\ __MODULE__) do
+    GenServer.call(registry, :begin_drain, 5_000)
+  end
+
+  @spec cancel_all(term(), GenServer.server()) :: :ok
+  def cancel_all(reason, registry \\ __MODULE__) do
+    GenServer.call(registry, {:cancel_all, reason}, 5_000)
+  end
+
   @impl GenServer
   def handle_call({:create, owner, protocol_version}, _from, state) do
     cond do
@@ -67,15 +78,27 @@ defmodule PtcRunnerMcp.Http.SessionRegistry do
         {:reply, {:error, :draining}, state}
 
       map_size(state.sessions) >= state.config.max_sessions ->
+        Telemetry.emit([:limit, :rejected], %{count: 1}, %{
+          instance: state.config.instance_label,
+          owner_hash: owner.hash,
+          limit_name: :max_sessions
+        })
+
         {:reply, {:error, :max_sessions}, state}
 
       owner_count(state, owner.hash) >= state.config.max_sessions_per_owner ->
+        Telemetry.emit([:limit, :rejected], %{count: 1}, %{
+          instance: state.config.instance_label,
+          owner_hash: owner.hash,
+          limit_name: :max_sessions_per_owner
+        })
+
         {:reply, {:error, :max_sessions_per_owner}, state}
 
       true ->
         id = generate_id()
 
-        case Session.start(
+        case Session.start_link(
                id: id,
                owner: owner,
                owner_hash: owner.hash,
@@ -90,7 +113,8 @@ defmodule PtcRunnerMcp.Http.SessionRegistry do
               pid: pid,
               owner: owner,
               owner_hash: owner.hash,
-              protocol_version: protocol_version
+              protocol_version: protocol_version,
+              created_mono: System.monotonic_time(:millisecond)
             }
 
             state =
@@ -98,6 +122,22 @@ defmodule PtcRunnerMcp.Http.SessionRegistry do
               |> put_in([Access.key!(:sessions), id], meta)
               |> put_in([Access.key!(:monitors), ref], id)
               |> add_owner_index(owner.hash, id)
+
+            session_hash = Telemetry.hash_id(id)
+
+            Log.log(:info, "http_session_created", %{
+              instance: state.config.instance_label,
+              owner_hash: owner.hash,
+              session_hash: session_hash,
+              protocol_version: protocol_version
+            })
+
+            Telemetry.emit([:session, :created], %{count: 1}, %{
+              instance: state.config.instance_label,
+              owner_hash: owner.hash,
+              session_hash: session_hash,
+              protocol_version: protocol_version
+            })
 
             {:reply, {:ok, meta}, state}
 
@@ -132,12 +172,28 @@ defmodule PtcRunnerMcp.Http.SessionRegistry do
 
   def handle_call(:draining?, _from, state), do: {:reply, state.draining?, state}
 
+  def handle_call(:begin_drain, _from, state) do
+    {:reply, :ok, %{state | draining?: true}}
+  end
+
+  def handle_call({:cancel_all, reason}, _from, state) do
+    Enum.each(state.sessions, fn {_id, meta} -> _ = Session.cancel_all(meta.pid, reason) end)
+    {:reply, :ok, state}
+  end
+
   def handle_call(:drain, _from, state) do
     Enum.each(state.sessions, fn {_id, meta} -> _ = Session.cancel_all(meta.pid, :shutdown) end)
     {:reply, :ok, %{state | draining?: true}}
   end
 
   @impl GenServer
+  def handle_info({:EXIT, pid, reason}, state) do
+    case find_session_id_by_pid(state, pid) do
+      nil -> {:noreply, state}
+      id -> {:noreply, remove_session(state, id, reason)}
+    end
+  end
+
   def handle_info({:DOWN, ref, :process, _pid, reason}, state) do
     case Map.pop(state.monitors, ref) do
       {nil, monitors} -> {:noreply, %{state | monitors: monitors}}
@@ -170,18 +226,64 @@ defmodule PtcRunnerMcp.Http.SessionRegistry do
     {:noreply, %{state | cleanup_ref: ref}}
   end
 
+  @impl GenServer
+  def terminate(reason, state) do
+    if is_reference(state.cleanup_ref), do: Process.cancel_timer(state.cleanup_ref)
+
+    Enum.each(state.sessions, fn {_id, meta} ->
+      _ = Session.cancel_all(meta.pid, reason)
+      stop_session(meta.pid)
+    end)
+
+    :ok
+  end
+
   defp remove_session(state, id, reason) do
     case Map.pop(state.sessions, id) do
       {nil, sessions} ->
         %{state | sessions: sessions}
 
       {meta, sessions} ->
-        Log.log(:info, "http_session_closed", %{session_hash: hash(id), reason: inspect(reason)})
+        session_hash = Telemetry.hash_id(id)
+
+        Log.log(:info, "http_session_closed", %{
+          instance: state.config.instance_label,
+          owner_hash: meta.owner_hash,
+          session_hash: session_hash,
+          reason: inspect(reason)
+        })
+
+        Telemetry.emit([:session, :closed], %{age_ms: session_age_ms(meta)}, %{
+          instance: state.config.instance_label,
+          owner_hash: meta.owner_hash,
+          session_hash: session_hash,
+          reason: reason
+        })
+
         Sessions.close_owner(PtcOwner.http(id), reason)
 
         state
         |> Map.put(:sessions, sessions)
+        |> remove_monitor(id)
         |> remove_owner_index(meta.owner_hash, id)
+    end
+  end
+
+  defp find_session_id_by_pid(state, pid) do
+    Enum.find_value(state.sessions, fn
+      {id, %{pid: ^pid}} -> id
+      _ -> nil
+    end)
+  end
+
+  defp remove_monitor(state, id) do
+    case Enum.find(state.monitors, fn {_ref, session_id} -> session_id == id end) do
+      {ref, ^id} ->
+        Process.demonitor(ref, [:flush])
+        %{state | monitors: Map.delete(state.monitors, ref)}
+
+      nil ->
+        state
     end
   end
 
@@ -232,6 +334,9 @@ defmodule PtcRunnerMcp.Http.SessionRegistry do
     "mcp_" <> Base.url_encode64(:crypto.strong_rand_bytes(24), padding: false)
   end
 
-  defp hash(id),
-    do: :crypto.hash(:sha256, id) |> Base.encode16(case: :lower) |> String.slice(0, 16)
+  defp session_age_ms(%{created_mono: created_mono}) when is_integer(created_mono) do
+    max(System.monotonic_time(:millisecond) - created_mono, 0)
+  end
+
+  defp session_age_ms(_meta), do: 0
 end

--- a/mcp_server/lib/ptc_runner_mcp/http/session_registry.ex
+++ b/mcp_server/lib/ptc_runner_mcp/http/session_registry.ex
@@ -1,0 +1,237 @@
+defmodule PtcRunnerMcp.Http.SessionRegistry do
+  @moduledoc false
+
+  use GenServer
+
+  alias PtcRunnerMcp.Http.Session
+  alias PtcRunnerMcp.{Log, Sessions}
+  alias PtcRunnerMcp.Sessions.Owner, as: PtcOwner
+
+  defstruct sessions: %{},
+            by_owner: %{},
+            monitors: %{},
+            config: %{},
+            draining?: false,
+            cleanup_ref: nil
+
+  @cleanup_interval_ms 30_000
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts) do
+    name = Keyword.get(opts, :name, __MODULE__)
+    GenServer.start_link(__MODULE__, opts, name: name)
+  end
+
+  @impl GenServer
+  def init(opts) do
+    config = Keyword.fetch!(opts, :config)
+    ref = Process.send_after(self(), :cleanup, @cleanup_interval_ms)
+    {:ok, %__MODULE__{config: config, cleanup_ref: ref}}
+  end
+
+  @spec create(map(), String.t(), GenServer.server()) ::
+          {:ok, map()} | {:error, :max_sessions | :max_sessions_per_owner}
+  def create(owner, protocol_version, registry \\ __MODULE__) do
+    GenServer.call(registry, {:create, owner, protocol_version}, 5_000)
+  end
+
+  @spec lookup(String.t(), map(), GenServer.server()) :: {:ok, map()} | {:error, :not_found}
+  def lookup(id, owner, registry \\ __MODULE__) do
+    GenServer.call(registry, {:lookup, id, owner}, 5_000)
+  end
+
+  @spec delete(String.t(), map(), GenServer.server()) :: :ok | {:error, :not_found}
+  def delete(id, owner, registry \\ __MODULE__) do
+    GenServer.call(registry, {:delete, id, owner}, 5_000)
+  end
+
+  @spec saturated?(GenServer.server()) :: boolean()
+  def saturated?(registry \\ __MODULE__) do
+    GenServer.call(registry, :saturated?, 5_000)
+  end
+
+  @spec draining?(GenServer.server()) :: boolean()
+  def draining?(registry \\ __MODULE__) do
+    GenServer.call(registry, :draining?, 5_000)
+  end
+
+  @spec drain(GenServer.server()) :: :ok
+  def drain(registry \\ __MODULE__) do
+    GenServer.call(registry, :drain, 5_000)
+  end
+
+  @impl GenServer
+  def handle_call({:create, owner, protocol_version}, _from, state) do
+    cond do
+      state.draining? ->
+        {:reply, {:error, :draining}, state}
+
+      map_size(state.sessions) >= state.config.max_sessions ->
+        {:reply, {:error, :max_sessions}, state}
+
+      owner_count(state, owner.hash) >= state.config.max_sessions_per_owner ->
+        {:reply, {:error, :max_sessions_per_owner}, state}
+
+      true ->
+        id = generate_id()
+
+        case Session.start(
+               id: id,
+               owner: owner,
+               owner_hash: owner.hash,
+               protocol_version: protocol_version,
+               max_in_flight: state.config.max_in_flight_per_session
+             ) do
+          {:ok, pid} ->
+            ref = Process.monitor(pid)
+
+            meta = %{
+              id: id,
+              pid: pid,
+              owner: owner,
+              owner_hash: owner.hash,
+              protocol_version: protocol_version
+            }
+
+            state =
+              state
+              |> put_in([Access.key!(:sessions), id], meta)
+              |> put_in([Access.key!(:monitors), ref], id)
+              |> add_owner_index(owner.hash, id)
+
+            {:reply, {:ok, meta}, state}
+
+          {:error, reason} ->
+            {:reply, {:error, reason}, state}
+        end
+    end
+  end
+
+  def handle_call({:lookup, id, owner}, _from, state) do
+    case Map.fetch(state.sessions, id) do
+      {:ok, %{owner: ^owner} = meta} -> {:reply, {:ok, meta}, state}
+      _ -> {:reply, {:error, :not_found}, state}
+    end
+  end
+
+  def handle_call({:delete, id, owner}, _from, state) do
+    case Map.fetch(state.sessions, id) do
+      {:ok, %{owner: ^owner, pid: pid}} ->
+        _ = Session.cancel_all(pid, :delete)
+        stop_session(pid)
+        {:reply, :ok, remove_session(state, id, :delete)}
+
+      _ ->
+        {:reply, {:error, :not_found}, state}
+    end
+  end
+
+  def handle_call(:saturated?, _from, state) do
+    {:reply, map_size(state.sessions) >= state.config.max_sessions, state}
+  end
+
+  def handle_call(:draining?, _from, state), do: {:reply, state.draining?, state}
+
+  def handle_call(:drain, _from, state) do
+    Enum.each(state.sessions, fn {_id, meta} -> _ = Session.cancel_all(meta.pid, :shutdown) end)
+    {:reply, :ok, %{state | draining?: true}}
+  end
+
+  @impl GenServer
+  def handle_info({:DOWN, ref, :process, _pid, reason}, state) do
+    case Map.pop(state.monitors, ref) do
+      {nil, monitors} -> {:noreply, %{state | monitors: monitors}}
+      {id, monitors} -> {:noreply, remove_session(%{state | monitors: monitors}, id, reason)}
+    end
+  end
+
+  def handle_info(:cleanup, state) do
+    now = System.monotonic_time(:millisecond)
+
+    state =
+      Enum.reduce(state.sessions, state, fn {id, meta}, acc ->
+        cond do
+          safe_expired?(meta.pid, now, acc.config.session_ttl_ms) ->
+            _ = Session.cancel_all(meta.pid, :ttl)
+            stop_session(meta.pid)
+            remove_session(acc, id, :ttl)
+
+          safe_idle?(meta.pid, now, acc.config.session_idle_timeout_ms) ->
+            _ = Session.cancel_all(meta.pid, :idle)
+            stop_session(meta.pid)
+            remove_session(acc, id, :idle)
+
+          true ->
+            acc
+        end
+      end)
+
+    ref = Process.send_after(self(), :cleanup, @cleanup_interval_ms)
+    {:noreply, %{state | cleanup_ref: ref}}
+  end
+
+  defp remove_session(state, id, reason) do
+    case Map.pop(state.sessions, id) do
+      {nil, sessions} ->
+        %{state | sessions: sessions}
+
+      {meta, sessions} ->
+        Log.log(:info, "http_session_closed", %{session_hash: hash(id), reason: inspect(reason)})
+        Sessions.close_owner(PtcOwner.http(id), reason)
+
+        state
+        |> Map.put(:sessions, sessions)
+        |> remove_owner_index(meta.owner_hash, id)
+    end
+  end
+
+  defp safe_idle?(pid, now, ms) do
+    Session.idle?(pid, now, ms)
+  catch
+    :exit, _ -> false
+  end
+
+  defp safe_expired?(pid, now, ms) do
+    Session.expired?(pid, now, ms)
+  catch
+    :exit, _ -> false
+  end
+
+  defp stop_session(pid) when is_pid(pid) do
+    Session.stop(pid)
+  catch
+    :exit, _ -> :ok
+  end
+
+  defp add_owner_index(state, owner_hash, id) do
+    update_in(state.by_owner[owner_hash], fn ids -> MapSet.put(ids || MapSet.new(), id) end)
+  end
+
+  defp remove_owner_index(state, owner_hash, id) do
+    state =
+      update_in(state.by_owner[owner_hash], fn
+        nil ->
+          nil
+
+        ids ->
+          ids = MapSet.delete(ids, id)
+          if MapSet.size(ids) == 0, do: nil, else: ids
+      end)
+
+    if is_nil(Map.get(state.by_owner, owner_hash)) do
+      %{state | by_owner: Map.delete(state.by_owner, owner_hash)}
+    else
+      state
+    end
+  end
+
+  defp owner_count(state, owner_hash),
+    do: state.by_owner |> Map.get(owner_hash, MapSet.new()) |> MapSet.size()
+
+  defp generate_id do
+    "mcp_" <> Base.url_encode64(:crypto.strong_rand_bytes(24), padding: false)
+  end
+
+  defp hash(id),
+    do: :crypto.hash(:sha256, id) |> Base.encode16(case: :lower) |> String.slice(0, 16)
+end

--- a/mcp_server/lib/ptc_runner_mcp/http/session_registry.ex
+++ b/mcp_server/lib/ptc_runner_mcp/http/session_registry.ex
@@ -230,9 +230,10 @@ defmodule PtcRunnerMcp.Http.SessionRegistry do
   def terminate(reason, state) do
     if is_reference(state.cleanup_ref), do: Process.cancel_timer(state.cleanup_ref)
 
-    Enum.each(state.sessions, fn {_id, meta} ->
+    Enum.each(state.sessions, fn {id, meta} ->
       _ = Session.cancel_all(meta.pid, reason)
       stop_session(meta.pid)
+      Sessions.close_owner(PtcOwner.http(id), reason)
     end)
 
     :ok

--- a/mcp_server/lib/ptc_runner_mcp/http/telemetry.ex
+++ b/mcp_server/lib/ptc_runner_mcp/http/telemetry.ex
@@ -1,7 +1,33 @@
 defmodule PtcRunnerMcp.Http.Telemetry do
   @moduledoc false
 
+  @spec emit(atom() | [atom()], map(), map()) :: :ok
   def emit(event, measurements, metadata) do
-    :telemetry.execute([:ptc_runner_mcp, :http | List.wrap(event)], measurements, metadata)
+    :telemetry.execute(
+      [:ptc_runner_mcp, :http | List.wrap(event)],
+      measurements,
+      sanitize_metadata(metadata)
+    )
   end
+
+  @spec hash_id(term()) :: String.t() | nil
+  def hash_id(nil), do: nil
+
+  def hash_id(id) do
+    :crypto.hash(:sha256, to_string(id))
+    |> Base.encode16(case: :lower)
+    |> String.slice(0, 16)
+  end
+
+  defp sanitize_metadata(metadata) do
+    metadata
+    |> Enum.reject(fn {_key, value} -> is_nil(value) end)
+    |> Map.new(fn {key, value} -> {key, sanitize_value(value)} end)
+  end
+
+  defp sanitize_value(value) when is_binary(value), do: value
+  defp sanitize_value(value) when is_atom(value), do: value
+  defp sanitize_value(value) when is_integer(value), do: value
+  defp sanitize_value(value) when is_boolean(value), do: value
+  defp sanitize_value(value), do: inspect(value, limit: 20, printable_limit: 100)
 end

--- a/mcp_server/lib/ptc_runner_mcp/http/telemetry.ex
+++ b/mcp_server/lib/ptc_runner_mcp/http/telemetry.ex
@@ -1,0 +1,7 @@
+defmodule PtcRunnerMcp.Http.Telemetry do
+  @moduledoc false
+
+  def emit(event, measurements, metadata) do
+    :telemetry.execute([:ptc_runner_mcp, :http | List.wrap(event)], measurements, metadata)
+  end
+end

--- a/mcp_server/lib/ptc_runner_mcp/json_rpc.ex
+++ b/mcp_server/lib/ptc_runner_mcp/json_rpc.ex
@@ -103,7 +103,16 @@ defmodule PtcRunnerMcp.JsonRpc do
       case method do
         "initialize" ->
           Log.log(:info, "initialize", %{request_id: id})
-          {:reply, success_reply(id, Lifecycle.initialize_reply(params)), :continue}
+
+          protocol_version =
+            Keyword.get_lazy(opts, :protocol_version, fn ->
+              params
+              |> requested_protocol_version()
+              |> Version.negotiate()
+            end)
+
+          {:reply, success_reply(id, Lifecycle.initialize_reply(params, protocol_version)),
+           :continue}
 
         "notifications/initialized" ->
           Lifecycle.on_initialized()
@@ -125,7 +134,12 @@ defmodule PtcRunnerMcp.JsonRpc do
           {:reply, success_reply(id, Tools.list()), :continue}
 
         "tools/call" ->
-          handle_tools_call(id, params, draining?)
+          handle_tools_call(
+            id,
+            params,
+            draining?,
+            Keyword.get(opts, :protocol_version, Version.primary())
+          )
 
         _ ->
           Log.log(:warn, "method_not_found", %{request_id: id, method: method})
@@ -157,6 +171,11 @@ defmodule PtcRunnerMcp.JsonRpc do
   defp handle(_other, _opts) do
     {:reply, error_reply(nil, -32_600, "Invalid Request"), :continue}
   end
+
+  defp requested_protocol_version(%{"protocolVersion" => version}) when is_binary(version),
+    do: version
+
+  defp requested_protocol_version(_params), do: nil
 
   # § 6.4 row 3: `notifications/cancelled` for an in-flight requestId
   # signals stdio to kill that worker and emit no response. § 6.4
@@ -195,7 +214,7 @@ defmodule PtcRunnerMcp.JsonRpc do
 
   defp suppress_reply_if_notification(other, _), do: other
 
-  defp handle_tools_call(id, params, draining?) when is_map(params) do
+  defp handle_tools_call(id, params, draining?, protocol_version) when is_map(params) do
     Log.log(:info, "tools_call_start", %{
       request_id: id,
       tool: Map.get(params, "name")
@@ -234,7 +253,10 @@ defmodule PtcRunnerMcp.JsonRpc do
         # Unknown tool: handled synchronously (no Lisp execution, no
         # gate). We still trace + emit `[:ptc_runner_mcp, :call, :*]`
         # so subscribers see the call regardless of outcome.
-        envelope = traced_tools_call(id, params, fn -> Tools.call(params) end)
+        envelope =
+          traced_tools_call(id, params, fn -> Tools.call(params) end,
+            protocol_version: protocol_version
+          )
 
         Log.log(:info, "tools_call_stop", %{
           request_id: id,
@@ -246,25 +268,33 @@ defmodule PtcRunnerMcp.JsonRpc do
       Sessions.tool_name?(Map.get(params, "name")) and
           not Sessions.async_tool_name?(Map.get(params, "name")) ->
         envelope =
-          traced_tools_call(id, params, fn ->
-            Tools.call(params)
-          end)
+          traced_tools_call(
+            id,
+            params,
+            fn ->
+              Tools.call(params)
+            end,
+            protocol_version: protocol_version
+          )
 
         Log.log(:info, "tools_call_stop", %{
           request_id: id,
           is_error: Map.get(envelope, "isError")
         })
 
-        DebugRecorder.record_outcome(id, params, envelope, duration_ms: 0)
+        DebugRecorder.record_outcome(id, params, envelope,
+          duration_ms: 0,
+          protocol_version: protocol_version
+        )
 
         {:reply, success_reply(id, envelope), :continue}
 
       true ->
-        async_tools_call(id, params)
+        async_tools_call(id, params, protocol_version)
     end
   end
 
-  defp handle_tools_call(id, _, _draining?) do
+  defp handle_tools_call(id, _, _draining?, _protocol_version) do
     {:reply, error_reply(id, -32_602, "Invalid params"), :continue}
   end
 
@@ -286,7 +316,7 @@ defmodule PtcRunnerMcp.JsonRpc do
   # built via `DebugRecorder.record_outcome/4`, which no-ops when
   # `--debug-tool` is disabled and swallows + `warn`-logs any failure
   # — it can never affect the response.
-  defp async_tools_call(id, params) do
+  defp async_tools_call(id, params, protocol_version) do
     args = extract_arguments(params)
 
     case validate_tool_args(params, args) do
@@ -296,41 +326,61 @@ defmodule PtcRunnerMcp.JsonRpc do
           is_error: true
         })
 
-        DebugRecorder.record_outcome(id, params, args_error_envelope, duration_ms: 0)
+        DebugRecorder.record_outcome(id, params, args_error_envelope,
+          duration_ms: 0,
+          protocol_version: protocol_version
+        )
 
         {:reply, success_reply(id, args_error_envelope), :continue}
 
       {:ok, :ptc_lisp_execute, {program, context, parsed_signature}} ->
         work_fn =
-          recorded_work_fn(id, params, fn ->
-            traced_tools_call(id, params, fn ->
-              # Phase 1a §10: thread the JSON-RPC request id into
-              # `Tools.call_validated/4` so the
-              # `[:ptc_runner_mcp, :upstream, :call, :*]` telemetry
-              # metadata can correlate upstream calls back to the
-              # parent `tools/call` request.
-              Tools.call_validated(program, context, parsed_signature, request_id: id)
-            end)
+          recorded_work_fn(id, params, [protocol_version: protocol_version], fn ->
+            traced_tools_call(
+              id,
+              params,
+              fn ->
+                # Phase 1a §10: thread the JSON-RPC request id into
+                # `Tools.call_validated/4` so the
+                # `[:ptc_runner_mcp, :upstream, :call, :*]` telemetry
+                # metadata can correlate upstream calls back to the
+                # parent `tools/call` request.
+                Tools.call_validated(program, context, parsed_signature, request_id: id)
+              end,
+              protocol_version: protocol_version
+            )
           end)
 
-        {:async_call, id, work_fn, busy_record_fn(id, params), noop_fn(), :continue}
+        {:async_call, id, work_fn, busy_record_fn(id, params, protocol_version), noop_fn(),
+         :continue}
 
       {:ok, :ptc_task, validated} ->
         work_fn =
-          recorded_work_fn(id, params, fn ->
-            traced_tools_call(id, params, fn ->
-              Tools.call_agentic_validated(validated, request_id: id)
-            end)
+          recorded_work_fn(id, params, [protocol_version: protocol_version], fn ->
+            traced_tools_call(
+              id,
+              params,
+              fn ->
+                Tools.call_agentic_validated(validated, request_id: id)
+              end,
+              protocol_version: protocol_version
+            )
           end)
 
-        {:async_call, id, work_fn, busy_record_fn(id, params), noop_fn(), :continue}
+        {:async_call, id, work_fn, busy_record_fn(id, params, protocol_version), noop_fn(),
+         :continue}
 
       {:ok, :ptc_session_eval, validated} ->
         work_fn =
-          recorded_work_fn(id, params, fn ->
-            traced_tools_call(id, params, fn ->
-              Tools.call_session_eval_reserved(validated, request_id: id)
-            end)
+          recorded_work_fn(id, params, [protocol_version: protocol_version], fn ->
+            traced_tools_call(
+              id,
+              params,
+              fn ->
+                Tools.call_session_eval_reserved(validated, request_id: id)
+              end,
+              protocol_version: protocol_version
+            )
           end)
 
         on_discard = fn ->
@@ -339,7 +389,11 @@ defmodule PtcRunnerMcp.JsonRpc do
 
         on_busy = fn busy_envelope ->
           _ = Tools.abort_session_eval_reserved(validated, :global_busy)
-          DebugRecorder.record_outcome(id, params, busy_envelope, duration_ms: 0)
+
+          DebugRecorder.record_outcome(id, params, busy_envelope,
+            duration_ms: 0,
+            protocol_version: protocol_version
+          )
         end
 
         {:async_call, id, work_fn, on_busy, on_discard, :continue}
@@ -350,21 +404,29 @@ defmodule PtcRunnerMcp.JsonRpc do
   # record the call into the `ptc_debug` ring with the measured
   # duration. The recorder itself is fault-isolated; this wrapper adds
   # the timing only.
-  defp recorded_work_fn(id, params, run_fn) when is_function(run_fn, 0) do
+  defp recorded_work_fn(id, params, opts, run_fn) when is_function(run_fn, 0) do
     fn ->
       started = System.monotonic_time(:millisecond)
       envelope = run_fn.()
       duration_ms = max(System.monotonic_time(:millisecond) - started, 0)
-      DebugRecorder.record_outcome(id, params, envelope, duration_ms: duration_ms)
+
+      DebugRecorder.record_outcome(id, params, envelope,
+        duration_ms: duration_ms,
+        protocol_version: Keyword.get(opts, :protocol_version, Version.primary())
+      )
+
       strip_private_result(envelope)
     end
   end
 
   # 1-arity callback Stdio runs (passing the `busy` envelope it built)
   # when it rejects this call at the concurrency cap.
-  defp busy_record_fn(id, params) do
+  defp busy_record_fn(id, params, protocol_version) do
     fn busy_envelope ->
-      DebugRecorder.record_outcome(id, params, busy_envelope, duration_ms: 0)
+      DebugRecorder.record_outcome(id, params, busy_envelope,
+        duration_ms: 0,
+        protocol_version: protocol_version
+      )
     end
   end
 
@@ -438,8 +500,8 @@ defmodule PtcRunnerMcp.JsonRpc do
   Phase 4 it's `fn -> Tools.call_validated(program, ctx, sig) end`;
   the gate is owned by `Stdio` outside this wrap.
   """
-  @spec traced_tools_call(term(), map(), (-> map())) :: map()
-  def traced_tools_call(request_id, params, run_fn) when is_function(run_fn, 0) do
+  @spec traced_tools_call(term(), map(), (-> map()), keyword()) :: map()
+  def traced_tools_call(request_id, params, run_fn, opts \\ []) when is_function(run_fn, 0) do
     payload_level = PtcRunnerMcp.TraceConfig.trace_payloads()
     args = extract_arguments(params)
     program = Map.get(args, "program")
@@ -457,7 +519,13 @@ defmodule PtcRunnerMcp.JsonRpc do
       end
 
     TraceFile.with_traced_call(request_id, query_str, [], fn ->
-      span_meta = call_start_meta(request_id, params, args)
+      span_meta =
+        call_start_meta(
+          request_id,
+          params,
+          args,
+          Keyword.get(opts, :protocol_version, Version.primary())
+        )
 
       :telemetry.span([:ptc_runner_mcp, :call], span_meta, fn ->
         envelope = run_fn.()
@@ -474,7 +542,7 @@ defmodule PtcRunnerMcp.JsonRpc do
   defp extract_arguments(%{"arguments" => args}) when is_map(args), do: args
   defp extract_arguments(_), do: %{}
 
-  defp call_start_meta(request_id, params, args) do
+  defp call_start_meta(request_id, params, args, protocol_version) do
     program = Map.get(args, "program")
     context = Map.get(args, "context")
 
@@ -503,7 +571,7 @@ defmodule PtcRunnerMcp.JsonRpc do
       program_bytes: program_bytes,
       context_bytes: context_bytes,
       signature_present?: Map.has_key?(args, "signature") and not is_nil(args["signature"]),
-      protocol_version: Version.negotiated()
+      protocol_version: protocol_version
     }
   end
 

--- a/mcp_server/lib/ptc_runner_mcp/json_rpc.ex
+++ b/mcp_server/lib/ptc_runner_mcp/json_rpc.ex
@@ -134,12 +134,7 @@ defmodule PtcRunnerMcp.JsonRpc do
           {:reply, success_reply(id, Tools.list()), :continue}
 
         "tools/call" ->
-          handle_tools_call(
-            id,
-            params,
-            draining?,
-            Keyword.get(opts, :protocol_version, Version.primary())
-          )
+          handle_tools_call(id, params, draining?, call_opts(opts))
 
         _ ->
           Log.log(:warn, "method_not_found", %{request_id: id, method: method})
@@ -214,7 +209,9 @@ defmodule PtcRunnerMcp.JsonRpc do
 
   defp suppress_reply_if_notification(other, _), do: other
 
-  defp handle_tools_call(id, params, draining?, protocol_version) when is_map(params) do
+  defp handle_tools_call(id, params, draining?, opts) when is_map(params) do
+    protocol_version = Keyword.get(opts, :protocol_version, Version.primary())
+
     Log.log(:info, "tools_call_start", %{
       request_id: id,
       tool: Map.get(params, "name")
@@ -255,7 +252,10 @@ defmodule PtcRunnerMcp.JsonRpc do
         # so subscribers see the call regardless of outcome.
         envelope =
           traced_tools_call(id, params, fn -> Tools.call(params) end,
-            protocol_version: protocol_version
+            protocol_version: protocol_version,
+            transport_request_id: Keyword.get(opts, :transport_request_id),
+            owner_hash: Keyword.get(opts, :owner_hash),
+            mcp_session_hash: Keyword.get(opts, :mcp_session_hash)
           )
 
         Log.log(:info, "tools_call_stop", %{
@@ -274,7 +274,10 @@ defmodule PtcRunnerMcp.JsonRpc do
             fn ->
               Tools.call(params)
             end,
-            protocol_version: protocol_version
+            protocol_version: protocol_version,
+            transport_request_id: Keyword.get(opts, :transport_request_id),
+            owner_hash: Keyword.get(opts, :owner_hash),
+            mcp_session_hash: Keyword.get(opts, :mcp_session_hash)
           )
 
         Log.log(:info, "tools_call_stop", %{
@@ -290,11 +293,11 @@ defmodule PtcRunnerMcp.JsonRpc do
         {:reply, success_reply(id, envelope), :continue}
 
       true ->
-        async_tools_call(id, params, protocol_version)
+        async_tools_call(id, params, opts)
     end
   end
 
-  defp handle_tools_call(id, _, _draining?, _protocol_version) do
+  defp handle_tools_call(id, _, _draining?, _opts) do
     {:reply, error_reply(id, -32_602, "Invalid params"), :continue}
   end
 
@@ -316,7 +319,8 @@ defmodule PtcRunnerMcp.JsonRpc do
   # built via `DebugRecorder.record_outcome/4`, which no-ops when
   # `--debug-tool` is disabled and swallows + `warn`-logs any failure
   # — it can never affect the response.
-  defp async_tools_call(id, params, protocol_version) do
+  defp async_tools_call(id, params, opts) do
+    protocol_version = Keyword.get(opts, :protocol_version, Version.primary())
     args = extract_arguments(params)
 
     case validate_tool_args(params, args) do
@@ -335,7 +339,7 @@ defmodule PtcRunnerMcp.JsonRpc do
 
       {:ok, :ptc_lisp_execute, {program, context, parsed_signature}} ->
         work_fn =
-          recorded_work_fn(id, params, [protocol_version: protocol_version], fn ->
+          recorded_work_fn(id, params, opts, fn ->
             traced_tools_call(
               id,
               params,
@@ -347,7 +351,10 @@ defmodule PtcRunnerMcp.JsonRpc do
                 # parent `tools/call` request.
                 Tools.call_validated(program, context, parsed_signature, request_id: id)
               end,
-              protocol_version: protocol_version
+              protocol_version: protocol_version,
+              transport_request_id: Keyword.get(opts, :transport_request_id),
+              owner_hash: Keyword.get(opts, :owner_hash),
+              mcp_session_hash: Keyword.get(opts, :mcp_session_hash)
             )
           end)
 
@@ -356,14 +363,17 @@ defmodule PtcRunnerMcp.JsonRpc do
 
       {:ok, :ptc_task, validated} ->
         work_fn =
-          recorded_work_fn(id, params, [protocol_version: protocol_version], fn ->
+          recorded_work_fn(id, params, opts, fn ->
             traced_tools_call(
               id,
               params,
               fn ->
                 Tools.call_agentic_validated(validated, request_id: id)
               end,
-              protocol_version: protocol_version
+              protocol_version: protocol_version,
+              transport_request_id: Keyword.get(opts, :transport_request_id),
+              owner_hash: Keyword.get(opts, :owner_hash),
+              mcp_session_hash: Keyword.get(opts, :mcp_session_hash)
             )
           end)
 
@@ -372,14 +382,17 @@ defmodule PtcRunnerMcp.JsonRpc do
 
       {:ok, :ptc_session_eval, validated} ->
         work_fn =
-          recorded_work_fn(id, params, [protocol_version: protocol_version], fn ->
+          recorded_work_fn(id, params, opts, fn ->
             traced_tools_call(
               id,
               params,
               fn ->
                 Tools.call_session_eval_reserved(validated, request_id: id)
               end,
-              protocol_version: protocol_version
+              protocol_version: protocol_version,
+              transport_request_id: Keyword.get(opts, :transport_request_id),
+              owner_hash: Keyword.get(opts, :owner_hash),
+              mcp_session_hash: Keyword.get(opts, :mcp_session_hash)
             )
           end)
 
@@ -417,6 +430,16 @@ defmodule PtcRunnerMcp.JsonRpc do
 
       strip_private_result(envelope)
     end
+  end
+
+  defp call_opts(opts) do
+    Keyword.take(opts, [
+      :protocol_version,
+      :transport,
+      :transport_request_id,
+      :owner_hash,
+      :mcp_session_hash
+    ])
   end
 
   # 1-arity callback Stdio runs (passing the `busy` envelope it built)
@@ -518,13 +541,14 @@ defmodule PtcRunnerMcp.JsonRpc do
         other -> Jason.encode!(other)
       end
 
-    TraceFile.with_traced_call(request_id, query_str, [], fn ->
+    TraceFile.with_traced_call(request_id, query_str, trace_header_opts(opts), fn ->
       span_meta =
         call_start_meta(
           request_id,
           params,
           args,
-          Keyword.get(opts, :protocol_version, Version.primary())
+          Keyword.get(opts, :protocol_version, Version.primary()),
+          opts
         )
 
       :telemetry.span([:ptc_runner_mcp, :call], span_meta, fn ->
@@ -542,7 +566,7 @@ defmodule PtcRunnerMcp.JsonRpc do
   defp extract_arguments(%{"arguments" => args}) when is_map(args), do: args
   defp extract_arguments(_), do: %{}
 
-  defp call_start_meta(request_id, params, args, protocol_version) do
+  defp call_start_meta(request_id, params, args, protocol_version, opts) do
     program = Map.get(args, "program")
     context = Map.get(args, "context")
 
@@ -571,8 +595,14 @@ defmodule PtcRunnerMcp.JsonRpc do
       program_bytes: program_bytes,
       context_bytes: context_bytes,
       signature_present?: Map.has_key?(args, "signature") and not is_nil(args["signature"]),
-      protocol_version: protocol_version
+      protocol_version: protocol_version,
+      transport: Keyword.get(opts, :transport),
+      transport_request_id: Keyword.get(opts, :transport_request_id),
+      owner_hash: Keyword.get(opts, :owner_hash),
+      mcp_session_hash: Keyword.get(opts, :mcp_session_hash)
     }
+    |> Enum.reject(fn {_key, value} -> is_nil(value) end)
+    |> Map.new()
   end
 
   defp call_stop_meta(start_meta, envelope) do
@@ -590,19 +620,32 @@ defmodule PtcRunnerMcp.JsonRpc do
     # the full `validated` value or `prints`. Same payload-policy
     # bypass concern as call_start_meta — third-party subscribers
     # MUST NOT receive raw user content via telemetry.
-    base = %{
-      request_id: start_meta.request_id,
-      tool_name: start_meta.tool_name,
-      protocol_version: start_meta.protocol_version,
-      status: status,
-      is_error: is_error,
-      validated_present?: Map.has_key?(sc, "validated")
-    }
+    base =
+      %{
+        request_id: start_meta.request_id,
+        tool_name: start_meta.tool_name,
+        protocol_version: start_meta.protocol_version,
+        transport: Map.get(start_meta, :transport),
+        transport_request_id: Map.get(start_meta, :transport_request_id),
+        owner_hash: Map.get(start_meta, :owner_hash),
+        mcp_session_hash: Map.get(start_meta, :mcp_session_hash),
+        status: status,
+        is_error: is_error,
+        validated_present?: Map.has_key?(sc, "validated")
+      }
+      |> Enum.reject(fn {_key, value} -> is_nil(value) end)
+      |> Map.new()
 
     case reason do
       nil -> base
       r -> Map.put(base, :reason, r)
     end
+  end
+
+  defp trace_header_opts(opts) do
+    opts
+    |> Keyword.take([:transport_request_id, :owner_hash, :mcp_session_hash])
+    |> Enum.reject(fn {_key, value} -> is_nil(value) end)
   end
 
   # ----------------------------------------------------------------

--- a/mcp_server/lib/ptc_runner_mcp/lifecycle.ex
+++ b/mcp_server/lib/ptc_runner_mcp/lifecycle.ex
@@ -19,16 +19,10 @@ defmodule PtcRunnerMcp.Lifecycle do
   `tools.listChanged: false`, and intentionally omits `resources`,
   `prompts`, `experimental`, `elicitation`, and `sampling`.
   """
-  @spec initialize_reply(map() | nil) :: map()
-  def initialize_reply(params) do
-    requested =
-      case params do
-        %{"protocolVersion" => v} when is_binary(v) -> v
-        _ -> nil
-      end
-
+  @spec initialize_reply(map() | nil, String.t()) :: map()
+  def initialize_reply(_params, protocol_version) when is_binary(protocol_version) do
     %{
-      "protocolVersion" => Version.negotiate(requested),
+      "protocolVersion" => protocol_version,
       "serverInfo" => %{
         "name" => "ptc_runner_mcp",
         "version" => Version.package_version()

--- a/mcp_server/lib/ptc_runner_mcp/sessions.ex
+++ b/mcp_server/lib/ptc_runner_mcp/sessions.ex
@@ -439,6 +439,22 @@ defmodule PtcRunnerMcp.Sessions do
     {:error, Projection.error(:session_args_error, "session_id must be a non-empty string")}
   end
 
+  @doc "Close every live PTC-Lisp session owned by the given owner context."
+  @spec close_owner(map() | keyword() | nil, term()) :: :ok
+  def close_owner(owner_context, reason \\ "owner_closed") do
+    with :ok <- enabled(),
+         :ok <- ensure_started(),
+         {:ok, owner} <- Owner.from_context(owner_context) do
+      owner
+      |> Registry.list()
+      |> Enum.each(fn meta ->
+        _ = Session.close(meta.pid, owner, reason)
+      end)
+    end
+
+    :ok
+  end
+
   defp enabled do
     if Config.enabled?(), do: :ok, else: :disabled
   end
@@ -533,11 +549,12 @@ defmodule PtcRunnerMcp.Sessions do
   end
 
   defp list_session_args(args) do
-    case map_size(args) do
-      0 ->
-        list(nil)
+    case Map.drop(args, [:owner]) do
+      empty when map_size(empty) == 0 ->
+        owner_context = owner_context(args)
+        list(owner_context)
 
-      _count ->
+      _other ->
         {:error, Projection.error(:session_args_error, "ptc_session_list takes no arguments")}
     end
   end
@@ -545,7 +562,7 @@ defmodule PtcRunnerMcp.Sessions do
   defp owner_context(args) when is_map(args) do
     # Internal/test override for ownership simulation. Public clients should
     # rely on transport-derived ownership and should not send this field.
-    Map.get(args, "owner") || Map.get(args, :owner) || nil
+    Map.get(args, :owner) || Map.get(args, "owner") || nil
   end
 
   defp validate_start_args(args) when is_map(args) do

--- a/mcp_server/lib/ptc_runner_mcp/stdio.ex
+++ b/mcp_server/lib/ptc_runner_mcp/stdio.ex
@@ -28,7 +28,7 @@ defmodule PtcRunnerMcp.Stdio do
 
   use GenServer
 
-  alias PtcRunnerMcp.{ConcurrencyGate, Envelope, JsonRpc, Limits, Log}
+  alias PtcRunnerMcp.{ConcurrencyGate, Envelope, JsonRpc, Limits, Log, Version}
 
   @newline ?\n
 
@@ -48,6 +48,7 @@ defmodule PtcRunnerMcp.Stdio do
             max_frame_bytes: pos_integer(),
             draining: boolean(),
             exited: boolean(),
+            protocol_version: String.t(),
             auto_read: boolean(),
             observer: pid() | nil,
             in_flight: %{
@@ -71,6 +72,7 @@ defmodule PtcRunnerMcp.Stdio do
               # notification so any frames buffered behind it are not
               # dispatched (avoids replies after the client said exit).
               exited: false,
+              protocol_version: Version.primary(),
               # When true, run the read loop. Tests set this to false
               # and feed bytes directly via Stdio.feed/2.
               auto_read: true,
@@ -514,7 +516,12 @@ defmodule PtcRunnerMcp.Stdio do
         {:error, _} -> {:error, :parse_error}
       end
 
-    case JsonRpc.dispatch(decoded, draining: state.draining) do
+    {protocol_version, state} = negotiate_if_initialize(decoded, state)
+
+    case JsonRpc.dispatch(decoded,
+           draining: state.draining,
+           protocol_version: protocol_version
+         ) do
       {:reply, frame, lifecycle} ->
         write_reply(state, frame)
         apply_lifecycle(state, lifecycle)
@@ -545,6 +552,22 @@ defmodule PtcRunnerMcp.Stdio do
 
     state
   end
+
+  defp negotiate_if_initialize(
+         {:ok, %{"jsonrpc" => "2.0", "method" => "initialize", "params" => params}},
+         state
+       ) do
+    requested =
+      case params do
+        %{"protocolVersion" => v} when is_binary(v) -> v
+        _ -> nil
+      end
+
+    protocol_version = Version.negotiate(requested)
+    {protocol_version, %{state | protocol_version: protocol_version}}
+  end
+
+  defp negotiate_if_initialize(_decoded, state), do: {state.protocol_version, state}
 
   defp write_reply(%State{io: io, observer: observer} = _state, frame) do
     # `Jason.encode!/1` produces a binary of UTF-8 bytes (raw, regardless

--- a/mcp_server/lib/ptc_runner_mcp/tools.ex
+++ b/mcp_server/lib/ptc_runner_mcp/tools.ex
@@ -92,6 +92,7 @@ defmodule PtcRunnerMcp.Tools do
               "fail",
               "validation_error",
               "busy",
+              "cancelled",
               "unknown_tool",
               # MCP-only reason emitted by the drain path after `shutdown`.
               # Codex review of 0fe4c78: clients validating tool results

--- a/mcp_server/lib/ptc_runner_mcp/version.ex
+++ b/mcp_server/lib/ptc_runner_mcp/version.ex
@@ -36,10 +36,6 @@ defmodule PtcRunnerMcp.Version do
   @doc """
   Pick the server's reply `protocolVersion` for a given client request.
 
-  Stashes the negotiated version in `:persistent_term` as a side effect
-  so downstream code (e.g. per-call telemetry under § 6.7) can read
-  the most recently negotiated revision via `negotiated/0`.
-
   ## Examples
 
       iex> PtcRunnerMcp.Version.negotiate("2025-11-25")
@@ -56,23 +52,10 @@ defmodule PtcRunnerMcp.Version do
   """
   @spec negotiate(term()) :: String.t()
   def negotiate(version) do
-    chosen =
-      case version do
-        v when v in @supported -> v
-        _ -> @primary
-      end
-
-    :persistent_term.put({__MODULE__, :negotiated}, chosen)
-    chosen
-  end
-
-  @doc """
-  Most recently negotiated protocol version (defaults to `primary/0`
-  before any `initialize` request lands).
-  """
-  @spec negotiated() :: String.t()
-  def negotiated do
-    :persistent_term.get({__MODULE__, :negotiated}, @primary)
+    case version do
+      v when v in @supported -> v
+      _ -> @primary
+    end
   end
 
   @doc "The package version (`mix.exs` `@version`)."

--- a/mcp_server/mix.exs
+++ b/mcp_server/mix.exs
@@ -83,8 +83,8 @@ defmodule PtcRunnerMcp.MixProject do
       # Phase 2F (`Plans/http-transport-credentials.md` §13.2): the
       # local HTTP fixture is a Plug served by Bandit. Test/dev only;
       # never shipped in the release.
-      {:bandit, "~> 1.5", only: [:dev, :test]},
-      {:plug, "~> 1.16", only: [:dev, :test]},
+      {:bandit, "~> 1.5"},
+      {:plug, "~> 1.16"},
       {:credo, "~> 1.7", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.4", only: [:dev, :test], runtime: false},
       {:ex_dna, "~> 1.5", only: [:dev, :test], runtime: false},

--- a/mcp_server/test/fixtures/tool_entry_v1.json
+++ b/mcp_server/test/fixtures/tool_entry_v1.json
@@ -82,6 +82,7 @@
               "fail",
               "validation_error",
               "busy",
+              "cancelled",
               "unknown_tool",
               "shutting_down"
             ],
@@ -106,4 +107,3 @@
     "type": "object"
   }
 }
-

--- a/mcp_server/test/ptc_runner_mcp/http_config_test.exs
+++ b/mcp_server/test/ptc_runner_mcp/http_config_test.exs
@@ -40,6 +40,20 @@ defmodule PtcRunnerMcp.HttpConfigTest do
     refute Config.loopback_host?("0.0.0.0")
   end
 
+  test "rejects non-IP bind hostnames except localhost" do
+    assert {:ok, cfg} = Config.resolve(%{http: true, http_host: "localhost"})
+    assert cfg.host == "localhost"
+
+    assert {:error, message} =
+             Config.resolve(%{
+               http: true,
+               http_host: "example.internal",
+               http_auth_token: String.duplicate("a", 32)
+             })
+
+    assert message =~ "IP address or localhost"
+  end
+
   test "parse_args preserves repeated allowed-origin flags" do
     args =
       PtcRunnerMcp.Application.parse_args([

--- a/mcp_server/test/ptc_runner_mcp/http_config_test.exs
+++ b/mcp_server/test/ptc_runner_mcp/http_config_test.exs
@@ -1,0 +1,64 @@
+defmodule PtcRunnerMcp.HttpConfigTest do
+  use ExUnit.Case, async: false
+
+  alias PtcRunnerMcp.Http.Config
+
+  test "rejects short auth tokens" do
+    assert {:error, message} =
+             Config.resolve(%{
+               http: true,
+               http_host: "0.0.0.0",
+               http_auth_token: "short"
+             })
+
+    assert message =~ "at least 32"
+  end
+
+  test "requires auth for non-loopback binds unless explicitly unsafe" do
+    assert {:error, message} = Config.resolve(%{http: true, http_host: "0.0.0.0"})
+    assert message =~ "required"
+
+    assert {:ok, cfg} =
+             Config.resolve(%{
+               http: true,
+               http_host: "0.0.0.0",
+               http_disable_auth: true,
+               http_allow_unsafe_network: true
+             })
+
+    assert cfg.auth_disabled
+  end
+
+  test "rejects endpoint path collisions" do
+    assert {:error, "HTTP paths must be distinct"} =
+             Config.resolve(%{http: true, http_path: "/health"})
+  end
+
+  test "loopback detection covers 127/8 and ::1" do
+    assert Config.loopback_host?("127.9.8.7")
+    assert Config.loopback_host?("::1")
+    refute Config.loopback_host?("0.0.0.0")
+  end
+
+  test "parse_args preserves repeated allowed-origin flags" do
+    args =
+      PtcRunnerMcp.Application.parse_args([
+        "--http-allowed-origin",
+        "http://a.test",
+        "--http-allowed-origin",
+        "http://b.test"
+      ])
+
+    assert args.http_allowed_origin == ["http://a.test", "http://b.test"]
+  end
+
+  test "default body limit follows the applied max frame limit" do
+    on_exit(fn -> PtcRunnerMcp.Limits.set(PtcRunnerMcp.Limits.defaults()) end)
+
+    args = %{http: true, max_frame_bytes: 12_345}
+
+    :ok = PtcRunnerMcp.Application.apply_limits(args)
+    assert {:ok, cfg} = Config.resolve(args)
+    assert cfg.max_body_bytes == 12_345
+  end
+end

--- a/mcp_server/test/ptc_runner_mcp/http_router_test.exs
+++ b/mcp_server/test/ptc_runner_mcp/http_router_test.exs
@@ -12,7 +12,7 @@ defmodule PtcRunnerMcp.HttpRouterTest do
   alias PtcRunnerMcp.Log
   alias PtcRunnerMcp.McpTestHelpers
   alias PtcRunnerMcp.Sessions.Config, as: SessionsConfig
-  alias PtcRunnerMcp.Sessions.{Names, Registry, Supervisor}
+  alias PtcRunnerMcp.Sessions.{Names, Owner, Registry, Supervisor}
   alias PtcRunnerMcp.TraceConfig
   alias PtcRunnerMcp.TraceHandler
 
@@ -361,6 +361,35 @@ defmodule PtcRunnerMcp.HttpRouterTest do
 
     assert :ok = stop_supervised(SessionRegistry)
     assert_receive {:DOWN, ^ref, :process, _pid, :normal}, 1_000
+  end
+
+  test "stopping registry closes PTC-Lisp sessions owned by HTTP sessions" do
+    start_ptc_sessions!()
+    session_id = initialize_session()
+
+    start_call = %{
+      "jsonrpc" => "2.0",
+      "id" => "start-owned-session",
+      "method" => "tools/call",
+      "params" => %{"name" => "ptc_session_start", "arguments" => %{}}
+    }
+
+    conn =
+      conn(:post, "/mcp", Jason.encode!(start_call))
+      |> auth()
+      |> put_req_header("mcp-session-id", session_id)
+      |> call()
+
+    assert conn.status == 200
+    body = Jason.decode!(conn.resp_body)
+    assert get_in(body, ["result", "structuredContent", "status"]) == "ok"
+
+    owner = Owner.http(session_id)
+    assert [_] = Registry.list(owner)
+
+    assert :ok = stop_supervised(SessionRegistry)
+
+    wait_until(fn -> Registry.list(owner) == [] end)
   end
 
   test "client disconnect cancels in-flight HTTP work and releases permit" do

--- a/mcp_server/test/ptc_runner_mcp/http_router_test.exs
+++ b/mcp_server/test/ptc_runner_mcp/http_router_test.exs
@@ -1,0 +1,313 @@
+defmodule PtcRunnerMcp.HttpRouterTest do
+  use ExUnit.Case, async: false
+  import Plug.Conn
+  import Plug.Test
+
+  alias PtcRunnerMcp.Http.{Auth, Router, SessionRegistry}
+  alias PtcRunnerMcp.Http.Config, as: HttpConfig
+  alias PtcRunnerMcp.McpTestHelpers
+  alias PtcRunnerMcp.Sessions.Config, as: SessionsConfig
+  alias PtcRunnerMcp.Sessions.{Names, Registry, Supervisor}
+
+  @token String.duplicate("a", 32)
+
+  setup context do
+    McpTestHelpers.stop_existing_registry(SessionRegistry)
+    {:ok, cfg} = HttpConfig.resolve(%{http: true, http_auth_token: @token})
+    cfg = %{cfg | max_sessions: Map.get(context, :max_sessions, cfg.max_sessions)}
+    Application.put_env(:ptc_runner_mcp, :http_config, cfg)
+    start_supervised!({SessionRegistry, [config: cfg]})
+    PtcRunnerMcp.ConcurrencyGate.init()
+    on_exit(fn -> SessionsConfig.set(SessionsConfig.defaults()) end)
+    {:ok, cfg: cfg}
+  end
+
+  test "GET /mcp returns 405 with Allow" do
+    conn = call(conn(:get, "/mcp"))
+    assert conn.status == 405
+    assert get_resp_header(conn, "allow") == ["POST, DELETE"]
+  end
+
+  test "health and ready are unauthenticated" do
+    assert call(conn(:get, "/health")).status == 200
+    assert call(conn(:get, "/ready")).status == 200
+  end
+
+  test "missing and bad auth return bearer challenges" do
+    conn =
+      conn(:post, "/mcp", "{}") |> put_req_header("content-type", "application/json") |> call()
+
+    assert conn.status == 401
+    assert get_resp_header(conn, "www-authenticate") == ["Bearer"]
+
+    conn =
+      conn(:post, "/mcp", "{}")
+      |> put_req_header("authorization", "Bearer nope")
+      |> call()
+
+    assert conn.status == 401
+    assert get_resp_header(conn, "www-authenticate") == [~s(Bearer error="invalid_token")]
+  end
+
+  test "initialize creates a session and later notification returns 202" do
+    init = %{
+      "jsonrpc" => "2.0",
+      "id" => 1,
+      "method" => "initialize",
+      "params" => %{"protocolVersion" => "2025-06-18"}
+    }
+
+    conn =
+      conn(:post, "/mcp", Jason.encode!(init))
+      |> auth()
+      |> call()
+
+    assert conn.status == 200
+    [session_id] = get_resp_header(conn, "mcp-session-id")
+    body = Jason.decode!(conn.resp_body)
+    assert body["result"]["protocolVersion"] == "2025-06-18"
+
+    notification = %{"jsonrpc" => "2.0", "method" => "notifications/initialized"}
+
+    conn =
+      conn(:post, "/mcp", Jason.encode!(notification))
+      |> auth()
+      |> put_req_header("mcp-session-id", session_id)
+      |> call()
+
+    assert conn.status == 202
+  end
+
+  test "exit notification retires the HTTP session" do
+    session_id = initialize_session()
+
+    conn =
+      conn(:post, "/mcp", Jason.encode!(%{"jsonrpc" => "2.0", "method" => "exit"}))
+      |> auth()
+      |> put_req_header("mcp-session-id", session_id)
+      |> call()
+
+    assert conn.status == 202
+
+    wait_until(fn ->
+      SessionRegistry.lookup(session_id, Auth.owner_for(@token)) ==
+        {:error, :not_found}
+    end)
+
+    conn =
+      conn(
+        :post,
+        "/mcp",
+        Jason.encode!(%{"jsonrpc" => "2.0", "method" => "tools/list", "id" => 2})
+      )
+      |> auth()
+      |> put_req_header("mcp-session-id", session_id)
+      |> call()
+
+    assert conn.status == 404
+  end
+
+  test "JSON-RPC response POST validates protocol version" do
+    session_id = initialize_session()
+
+    conn =
+      conn(:post, "/mcp", Jason.encode!(%{"jsonrpc" => "2.0", "id" => "r", "result" => %{}}))
+      |> auth()
+      |> put_req_header("mcp-session-id", session_id)
+      |> put_req_header("mcp-protocol-version", "1999-01-01")
+      |> call()
+
+    assert conn.status == 400
+  end
+
+  test "invalid initialize does not allocate a session" do
+    conn =
+      conn(:post, "/mcp", Jason.encode!(%{"id" => 1, "method" => "initialize"}))
+      |> auth()
+      |> call()
+
+    assert conn.status == 200
+    assert get_resp_header(conn, "mcp-session-id") == []
+    assert Jason.decode!(conn.resp_body)["error"]["code"] == -32_600
+    refute SessionRegistry.saturated?()
+  end
+
+  @tag max_sessions: 0
+  test "initialize capacity errors echo the request id" do
+    conn =
+      conn(
+        :post,
+        "/mcp",
+        Jason.encode!(%{"jsonrpc" => "2.0", "id" => "cap", "method" => "initialize"})
+      )
+      |> auth()
+      |> call()
+
+    assert conn.status == 503
+    assert Jason.decode!(conn.resp_body)["id"] == "cap"
+  end
+
+  test "malformed POST mappings are deterministic" do
+    assert (conn(:post, "/mcp", "") |> auth() |> call()).status == 400
+
+    conn = conn(:post, "/mcp", "not-json") |> auth() |> call()
+    assert conn.status == 200
+    assert Jason.decode!(conn.resp_body)["error"]["code"] == -32_700
+
+    conn = conn(:post, "/mcp", "[]") |> auth() |> call()
+    assert conn.status == 200
+    assert Jason.decode!(conn.resp_body)["error"]["code"] == -32_600
+  end
+
+  test "DELETE closes a session" do
+    session_id = initialize_session()
+    {:ok, meta} = SessionRegistry.lookup(session_id, Auth.owner_for(@token))
+    ref = Process.monitor(meta.pid)
+
+    conn =
+      conn(:delete, "/mcp")
+      |> auth()
+      |> put_req_header("mcp-session-id", session_id)
+      |> call()
+
+    assert conn.status == 202
+    assert_receive {:DOWN, ^ref, :process, _pid, :normal}, 1_000
+
+    conn =
+      conn(
+        :post,
+        "/mcp",
+        Jason.encode!(%{"jsonrpc" => "2.0", "method" => "notifications/initialized"})
+      )
+      |> auth()
+      |> put_req_header("mcp-session-id", session_id)
+      |> call()
+
+    assert conn.status == 404
+  end
+
+  test "deleted owner index allows same owner to initialize again" do
+    first_id = initialize_session()
+
+    conn =
+      conn(:delete, "/mcp")
+      |> auth()
+      |> put_req_header("mcp-session-id", first_id)
+      |> call()
+
+    assert conn.status == 202
+
+    second_id = initialize_session()
+    assert second_id != first_id
+  end
+
+  test "session crash is monitored without taking down registry" do
+    session_id = initialize_session()
+    {:ok, meta} = SessionRegistry.lookup(session_id, Auth.owner_for(@token))
+
+    registry = Process.whereis(SessionRegistry)
+    ref = Process.monitor(meta.pid)
+    Process.exit(meta.pid, :kill)
+    assert_receive {:DOWN, ^ref, :process, _pid, :killed}, 1_000
+
+    assert Process.alive?(registry)
+
+    wait_until(fn ->
+      SessionRegistry.lookup(session_id, Auth.owner_for(@token)) ==
+        {:error, :not_found}
+    end)
+
+    _new_session_id = initialize_session()
+  end
+
+  test "session tools use transport owner even when client supplies owner" do
+    start_ptc_sessions!()
+    session_id = initialize_session()
+
+    start_call = %{
+      "jsonrpc" => "2.0",
+      "id" => "start",
+      "method" => "tools/call",
+      "params" => %{
+        "name" => "ptc_session_start",
+        "arguments" => %{"owner" => %{"transport" => "stdio", "instance_id" => "forged"}}
+      }
+    }
+
+    conn =
+      conn(:post, "/mcp", Jason.encode!(start_call))
+      |> auth()
+      |> put_req_header("mcp-session-id", session_id)
+      |> call()
+
+    assert conn.status == 200
+    start_body = Jason.decode!(conn.resp_body)
+    assert get_in(start_body, ["result", "structuredContent", "status"]) == "ok"
+
+    list_call = %{
+      "jsonrpc" => "2.0",
+      "id" => "list",
+      "method" => "tools/call",
+      "params" => %{"name" => "ptc_session_list", "arguments" => %{}}
+    }
+
+    conn =
+      conn(:post, "/mcp", Jason.encode!(list_call))
+      |> auth()
+      |> put_req_header("mcp-session-id", session_id)
+      |> call()
+
+    assert conn.status == 200
+    list_body = Jason.decode!(conn.resp_body)
+    assert [%{"session_id" => _}] = get_in(list_body, ["result", "structuredContent", "sessions"])
+  end
+
+  defp auth(conn), do: put_req_header(conn, "authorization", "Bearer " <> @token)
+  defp call(conn), do: Router.call(conn, [])
+
+  defp initialize_session do
+    conn =
+      conn(
+        :post,
+        "/mcp",
+        Jason.encode!(%{"jsonrpc" => "2.0", "id" => "i", "method" => "initialize"})
+      )
+      |> auth()
+      |> call()
+
+    assert conn.status == 200
+    [session_id] = get_resp_header(conn, "mcp-session-id")
+    session_id
+  end
+
+  defp start_ptc_sessions! do
+    McpTestHelpers.stop_existing_registry(Registry)
+    McpTestHelpers.stop_existing_registry(Supervisor)
+    McpTestHelpers.stop_existing_registry(Names)
+
+    cfg = %{SessionsConfig.defaults() | enabled: true}
+    SessionsConfig.set(cfg)
+
+    Enum.each(PtcRunnerMcp.Sessions.child_specs(), &start_supervised!/1)
+  end
+
+  defp wait_until(fun, timeout_ms \\ 1_000) do
+    deadline = System.monotonic_time(:millisecond) + timeout_ms
+    do_wait_until(fun, deadline)
+  end
+
+  defp do_wait_until(fun, deadline) do
+    if fun.() do
+      :ok
+    else
+      if System.monotonic_time(:millisecond) >= deadline do
+        flunk("wait_until timed out")
+      else
+        receive do
+        after
+          5 -> do_wait_until(fun, deadline)
+        end
+      end
+    end
+  end
+end

--- a/mcp_server/test/ptc_runner_mcp/http_router_test.exs
+++ b/mcp_server/test/ptc_runner_mcp/http_router_test.exs
@@ -25,6 +25,7 @@ defmodule PtcRunnerMcp.HttpRouterTest do
     Application.put_env(:ptc_runner_mcp, :http_config, cfg)
     start_supervised!({SessionRegistry, [config: cfg]})
     PtcRunnerMcp.ConcurrencyGate.init()
+    PtcRunnerMcp.ConcurrencyGate.reset()
 
     original_trace = TraceConfig.get()
     original_log_level = Log.level()
@@ -313,6 +314,44 @@ defmodule PtcRunnerMcp.HttpRouterTest do
     end)
 
     _new_session_id = initialize_session()
+  end
+
+  test "worker-tracked permit is released after hard session kill" do
+    session_id = initialize_session()
+    {:ok, meta} = SessionRegistry.lookup(session_id, Auth.owner_for(@token))
+
+    call = %{
+      "jsonrpc" => "2.0",
+      "id" => "hard-kill",
+      "method" => "tools/call",
+      "params" => %{
+        "name" => "ptc_lisp_execute",
+        "arguments" => %{"program" => long_running_program(), "context" => %{}}
+      }
+    }
+
+    task =
+      Task.async(fn ->
+        conn(:post, "/mcp", Jason.encode!(call))
+        |> auth()
+        |> put_req_header("mcp-session-id", session_id)
+        |> call()
+      end)
+
+    wait_until(fn -> map_size(:sys.get_state(meta.pid).in_flight) == 1 end)
+    [%{pid: worker_pid}] = :sys.get_state(meta.pid).in_flight |> Map.values()
+    assert ConcurrencyGate.in_flight() == 1
+
+    session_ref = Process.monitor(meta.pid)
+    Process.exit(meta.pid, :kill)
+    assert_receive {:DOWN, ^session_ref, :process, _pid, :killed}, 1_000
+
+    worker_ref = Process.monitor(worker_pid)
+    Process.exit(worker_pid, :kill)
+    assert_receive {:DOWN, ^worker_ref, :process, ^worker_pid, :killed}, 1_000
+
+    wait_until(fn -> ConcurrencyGate.in_flight() == 0 end)
+    Task.shutdown(task, :brutal_kill)
   end
 
   test "stopping registry stops live sessions" do

--- a/mcp_server/test/ptc_runner_mcp/http_router_test.exs
+++ b/mcp_server/test/ptc_runner_mcp/http_router_test.exs
@@ -3,11 +3,18 @@ defmodule PtcRunnerMcp.HttpRouterTest do
   import Plug.Conn
   import Plug.Test
 
-  alias PtcRunnerMcp.Http.{Auth, Router, SessionRegistry}
+  alias PtcRunnerMcp.ConcurrencyGate
+  alias PtcRunnerMcp.Http.Auth
   alias PtcRunnerMcp.Http.Config, as: HttpConfig
+  alias PtcRunnerMcp.Http.Router
+  alias PtcRunnerMcp.Http.SessionRegistry
+  alias PtcRunnerMcp.Http.Telemetry
+  alias PtcRunnerMcp.Log
   alias PtcRunnerMcp.McpTestHelpers
   alias PtcRunnerMcp.Sessions.Config, as: SessionsConfig
   alias PtcRunnerMcp.Sessions.{Names, Registry, Supervisor}
+  alias PtcRunnerMcp.TraceConfig
+  alias PtcRunnerMcp.TraceHandler
 
   @token String.duplicate("a", 32)
 
@@ -18,7 +25,17 @@ defmodule PtcRunnerMcp.HttpRouterTest do
     Application.put_env(:ptc_runner_mcp, :http_config, cfg)
     start_supervised!({SessionRegistry, [config: cfg]})
     PtcRunnerMcp.ConcurrencyGate.init()
-    on_exit(fn -> SessionsConfig.set(SessionsConfig.defaults()) end)
+
+    original_trace = TraceConfig.get()
+    original_log_level = Log.level()
+
+    on_exit(fn ->
+      SessionsConfig.set(SessionsConfig.defaults())
+      TraceConfig.set(original_trace)
+      TraceHandler.detach()
+      Log.set_level(original_log_level)
+    end)
+
     {:ok, cfg: cfg}
   end
 
@@ -120,6 +137,24 @@ defmodule PtcRunnerMcp.HttpRouterTest do
     assert conn.status == 400
   end
 
+  test "POST rejects supported protocol version different from negotiated session" do
+    session_id = initialize_session("2025-06-18")
+
+    conn =
+      conn(
+        :post,
+        "/mcp",
+        Jason.encode!(%{"jsonrpc" => "2.0", "id" => "v", "method" => "tools/list"})
+      )
+      |> auth()
+      |> put_req_header("mcp-session-id", session_id)
+      |> put_req_header("mcp-protocol-version", "2025-11-25")
+      |> call()
+
+    assert conn.status == 400
+    assert conn.resp_body == "bad MCP-Protocol-Version"
+  end
+
   test "invalid initialize does not allocate a session" do
     conn =
       conn(:post, "/mcp", Jason.encode!(%{"id" => 1, "method" => "initialize"}))
@@ -201,6 +236,66 @@ defmodule PtcRunnerMcp.HttpRouterTest do
     assert second_id != first_id
   end
 
+  test "draining registry makes ready and POST return 503 JSON-RPC error" do
+    assert :ok = SessionRegistry.begin_drain()
+
+    ready = call(conn(:get, "/ready"))
+    assert ready.status == 503
+    assert Jason.decode!(ready.resp_body)["status"] == "draining"
+
+    conn =
+      conn(
+        :post,
+        "/mcp",
+        Jason.encode!(%{"jsonrpc" => "2.0", "id" => "during-drain", "method" => "initialize"})
+      )
+      |> auth()
+      |> call()
+
+    assert conn.status == 503
+    body = Jason.decode!(conn.resp_body)
+    assert body["id"] == "during-drain"
+    assert body["error"]["message"] == "server draining"
+  end
+
+  test "drain waits for explicit cancellation rather than cancelling immediately" do
+    session_id = initialize_session()
+    {:ok, meta} = SessionRegistry.lookup(session_id, Auth.owner_for(@token))
+
+    call = %{
+      "jsonrpc" => "2.0",
+      "id" => "slow",
+      "method" => "tools/call",
+      "params" => %{
+        "name" => "ptc_lisp_execute",
+        "arguments" => %{"program" => long_running_program(), "context" => %{}}
+      }
+    }
+
+    parent = self()
+
+    task =
+      Task.async(fn ->
+        conn =
+          conn(:post, "/mcp", Jason.encode!(call))
+          |> auth()
+          |> put_req_header("mcp-session-id", session_id)
+          |> call()
+
+        send(parent, {:slow_done, conn.status, Jason.decode!(conn.resp_body)})
+      end)
+
+    wait_until(fn -> map_size(:sys.get_state(meta.pid).in_flight) == 1 end)
+    assert :ok = SessionRegistry.begin_drain()
+
+    refute_receive {:slow_done, _, _}, 30
+    assert :ok = SessionRegistry.cancel_all(:shutdown)
+    assert_receive {:slow_done, 200, body}, 1_000
+    assert get_in(body, ["result", "structuredContent", "reason"]) == "cancelled"
+
+    Task.await(task, 1_000)
+  end
+
   test "session crash is monitored without taking down registry" do
     session_id = initialize_session()
     {:ok, meta} = SessionRegistry.lookup(session_id, Auth.owner_for(@token))
@@ -218,6 +313,47 @@ defmodule PtcRunnerMcp.HttpRouterTest do
     end)
 
     _new_session_id = initialize_session()
+  end
+
+  test "stopping registry stops live sessions" do
+    session_id = initialize_session()
+    {:ok, meta} = SessionRegistry.lookup(session_id, Auth.owner_for(@token))
+    ref = Process.monitor(meta.pid)
+
+    assert :ok = stop_supervised(SessionRegistry)
+    assert_receive {:DOWN, ^ref, :process, _pid, :normal}, 1_000
+  end
+
+  test "client disconnect cancels in-flight HTTP work and releases permit" do
+    session_id = initialize_session()
+    {:ok, meta} = SessionRegistry.lookup(session_id, Auth.owner_for(@token))
+
+    call = %{
+      "jsonrpc" => "2.0",
+      "id" => "disconnect",
+      "method" => "tools/call",
+      "params" => %{
+        "name" => "ptc_lisp_execute",
+        "arguments" => %{"program" => long_running_program(), "context" => %{}}
+      }
+    }
+
+    task =
+      Task.async(fn ->
+        conn(:post, "/mcp", Jason.encode!(call))
+        |> auth()
+        |> put_req_header("mcp-session-id", session_id)
+        |> call()
+      end)
+
+    wait_until(fn -> map_size(:sys.get_state(meta.pid).in_flight) == 1 end)
+    assert ConcurrencyGate.in_flight() == 1
+
+    Task.shutdown(task, :brutal_kill)
+
+    wait_until(fn ->
+      map_size(:sys.get_state(meta.pid).in_flight) == 0 and ConcurrencyGate.in_flight() == 0
+    end)
   end
 
   test "session tools use transport owner even when client supplies owner" do
@@ -248,7 +384,10 @@ defmodule PtcRunnerMcp.HttpRouterTest do
       "jsonrpc" => "2.0",
       "id" => "list",
       "method" => "tools/call",
-      "params" => %{"name" => "ptc_session_list", "arguments" => %{}}
+      "params" => %{
+        "name" => "ptc_session_list",
+        "arguments" => %{"owner" => %{"transport" => "stdio", "instance_id" => "forged"}}
+      }
     }
 
     conn =
@@ -262,15 +401,169 @@ defmodule PtcRunnerMcp.HttpRouterTest do
     assert [%{"session_id" => _}] = get_in(list_body, ["result", "structuredContent", "sessions"])
   end
 
-  defp auth(conn), do: put_req_header(conn, "authorization", "Bearer " <> @token)
-  defp call(conn), do: Router.call(conn, [])
+  test "HTTP request telemetry carries request, owner, and session correlation" do
+    handler_id = attach_http_telemetry()
 
-  defp initialize_session do
     conn =
       conn(
         :post,
         "/mcp",
-        Jason.encode!(%{"jsonrpc" => "2.0", "id" => "i", "method" => "initialize"})
+        Jason.encode!(%{"jsonrpc" => "2.0", "id" => "obs-init", "method" => "initialize"})
+      )
+      |> auth()
+      |> put_req_header("x-request-id", "http-request-1")
+      |> call()
+
+    assert conn.status == 200
+    assert get_resp_header(conn, "x-request-id") == ["http-request-1"]
+    [session_id] = get_resp_header(conn, "mcp-session-id")
+
+    owner_hash = Auth.owner_for(@token).hash
+    session_hash = Telemetry.hash_id(session_id)
+
+    assert_receive {:http_telemetry, ^handler_id, [:ptc_runner_mcp, :http, :request, :start],
+                    %{system_time: _}, %{request_id: "http-request-1"}}
+
+    assert_receive {:http_telemetry, ^handler_id, [:ptc_runner_mcp, :http, :session, :created],
+                    %{count: 1},
+                    %{
+                      owner_hash: ^owner_hash,
+                      session_hash: ^session_hash,
+                      protocol_version: _
+                    }}
+
+    assert_receive {:http_telemetry, ^handler_id, [:ptc_runner_mcp, :http, :request, :stop],
+                    %{duration: duration},
+                    %{
+                      request_id: "http-request-1",
+                      status: 200,
+                      owner_hash: ^owner_hash,
+                      session_hash: ^session_hash
+                    }}
+                   when is_integer(duration)
+  end
+
+  test "HTTP request log line is correlated and does not leak the raw session id" do
+    Log.set_level(:info)
+    parent = self()
+
+    stderr =
+      ExUnit.CaptureIO.capture_io(:stderr, fn ->
+        conn =
+          conn(
+            :post,
+            "/mcp",
+            Jason.encode!(%{"jsonrpc" => "2.0", "id" => "log-init", "method" => "initialize"})
+          )
+          |> auth()
+          |> put_req_header("x-request-id", "http-log-1")
+          |> call()
+
+        assert conn.status == 200
+        [session_id] = get_resp_header(conn, "mcp-session-id")
+        send(parent, {:created_session_id, session_id})
+      end)
+
+    assert_receive {:created_session_id, session_id}
+
+    line =
+      stderr
+      |> String.split("\n", trim: true)
+      |> Enum.map(&Jason.decode!/1)
+      |> Enum.find(&(&1["event"] == "http_request_stop"))
+
+    assert line["request_id"] == "http-log-1"
+    assert line["fields"]["status"] == 200
+    assert line["fields"]["owner_hash"] == Auth.owner_for(@token).hash
+    refute String.contains?(stderr, @token)
+    refute String.contains?(stderr, session_id)
+  end
+
+  test "HTTP tool-call traces carry owner and session hashes" do
+    dir = Path.join(System.tmp_dir!(), "ptc_mcp_http_trace_#{System.unique_integer([:positive])}")
+    File.rm_rf!(dir)
+    File.mkdir_p!(dir)
+    TraceConfig.set(%{trace_dir: dir, trace_payloads: :summary, trace_max_files: 1000})
+    TraceHandler.attach()
+
+    session_id = initialize_session()
+    owner_hash = Auth.owner_for(@token).hash
+    session_hash = Telemetry.hash_id(session_id)
+
+    call = %{
+      "jsonrpc" => "2.0",
+      "id" => "trace-call",
+      "method" => "tools/call",
+      "params" => %{
+        "name" => "ptc_lisp_execute",
+        "arguments" => %{"program" => "(+ 1 2)", "context" => %{}}
+      }
+    }
+
+    conn =
+      conn(:post, "/mcp", Jason.encode!(call))
+      |> auth()
+      |> put_req_header("x-request-id", "http-trace-1")
+      |> put_req_header("mcp-session-id", session_id)
+      |> call()
+
+    assert conn.status == 200
+
+    [file] = wait_for_files(dir, 1)
+    events = read_jsonl(Path.join(dir, file))
+    call_start = Enum.find(events, &(&1["event"] == "ptc_runner_mcp.call.start"))
+
+    assert call_start["metadata"]["owner_hash"] == owner_hash
+    assert call_start["metadata"]["mcp_session_hash"] == session_hash
+    assert call_start["metadata"]["transport_request_id"] == "http-trace-1"
+    refute inspect(events) =~ @token
+    refute inspect(events) =~ session_id
+
+    File.rm_rf!(dir)
+  end
+
+  defp auth(conn), do: put_req_header(conn, "authorization", "Bearer " <> @token)
+  defp call(conn), do: Router.call(conn, [])
+
+  defp attach_http_telemetry do
+    handler_id = "http-router-test-#{System.unique_integer([:positive])}"
+    parent = self()
+
+    :ok =
+      :telemetry.attach_many(
+        handler_id,
+        [
+          [:ptc_runner_mcp, :http, :request, :start],
+          [:ptc_runner_mcp, :http, :request, :stop],
+          [:ptc_runner_mcp, :http, :session, :created]
+        ],
+        fn event, measurements, metadata, _config ->
+          send(parent, {:http_telemetry, handler_id, event, measurements, metadata})
+        end,
+        %{}
+      )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+    handler_id
+  end
+
+  defp initialize_session(protocol_version \\ nil) do
+    params =
+      case protocol_version do
+        nil -> %{}
+        version -> %{"protocolVersion" => version}
+      end
+
+    conn =
+      conn(
+        :post,
+        "/mcp",
+        Jason.encode!(%{
+          "jsonrpc" => "2.0",
+          "id" => "i",
+          "method" => "initialize",
+          "params" => params
+        })
       )
       |> auth()
       |> call()
@@ -294,6 +587,46 @@ defmodule PtcRunnerMcp.HttpRouterTest do
   defp wait_until(fun, timeout_ms \\ 1_000) do
     deadline = System.monotonic_time(:millisecond) + timeout_ms
     do_wait_until(fun, deadline)
+  end
+
+  defp wait_for_files(dir, expected, timeout_ms \\ 1_000) do
+    deadline = System.monotonic_time(:millisecond) + timeout_ms
+    do_wait_for_files(dir, expected, deadline)
+  end
+
+  defp do_wait_for_files(dir, expected, deadline) do
+    files =
+      dir
+      |> File.ls!()
+      |> Enum.reject(&String.ends_with?(&1, ".pending"))
+      |> Enum.sort()
+
+    if length(files) >= expected do
+      files
+    else
+      if System.monotonic_time(:millisecond) >= deadline do
+        flunk("timed out waiting for trace files in #{dir}")
+      else
+        receive do
+        after
+          10 -> do_wait_for_files(dir, expected, deadline)
+        end
+      end
+    end
+  end
+
+  defp read_jsonl(path) do
+    path
+    |> File.read!()
+    |> String.split("\n", trim: true)
+    |> Enum.map(&Jason.decode!/1)
+  end
+
+  defp long_running_program do
+    "((fn ack [m n] " <>
+      "(cond (= m 0) (+ n 1) " <>
+      "(= n 0) (ack (- m 1) 1) " <>
+      ":else (ack (- m 1) (ack m (- n 1))))) 3 8)"
   end
 
   defp do_wait_until(fun, deadline) do

--- a/mcp_server/test/ptc_runner_mcp/output_schema_test.exs
+++ b/mcp_server/test/ptc_runner_mcp/output_schema_test.exs
@@ -87,6 +87,7 @@ defmodule PtcRunnerMcp.OutputSchemaTest do
                   "fail",
                   "validation_error",
                   "busy",
+                  "cancelled",
                   "unknown_tool",
                   "shutting_down"
                 ]
@@ -189,6 +190,11 @@ defmodule PtcRunnerMcp.OutputSchemaTest do
     test "tool entry includes outputSchema" do
       %{"tools" => [tool]} = Tools.list()
       assert tool["outputSchema"] == Tools.output_schema()
+    end
+
+    test "error schema advertises HTTP cancellation envelopes" do
+      [_, error_branch] = Tools.output_schema()["oneOf"]
+      assert "cancelled" in error_branch["properties"]["reason"]["enum"]
     end
   end
 end

--- a/mcp_server/test/soak/http_mcp_soak_test.exs
+++ b/mcp_server/test/soak/http_mcp_soak_test.exs
@@ -1,0 +1,292 @@
+defmodule PtcRunnerMcp.HttpMcpSoakTest do
+  @moduledoc """
+  Soak test: drive the Streamable HTTP MCP endpoint over a real Bandit
+  listener and assert request/session churn does not leak processes,
+  memory, concurrency permits, or HTTP-owned PTC-Lisp sessions.
+
+  This complements `mcp_stdio_soak_test.exs`: stdio catches pipe/framing
+  leaks, while this test exercises the production HTTP router,
+  `Http.SessionRegistry`, `Http.Session`, Bandit request processes, and
+  downstream stateful PTC-Lisp session ownership.
+
+  Scenarios:
+
+    * initialize -> notifications/initialized -> stateless
+      `ptc_lisp_execute` -> DELETE
+    * initialize -> `ptc_session_start` -> forced HTTP registry stop
+      and restart
+
+  ## Run
+
+      MIX_ENV=test mix test --only soak \\
+        test/soak/http_mcp_soak_test.exs --color
+
+      PTC_SOAK_ITERATIONS=5000 \\
+        MIX_ENV=test mix test --only soak \\
+        test/soak/http_mcp_soak_test.exs
+  """
+
+  use ExUnit.Case, async: false
+
+  alias PtcRunnerMcp.ConcurrencyGate
+  alias PtcRunnerMcp.Http.{Config, Server, SessionRegistry}
+  alias PtcRunnerMcp.Sessions.Config, as: SessionsConfig
+  alias PtcRunnerMcp.Sessions.{Owner, Registry}
+  alias PtcRunnerMcp.TestSupport.{MemorySoak, SoakHelpers}
+
+  @moduletag :soak
+  @moduletag timeout: :infinity
+
+  @token String.duplicate("h", 32)
+  @protocol_version "2025-11-25"
+
+  setup do
+    SoakHelpers.setup_sessions(%{enabled: true, max_sessions: 100_000})
+    ConcurrencyGate.init()
+    ConcurrencyGate.reset()
+
+    {:ok, cfg} =
+      Config.resolve(%{
+        http: true,
+        http_auth_token: @token,
+        http_max_sessions: 100_000,
+        http_max_sessions_per_owner: 100_000,
+        http_max_in_flight_per_session: 8,
+        http_session_ttl_ms: 3_600_000,
+        http_session_idle_timeout_ms: 3_600_000,
+        http_request_timeout_ms: 30_000
+      })
+
+    cfg = %{cfg | port: 0}
+    start_registry!(cfg)
+    bandit = start_supervised!(Server.child_spec(cfg))
+    {:ok, {_addr, port}} = ThousandIsland.listener_info(bandit)
+
+    on_exit(fn ->
+      stop_registry()
+      SessionsConfig.reset()
+      ConcurrencyGate.reset()
+    end)
+
+    {:ok,
+     cfg: cfg, url: "http://127.0.0.1:#{port}#{cfg.path}", iters: MemorySoak.iteration_count()}
+  end
+
+  test "HTTP session and stateless eval churn returns to baseline", %{url: url, iters: iters} do
+    {before, aft} =
+      MemorySoak.measure(iters, fn _phase ->
+        session_id = initialize!(url)
+        initialized!(url, session_id)
+        execute_ok!(url, session_id, "(+ 1 2 3)")
+        delete!(url, session_id)
+      end)
+
+    assert_registry_empty!()
+
+    IO.puts("BEFORE (http stateless churn, n=#{iters}):\n#{MemorySoak.format(before)}")
+    IO.puts("AFTER  (http stateless churn, n=#{iters}):\n#{MemorySoak.format(aft)}")
+
+    assert ConcurrencyGate.in_flight() == 0
+    MemorySoak.assert_procs_stable!(before, aft, tolerance: 20)
+    MemorySoak.assert_flat!(before, aft, :total, tolerance_pct: 35)
+    MemorySoak.assert_flat!(before, aft, :binary, tolerance_pct: 60)
+    MemorySoak.assert_atoms_per_iter!(before, aft, iters)
+  end
+
+  test "HTTP registry restart closes owned PTC-Lisp sessions", %{
+    cfg: cfg,
+    url: url,
+    iters: iters
+  } do
+    registry_iters = max(div(iters, 5), 1)
+
+    {before, aft} =
+      MemorySoak.measure(registry_iters, fn _phase ->
+        session_id = initialize!(url)
+        ptc_session_id = start_ptc_session!(url, session_id)
+        owner = Owner.http(session_id)
+
+        assert [_] = Registry.list(owner)
+
+        stop_registry()
+        wait_until(fn -> Registry.list(owner) == [] end)
+        start_registry!(cfg)
+
+        refute ptc_session_id in Enum.map(Registry.list(owner), & &1.id)
+      end)
+
+    assert_registry_empty!()
+
+    IO.puts(
+      "BEFORE (http registry restart churn, n=#{registry_iters}):\n#{MemorySoak.format(before)}"
+    )
+
+    IO.puts(
+      "AFTER  (http registry restart churn, n=#{registry_iters}):\n#{MemorySoak.format(aft)}"
+    )
+
+    assert ConcurrencyGate.in_flight() == 0
+    MemorySoak.assert_procs_stable!(before, aft, tolerance: 20)
+    MemorySoak.assert_flat!(before, aft, :total, tolerance_pct: 35)
+    MemorySoak.assert_flat!(before, aft, :binary, tolerance_pct: 60)
+    MemorySoak.assert_atoms_per_iter!(before, aft, registry_iters)
+  end
+
+  defp initialize!(url) do
+    resp =
+      post!(url, %{
+        "jsonrpc" => "2.0",
+        "id" => "init",
+        "method" => "initialize",
+        "params" => %{"protocolVersion" => @protocol_version}
+      })
+
+    assert resp.status == 200
+    assert resp.body["result"]["protocolVersion"] == @protocol_version
+    get_header!(resp, "mcp-session-id")
+  end
+
+  defp initialized!(url, session_id) do
+    resp =
+      post!(
+        url,
+        %{"jsonrpc" => "2.0", "method" => "notifications/initialized"},
+        session_id: session_id
+      )
+
+    assert resp.status == 202
+  end
+
+  defp execute_ok!(url, session_id, program) do
+    resp =
+      post!(
+        url,
+        %{
+          "jsonrpc" => "2.0",
+          "id" => "eval",
+          "method" => "tools/call",
+          "params" => %{
+            "name" => "ptc_lisp_execute",
+            "arguments" => %{"program" => program, "context" => %{}}
+          }
+        },
+        session_id: session_id
+      )
+
+    assert resp.status == 200
+    assert get_in(resp.body, ["result", "structuredContent", "status"]) == "ok"
+  end
+
+  defp start_ptc_session!(url, session_id) do
+    resp =
+      post!(
+        url,
+        %{
+          "jsonrpc" => "2.0",
+          "id" => "start-session",
+          "method" => "tools/call",
+          "params" => %{"name" => "ptc_session_start", "arguments" => %{}}
+        },
+        session_id: session_id
+      )
+
+    assert resp.status == 200
+    assert get_in(resp.body, ["result", "structuredContent", "status"]) == "ok"
+    get_in(resp.body, ["result", "structuredContent", "session_id"])
+  end
+
+  defp delete!(url, session_id) do
+    resp =
+      Req.delete!(url,
+        headers: auth_headers(session_id: session_id),
+        receive_timeout: 30_000
+      )
+
+    assert resp.status == 202
+  end
+
+  defp post!(url, body, opts \\ []) do
+    Req.post!(url,
+      json: body,
+      headers: auth_headers(opts),
+      receive_timeout: 30_000
+    )
+  end
+
+  defp auth_headers(opts) do
+    [{"authorization", "Bearer " <> @token}] ++ session_headers(opts)
+  end
+
+  defp session_headers(opts) do
+    case Keyword.get(opts, :session_id) do
+      nil ->
+        []
+
+      session_id ->
+        [
+          {"mcp-session-id", session_id},
+          {"mcp-protocol-version", @protocol_version}
+        ]
+    end
+  end
+
+  defp get_header!(%Req.Response{headers: headers}, name) do
+    name = String.downcase(name)
+
+    case Map.get(headers, name) do
+      [value | _] -> value
+      value when is_binary(value) -> value
+      _ -> flunk("missing response header #{name}: #{inspect(headers)}")
+    end
+  end
+
+  defp start_registry!(cfg) do
+    stop_registry()
+    {:ok, _pid} = SessionRegistry.start_link(config: cfg)
+    :ok
+  end
+
+  defp stop_registry do
+    case Process.whereis(SessionRegistry) do
+      nil ->
+        :ok
+
+      pid ->
+        GenServer.stop(pid, :normal, 5_000)
+    end
+  catch
+    :exit, _ -> :ok
+  end
+
+  defp assert_registry_empty! do
+    case Process.whereis(SessionRegistry) do
+      nil ->
+        :ok
+
+      pid ->
+        state = :sys.get_state(pid, 5_000)
+        assert map_size(state.sessions) == 0
+        assert state.by_owner == %{}
+    end
+  end
+
+  defp wait_until(fun, timeout_ms \\ 1_000) do
+    deadline = System.monotonic_time(:millisecond) + timeout_ms
+    do_wait_until(fun, deadline)
+  end
+
+  defp do_wait_until(fun, deadline) do
+    if fun.() do
+      :ok
+    else
+      if System.monotonic_time(:millisecond) >= deadline do
+        flunk("wait_until timed out")
+      else
+        receive do
+        after
+          5 -> do_wait_until(fun, deadline)
+        end
+      end
+    end
+  end
+end

--- a/test/soak/README.md
+++ b/test/soak/README.md
@@ -30,6 +30,7 @@ MIX_ENV=test mix test --only soak test/soak/mcp_stdio_soak_test.exs
 | `mcp_server/.../session_churn_soak_test.exs`    | `Sessions.Registry` + DynamicSupervisor cleanup over many start/eval/close cycles |
 | `mcp_server/.../many_turns_soak_test.exs`       | Per-turn projection state growth; atom-table growth on user-supplied var names |
 | `mcp_server/.../mcp_stdio_soak_test.exs`        | Built release driven over real stdio with repeated stateless eval calls |
+| `mcp_server/.../http_mcp_soak_test.exs`         | Real Bandit HTTP MCP endpoint churn, DELETE cleanup, registry restart cleanup, and HTTP-owned PTC session ownership |
 
 ## Tunables (env vars)
 


### PR DESCRIPTION
## Summary
- Add an opt-in Streamable HTTP server for `mcp_server` using Plug/Bandit, with `/health`, `/ready`, and `/mcp` POST/DELETE handling.
- Add HTTP config resolution, bearer authentication, origin checks, per-session registry/state, capacity limits, idle/TTL cleanup, DELETE cleanup, request cancellation, and negotiated protocol-version validation.
- Add correlated HTTP request/session telemetry, structured request-stop logs, redacted owner/session hashing, request-id propagation, and HTTP metadata in tool-call traces.
- Harden HTTP lifecycle cleanup: registry-owned linked sessions, client-disconnect cancellation, shutdown-grace drain mode, strict session protocol-version headers, transport-derived PTC session ownership, and worker-tracked concurrency permits that release after hard session crashes.
- Document Streamable HTTP deployment/configuration, health/readiness, security posture, observability, drain behavior, and current metrics/SSE limitations.

## Verification
- `mix compile --warnings-as-errors` in `mcp_server`
- `mix credo --strict` in `mcp_server`
- `mix dialyzer` in `mcp_server`
- `mix test test/ptc_runner_mcp/http_router_test.exs` in `mcp_server`
- `mix test test/ptc_runner_mcp/http_router_test.exs:318` in `mcp_server` for the hard-session-kill permit regression
- `mix test test/ptc_runner_mcp/http_config_test.exs test/ptc_runner_mcp/http_router_test.exs test/ptc_runner_mcp/output_schema_test.exs test/ptc_runner_mcp/tools_phase0_test.exs` in `mcp_server`
- Full `mcp_server` suite: `9 doctests, 1116 tests, 0 failures, 1 skipped (21 excluded)`
- Pre-push gate passed:
  - root: `375 doctests, 3 properties, 4971 tests, 0 failures (373 excluded)` plus Dialyzer
  - `mcp_server`: `9 doctests, 1116 tests, 0 failures, 1 skipped (21 excluded)` plus Dialyzer
  - `ptc_viewer`: `9 tests, 0 failures`
- `git diff --check`

## Reviews
- Independent high-effort Codex review was run during the core HTTP implementation; findings around invalid initialization allocation, registry crash isolation, owner spoofing, timeout cleanup, exit handling, and protocol-header validation were fixed.
- A second high-effort review of the follow-up phases found and drove fixes for linked session cleanup, client-disconnect cancellation, and cancelled-envelope schema coverage.
- A final high-effort review after those fixes found no material issues. Residual risks called out there: SSE/resumability and Prometheus `/metrics` are intentionally deferred and documented.
- Follow-up audit found a real ConcurrencyGate permit leak on hard-killed `Http.Session` processes; fixed by tracking HTTP permits with worker monitors and adding a failing regression test.

## Notes
This PR now covers the core opt-in HTTP transport plus the follow-up observability, hardening, shutdown-drain, and deployment-documentation phases. Remaining follow-ups are the deeper transport abstraction, SSE/resumability, direct Bandit listener drain refinements, and Prometheus metrics endpoint implementation.

Specification: https://github.com/andreasronge/ptc_runner/blob/main/Plans/ptc-runner-mcp-streamable-http-server.md

## Fix Automation State
<!-- fix-state: {"attempts":2} -->
Fix attempts: 2/3
