### PR TITLE
fix(security): cap pmap/pcalls parallel workers (H1)

### DIFF
--- a/docs/ptc-lisp-specification.md
+++ b/docs/ptc-lisp-specification.md
@@ -3843,9 +3843,27 @@ This means `-1` is always the integer negative one, never a symbol named "-1". S
 | Resource | Default | Notes |
 |----------|---------|-------|
 | Timeout | 1,000 ms | Execution time limit |
-| Max Heap | ~10 MB | Memory limit (1,250,000 words) |
+| Max Heap | ~10 MB | Sandbox-process memory limit (1,250,000 words) |
+| Worker Max Heap | = Max Heap | Fixed per-worker `pmap`/`pcalls` heap cap |
+| Max Parallel Workers | 8 | Global cap on live `pmap`/`pcalls` workers |
 | Max Tool Calls | 10 | Per-program tool invocation limit |
 | Loop/Recur Iterations | 1,000 | Per-loop/recur jump limit; ordinary non-tail recursion is bounded by timeout and heap |
+
+Every `pmap`/`pcalls` worker process — top-level *and* nested — is
+spawned with a **fixed** `max_heap_size` of `Worker Max Heap` words (the
+cap is NOT divided by concurrency). The number of such workers alive at
+once, across the whole program and at every nesting depth, is bounded by
+a shared slot budget of `Max Parallel Workers`. Aggregate live parallel
+heap is therefore bounded by `Max Parallel Workers × Worker Max Heap`.
+
+- A worker that exceeds its fixed heap cap is killed; the program fails
+  with `:memory_exceeded`.
+- A `pmap`/`pcalls` that cannot obtain a worker slot — e.g. deeply
+  nested parallelism that would exceed the global budget — fails with
+  `:parallel_capacity_exceeded` (there is no sequential fallback).
+- The whole parallel operation (including nested `pmap`/`pcalls`) shares
+  one deadline derived from `pmap_timeout`; exceeding it fails with
+  `:timeout`.
 
 *Note: Hosts may configure higher timeouts (e.g., 5,000ms) to accommodate slow tool calls.*
 

--- a/lib/ptc_runner/lisp.ex
+++ b/lib/ptc_runner/lisp.ex
@@ -43,6 +43,15 @@ defmodule PtcRunner.Lisp do
 
   alias PtcRunner.Lisp.Eval.Context, as: EvalContext
   alias PtcRunner.Lisp.Eval.Helpers
+  alias PtcRunner.Lisp.Eval.ParallelBudget
+
+  # Default capacity of the global parallel-worker slot semaphore (see
+  # `PtcRunner.Lisp.Eval.ParallelBudget`). Conservative: with the
+  # default ~10 MB (`1_250_000`-word) `worker_max_heap`, the aggregate
+  # worst-case parallel heap is bounded at roughly `8 × 10 MB = 80 MB`.
+  # The top-level sandbox process is NOT counted as a slot. Overridable
+  # per call via the `:max_parallel_workers` option to `run/2`.
+  @default_max_parallel_workers 8
   alias PtcRunner.Lisp.Format.Var
   alias PtcRunner.Lisp.Keyword, as: LispKeyword
   alias PtcRunner.Step
@@ -64,8 +73,10 @@ defmodule PtcRunner.Lisp do
     - `:timeout` - Timeout in milliseconds for entire sandbox execution (default: 1000)
     - `:compile_timeout` - Timeout in milliseconds for the compile phase (parse + analyze) (default: 5000)
     - `:pmap_timeout` - Timeout in milliseconds per pmap/pcalls task (default: 5000). Increase for LLM-backed tools.
-    - `:pmap_max_concurrency` - Max concurrent tasks in pmap/pcalls (default: `System.schedulers_online() * 2`). Reduce to avoid overflowing connection pools.
-    - `:max_heap` - Max heap size in words (default: 1_250_000)
+    - `:pmap_max_concurrency` - Local pmap/pcalls scheduling window — max tasks one call keeps in flight (default: `System.schedulers_online() * 2`). Reduce to avoid overflowing connection pools. The HARD aggregate cap is `:max_parallel_workers`.
+    - `:max_heap` - Sandbox-process max heap size in words (default: 1_250_000)
+    - `:worker_max_heap` - Fixed `max_heap_size` (words) for every pmap/pcalls worker, top-level and nested (default: the `:max_heap` value)
+    - `:max_parallel_workers` - Global cap on pmap/pcalls worker processes alive at once across the whole run, at any nesting depth (default: 8). Aggregate live parallel heap ≈ `max_parallel_workers * worker_max_heap`. A pmap/pcalls that cannot get a slot fails with `:parallel_capacity_exceeded`.
     - `:max_symbols` - Max unique symbols/keywords allowed (default: 10_000)
     - `:max_program_bytes` - Max source code size in bytes (default: 1_000_000)
     - `:max_print_length` - Max characters per `println` call (default: 2000)
@@ -262,6 +273,13 @@ defmodule PtcRunner.Lisp do
     float_precision = Keyword.get(opts, :float_precision)
     timeout = Keyword.get(opts, :timeout, 1000)
     max_heap = Keyword.get(opts, :max_heap, 1_250_000)
+    # Security H1: every pmap/pcalls worker runs under this FIXED heap
+    # cap (default: the sandbox `max_heap`), and the global
+    # `max_parallel_workers` semaphore caps how many such workers are
+    # alive at once across the whole run. Aggregate live parallel heap
+    # is therefore bounded by `max_parallel_workers * worker_max_heap`.
+    worker_max_heap = Keyword.get(opts, :worker_max_heap, max_heap)
+    max_parallel_workers = Keyword.get(opts, :max_parallel_workers, @default_max_parallel_workers)
     max_symbols = Keyword.get(opts, :max_symbols, 10_000)
     max_program_bytes = Keyword.get(opts, :max_program_bytes, @default_max_program_bytes)
     compile_timeout = Keyword.get(opts, :compile_timeout, @default_compile_timeout)
@@ -298,6 +316,8 @@ defmodule PtcRunner.Lisp do
         float_precision: float_precision,
         timeout: timeout,
         max_heap: max_heap,
+        worker_max_heap: worker_max_heap,
+        max_parallel_workers: max_parallel_workers,
         max_symbols: max_symbols,
         compile_timeout: compile_timeout,
         turn_history: turn_history,
@@ -321,7 +341,8 @@ defmodule PtcRunner.Lisp do
     signature_str = params.signature_str
 
     # Normalize tools to Tool structs
-    with {:ok, normalized_tools} <- normalize_tools(raw_tools),
+    with :ok <- validate_parallel_config(params.worker_max_heap, params.max_parallel_workers),
+         {:ok, normalized_tools} <- normalize_tools(raw_tools),
          {:ok, parsed_signature} <- parse_signature(signature_str) do
       tool_executor = fn name, args ->
         execute_tool(normalized_tools, name, args)
@@ -350,6 +371,33 @@ defmodule PtcRunner.Lisp do
       {:error, {:invalid_signature, msg}} ->
         {:error,
          Step.error(:parse_error, "Invalid signature: #{msg}", memory, %{}, journal: journal)}
+
+      {:error, {:invalid_config, msg}} ->
+        {:error, Step.error(:invalid_config, msg, memory, %{}, journal: journal)}
+    end
+  end
+
+  # P2: validate operator-supplied parallel-worker config before it can
+  # reach `Process.spawn`, where a bad `max_heap_size` value would raise
+  # a raw `ArgumentError`. `worker_max_heap` must be a positive integer
+  # (a valid `max_heap_size` spawn value) or `nil`; `max_parallel_workers`
+  # must be a positive integer.
+  defp validate_parallel_config(worker_max_heap, max_parallel_workers) do
+    cond do
+      not (is_nil(worker_max_heap) or (is_integer(worker_max_heap) and worker_max_heap > 0)) ->
+        {:error,
+         {:invalid_config,
+          ":worker_max_heap must be a positive integer (heap words) or nil, got " <>
+            inspect(worker_max_heap)}}
+
+      not (is_integer(max_parallel_workers) and max_parallel_workers > 0) ->
+        {:error,
+         {:invalid_config,
+          ":max_parallel_workers must be a positive integer, got " <>
+            inspect(max_parallel_workers)}}
+
+      true ->
+        :ok
     end
   end
 
@@ -508,6 +556,8 @@ defmodule PtcRunner.Lisp do
       float_precision: float_precision,
       timeout: timeout,
       max_heap: max_heap,
+      worker_max_heap: worker_max_heap,
+      max_parallel_workers: max_parallel_workers,
       turn_history: turn_history,
       max_print_length: max_print_length,
       filter_context: filter_context,
@@ -526,10 +576,15 @@ defmodule PtcRunner.Lisp do
     filtered_ctx = if filter_context, do: DataKeys.filter_context(core_ast, ctx), else: ctx
     context = PtcRunner.Context.new(filtered_ctx, memory, normalized_tools, turn_history)
 
