### PR TITLE
fix(mcp): harden HTTP DNS rebinding checks

### DIFF
--- a/docs/mcp-server-configuration.md
+++ b/docs/mcp-server-configuration.md
@@ -91,6 +91,12 @@ HTTP emits sanitized telemetry under `[:ptc_runner_mcp, :http, ...]`
 and logs request stop lines to stderr. Raw bearer tokens and raw
 `MCP-Session-Id` values are not logged.
 
+When the HTTP listener is bound to loopback, `/mcp` also requires a
+loopback `Host`/authority value. This lets non-browser clients omit
+`Origin` while still rejecting DNS-rebinding requests that arrive with a
+public attacker-controlled host. POST requests with a present
+`Content-Type` must use `application/json` or a `+json` media type.
+
 ## Response profiles
 
 `ptc_lisp_execute` renders its result according to a boot-time **response profile** (`--response-profile`). The default is **`slim`**: optimized for the model consuming the tool result, not for an operator reading a trace.

--- a/docs/mcp-server-http-deployment.md
+++ b/docs/mcp-server-http-deployment.md
@@ -115,3 +115,9 @@ sessions return `404` on later use.
 | `--http-session-ttl-ms` | `3600000` | Absolute protocol-session lifetime. |
 | `--http-session-idle-timeout-ms` | `900000` | Idle protocol-session timeout. |
 | `--http-instance-label` | hostname | Label stamped into HTTP logs/telemetry/traces. |
+
+For loopback binds, the MCP endpoint rejects requests whose
+`Host`/authority is not loopback. Missing `Origin` remains valid for
+non-browser clients, but invalid browser `Origin` values are rejected.
+POST requests with a present `Content-Type` must be JSON
+(`application/json` or a `+json` media type).

--- a/mcp_server/lib/ptc_runner_mcp/http/host.ex
+++ b/mcp_server/lib/ptc_runner_mcp/http/host.ex
@@ -1,0 +1,36 @@
+defmodule PtcRunnerMcp.Http.Host do
+  @moduledoc false
+
+  alias PtcRunnerMcp.Http.Config
+
+  @spec allowed?(Plug.Conn.t(), map()) :: boolean()
+  def allowed?(conn, cfg) do
+    if Config.loopback_host?(Map.fetch!(cfg, :host)) do
+      loopback_host?(conn.host)
+    else
+      true
+    end
+  end
+
+  defp loopback_host?(host) when is_binary(host) do
+    host
+    |> host_without_port()
+    |> Config.loopback_host?()
+  end
+
+  defp loopback_host?(_host), do: false
+
+  defp host_without_port("[" <> rest) do
+    case String.split(rest, "]", parts: 2) do
+      [host, _suffix] -> host
+      _ -> rest
+    end
+  end
+
+  defp host_without_port(host) do
+    case URI.parse("//" <> host) do
+      %URI{host: parsed} when is_binary(parsed) -> parsed
+      _ -> host
+    end
+  end
+end

--- a/mcp_server/lib/ptc_runner_mcp/http/router.ex
+++ b/mcp_server/lib/ptc_runner_mcp/http/router.ex
@@ -3,7 +3,7 @@ defmodule PtcRunnerMcp.Http.Router do
 
   use Plug.Router
 
-  alias PtcRunnerMcp.Http.{Auth, Origin, Session, SessionRegistry, Telemetry}
+  alias PtcRunnerMcp.Http.{Auth, Host, Origin, Session, SessionRegistry, Telemetry}
   alias PtcRunnerMcp.{JsonRpc, Limits, Log, Version}
 
   plug(:match)
@@ -65,11 +65,13 @@ defmodule PtcRunnerMcp.Http.Router do
       {:error, {:auth, reason}} -> auth_error(conn, reason)
       {:error, :missing_session} -> Plug.Conn.send_resp(conn, 400, "missing MCP-Session-Id")
       {:error, :origin} -> Plug.Conn.send_resp(conn, 403, "forbidden")
+      {:error, :host} -> Plug.Conn.send_resp(conn, 403, "forbidden")
     end
   end
 
   defp route_mcp(%{method: "POST"} = conn, cfg) do
-    with {:ok, owner} <- authenticate(conn, cfg),
+    with :ok <- acceptable_content_type(conn),
+         {:ok, owner} <- authenticate(conn, cfg),
          {:ok, body, conn} <- read_body_capped(conn, cfg),
          {:ok, decoded} <- decode_body(body) do
       if registry_draining?() do
@@ -83,6 +85,12 @@ defmodule PtcRunnerMcp.Http.Router do
 
       {:error, :origin} ->
         Plug.Conn.send_resp(conn, 403, "forbidden")
+
+      {:error, :host} ->
+        Plug.Conn.send_resp(conn, 403, "forbidden")
+
+      {:error, :unsupported_media_type} ->
+        Plug.Conn.send_resp(conn, 415, "unsupported media type")
 
       {:error, :empty_body} ->
         Plug.Conn.send_resp(conn, 400, "empty body")
@@ -213,17 +221,49 @@ defmodule PtcRunnerMcp.Http.Router do
   end
 
   defp authenticate(conn, cfg) do
-    if Origin.allowed?(conn, cfg) do
-      case Auth.authenticate(conn, cfg) do
-        {:ok, owner} ->
-          {:ok, owner}
+    cond do
+      not Host.allowed?(conn, cfg) ->
+        {:error, :host}
 
