### PR TITLE
fix(lisp): bound compile phase under sandbox limits

### DIFF
--- a/lib/ptc_runner/lisp.ex
+++ b/lib/ptc_runner/lisp.ex
@@ -62,10 +62,12 @@ defmodule PtcRunner.Lisp do
     - `:signature` - Optional signature string for return value validation
     - `:float_precision` - Number of decimal places for floats in result (default: nil = full precision)
     - `:timeout` - Timeout in milliseconds for entire sandbox execution (default: 1000)
+    - `:compile_timeout` - Timeout in milliseconds for the compile phase (parse + analyze) (default: 5000)
     - `:pmap_timeout` - Timeout in milliseconds per pmap/pcalls task (default: 5000). Increase for LLM-backed tools.
     - `:pmap_max_concurrency` - Max concurrent tasks in pmap/pcalls (default: `System.schedulers_online() * 2`). Reduce to avoid overflowing connection pools.
     - `:max_heap` - Max heap size in words (default: 1_250_000)
     - `:max_symbols` - Max unique symbols/keywords allowed (default: 10_000)
+    - `:max_program_bytes` - Max source code size in bytes (default: 1_000_000)
     - `:max_print_length` - Max characters per `println` call (default: 2000)
     - `:filter_context` - Filter context to only include accessed data keys (default: true)
     - `:budget` - Budget info map for `(budget/remaining)` introspection (default: nil)
@@ -248,6 +250,9 @@ defmodule PtcRunner.Lisp do
   defp safe_length(list) when is_list(list), do: length(list)
   defp safe_length(_), do: 0
 
+  @default_max_program_bytes 1_000_000
+  @default_compile_timeout 5_000
+
   @spec do_run(String.t(), keyword()) :: {:ok, Step.t()} | {:error, Step.t()}
   defp do_run(source, opts) do
     ctx = Keyword.get(opts, :context, %{})
@@ -258,6 +263,8 @@ defmodule PtcRunner.Lisp do
     timeout = Keyword.get(opts, :timeout, 1000)
     max_heap = Keyword.get(opts, :max_heap, 1_250_000)
     max_symbols = Keyword.get(opts, :max_symbols, 10_000)
+    max_program_bytes = Keyword.get(opts, :max_program_bytes, @default_max_program_bytes)
+    compile_timeout = Keyword.get(opts, :compile_timeout, @default_compile_timeout)
     turn_history = Keyword.get(opts, :turn_history, [])
     max_print_length = Keyword.get(opts, :max_print_length)
     filter_context = Keyword.get(opts, :filter_context, true)
@@ -270,37 +277,29 @@ defmodule PtcRunner.Lisp do
     max_tool_calls = Keyword.get(opts, :max_tool_calls)
     strict_data = Keyword.get(opts, :strict_data, false)
     catalog_exec = Keyword.get(opts, :catalog_exec)
-    # Phase 4: when `link: true`, the sandbox child is spawned linked to
-    # the caller (in addition to monitored). MCP server uses this so a
-    # cancelled call's worker, when killed, takes the sandbox child
-    # with it. Default `false` preserves the legacy behavior.
     link_sandbox = Keyword.get(opts, :link, false)
 
-    # Normalize tools to Tool structs
-    with {:ok, normalized_tools} <- normalize_tools(raw_tools),
-         {:ok, parsed_signature} <- parse_signature(signature_str) do
-      # Note: tool_executor handles {:error, reason} returns and unknown tools by raising
-      # ExecutionError. This matches the behavior in SubAgent.Loop.ToolNormalizer,
-      # which handles the SubAgent execution path.
-      tool_executor = fn name, args ->
-        execute_tool(normalized_tools, name, args)
-      end
-
-      # Build tools_meta lookup: %{name => %{cache: bool}}
-      tools_meta =
-        Map.new(normalized_tools, fn {name, tool} -> {name, %{cache: tool.cache}} end)
-
-      opts = %{
+    # Preflight: reject oversized source before any parsing
+    if is_binary(source) and byte_size(source) > max_program_bytes do
+      {:error,
+       Step.error(
+         :program_too_large,
+         "program size #{byte_size(source)} bytes exceeds limit of #{max_program_bytes}",
+         memory,
+         %{},
+         journal: journal
+       )}
+    else
+      do_run_inner(source, %{
         ctx: ctx,
         memory: memory,
-        normalized_tools: normalized_tools,
-        tool_executor: tool_executor,
-        parsed_signature: parsed_signature,
+        raw_tools: raw_tools,
         signature_str: signature_str,
         float_precision: float_precision,
         timeout: timeout,
         max_heap: max_heap,
         max_symbols: max_symbols,
+        compile_timeout: compile_timeout,
         turn_history: turn_history,
         max_print_length: max_print_length,
         filter_context: filter_context,
@@ -310,12 +309,35 @@ defmodule PtcRunner.Lisp do
         trace_context: trace_context,
         journal: journal,
         tool_cache: tool_cache,
-        tools_meta: tools_meta,
         max_tool_calls: max_tool_calls,
         strict_data: strict_data,
         catalog_exec: catalog_exec,
         link: link_sandbox
-      }
+      })
+    end
+  end
+
+  defp do_run_inner(source, %{raw_tools: raw_tools, memory: memory, journal: journal} = params) do
+    signature_str = params.signature_str
+
+    # Normalize tools to Tool structs
+    with {:ok, normalized_tools} <- normalize_tools(raw_tools),
+         {:ok, parsed_signature} <- parse_signature(signature_str) do
+      tool_executor = fn name, args ->
+        execute_tool(normalized_tools, name, args)
+      end
+
+      tools_meta =
+        Map.new(normalized_tools, fn {name, tool} -> {name, %{cache: tool.cache}} end)
+
+      opts =
+        Map.merge(params, %{
+          normalized_tools: normalized_tools,
+          tool_executor: tool_executor,
+          parsed_signature: parsed_signature,
+          signature_str: signature_str,
+          tools_meta: tools_meta
+        })
 
       execute_program(source, opts)
     else
@@ -337,6 +359,12 @@ defmodule PtcRunner.Lisp do
   Parses and analyzes the source, then checks for undefined variables.
   Returns `:ok` if valid, or `{:error, messages}` with a list of error strings.
 
