### PR TITLE
fix(mcp): address HTTP review follow-ups

### DIFF
--- a/mcp_server/lib/ptc_runner_mcp/http/session_registry.ex
+++ b/mcp_server/lib/ptc_runner_mcp/http/session_registry.ex
@@ -9,7 +9,6 @@ defmodule PtcRunnerMcp.Http.SessionRegistry do
 
   defstruct sessions: %{},
             by_owner: %{},
-            monitors: %{},
             config: %{},
             draining?: false,
             cleanup_ref: nil
@@ -106,8 +105,6 @@ defmodule PtcRunnerMcp.Http.SessionRegistry do
                max_in_flight: state.config.max_in_flight_per_session
              ) do
           {:ok, pid} ->
-            ref = Process.monitor(pid)
-
             meta = %{
               id: id,
               pid: pid,
@@ -120,7 +117,6 @@ defmodule PtcRunnerMcp.Http.SessionRegistry do
             state =
               state
               |> put_in([Access.key!(:sessions), id], meta)
-              |> put_in([Access.key!(:monitors), ref], id)
               |> add_owner_index(owner.hash, id)
 
             session_hash = Telemetry.hash_id(id)
@@ -194,13 +190,6 @@ defmodule PtcRunnerMcp.Http.SessionRegistry do
     end
   end
 
-  def handle_info({:DOWN, ref, :process, _pid, reason}, state) do
-    case Map.pop(state.monitors, ref) do
-      {nil, monitors} -> {:noreply, %{state | monitors: monitors}}
-      {id, monitors} -> {:noreply, remove_session(%{state | monitors: monitors}, id, reason)}
-    end
-  end
-
   def handle_info(:cleanup, state) do
     now = System.monotonic_time(:millisecond)
 
@@ -265,7 +254,6 @@ defmodule PtcRunnerMcp.Http.SessionRegistry do
 
         state
         |> Map.put(:sessions, sessions)
-        |> remove_monitor(id)
         |> remove_owner_index(meta.owner_hash, id)
     end
   end
@@ -275,17 +263,6 @@ defmodule PtcRunnerMcp.Http.SessionRegistry do
       {id, %{pid: ^pid}} -> id
       _ -> nil
     end)
-  end
-
-  defp remove_monitor(state, id) do
-    case Enum.find(state.monitors, fn {_ref, session_id} -> session_id == id end) do
-      {ref, ^id} ->
-        Process.demonitor(ref, [:flush])
-        %{state | monitors: Map.delete(state.monitors, ref)}
-
-      nil ->
-        state
-    end
   end
 
   defp safe_idle?(pid, now, ms) do

--- a/mcp_server/test/ptc_runner_mcp/cancellation_test.exs
+++ b/mcp_server/test/ptc_runner_mcp/cancellation_test.exs
@@ -22,6 +22,7 @@ defmodule PtcRunnerMcp.CancellationTest do
       worker processes with correct metadata.
   """
   use ExUnit.Case, async: false
+  import PtcRunnerMcp.TestSupport.WaitHelpers
 
   alias PtcRunnerMcp.{ConcurrencyGate, Limits, Stdio}
   alias PtcRunnerMcp.Test.JsonRpcHarness
@@ -482,29 +483,4 @@ defmodule PtcRunnerMcp.CancellationTest do
   # ----------------------------------------------------------------
   # Helpers
   # ----------------------------------------------------------------
-
-  defp wait_until(fun, timeout_ms) do
-    deadline = System.monotonic_time(:millisecond) + timeout_ms
-    do_wait_until(fun, deadline)
-  end
-
-  defp do_wait_until(fun, deadline) do
-    if fun.() do
-      :ok
-    else
-      if System.monotonic_time(:millisecond) > deadline do
-        flunk("wait_until timed out")
-      else
-        # Non-blocking pause: a `receive` with `after` parks the
-        # scheduler without consuming CPU and avoids the explicit
-        # `Process.sleep` ban from CLAUDE.md.
-        receive do
-        after
-          10 -> :ok
-        end
-
-        do_wait_until(fun, deadline)
-      end
-    end
-  end
 end

--- a/mcp_server/test/ptc_runner_mcp/debug_tool_test.exs
+++ b/mcp_server/test/ptc_runner_mcp/debug_tool_test.exs
@@ -11,6 +11,7 @@ defmodule PtcRunnerMcp.DebugToolTest do
   aggregation; `record/1` fault isolation.
   """
   use ExUnit.Case, async: false