+    parallel_budget = ParallelBudget.new(max_parallel_workers)
+
     eval_opts =
       [
         max_print_length: max_print_length,
         budget: budget,
+        max_heap: max_heap,
+        worker_max_heap: worker_max_heap,
+        parallel_budget: parallel_budget,
         pmap_timeout: pmap_timeout,
         pmap_max_concurrency: pmap_max_concurrency,
         trace_context: trace_context,

--- a/lib/ptc_runner/lisp/eval.ex
+++ b/lib/ptc_runner/lisp/eval.ex
@@ -20,7 +20,7 @@ defmodule PtcRunner.Lisp.Eval do
   alias PtcRunner.Lisp.ClosureCapture
   alias PtcRunner.Lisp.CoreAST
   alias PtcRunner.Lisp.Env
-  alias PtcRunner.Lisp.Eval.{Apply, Patterns}
+  alias PtcRunner.Lisp.Eval.{Apply, ParallelRunner, Patterns}
   alias PtcRunner.Lisp.Eval.Context, as: EvalContext
   alias PtcRunner.Lisp.ExecutionError
   alias PtcRunner.Lisp.Format.Var
@@ -450,56 +450,71 @@ defmodule PtcRunner.Lisp.Eval do
         coll_list = Enum.to_list(coll_val)
         count = length(coll_list)
 
+        # Security H1: every pmap/pcalls worker — top-level and nested —
+        # is spawned with a FIXED `max_heap_size` (`worker_max_heap`),
+        # NOT divided by concurrency. A shared `ParallelBudget` semaphore
+        # (`parallel_budget`) caps how many workers may be alive at once
+        # across the whole run, so aggregate live parallel heap is
+        # bounded by `max_parallel_workers * worker_max_heap` at any
+        # nesting depth. The worker's `EvalContext` keeps the SAME
+        # `worker_max_heap` and `parallel_budget`, so a nested
+        # pmap/pcalls inherits both. `pmap_deadline` is inherited so all
+        # nested calls share one deadline.
+        worker_max_heap = eval_ctx2.worker_max_heap
+        concurrency = bounded_concurrency(eval_ctx2.pmap_max_concurrency)
+        deadline_mono = parallel_deadline(eval_ctx2)
+        worker_eval_ctx = %{eval_ctx2 | pmap_deadline: deadline_mono}
+
         # Convert the function value to a callable (may be a tuple for builtins)
         # The closure captures a read-only snapshot of the environment at creation time
-        callable_fn = value_to_erlang_fn(fn_val, eval_ctx2)
+        callable_fn = value_to_erlang_fn(fn_val, worker_eval_ctx)
 
         # Capture trace context for propagation into worker processes
         trace_ctx = TraceContext.capture()
 
-        # Execute in parallel using Task.async_stream
-        # Limit concurrency to available schedulers to prevent resource exhaustion
-        # when LLM generates pmap over large collections (e.g., unbounded search results)
-        # Timeout is configurable via pmap_timeout for LLM-backed tool calls
-        results =
-          coll_list
-          |> Task.async_stream(
-            fn elem ->
-              # Re-attach trace context in worker process
-              TraceContext.attach(trace_ctx)
+        worker_fun = fn elem ->
+          try do
+            TraceContext.take_child_result()
+            value = Callable.call(callable_fn, [elem])
 
-              try do
-                TraceContext.take_child_result()
-                value = Callable.call(callable_fn, [elem])
+            case TraceContext.take_child_result() do
+              {trace_id, child_step} -> {:ok, {:ok, value, trace_id, child_step}}
+              nil -> {:ok, {:ok, value, nil, nil}}
+            end
+          rescue
+            e in PtcRunner.ToolExecutionError ->
+              {:error, {:pmap_error, "tool '#{e.tool_name}' failed: #{e.message}"}}
 
-                case TraceContext.take_child_result() do
-                  {trace_id, child_step} -> {:ok, value, trace_id, child_step}
-                  nil -> {:ok, value, nil, nil}
-                end
-              rescue
-                e in PtcRunner.ToolExecutionError ->
-                  {:error, {:pmap_error, "tool '#{e.tool_name}' failed: #{e.message}"}}
+            e in ExecutionError ->
+              # Re-surface stable error atoms from a nested pmap/pcalls
+              # (heap kill / shared-deadline timeout) instead of
+              # flattening them into a generic :pmap_error string.
+              {:error, nested_parallel_error(e)}
 
-                e ->
-                  {:error, {:pmap_error, Exception.message(e)}}
-              catch
-                {:return_signal, _, _} ->
-                  {:error, {:pmap_error, "return called inside pmap"}}
+            e ->
+              {:error, {:pmap_error, Exception.message(e)}}
+          catch
+            {:return_signal, _, _} ->
+              {:error, {:pmap_error, "return called inside pmap"}}
 
-                {:fail_signal, _, _} ->
-                  {:error, {:pmap_error, "fail called inside pmap"}}
-              end
-            end,
-            timeout: eval_ctx2.pmap_timeout,
-            ordered: true,
-            max_concurrency: eval_ctx2.pmap_max_concurrency
+            {:fail_signal, _, _} ->
+              {:error, {:pmap_error, "fail called inside pmap"}}
+          end
+        end
+
+        runner_result =
+          ParallelRunner.run(coll_list, worker_fun,
+            worker_max_heap: worker_max_heap,
+            max_concurrency: concurrency,
+            budget: eval_ctx2.parallel_budget,
+            deadline_mono: deadline_mono,
+            trace_ctx: trace_ctx
           )
-          |> Enum.to_list()
 
         # Collect results and child trace IDs
         duration_ms = System.monotonic_time(:millisecond) - start_time
 
-        case collect_parallel_results(results, :pmap) do
+        case collect_runner_results(runner_result, :pmap) do
           {:ok, values, child_trace_ids, child_steps} ->
             # Count successes and errors
             success_count = length(values)
@@ -540,6 +555,13 @@ defmodule PtcRunner.Lisp.Eval do
         timestamp = DateTime.utc_now()
         count = length(fn_vals)
 
+        # Security H1: fixed per-worker heap cap + shared slot budget —
+        # see the pmap clause above for the full rationale.
+        worker_max_heap = eval_ctx2.worker_max_heap
+        concurrency = bounded_concurrency(eval_ctx2.pmap_max_concurrency)
+        deadline_mono = parallel_deadline(eval_ctx2)
+        worker_eval_ctx = %{eval_ctx2 | pmap_deadline: deadline_mono}
+
         # Convert each function value to an Erlang function (zero-arity thunk)
         # Use a try/rescue to catch validation errors (wrong arity, non-callable)
         try do
@@ -547,51 +569,51 @@ defmodule PtcRunner.Lisp.Eval do
             fn_vals
             |> Enum.with_index()
             |> Enum.map(fn {fn_val, idx} ->
-              {pcalls_fn_to_erlang(fn_val, eval_ctx2), idx}
+              {pcalls_fn_to_erlang(fn_val, worker_eval_ctx), idx}
             end)
 
           # Capture trace context for propagation into worker processes
           trace_ctx = TraceContext.capture()
 
-          # Execute all thunks in parallel using Task.async_stream
-          # Limit concurrency to prevent resource exhaustion
-          # Timeout is configurable via pmap_timeout for LLM-backed tool calls
-          results =
-            erlang_fns
-            |> Task.async_stream(
-              fn {erlang_fn, idx} ->
-                # Re-attach trace context in worker process
-                TraceContext.attach(trace_ctx)
+          worker_fun = fn {erlang_fn, idx} ->
+            try do
+              TraceContext.take_child_result()
+              value = erlang_fn.()
 
-                try do
-                  TraceContext.take_child_result()
-                  value = erlang_fn.()
+              case TraceContext.take_child_result() do
+                {trace_id, child_step} -> {:ok, {:ok, value, trace_id, idx, child_step}}
+                nil -> {:ok, {:ok, value, nil, idx, nil}}
+              end
+            rescue
+              e in ExecutionError ->
+                # Re-surface stable error atoms from a nested
+                # pmap/pcalls (heap kill / shared-deadline timeout).
+                {:error, nested_parallel_error(e, idx)}
 
-                  case TraceContext.take_child_result() do
-                    {trace_id, child_step} -> {:ok, value, trace_id, idx, child_step}
-                    nil -> {:ok, value, nil, idx, nil}
-                  end
-                rescue
-                  e ->
-                    {:error, {:pcalls_error, idx, Exception.message(e)}}
-                catch
-                  {:return_signal, _, _} ->
-                    {:error, {:pcalls_error, idx, "return called inside pcalls"}}
+              e ->
+                {:error, {:pcalls_error, idx, Exception.message(e)}}
+            catch
+              {:return_signal, _, _} ->
+                {:error, {:pcalls_error, idx, "return called inside pcalls"}}
 
-                  {:fail_signal, _, _} ->
-                    {:error, {:pcalls_error, idx, "fail called inside pcalls"}}
-                end
-              end,
-              timeout: eval_ctx2.pmap_timeout,
-              ordered: true,
-              max_concurrency: eval_ctx2.pmap_max_concurrency
+              {:fail_signal, _, _} ->
+                {:error, {:pcalls_error, idx, "fail called inside pcalls"}}
+            end
+          end
+
+          runner_result =
+            ParallelRunner.run(erlang_fns, worker_fun,
+              worker_max_heap: worker_max_heap,
+              max_concurrency: concurrency,
+              budget: eval_ctx2.parallel_budget,
+              deadline_mono: deadline_mono,
+              trace_ctx: trace_ctx
             )
-            |> Enum.to_list()
 
           # Collect results and child trace IDs
           duration_ms = System.monotonic_time(:millisecond) - start_time
 
-          case collect_parallel_results(results, :pcalls) do
+          case collect_runner_results(runner_result, :pcalls) do
             {:ok, values, child_trace_ids, child_steps} ->
               # Count successes and errors
               success_count = length(values)
@@ -1244,36 +1266,100 @@ defmodule PtcRunner.Lisp.Eval do
   # Parallel execution helpers (shared by pmap and pcalls)
   # ============================================================
 
-  # Unified helper to collect parallel results with child trace IDs and child steps
-  # Works for both pmap and pcalls result formats
-  defp collect_parallel_results(results, type) do
-    collect_parallel_results(results, [], [], [], type)
+  # Defensive bound on the local pmap/pcalls scheduling window. The HARD
+  # aggregate cap is the global `ParallelBudget` semaphore;
+  # `pmap_max_concurrency` is only a per-call window size. Clamp to a
+  # positive integer.
+  defp bounded_concurrency(conc) when is_integer(conc) and conc > 0, do: conc
+  defp bounded_concurrency(_), do: 1
+
+  # Resolve the shared absolute deadline for a parallel operation. The
+  # OUTERMOST pmap/pcalls computes `now + pmap_timeout`; a nested call
+  # inherits the parent's `pmap_deadline` unchanged so N branches cannot
+  # multiply total wall time.
+  defp parallel_deadline(%EvalContext{pmap_deadline: deadline}) when is_integer(deadline),
+    do: deadline
+
+  defp parallel_deadline(%EvalContext{pmap_timeout: timeout}),
+    do: System.monotonic_time(:millisecond) + timeout
+
+  # Adapt a `ParallelRunner.run/3` result to the
+  # `{:ok, values, trace_ids, child_steps}` / `{:error, reason}` shape
+  # the pmap/pcalls clauses expect.
+  defp collect_runner_results({:ok, internal_results}, _type) do
+    {values, trace_ids, child_steps} =
+      Enum.reduce(internal_results, {[], [], []}, fn result, {vals, tids, steps} ->
+        {:ok, val, trace_id, child_step} = extract_parallel_result(result)
+        {[val | vals], [trace_id | tids], [child_step | steps]}
+      end)
+
+    {:ok, Enum.reverse(values), Enum.reverse(trace_ids), Enum.reverse(child_steps)}
   end
 
-  defp collect_parallel_results([], acc, trace_ids, child_steps, _type) do
-    {:ok, Enum.reverse(acc), Enum.reverse(trace_ids), Enum.reverse(child_steps)}
+  defp collect_runner_results({:error, reason}, type) do
+    {:error, classify_runner_error(reason, type)}
   end
 
-  defp collect_parallel_results([{:ok, result} | rest], acc, trace_ids, child_steps, type) do
-    case extract_parallel_result(result) do
-      {:ok, val, trace_id, child_step} ->
-        collect_parallel_results(
-          rest,
-          [val | acc],
-          [trace_id | trace_ids],
-          [child_step | child_steps],
-          type
-        )
+  # Map `ParallelRunner`'s stable error reasons onto the pmap/pcalls
+  # error shape.
+  #
+  # P3 fix: heap/timeout/capacity failures are surfaced as the 3-tuple
+  # `{reason_atom, message, nil}`. `Lisp.execute_program/2` routes
+  # 3-tuples through `format_error/1` (which renders `"reason: msg"`)
+  # and tags the step with `reason_atom` directly — so `step.fail.reason`
+  # stays `:memory_exceeded` / `:timeout` / `:parallel_capacity_exceeded`
+  # AND the message reads cleanly. The 2-tuple `{:memory_exceeded, bytes}`
+  # shape is reserved for the sandbox-process heap kill, where element 2
+  # really is a numeric byte limit.
+  defp classify_runner_error({:memory_exceeded, _index}, _type),
+    do: {:memory_exceeded, "a parallel worker exceeded its per-worker heap cap", nil}
 
-      {:error, reason} ->
-        {:error, reason}
-    end
+  defp classify_runner_error({:timeout, _index}, _type),
+    do: {:timeout, "the parallel operation exceeded its deadline", nil}
+
+  defp classify_runner_error(:parallel_capacity_exceeded, _type),
+    do:
+      {:parallel_capacity_exceeded,
+       "the parallel worker budget is exhausted; reduce nesting or collection size", nil}
+
+  # A nested capacity/heap/timeout failure re-surfaced by
+  # `nested_parallel_error/1,2` arrives as a `{reason, message}` tuple —
+  # normalise it through the same clauses above.
+  defp classify_runner_error({:parallel_capacity_exceeded, _msg}, type),
+    do: classify_runner_error(:parallel_capacity_exceeded, type)
+
+  defp classify_runner_error({:runtime_error, index, detail}, type),
+    do: {parallel_error_type(type), "parallel worker #{index} crashed: #{inspect(detail)}"}
+
+  defp classify_runner_error({:pmap_error, _} = err, _type), do: err
+  defp classify_runner_error({:pcalls_error, _, _} = err, _type), do: err
+  defp classify_runner_error(other, type), do: {parallel_error_type(type), inspect(other)}
+
+  defp parallel_error_type(:pmap), do: :pmap_error
+  defp parallel_error_type(:pcalls), do: :pcalls_error
+
+  # Stable parallel error atoms that must survive nesting unchanged so
+  # the security/capacity outcome is deterministic at any depth.
+  @nested_stable_reasons [:memory_exceeded, :timeout, :parallel_capacity_exceeded]
+
+  # Re-surface a nested pmap/pcalls failure caught as an ExecutionError
+  # inside a pmap worker. A stable reason keeps its atom; anything else
+  # stays a generic :pmap_error.
+  defp nested_parallel_error(%ExecutionError{reason: reason, message: msg})
+       when reason in @nested_stable_reasons do
+    {reason, msg}
   end
 
-  defp collect_parallel_results([{:exit, reason} | _rest], _acc, _trace_ids, _child_steps, type) do
-    error_type = if type == :pmap, do: :pmap_error, else: :pcalls_error
-    {:error, {error_type, "parallel task failed: #{inspect(reason)}"}}
+  defp nested_parallel_error(%ExecutionError{message: msg}), do: {:pmap_error, msg}
+
+  # pcalls variant — same, but produces the 3-tuple pcalls error shape.
+  defp nested_parallel_error(%ExecutionError{reason: reason, message: msg}, _idx)
+       when reason in @nested_stable_reasons do
+    {reason, msg}
   end
+
+  defp nested_parallel_error(%ExecutionError{message: msg}, idx),
+    do: {:pcalls_error, idx, msg}
 
   # Extract value, trace_id, and child_step from different result formats
   defp extract_parallel_result({:ok, val, trace_id, child_step})
@@ -1285,7 +1371,6 @@ defmodule PtcRunner.Lisp.Eval do
     do: {:ok, val, trace_id, child_step}
 
   defp extract_parallel_result({:ok, val, trace_id}), do: {:ok, val, trace_id, nil}
-  defp extract_parallel_result({:error, _reason} = error), do: error
 
   # ============================================================
   # Pcalls helpers
@@ -1315,12 +1400,24 @@ defmodule PtcRunner.Lisp.Eval do
           prints: eval_ctx.prints,
           max_print_length: eval_ctx.max_print_length,
           pmap_timeout: eval_ctx.pmap_timeout,
+          pmap_max_concurrency: eval_ctx.pmap_max_concurrency,
+          # Security H1: propagate the heap caps + shared worker-slot
+          # budget so a nested pmap/pcalls inside this thunk caps and
+          # counts its workers, and the shared deadline so nested calls
+          # don't multiply total wall time.
+          max_heap: eval_ctx.max_heap,
+          worker_max_heap: eval_ctx.worker_max_heap,
+          parallel_budget: eval_ctx.parallel_budget,
+          pmap_deadline: eval_ctx.pmap_deadline,
           catalog_exec: eval_ctx.catalog_exec
       }
 
       case do_eval(body, ctx) do
-        {:ok, result, _ctx2} -> result
-        {:error, reason} -> raise "pcalls function failed: #{inspect(reason)}"
+        {:ok, result, _ctx2} ->
+          result
+
+        {:error, reason} ->
+          raise_pcalls_body_error(reason)
       end
     end
   end
@@ -1344,6 +1441,28 @@ defmodule PtcRunner.Lisp.Eval do
 
   defp pcalls_fn_to_erlang(value, %EvalContext{}) do
     raise "pcalls requires callable thunks, got: #{inspect(value)}"
+  end
+
+  # A nested pmap/pcalls failure (heap kill, deadline, exhausted worker
+  # budget) raises structured so a surrounding worker re-surfaces the
+  # stable atom; every other body error keeps the legacy RuntimeError
+  # shape. Parallel errors arrive as 2- or 3-tuples.
+  @spec raise_pcalls_body_error(term()) :: no_return()
+  defp raise_pcalls_body_error({atom, _} = reason) when atom in @nested_stable_reasons do
+    raise_pcalls_parallel_error(atom, reason)
+  end
+
+  defp raise_pcalls_body_error({atom, _, _} = reason) when atom in @nested_stable_reasons do
+    raise_pcalls_parallel_error(atom, reason)
+  end
+
+  defp raise_pcalls_body_error(reason) do
+    raise "pcalls function failed: #{inspect(reason)}"
+  end
+
+  @spec raise_pcalls_parallel_error(atom(), term()) :: no_return()
+  defp raise_pcalls_parallel_error(atom, reason) do
+    raise ExecutionError, reason: atom, message: "pcalls function failed: #{inspect(reason)}"
   end
 
   # ============================================================

--- a/lib/ptc_runner/lisp/eval/apply.ex
+++ b/lib/ptc_runner/lisp/eval/apply.ex
@@ -132,6 +132,14 @@ defmodule PtcRunner.Lisp.Eval.Apply do
         # Catch errors from closure evaluation (destructuring, arity, eval errors)
         {:error, {:type_error, Exception.message(e), converted_args}}
 
+      e in ExecutionError ->
+        # A nested pmap/pcalls failure (`:memory_exceeded` / `:timeout`)
+        # raised through a closure run by a regular HOF (map/filter/...).
+        # Surface its stable reason instead of letting it crash the
+        # sandbox as `:execution_error`. Non-parallel ExecutionErrors
+        # (e.g. tool errors) are re-raised to keep their semantics.
+        reraise_unless_parallel(e, __STACKTRACE__)
+
       e in ArithmeticError ->
         {:error, {:arithmetic_error, Exception.message(e)}}
 
@@ -271,6 +279,11 @@ defmodule PtcRunner.Lisp.Eval.Apply do
         e in RuntimeError ->
           # Catch errors from closure evaluation (destructuring, arity, eval errors)
           {:error, {:type_error, Exception.message(e), converted_args}}
+
+        e in ExecutionError ->
+          # See the `{:normal, fun}` clause: surface nested parallel
+          # `:memory_exceeded` / `:timeout` rather than crash the sandbox.
+          reraise_unless_parallel(e, __STACKTRACE__)
       end
     else
       arities = Enum.map(0..(tuple_size(funs) - 1), fn i -> i + min_arity end)
@@ -624,10 +637,24 @@ defmodule PtcRunner.Lisp.Eval.Apply do
         eval_context.tool_exec,
         eval_context.turn_history,
         pmap_timeout: eval_context.pmap_timeout,
+        pmap_max_concurrency: eval_context.pmap_max_concurrency,
+        # Security H1: propagate the sandbox cap, the FIXED per-worker
+        # heap cap, and the shared worker-slot budget so a nested
+        # pmap/pcalls invoked from inside this closure caps and counts
+        # its workers against the same global budget.
+        max_heap: eval_context.max_heap,
+        worker_max_heap: eval_context.worker_max_heap,
+        parallel_budget: eval_context.parallel_budget,
         catalog_exec: eval_context.catalog_exec
       )
 
-    eval_ctx = %{eval_ctx | locals: closure_locals(metadata, bindings)}
+    eval_ctx = %{
+      eval_ctx
+      | locals: closure_locals(metadata, bindings),
+        # Security H1: propagate the shared parallel deadline so a
+        # nested pmap/pcalls inside this closure inherits it.
+        pmap_deadline: eval_context.pmap_deadline
+    }
 
     case do_eval_fn.(body, eval_ctx) do
       {:ok, result, final_ctx} ->
@@ -637,8 +664,38 @@ defmodule PtcRunner.Lisp.Eval.Apply do
         result
 
       {:error, reason} ->
-        raise RuntimeError, Helpers.format_closure_error(reason)
+        raise_closure_error(reason)
     end
+  end
+
+  # Stable parallel error reasons that must survive nesting unchanged.
+  @parallel_reasons [:memory_exceeded, :timeout, :parallel_capacity_exceeded]
+
+  # A closure-eval error from a *nested* pmap/pcalls (heap kill, shared
+  # deadline, exhausted worker budget) is raised as `ExecutionError`
+  # carrying the structured reason, so the surrounding pmap/pcalls worker
+  # can re-surface the stable atom instead of flattening it into a
+  # string. Every other closure error keeps the legacy `RuntimeError`
+  # shape that `do_apply_fun/4`'s rescue clauses convert into `{:error,
+  # ...}`. Parallel errors arrive as 2- or 3-tuples.
+  @spec raise_closure_error(term()) :: no_return()
+  defp raise_closure_error({atom, _} = reason) when atom in @parallel_reasons do
+    raise_parallel_closure_error(atom, reason)
+  end
+
+  defp raise_closure_error({atom, _, _} = reason) when atom in @parallel_reasons do
+    raise_parallel_closure_error(atom, reason)
+  end
+
+  defp raise_closure_error(reason) do
+    raise RuntimeError, Helpers.format_closure_error(reason)
+  end
+
+  @spec raise_parallel_closure_error(atom(), term()) :: no_return()
+  defp raise_parallel_closure_error(atom, reason) do
+    raise PtcRunner.Lisp.ExecutionError,
+      reason: atom,
+      message: Helpers.format_closure_error(reason)
   end
 
   # Side-effect accumulation via Process dictionary.
@@ -722,6 +779,20 @@ defmodule PtcRunner.Lisp.Eval.Apply do
   defp execution_error_tuple(%ExecutionError{reason: reason, message: message, data: data}),
     do: {reason, message, data}
 
+  # An `ExecutionError` raised from a closure run inside a regular HOF.
+  # If it carries a nested-parallel reason (`:memory_exceeded`,
+  # `:timeout`, `:parallel_capacity_exceeded`) surface it as a structured
+  # error tuple so the stable reason reaches the caller. Anything else
+  # (e.g. `:tool_error`) is re-raised unchanged.
+  defp reraise_unless_parallel(%ExecutionError{reason: reason} = e, _stacktrace)
+       when reason in @parallel_reasons do
+    {:error, execution_error_tuple(e)}
+  end
+
+  defp reraise_unless_parallel(%ExecutionError{} = e, stacktrace) do
+    reraise e, stacktrace
+  end
+
   # ============================================================
   # Closure Execution Helpers
   # ============================================================
@@ -785,6 +856,15 @@ defmodule PtcRunner.Lisp.Eval.Apply do
             prints: caller_ctx.prints,
             max_print_length: caller_ctx.max_print_length,
             pmap_timeout: caller_ctx.pmap_timeout,
+            pmap_max_concurrency: caller_ctx.pmap_max_concurrency,
+            # Security H1: propagate the heap caps + shared worker-slot
+            # budget into nested closure evaluation so a nested
+            # pmap/pcalls caps and counts its workers, and the shared
+            # deadline so nested calls share one wall clock.
+            max_heap: caller_ctx.max_heap,
+            worker_max_heap: caller_ctx.worker_max_heap,
+            parallel_budget: caller_ctx.parallel_budget,
+            pmap_deadline: caller_ctx.pmap_deadline,
             tool_calls: caller_ctx.tool_calls,
             pmap_calls: caller_ctx.pmap_calls,
             tool_cache: caller_ctx.tool_cache,

--- a/lib/ptc_runner/lisp/eval/context.ex
+++ b/lib/ptc_runner/lisp/eval/context.ex
@@ -41,6 +41,27 @@ defmodule PtcRunner.Lisp.Eval.Context do
     max_tool_calls: nil,
     pmap_timeout: @default_pmap_timeout,
     pmap_max_concurrency: @default_pmap_max_concurrency,
+    # Absolute monotonic-time deadline (ms) shared by an in-progress
+    # pmap/pcalls operation and all of its nested parallel calls. `nil`
+    # outside any parallel operation; the outermost pmap/pcalls sets it
+    # to `now + pmap_timeout` and nested calls inherit it unchanged, so
+    # N parallel branches cannot multiply total wall time.
+    pmap_deadline: nil,
+    # Per-process heap cap (in words) applied to the sandbox process.
+    # `nil` means no sandbox cap is configured.
+    max_heap: nil,
+    # FIXED `max_heap_size` (in words) applied to every pmap/pcalls
+    # worker — top-level and nested alike — at spawn time. NOT divided
+    # by concurrency: division is unsound for nested parallelism (a
+    # parent worker is alive while its nested children run). Defaults to
+    # the sandbox `max_heap`; overridable. `nil` means no per-worker cap.
+    worker_max_heap: nil,
+    # Shared `PtcRunner.Lisp.Eval.ParallelBudget` slot semaphore — the
+    # HARD global cap on how many pmap/pcalls workers may be alive at
+    # once across the whole `Lisp.run`. ONE object per top-level run;
+    # nested pmap/pcalls inherit and reuse the SAME object. `nil` when
+    # no global cap is configured (uncounted parallel execution).
+    parallel_budget: nil,
     prints: [],
     tool_calls: [],
     pmap_calls: [],
@@ -153,6 +174,10 @@ defmodule PtcRunner.Lisp.Eval.Context do
           max_print_length: pos_integer(),
           pmap_timeout: pos_integer(),
           pmap_max_concurrency: pos_integer(),
+          pmap_deadline: integer() | nil,
+          max_heap: pos_integer() | nil,
+          worker_max_heap: pos_integer() | nil,
+          parallel_budget: PtcRunner.Lisp.Eval.ParallelBudget.t() | nil,
           prints: [String.t()],
           tool_calls: [tool_call()],
           pmap_calls: [pmap_call()],
@@ -179,6 +204,13 @@ defmodule PtcRunner.Lisp.Eval.Context do
   - `:budget` - Budget info map for `(budget/remaining)` introspection (default: nil)
   - `:pmap_timeout` - Timeout in ms for each pmap task (default: 5000). Increase for LLM-backed tools.
   - `:pmap_max_concurrency` - Max concurrent tasks in pmap/pcalls (default: `System.schedulers_online() * 2`)
+  - `:max_heap` - Sandbox per-process heap cap in words (default: nil).
+  - `:worker_max_heap` - FIXED `max_heap_size` (in words) for every
+    pmap/pcalls worker, top-level and nested (default: the `:max_heap`
+    value). Not divided by concurrency. See `PtcRunner.Lisp.Eval.ParallelRunner`.
+  - `:parallel_budget` - shared `PtcRunner.Lisp.Eval.ParallelBudget`
+    semaphore bounding the number of parallel workers alive at once
+    across the whole run (default: nil = uncounted).
   - `:trace_context` - Trace context for nested agent tracing (default: nil)
 
   ## Examples
@@ -214,6 +246,9 @@ defmodule PtcRunner.Lisp.Eval.Context do
       pmap_timeout: Keyword.get(opts, :pmap_timeout, @default_pmap_timeout),
       pmap_max_concurrency:
         Keyword.get(opts, :pmap_max_concurrency, @default_pmap_max_concurrency),
+      max_heap: Keyword.get(opts, :max_heap),
+      worker_max_heap: Keyword.get(opts, :worker_max_heap, Keyword.get(opts, :max_heap)),
+      parallel_budget: Keyword.get(opts, :parallel_budget),
       budget: Keyword.get(opts, :budget),
       trace_context: Keyword.get(opts, :trace_context),
       journal: Keyword.get(opts, :journal),

--- a/lib/ptc_runner/lisp/eval/parallel_budget.ex
+++ b/lib/ptc_runner/lisp/eval/parallel_budget.ex
@@ -1,0 +1,132 @@
+defmodule PtcRunner.Lisp.Eval.ParallelBudget do
+  @moduledoc """
+  A shared, lock-free slot semaphore bounding the number of parallel
+  `pmap`/`pcalls` worker processes alive at once across a whole
+  `PtcRunner.Lisp.run/2`.
+
+  ## Why a global slot budget (and not heap division)
+
+  An earlier model gave each worker `max_heap / concurrency`. That is
+  unsound for *nested* parallelism: a parent `pmap` worker stays alive
+  while its nested children run, so a parent and its children are all
+  live simultaneously — dividing the heap cannot bound the aggregate
+  once nesting compounds.
+
+  The model instead is: every parallel worker (top-level and nested)
+  runs under a **fixed** `max_heap_size` cap, and one shared semaphore
+  with capacity `max_parallel_workers` limits how many such workers may
+  be alive at once. The aggregate guarantee is then simply:
+
+      max live parallel heap ≈ max_parallel_workers × worker_max_heap
+
+  ## Why `:atomics` (not `:counters`, not a GenServer)
+
+  - **`:atomics`** gives `add_get/3` — an atomic increment-and-fetch.
+    Try-acquire is one atomic op with no race: bump the counter, and if
+    the new value exceeds capacity, atomically give it back. No lock,
+    no extra process, no message round-trip.
+  - **`:counters`** has only `add/3` (returns `:ok`) + a separate
+    `get/2`; a try-acquire built from those two has a check-then-act
+    race between concurrent acquirers.
+  - **A GenServer** would add a process to supervise, monitor and clean
+    up, plus a message round-trip on every spawn — all to serialise an
+    operation `:atomics` already does atomically.
+
+  The `:atomics` reference is an opaque term; it is threaded through
+  `EvalContext` and copied into worker closures unchanged — every
+  process operates on the *same* underlying counter.
+
+  ## Acquire / release contract
+
+  - `try_acquire/1` is **non-blocking**. It never waits for a slot —
+    a worker that cannot get one fails fast with
+    `:parallel_capacity_exceeded` rather than deadlocking on a slot that
+    can only free when the worker itself finishes.
+  - Every acquired slot MUST be released on every termination path
+    (normal, timeout, heap kill, cancellation). Callers pair
+    `try_acquire/1` with `release/1` via monitor cleanup / `after`.
+  - Releasing without a held slot is a caller bug. It raises rather
+    than clamping because a decrement-then-clamp release can race with a
+    valid acquire and erase the acquired slot.
+  """
+
+  @enforce_keys [:atomics_ref, :capacity]
+  defstruct [:atomics_ref, :capacity]
+
+  @typedoc "Shared parallel-worker slot budget."
+  @type t :: %__MODULE__{atomics_ref: :atomics.atomics_ref(), capacity: pos_integer()}
+
+  # Single atomic slot holding the count of currently-held slots.
+  @slot 1
+
+  @doc """
+  Creates a budget with `capacity` slots, all initially free.
+  """
+  @spec new(pos_integer()) :: t()
+  def new(capacity) when is_integer(capacity) and capacity > 0 do
+    ref = :atomics.new(1, signed: true)
+    :atomics.put(ref, @slot, 0)
+    %__MODULE__{atomics_ref: ref, capacity: capacity}
+  end
+
+  @doc """
+  Non-blocking attempt to acquire one slot.
+
+  Returns `:ok` if a slot was acquired (the caller now owns it and must
+  `release/1` it), or `:full` if all slots are in use. Never blocks.
+  """
+  @spec try_acquire(t()) :: :ok | :full
+  def try_acquire(%__MODULE__{atomics_ref: ref, capacity: capacity}) do
+    # Atomic increment-and-fetch: claim a slot optimistically.
+    case :atomics.add_get(ref, @slot, 1) do
+      held when held <= capacity ->
+        :ok
+
+      _over ->
+        # Over capacity — atomically hand the slot back.
+        :atomics.sub(ref, @slot, 1)
+        :full
+    end
+  end
+
+  @doc """
+  Releases one previously-acquired slot.
+
+  Safe to call exactly once per successful `try_acquire/1`. Raises if
+  no slot is currently held; underflow is a caller bug and must not be
+  hidden in a hard security budget.
+  """
+  @spec release(t()) :: :ok
+  def release(%__MODULE__{atomics_ref: ref}) do
+    do_release(ref)
+  end
+
+  defp do_release(ref) do
+    case :atomics.get(ref, @slot) do
+      held when held > 0 ->
+        case :atomics.compare_exchange(ref, @slot, held, held - 1) do
+          :ok -> :ok
+          _current -> do_release(ref)
+        end
+
+      _zero ->
+        raise RuntimeError, "parallel budget release underflow"
+    end
+  end
+
+  @doc """
+  Returns the number of slots currently held (for tests / introspection).
+  """
+  @spec held(t()) :: non_neg_integer()
+  def held(%__MODULE__{atomics_ref: ref}) do
+    max(:atomics.get(ref, @slot), 0)
+  end
+
+  @doc """
+  Returns the number of slots currently free.
+  """
+  @spec available(t()) :: non_neg_integer()
+  def available(%__MODULE__{capacity: capacity} = budget) do
+    max(capacity - held(budget), 0)
+  end
+end

--- a/lib/ptc_runner/lisp/eval/parallel_runner.ex
+++ b/lib/ptc_runner/lisp/eval/parallel_runner.ex
@@ -1,0 +1,764 @@
+defmodule PtcRunner.Lisp.Eval.ParallelRunner do
+  @moduledoc """
+  Heap-capped, slot-bounded parallel execution of untrusted PTC-Lisp
+  work (`pmap`/`pcalls`).
+
+  ## Why not `Task.async_stream`
+
+  `max_heap_size` is a *spawn-time* BEAM option: it must be in force the
+  instant a process is created, because the closure (and everything it
+  captures — e.g. a large `data/` snapshot bound by an enclosing `let`)
+  is copied onto the new process heap before any line of the worker
+  function runs. `Task.async_stream` creates the worker process itself,
+  so a heap cap set from inside the worker body is too late by
+  construction: the unbounded closure copy has already happened.
+
+  `ParallelRunner` owns the worker lifecycle so it can pass
+  `{:max_heap_size, ...}` to `Process.spawn` at creation. The cap is then
+  in force from process birth and the closure copy lands on a limited
+  heap — a worker whose captured environment alone exceeds the budget is
+  killed at the first garbage collection.
+
+  ## Heap model: fixed per-worker cap + global slot budget
+
+  Every parallel worker — top-level AND nested — is spawned with the same
+  **fixed** `worker_max_heap` `max_heap_size` with shared-binary
+  accounting enabled. The heap cap is NOT divided by concurrency:
+  dividing is unsound for nested parallelism, because a parent worker
+  stays alive while its nested children run, so a parent and its children
+  are all live at once.
+
+  Instead, a single shared `PtcRunner.Lisp.Eval.ParallelBudget` semaphore
+  (capacity `max_parallel_workers`) bounds how many workers may be alive
+  at once across the *whole* `Lisp.run/2`, at every nesting depth. Each
+  worker acquires exactly one slot before spawn and releases it on every
+  termination path. The aggregate guarantee is:
+
+      max live parallel heap ≈ max_parallel_workers × worker_max_heap
+
+  A worker that wants to spawn nested parallelism with no slot free fails
+  fast with `:parallel_capacity_exceeded` — slot acquisition is a
+  non-blocking try-acquire, so it never deadlocks waiting on a slot that
+  can only free when the worker itself finishes.
+
+  ## Other guarantees
+
+  - **Heap cap at birth** — every worker is spawned with
+    `{:max_heap_size, %{size: worker_max_heap, kill: true,
+    include_shared_binaries: true, ...}}`.
+  - **One shared deadline** — a single absolute `deadline_mono` bounds the
+    whole operation. Nested runner calls inherit the *same* deadline.
+  - **Orphan cleanup** — workers are linked to the calling (sandbox)
+    process, so if it is killed mid-operation the BEAM tears the workers
+    down with it. On the normal failure/success path the runner
+    explicitly kills any worker still alive.
+  - **Deterministic error classification** — abnormal exits map to stable
+    atoms: `:killed → :memory_exceeded`, past-deadline → `:timeout`, any
+    other abnormal exit → `:runtime_error`.
+
+  ## Link vs monitor — and the scoped `trap_exit`
+
+  Each worker is spawned with BOTH `:link` and `:monitor`:
+
+  - `:link` gives **orphan cleanup for free** when the *caller* dies. A
+    plain `:monitor` does not — a monitored worker outlives its dead
+    monitor. Since `run/3` executes synchronously inside the sandbox
+    process, the only signal that reaches a worker when the sandbox is
+    `Process.exit(pid, :kill)`-ed is a link signal.
+  - `:monitor` gives the `{:DOWN, ...}` notification used to classify a
+    worker's exit reason without ambiguity.
+
+  A worker killed by its heap cap exits `:killed`, which would propagate
+  through the link and take the sandbox down too. To prevent that,
+  `run/3` enables `trap_exit` **only for the duration of the call** and
+  restores the prior flag in an `after` block, converting worker link
+  signals into `{:EXIT, _, _}` messages.
+
+  Because the sandbox process may *itself* be linked to its caller (the
+  `link: true` mode of `Sandbox.execute/3`, used by the MCP request
+  worker), the temporary `trap_exit` must not swallow that caller's
+  cancellation. `run/3` therefore distinguishes `{:EXIT, ...}` signals
+  by source: signals from its own workers are handled as worker exits,
+  while an *abnormal* exit from any non-worker is treated as real
+  cancellation — all workers are killed and the exit is re-propagated so
+  linked cancellation still tears the sandbox down. `:normal` exits from
+  non-workers are ignored.
+  """
+
+  alias PtcRunner.Lisp.Eval.ParallelBudget
+  alias PtcRunner.TraceContext
+
+  # Process-dictionary key: append-only `MapSet` of EVERY worker pid
+  # spawned by the in-progress `run/3` call. Never shrinks for the call
+  # — read by the signal drain so it can distinguish our workers' EXITs
+  # (including a just-killed worker's trailing `:killed`) from a linked
+  # caller's cancellation EXIT.
+  @worker_pids_key :__ptc_parallel_runner_worker_pids__
+
+  # Process-dictionary key: registry of workers NOT YET REAPED —
+  # `%{pid => %{ref, slot_held?}}`. A worker is removed the moment a
+  # normal path reaps it (slot released). The `after`-block sweep kills
+  # whatever is left, so a raise partway through `fill_window/1` cannot
+  # orphan a worker or leak its slot. Distinct from `@worker_pids_key`
+  # (which must keep killed workers so their trailing EXIT is still
+  # recognised as ours, not mistaken for caller cancellation).
+  @worker_registry_key :__ptc_parallel_runner_worker_registry__
+
+  @typedoc "Per-worker payload returned by `fun`."
+  @type worker_result :: {:ok, term()} | {:error, term()}
+
+  @typedoc """
+  Options for `run/3`.
+
+  - `:worker_max_heap` - FIXED `max_heap_size` (in words) applied to
+    every worker at spawn time. `nil` means no cap (only when the
+    sandbox is uncapped).
+  - `:max_concurrency` - local scheduling window: max workers this call
+    keeps alive at once (>= 1).
+  - `:budget` - shared `ParallelBudget` semaphore (the HARD global cap on
+    parallel workers across the whole `Lisp.run`). `nil` disables the
+    slot budget (used only when there is no global cap configured).
+  - `:deadline_mono` - absolute monotonic-time deadline in ms shared by
+    the whole operation (including nested runner calls).
+  - `:trace_ctx` - trace context captured in the parent, re-attached
+    inside each worker.
+  - `:spawn_fun` - the 2-arity `(fun, spawn_opts) -> {pid, ref}` used to
+    create each worker (default: `&Process.spawn/2`). A seam for
+    fault-injection tests that need a spawn to raise partway through
+    filling the window; production callers never set it.
+  """
+  @type opts :: [
+          worker_max_heap: pos_integer() | nil,
+          max_concurrency: pos_integer(),
+          budget: ParallelBudget.t() | nil,
+          deadline_mono: integer(),
+          trace_ctx: term(),
+          spawn_fun: (function(), list() -> {pid(), reference()})
+        ]
+
+  @doc """
+  Runs `fun` over `items` in parallel under a fixed per-worker heap cap
+  and a shared global worker-slot budget.
+
+  `fun` is invoked as `fun.(item)` inside a freshly spawned, heap-capped
+  worker process and must return a `worker_result`. The worker re-attaches
+  the supplied trace context before calling `fun`.
+
+  Returns `{:ok, results}` (per-worker return values, in input order) or
+  `{:error, reason}` on the first failure. `reason` is one of:
+
+  - `{:memory_exceeded, index}` - worker `index` was killed by its heap cap
+  - `{:timeout, index}` - the shared deadline elapsed before worker `index`
+    finished
+  - `:parallel_capacity_exceeded` - the global worker-slot budget was
+    exhausted, so a worker could not be started
+  - `{:runtime_error, index, term}` - worker `index` exited abnormally
+  - any `term` from an `{:error, term}` returned by `fun` itself
+  """
+  @spec run([term()], (term() -> worker_result()), opts()) ::
+          {:ok, [term()]} | {:error, term()}
+  def run([], _fun, _opts), do: {:ok, []}
+
+  def run(items, fun, opts) when is_list(items) and is_function(fun, 1) do
+    worker_max_heap = Keyword.get(opts, :worker_max_heap)
+    max_concurrency = opts |> Keyword.fetch!(:max_concurrency) |> normalize_concurrency()
+    budget = Keyword.get(opts, :budget)
+    deadline_mono = Keyword.fetch!(opts, :deadline_mono)
+    trace_ctx = Keyword.get(opts, :trace_ctx)
+    spawn_fun = Keyword.get(opts, :spawn_fun, &Process.spawn/2)
+
+    indexed = items |> Enum.with_index() |> Map.new(fn {item, idx} -> {idx, item} end)
+    total = map_size(indexed)
+
+    state = %{
+      indexed: indexed,
+      fun: fun,
+      worker_max_heap: worker_max_heap,
+      max_concurrency: max_concurrency,
+      budget: budget,
+      deadline_mono: deadline_mono,
+      trace_ctx: trace_ctx,
+      spawn_fun: spawn_fun,
+      total: total,
+      next: 0,
+      # %{ref => %{pid, index, slot_held?: boolean}}
+      live: %{},
+      results: %{},
+      # `true` when the LAST `fill_window/1` could not spawn an item
+      # because the global slot budget was full. It is only a genuine
+      # `:parallel_capacity_exceeded` failure if it persists while NO
+      # worker of this run is live (no slot will ever free for us);
+      # otherwise a live worker finishing frees a slot and filling
+      # resumes. `collect/1` makes that call.
+      budget_blocked?: false
+    }
+
+    # Append-only set of every worker pid ever spawned by this run
+    # (signal-drain EXIT classification), and the not-yet-reaped worker
+    # registry (the `after`-block sweep's safety net). Both live in the
+    # process dictionary so the sweep finds workers even when a raise
+    # mid-`fill_window/1` means the per-iteration `state` never reached
+    # us. Cleared in the `after` block.
+    Process.put(@worker_pids_key, MapSet.new())
+    Process.put(@worker_registry_key, %{})
+
+    # `Process.spawn` raising mid-`fill_window/1` (e.g. the VM process
+    # limit) would otherwise orphan already-spawned workers and leak
+    # their slots + the `trap_exit` flag. So BOTH the `trap_exit` set
+    # and the initial spawn happen INSIDE the `try`; the `after` block
+    # sweeps the registry, killing every still-live worker and releasing
+    # every still-held slot, on every exit path including a raise.
+    prior_trap_exit = Process.flag(:trap_exit, true)
+
+    try do
+      state |> fill_window() |> collect()
+    after
+      # Final orphan/slot cleanup. `sweep_registry/1` kills any worker
+      # still registered (i.e. not already reaped + slot-released by the
+      # normal paths) and releases its slot — this covers a raise
+      # partway through `fill_window/1`.
+      sweep_registry(budget)
+      Process.delete(@worker_registry_key)
+
+      # P2-b — trap_exit restoration / cancellation ordering.
+      #
+      # While `trap_exit` is `true`, an incoming exit signal is converted
+      # into a queued `{:EXIT, _, _}` MESSAGE. Once the flag is restored
+      # to `prior_trap_exit` (false for a normal sandbox), an exit signal
+      # is instead delivered as a direct kill.
+      #
+      # `drain1` (still trapping) catches every cancellation already
+      # converted to a message. But a cancellation signal can still be
+      # *in flight* — sent by the dying linked caller, not yet processed
+      # by this process. A single `receive ... after 0` scan after the
+      # restore can miss it (it has not landed yet); the process would
+      # then run on with the cancellation un-acted-on.
+      #
+      # Ordering argument for the close:
+      #   1. `drain1` runs while `trap_exit` is still true — it drains
+      #      every cancellation ALREADY converted to a message.
+      #   2. `Process.flag/2` restores the flag. From here on an exit
+      #      signal is a direct kill, never a droppable message.
+      #   3. `blocking_cancellation_drain/1` parks this process at a
+      #      signal-processing `receive` for a short BOUNDED window. A
+      #      cancellation still in flight is delivered during that window
+      #      and — `trap_exit` now false — directly kills this process.
+      #      A cancellation that was already a trapped message is matched
+      #      and re-propagated.
+      #
+      # So a cancellation is ALWAYS either (a) a message that drain1 or
+      # the blocking drain re-propagates, or (b) a signal that kills the
+      # process directly. It is never silently swallowed. A cancellation
+      # arriving after the bounded window is still a signal against the
+      # restored flag and kills the (still-running) process at its next
+      # scheduling point — deferred, never lost.
+      cancellation = drain_worker_signals(nil)
+      Process.flag(:trap_exit, prior_trap_exit)
+      cancellation = blocking_cancellation_drain(cancellation)
+      Process.delete(@worker_pids_key)
+
+      if cancellation, do: exit(cancellation)
+    end
+  end
+
+  # Length of the bounded window (ms) over which, after `trap_exit` has
+  # been restored, this process parks at a `receive` so any in-flight
+  # cancellation signal is delivered (as a direct kill) or any trapped
+  # cancellation message is observed. See the P2-b note in `run/3`.
+  @cancellation_drain_window_ms 5
+
+  # Post-restore drain. By this point every worker has been reaped and
+  # unlinked, so the only remaining link is to an external caller (the
+  # `link: true` sandbox's caller). If there is NO such link, no
+  # cancellation is possible — drain the mailbox non-blocking (zero
+  # added latency, the common case). If there IS a linked caller, park
+  # briefly so an in-flight cancellation is delivered: as a direct kill
+  # (`trap_exit` now false) or, if already a trapped message, matched
+  # and re-propagated. See the P2-b ordering argument in `run/3`.
+  defp blocking_cancellation_drain(cancellation) do
+    case Process.info(self(), :links) do
+      {:links, []} -> drain_worker_signals(cancellation)
+      _linked -> drain_cancellations(cancellation, deadline_after(@cancellation_drain_window_ms))
+    end
+  end
+
+  defp deadline_after(ms), do: System.monotonic_time(:millisecond) + ms
+
+  defp drain_cancellations(cancellation, deadline) do
+    timeout = max(deadline - System.monotonic_time(:millisecond), 0)
+
+    receive do
+      {:DOWN, _ref, :process, _pid, _reason} ->
+        drain_cancellations(cancellation, deadline)
+
+      {:worker_result, _pid, _idx, _result} ->
+        drain_cancellations(cancellation, deadline)
+
+      {:EXIT, pid, reason} ->
+        worker_pids = Process.get(@worker_pids_key, MapSet.new())
+
+        case classify_drain_exit(pid, reason, worker_pids) do
+          :drain -> drain_cancellations(cancellation, deadline)
+          {:cancel, cancel_reason} -> drain_cancellations(cancellation || cancel_reason, deadline)
+        end
+    after
+      timeout -> cancellation
+    end
+  end
+
+  # ---- worker registry (process-dictionary; see `run/3`) ----
+
+  defp registry, do: Process.get(@worker_registry_key, %{})
+
+  defp register_worker(pid, ref, slot_held?) do
+    # Append-only "ever spawned" set (drain classification).
+    Process.put(
+      @worker_pids_key,
+      MapSet.put(Process.get(@worker_pids_key, MapSet.new()), pid)
+    )
+
+    # Not-yet-reaped registry (sweep safety net).
+    Process.put(
+      @worker_registry_key,
+      Map.put(registry(), pid, %{ref: ref, slot_held?: slot_held?})
+    )
+  end
+
+  # Remove a worker from the not-yet-reaped registry once a normal path
+  # has reaped it (slot released), so the `after`-block sweep does not
+  # double-kill / double-release it. The append-only `@worker_pids_key`
+  # set deliberately keeps it — the worker's trailing `:killed`/`:normal`
+  # EXIT must still be recognised as ours by the drain.
+  defp unregister_worker(pid) do
+    Process.put(@worker_registry_key, Map.delete(registry(), pid))
+  end
+
+  # `after`-block safety net: kill every worker still in the registry
+  # and release its slot. On the normal paths the registry is already
+  # empty (every worker reaped via `reap_worker/5`); this only fires
+  # when `fill_window/1` raised partway and left workers unreaped.
+  defp sweep_registry(budget) do
+    Enum.each(registry(), fn {pid, %{ref: ref, slot_held?: slot_held?}} ->
+      Process.demonitor(ref, [:flush])
+      Process.unlink(pid)
+      Process.exit(pid, :kill)
+      release_slot(budget, slot_held?)
+    end)
+
+    Process.put(@worker_registry_key, %{})
+  end
+
+  # Spawn workers until the local scheduling window is full, items run
+  # out, the shared deadline has passed, or the global slot budget is
+  # exhausted.
+  defp fill_window(state) do
+    window_open? =
+      spawn_next?(map_size(state.live), state.max_concurrency, state.next, state.total)
+
+    cond do
+      # Window full / all items started — clear any stale block flag.
+      not window_open? ->
+        %{state | budget_blocked?: false}
+
+      # The deadline is re-checked against the live clock before EVERY
+      # spawn: a nested pmap/pcalls may enter `run/3` with an already
+      # expired inherited deadline, and a slot may free up (via
+      # `handle_worker_result/4`) after the deadline elapsed. In both
+      # cases an unstarted item must never start.
+      deadline_passed?(state.deadline_mono) ->
+        %{state | budget_blocked?: false}
+
+      true ->
+        # Try to claim a global worker slot — a non-blocking try-acquire.
+        case acquire_slot(state.budget) do
+          :ok ->
+            state |> spawn_one(true) |> fill_window()
+
+          :no_budget ->
+            # No global budget configured for this run — spawn uncounted.
+            state |> spawn_one(false) |> fill_window()
+
+          :full ->
+            # No slot free right now. Stop filling and record the block.
+            # `collect/1` resolves it: if a live worker finishes, a slot
+            # frees and filling resumes; if NO worker of this run is
+            # live, the budget is held entirely by other parallelism and
+            # the run fails closed with `:parallel_capacity_exceeded`.
+            %{state | budget_blocked?: true}
+        end
+    end
+  end
+
+  # `:ok` — a slot was acquired (must be released on worker termination).
+  # `:full` — budget exhausted.
+  # `:no_budget` — no budget object; nothing to acquire or release.
+  defp acquire_slot(nil), do: :no_budget
+
+  defp acquire_slot(%ParallelBudget{} = budget) do
+    case ParallelBudget.try_acquire(budget) do
+      :ok -> :ok
+      :full -> :full
+    end
+  end
+
+  defp release_slot(_budget, false), do: :ok
+  defp release_slot(nil, true), do: :ok
+  defp release_slot(%ParallelBudget{} = budget, true), do: ParallelBudget.release(budget)
+
+  @doc false
+  # Pure predicate: may `fill_window/1` spawn the next worker right now,
+  # given the live-worker count, the local scheduling cap, the next item
+  # index, and the total item count?
+  #
+  # `false` when the scheduling window is full or when every item has
+  # already been started. The deadline check and the global slot budget
+  # are applied separately in `fill_window/1`. Public only so this logic
+  # can be pinned by a unit test.
+  @spec spawn_next?(non_neg_integer(), pos_integer(), non_neg_integer(), non_neg_integer()) ::
+          boolean()
+  def spawn_next?(live_count, max_concurrency, next, total) do
+    live_count < max_concurrency and next < total
+  end
+
+  @doc false
+  # Has the shared `deadline_mono` already elapsed? When it has,
+  # `fill_window/1` must not start any further worker. Public so this
+  # exact branch is pinned deterministically by a unit test.
+  @spec deadline_passed?(integer()) :: boolean()
+  def deadline_passed?(deadline_mono) do
+    System.monotonic_time(:millisecond) >= deadline_mono
+  end
+
+  # `slot_held?` records whether this worker holds a global budget slot
+  # (so it is released exactly once, when the worker leaves `live`).
+  defp spawn_one(state, slot_held?) do
+    index = state.next
+    item = Map.fetch!(state.indexed, index)
+    parent = self()
+    fun = state.fun
+    trace_ctx = state.trace_ctx
+
+    worker = fn ->
+      # The heap cap is set as a spawn option, so it is in force the
+      # instant this process exists — the closure (and its captured
+      # environment, e.g. a large `let`-bound vector) is copied onto a
+      # heap that is already governed by `max_heap_size`.
+      #
+      # `max_heap_size` with `kill: true` is enforced at garbage
+      # collection. Force one GC immediately so an oversized captured
+      # environment is caught *before* `fun` runs, even when `fun`
+      # itself is too cheap to trigger a GC on its own.
+      :erlang.garbage_collect()
+      TraceContext.attach(trace_ctx)
+      result = fun.(item)
+      send(parent, {:worker_result, self(), index, result})
+    end
+
+    # The budget slot for this worker was already acquired by
+    # `fill_window/1`. If the spawn itself raises (e.g. VM process
+    # limit), that slot is not yet attached to any worker the sweep can
+    # find — release it here before re-raising, so it does not leak.
+    pid_ref =
+      try do
+        state.spawn_fun.(worker, spawn_opts(state.worker_max_heap))
+      rescue
+        e ->
+          release_slot(state.budget, slot_held?)
+          reraise e, __STACKTRACE__
+      end
+
+    {pid, ref} = pid_ref
+
+    # Register BEFORE returning, so even if a later iteration of
+    # `fill_window/1` raises, the `after`-block sweep finds this worker.
+    register_worker(pid, ref, slot_held?)
+
+    %{
+      state
+      | next: index + 1,
+        live: Map.put(state.live, ref, %{pid: pid, index: index, slot_held?: slot_held?})
+    }
+  end
+
+  # `:link` for orphan cleanup when the caller dies; `:monitor` for the
+  # `{:DOWN, ...}` exit-reason notification. See moduledoc.
+  defp spawn_opts(nil), do: [:link, :monitor]
+
+  defp spawn_opts(worker_max_heap) when is_integer(worker_max_heap) and worker_max_heap > 0 do
+    [
+      {:max_heap_size,
+       %{size: worker_max_heap, kill: true, error_logger: false, include_shared_binaries: true}},
+      :link,
+      :monitor
+    ]
+  end
+
+  # Drive the receive loop until all results are in, a worker fails, the
+  # slot budget is genuinely exhausted, or the shared deadline elapses.
+  defp collect(%{results: results, total: total} = state) do
+    cond do
+      # `fill_window/1` could not get a slot AND no worker of this run
+      # is live — no slot will ever free for us, so the global budget
+      # is held entirely by other parallelism. Fail closed. (If a worker
+      # WERE live, we instead fall through to `collect_receive/1`: that
+      # worker finishing frees a slot and filling resumes — so a run
+      # whose own window simply exceeds the budget is never failed, and
+      # nesting cannot deadlock.)
+      state.budget_blocked? and map_size(state.live) == 0 and map_size(results) < total ->
+        finish_error(state, :parallel_capacity_exceeded)
+
+      map_size(results) == total and map_size(state.live) == 0 ->
+        {:ok, ordered_results(results, total)}
+
+      true ->
+        collect_receive(state)
+    end
+  end
+
+  defp collect_receive(state) do
+    remaining = state.deadline_mono - System.monotonic_time(:millisecond)
+
+    if remaining <= 0 do
+      finish_error(state, {:timeout, any_live_index(state)})
+    else
+      receive do
+        {:worker_result, pid, index, result} ->
+          handle_worker_result(state, pid, index, result)
+
+        {:DOWN, ref, :process, _pid, reason} ->
+          handle_down(state, ref, reason)
+
+        {:EXIT, pid, reason} ->
+          handle_exit(state, pid, reason)
+      after
+        remaining ->
+          finish_error(state, {:timeout, any_live_index(state)})
+      end
+    end
+  end
+
+  # A worker has sent its `{:worker_result, ...}`. CRITICAL (P2-a): the
+  # result `send/2` happens *before* the worker process exits, so the
+  # worker may still be alive and still holding its heap. We therefore
+  # do NOT release its budget slot or remove it from `live` here — the
+  # slot belongs to the worker until its termination is *confirmed* by
+  # the monitor `:DOWN`. We only record the result; `handle_down/3`
+  # later releases the slot and frees the `fill_window` capacity. This
+  # guarantees `fill_window` cannot spawn a replacement while the
+  # completed worker is still running, so live workers (and aggregate
+  # heap) never exceed `max_parallel_workers`.
+  # `index` from the message is ignored — the authoritative index is
+  # the one in the worker's `live` entry, keyed by its monitor ref.
+  defp handle_worker_result(state, pid, _index, result) do
+    case pop_by_pid(state.live, pid) do
+      {nil, _live} ->
+        # Worker already reaped (DOWN seen first) — its result is stale.
+        collect(state)
+
+      {%{ref: ref} = info, live_without} ->
+        case result do
+          {:ok, value} ->
+            # Stash the value; keep the worker in `live` (slot still
+            # held) tagged with its result, awaiting its `:DOWN`.
+            entry =
+              info
+              |> Map.delete(:ref)
+              |> Map.put(:result, {:ok, value})
+
+            %{state | live: Map.put(live_without, ref, entry)}
+            |> collect()
+
+          {:error, reason} ->
+            # A `fun`-returned error fails the whole run. The worker is
+            # finishing; `finish_error/2` -> `kill_all/1` reaps it
+            # (releasing its slot) along with the rest.
+            finish_error(state, {:fun_error, reason})
+        end
+    end
+  end
+
+  # A worker's monitor `:DOWN` — the worker process has *actually*
+  # terminated. Termination of a worker is confirmed by `:DOWN` OR by
+  # its `{:EXIT, ...}` (we trap exits); whichever arrives first reaps
+  # the worker via `reap_terminated_worker/3`. This is the single point
+  # where a worker's budget slot is released and its `fill_window`
+  # capacity is freed (P2-a).
+  defp handle_down(state, ref, reason) do
+    case Map.pop(state.live, ref) do
+      {nil, _live} ->
+        # Already reaped (its `{:EXIT, ...}` was handled first).
+        collect(state)
+
+      {info, live} ->
+        reap_terminated_worker(%{state | live: live}, Map.put(info, :ref, ref), reason)
+    end
+  end
+
+  # `{:EXIT, ...}` while `trap_exit` is enabled. See moduledoc.
+  defp handle_exit(state, pid, reason) do
+    case pop_by_pid(state.live, pid) do
+      {%{} = info, live} ->
+        # Case 1: an EXIT from one of our workers — confirms its
+        # termination, exactly like `:DOWN` (it may arrive first).
+        reap_terminated_worker(%{state | live: live}, info, reason)
+
+      {nil, _live} when reason == :normal ->
+        # Case 3: a non-worker exited normally — not cancellation.
+        collect(state)
+
+      {nil, _live} ->
+        # Case 2: abnormal exit from a non-worker (linked caller
+        # cancellation). Tear down workers (releasing their slots),
+        # then propagate so the sandbox process dies.
+        kill_all(state)
+        _ = drain_worker_signals(nil)
+        exit(reason)
+    end
+  end
+
+  # A worker (already removed from `state.live`) has terminated. Reap it
+  # — release its budget slot — then either record its successful result
+  # and resume filling, or fail the run if it died without one.
+  #
+  # `info` carries the per-worker `live` entry plus its `:ref`. If the
+  # worker had already delivered a successful result (P2-a: result and
+  # termination are two events) the `live` entry is tagged `:result`,
+  # and the slot is being released only NOW that termination is
+  # confirmed — never on result receipt.
+  defp reap_terminated_worker(state, %{pid: pid, ref: ref, index: index} = info, reason) do
+    reap_worker(state.budget, pid, ref, info.slot_held?, kill: false)
+
+    case info do
+      %{result: {:ok, value}} ->
+        state
+        |> Map.update!(:results, &Map.put(&1, index, value))
+        |> fill_window()
+        |> collect()
+
+      _no_result ->
+        finish_error(state, classify_down(index, reason))
+    end
+  end
+
+  # Stable classification of an abnormal worker exit (issue H1):
+  # callers can assert ONE reason, not a set.
+  defp classify_down(index, :killed), do: {:memory_exceeded, index}
+  defp classify_down(index, :normal), do: {:runtime_error, index, :exited_without_result}
+  defp classify_down(index, reason), do: {:runtime_error, index, reason}
+
+  # Kill every still-live worker (releasing its slot), then return the
+  # error. A linked caller's abnormal cancellation EXIT seen while
+  # draining is re-propagated rather than masked by the error tuple.
+  defp finish_error(state, error) do
+    kill_all(state)
+
+    case drain_worker_signals(nil) do
+      nil -> {:error, unwrap_error(error)}
+      cancellation -> exit(cancellation)
+    end
+  end
+
+  # A `{:error, term}` returned by `fun` is surfaced as `term` verbatim.
+  defp unwrap_error({:fun_error, term}), do: term
+  defp unwrap_error(other), do: other
+
+  # Kill every live worker and release each one's global budget slot.
+  defp kill_all(state) do
+    Enum.each(state.live, fn {ref, %{pid: pid} = info} ->
+      reap_worker(state.budget, pid, ref, info.slot_held?, kill: true)
+    end)
+  end
+
+  # Reap a worker: demonitor + unlink + (optionally) kill it, release
+  # its global budget slot, and remove it from the registry so the
+  # `after`-block sweep does not double-act on it. The single place
+  # every worker termination path funnels through.
+  defp reap_worker(budget, pid, ref, slot_held?, kill: kill?) do
+    Process.demonitor(ref, [:flush])
+    Process.unlink(pid)
+
+    if kill? do
+      Process.exit(pid, :kill)
+    else
+      drain_exit_for(pid)
+    end
+
+    release_slot(budget, slot_held?)
+    unregister_worker(pid)
+  end
+
+  defp pop_by_pid(live, pid) do
+    case Enum.find(live, fn {_ref, %{pid: p}} -> p == pid end) do
+      {ref, info} -> {Map.put(info, :ref, ref), Map.delete(live, ref)}
+      nil -> {nil, live}
+    end
+  end
+
+  # Drain a possibly-pending `{:EXIT, pid, _}` for a specific worker we
+  # just unlinked, so it never leaks into a later receive.
+  defp drain_exit_for(pid) do
+    receive do
+      {:EXIT, ^pid, _reason} -> :ok
+    after
+      0 -> :ok
+    end
+  end
+
+  # Drain stray worker signals; see moduledoc. Returns a non-worker
+  # abnormal-EXIT cancellation reason if one was seen, else `nil`.
+  defp drain_worker_signals(cancellation) do
+    receive do
+      {:DOWN, _ref, :process, _pid, _reason} ->
+        drain_worker_signals(cancellation)
+
+      {:worker_result, _pid, _idx, _result} ->
+        drain_worker_signals(cancellation)
+
+      {:EXIT, pid, reason} ->
+        # Use the APPEND-ONLY ever-spawned set, not the not-yet-reaped
+        # registry: a worker just reaped (e.g. heap-killed, slot
+        # released, unregistered) can still have a trailing
+        # `{:EXIT, _, :killed}` in the mailbox, and that EXIT is still
+        # ours — it must be drained, not mistaken for caller cancellation.
+        worker_pids = Process.get(@worker_pids_key, MapSet.new())
+
+        case classify_drain_exit(pid, reason, worker_pids) do
+          :drain -> drain_worker_signals(cancellation)
+          {:cancel, cancel_reason} -> drain_worker_signals(cancellation || cancel_reason)
+        end
+    after
+      0 -> cancellation
+    end
+  end
+
+  @doc false
+  # Pure classification of an `{:EXIT, pid, reason}` seen during the
+  # finish-path drain, given the set of known (still-registered) worker
+  # pids.
+  #
+  #   - EXIT from a known worker            -> `:drain`
+  #   - `:normal` EXIT from a non-worker    -> `:drain`
+  #   - abnormal EXIT from a non-worker     -> `{:cancel, reason}`
+  @spec classify_drain_exit(pid(), term(), MapSet.t()) :: :drain | {:cancel, term()}
+  def classify_drain_exit(pid, reason, worker_pids) do
+    cond do
+      MapSet.member?(worker_pids, pid) -> :drain
+      reason == :normal -> :drain
+      true -> {:cancel, reason}
+    end
+  end
+
+  defp ordered_results(results, total) do
+    Enum.map(0..(total - 1), fn idx -> Map.fetch!(results, idx) end)
+  end
+
+  defp any_live_index(%{live: live}) do
+    case Enum.min_by(live, fn {_ref, %{index: idx}} -> idx end, fn -> nil end) do
+      {_ref, %{index: idx}} -> idx
+      nil -> 0
+    end
+  end
+
+  defp normalize_concurrency(c) when is_integer(c) and c > 0, do: c
+  defp normalize_concurrency(_), do: 1
+end

--- a/lib/ptc_runner/sandbox.ex
+++ b/lib/ptc_runner/sandbox.ex
@@ -11,11 +11,31 @@ defmodule PtcRunner.Sandbox do
   |----------|---------|--------|
   | Timeout | 1,000 ms | `:timeout` |
   | Max Heap | ~10 MB (1,250,000 words) | `:max_heap` |
+  | Worker Max Heap | = `:max_heap` | `:worker_max_heap` |
+  | Max Parallel Workers | 8 | `:max_parallel_workers` |
 
-  The `:max_heap` limit is enforced via BEAM's `:max_heap_size` process flag
-  with `include_shared_binaries: true`, so it accounts for both process-local
-  heap terms and shared (refc) binaries referenced by the process. This prevents
-  binary-heavy programs from exceeding the memory budget via off-heap allocations.
+  `:max_heap` sets a `max_heap_size` flag on the sandbox process. That
+  flag is per-process and is *not* inherited by child processes, so the
+  PTC-Lisp `pmap`/`pcalls` builtins spawn each worker (via
+  `PtcRunner.Lisp.Eval.ParallelRunner`) with its OWN fixed
+  `max_heap_size` of `:worker_max_heap` words. The number of parallel
+  workers alive at once — across the whole run, at every nesting depth —
+  is capped by a shared slot semaphore of `:max_parallel_workers`
+  (`PtcRunner.Lisp.Eval.ParallelBudget`). Aggregate live parallel heap
+  is therefore bounded by:
+
+      max_parallel_workers × worker_max_heap
+
+  A pmap/pcalls worker that cannot obtain a slot fails the run with
+  `:parallel_capacity_exceeded` (no sequential fallback). The top-level
+  sandbox process is not counted as a parallel slot.
+
+  The `:max_heap` sandbox limit and each `:worker_max_heap` parallel-worker
+  limit are enforced via BEAM's `:max_heap_size` process flag with
+  `include_shared_binaries: true`, so they account for both process-local heap
+  terms and shared (refc) binaries referenced by the process. This prevents
+  binary-heavy programs from exceeding the memory budget via off-heap
+  allocations.
 
   Note that this is a per-process BEAM budget, not a whole-node or container
   memory limit. For adversarial multi-tenant deployments, back this with an

--- a/mcp_server/lib/ptc_runner_mcp/sandbox.ex
+++ b/mcp_server/lib/ptc_runner_mcp/sandbox.ex
@@ -195,13 +195,9 @@ defmodule PtcRunnerMcp.Sandbox do
     #
     # except for runtime-floor tiny limits, where one worker at the BEAM
     # minimum is the tightest enforceable cap.
+
     # § 9.3: a `data/<key>` reference for an absent key must produce
     # a runtime_error naming the binding, not silently return nil.
-    # No :signature passed to Lisp.run/2 — MCP performs signature
-    # validation post-hoc via `PtcToolProtocol.validate_return/2` so
-    # parse errors are caught before permit acquisition (§ 9.4) and
-    # validation errors render through the MCP `validation_error`
-    # path with `to_json_value/1` for the `validated` field (§ 13).
     base =
       ([
          caller: :mcp,
@@ -217,6 +213,12 @@ defmodule PtcRunnerMcp.Sandbox do
       |> then(fn opts ->
         if catalog_exec, do: Keyword.put(opts, :catalog_exec, catalog_exec), else: opts
       end)
+
+    # No :signature passed to Lisp.run/2 — MCP performs signature
+    # validation post-hoc via `PtcToolProtocol.validate_return/2` so
+    # parse errors are caught before permit acquisition (§ 9.4) and
+    # validation errors render through the MCP `validation_error`
+    # path with `to_json_value/1` for the `validated` field (§ 13).
 
     # Phase 4: when called from a per-call worker (Stdio), `link: true`
     # tells the inner `PtcRunner.Sandbox` to spawn its child linked

--- a/mcp_server/lib/ptc_runner_mcp/sandbox.ex
+++ b/mcp_server/lib/ptc_runner_mcp/sandbox.ex
@@ -88,6 +88,7 @@ defmodule PtcRunnerMcp.Sandbox do
   # which trips on virtually any allocation — preserving "tight cap
   # → tight enforcement" semantics.
   @min_max_heap_words 233
+  @default_max_parallel_workers 8
 
   @typedoc "Already-parsed signature term, or `nil` when no signature was supplied."
   @type parsed_signature :: term() | nil
@@ -181,31 +182,38 @@ defmodule PtcRunnerMcp.Sandbox do
     # crashing the spawn.
     timeout_ms = Limits.program_timeout_ms()
 
-    max_heap_words =
-      max(
-        @min_max_heap_words,
-        div(Limits.program_memory_limit_bytes(), @bytes_per_word)
-      )
+    max_heap_words = max_heap_words_from_limit()
 
+    # Preserve MCP's configured program memory limit as an aggregate
+    # parallel-worker budget. Lisp.run/2 defaults to
+    # `worker_max_heap == max_heap` and `max_parallel_workers == 8`,
+    # which is appropriate for in-process callers but would multiply
+    # MCP's user-facing program limit by 8 for pmap/pcalls. Derive an
+    # MCP-specific per-worker cap so:
+    #
+    #   max_parallel_workers * worker_max_heap <= max_heap_words
+    #
+    # except for runtime-floor tiny limits, where one worker at the BEAM
+    # minimum is the tightest enforceable cap.
+    # § 9.3: a `data/<key>` reference for an absent key must produce
+    # a runtime_error naming the binding, not silently return nil.
+    # No :signature passed to Lisp.run/2 — MCP performs signature
+    # validation post-hoc via `PtcToolProtocol.validate_return/2` so
+    # parse errors are caught before permit acquisition (§ 9.4) and
+    # validation errors render through the MCP `validation_error`
+    # path with `to_json_value/1` for the `validated` field (§ 13).
     base =
-      [
-        caller: :mcp,
-        profile: profile,
-        memory: %{},
-        tools: tools,
-        tool_cache: %{},
-        context: context,
-        timeout: timeout_ms,
-        max_heap: max_heap_words,
-        # § 9.3: a `data/<key>` reference for an absent key must produce
-        # a runtime_error naming the binding, not silently return nil.
-        strict_data: true
-        # No :signature passed to Lisp.run/2 — MCP performs signature
-        # validation post-hoc via `PtcToolProtocol.validate_return/2` so
-        # parse errors are caught before permit acquisition (§ 9.4) and
-        # validation errors render through the MCP `validation_error`
-        # path with `to_json_value/1` for the `validated` field (§ 13).
-      ]
+      ([
+         caller: :mcp,
+         profile: profile,
+         memory: %{},
+         tools: tools,
+         tool_cache: %{},
+         context: context,
+         timeout: timeout_ms,
+         max_heap: max_heap_words,
+         strict_data: true
+       ] ++ parallel_limit_opts(max_heap_words))
       |> then(fn opts ->
         if catalog_exec, do: Keyword.put(opts, :catalog_exec, catalog_exec), else: opts
       end)
@@ -335,5 +343,27 @@ defmodule PtcRunnerMcp.Sandbox do
       String.contains?(reason_str, "memory") -> :memory_limit
       true -> :runtime_error
     end
+  end
+
+  @doc false
+  @spec max_heap_words_from_limit(pos_integer()) :: pos_integer()
+  def max_heap_words_from_limit(limit_bytes \\ Limits.program_memory_limit_bytes())
+      when is_integer(limit_bytes) and limit_bytes > 0 do
+    max(@min_max_heap_words, div(limit_bytes, @bytes_per_word))
+  end
+
+  @doc false
+  @spec parallel_limit_opts(pos_integer()) :: keyword(pos_integer())
+  def parallel_limit_opts(max_heap_words)
+      when is_integer(max_heap_words) and max_heap_words > 0 do
+    max_parallel_workers =
+      min(@default_max_parallel_workers, max(1, div(max_heap_words, @min_max_heap_words)))
+
+    worker_max_heap = max(@min_max_heap_words, div(max_heap_words, max_parallel_workers))
+
+    [
+      worker_max_heap: worker_max_heap,
+      max_parallel_workers: max_parallel_workers
+    ]
   end
 end

--- a/mcp_server/lib/ptc_runner_mcp/sessions/session.ex
+++ b/mcp_server/lib/ptc_runner_mcp/sessions/session.ex
@@ -13,6 +13,7 @@ defmodule PtcRunnerMcp.Sessions.Session do
   alias PtcRunner.PtcToolProtocol
   alias PtcRunnerMcp.Limits, as: McpLimits
   alias PtcRunnerMcp.PayloadMetrics
+  alias PtcRunnerMcp.Sandbox
   alias PtcRunnerMcp.Sessions.{Limits, Owner, Projection, Registry}
 
   @bytes_per_word :erlang.system_info(:wordsize)
@@ -726,24 +727,26 @@ defmodule PtcRunnerMcp.Sessions.Session do
   @doc false
   @spec lisp_opts(map(), String.t(), map()) :: keyword()
   def lisp_opts(snapshot, _program, opts) when is_map(snapshot) and is_map(opts) do
-    [
-      memory: snapshot.memory,
-      turn_history: snapshot.turn_history,
-      context: Map.get(opts, :context, %{}),
-      tools: Map.get(opts, :tools, []),
-      tool_cache: %{},
-      caller: :mcp,
-      profile: Map.get(opts, :profile, :mcp_no_tools),
-      timeout: Map.get(opts, :timeout, McpLimits.program_timeout_ms()),
-      max_heap:
-        Map.get(
-          opts,
-          :max_heap,
-          max(@min_max_heap_words, div(McpLimits.program_memory_limit_bytes(), @bytes_per_word))
-        ),
-      strict_data: true,
-      link: true
-    ]
+    max_heap =
+      Map.get(
+        opts,
+        :max_heap,
+        max(@min_max_heap_words, div(McpLimits.program_memory_limit_bytes(), @bytes_per_word))
+      )
+
+    ([
+       memory: snapshot.memory,
+       turn_history: snapshot.turn_history,
+       context: Map.get(opts, :context, %{}),
+       tools: Map.get(opts, :tools, []),
+       tool_cache: %{},
+       caller: :mcp,
+       profile: Map.get(opts, :profile, :mcp_no_tools),
+       timeout: Map.get(opts, :timeout, McpLimits.program_timeout_ms()),
+       max_heap: max_heap,
+       strict_data: true,
+       link: true
+     ] ++ Sandbox.parallel_limit_opts(max_heap))
     |> maybe_put(:catalog_exec, Map.get(opts, :catalog_exec))
   end
 

--- a/mcp_server/test/ptc_runner_mcp/sandbox_phase0_test.exs
+++ b/mcp_server/test/ptc_runner_mcp/sandbox_phase0_test.exs
@@ -189,5 +189,22 @@ defmodule PtcRunnerMcp.SandboxPhase0Test do
       assert payload["status"] == "error"
       assert payload["reason"] == "memory_limit"
     end
+
+    test "parallel worker limits preserve the MCP aggregate memory budget" do
+      max_heap_words = div(10 * 1024 * 1024, :erlang.system_info(:wordsize))
+
+      opts = Sandbox.parallel_limit_opts(max_heap_words)
+
+      assert opts[:max_parallel_workers] == 8
+      assert opts[:worker_max_heap] > 0
+      assert opts[:worker_max_heap] * opts[:max_parallel_workers] <= max_heap_words
+    end
+
+    test "tiny MCP memory budgets use the tightest single-worker cap" do
+      opts = Sandbox.parallel_limit_opts(233)
+
+      assert opts[:max_parallel_workers] == 1
+      assert opts[:worker_max_heap] == 233
+    end
   end
 end

--- a/mcp_server/test/ptc_runner_mcp/sessions_test.exs
+++ b/mcp_server/test/ptc_runner_mcp/sessions_test.exs
@@ -13,6 +13,7 @@ defmodule PtcRunnerMcp.SessionsTest do
   alias PtcRunnerMcp.Sessions.Limits, as: SessionLimits
   alias PtcRunnerMcp.Sessions.Owner
   alias PtcRunnerMcp.Sessions.Registry
+  alias PtcRunnerMcp.Sessions.Session
   alias PtcRunnerMcp.Stdio
   alias PtcRunnerMcp.Test.JsonRpcHarness
   alias PtcRunnerMcp.Tools
@@ -40,6 +41,14 @@ defmodule PtcRunnerMcp.SessionsTest do
 
     refute "ptc_session_start" in names
     refute "ptc_session_eval" in names
+  end
+
+  test "session Lisp opts preserve the aggregate parallel memory budget" do
+    snapshot = %{memory: %{}, turn_history: []}
+    opts = Session.lisp_opts(snapshot, "(+ 1 2)", %{max_heap: 1_250_000})
+
+    assert opts[:max_parallel_workers] == 8
+    assert opts[:worker_max_heap] * opts[:max_parallel_workers] <= opts[:max_heap]
   end
 
   test "session tools advertise output schemas when enabled" do

--- a/test/ptc_runner/lisp/eval/parallel_budget_test.exs
+++ b/test/ptc_runner/lisp/eval/parallel_budget_test.exs
@@ -1,0 +1,86 @@
+defmodule PtcRunner.Lisp.Eval.ParallelBudgetTest do
+  @moduledoc """
+  Unit tests for `ParallelBudget` — the shared, lock-free slot semaphore
+  that bounds the number of parallel pmap/pcalls workers alive at once.
+  """
+  use ExUnit.Case, async: true
+
+  alias PtcRunner.Lisp.Eval.ParallelBudget
+
+  describe "acquire / release" do
+    test "a fresh budget has all slots free" do
+      budget = ParallelBudget.new(3)
+      assert ParallelBudget.held(budget) == 0
+      assert ParallelBudget.available(budget) == 3
+    end
+
+    test "try_acquire claims slots up to capacity, then reports :full" do
+      budget = ParallelBudget.new(2)
+
+      assert :ok = ParallelBudget.try_acquire(budget)
+      assert :ok = ParallelBudget.try_acquire(budget)
+      assert ParallelBudget.held(budget) == 2
+
+      # Capacity exhausted — non-blocking, returns :full immediately.
+      assert :full = ParallelBudget.try_acquire(budget)
+      assert ParallelBudget.held(budget) == 2
+    end
+
+    test "release frees a slot back to the pool" do
+      budget = ParallelBudget.new(1)
+
+      assert :ok = ParallelBudget.try_acquire(budget)
+      assert :full = ParallelBudget.try_acquire(budget)
+
+      ParallelBudget.release(budget)
+      assert ParallelBudget.available(budget) == 1
+
+      # The freed slot can be re-acquired.
+      assert :ok = ParallelBudget.try_acquire(budget)
+    end
+
+    test "held count returns to zero after every slot is released" do
+      budget = ParallelBudget.new(3)
+
+      for _ <- 1..3, do: assert(:ok = ParallelBudget.try_acquire(budget))
+      assert ParallelBudget.held(budget) == 3
+
+      for _ <- 1..3, do: ParallelBudget.release(budget)
+      assert ParallelBudget.held(budget) == 0
+      assert ParallelBudget.available(budget) == 3
+    end
+
+    test "release underflow raises and leaves the held count unchanged" do
+      budget = ParallelBudget.new(2)
+
+      assert_raise RuntimeError, "parallel budget release underflow", fn ->
+        ParallelBudget.release(budget)
+      end
+
+      assert ParallelBudget.held(budget) == 0
+      assert :ok = ParallelBudget.try_acquire(budget)
+      assert ParallelBudget.held(budget) == 1
+    end
+  end
+
+  describe "concurrent acquisition" do
+    test "exactly `capacity` of N racing acquirers succeed" do
+      capacity = 4
+      racers = 40
+      budget = ParallelBudget.new(capacity)
+      test_pid = self()
+
+      # Many processes race to acquire. The lock-free `add_get`
+      # try-acquire must hand out no more than `capacity` slots total.
+      for _ <- 1..racers do
+        spawn(fn -> send(test_pid, {:result, ParallelBudget.try_acquire(budget)}) end)
+      end
+
+      results = for _ <- 1..racers, do: assert_receive({:result, r}) && r
+
+      assert Enum.count(results, &(&1 == :ok)) == capacity
+      assert Enum.count(results, &(&1 == :full)) == racers - capacity
+      assert ParallelBudget.held(budget) == capacity
+    end
+  end
+end

--- a/test/ptc_runner/lisp/eval/parallel_runner_test.exs
+++ b/test/ptc_runner/lisp/eval/parallel_runner_test.exs
@@ -1,0 +1,879 @@
+defmodule PtcRunner.Lisp.Eval.ParallelRunnerTest do
+  @moduledoc """
+  Unit tests for `ParallelRunner` — the heap-capped worker runner that
+  replaces `Task.async_stream` in the untrusted pmap/pcalls paths.
+
+  These exercise the runner directly (no Lisp layer) so the lifecycle
+  guarantees — heap cap at spawn, ordering, deadline, error
+  classification, orphan cleanup — are pinned independently.
+
+  Worker synchronisation uses message passing and monitors (never
+  `Process.sleep` as test scaffolding).
+  """
+  use ExUnit.Case, async: true
+
+  alias PtcRunner.Lisp.Eval.ParallelBudget
+  alias PtcRunner.Lisp.Eval.ParallelRunner
+
+  # A far-future deadline for tests that should not time out.
+  defp far_deadline, do: System.monotonic_time(:millisecond) + 60_000
+
+  defp base_opts(extra \\ []) do
+    Keyword.merge(
+      [
+        worker_max_heap: nil,
+        max_concurrency: 4,
+        budget: nil,
+        deadline_mono: far_deadline(),
+        trace_ctx: nil
+      ],
+      extra
+    )
+  end
+
+  # Block a worker until the test sends it `:go` (so the test controls
+  # completion ordering without sleeps).
+  defp wait_for_go do
+    receive do
+      :go -> :ok
+    end
+  end
+
+  describe "basic execution" do
+    test "empty input returns {:ok, []}" do
+      assert {:ok, []} = ParallelRunner.run([], fn x -> {:ok, x} end, base_opts())
+    end
+
+    test "maps fun over items and preserves input ordering" do
+      # Each worker announces itself, then waits for an explicit `:go`.
+      # The test releases them in REVERSE order; results must still be
+      # aligned to the input positions.
+      test_pid = self()
+
+      fun = fn item ->
+        send(test_pid, {:ready, item, self()})
+        wait_for_go()
+        {:ok, item}
+      end
+
+      parent =
+        spawn(fn ->
+          send(test_pid, {:result, ParallelRunner.run([:a, :b, :c, :d], fun, base_opts())})
+        end)
+
+      _ref = Process.monitor(parent)
+
+      workers =
+        Map.new(for _ <- 1..4, do: assert_receive({:ready, item, pid}) && {item, pid})
+
+      # Release in reverse input order.
+      for item <- [:d, :c, :b, :a], do: send(workers[item], :go)
+
+      assert_receive {:result, {:ok, [:a, :b, :c, :d]}}
+    end
+
+    test "respects max_concurrency (never more than N workers alive)" do
+      # Each worker reports the live count it observed; the peak must
+      # not exceed max_concurrency.
+      {:ok, agent} = start_supervised({Agent, fn -> {0, 0} end})
+
+      fun = fn _ ->
+        Agent.update(agent, fn {live, peak} -> {live + 1, max(peak, live + 1)} end)
+        Agent.update(agent, fn {live, peak} -> {live - 1, peak} end)
+        {:ok, :done}
+      end
+
+      assert {:ok, results} =
+               ParallelRunner.run(Enum.to_list(1..12), fun, base_opts(max_concurrency: 3))
+
+      assert length(results) == 12
+      {_live, peak} = Agent.get(agent, & &1)
+      assert peak <= 3
+    end
+
+    test "an {:error, _} returned by fun is surfaced verbatim" do
+      fun = fn
+        2 -> {:error, :boom}
+        x -> {:ok, x}
+      end
+
+      assert {:error, :boom} = ParallelRunner.run([1, 2, 3], fun, base_opts())
+    end
+  end
+
+  describe "heap cap at spawn time" do
+    test "a worker whose work exceeds worker_max_heap is killed -> :memory_exceeded" do
+      fun = fn _ ->
+        _huge = Enum.to_list(1..2_000_000)
+        {:ok, :should_not_reach}
+      end
+
+      assert {:error, {:memory_exceeded, 0}} =
+               ParallelRunner.run([:a], fun, base_opts(worker_max_heap: 50_000))
+    end
+
+    test "the cap is in force before the worker body runs (closure copy)" do
+      # The captured `big` lands on the worker heap at spawn. With the
+      # cap set as a creation option, the oversized closure copy is
+      # killed even though the body itself never allocates.
+      big = Enum.to_list(1..2_000_000)
+      fun = fn _ -> {:ok, length(big)} end
+
+      assert {:error, {:memory_exceeded, 0}} =
+               ParallelRunner.run([:a], fun, base_opts(worker_max_heap: 50_000))
+    end
+  end
+
+  describe "spawn failure partway through filling the window" do
+    test "a raise mid-fill leaks no worker and no budget slot" do
+      # Round-8 P2: the initial `fill_window/1` runs inside `run/3`'s
+      # `try ... after`. A spawn that raises after earlier workers in the
+      # same fill already spawned + acquired slots must still trigger the
+      # kill-all-workers + slot-release cleanup.
+      #
+      # `:spawn_fun` is a fault-injection seam: it spawns normally for
+      # the first 3 workers, then raises on the 4th — simulating a VM
+      # process-limit failure partway through the window.
+      test_pid = self()
+      budget = ParallelBudget.new(8)
+
+      {:ok, counter} = start_supervised({Agent, fn -> 0 end})
+
+      spawn_fun = fn worker, opts ->
+        n = Agent.get_and_update(counter, fn n -> {n + 1, n + 1} end)
+        if n >= 4, do: raise("injected spawn failure")
+        {pid, ref} = Process.spawn(worker, opts)
+        send(test_pid, {:spawned, pid})
+        {pid, ref}
+      end
+
+      # Workers block forever — so if any survived the cleanup, they
+      # would still be alive when we check.
+      fun = fn _ -> wait_for_go() end
+
+      opts =
+        base_opts(
+          budget: budget,
+          max_concurrency: 8,
+          spawn_fun: spawn_fun
+        )
+
+      # `run/3` re-raises the injected failure after its `after`-block
+      # cleanup; the caller sees the raise.
+      assert_raise RuntimeError, ~r/injected spawn failure/, fn ->
+        ParallelRunner.run([:a, :b, :c, :d, :e], fun, opts)
+      end
+
+      # The 3 workers that DID spawn before the failure must all be dead
+      # — killed by the `after`-block sweep, not orphaned.
+      spawned = collect_pids(:spawned, [])
+      assert length(spawned) == 3
+      refs = Enum.map(spawned, &Process.monitor/1)
+      for ref <- refs, do: assert_receive({:DOWN, ^ref, :process, _, _}, 1_000)
+
+      # Every acquired budget slot must have been released.
+      assert ParallelBudget.held(budget) == 0
+    end
+
+    test "a raise on the very first spawn leaks no slot" do
+      # The slot for worker 0 is acquired by `fill_window/1` before
+      # `spawn_one/2` calls `spawn_fun`; a raise there must still release
+      # it (covered by `spawn_one/2`'s own rescue, before any worker is
+      # registered for the sweep).
+      budget = ParallelBudget.new(4)
+
+      spawn_fun = fn _worker, _opts -> raise "injected immediate failure" end
+
+      assert_raise RuntimeError, ~r/injected immediate failure/, fn ->
+        ParallelRunner.run(
+          [:a, :b],
+          fn _ -> {:ok, :x} end,
+          base_opts(budget: budget, spawn_fun: spawn_fun)
+        )
+      end
+
+      assert ParallelBudget.held(budget) == 0
+    end
+
+    test "pending abnormal worker EXIT does not mask a later spawn failure" do
+      # Regression: the after-block cleanup used to delete the
+      # append-only worker pid set before the final worker-signal drain.
+      # If worker 1 had already exited abnormally and worker 2's spawn
+      # then raised, the pending `{:EXIT, worker1, :boom}` was
+      # misclassified as non-worker cancellation and `run/3` exited
+      # :boom, masking the real spawn failure.
+      budget = ParallelBudget.new(4)
+      {:ok, state} = start_supervised({Agent, fn -> %{count: 0, first_ref: nil} end})
+
+      spawn_fun = fn _worker, opts ->
+        {n, first_ref} =
+          Agent.get_and_update(state, fn %{count: count, first_ref: first_ref} = state ->
+            {{count + 1, first_ref}, %{state | count: count + 1}}
+          end)
+
+        if n == 1 do
+          {pid, ref} = Process.spawn(fn -> exit(:boom) end, opts)
+          Agent.update(state, &%{&1 | first_ref: ref})
+          {pid, ref}
+        else
+          receive do
+            {:DOWN, ^first_ref, :process, _pid, :boom} ->
+              :ok
+          after
+            1_000 ->
+              raise "first worker did not exit"
+          end
+
+          raise "injected spawn failure"
+        end
+      end
+
+      assert_raise RuntimeError, ~r/injected spawn failure/, fn ->
+        ParallelRunner.run(
+          [:first, :second],
+          fn _ -> {:ok, :unused} end,
+          base_opts(budget: budget, max_concurrency: 2, spawn_fun: spawn_fun)
+        )
+      end
+
+      assert ParallelBudget.held(budget) == 0
+    end
+  end
+
+  describe "worker lifecycle: slot released on termination, not result (P2-a)" do
+    # `:spawn_fun` seam that makes every worker LINGER after it has
+    # delivered its `{:worker_result, ...}`: the wrapper runs the real
+    # worker fn (which sends the result) and then blocks on a `:release`
+    # message before letting the process exit. So between "result
+    # delivered" and "process terminated" the worker is provably alive —
+    # exactly the window P2-a is about.
+    defp lingering_spawn_fun(test_pid) do
+      fn worker, opts ->
+        wrapped = fn ->
+          worker.()
+          send(test_pid, {:worker_lingering, self()})
+
+          receive do
+            :release -> :ok
+          end
+        end
+
+        Process.spawn(wrapped, opts)
+      end
+    end
+
+    test "a completed-but-lingering worker keeps its slot; fill_window cannot exceed the budget" do
+      # Budget 2, window 4, 4 items. With P2-a the slot is released only
+      # on the worker's `:DOWN` — so while workers 0 and 1 have delivered
+      # results but their processes still linger, NO slot is free and
+      # `fill_window` cannot start workers 2 and 3. The budget stays
+      # fully held; live workers never exceed `max_parallel_workers`.
+      #
+      # WITHOUT P2-a (slot released on result receipt) `fill_window`
+      # would spawn replacements while the lingering workers are still
+      # alive — 3+ live at once, breaking the bound.
+      test_pid = self()
+      budget = ParallelBudget.new(2)
+
+      runner =
+        spawn(fn ->
+          send(
+            test_pid,
+            {:result,
+             ParallelRunner.run(
+               [0, 1, 2, 3],
+               fn x -> {:ok, x} end,
+               base_opts(
+                 budget: budget,
+                 max_concurrency: 4,
+                 spawn_fun: lingering_spawn_fun(test_pid)
+               )
+             )}
+          )
+        end)
+
+      _ = Process.monitor(runner)
+
+      # Exactly 2 workers (the budget) reach the lingering point. A 3rd
+      # would only appear if a slot were wrongly freed on result receipt.
+      first = collect_pids(:worker_lingering, [])
+      assert length(first) == 2, "expected exactly 2 lingering workers, got #{length(first)}"
+
+      # Both slots are still held while those 2 workers linger — the run
+      # has their results but cannot free capacity until they terminate.
+      assert ParallelBudget.held(budget) == 2
+
+      # Release the 2 lingering workers; their `:DOWN` frees the slots,
+      # and only THEN do workers 2 and 3 get to run.
+      for pid <- first, do: send(pid, :release)
+
+      second = collect_pids(:worker_lingering, [])
+      assert length(second) == 2
+
+      # Still never more than `max_parallel_workers` (2) live at once.
+      assert ParallelBudget.held(budget) == 2
+      for pid <- second, do: send(pid, :release)
+
+      assert_receive {:result, {:ok, [0, 1, 2, 3]}}, 2_000
+      assert ParallelBudget.held(budget) == 0
+    end
+  end
+
+  describe "deadline" do
+    test "a worker past the shared deadline yields :timeout" do
+      # Worker blocks forever (until killed); deadline is in the past.
+      fun = fn _ -> wait_for_go() end
+      deadline = System.monotonic_time(:millisecond) + 30
+
+      assert {:error, {:timeout, _index}} =
+               ParallelRunner.run([:a, :b], fun, base_opts(deadline_mono: deadline))
+    end
+
+    test "timeout is distinct from memory_exceeded" do
+      fun = fn _ -> wait_for_go() end
+      deadline = System.monotonic_time(:millisecond) + 30
+
+      assert {:error, {:timeout, _}} =
+               ParallelRunner.run([:a], fun, base_opts(deadline_mono: deadline))
+    end
+
+    test "deadline_passed? gates spawning before vs after the deadline" do
+      # Round-6 P2 fix, pinned deterministically. `fill_window/1` calls
+      # `deadline_passed?/1` before every spawn; this is the exact
+      # branch that stops a worker from starting past the deadline.
+      now = System.monotonic_time(:millisecond)
+
+      # Comfortably in the future -> not passed, spawning still allowed.
+      refute ParallelRunner.deadline_passed?(now + 60_000)
+
+      # In the past -> passed, no further worker may start.
+      assert ParallelRunner.deadline_passed?(now - 1_000)
+
+      # The window/total predicate is independent of the deadline.
+      assert ParallelRunner.spawn_next?(0, 4, 0, 4)
+      refute ParallelRunner.spawn_next?(4, 4, 0, 4)
+      refute ParallelRunner.spawn_next?(0, 4, 4, 4)
+    end
+
+    test "an already-expired deadline spawns ZERO workers and returns :timeout" do
+      # End-to-end: a nested pmap/pcalls may enter `run/3` with an
+      # inherited `deadline_mono` that has already passed. With the
+      # round-6 fix `fill_window/1` spawns nothing and `collect/1`
+      # returns `:timeout`; no item's `fun` ever runs.
+      #
+      # Deterministic: the deadline is set in the PAST, so the spawn
+      # guard fails on the very first `fill_window/1` evaluation. Each
+      # worker, if it were ever spawned and run, would announce itself.
+      test_pid = self()
+
+      fun = fn item ->
+        send(test_pid, {:worker_started, item})
+        {:ok, item}
+      end
+
+      expired = System.monotonic_time(:millisecond) - 1_000
+
+      assert {:error, {:timeout, _index}} =
+               ParallelRunner.run([:a, :b, :c, :d], fun,
+                 worker_max_heap: nil,
+                 max_concurrency: 4,
+                 deadline_mono: expired,
+                 trace_ctx: nil
+               )
+
+      # No worker's `fun` may have run.
+      refute_receive {:worker_started, _}, 100
+    end
+  end
+
+  describe "error classification" do
+    test "an abnormal worker crash maps to :runtime_error" do
+      fun = fn _ -> raise "kaboom" end
+
+      assert {:error, {:runtime_error, 0, _reason}} =
+               ParallelRunner.run([:a], fun, base_opts())
+    end
+  end
+
+  describe "global worker-slot budget" do
+    test "fails closed with :parallel_capacity_exceeded when no slot is free" do
+      # Budget pre-exhausted: every slot already held by something else.
+      budget = ParallelBudget.new(2)
+      assert :ok = ParallelBudget.try_acquire(budget)
+      assert :ok = ParallelBudget.try_acquire(budget)
+
+      fun = fn x -> {:ok, x} end
+
+      # The run cannot start a single worker — fail fast, do not block,
+      # do not fall back to sequential.
+      assert {:error, :parallel_capacity_exceeded} =
+               ParallelRunner.run([:a, :b], fun, base_opts(budget: budget))
+    end
+
+    test "never exceeds capacity, and frees every slot on normal completion" do
+      budget = ParallelBudget.new(3)
+      {:ok, agent} = start_supervised({Agent, fn -> {0, 0} end})
+
+      fun = fn _ ->
+        held = ParallelBudget.held(budget)
+        Agent.update(agent, fn {_last, peak} -> {held, max(peak, held)} end)
+        {:ok, :done}
+      end
+
+      assert {:ok, results} =
+               ParallelRunner.run(Enum.to_list(1..20), fun, base_opts(budget: budget))
+
+      assert length(results) == 20
+      {_last, peak} = Agent.get(agent, & &1)
+      assert peak <= 3
+      # Every slot released on normal completion.
+      assert ParallelBudget.held(budget) == 0
+    end
+
+    test "frees every slot after a worker heap kill" do
+      budget = ParallelBudget.new(3)
+
+      fun = fn _ ->
+        _huge = Enum.to_list(1..2_000_000)
+        {:ok, :unreached}
+      end
+
+      assert {:error, {:memory_exceeded, _}} =
+               ParallelRunner.run(
+                 [:a, :b],
+                 fun,
+                 base_opts(budget: budget, worker_max_heap: 50_000)
+               )
+
+      assert ParallelBudget.held(budget) == 0
+    end
+
+    test "frees every slot after a deadline timeout" do
+      budget = ParallelBudget.new(3)
+      fun = fn _ -> wait_for_go() end
+      deadline = System.monotonic_time(:millisecond) + 30
+
+      assert {:error, {:timeout, _}} =
+               ParallelRunner.run(
+                 [:a, :b],
+                 fun,
+                 base_opts(budget: budget, deadline_mono: deadline)
+               )
+
+      assert ParallelBudget.held(budget) == 0
+    end
+
+    test "frees every slot after parent cancellation" do
+      # A `link: true`-style cancellation: kill the runner's caller and
+      # assert the shared budget returns to full capacity.
+      budget = ParallelBudget.new(3)
+      test_pid = self()
+
+      runner_proc =
+        spawn(fn ->
+          caller = receive(do: ({:caller, c} -> c))
+          Process.link(caller)
+
+          fun = fn _ ->
+            send(test_pid, {:worker, self()})
+            wait_for_go()
+          end
+
+          ParallelRunner.run([:a, :b], fun, base_opts(budget: budget))
+        end)
+
+      runner_ref = Process.monitor(runner_proc)
+      caller = spawn(fn -> wait_for_go() end)
+      send(runner_proc, {:caller, caller})
+
+      workers = collect_pids(:worker, [])
+      worker_refs = Enum.map(workers, &Process.monitor/1)
+
+      Process.exit(caller, :shutdown)
+
+      assert_receive {:DOWN, ^runner_ref, :process, _, :shutdown}, 1_000
+      for ref <- worker_refs, do: assert_receive({:DOWN, ^ref, :process, _, _}, 1_000)
+
+      # Every worker slot released despite the abnormal teardown.
+      assert ParallelBudget.held(budget) == 0
+    end
+
+    test "a worker can spawn a nested run when slots remain (no deadlock)" do
+      # The parent worker holds one slot for its whole body; a nested
+      # run inside it acquires a second. Try-acquire is non-blocking, so
+      # this completes — it does not hang waiting on a slot.
+      budget = ParallelBudget.new(2)
+
+      nested_fun = fn x -> {:ok, x * 10} end
+
+      fun = fn _ ->
+        # Inside this worker (1 slot held), run a nested operation.
+        result = ParallelRunner.run([1, 2], nested_fun, base_opts(budget: budget))
+        {:ok, result}
+      end
+
+      assert {:ok, [{:ok, [10, 20]}]} =
+               ParallelRunner.run([:outer], fun, base_opts(budget: budget))
+
+      assert ParallelBudget.held(budget) == 0
+    end
+
+    test "a worker attempting a nested run with no slot fails fast, not hangs" do
+      # Capacity 1: the single outer worker holds the only slot. Its
+      # nested run cannot get one — it must fail fast with
+      # `:parallel_capacity_exceeded`, never block on a slot that can
+      # only free when the outer worker itself finishes.
+      budget = ParallelBudget.new(1)
+
+      fun = fn _ ->
+        nested = ParallelRunner.run([1, 2], fn x -> {:ok, x} end, base_opts(budget: budget))
+        {:ok, nested}
+      end
+
+      # The outer worker completes; its `fun` returns the nested run's
+      # result verbatim — a fast `{:error, :parallel_capacity_exceeded}`,
+      # never a hang.
+      assert {:ok, [{:error, :parallel_capacity_exceeded}]} =
+               ParallelRunner.run([:outer], fun, base_opts(budget: budget))
+
+      assert ParallelBudget.held(budget) == 0
+    end
+  end
+
+  describe "orphan cleanup" do
+    test "a worker failure kills all sibling workers" do
+      # Sibling workers announce their pid then block forever. The
+      # runner fails fast on worker 0; siblings must be killed.
+      test_pid = self()
+
+      fun = fn
+        0 ->
+          {:error, :fail_fast}
+
+        _ ->
+          send(test_pid, {:sibling, self()})
+          wait_for_go()
+      end
+
+      # Spawn the runner so we can collect sibling pids while it runs.
+      runner =
+        spawn(fn ->
+          send(test_pid, {:result, ParallelRunner.run([0, 1, 2, 3], fun, base_opts())})
+        end)
+
+      _ = Process.monitor(runner)
+
+      # Collect siblings (best-effort: 0 fails fast, up to 3 siblings).
+      siblings = collect_pids(:sibling, [])
+      refs = Enum.map(siblings, &Process.monitor/1)
+
+      assert_receive {:result, {:error, :fail_fast}}
+
+      # Every sibling must terminate (killed by the runner's cleanup).
+      for ref <- refs, do: assert_receive({:DOWN, ^ref, :process, _, _}, 1_000)
+    end
+
+    test "killing the calling process tears down all live workers (link)" do
+      # Workers are linked to the runner's caller. Killing that caller
+      # mid-run must take the workers down with it.
+      test_pid = self()
+
+      caller =
+        spawn(fn ->
+          fun = fn _ ->
+            send(test_pid, {:worker, self()})
+            wait_for_go()
+          end
+
+          ParallelRunner.run([:a, :b, :c], fun, base_opts(max_concurrency: 3))
+        end)
+
+      workers = collect_pids(:worker, [])
+      assert length(workers) == 3
+      refs = Enum.map(workers, &Process.monitor/1)
+
+      Process.exit(caller, :kill)
+
+      for ref <- refs, do: assert_receive({:DOWN, ^ref, :process, _, _}, 1_000)
+    end
+
+    test "an abnormal non-worker EXIT is not swallowed by the temporary trap_exit" do
+      # Regression for round-4 P1. `run/3` enables `trap_exit` for the
+      # duration of the call. A `link: true` sandbox is linked to its
+      # caller; if that caller dies abnormally (with a reason OTHER than
+      # `:kill`, so it arrives as a trapped `{:EXIT, _, _}` message
+      # rather than an untrappable signal), the runner must NOT treat it
+      # as a harmless non-worker exit. It must kill the workers and
+      # re-propagate, so the runner (sandbox) process dies too.
+      test_pid = self()
+
+      # `runner_proc` stands in for the sandbox process: it links to a
+      # `caller` and then runs the parallel operation.
+      runner_proc =
+        spawn(fn ->
+          caller = receive(do: ({:caller, c} -> c))
+          Process.link(caller)
+
+          fun = fn _ ->
+            send(test_pid, {:worker, self()})
+            wait_for_go()
+          end
+
+          ParallelRunner.run([:a, :b, :c], fun, base_opts(max_concurrency: 3))
+        end)
+
+      runner_ref = Process.monitor(runner_proc)
+
+      # The caller blocks until we kill it.
+      caller = spawn(fn -> wait_for_go() end)
+      send(runner_proc, {:caller, caller})
+
+      workers = collect_pids(:worker, [])
+      assert length(workers) == 3
+      worker_refs = Enum.map(workers, &Process.monitor/1)
+
+      # Abnormal exit, NOT :kill — so the runner traps it as a message.
+      Process.exit(caller, :shutdown)
+
+      # The runner (sandbox stand-in) must die — its exit reason
+      # propagated, not swallowed.
+      assert_receive {:DOWN, ^runner_ref, :process, _, :shutdown}, 1_000
+
+      # ...and every worker must be torn down, not orphaned.
+      for ref <- worker_refs, do: assert_receive({:DOWN, ^ref, :process, _, _}, 1_000)
+    end
+
+    test "the finish-path drain re-propagates a non-worker cancellation EXIT" do
+      # Regression for round-5 P2-b. The finish-path / `after`-block
+      # signal drain previously consumed EVERY `{:EXIT, ...}` message,
+      # swallowing a linked caller's cancellation that lands during
+      # cleanup. The drain now classifies each EXIT via
+      # `classify_drain_exit/3`.
+      #
+      # The live drain runs in a microsecond window with no external
+      # hook, so its decision table is pinned here directly and
+      # deterministically. The cases mirror the cond in the drain.
+      worker = spawn(fn -> :ok end)
+      non_worker = spawn(fn -> :ok end)
+      workers = MapSet.new([worker])
+
+      # An EXIT from one of our own workers is drained (consumed).
+      assert :drain = ParallelRunner.classify_drain_exit(worker, :killed, workers)
+      assert :drain = ParallelRunner.classify_drain_exit(worker, :normal, workers)
+
+      # A `:normal` EXIT from a non-worker is harmless — drained.
+      assert :drain = ParallelRunner.classify_drain_exit(non_worker, :normal, workers)
+
+      # An ABNORMAL EXIT from a non-worker is a linked caller's
+      # cancellation — it must be re-propagated, NOT swallowed.
+      assert {:cancel, :shutdown} =
+               ParallelRunner.classify_drain_exit(non_worker, :shutdown, workers)
+
+      assert {:cancel, :some_crash} =
+               ParallelRunner.classify_drain_exit(non_worker, :some_crash, workers)
+    end
+
+    test "cancellation while the runner runs tears down the runner and workers" do
+      # End-to-end companion to the round-4 test: a `link: true` sandbox
+      # stand-in is cancelled (abnormally, non-`:kill`) while `run/3` is
+      # active. Whichever cleanup path observes it — `handle_exit/3` or
+      # the finish-path drain — the cancellation must not be swallowed:
+      # the runner dies with the reason and every worker is torn down.
+      test_pid = self()
+
+      runner_proc =
+        spawn(fn ->
+          caller = receive(do: ({:caller, c} -> c))
+          Process.link(caller)
+
+          fun = fn _ ->
+            send(test_pid, {:worker, self()})
+            wait_for_go()
+          end
+
+          ParallelRunner.run([:a, :b], fun, base_opts(max_concurrency: 2))
+        end)
+
+      runner_ref = Process.monitor(runner_proc)
+
+      caller = spawn(fn -> wait_for_go() end)
+      send(runner_proc, {:caller, caller})
+
+      workers = collect_pids(:worker, [])
+      assert length(workers) == 2
+      worker_refs = Enum.map(workers, &Process.monitor/1)
+
+      Process.exit(caller, :shutdown)
+
+      assert_receive {:DOWN, ^runner_ref, :process, _, :shutdown}, 1_000
+      for ref <- worker_refs, do: assert_receive({:DOWN, ^ref, :process, _, _}, 1_000)
+    end
+  end
+
+  describe "concurrency stress" do
+    # Round-8: a round-7 combined-suite run had one transient single
+    # failure that did not reproduce. Rather than dismiss it, these
+    # tight-loop tests hammer the most race-prone paths — slot churn,
+    # worker EXIT/DOWN signal interleaving, and ordering under a
+    # constrained budget — so any residual race surfaces deterministically
+    # here (in CI) instead of as an occasional flake.
+
+    @stress_iterations 300
+
+    test "budget-constrained churn: slots always return to zero, results stay ordered" do
+      # `max_concurrency` (10) deliberately exceeds the budget (3): every
+      # iteration churns slots — workers complete, free a slot, the next
+      # item acquires it — exercising the
+      # complete -> drop_worker -> fill_window -> collect path and the
+      # trailing {:worker_result}/{:DOWN}/{:EXIT} interleaving.
+      for i <- 1..@stress_iterations do
+        budget = ParallelBudget.new(3)
+        items = Enum.to_list(1..20)
+
+        assert {:ok, results} =
+                 ParallelRunner.run(
+                   items,
+                   fn x -> {:ok, x * 2} end,
+                   base_opts(budget: budget, max_concurrency: 10)
+                 ),
+               "iteration #{i} did not complete cleanly"
+
+        # Input ordering preserved despite out-of-order completion.
+        assert results == Enum.map(items, &(&1 * 2)), "iteration #{i}: results out of order"
+        # Every slot released — no leak across the churn.
+        assert ParallelBudget.held(budget) == 0, "iteration #{i}: slot leak"
+      end
+    end
+
+    test "heap-kill churn: a killed worker never leaks a slot or orphans a sibling" do
+      # Every iteration: one worker heap-kills while siblings run, then
+      # the run fails fast and kills the siblings. The killed worker's
+      # `{:DOWN, :killed}` / `{:EXIT, :killed}` race the sibling kills
+      # and the drain. Slots must always return to zero.
+      for i <- 1..@stress_iterations do
+        budget = ParallelBudget.new(4)
+
+        fun = fn
+          0 -> (fn -> _h = Enum.to_list(1..2_000_000) end).()
+          _ -> {:ok, :ran}
+        end
+
+        assert {:error, {:memory_exceeded, _}} =
+                 ParallelRunner.run(
+                   [0, 1, 2, 3],
+                   fun,
+                   base_opts(budget: budget, worker_max_heap: 50_000, max_concurrency: 4)
+                 ),
+               "iteration #{i}: expected a heap-kill failure"
+
+        assert ParallelBudget.held(budget) == 0, "iteration #{i}: slot leak after heap kill"
+      end
+    end
+
+    test "nested-run churn: shared budget always returns to zero" do
+      # Every iteration runs nested parallelism on a shared budget that
+      # is exercised at two depths; the budget must always settle at 0.
+      for i <- 1..@stress_iterations do
+        budget = ParallelBudget.new(8)
+
+        nested_fun = fn x -> {:ok, x + 1} end
+
+        fun = fn _ ->
+          {:ok, ParallelRunner.run([1, 2, 3], nested_fun, base_opts(budget: budget))}
+        end
+
+        assert {:ok, _} =
+                 ParallelRunner.run([:a, :b], fun, base_opts(budget: budget, max_concurrency: 2)),
+               "iteration #{i}: nested run did not complete"
+
+        assert ParallelBudget.held(budget) == 0, "iteration #{i}: shared-budget slot leak"
+      end
+    end
+
+    test "cancellation racing run/3 teardown is never swallowed (P2-b)" do
+      # Round-9 P2-b: a linked caller exiting WHILE `run/3` is running —
+      # in particular in the old `drain -> restore trap_exit` window —
+      # must not be trapped-into-a-message and dropped.
+      #
+      # The runner mirrors the REAL sandbox: after `run/3` it does NOT
+      # exit — it blocks (`receive`-ing), the way `do_eval` keeps
+      # evaluating the rest of the program after a `pmap`. So:
+      #
+      #   - if `run/3` itself handles the cancellation -> exit :shutdown
+      #   - if a cancellation signal is still in flight after `run/3`,
+      #     it is delivered against the restored (false) `trap_exit` and
+      #     KILLS the still-linked, still-running runner -> exit :shutdown
+      #   - ONLY a genuine swallow (cancellation converted to a message
+      #     inside `run/3` and dropped) lets the runner survive into its
+      #     post-`run/3` `receive` -> it reports `:survived`, the bug.
+      #
+      # The caller is killed while `run/3` is provably mid-flight (both
+      # workers blocked), and the workers are then released so `run/3`
+      # races to completion against the cancellation. Repeated under the
+      # stress loop to exercise the timing-sensitive interleaving.
+      for i <- 1..@stress_iterations do
+        test_pid = self()
+
+        runner =
+          spawn(fn ->
+            caller = receive(do: ({:caller, c} -> c))
+            Process.link(caller)
+            send(test_pid, :linked)
+
+            fun = fn _item ->
+              send(test_pid, {:worker_up, self()})
+              receive(do: (:release -> :ok))
+              {:ok, :done}
+            end
+
+            _ = ParallelRunner.run([1, 2], fun, base_opts(max_concurrency: 2))
+
+            # Mirror the real sandbox continuing to run after the pmap.
+            # If we are still alive here, no cancellation killed us and
+            # `run/3` did not propagate one — i.e. it was swallowed.
+            send(test_pid, :survived_run)
+            receive(do: (:never -> :ok))
+          end)
+
+        runner_ref = Process.monitor(runner)
+        caller = spawn(fn -> receive(do: (:never -> :ok)) end)
+        send(runner, {:caller, caller})
+        assert_receive :linked, 1_000
+
+        w1 = assert_receive({:worker_up, p1}) && p1
+        w2 = assert_receive({:worker_up, p2}) && p2
+
+        # Kill the caller WHILE run/3 is in flight, then release the
+        # workers so run/3 races to completion against the cancellation.
+        Process.exit(caller, :shutdown)
+        send(w1, :release)
+        send(w2, :release)
+
+        # The runner must die from the cancellation — never survive into
+        # its post-`run/3` continuation.
+        receive do
+          {:DOWN, ^runner_ref, :process, _, reason} ->
+            assert reason == :shutdown,
+                   "iteration #{i}: P2-b — cancellation surfaced as #{inspect(reason)}"
+
+          :survived_run ->
+            flunk(
+              "iteration #{i}: P2-b — cancellation swallowed: runner survived `run/3` " <>
+                "into its continuation despite its linked caller dying :shutdown mid-run"
+            )
+        after
+          2_000 -> flunk("iteration #{i}: runner neither died nor reported survival")
+        end
+      end
+    end
+  end
+
+  # Collect `{tag, pid}` messages until a short quiet period.
+  defp collect_pids(tag, acc) do
+    receive do
+      {^tag, pid} -> collect_pids(tag, [pid | acc])
+    after
+      300 -> acc
+    end
+  end
+end

--- a/test/ptc_runner/lisp/integration/parallel_limits_test.exs
+++ b/test/ptc_runner/lisp/integration/parallel_limits_test.exs
@@ -1,0 +1,188 @@
+defmodule PtcRunner.Lisp.Integration.ParallelLimitsTest do
+  @moduledoc """
+  Lisp-level integration tests for pmap/pcalls resource limits.
+
+  These tests prove the user-visible contract through `Lisp.run/2`.
+  Lower-level `ParallelRunner` tests still own deterministic OTP race
+  cases such as stale EXIT messages, spawn failures, and cancellation
+  ordering.
+  """
+  use ExUnit.Case, async: true
+
+  alias PtcRunner.Lisp
+
+  @timeout 5_000
+
+  defp barrier_tool(target) do
+    {:ok, counter} = start_supervised({Agent, fn -> 0 end})
+
+    fn _ ->
+      Agent.update(counter, &(&1 + 1))
+      wait_until(fn -> Agent.get(counter, & &1) >= target end)
+      :ok
+    end
+  end
+
+  defp wait_until(fun) do
+    if fun.() do
+      :ok
+    else
+      Process.sleep(5)
+      wait_until(fun)
+    end
+  end
+
+  test "pmap worker heap cap is enforced" do
+    program = "(pmap (fn [_] (count (vec (range 0 500000)))) [1 2])"
+
+    assert {:error, step} =
+             Lisp.run(program,
+               max_heap: 200_000,
+               worker_max_heap: 50_000,
+               timeout: @timeout,
+               pmap_max_concurrency: 2
+             )
+
+    assert step.fail.reason == :memory_exceeded
+  end
+
+  test "pcalls worker heap cap is enforced" do
+    program = "(pcalls (fn [] (count (vec (range 0 500000)))))"
+
+    assert {:error, step} =
+             Lisp.run(program,
+               max_heap: 200_000,
+               worker_max_heap: 50_000,
+               timeout: @timeout
+             )
+
+    assert step.fail.reason == :memory_exceeded
+  end
+
+  test "worker_max_heap is independent from a generous sandbox max_heap" do
+    program = "(pmap (fn [_] (count (vec (range 0 500000)))) [1])"
+
+    assert {:error, step} =
+             Lisp.run(program,
+               max_heap: 1_000_000,
+               worker_max_heap: 50_000,
+               timeout: @timeout
+             )
+
+    assert step.fail.reason == :memory_exceeded
+  end
+
+  test "captured closure data is capped at worker spawn" do
+    program = "(let [xs (vec (range 0 400000))] (pmap (fn [_] (count xs)) [1]))"
+
+    assert {:error, step} =
+             Lisp.run(program,
+               max_heap: 300_000,
+               worker_max_heap: 50_000,
+               timeout: @timeout
+             )
+
+    assert step.fail.reason == :memory_exceeded
+  end
+
+  test "nested parallelism fails closed when global worker budget is exhausted" do
+    tools = %{"barrier" => barrier_tool(2)}
+
+    program = """
+    (pmap
+      (fn [_]
+        (tool/barrier {})
+        (pmap inc [1 2 3]))
+      [1 2])
+    """
+
+    assert {:error, step} =
+             Lisp.run(program,
+               tools: tools,
+               max_heap: 200_000,
+               worker_max_heap: 200_000,
+               max_parallel_workers: 2,
+               timeout: @timeout
+             )
+
+    assert step.fail.reason == :parallel_capacity_exceeded
+  end
+
+  test "nested pcalls fails closed when global worker budget is exhausted" do
+    tools = %{"barrier" => barrier_tool(2)}
+
+    program = """
+    (pmap
+      (fn [_]
+        (tool/barrier {})
+        (pcalls (fn [] 1) (fn [] 2)))
+      [1 2])
+    """
+
+    assert {:error, step} =
+             Lisp.run(program,
+               tools: tools,
+               max_heap: 200_000,
+               worker_max_heap: 200_000,
+               max_parallel_workers: 2,
+               timeout: @timeout
+             )
+
+    assert step.fail.reason == :parallel_capacity_exceeded
+  end
+
+  test "max_parallel_workers of one still permits a single non-nested pmap" do
+    assert {:ok, step} =
+             Lisp.run("(pmap inc [1 2 3])",
+               max_heap: 200_000,
+               worker_max_heap: 200_000,
+               max_parallel_workers: 1,
+               pmap_max_concurrency: 3,
+               timeout: @timeout
+             )
+
+    assert step.return == [2, 3, 4]
+  end
+
+  test "ordinary parallel programs still succeed under explicit worker limits" do
+    assert {:ok, pmap_step} =
+             Lisp.run("(pmap (fn [x] (* x x)) [1 2 3 4])",
+               max_heap: 200_000,
+               worker_max_heap: 200_000,
+               max_parallel_workers: 4,
+               timeout: @timeout
+             )
+
+    assert pmap_step.return == [1, 4, 9, 16]
+
+    assert {:ok, pcalls_step} =
+             Lisp.run("(pcalls (fn [] (+ 1 2)) (fn [] (* 3 4)))",
+               max_heap: 200_000,
+               worker_max_heap: 200_000,
+               max_parallel_workers: 4,
+               timeout: @timeout
+             )
+
+    assert pcalls_step.return == [3, 12]
+  end
+
+  test "parallel timeout remains distinct from memory_exceeded" do
+    tools = %{
+      "sleep" => fn _ ->
+        Process.sleep(50)
+        :done
+      end
+    }
+
+    assert {:error, step} =
+             Lisp.run("(pmap (fn [_] (tool/sleep {})) [1])",
+               tools: tools,
+               max_heap: 200_000,
+               worker_max_heap: 200_000,
+               timeout: @timeout,
+               pmap_timeout: 1
+             )
+
+    assert step.fail.reason == :timeout
+  end
+end

--- a/test/ptc_runner/lisp/pmap_heap_cap_test.exs
+++ b/test/ptc_runner/lisp/pmap_heap_cap_test.exs
@@ -1,0 +1,351 @@
+defmodule PtcRunner.Lisp.PmapHeapCapTest do
+  @moduledoc """
+  Security regression tests for finding H1 (issue #987).
+
+  `max_heap_size` is a *spawn-time* BEAM option, so it can only bound a
+  worker if the worker is created with it. `Task.async_stream` creates
+  the worker process itself, so the captured closure (e.g. a large `let`
+  binding) lands on an uncapped heap before any worker line runs — a
+  setting applied from inside the worker body is too late.
+
+  The fix replaces `Task.async_stream` in the `pmap`/`pcalls` paths with
+  `PtcRunner.Lisp.Eval.ParallelRunner`, which spawns every worker with a
+  FIXED `max_heap_size` creation option already in force, and bounds the
+  number of workers alive at once — at every nesting depth — with a
+  shared `PtcRunner.Lisp.Eval.ParallelBudget` slot semaphore. A worker
+  that exceeds its per-worker heap cap is killed (`:memory_exceeded`); a
+  run that cannot get a worker slot fails closed
+  (`:parallel_capacity_exceeded`). Aggregate live parallel heap is
+  bounded by `max_parallel_workers × worker_max_heap`.
+  """
+  use ExUnit.Case, async: true
+
+  alias PtcRunner.Lisp
+
+  # Per-worker heap cap (in words) so a worker allocating a large list
+  # blows the FIXED `worker_max_heap` (which defaults to `:max_heap`).
+  # With a generous timeout the run cannot pass by timing out instead —
+  # it must be the heap limit doing the work.
+  @small_max_heap 200_000
+  @generous_timeout 5_000
+
+  # A per-element function that allocates a large list — far more than
+  # the @small_max_heap per-worker cap.
+  @big_alloc_fn "(fn [x] (count (vec (range 0 500000))))"
+
+  describe "pmap worker heap cap (H1)" do
+    test "worker allocating past its per-worker budget fails with :memory_exceeded" do
+      program = "(pmap #{@big_alloc_fn} [1 2 3 4])"
+
+      assert {:error, step} =
+               Lisp.run(program,
+                 max_heap: @small_max_heap,
+                 timeout: @generous_timeout,
+                 pmap_max_concurrency: 4
+               )
+
+      # Deterministic now that ParallelRunner classifies a `:killed`
+      # worker exit as `:memory_exceeded`.
+      assert step.fail.reason == :memory_exceeded
+    end
+
+    test "pcalls thunk allocating past its budget fails with :memory_exceeded" do
+      program =
+        "(pcalls (fn [] (count (vec (range 0 500000)))) " <>
+          "(fn [] (count (vec (range 0 500000)))))"
+
+      assert {:error, step} =
+               Lisp.run(program,
+                 max_heap: @small_max_heap,
+                 timeout: @generous_timeout,
+                 pmap_max_concurrency: 4
+               )
+
+      assert step.fail.reason == :memory_exceeded
+    end
+
+    test "pmap worker accounts for shared binary memory" do
+      tools = %{
+        "big-binary" => fn _ -> String.duplicate("x", 20_000_000) end
+      }
+
+      assert {:error, step} =
+               Lisp.run("(pmap (fn [_] (count (tool/big-binary {}))) [1])",
+                 tools: tools,
+                 max_heap: @small_max_heap,
+                 worker_max_heap: 1_000,
+                 timeout: @generous_timeout
+               )
+
+      assert step.fail.reason == :memory_exceeded
+    end
+
+    test "pcalls worker accounts for shared binary memory" do
+      tools = %{
+        "big-binary" => fn _ -> String.duplicate("x", 20_000_000) end
+      }
+
+      assert {:error, step} =
+               Lisp.run("(pcalls (fn [] (count (tool/big-binary {}))))",
+                 tools: tools,
+                 max_heap: @small_max_heap,
+                 worker_max_heap: 1_000,
+                 timeout: @generous_timeout
+               )
+
+      assert step.fail.reason == :memory_exceeded
+    end
+
+    test "closure-copy pressure: a large captured env is capped at worker birth" do
+      # Codex's exact repro. `xs` is a large vector bound by an enclosing
+      # `let`; the pmap closure `(fn [_] (count xs))` captures it. Each
+      # worker therefore receives a copy of `xs` on its heap *before* its
+      # body runs. Under `Task.async_stream` the copy landed on an
+      # uncapped heap (bypass). With ParallelRunner the worker is spawned
+      # with `max_heap_size` already set, so the oversized closure copy
+      # is killed at birth.
+      #
+      # `xs` = range 0 400000 (multi-MB) vs a per-worker budget of
+      # `200_000 / min(32, 4) = 50_000` words.
+      program = "(let [xs (vec (range 0 400000))] (pmap (fn [_] (count xs)) (range 0 32)))"
+
+      assert {:error, step} =
+               Lisp.run(program,
+                 max_heap: @small_max_heap,
+                 timeout: @generous_timeout,
+                 pmap_max_concurrency: 4
+               )
+
+      assert step.fail.reason == :memory_exceeded
+    end
+
+    test "nested pmap inside a pmap worker also heap-caps its inner workers" do
+      program = "(pmap (fn [x] (pmap #{@big_alloc_fn} [1 2])) [1 2])"
+
+      assert {:error, step} =
+               Lisp.run(program,
+                 max_heap: @small_max_heap,
+                 timeout: @generous_timeout,
+                 pmap_max_concurrency: 4
+               )
+
+      assert step.fail.reason == :memory_exceeded
+    end
+
+    test "nested pcalls inside a pmap worker also heap-caps its inner workers" do
+      program =
+        "(pmap (fn [x] (pcalls (fn [] (count (vec (range 0 500000)))))) [1 2])"
+
+      assert {:error, step} =
+               Lisp.run(program,
+                 max_heap: @small_max_heap,
+                 timeout: @generous_timeout,
+                 pmap_max_concurrency: 4
+               )
+
+      assert step.fail.reason == :memory_exceeded
+    end
+
+    test "a regular HOF wrapping a heap-exceeding pmap fails with :memory_exceeded" do
+      # Round-5 P2-a regression. `map` is a regular HOF — its apply path
+      # rescues closure errors. The closure runs a nested `pmap` whose
+      # workers blow the heap budget. The nested heap kill is raised as
+      # an ExecutionError; the HOF apply path must surface its stable
+      # `:memory_exceeded` reason rather than let it crash the sandbox
+      # as a generic `:execution_error`.
+      program = "(map (fn [_] (pmap #{@big_alloc_fn} [1 2 3 4])) [1 2])"
+
+      assert {:error, step} =
+               Lisp.run(program,
+                 max_heap: @small_max_heap,
+                 timeout: @generous_timeout,
+                 pmap_max_concurrency: 4
+               )
+
+      assert step.fail.reason == :memory_exceeded
+    end
+
+    test "a regular HOF wrapping a heap-exceeding pcalls fails with :memory_exceeded" do
+      # Same as above for `filter` + nested `pcalls`.
+      program =
+        "(filter (fn [_] (pcalls (fn [] (count (vec (range 0 500000)))))) [1 2])"
+
+      assert {:error, step} =
+               Lisp.run(program,
+                 max_heap: @small_max_heap,
+                 timeout: @generous_timeout,
+                 pmap_max_concurrency: 4
+               )
+
+      assert step.fail.reason == :memory_exceeded
+    end
+
+    test "nested pmap fails with :parallel_capacity_exceeded when the slot budget is small" do
+      # Round-7 model: the global worker-slot budget — not heap division
+      # — bounds aggregate parallelism. With `max_parallel_workers: 2`,
+      # two outer workers fill the budget; their nested pmaps cannot get
+      # a slot and fail closed with `:parallel_capacity_exceeded` rather
+      # than spawning unbounded nested workers.
+      program = "(pmap (fn [x] (pmap (fn [y] (* y 2)) [1 2 3])) [1 2 3])"
+
+      assert {:error, step} =
+               Lisp.run(program,
+                 max_heap: @small_max_heap,
+                 timeout: @generous_timeout,
+                 max_parallel_workers: 2
+               )
+
+      assert step.fail.reason == :parallel_capacity_exceeded
+      # The message must render cleanly (round-7 P3 — no garbled
+      # "... bytes exceeded" from the numeric-limit formatter).
+      assert step.fail.message =~ "parallel worker budget"
+      refute step.fail.message =~ "bytes"
+    end
+
+    test "nested pmap succeeds when the slot budget is large enough" do
+      # Same nesting shape, ample budget — the global cap does not
+      # reject legitimate nested parallelism.
+      program = "(pmap (fn [x] (pmap (fn [y] (* y 2)) [1 2])) [1 2])"
+
+      assert {:ok, step} =
+               Lisp.run(program,
+                 max_heap: @small_max_heap,
+                 timeout: @generous_timeout,
+                 max_parallel_workers: 32
+               )
+
+      assert step.return == [[2, 4], [2, 4]]
+    end
+
+    test "total live parallel workers never exceed max_parallel_workers" do
+      # Each worker level observes the live worker count via a
+      # tool-backed shared counter; the peak must never exceed the
+      # global cap, even with nested pmap at multiple depths.
+      {:ok, agent} = start_supervised({Agent, fn -> {0, 0} end})
+
+      tools = %{
+        "enter" => fn _ ->
+          Agent.update(agent, fn {live, peak} -> {live + 1, max(peak, live + 1)} end)
+          Process.sleep(10)
+          :ok
+        end,
+        "leave" => fn _ ->
+          Agent.update(agent, fn {live, peak} -> {live - 1, peak} end)
+          :ok
+        end
+      }
+
+      # Outer pmap of 2; each runs an inner pmap of 2. Instrument both
+      # levels and assert the run succeeds so the counter proves the
+      # cap on a real nested parallel execution rather than only
+      # observing a pre-failure subset of inner workers.
+      program = """
+      (pmap (fn [x]
+              (tool/enter {})
+              (pmap (fn [y]
+                      (tool/enter {})
+                      (tool/leave {})
+                      y)
+                    [1 2])
+              (tool/leave {})
+              x)
+            [1 2])
+      """
+
+      assert {:ok, step} =
+               Lisp.run(program,
+                 tools: tools,
+                 max_heap: @small_max_heap,
+                 timeout: @generous_timeout,
+                 max_parallel_workers: 6
+               )
+
+      assert step.return == [1, 2]
+
+      {_live, peak} = Agent.get(agent, & &1)
+      assert peak <= 6
+    end
+  end
+
+  describe "timeout classification is distinct from memory_exceeded" do
+    test "a slow pmap worker yields :timeout, not :memory_exceeded" do
+      # A worker that spins past the deadline without allocating. The
+      # shared deadline elapses; ParallelRunner classifies this as
+      # `:timeout` — a different, stable reason from a heap kill.
+      #
+      # `(loop ...)` of 10_000 cheap iterations with a tiny timeout
+      # reliably outlives the deadline without growing the heap.
+      slow_program =
+        "(pmap (fn [x] (loop [i 0] (if (< i 10000) (recur (+ i 1)) i))) [1 2 3 4])"
+
+      assert {:error, step} =
+               Lisp.run(slow_program,
+                 max_heap: @small_max_heap,
+                 timeout: 1,
+                 pmap_max_concurrency: 4
+               )
+
+      assert step.fail.reason == :timeout
+    end
+  end
+
+  describe "normal pmap/pcalls behavior is unchanged" do
+    test "small pmap program runs successfully under a normal heap cap" do
+      assert {:ok, step} =
+               Lisp.run("(pmap (fn [x] (* x x)) [1 2 3 4 5])",
+                 max_heap: @small_max_heap,
+                 timeout: @generous_timeout
+               )
+
+      assert step.return == [1, 4, 9, 16, 25]
+    end
+
+    test "small pcalls program runs successfully under a normal heap cap" do
+      assert {:ok, step} =
+               Lisp.run("(pcalls (fn [] (+ 1 2)) (fn [] (* 3 4)))",
+                 max_heap: @small_max_heap,
+                 timeout: @generous_timeout
+               )
+
+      assert step.return == [3, 12]
+    end
+
+    test "pmap works with the default heap cap" do
+      assert {:ok, step} = Lisp.run("(pmap (fn [x] (inc x)) [10 20 30])")
+      assert step.return == [11, 21, 31]
+    end
+
+    test "pmap preserves input ordering" do
+      # Workers finish out of order but results stay aligned to input.
+      assert {:ok, step} = Lisp.run("(pmap (fn [x] (* x 10)) [5 1 4 2 3])")
+      assert step.return == [50, 10, 40, 20, 30]
+    end
+
+    test "single-item pmap gets the full heap budget, not max_heap/concurrency" do
+      # P2: the per-worker budget divides by the live worker count (1),
+      # not the configured `pmap_max_concurrency` (8).
+      program = "(pmap (fn [x] (count (vec (range 0 8000)))) [1])"
+
+      assert {:ok, step} =
+               Lisp.run(program,
+                 max_heap: @small_max_heap,
+                 timeout: @generous_timeout,
+                 pmap_max_concurrency: 8
+               )
+
+      assert step.return == [8000]
+
+      # Contrast: the same program under a heap cap equal to the pre-fix
+      # /8 slice genuinely exceeds the budget — proving the program is a
+      # real boundary test, not trivially small.
+      assert {:error, slice_step} =
+               Lisp.run(program,
+                 max_heap: 25_000,
+                 timeout: @generous_timeout,
+                 pmap_max_concurrency: 1
+               )
+
+      assert slice_step.fail.reason == :memory_exceeded
+    end
+  end
+end


### PR DESCRIPTION
Fixes security finding **H1** of #987: PTC-Lisp `pmap`/`pcalls` parallel workers were not covered by the sandbox heap cap.

## Problem

`pmap`/`pcalls` previously spawned workers through `Task.async_stream`. `max_heap_size` is a **process-creation** BEAM option, and `Task` creates the worker process internally, so there is no hook to apply the flag before the worker heap is created. The closure, including captured values such as a large `let`-bound collection, could be copied onto an uncapped worker heap before any worker code ran.

That made it possible for generated PTC-Lisp to allocate effectively unbounded memory across parallel workers, bypassing the documented sandbox heap cap.

## What This PR Does

Replaces the Task-based `pmap`/`pcalls` paths with an owned worker lifecycle:

- Adds `PtcRunner.Lisp.Eval.ParallelRunner`.
  It owns worker spawn, bounded scheduling, result collection, shared deadline handling, exit classification, and cleanup. Workers are spawned through `Process.spawn` with `{:max_heap_size, ...}` set at creation.
- Adds `PtcRunner.Lisp.Eval.ParallelBudget`.
  It is an `:atomics`-backed global slot semaphore created once per top-level `Lisp.run/2` and shared through nested `pmap`/`pcalls`.
- MCP callers pass explicit worker limits derived from `program_memory_limit_bytes`, so the user-facing MCP program memory limit is not silently multiplied by the in-process `max_parallel_workers` default.
- Uses a **fixed per-worker heap cap plus a global worker slot cap**, rather than dividing the heap budget by local concurrency:

```text
max live parallel heap ~= max_parallel_workers * worker_max_heap
```

Defaults:

- `worker_max_heap` defaults to the sandbox `max_heap`.
- `max_parallel_workers` defaults to `8`.

Both are operator-configurable. If no worker slot is available, nested parallelism fails closed with `:parallel_capacity_exceeded`; it does not silently fall back to sequential execution.

## Guarantees

- Worker heap cap applies at process birth, before closure/captured data is copied.
- Worker heap caps include shared/refc binary accounting via `include_shared_binaries: true`, matching the current sandbox memory model from #995.
- Nested `pmap`/`pcalls` share the same global worker budget and the same absolute deadline.
- Heap kills are surfaced as `:memory_exceeded`.
- Deadline expiry is surfaced as `:timeout`, distinct from heap failure.
- Global worker budget exhaustion is surfaced as `:parallel_capacity_exceeded`.
- Worker slots are released only after worker termination, not just after result delivery.
- `ParallelBudget.release/1` uses a CAS loop and raises on underflow rather than decrementing then clamping. Underflow is treated as a caller bug because clamping can race with a valid acquire and corrupt a hard security semaphore.
- Cleanup covers normal completion, heap kill, timeout, worker crash, spawn failure, and linked-caller cancellation.

## Rebase / Follow-Up Fixes Included

This branch has been rebased onto current `main` (`502b3bcd`) and the earlier review follow-ups have been incorporated:

- Hand-integrated with main's newer `Lisp.run/2` flow around `max_program_bytes`, bounded compile, `do_run_inner/2`, and `execute_eval/2`.
- Added `include_shared_binaries: true` to parallel worker `max_heap_size` options.
- Added shared/refc binary worker regression coverage for both `pmap` and `pcalls`.
- Added MCP-specific parallel limit derivation so `program_memory_limit_bytes` remains an aggregate program budget for parallel workers in stateless and session execution paths.
- Fixed stale worker `EXIT` cleanup ordering so worker exits cannot be mistaken for linked-caller cancellation after spawn failure.
- Replaced decrement-then-clamp `ParallelBudget.release/1` with CAS decrement and visible underflow failure.
- Added deterministic lower-level `ParallelRunner` tests for spawn failure, stale worker exits, slot leaks, deadlines, cancellation, and lifecycle cleanup.
- Added Lisp-level integration coverage for the public contract.

## Tests

Verified locally on this branch:

- `mix format --check-formatted`
- Focused H1 suite: `80 tests, 0 failures`
- Full root suite: `5104 tests, 380 doctests, 3 properties, 0 failures`
- `mix credo --strict`
- `mix dialyzer`
- `mcp_server`: `mix format --check-formatted`
- `mcp_server`: targeted tests for sandbox/session limit plumbing, `44 tests, 0 failures`
- `mcp_server`: `mix credo --strict`
- `mcp_server`: `mix dialyzer`
- Pre-commit hook passed during amend

New or expanded coverage includes:

- `pmap` worker heap cap -> `:memory_exceeded`
- `pcalls` worker heap cap -> `:memory_exceeded`
- captured closure data capped at worker spawn
- shared/refc binary memory accounted in workers
- nested `pmap` capacity exhaustion -> `:parallel_capacity_exceeded`
- nested `pcalls` capacity exhaustion -> `:parallel_capacity_exceeded`
- `max_parallel_workers: 1` still permits a single non-nested pmap
- timeout remains distinct from memory exhaustion
- stale worker `EXIT` does not mask a later spawn failure
- worker slots are released after termination
- budget release underflow is visible and does not mutate the counter
- MCP stateless and session execution derive parallel worker limits from the configured program memory limit
- linked-caller cancellation is not swallowed by scoped `trap_exit`

## Known Caveat

`mix prepush` was attempted after installing `mcp_server/` deps. The root project tests and Dialyzer passed under the hook, but the nested `mcp_server/` suite failed in existing stdio fixture tests because `test/support/mock_server.exs` is launched as plain `elixir` and cannot load `Jason` in that subprocess:

```text
** (UndefinedFunctionError) function Jason.decode/1 is undefined (module Jason is not available)
```

That appears unrelated to this H1 change and is not addressed in this PR.

## Scope Notes

This PR is scoped to H1 from #987. Other sibling findings have already landed separately, including the shared-binary sandbox memory accounting from #993/#995, which this PR now mirrors for parallel workers.

Refs #987 (H1).

## Fix Automation State
<!-- fix-state: {"attempts":2} -->
Fix attempts: 2/3