-        {:error, reason} ->
-          Telemetry.emit([:auth, :failure], %{count: 1}, base_meta(conn, cfg, %{reason: reason}))
-          {:error, {:auth, reason}}
-      end
+      Origin.allowed?(conn, cfg) ->
+        case Auth.authenticate(conn, cfg) do
+          {:ok, owner} ->
+            {:ok, owner}
+
+          {:error, reason} ->
+            Telemetry.emit(
+              [:auth, :failure],
+              %{count: 1},
+              base_meta(conn, cfg, %{reason: reason})
+            )
+
+            {:error, {:auth, reason}}
+        end
+
+      true ->
+        {:error, :origin}
+    end
+  end
+
+  defp acceptable_content_type(conn) do
+    case Plug.Conn.get_req_header(conn, "content-type") do
+      [] -> :ok
+      [content_type | _] -> json_content_type?(content_type)
+    end
+  end
+
+  defp json_content_type?(content_type) do
+    media_type =
+      content_type
+      |> String.split(";", parts: 2)
+      |> hd()
+      |> String.downcase()
+      |> String.trim()
+
+    if media_type == "application/json" or String.ends_with?(media_type, "+json") do
+      :ok
     else
-      {:error, :origin}
+      {:error, :unsupported_media_type}
     end
   end
 

--- a/mcp_server/test/ptc_runner_mcp/http_router_test.exs
+++ b/mcp_server/test/ptc_runner_mcp/http_router_test.exs
@@ -68,6 +68,67 @@ defmodule PtcRunnerMcp.HttpRouterTest do
     assert get_resp_header(conn, "www-authenticate") == [~s(Bearer error="invalid_token")]
   end
 
+  test "loopback bind rejects hostile Host before reading MCP POST body" do
+    conn =
+      conn(
+        :post,
+        "/mcp",
+        Jason.encode!(%{"jsonrpc" => "2.0", "id" => 1, "method" => "initialize"})
+      )
+      |> auth()
+      |> with_host("attacker.example")
+      |> call()
+
+    assert conn.status == 403
+    assert conn.resp_body == "forbidden"
+  end
+
+  test "missing Origin is allowed when Host is loopback" do
+    conn =
+      conn(
+        :post,
+        "/mcp",
+        Jason.encode!(%{"jsonrpc" => "2.0", "id" => 1, "method" => "initialize"})
+      )
+      |> auth()
+      |> with_host("127.0.0.1")
+      |> call()
+
+    assert conn.status == 200
+    assert get_resp_header(conn, "mcp-session-id") != []
+  end
+
+  test "invalid browser Origin is rejected even with loopback Host" do
+    conn =
+      conn(
+        :post,
+        "/mcp",
+        Jason.encode!(%{"jsonrpc" => "2.0", "id" => 1, "method" => "initialize"})
+      )
+      |> auth()
+      |> with_host("127.0.0.1")
+      |> put_req_header("origin", "http://attacker.example")
+      |> call()
+
+    assert conn.status == 403
+    assert conn.resp_body == "forbidden"
+  end
+
+  test "POST rejects present non-JSON content types" do
+    conn =
+      conn(
+        :post,
+        "/mcp",
+        Jason.encode!(%{"jsonrpc" => "2.0", "id" => 1, "method" => "initialize"})
+      )
+      |> auth()
+      |> put_req_header("content-type", "text/plain")
+      |> call()
+
+    assert conn.status == 415
+    assert conn.resp_body == "unsupported media type"
+  end
+
   test "initialize creates a session and later notification returns 202" do
     init = %{
       "jsonrpc" => "2.0",
@@ -592,7 +653,13 @@ defmodule PtcRunnerMcp.HttpRouterTest do
   end
 
   defp auth(conn), do: put_req_header(conn, "authorization", "Bearer " <> @token)
+
+  defp call(%{host: host} = conn) when host in ["example.com", "www.example.com"],
+    do: conn |> with_host("127.0.0.1") |> Router.call([])
+
   defp call(conn), do: Router.call(conn, [])
+
+  defp with_host(conn, host), do: %{conn | host: host, port: 7332}
 
   defp attach_http_telemetry do
     handler_id = "http-router-test-#{System.unique_integer([:positive])}"

--- a/mcp_server/test/ptc_runner_mcp/http_router_test.exs
+++ b/mcp_server/test/ptc_runner_mcp/http_router_test.exs
@@ -284,6 +284,17 @@ defmodule PtcRunnerMcp.HttpRouterTest do
     assert conn.status == 404
   end
 
+  test "loopback bind rejects hostile Host on DELETE" do
+    conn =
+      conn(:delete, "/mcp")
+      |> auth()
+      |> with_host("attacker.example")
+      |> call()
+
+    assert conn.status == 403
+    assert conn.resp_body == "forbidden"
+  end
+
   test "deleted owner index allows same owner to initialize again" do
     first_id = initialize_session()
 


### PR DESCRIPTION
## Summary
- validate loopback-bound MCP HTTP requests against loopback Host/authority before auth/body handling
- keep missing Origin valid for non-browser clients while rejecting invalid browser Origins
- reject present non-JSON POST Content-Type values and document the behavior

Closes medium issue: https://github.com/andreasronge/ptc_runner/issues/987

## Verification
- mix test test/ptc_runner_mcp/http_router_test.exs test/ptc_runner_mcp/http_config_test.exs
- mix test (from mcp_server/)
- pre-commit: format, compile --warnings-as-errors, Credo, scoped tests
- pre-push: root tests + dialyzer, mcp_server tests + dialyzer, ptc_viewer tests

## Fix Automation State
<!-- fix-state: {"attempts":2} -->
Fix attempts: 2/3