+  Accepts optional keyword options to configure compile-phase limits:
+
+    * `:compile_timeout` - Timeout in ms for bounded compile (default: 5000)
+    * `:max_heap` - Max heap words for bounded compile (default: 1_250_000)
+    * `:max_program_bytes` - Max source size in bytes (default: 1_000_000)
+
   ## Examples
 
       iex> PtcRunner.Lisp.validate("(and (map? data/result) (> (count data/result) 0))")
@@ -348,20 +376,128 @@ defmodule PtcRunner.Lisp do
       iex> PtcRunner.Lisp.validate("(let [x 1] (> x 0))")
       :ok
   """
-  @spec validate(String.t()) :: :ok | {:error, [String.t()]}
-  def validate(source) when is_binary(source) do
-    with {:ok, raw_ast} <- Parser.parse(source),
-         {:ok, core_ast} <- Analyze.analyze(raw_ast) do
-      case collect_undefined_vars(core_ast, MapSet.new()) do
-        [] -> :ok
-        undefined -> {:error, Enum.uniq(undefined)}
-      end
+  @spec validate(String.t(), keyword()) :: :ok | {:error, [String.t()]}
+  def validate(source, opts \\ [])
+
+  def validate(source, opts) when is_binary(source) do
+    max_program_bytes = Keyword.get(opts, :max_program_bytes, @default_max_program_bytes)
+    compile_timeout = Keyword.get(opts, :compile_timeout, @default_compile_timeout)
+    max_heap = Keyword.get(opts, :max_heap, 1_250_000)
+
+    if byte_size(source) > max_program_bytes do
+      {:error, ["program size #{byte_size(source)} bytes exceeds limit of #{max_program_bytes}"]}
     else
-      {:error, reason} -> {:error, [format_validate_error(reason)]}
+      validate_bounded(source, compile_timeout, max_heap)
+    end
+  end
+
+  defp validate_bounded(source, compile_timeout, max_heap) do
+    compile_fn = fn ->
+      with {:ok, raw_ast} <- Parser.parse(source),
+           {:ok, core_ast} <- Analyze.analyze(raw_ast) do
+        case collect_undefined_vars(core_ast, MapSet.new()) do
+          [] -> :ok
+          undefined -> {:error, Enum.uniq(undefined)}
+        end
+      else
+        {:error, reason} -> {:error, [format_validate_error(reason)]}
+      end
+    end
+
+    case PtcRunner.Sandbox.run_bounded(compile_fn,
+           timeout: compile_timeout,
+           max_heap: max_heap
+         ) do
+      {:ok, result} ->
+        result
+
+      {:error, {:timeout, ms}} ->
+        {:error, ["compilation exceeded #{ms}ms limit"]}
+
+      {:error, {:memory_exceeded, bytes}} ->
+        {:error, ["compilation exceeded #{bytes} byte heap limit"]}
+
+      {:error, {:execution_error, msg}} ->
+        {:error, ["compilation failed: #{msg}"]}
     end
   end
 
   defp execute_program(source, opts) do
+    %{
+      memory: memory,
+      normalized_tools: normalized_tools,
+      max_symbols: max_symbols,
+      compile_timeout: compile_timeout,
+      journal: journal
+    } = opts
+
+    compile_fn = fn ->
+      with {:ok, raw_ast} <- Parser.parse(source),
+           :ok <- check_symbol_limit(raw_ast, max_symbols, memory, journal),
+           {:ok, core_ast} <- Analyze.analyze(raw_ast),
+           :ok <- check_undefined_vars(core_ast, memory, journal),
+           :ok <- check_undefined_tools(core_ast, normalized_tools, memory, journal) do
+        {:ok, core_ast}
+      end
+    end
+
+    compile_max_heap =
+      Application.get_env(:ptc_runner, :default_max_heap, 1_250_000)
+
+    compile_opts = [timeout: compile_timeout, max_heap: compile_max_heap]
+
+    case PtcRunner.Sandbox.run_bounded(compile_fn, compile_opts) do
+      {:ok, {:ok, core_ast}} ->
+        execute_eval(core_ast, opts)
+
+      {:ok, {:error, _} = compile_error} ->
+        handle_compile_error(compile_error, memory, journal)
+
+      {:error, {:timeout, ms}} ->
+        {:error,
+         Step.error(
+           :compile_timeout,
+           "compilation exceeded #{ms}ms limit",
+           memory,
+           %{},
+           journal: journal
+         )}
+
+      {:error, {:memory_exceeded, bytes}} ->
+        {:error,
+         Step.error(
+           :compile_memory_exceeded,
+           "compilation exceeded #{bytes} byte heap limit",
+           memory,
+           %{},
+           journal: journal
+         )}
+
+      {:error, {:execution_error, msg}} ->
+        {:error,
+         Step.error(:compile_error, "compilation failed: #{msg}", memory, %{}, journal: journal)}
+    end
+  end
+
+  defp handle_compile_error({:error, {:parse_error, msg}}, memory, journal) do
+    {:error, Step.error(:parse_error, msg, memory, %{}, journal: journal)}
+  end
+
+  defp handle_compile_error({:error, %Step{} = step}, _memory, _journal) do
+    {:error, step}
+  end
+
+  defp handle_compile_error({:error, {reason_atom, _, _} = reason}, memory, journal)
+       when is_atom(reason_atom) do
+    {:error, Step.error(reason_atom, format_error(reason), memory, %{}, journal: journal)}
+  end
+
+  defp handle_compile_error({:error, {reason_atom, _} = reason}, memory, journal)
+       when is_atom(reason_atom) do
+    {:error, Step.error(reason_atom, format_error(reason), memory, %{}, journal: journal)}
+  end
+
+  defp execute_eval(core_ast, opts) do
     %{
       ctx: ctx,
       memory: memory,
@@ -372,7 +508,6 @@ defmodule PtcRunner.Lisp do
       float_precision: float_precision,
       timeout: timeout,
       max_heap: max_heap,
-      max_symbols: max_symbols,
       turn_history: turn_history,
       max_print_length: max_print_length,
       filter_context: filter_context,
@@ -388,183 +523,146 @@ defmodule PtcRunner.Lisp do
       catalog_exec: catalog_exec
     } = opts
 
-    with {:ok, raw_ast} <- Parser.parse(source),
-         :ok <- check_symbol_limit(raw_ast, max_symbols, memory, journal),
-         {:ok, core_ast} <- Analyze.analyze(raw_ast),
-         :ok <- check_undefined_vars(core_ast, memory, journal),
-         :ok <- check_undefined_tools(core_ast, normalized_tools, memory, journal) do
-      # Filter context to only include data keys accessed by the program
-      # This reduces memory pressure by not loading unused datasets
-      filtered_ctx = if filter_context, do: DataKeys.filter_context(core_ast, ctx), else: ctx
+    filtered_ctx = if filter_context, do: DataKeys.filter_context(core_ast, ctx), else: ctx
+    context = PtcRunner.Context.new(filtered_ctx, memory, normalized_tools, turn_history)
 
-      # Build Context for sandbox (turn_history passed for completeness, used via eval_fn)
-      context = PtcRunner.Context.new(filtered_ctx, memory, normalized_tools, turn_history)
-
-      # Build eval options (only include options if set)
-      eval_opts =
-        [
-          max_print_length: max_print_length,
-          budget: budget,
-          pmap_timeout: pmap_timeout,
-          pmap_max_concurrency: pmap_max_concurrency,
-          trace_context: trace_context,
-          journal: journal,
-          tool_cache: tool_cache,
-          tools_meta: tools_meta,
-          max_tool_calls: max_tool_calls,
-          strict_data: strict_data,
-          catalog_exec: catalog_exec
-        ]
-        |> Enum.reject(fn {_k, v} -> is_nil(v) end)
-
-      # Wrapper to adapt Lisp eval signature to sandbox's expected (ast, context) -> result
-      eval_fn = fn _ast, sandbox_context ->
-        try do
-          Eval.eval_with_context(
-            core_ast,
-            sandbox_context.ctx,
-            sandbox_context.memory,
-            Env.initial(),
-            tool_executor,
-            sandbox_context.turn_history,
-            eval_opts
-          )
-        rescue
-          e in ExecutionError ->
-            {:error, {e.reason, e.message, e.data}}
-
-          e in PtcRunner.ToolExecutionError ->
-            # Tool error with eval_ctx preserved (contains recorded tool_calls)
-            {:error, {:tool_error, e.tool_name, e.message}, e.eval_ctx}
-
-          e ->
-            # Unexpected exception (e.g., ArgumentError in a built-in) — not a tool failure
-            {:error, {:runtime_error, Exception.message(e)}}
-        end
-      end
-
-      sandbox_opts = [
-        timeout: timeout,
-        max_heap: max_heap,
-        eval_fn: eval_fn,
-        link: Map.get(opts, :link, false)
+    eval_opts =
+      [
+        max_print_length: max_print_length,
+        budget: budget,
+        pmap_timeout: pmap_timeout,
+        pmap_max_concurrency: pmap_max_concurrency,
+        trace_context: trace_context,
+        journal: journal,
+        tool_cache: tool_cache,
+        tools_meta: tools_meta,
+        max_tool_calls: max_tool_calls,
+        strict_data: strict_data,
+        catalog_exec: catalog_exec
       ]
+      |> Enum.reject(fn {_k, v} -> is_nil(v) end)
 
-      case PtcRunner.Sandbox.execute(core_ast, context, sandbox_opts) do
-        {:ok, {:return_signal, value}, metrics, %EvalContext{} = eval_ctx} ->
-          # For return signal, we return the value but wrap it in the sentinel for SubAgent to detect
-          step =
-            apply_memory_contract({:__ptc_return__, value}, float_precision, eval_ctx)
+    eval_fn = fn _ast, sandbox_context ->
+      try do
+        Eval.eval_with_context(
+          core_ast,
+          sandbox_context.ctx,
+          sandbox_context.memory,
+          Env.initial(),
+          tool_executor,
+          sandbox_context.turn_history,
+          eval_opts
+        )
+      rescue
+        e in ExecutionError ->
+          {:error, {e.reason, e.message, e.data}}
 
-          {:ok, %{step | usage: metrics}}
+        e in PtcRunner.ToolExecutionError ->
+          {:error, {:tool_error, e.tool_name, e.message}, e.eval_ctx}
 
-        {:ok, {:fail_signal, value}, metrics, %EvalContext{} = eval_ctx} ->
-          step =
-            apply_memory_contract({:__ptc_fail__, value}, float_precision, eval_ctx)
-
-          {:ok, %{step | usage: metrics}}
-
-        {:ok, {:error_with_ctx, reason}, metrics, %EvalContext{} = eval_ctx} ->
-          # Error with eval_ctx preserved (e.g., from tool execution error)
-          reason_atom = if is_tuple(reason), do: elem(reason, 0), else: reason
-
-          # Extract child_trace_ids from both direct tool calls and pmap/pcalls
-          tool_child_traces =
-            eval_ctx.tool_calls
-            |> Enum.filter(&Map.has_key?(&1, :child_trace_id))
-            |> Enum.map(& &1.child_trace_id)
-
-          pmap_child_traces =
-            eval_ctx.pmap_calls
-            |> Enum.flat_map(& &1.child_trace_ids)
-
-          child_traces = tool_child_traces ++ pmap_child_traces
-
-          # Extract child_steps from tool calls and pmap/pcalls
-          tool_child_steps =
-            eval_ctx.tool_calls
-            |> Enum.filter(&Map.has_key?(&1, :child_step))
-            |> Enum.map(& &1.child_step)
-
-          pmap_child_steps =
-            eval_ctx.pmap_calls
-            |> Enum.flat_map(&Map.get(&1, :child_steps, []))
-
-          child_steps = tool_child_steps ++ pmap_child_steps
-
-          # Strip child_step/child_steps from tool/pmap_calls
-          cleaned_tool_calls = Enum.map(eval_ctx.tool_calls, &Map.delete(&1, :child_step))
-          cleaned_pmap_calls = Enum.map(eval_ctx.pmap_calls, &Map.delete(&1, :child_steps))
-
-          step = %Step{
-            return: nil,
-            fail: %{reason: reason_atom, message: format_error(reason)},
-            memory: memory,
-            signature: nil,
-            usage: metrics,
-            turns: nil,
-            trace_id: nil,
-            parent_trace_id: nil,
-            field_descriptions: nil,
-            prints: eval_ctx.prints,
-            tool_calls: cleaned_tool_calls,
-            pmap_calls: cleaned_pmap_calls,
-            catalog_ops: Enum.reverse(eval_ctx.catalog_ops),
-            child_traces: child_traces,
-            child_steps: child_steps,
-            journal: eval_ctx.journal,
-            summaries: eval_ctx.summaries,
-            tool_cache: eval_ctx.tool_cache
-          }
-
-          {:error, step}
-
-        {:ok, value, metrics, %EvalContext{} = eval_ctx} ->
-          step =
-            apply_memory_contract(value, float_precision, eval_ctx)
-
-          step_with_usage = %{step | usage: metrics}
-
-          # Validate signature if provided
-          case validate_return_value(parsed_signature, signature_str, step_with_usage) do
-            {:ok, validated_step} -> {:ok, validated_step}
-            {:error, reason} -> {:error, reason}
-          end
-
-        {:error, {:timeout, ms}} ->
-          {:error,
-           Step.error(:timeout, "execution exceeded #{ms}ms limit", memory, %{}, journal: journal)}
-
-        {:error, {:memory_exceeded, bytes}} ->
-          Logger.warning("PTC-Lisp execution killed: heap limit #{bytes} bytes exceeded")
-
-          {:error,
-           Step.error(:memory_exceeded, "heap limit #{bytes} bytes exceeded", memory, %{},
-             journal: journal
-           )}
-
-        {:error, {reason_atom, _, _} = reason} when is_atom(reason_atom) ->
-          # Handle 3-tuple error format: {:error, {:type_error, message, data}}
-          {:error, Step.error(reason_atom, format_error(reason), memory, %{}, journal: journal)}
-
-        {:error, {reason_atom, _} = reason} when is_atom(reason_atom) ->
-          # Handle 2-tuple error format: {:error, {:type_error, message}}
-          {:error, Step.error(reason_atom, format_error(reason), memory, %{}, journal: journal)}
+        e ->
+          {:error, {:runtime_error, Exception.message(e)}}
       end
-    else
-      {:error, {:parse_error, msg}} ->
-        {:error, Step.error(:parse_error, msg, memory, %{}, journal: journal)}
+    end
 
-      {:error, %Step{} = step} ->
-        # Pass through Step errors from check_symbol_limit
+    sandbox_opts = [
+      timeout: timeout,
+      max_heap: max_heap,
+      eval_fn: eval_fn,
+      link: Map.get(opts, :link, false)
+    ]
+
+    case PtcRunner.Sandbox.execute(core_ast, context, sandbox_opts) do
+      {:ok, {:return_signal, value}, metrics, %EvalContext{} = eval_ctx} ->
+        step =
+          apply_memory_contract({:__ptc_return__, value}, float_precision, eval_ctx)
+
+        {:ok, %{step | usage: metrics}}
+
+      {:ok, {:fail_signal, value}, metrics, %EvalContext{} = eval_ctx} ->
+        step =
+          apply_memory_contract({:__ptc_fail__, value}, float_precision, eval_ctx)
+
+        {:ok, %{step | usage: metrics}}
+
+      {:ok, {:error_with_ctx, reason}, metrics, %EvalContext{} = eval_ctx} ->
+        reason_atom = if is_tuple(reason), do: elem(reason, 0), else: reason
+
+        tool_child_traces =
+          eval_ctx.tool_calls
+          |> Enum.filter(&Map.has_key?(&1, :child_trace_id))
+          |> Enum.map(& &1.child_trace_id)
+
+        pmap_child_traces =
+          eval_ctx.pmap_calls
+          |> Enum.flat_map(& &1.child_trace_ids)
+
+        child_traces = tool_child_traces ++ pmap_child_traces
+
+        tool_child_steps =
+          eval_ctx.tool_calls
+          |> Enum.filter(&Map.has_key?(&1, :child_step))
+          |> Enum.map(& &1.child_step)
+
+        pmap_child_steps =
+          eval_ctx.pmap_calls
+          |> Enum.flat_map(&Map.get(&1, :child_steps, []))
+
+        child_steps = tool_child_steps ++ pmap_child_steps
+
+        cleaned_tool_calls = Enum.map(eval_ctx.tool_calls, &Map.delete(&1, :child_step))
+        cleaned_pmap_calls = Enum.map(eval_ctx.pmap_calls, &Map.delete(&1, :child_steps))
+
+        step = %Step{
+          return: nil,
+          fail: %{reason: reason_atom, message: format_error(reason)},
+          memory: memory,
+          signature: nil,
+          usage: metrics,
+          turns: nil,
+          trace_id: nil,
+          parent_trace_id: nil,
+          field_descriptions: nil,
+          prints: eval_ctx.prints,
+          tool_calls: cleaned_tool_calls,
+          pmap_calls: cleaned_pmap_calls,
+          catalog_ops: Enum.reverse(eval_ctx.catalog_ops),
+          child_traces: child_traces,
+          child_steps: child_steps,
+          journal: eval_ctx.journal,
+          summaries: eval_ctx.summaries,
+          tool_cache: eval_ctx.tool_cache
+        }
+
         {:error, step}
 
+      {:ok, value, metrics, %EvalContext{} = eval_ctx} ->
+        step =
+          apply_memory_contract(value, float_precision, eval_ctx)
+
+        step_with_usage = %{step | usage: metrics}
+
+        case validate_return_value(parsed_signature, signature_str, step_with_usage) do
+          {:ok, validated_step} -> {:ok, validated_step}
+          {:error, reason} -> {:error, reason}
+        end
+
+      {:error, {:timeout, ms}} ->
+        {:error,
+         Step.error(:timeout, "execution exceeded #{ms}ms limit", memory, %{}, journal: journal)}
+
+      {:error, {:memory_exceeded, bytes}} ->
+        Logger.warning("PTC-Lisp execution killed: heap limit #{bytes} bytes exceeded")
+
+        {:error,
+         Step.error(:memory_exceeded, "heap limit #{bytes} bytes exceeded", memory, %{},
+           journal: journal
+         )}
+
       {:error, {reason_atom, _, _} = reason} when is_atom(reason_atom) ->
-        # Preserve specific error atoms from Analyze phase (e.g., {:invalid_arity, :if, "msg"})
         {:error, Step.error(reason_atom, format_error(reason), memory, %{}, journal: journal)}
 
       {:error, {reason_atom, _} = reason} when is_atom(reason_atom) ->
-        # Handle other 2-tuple errors from Analyze phase
         {:error, Step.error(reason_atom, format_error(reason), memory, %{}, journal: journal)}
     end
   end

--- a/lib/ptc_runner/lisp/analyze/short_fn.ex
+++ b/lib/ptc_runner/lisp/analyze/short_fn.ex
@@ -9,6 +9,8 @@ defmodule PtcRunner.Lisp.Analyze.ShortFn do
   alias PtcRunner.Lisp.Analyze
   alias PtcRunner.Lisp.SourceAtoms
 
+  @max_short_fn_arity 20
+
   @doc """
   Desugars short function syntax into a transformed AST.
 
