### PR TITLE
fix: batch quick-fixes (1 issue)

### DIFF
--- a/lib/ptc_runner/lisp/eval.ex
+++ b/lib/ptc_runner/lisp/eval.ex
@@ -23,6 +23,7 @@ defmodule PtcRunner.Lisp.Eval do
   alias PtcRunner.Lisp.Eval.{Apply, ParallelRunner, Patterns}
   alias PtcRunner.Lisp.Eval.Context, as: EvalContext
   alias PtcRunner.Lisp.ExecutionError
+  require PtcRunner.Lisp.ExecutionError
   alias PtcRunner.Lisp.Format.Var
   alias PtcRunner.Lisp.Keyword, as: LispKeyword
   alias PtcRunner.Lisp.Runtime.Callable
@@ -1338,15 +1339,11 @@ defmodule PtcRunner.Lisp.Eval do
   defp parallel_error_type(:pmap), do: :pmap_error
   defp parallel_error_type(:pcalls), do: :pcalls_error
 
-  # Stable parallel error atoms that must survive nesting unchanged so
-  # the security/capacity outcome is deterministic at any depth.
-  @nested_stable_reasons [:memory_exceeded, :timeout, :parallel_capacity_exceeded]
-
   # Re-surface a nested pmap/pcalls failure caught as an ExecutionError
   # inside a pmap worker. A stable reason keeps its atom; anything else
   # stays a generic :pmap_error.
   defp nested_parallel_error(%ExecutionError{reason: reason, message: msg})
-       when reason in @nested_stable_reasons do
+       when reason in ExecutionError.stable_parallel_reasons() do
     {reason, msg}
   end
 
@@ -1354,7 +1351,7 @@ defmodule PtcRunner.Lisp.Eval do
 
   # pcalls variant — same, but produces the 3-tuple pcalls error shape.
   defp nested_parallel_error(%ExecutionError{reason: reason, message: msg}, _idx)
-       when reason in @nested_stable_reasons do
+       when reason in ExecutionError.stable_parallel_reasons() do
     {reason, msg}
   end
 
@@ -1448,11 +1445,13 @@ defmodule PtcRunner.Lisp.Eval do
   # stable atom; every other body error keeps the legacy RuntimeError
   # shape. Parallel errors arrive as 2- or 3-tuples.
   @spec raise_pcalls_body_error(term()) :: no_return()
-  defp raise_pcalls_body_error({atom, _} = reason) when atom in @nested_stable_reasons do
+  defp raise_pcalls_body_error({atom, _} = reason)
+       when atom in ExecutionError.stable_parallel_reasons() do
     raise_pcalls_parallel_error(atom, reason)
   end
 
-  defp raise_pcalls_body_error({atom, _, _} = reason) when atom in @nested_stable_reasons do
+  defp raise_pcalls_body_error({atom, _, _} = reason)
+       when atom in ExecutionError.stable_parallel_reasons() do
     raise_pcalls_parallel_error(atom, reason)
   end
 

--- a/lib/ptc_runner/lisp/eval/apply.ex
+++ b/lib/ptc_runner/lisp/eval/apply.ex
@@ -18,6 +18,7 @@ defmodule PtcRunner.Lisp.Eval.Apply do
   alias PtcRunner.Lisp.Eval.Helpers
   alias PtcRunner.Lisp.Eval.Patterns
   alias PtcRunner.Lisp.ExecutionError
+  require PtcRunner.Lisp.ExecutionError
   alias PtcRunner.Lisp.Format
   alias PtcRunner.Lisp.Keyword, as: LispKeyword
   alias PtcRunner.Lisp.Runtime.Math
@@ -668,9 +669,6 @@ defmodule PtcRunner.Lisp.Eval.Apply do
     end
   end
 
-  # Stable parallel error reasons that must survive nesting unchanged.
-  @parallel_reasons [:memory_exceeded, :timeout, :parallel_capacity_exceeded]
-
   # A closure-eval error from a *nested* pmap/pcalls (heap kill, shared
   # deadline, exhausted worker budget) is raised as `ExecutionError`
   # carrying the structured reason, so the surrounding pmap/pcalls worker
@@ -679,11 +677,13 @@ defmodule PtcRunner.Lisp.Eval.Apply do
   # shape that `do_apply_fun/4`'s rescue clauses convert into `{:error,
   # ...}`. Parallel errors arrive as 2- or 3-tuples.
   @spec raise_closure_error(term()) :: no_return()
-  defp raise_closure_error({atom, _} = reason) when atom in @parallel_reasons do
+  defp raise_closure_error({atom, _} = reason)
+       when atom in ExecutionError.stable_parallel_reasons() do
     raise_parallel_closure_error(atom, reason)
   end
 
-  defp raise_closure_error({atom, _, _} = reason) when atom in @parallel_reasons do
+  defp raise_closure_error({atom, _, _} = reason)
+       when atom in ExecutionError.stable_parallel_reasons() do
     raise_parallel_closure_error(atom, reason)
   end
 
@@ -785,7 +785,7 @@ defmodule PtcRunner.Lisp.Eval.Apply do
   # error tuple so the stable reason reaches the caller. Anything else
   # (e.g. `:tool_error`) is re-raised unchanged.
   defp reraise_unless_parallel(%ExecutionError{reason: reason} = e, _stacktrace)
-       when reason in @parallel_reasons do
+       when reason in ExecutionError.stable_parallel_reasons() do
     {:error, execution_error_tuple(e)}
   end
 

--- a/lib/ptc_runner/lisp/execution_error.ex
+++ b/lib/ptc_runner/lisp/execution_error.ex
@@ -7,4 +7,13 @@ defmodule PtcRunner.Lisp.ExecutionError do
   out of the evaluation loop and into the `Step` failure result.
   """
   defexception [:reason, :message, :data, :child_trace_id, :child_step]
+
+  @doc """
+  Compile-time list of stable parallel error reasons that must survive
+  nesting unchanged so the security/capacity outcome is deterministic at
+  any depth. Safe to use in guard clauses.
+  """
+  defmacro stable_parallel_reasons do
+    [:memory_exceeded, :timeout, :parallel_capacity_exceeded]
+  end
 end


### PR DESCRIPTION
## Summary
Batch fix for quick-fix issues.

## Issues Fixed
- Closes #1011: Extract duplicated stable-reason constant shared by eval.ex and apply.ex

## Changes
- Added `ExecutionError.stable_parallel_reasons/0` macro to `execution_error.ex` — a compile-time list of `[:memory_exceeded, :timeout, :parallel_capacity_exceeded]` that is safe to use in guard clauses
- Removed `@nested_stable_reasons` from `eval.ex` and replaced all four guard usages with `ExecutionError.stable_parallel_reasons()`
- Removed `@parallel_reasons` from `eval/apply.ex` and replaced all three guard usages with `ExecutionError.stable_parallel_reasons()`
- Added `require PtcRunner.Lisp.ExecutionError` to both consuming modules so the macro is available

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)