+  import PtcRunnerMcp.TestSupport.WaitHelpers
 
   alias PtcRunnerMcp.{
     ConcurrencyGate,
@@ -785,28 +786,5 @@ defmodule PtcRunnerMcp.DebugToolTest do
       "(cond (= m 0) (+ n 1) " <>
       "(= n 0) (ack (- m 1) 1) " <>
       ":else (ack (- m 1) (ack m (- n 1))))) 3 9)"
-  end
-
-  defp wait_until(fun, timeout_ms) do
-    deadline = System.monotonic_time(:millisecond) + timeout_ms
-    do_wait(fun, deadline)
-  end
-
-  defp do_wait(fun, deadline) do
-    cond do
-      fun.() ->
-        :ok
-
-      System.monotonic_time(:millisecond) > deadline ->
-        flunk("wait_until timed out")
-
-      true ->
-        receive do
-        after
-          10 -> :ok
-        end
-
-        do_wait(fun, deadline)
-    end
   end
 end

--- a/mcp_server/test/ptc_runner_mcp/http_router_test.exs
+++ b/mcp_server/test/ptc_runner_mcp/http_router_test.exs
@@ -2,6 +2,7 @@ defmodule PtcRunnerMcp.HttpRouterTest do
   use ExUnit.Case, async: false
   import Plug.Conn
   import Plug.Test
+  import PtcRunnerMcp.TestSupport.WaitHelpers
 
   alias PtcRunnerMcp.ConcurrencyGate
   alias PtcRunnerMcp.Http.Auth
@@ -652,11 +653,6 @@ defmodule PtcRunnerMcp.HttpRouterTest do
     Enum.each(PtcRunnerMcp.Sessions.child_specs(), &start_supervised!/1)
   end
 
-  defp wait_until(fun, timeout_ms \\ 1_000) do
-    deadline = System.monotonic_time(:millisecond) + timeout_ms
-    do_wait_until(fun, deadline)
-  end
-
   defp wait_for_files(dir, expected, timeout_ms \\ 1_000) do
     deadline = System.monotonic_time(:millisecond) + timeout_ms
     do_wait_for_files(dir, expected, deadline)
@@ -695,20 +691,5 @@ defmodule PtcRunnerMcp.HttpRouterTest do
       "(cond (= m 0) (+ n 1) " <>
       "(= n 0) (ack (- m 1) 1) " <>
       ":else (ack (- m 1) (ack m (- n 1))))) 3 8)"
-  end
-
-  defp do_wait_until(fun, deadline) do
-    if fun.() do
-      :ok
-    else
-      if System.monotonic_time(:millisecond) >= deadline do
-        flunk("wait_until timed out")
-      else
-        receive do
-        after
-          5 -> do_wait_until(fun, deadline)
-        end
-      end
-    end
   end
 end

--- a/mcp_server/test/ptc_runner_mcp/sessions_test.exs
+++ b/mcp_server/test/ptc_runner_mcp/sessions_test.exs
@@ -1,5 +1,6 @@
 defmodule PtcRunnerMcp.SessionsTest do
   use ExUnit.Case, async: false
+  import PtcRunnerMcp.TestSupport.WaitHelpers
 
   alias PtcRunnerMcp.ConcurrencyGate
   alias PtcRunnerMcp.Credentials
@@ -690,28 +691,6 @@ defmodule PtcRunnerMcp.SessionsTest do
       "(cond (= m 0) (+ n 1) " <>
       "(= n 0) (ack (- m 1) 1) " <>
       ":else (ack (- m 1) (ack m (- n 1))))) 3 8)"
-  end
-
-  defp wait_until(fun, timeout_ms) do
-    deadline = System.monotonic_time(:millisecond) + timeout_ms
-    do_wait_until(fun, deadline)
-  end
-
-  defp do_wait_until(fun, deadline) do
-    if fun.() do
-      :ok
-    else
-      if System.monotonic_time(:millisecond) > deadline do
-        flunk("wait_until timed out")
-      else
-        receive do
-        after
-          10 -> :ok
-        end
-
-        do_wait_until(fun, deadline)
-      end
-    end
   end
 
   defp stop_sessions_processes do

--- a/mcp_server/test/soak/http_mcp_soak_test.exs
+++ b/mcp_server/test/soak/http_mcp_soak_test.exs
@@ -27,6 +27,7 @@ defmodule PtcRunnerMcp.HttpMcpSoakTest do
   """
 
   use ExUnit.Case, async: false
+  import PtcRunnerMcp.TestSupport.WaitHelpers
 
   alias PtcRunnerMcp.ConcurrencyGate
   alias PtcRunnerMcp.Http.{Config, Server, SessionRegistry}
@@ -267,26 +268,6 @@ defmodule PtcRunnerMcp.HttpMcpSoakTest do
         state = :sys.get_state(pid, 5_000)
         assert map_size(state.sessions) == 0
         assert state.by_owner == %{}
-    end
-  end
-
-  defp wait_until(fun, timeout_ms \\ 1_000) do
-    deadline = System.monotonic_time(:millisecond) + timeout_ms
-    do_wait_until(fun, deadline)
-  end
-
-  defp do_wait_until(fun, deadline) do
-    if fun.() do
-      :ok
-    else
-      if System.monotonic_time(:millisecond) >= deadline do
-        flunk("wait_until timed out")
-      else
-        receive do
-        after
-          5 -> do_wait_until(fun, deadline)
-        end
-      end
     end
   end
 end

--- a/mcp_server/test/support/wait_helpers.ex
+++ b/mcp_server/test/support/wait_helpers.ex
@@ -1,0 +1,32 @@
+defmodule PtcRunnerMcp.TestSupport.WaitHelpers do
+  @moduledoc """
+  Polling helpers for asynchronous MCP tests.
+  """
+
+  import ExUnit.Assertions
+
+  @doc """
+  Wait until `fun` returns truthy, or fail after `timeout_ms`.
+  """
+  @spec wait_until((-> as_boolean(term())), non_neg_integer()) :: :ok
+  def wait_until(fun, timeout_ms \\ 1_000) when is_function(fun, 0) do
+    deadline = System.monotonic_time(:millisecond) + timeout_ms
+    do_wait_until(fun, deadline)
+  end
+
+  defp do_wait_until(fun, deadline) do
+    cond do
+      fun.() ->
+        :ok
+
+      System.monotonic_time(:millisecond) >= deadline ->
+        flunk("wait_until timed out")
+
+      true ->
+        receive do
+        after
+          10 -> do_wait_until(fun, deadline)
+        end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- simplify HTTP SessionRegistry lifecycle tracking by relying on linked sessions and trap_exit instead of redundant monitors
- extract shared MCP test wait_until helper and import it across the duplicated call sites

Closes #979
Closes #980

## Verification
- cd mcp_server && mix test test/ptc_runner_mcp/http_router_test.exs test/ptc_runner_mcp/cancellation_test.exs test/ptc_runner_mcp/debug_tool_test.exs test/ptc_runner_mcp/sessions_test.exs
- cd mcp_server && mix test --include soak test/soak/http_mcp_soak_test.exs
- cd mcp_server && mix format --check-formatted
- cd mcp_server && mix compile --warnings-as-errors
- pre-commit hook: format, compile, credo, scoped tests
- pre-push hook: full tests + dialyzer for root and mcp_server, ptc_viewer tests