@@ -52,13 +54,9 @@ defmodule PtcRunner.Lisp.Analyze.ShortFn do
     # Now find placeholders in the expression
     with placeholders_result <- extract_placeholders([body_expr]),
          {:ok, placeholders} <- validate_placeholder_result(placeholders_result),
-         # 2. Determine arity
-         arity <- determine_arity(placeholders),
-         # 3. Generate parameter list [{:symbol, :p1}, {:symbol, :p2}, ...]
+         {:ok, arity} <- determine_arity(placeholders),
          params <- generate_params(arity),
-         # 4. Replace placeholders in body
          transformed_body <- transform_body(body_expr, placeholders) do
-      # Return desugared form: (fn [params] transformed_body)
       {:ok, {:list, [{:symbol, :fn}, {:vector, params}, transformed_body]}}
     end
   end
@@ -129,34 +127,54 @@ defmodule PtcRunner.Lisp.Analyze.ShortFn do
   # Arity and parameter generation
   # ============================================================
 
-  # Determine arity from placeholders
   defp determine_arity(placeholders) do
     has_rest? = Enum.any?(placeholders, &(to_string(&1) == "%&"))
 
-    # Extract numeric placeholders (filter out % and %&)
-    numeric =
+    numeric_result =
       placeholders
       |> Enum.filter(fn p ->
         s = to_string(p)
         s != "%" and s != "%&"
       end)
