### PR TITLE
test(mcp): extract wait_for_files helper

### DIFF
--- a/mcp_server/test/ptc_runner_mcp/agentic_test.exs
+++ b/mcp_server/test/ptc_runner_mcp/agentic_test.exs
@@ -2,6 +2,7 @@ defmodule PtcRunnerMcp.AgenticTest do
   use ExUnit.Case, async: false
 
   import PtcRunnerMcp.McpTestHelpers, only: [stop_existing_registry: 1]
+  import PtcRunnerMcp.TestSupport.WaitHelpers, only: [wait_for_files: 2]
 
   alias PtcRunnerMcp.{
     AgenticConfig,
@@ -695,27 +696,6 @@ defmodule PtcRunnerMcp.AgenticTest do
     |> File.read!()
     |> String.split("\n", trim: true)
     |> Enum.map(&Jason.decode!/1)
-  end
-
-  defp wait_for_files(dir, expected, timeout_ms \\ 1_000) do
-    deadline = System.monotonic_time(:millisecond) + timeout_ms
-    do_wait_for_files(dir, expected, deadline)
-  end
-
-  defp do_wait_for_files(dir, expected, deadline) do
-    files = File.ls!(dir) |> Enum.filter(&String.ends_with?(&1, ".jsonl"))
-
-    cond do
-      length(files) >= expected ->
-        files
-
-      System.monotonic_time(:millisecond) > deadline ->
-        flunk("expected at least #{expected} jsonl files; got #{length(files)}")
-
-      true ->
-        Process.sleep(20)
-        do_wait_for_files(dir, expected, deadline)
-    end
   end
 
   defp restore_app_env(key, nil), do: Elixir.Application.delete_env(:ptc_runner_mcp, key)

--- a/mcp_server/test/ptc_runner_mcp/http_router_test.exs
+++ b/mcp_server/test/ptc_runner_mcp/http_router_test.exs
@@ -653,32 +653,6 @@ defmodule PtcRunnerMcp.HttpRouterTest do
     Enum.each(PtcRunnerMcp.Sessions.child_specs(), &start_supervised!/1)
   end
 
-  defp wait_for_files(dir, expected, timeout_ms \\ 1_000) do
-    deadline = System.monotonic_time(:millisecond) + timeout_ms
-    do_wait_for_files(dir, expected, deadline)
-  end
-
-  defp do_wait_for_files(dir, expected, deadline) do
-    files =
-      dir
-      |> File.ls!()
-      |> Enum.reject(&String.ends_with?(&1, ".pending"))
-      |> Enum.sort()
-
-    if length(files) >= expected do
-      files
-    else
-      if System.monotonic_time(:millisecond) >= deadline do
-        flunk("timed out waiting for trace files in #{dir}")
-      else
-        receive do
-        after
-          10 -> do_wait_for_files(dir, expected, deadline)
-        end
-      end
-    end
-  end
-
   defp read_jsonl(path) do
     path
     |> File.read!()

--- a/mcp_server/test/ptc_runner_mcp/tracing_test.exs
+++ b/mcp_server/test/ptc_runner_mcp/tracing_test.exs
@@ -15,6 +15,8 @@ defmodule PtcRunnerMcp.TracingTest do
   # async: false because TraceConfig + TraceHandler attach process-wide.
   use ExUnit.Case, async: false
 
+  import PtcRunnerMcp.TestSupport.WaitHelpers, only: [wait_for_files: 2]
+
   alias PtcRunnerMcp.{JsonRpc, TraceConfig, TraceHandler}
 
   @program_ok "(+ 1 2)"
@@ -78,29 +80,6 @@ defmodule PtcRunnerMcp.TracingTest do
     |> File.read!()
     |> String.split("\n", trim: true)
     |> Enum.map(&Jason.decode!/1)
-  end
-
-  defp wait_for_files(dir, expected, timeout_ms \\ 1_000) do
-    deadline = System.monotonic_time(:millisecond) + timeout_ms
-    do_wait_for_files(dir, expected, deadline)
-  end
-
-  defp do_wait_for_files(dir, expected, deadline) do
-    files = File.ls!(dir) |> Enum.filter(&String.ends_with?(&1, ".jsonl"))
-
-    cond do
-      length(files) >= expected ->
-        files
-
-      System.monotonic_time(:millisecond) > deadline ->
-        flunk(
-          "expected at least #{expected} jsonl files; got #{length(files)}: #{inspect(files)}"
-        )
-
-      true ->
-        Process.sleep(20)
-        do_wait_for_files(dir, expected, deadline)
-    end
   end
 
   # ----------------------------------------------------------------

--- a/mcp_server/test/support/wait_helpers.ex
+++ b/mcp_server/test/support/wait_helpers.ex
@@ -14,6 +14,16 @@ defmodule PtcRunnerMcp.TestSupport.WaitHelpers do
     do_wait_until(fun, deadline)
   end
 
+  @doc """
+  Wait until `dir` contains at least `expected` completed JSONL trace files.
+  """
+  @spec wait_for_files(Path.t(), non_neg_integer(), non_neg_integer()) :: [String.t()]
+  def wait_for_files(dir, expected, timeout_ms \\ 1_000)
+      when is_binary(dir) and is_integer(expected) and expected >= 0 and is_integer(timeout_ms) do
+    deadline = System.monotonic_time(:millisecond) + timeout_ms
+    do_wait_for_files(dir, expected, deadline)
+  end
+
   defp do_wait_until(fun, deadline) do
     cond do
       fun.() ->
@@ -26,6 +36,29 @@ defmodule PtcRunnerMcp.TestSupport.WaitHelpers do
         receive do
         after
           10 -> do_wait_until(fun, deadline)
+        end
+    end
+  end
+
+  defp do_wait_for_files(dir, expected, deadline) do
+    files =
+      dir
+      |> File.ls!()
+      |> Enum.reject(&String.ends_with?(&1, ".pending"))
+      |> Enum.filter(&String.ends_with?(&1, ".jsonl"))
+      |> Enum.sort()
+
+    cond do
+      length(files) >= expected ->
+        files
+
+      System.monotonic_time(:millisecond) >= deadline ->
+        flunk("expected at least #{expected} jsonl files in #{dir}; got #{length(files)}")
+
+      true ->
+        receive do
+        after
+          10 -> do_wait_for_files(dir, expected, deadline)
         end
     end
   end


### PR DESCRIPTION
## Summary

- Move duplicated JSONL trace-file polling into `PtcRunnerMcp.TestSupport.WaitHelpers`
- Replace local helper copies in tracing, agentic, and HTTP router tests

Closes #982

## Verification

- `cd mcp_server && mix test test/ptc_runner_mcp/tracing_test.exs test/ptc_runner_mcp/agentic_test.exs test/ptc_runner_mcp/http_router_test.exs`
- Pre-push hook: root tests + Dialyzer, mcp_server tests + Dialyzer, ptc_viewer tests