### PR TITLE
test(mcp): sync strict MemorySoak helpers

### DIFF
--- a/mcp_server/test/support/memory_soak.ex
+++ b/mcp_server/test/support/memory_soak.ex
@@ -125,6 +125,37 @@ defmodule PtcRunnerMcp.TestSupport.MemorySoak do
     {before, aft}
   end
 
+  def measure3(n, opts \\ [], fun) when is_function(fun, 1) and n >= 2 do
+    warmup = Keyword.get(opts, :warmup, warmup_count())
+    Enum.each(1..max(warmup, 1), fn i -> fun.({:warmup, i}) end)
+    before = snapshot()
+    fun.({:measured, 1})
+    mid = snapshot()
+    Enum.each(2..n, fn i -> fun.({:measured, i}) end)
+    aft = snapshot()
+    {before, mid, aft}
+  end
+
+  def assert_atoms_per_iter_strict!(before, mid, aft, n, opts \\ []) when n >= 2 do
+    max_per_iter = Keyword.get(opts, :max_per_iter, 0.1)
+    first_iter_cost = mid.atoms - before.atoms
+    steady_delta = aft.atoms - mid.atoms
+    rate = steady_delta / (n - 1)
+
+    if rate > max_per_iter do
+      raise ExUnit.AssertionError,
+        message:
+          "Atom growth rate #{Float.round(rate, 4)} atoms/iter exceeds budget " <>
+            "#{max_per_iter}/iter " <>
+            "(first_iter=#{first_iter_cost} atoms, " <>
+            "steady_delta=#{steady_delta} atoms over #{n - 1} iters). " <>
+            "This is a real per-iter atom leak — likely `String.to_atom/1` " <>
+            "on user-derived input."
+    end
+
+    :ok
+  end
+
   def loop(n, warmup \\ nil, fun) when is_function(fun, 1) do
     warmup = warmup || warmup_count()
     Enum.each(1..warmup, fn i -> fun.({:warmup, i}) end)


### PR DESCRIPTION
## Summary
- add canonical measure3/3 to the MCP MemorySoak test-support copy
- add assert_atoms_per_iter_strict!/5 so MCP soak tests can separate first-call interning from steady-state atom leaks

Closes #957

## Verification
- cd mcp_server && mix test --include soak test/soak/session_churn_soak_test.exs test/soak/many_turns_soak_test.exs test/soak/http_mcp_soak_test.exs
- cd mcp_server && mix format --check-formatted
- cd mcp_server && mix compile --warnings-as-errors
- pre-commit hook: format, compile, credo
- pre-push hook: full tests + dialyzer for root and mcp_server, ptc_viewer tests