-      |> Enum.map(fn p ->
-        p
-        |> to_string()
-        |> String.replace_leading("%", "")
-        |> String.to_integer()
+      |> Enum.reduce_while({:ok, []}, fn p, {:ok, acc} ->
+        num_str = p |> to_string() |> String.replace_leading("%", "")
+
+        if byte_size(num_str) > 3 do
+          {:halt,
+           {:error,
+            {:invalid_form,
+             "short function placeholder %#{num_str} exceeds max arity of #{@max_short_fn_arity}"}}}
+        else
+          n = String.to_integer(num_str)
+
+          if n > @max_short_fn_arity do
+            {:halt,
+             {:error,
+              {:invalid_form,
+               "short function placeholder %#{n} exceeds max arity of #{@max_short_fn_arity}"}}}
+          else
+            {:cont, {:ok, [n | acc]}}
+          end
+        end
       end)
 
-    base_arity =
-      case numeric do
-        [] ->
-          if Enum.any?(placeholders, &(to_string(&1) == "%")), do: 1, else: 0
+    case numeric_result do
+      {:error, _} = err ->
+        err
 
-        nums ->
-          Enum.max(nums)
-      end
+      {:ok, nums} ->
+        base_arity =
+          case nums do
+            [] ->
+              if Enum.any?(placeholders, &(to_string(&1) == "%")), do: 1, else: 0
 
-    if has_rest?, do: {:variadic, base_arity}, else: base_arity
+            nums ->
+              Enum.max(nums)
+          end
+
+        arity = if has_rest?, do: {:variadic, base_arity}, else: base_arity
+        {:ok, arity}
+    end
   end
 
   # Generate parameter list based on arity (as symbols, not yet analyzed)
@@ -223,12 +241,17 @@ defmodule PtcRunner.Lisp.Analyze.ShortFn do
     node
   end
 
-  # Convert placeholder symbol to parameter variable name
   defp placeholder_to_param(name_str) when is_binary(name_str) do
     case name_str do
-      "%" -> :p1
-      "%&" -> :rest
-      "%" <> num_str -> SourceAtoms.intern("p#{num_str}")
+      "%" ->
+        :p1
+
+      "%&" ->
+        :rest
+
+      "%" <> num_str ->
+        n = String.to_integer(num_str)
+        SourceAtoms.intern("p#{n}")
     end
   end
 end

--- a/lib/ptc_runner/lisp/fast_parser.ex
+++ b/lib/ptc_runner/lisp/fast_parser.ex
@@ -4,6 +4,9 @@ defmodule PtcRunner.Lisp.FastParser do
   alias PtcRunner.Lisp.AST
   alias PtcRunner.Lisp.SourceAtoms
 
+  @max_integer_digits 100
+  @max_nesting_depth 64
+
   @type cursor :: {binary(), non_neg_integer(), pos_integer(), pos_integer()}
 
   defguardp is_symbol_first(c)
@@ -28,14 +31,22 @@ defmodule PtcRunner.Lisp.FastParser do
         {:ok, Enum.reverse(acc), cursor}
 
       cursor ->
-        with {:ok, ast, cursor} <- parse_expr(cursor) do
+        with {:ok, ast, cursor} <- parse_expr(cursor, 0) do
           parse_program(cursor, [ast | acc])
         end
     end
   end
 
+  defp parse_expr(cursor, depth) do
+    if depth > @max_nesting_depth do
+      {:error, "nesting depth exceeds limit of #{@max_nesting_depth}"}
+    else
+      do_parse_expr(cursor, depth)
+    end
+  end
+
   # credo:disable-for-next-line Credo.Check.Refactor.CyclomaticComplexity
-  defp parse_expr(cursor) do
+  defp do_parse_expr(cursor, depth) do
     cursor = skip_ws(cursor)
 
     case cursor do
@@ -43,19 +54,19 @@ defmodule PtcRunner.Lisp.FastParser do
         {:error, "syntax error: could not parse expression at line #{line}, column #{column}"}
 
       {"(" <> rest, offset, line, column} ->
-        parse_sequence({rest, offset + 1, line, column + 1}, ?), :list, [])
+        parse_sequence({rest, offset + 1, line, column + 1}, ?), :list, [], depth)
 
       {"[" <> rest, offset, line, column} ->
-        parse_sequence({rest, offset + 1, line, column + 1}, ?], :vector, [])
+        parse_sequence({rest, offset + 1, line, column + 1}, ?], :vector, [], depth)
 
       {"{" <> rest, offset, line, column} ->
-        parse_sequence({rest, offset + 1, line, column + 1}, ?}, :map, [])
+        parse_sequence({rest, offset + 1, line, column + 1}, ?}, :map, [], depth)
 
       {<<?#, ?{, rest::binary>>, offset, line, column} ->
-        parse_sequence({rest, offset + 2, line, column + 2}, ?}, :set, [])
+        parse_sequence({rest, offset + 2, line, column + 2}, ?}, :set, [], depth)
 
       {"#(" <> rest, offset, line, column} ->
-        parse_sequence({rest, offset + 2, line, column + 2}, ?), :short_fn, [])
+        parse_sequence({rest, offset + 2, line, column + 2}, ?), :short_fn, [], depth)
 
       {"#\"" <> rest, offset, line, column} ->
         parse_string({rest, offset + 2, line, column + 2}, :regex_literal)
@@ -113,7 +124,7 @@ defmodule PtcRunner.Lisp.FastParser do
     end
   end
 
-  defp parse_sequence(cursor, close, type, acc) do
+  defp parse_sequence(cursor, close, type, acc, depth) do
     cursor = skip_ws(cursor)
 
     case cursor do
@@ -126,8 +137,8 @@ defmodule PtcRunner.Lisp.FastParser do
         {:error, "unclosed #{sequence_name(type)} at line #{line}, column #{column}"}
 
       _ ->
-        with {:ok, ast, cursor} <- parse_expr(cursor) do
-          parse_sequence(cursor, close, type, [ast | acc])
+        with {:ok, ast, cursor} <- parse_expr(cursor, depth + 1) do
+          parse_sequence(cursor, close, type, [ast | acc], depth)
         end
     end
   end
@@ -274,6 +285,9 @@ defmodule PtcRunner.Lisp.FastParser do
     cond do
       int == "" ->
         parse_symbol(cursor)
+
+      byte_size(int) > @max_integer_digits ->
+        {:error, "integer literal exceeds #{@max_integer_digits} digit limit"}
 
       match_fraction?(cursor) ->
         {fraction, cursor} = take_fraction(cursor)

--- a/lib/ptc_runner/lisp/parser_helpers.ex
+++ b/lib/ptc_runner/lisp/parser_helpers.ex
@@ -4,14 +4,22 @@ defmodule PtcRunner.Lisp.ParserHelpers do
   alias PtcRunner.Lisp.AST
   alias PtcRunner.Lisp.SourceAtoms
 
+  @max_integer_digits 100
+
   # ============================================================
   # Number parsing
   # ============================================================
 
   def parse_integer(parts) do
-    parts
-    |> Enum.map_join(&to_string_part/1)
-    |> String.to_integer()
+    str = Enum.map_join(parts, &to_string_part/1)
+
+    digit_count = count_digits(str)
+
+    if digit_count > @max_integer_digits do
+      raise ArgumentError, "integer literal exceeds #{@max_integer_digits} digit limit"
+    end
+
+    String.to_integer(str)
   end
 
   def parse_float(parts) do
@@ -24,6 +32,12 @@ defmodule PtcRunner.Lisp.ParserHelpers do
       {float, _rest} -> float
       :error -> raise ArgumentError, "invalid float: #{str}"
     end
+  end
+
+  defp count_digits(str) do
+    str
+    |> String.replace("-", "")
+    |> byte_size()
   end
 
   defp to_string_part(part) when is_integer(part), do: <<part::utf8>>

--- a/lib/ptc_runner/sandbox.ex
+++ b/lib/ptc_runner/sandbox.ex
@@ -176,6 +176,76 @@ defmodule PtcRunner.Sandbox do
     end
   end
 
+  @doc """
+  Runs an arbitrary function in an isolated process with resource limits.
+
+  Unlike `execute/3` which is specialized for Lisp evaluation, this function
+  runs any zero-arity function under the same process isolation primitives
+  (timeout, `max_heap_size`, monitored child).
+
+  ## Options
+
+    * `:timeout` - Timeout in milliseconds (default: 1000)
+    * `:max_heap` - Max heap size in words (default: 1_250_000)
+
+  ## Returns
+
+    * `{:ok, result}` — the function returned `result`
+    * `{:error, {:timeout, ms}}` — killed after timeout
+    * `{:error, {:memory_exceeded, bytes}}` — heap limit hit
+    * `{:error, {:execution_error, message}}` — process crashed
+
+  ## Examples
+
+      iex> PtcRunner.Sandbox.run_bounded(fn -> 1 + 1 end)
+      {:ok, 2}
+
+      iex> PtcRunner.Sandbox.run_bounded(fn -> :timer.sleep(:infinity) end, timeout: 50)
+      {:error, {:timeout, 50}}
+  """
+  @spec run_bounded((-> term()), keyword()) ::
+          {:ok, term()}
+          | {:error,
+             {:timeout, non_neg_integer()}
+             | {:memory_exceeded, non_neg_integer()}
+             | {:execution_error, String.t()}}
+  def run_bounded(fun, opts \\ []) when is_function(fun, 0) do
+    default_timeout = Application.get_env(:ptc_runner, :default_timeout, @default_timeout)
+    default_max_heap = Application.get_env(:ptc_runner, :default_max_heap, @default_max_heap)
+
+    timeout = Keyword.get(opts, :timeout, default_timeout)
+    max_heap = Keyword.get(opts, :max_heap, default_max_heap)
+
+    parent = self()
+
+    {pid, ref} =
+      Process.spawn(
+        fn ->
+          Process.flag(:priority, :normal)
+          result = fun.()
+          send(parent, {:bounded_result, self(), result})
+        end,
+        [{:max_heap_size, %{size: max_heap, kill: true, error_logger: false}}, :monitor]
+      )
+
+    receive do
+      {:bounded_result, ^pid, result} ->
+        Process.demonitor(ref, [:flush])
+        {:ok, result}
+
+      {:DOWN, ^ref, :process, ^pid, :killed} ->
+        {:error, {:memory_exceeded, max_heap * 8}}
+
+      {:DOWN, ^ref, :process, ^pid, reason} ->
+        {:error, {:execution_error, "Process terminated: #{inspect(reason)}"}}
+    after
+      timeout ->
+        Process.demonitor(ref, [:flush])
+        Process.exit(pid, :kill)
+        {:error, {:timeout, timeout}}
+    end
+  end
+
   defp get_process_memory do
     case Process.info(self(), :memory) do
       {:memory, bytes} -> bytes

--- a/test/ptc_runner/lisp/compile_limits_test.exs
+++ b/test/ptc_runner/lisp/compile_limits_test.exs
@@ -1,0 +1,217 @@
+defmodule PtcRunner.Lisp.CompileLimitsTest do
+  @moduledoc """
+  Regression tests for bounded compile phase (issue #988).
+
+  Verifies that adversarial source returns structured errors from both
+  `Lisp.run/2` and `Lisp.validate/1` without crashing the caller.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias PtcRunner.Lisp
+
+  # ============================================================
+  # Oversized source (max_program_bytes)
+  # ============================================================
+
+  describe "max_program_bytes" do
+    test "run/2 rejects oversized source" do
+      big = String.duplicate("a", 200)
+      assert {:error, step} = Lisp.run(big, max_program_bytes: 100)
+      assert step.fail.reason == :program_too_large
+      assert step.fail.message =~ "exceeds limit of 100"
+    end
+
+    test "validate/2 rejects oversized source" do
+      big = String.duplicate("a", 200)
+      assert {:error, [msg]} = Lisp.validate(big, max_program_bytes: 100)
+      assert msg =~ "exceeds limit of 100"
+    end
+
+    test "run/2 accepts source within limit" do
+      assert {:ok, _step} = Lisp.run("42", max_program_bytes: 100)
+    end
+  end
+
+  # ============================================================
+  # Huge integer literals (H4)
+  # ============================================================
+
+  describe "integer digit limit" do
+    test "run/2 rejects huge integer via FastParser" do
+      huge_int = String.duplicate("9", 200)
+      assert {:error, step} = Lisp.run(huge_int)
+      assert step.fail.reason == :parse_error
+      assert step.fail.message =~ "digit limit"
+    end
+
+    test "run/2 rejects huge negative integer" do
+      huge_int = "-" <> String.duplicate("9", 200)
+      assert {:error, step} = Lisp.run(huge_int)
+      assert step.fail.reason == :parse_error
+      assert step.fail.message =~ "digit limit"
+    end
+
+    test "run/2 accepts 100-digit integer" do
+      hundred_digits = String.duplicate("1", 100)
+      assert {:ok, step} = Lisp.run(hundred_digits)
+      assert step.return == String.to_integer(hundred_digits)
+    end
+
+    test "validate/2 rejects huge integer" do
+      huge_int = String.duplicate("9", 200)
+      assert {:error, [msg]} = Lisp.validate(huge_int)
+      assert msg =~ "digit limit"
+    end
+  end
+
+  # ============================================================
+  # Deeply nested forms
+  # ============================================================
+
+  describe "nesting depth limit" do
+    test "run/2 rejects deeply nested forms" do
+      depth = 70
+      nested = String.duplicate("(do ", depth) <> "1" <> String.duplicate(")", depth)
+      assert {:error, step} = Lisp.run(nested)
+      assert step.fail.reason == :parse_error
+      assert step.fail.message =~ "nesting depth"
+    end
+
+    test "validate/2 rejects deeply nested forms" do
+      depth = 70
+      nested = String.duplicate("(do ", depth) <> "1" <> String.duplicate(")", depth)
+      assert {:error, [msg]} = Lisp.validate(nested)
+      assert msg =~ "nesting depth"
+    end
+
+    test "run/2 accepts reasonably nested forms" do
+      depth = 10
+      nested = String.duplicate("(do ", depth) <> "42" <> String.duplicate(")", depth)
+      assert {:ok, step} = Lisp.run(nested)
+      assert step.return == 42
+    end
+  end
+
+  # ============================================================
+  # Huge short-fn placeholders (H3)
+  # ============================================================
+
+  describe "short-fn arity limit" do
+    test "run/2 rejects huge short-fn placeholder" do
+      assert {:error, step} = Lisp.run("#(+ %999999 1)")
+      assert step.fail.message =~ "max arity"
+    end
+
+    test "validate/2 rejects huge short-fn placeholder" do
+      assert {:error, [msg]} = Lisp.validate("#(+ %999999 1)")
+      assert msg =~ "max arity"
+    end
+
+    test "run/2 accepts short-fn within arity limit" do
+      assert {:ok, step} = Lisp.run("(#(+ %1 %2) 3 4)")
+      assert step.return == 7
+    end
+
+    test "run/2 accepts short-fn up to arity 20" do
+      assert {:ok, step} =
+               Lisp.run("(#(+ %20 1) 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 100)")
+
+      assert step.return == 101
+    end
+
+    test "run/2 rejects short-fn at arity 21" do
+      assert {:error, step} = Lisp.run("#(+ %21 1)")
+      assert step.fail.message =~ "max arity"
+    end
+  end
+
+  # ============================================================
+  # Compile timeout
+  # ============================================================
+
+  describe "compile_timeout" do
+    test "run/2 returns structured error on compile timeout" do
+      # A very short compile timeout with a somewhat complex program
+      # This is a best-effort test — we can't guarantee the compile
+      # actually takes longer than 1ms, but at minimum it verifies
+      # the code path is wired up
+      program = Enum.map_join(1..500, " ", fn i -> "(let [x#{i} #{i}] x#{i})" end)
+
+      case Lisp.run(program, compile_timeout: 1) do
+        {:error, step} ->
+          assert step.fail.reason in [:compile_timeout, :parse_error, :unbound_var]
+
+        {:ok, _step} ->
+          # If compile was fast enough, that's fine too
+          :ok
+      end
+    end
+  end
+
+  # ============================================================
+  # Positive regression: normal programs still work
+  # ============================================================
+
+  describe "normal programs" do
+    test "simple arithmetic" do
+      assert {:ok, step} = Lisp.run("(+ 1 2)")
+      assert step.return == 3
+    end
+
+    test "context filtering still works" do
+      ctx = %{"items" => [1, 2, 3], "unused" => List.duplicate(:big, 1000)}
+      assert {:ok, step} = Lisp.run("(count data/items)", context: ctx)
+      assert step.return == 3
+    end
+
+    test "tools still work" do
+      tools = %{"double" => fn %{"n" => n} -> n * 2 end}
+      assert {:ok, step} = Lisp.run(~S|(tool/double {:n 5})|, tools: tools)
+      assert step.return == 10
+    end
+
+    test "validate/1 still works for valid programs" do
+      assert :ok = Lisp.validate("(+ 1 2)")
+    end
+
+    test "validate/1 still reports undefined vars" do
+      assert {:error, ["foo"]} = Lisp.validate("(+ foo 1)")
+    end
+
+    test "memory persists across execution" do
+      assert {:ok, step} = Lisp.run("(do (def x 42) x)")
+      assert step.return == 42
+    end
+  end
+
+  # ============================================================
+  # Sandbox.run_bounded/2
+  # ============================================================
+
+  describe "Sandbox.run_bounded/2" do
+    test "returns function result" do
+      assert {:ok, 42} = PtcRunner.Sandbox.run_bounded(fn -> 42 end)
+    end
+
+    test "returns timeout error" do
+      assert {:error, {:timeout, 50}} =
+               PtcRunner.Sandbox.run_bounded(fn -> :timer.sleep(:infinity) end, timeout: 50)
+    end
+
+    test "returns memory error for heap-busting work" do
+      assert {:error, {:memory_exceeded, _bytes}} =
+               PtcRunner.Sandbox.run_bounded(
+                 fn -> Enum.to_list(1..10_000_000) end,
+                 max_heap: 1000
+               )
+    end
+
+    test "catches crashes gracefully" do
+      assert {:error, {:execution_error, msg}} =
+               PtcRunner.Sandbox.run_bounded(fn -> raise "boom" end)
+
+      assert msg =~ "RuntimeError"
+    end
+  end
+end

--- a/test/ptc_runner/lisp_telemetry_test.exs
+++ b/test/ptc_runner/lisp_telemetry_test.exs
@@ -152,18 +152,11 @@ defmodule PtcRunner.LispTelemetryTest do
     end
 
     test ":exception event fires when run/2 itself raises and carries caller + kind/reason/stacktrace" do
-      # An invalid (non-string, non-keyword) opts value forces a raise inside
-      # the span body. Use a tools value that fails Tool.new for a non-binary
-      # name? Easier: pass non-string source — Parser will likely raise.
-      # Cleanest path: pass :tools as a non-enumerable to force a runtime crash
-      # inside do_run.
-      #
-      # We use a custom telemetry handler that raises to verify our :exception
-      # path — but raising inside a handler doesn't exercise the span exception
-      # path (telemetry catches handler errors). Instead, directly cause a
-      # runtime failure inside the span by passing a source that's not a binary.
-      assert_raise FunctionClauseError, fn ->
-        Lisp.run(:not_a_binary, caller: :text_mode)
+      # Force a raise inside the span body by passing non-enumerable tools.
+      # normalize_tools calls Enum.reduce_while, which raises Protocol.UndefinedError
+      # for non-enumerable values. This happens before the bounded compile process.
+      assert_raise Protocol.UndefinedError, fn ->
+        Lisp.run("1", tools: :not_enumerable, caller: :text_mode)
       end
 
       assert_receive {:telemetry, [:ptc_runner, :lisp, :execute, :start], _,


### PR DESCRIPTION
## Summary

Closes #988

- Moves PTC-Lisp compile phase (parse + analyze + static checks) into a bounded BEAM process with timeout and heap limits, preventing adversarial source from consuming caller CPU/memory before the eval sandbox starts
- Adds cheap caller-side preflight caps (`max_program_bytes`) and structural parser/analyzer limits (integer digit cap, nesting depth, short-fn arity)
- Extends `validate/1` to `validate/2` with the same compile-phase protections

## Changes

| File | Change |
|------|--------|
| `sandbox.ex` | Add `run_bounded/2` — generic bounded process runner |
| `lisp.ex` | Preflight `max_program_bytes` check, bounded compile via `run_bounded`, new `compile_timeout` option, `validate/2` overload |
| `fast_parser.ex` | Integer digit cap (100), nesting depth limit (64) |
| `parser_helpers.ex` | Integer digit cap (100) for NimbleParsec path |
| `analyze/short_fn.ex` | Short-fn arity cap (20) on all three sites |
| `lisp_telemetry_test.exs` | Updated exception test trigger (non-binary source no longer crashes caller) |
| `compile_limits_test.exs` | 26 new regression tests |

## Design decisions

- **Separate `compile_timeout` (5s default)** — eval `timeout` (1s) stays unchanged; compile needs more headroom for large legitimate programs
- **Compile heap uses app-level default** — caller's `max_heap` only constrains eval, preventing `max_heap: 1000` from killing compilation of valid programs
- **Structural limits are compiled-in constants** — integer digit cap (100), nesting depth (64), short-fn arity (20) are not user-configurable since they're safety invariants, not tuning knobs
- **`run_bounded/2` uses unique message tag** — `{:bounded_result, pid, result}` avoids collision with `{:result, ...}` from `execute/3`

## Test plan

- [x] 26 new tests covering all adversarial input classes (oversized source, huge integers, deep nesting, huge short-fn placeholders, compile timeout)
- [x] Positive regression tests (arithmetic, context filtering, tools, validate, memory)
- [x] `Sandbox.run_bounded/2` unit tests (success, timeout, memory, crash)
- [x] Full test suite passes (5021 tests, 0 failures)
- [x] `mix precommit` passes (format, compile, credo, spec validation, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)