### PR TITLE
fix(lisp): standardize builtin type errors

### DIFF
--- a/lib/ptc_runner/lisp/env.ex
+++ b/lib/ptc_runner/lisp/env.ex
@@ -12,10 +12,12 @@ defmodule PtcRunner.Lisp.Env do
   - `{:collect, fun}` - Collects all args into a list and passes to unary function
   """
 
+  alias PtcRunner.Lisp.Env.Builtin
   alias PtcRunner.Lisp.Runtime
 
   @type binding ::
-          {:normal, function()}
+          Builtin.t()
+          | {:normal, function()}
           | {:variadic, function(), term()}
           | {:variadic_nonempty, atom(), function()}
           | {:multi_arity, atom(), tuple()}
@@ -27,7 +29,7 @@ defmodule PtcRunner.Lisp.Env do
   def initial do
     case :persistent_term.get({__MODULE__, :initial}, :unset) do
       :unset ->
-        env = builtin_bindings() |> Map.new()
+        env = builtin_bindings() |> Enum.map(&wrap_builtin_binding/1) |> Map.new()
         :persistent_term.put({__MODULE__, :initial}, env)
         env
 
@@ -130,6 +132,73 @@ defmodule PtcRunner.Lisp.Env do
     clojure_namespace?(ns) and Map.has_key?(initial(), name) and
       match?({:constant, _}, Map.get(initial(), name))
   end
+
+  defp wrap_builtin_binding({name, {tag, _} = binding})
+       when tag in [:normal, :collect] do
+    {name, Builtin.wrap(name, binding, args_spec(name))}
+  end
+
+  defp wrap_builtin_binding({name, {tag, _, _} = binding})
+       when tag in [:variadic, :variadic_nonempty, :multi_arity] do
+    {name, Builtin.wrap(name, binding, args_spec(name))}
+  end
+
+  defp wrap_builtin_binding(other), do: other
+
+  defp args_spec(:merge), do: {:rest, :map_or_nil}
+  defp args_spec(:"merge-with"), do: {:min, 1, [:callable], {:rest, :map_or_nil}}
+
+  defp args_spec(:get),
+    do: {:arity, %{2 => [:associative_or_nil, :any], 3 => [:associative_or_nil, :any, :any]}}
+
+  defp args_spec(:"get-in"),
+    do:
+      {:arity,
+       %{2 => [:associative_or_nil, :seqable], 3 => [:associative_or_nil, :seqable, :any]}}
+
+  defp args_spec(:assoc), do: {:min, 1, [:map_or_list_or_nil], {:rest, :any}}
+  defp args_spec(:"assoc-in"), do: [:any, :seqable, :any]
+  defp args_spec(:update), do: {:min, 3, [:map_or_list, :any, :callable], {:rest, :any}}
+  defp args_spec(:"update-in"), do: {:min, 3, [:any, :seqable, :callable], {:rest, :any}}
+  defp args_spec(:dissoc), do: {:min, 1, [:map_or_nil], {:rest, :any}}
+  defp args_spec(:"select-keys"), do: [:map_or_nil, :seqable]
+  defp args_spec(:keys), do: [:map_or_nil]
+  defp args_spec(:vals), do: [:map_or_nil]
+  defp args_spec(:"update-vals"), do: [:map_or_nil, :callable]
+  defp args_spec(:"update-keys"), do: [:map_or_nil, :callable]
+  defp args_spec(:"reduce-kv"), do: [:callable, :any, :map_or_nil]
+  defp args_spec(:zipmap), do: [:seqable, :seqable]
+
+  defp args_spec(:filter), do: [:predicate, :seqable]
+  defp args_spec(:remove), do: [:predicate, :seqable]
+
+  defp args_spec(:map),
+    do:
+      {:arity,
+       %{
+         2 => [:keyfn, :seqable],
+         3 => [:callable, :seqable, :seqable],
+         4 => [:callable, :seqable, :seqable, :seqable]
+       }}
+
+  defp args_spec(:mapv), do: args_spec(:map)
+  defp args_spec(:mapcat), do: [:callable, :seqable]
+  defp args_spec(:keep), do: [:keyfn, :seqable]
+  defp args_spec(:sort), do: {:arity, %{1 => [:seqable], 2 => [:callable, :seqable]}}
+
+  defp args_spec(:"sort-by"),
+    do: {:arity, %{2 => [:keyfn, :seqable], 3 => [:keyfn, :callable, :seqable]}}
+
+  defp args_spec(:take), do: [:integer, :seqable]
+  defp args_spec(:drop), do: [:integer, :seqable]
+  defp args_spec(:count), do: [:seqable]
+  defp args_spec(:concat), do: {:rest, :seqable}
+  defp args_spec(:into), do: [:any, :seqable]
+
+  defp args_spec(:reduce),
+    do: {:arity, %{2 => [:callable, :seqable], 3 => [:callable, :any, :seqable]}}
+
+  defp args_spec(_name), do: :unchecked
 
   @doc """
   Get the list of builtin functions for a category.

--- a/lib/ptc_runner/lisp/env/builtin.ex
+++ b/lib/ptc_runner/lisp/env/builtin.ex
@@ -29,10 +29,6 @@ defmodule PtcRunner.Lisp.Env.Builtin do
   def unwrap(%__MODULE__{binding: binding}), do: binding
   def unwrap(other), do: other
 
-  @spec binding(t() | term()) :: term()
-  def binding(%__MODULE__{binding: binding}), do: binding
-  def binding(other), do: other
-
   @spec name(t() | term()) :: atom() | nil
   def name(%__MODULE__{name: name}), do: name
   def name({:variadic_nonempty, name, _}) when is_atom(name), do: name

--- a/lib/ptc_runner/lisp/env/builtin.ex
+++ b/lib/ptc_runner/lisp/env/builtin.ex
@@ -1,0 +1,51 @@
+defmodule PtcRunner.Lisp.Env.Builtin do
+  @moduledoc """
+  Metadata wrapper for callable environment builtins.
+
+  Runtime-created callables still use the raw tuple shapes; this wrapper is for
+  Env bindings where we know the public builtin name and validation contract.
+  """
+
+  defstruct [:name, :binding, args: :unchecked]
+
+  @callable_tags [:normal, :variadic, :variadic_nonempty, :multi_arity, :collect]
+
+  @type raw_binding ::
+          {:normal, function()}
+          | {:variadic, function(), term()}
+          | {:variadic_nonempty, atom(), function()}
+          | {:multi_arity, atom(), tuple()}
+          | {:collect, function()}
+
+  @type t :: %__MODULE__{name: atom(), binding: raw_binding(), args: term()}
+
+  @spec wrap(atom(), raw_binding(), term()) :: t()
+  def wrap(name, binding, args \\ :unchecked)
+      when is_atom(name) and is_tuple(binding) do
+    %__MODULE__{name: name, binding: binding, args: args}
+  end
+
+  @spec unwrap(t() | term()) :: term()
+  def unwrap(%__MODULE__{binding: binding}), do: binding
+  def unwrap(other), do: other
+
+  @spec binding(t() | term()) :: term()
+  def binding(%__MODULE__{binding: binding}), do: binding
+  def binding(other), do: other
+
+  @spec name(t() | term()) :: atom() | nil
+  def name(%__MODULE__{name: name}), do: name
+  def name({:variadic_nonempty, name, _}) when is_atom(name), do: name
+  def name({:multi_arity, name, _}) when is_atom(name), do: name
+  def name(_), do: nil
+
+  @spec args(t() | term()) :: term()
+  def args(%__MODULE__{args: args}), do: args
+  def args(_), do: :unchecked
+
+  @spec builtin?(term()) :: boolean()
+  def builtin?(%__MODULE__{}), do: true
+  def builtin?({tag, _}) when tag in [:normal, :collect], do: true
+  def builtin?({tag, _, _}) when tag in @callable_tags, do: true
+  def builtin?(_), do: false
+end

--- a/lib/ptc_runner/lisp/eval/apply.ex
+++ b/lib/ptc_runner/lisp/eval/apply.ex
@@ -14,6 +14,7 @@ defmodule PtcRunner.Lisp.Eval.Apply do
   - Plain Erlang functions
   """
 
+  alias PtcRunner.Lisp.Env.Builtin
   alias PtcRunner.Lisp.Eval.Context, as: EvalContext
   alias PtcRunner.Lisp.Eval.Helpers
   alias PtcRunner.Lisp.Eval.Patterns
@@ -21,6 +22,7 @@ defmodule PtcRunner.Lisp.Eval.Apply do
   require PtcRunner.Lisp.ExecutionError
   alias PtcRunner.Lisp.Format
   alias PtcRunner.Lisp.Keyword, as: LispKeyword
+  alias PtcRunner.Lisp.Runtime.Args
   alias PtcRunner.Lisp.Runtime.Math
   alias PtcRunner.SubAgent.Namespace.TypeVocabulary
 
@@ -35,6 +37,12 @@ defmodule PtcRunner.Lisp.Eval.Apply do
           {:ok, term(), EvalContext.t()} | {:error, term()}
   def apply_fun(fun_val, args, eval_ctx, do_eval_fn) do
     do_apply_fun(fun_val, args, eval_ctx, do_eval_fn)
+  end
+
+  defp do_apply_fun(%Builtin{} = builtin, args, %EvalContext{} = eval_ctx, do_eval_fn) do
+    with :ok <- maybe_validate_builtin_args(builtin, args) do
+      do_apply_fun(Builtin.unwrap(builtin), args, eval_ctx, do_eval_fn)
+    end
   end
 
   # Keyword as function: (:key map) → Map.get(map, :key)
@@ -131,6 +139,9 @@ defmodule PtcRunner.Lisp.Eval.Apply do
 
       e in RuntimeError ->
         # Catch errors from closure evaluation (destructuring, arity, eval errors)
+        {:error, {:type_error, Exception.message(e), converted_args}}
+
+      e in PtcRunner.Lisp.TypeError ->
         {:error, {:type_error, Exception.message(e), converted_args}}
 
       e in ExecutionError ->
@@ -241,6 +252,9 @@ defmodule PtcRunner.Lisp.Eval.Apply do
       else
         {:error, Helpers.type_error_for_args(fun2, args)}
       end
+
+    e in PtcRunner.Lisp.TypeError ->
+      {:error, {:type_error, Exception.message(e), args}}
   end
 
   # Collect builtins: pass all args as a list to unary function
@@ -253,6 +267,9 @@ defmodule PtcRunner.Lisp.Eval.Apply do
   rescue
     e in ExecutionError ->
       {:error, execution_error_tuple(e)}
+
+    e in PtcRunner.Lisp.TypeError ->
+      {:error, {:type_error, Exception.message(e), args}}
   end
 
   # Multi-arity builtins: select function based on argument count
@@ -285,6 +302,9 @@ defmodule PtcRunner.Lisp.Eval.Apply do
           # See the `{:normal, fun}` clause: surface nested parallel
           # `:memory_exceeded` / `:timeout` rather than crash the sandbox.
           reraise_unless_parallel(e, __STACKTRACE__)
+
+        e in PtcRunner.Lisp.TypeError ->
+          {:error, {:type_error, Exception.message(e), converted_args}}
       end
     else
       arities = Enum.map(0..(tuple_size(funs) - 1), fn i -> i + min_arity end)
@@ -350,6 +370,38 @@ defmodule PtcRunner.Lisp.Eval.Apply do
         {:error, {:invalid_keyword_call, k, args}}
     end
   end
+
+  defp maybe_validate_builtin_args(%Builtin{binding: {:normal, fun}} = builtin, args) do
+    if function_arity(fun) == length(args), do: validate_builtin_args(builtin, args), else: :ok
+  end
+
+  defp maybe_validate_builtin_args(%Builtin{binding: {:multi_arity, _name, funs}} = builtin, args) do
+    arity = length(args)
+    min_arity = function_arity(elem(funs, 0))
+    idx = arity - min_arity
+
+    if idx >= 0 and idx < tuple_size(funs), do: validate_builtin_args(builtin, args), else: :ok
+  end
+
+  defp maybe_validate_builtin_args(%Builtin{binding: {:variadic_nonempty, _name, _fun}}, []) do
+    :ok
+  end
+
+  defp maybe_validate_builtin_args(%Builtin{name: :"merge-with"}, []) do
+    {:error, {:arity_error, "merge-with requires at least 1 argument, got 0"}}
+  end
+
+  defp maybe_validate_builtin_args(%Builtin{} = builtin, args),
+    do: validate_builtin_args(builtin, args)
+
+  defp validate_builtin_args(builtin, args) do
+    Args.validate!(builtin, args)
+    :ok
+  rescue
+    e in PtcRunner.Lisp.TypeError -> {:error, {:type_error, Exception.message(e), args}}
+  end
+
+  defp function_arity(fun), do: :erlang.fun_info(fun, :arity) |> elem(1)
 
   defp check_arity({:variadic, leading, _rest}, args) do
     if length(args) >= length(leading) do
@@ -526,6 +578,7 @@ defmodule PtcRunner.Lisp.Eval.Apply do
 
   def closure_to_fun({:multi_arity, _, _} = builtin, %EvalContext{}, _do_eval_fn), do: builtin
   def closure_to_fun({:collect, _} = builtin, %EvalContext{}, _do_eval_fn), do: builtin
+  def closure_to_fun(%Builtin{} = builtin, %EvalContext{}, _do_eval_fn), do: builtin
 
   # Special forms like println - convert to a function
   def closure_to_fun({:special, :println}, %EvalContext{}, _do_eval_fn) do

--- a/lib/ptc_runner/lisp/eval/helpers.ex
+++ b/lib/ptc_runner/lisp/eval/helpers.ex
@@ -6,6 +6,8 @@ defmodule PtcRunner.Lisp.Eval.Helpers do
   """
 
   alias PtcRunner.Lisp.Env
+  alias PtcRunner.Lisp.Env.Builtin
+  alias PtcRunner.Lisp.Keyword, as: LispKeyword
 
   @doc """
   Generates a type error tuple for FunctionClauseError in builtins.
@@ -32,8 +34,8 @@ defmodule PtcRunner.Lisp.Eval.Helpers do
   end
 
   # first/last/nth on maps - maps are unordered
-  defp specific_type_error(name, [%{} = _map] = args)
-       when name in [:first, :last, :reverse, :sort] do
+  defp specific_type_error(name, [%{} = map] = args)
+       when name in [:first, :last, :reverse, :sort] and not is_struct(map) do
     {:ok,
      {:type_error,
       "#{name} does not support maps (maps are unordered). " <>
@@ -48,6 +50,13 @@ defmodule PtcRunner.Lisp.Eval.Helpers do
   end
 
   defp specific_type_error(:update_vals, [f, m] = args) when is_function(f) and is_map(m) do
+    {:ok,
+     {:type_error,
+      "update-vals expects (map, function) but got (function, map). " <>
+        "Use -> (thread-first) instead of ->> (thread-last) with update-vals", args}}
+  end
+
+  defp specific_type_error(:update_vals, [%Builtin{} = _f, m] = args) when is_map(m) do
     {:ok,
      {:type_error,
       "update-vals expects (map, function) but got (function, map). " <>
@@ -109,7 +118,9 @@ defmodule PtcRunner.Lisp.Eval.Helpers do
   """
   @spec describe_type(term()) :: String.t()
   def describe_type(nil), do: "nil"
+  def describe_type(%Builtin{}), do: "function"
   def describe_type(%MapSet{}), do: "set"
+  def describe_type(%LispKeyword{}), do: "keyword"
   def describe_type(x) when is_list(x), do: "list"
   def describe_type(x) when is_map(x), do: "map"
   def describe_type(x) when is_binary(x), do: "string"
@@ -121,6 +132,7 @@ defmodule PtcRunner.Lisp.Eval.Helpers do
   # error formatting when a builtin is used as a value, e.g. `(first filter)`.
   # Surface them as "function" rather than the leaky "unknown".
   def describe_type({tag, _}) when tag in [:normal, :collect], do: "function"
+  def describe_type({:special, :println}), do: "function"
 
   def describe_type({tag, _, _}) when tag in [:variadic, :variadic_nonempty, :multi_arity],
     do: "function"

--- a/lib/ptc_runner/lisp/format.ex
+++ b/lib/ptc_runner/lisp/format.ex
@@ -50,6 +50,7 @@ defmodule PtcRunner.Lisp.Format do
     end
   end
 
+  alias PtcRunner.Lisp.Env.Builtin, as: EnvBuiltin
   alias PtcRunner.Lisp.Keyword, as: LispKeyword
 
   @doc """
@@ -349,6 +350,11 @@ defmodule PtcRunner.Lisp.Format do
     names = Enum.map_join(params, " ", &extract_param_name/1)
     %Fn{params: names}
   end
+
+  defp sanitize(%EnvBuiltin{binding: {:collect, fun}}) when is_function(fun),
+    do: %Fn{params: "..."}
+
+  defp sanitize(%EnvBuiltin{}), do: %Builtin{}
 
   defp sanitize({:normal, fun}) when is_function(fun), do: %Builtin{}
   defp sanitize({:variadic, fun, _identity}) when is_function(fun), do: %Builtin{}

--- a/lib/ptc_runner/lisp/runtime/args.ex
+++ b/lib/ptc_runner/lisp/runtime/args.ex
@@ -1,0 +1,210 @@
+defmodule PtcRunner.Lisp.Runtime.Args do
+  @moduledoc """
+  Shared runtime argument validation for Env builtin calls.
+  """
+
+  alias PtcRunner.Lisp.Env.Builtin
+  alias PtcRunner.Lisp.Eval.Helpers
+  alias PtcRunner.Lisp.Keyword, as: LispKeyword
+  alias PtcRunner.Lisp.TypeError
+
+  @spec validate!(Builtin.t() | term(), [term()]) :: :ok
+  def validate!(callable, args) do
+    name = display_name(callable)
+
+    case custom_call_error(name, args) do
+      nil ->
+        case Builtin.args(callable) do
+          :unchecked -> :ok
+          spec -> validate_shape!(name, spec, args)
+        end
+
+      message ->
+        raise TypeError, message: message
+    end
+  end
+
+  @spec valid_seqable?(term()) :: boolean()
+  def valid_seqable?(nil), do: true
+  def valid_seqable?(x) when is_list(x), do: true
+  def valid_seqable?(x) when is_binary(x), do: true
+  def valid_seqable?(%MapSet{}), do: true
+  def valid_seqable?(x) when is_function(x), do: false
+  def valid_seqable?(x) when is_map(x) and not is_struct(x), do: true
+  def valid_seqable?(x), do: !!Enumerable.impl_for(x)
+
+  @spec valid_callable?(term()) :: boolean()
+  def valid_callable?(x) when is_function(x), do: true
+  def valid_callable?({:special, :println}), do: true
+  def valid_callable?(%LispKeyword{}), do: true
+  def valid_callable?(x) when is_atom(x) and x not in [nil, true, false], do: true
+  def valid_callable?(x), do: Builtin.builtin?(x) or closure?(x)
+
+  @spec valid_predicate?(term()) :: boolean()
+  def valid_predicate?(%MapSet{}), do: true
+  def valid_predicate?(x), do: valid_keyfn?(x)
+
+  @spec valid_keyfn?(term()) :: boolean()
+  def valid_keyfn?(%MapSet{}), do: true
+  def valid_keyfn?(x) when is_atom(x) and x not in [nil, true, false], do: true
+  def valid_keyfn?(%LispKeyword{}), do: true
+  def valid_keyfn?(x), do: valid_callable?(x)
+
+  defp validate_shape!(_name, :unchecked, _args), do: :ok
+
+  defp validate_shape!(name, specs, args) when is_list(specs) do
+    validate_list!(name, specs, args)
+  end
+
+  defp validate_shape!(name, {:arity, arities}, args) when is_map(arities) do
+    case Map.fetch(arities, length(args)) do
+      {:ok, specs} -> validate_list!(name, specs, args)
+      :error -> :ok
+    end
+  end
+
+  defp validate_shape!(name, {:rest, spec}, args) do
+    Enum.with_index(args, 1)
+    |> Enum.each(fn {arg, index} -> validate_arg!(name, index, spec, arg, args) end)
+  end
+
+  defp validate_shape!(name, {:min, min, fixed_specs, {:rest, rest_spec}}, args) do
+    if length(args) >= min do
+      {fixed, rest} = Enum.split(args, length(fixed_specs))
+
+      validate_list!(name, fixed_specs, fixed, args)
+
+      rest
+      |> Enum.with_index(length(fixed_specs) + 1)
+      |> Enum.each(fn {arg, index} -> validate_arg!(name, index, rest_spec, arg, args) end)
+    else
+      :ok
+    end
+  end
+
+  defp validate_list!(name, specs, args), do: validate_list!(name, specs, args, args)
+
+  defp validate_list!(name, specs, args, all_args) do
+    Enum.zip(specs, args)
+    |> Enum.with_index(1)
+    |> Enum.each(fn {{spec, arg}, index} -> validate_arg!(name, index, spec, arg, all_args) end)
+  end
+
+  defp custom_call_error("sort-by", [key, coll, comp])
+       when (is_atom(key) or is_binary(key) or is_function(key, 1) or
+               is_struct(key, LispKeyword)) and is_list(coll) do
+    if valid_callable?(comp) or comp in [:asc, :desc, :>, :<] do
+      "sort-by expects (key, comparator, collection) but got (key, collection, comparator). Try: (sort-by #{inspect(key)} #{inspect(comp)} collection)"
+    end
+  end
+
+  defp custom_call_error(_name, _args), do: nil
+
+  defp validate_arg!(name, index, spec, arg, args) do
+    case custom_error(name, index, spec, arg, args) do
+      nil ->
+        if valid?(spec, arg) do
+          :ok
+        else
+          raise TypeError,
+            message: "#{name}: arg #{index} expected #{expected(spec)}, got #{actual(arg)}"
+        end
+
+      message ->
+        raise TypeError, message: message
+    end
+  end
+
+  defp custom_error("filter", 2, :seqable, arg, [_pred, arg]) when is_function(arg) do
+    "expected a collection, got a function — collection operations like filter/map/reduce take the collection last; arguments may be swapped"
+  end
+
+  defp custom_error("filter", 1, :predicate, _arg, [_coll, pred]) when is_function(pred) do
+    "expected a collection, got a function — collection operations like filter/map/reduce take the collection last; arguments may be swapped"
+  end
+
+  defp custom_error("filter", 1, :predicate, _arg, [coll, pred]) do
+    if valid_seqable?(coll) and valid_callable?(pred) do
+      "expected a collection, got a function — collection operations like filter/map/reduce take the collection last; arguments may be swapped"
+    end
+  end
+
+  defp custom_error("map", 2, :seqable, arg, [_f, arg]) when is_function(arg) do
+    "expected a collection, got a function — collection operations like filter/map/reduce take the collection last; arguments may be swapped"
+  end
+
+  defp custom_error("reduce", index, :seqable, arg, args)
+       when is_function(arg) and index == length(args) do
+    "expected a collection, got a function — collection operations like filter/map/reduce take the collection last; arguments may be swapped"
+  end
+
+  defp custom_error("get", 1, _spec, key, [key, m | _])
+       when is_map(m) and not is_struct(m) and
+              (is_atom(key) or is_binary(key) or is_list(key) or is_struct(key, LispKeyword)) do
+    "get expects the collection first, e.g. (get map key) — got (#{actual(key)}, map), arguments appear to be swapped"
+  end
+
+  defp custom_error("get-in", 1, _spec, key, [key, m | _])
+       when is_map(m) and not is_struct(m) and
+              (is_atom(key) or is_binary(key) or is_list(key) or is_struct(key, LispKeyword)) do
+    "get-in expects the collection first, e.g. (get-in map key) — got (#{actual(key)}, map), arguments appear to be swapped"
+  end
+
+  defp custom_error("sort-by", 3, :seqable, comp, [key, coll, comp])
+       when (is_atom(key) or is_binary(key) or is_function(key, 1)) and is_list(coll) and
+              (is_function(comp) or comp in [:asc, :desc, :>, :<]) do
+    "sort-by expects (key, comparator, collection) but got (key, collection, comparator). Try: (sort-by #{inspect(key)} #{inspect(comp)} collection)"
+  end
+
+  defp custom_error("update-vals", 1, _spec, f, [f, m]) when is_map(m) and is_function(f) do
+    "update-vals expects (map, function) but got (function, map). Use -> (thread-first) instead of ->> (thread-last) with update-vals"
+  end
+
+  defp custom_error("update-vals", 1, _spec, f, [f, m]) when is_map(m) do
+    if Builtin.builtin?(f) do
+      "update-vals expects (map, function) but got (function, map). Use -> (thread-first) instead of ->> (thread-last) with update-vals"
+    end
+  end
+
+  defp custom_error(_name, _index, _spec, _arg, _args), do: nil
+
+  defp valid?(:any, _), do: true
+  defp valid?(:map, x), do: is_map(x) and not is_struct(x)
+  defp valid?(:map_or_nil, nil), do: true
+  defp valid?(:map_or_nil, x), do: valid?(:map, x)
+  defp valid?(:associative_or_nil, nil), do: true
+  defp valid?(:associative_or_nil, x), do: (is_map(x) and not is_struct(x)) or is_list(x)
+  defp valid?(:map_or_list, x), do: valid?(:map, x) or is_list(x)
+  defp valid?(:map_or_list_or_nil, nil), do: true
+  defp valid?(:map_or_list_or_nil, x), do: valid?(:map_or_list, x)
+  defp valid?(:seqable, x), do: valid_seqable?(x)
+  defp valid?(:callable, x), do: valid_callable?(x)
+  defp valid?(:predicate, x), do: valid_predicate?(x)
+  defp valid?(:keyfn, x), do: valid_keyfn?(x)
+  defp valid?(:number, x), do: is_number(x)
+  defp valid?(:integer, x), do: is_integer(x)
+  defp valid?(:non_neg_integer, x), do: is_integer(x) and x >= 0
+  defp valid?(:string, x), do: is_binary(x)
+  defp valid?(:keyword, %LispKeyword{}), do: true
+  defp valid?(:keyword, x), do: is_atom(x) and x not in [nil, true, false]
+  defp valid?(:regex, {:re_mp, _, _, _}), do: true
+  defp valid?({:one_of, specs}, x), do: Enum.any?(specs, &valid?(&1, x))
+
+  defp expected(:map_or_nil), do: "map"
+  defp expected(:associative_or_nil), do: "associative"
+  defp expected(:map_or_list), do: "map or list"
+  defp expected(:map_or_list_or_nil), do: "map or list"
+  defp expected(:non_neg_integer), do: "non-negative integer"
+  defp expected({:one_of, specs}), do: Enum.map_join(specs, " or ", &expected/1)
+  defp expected(spec), do: spec |> Atom.to_string() |> String.replace("_", " ")
+
+  defp actual(value), do: Helpers.describe_type(value)
+
+  defp display_name(%Builtin{name: name}),
+    do: name |> Atom.to_string() |> String.replace("_", "-")
+
+  defp display_name(other), do: Builtin.name(other) || "function"
+
+  defp closure?({:closure, _, _, _, _, _}), do: true
+  defp closure?(_), do: false
+end

--- a/lib/ptc_runner/lisp/runtime/args.ex
+++ b/lib/ptc_runner/lisp/runtime/args.ex
@@ -150,12 +150,6 @@ defmodule PtcRunner.Lisp.Runtime.Args do
     "get-in expects the collection first, e.g. (get-in map key) — got (#{actual(key)}, map), arguments appear to be swapped"
   end
 
-  defp custom_error("sort-by", 3, :seqable, comp, [key, coll, comp])
-       when (is_atom(key) or is_binary(key) or is_function(key, 1)) and is_list(coll) and
-              (is_function(comp) or comp in [:asc, :desc, :>, :<]) do
-    "sort-by expects (key, comparator, collection) but got (key, collection, comparator). Try: (sort-by #{inspect(key)} #{inspect(comp)} collection)"
-  end
-
   defp custom_error("update-vals", 1, _spec, f, [f, m]) when is_map(m) and is_function(f) do
     "update-vals expects (map, function) but got (function, map). Use -> (thread-first) instead of ->> (thread-last) with update-vals"
   end

--- a/lib/ptc_runner/lisp/runtime/callable.ex
+++ b/lib/ptc_runner/lisp/runtime/callable.ex
@@ -16,7 +16,9 @@ defmodule PtcRunner.Lisp.Runtime.Callable do
       (map range [1 2 3])              ;; multi_arity - now works
   """
 
+  alias PtcRunner.Lisp.Env.Builtin
   alias PtcRunner.Lisp.Keyword, as: LispKeyword
+  alias PtcRunner.Lisp.Runtime.Args
   alias PtcRunner.Lisp.Runtime.FlexAccess
   alias PtcRunner.Lisp.Runtime.Math
 
@@ -24,6 +26,23 @@ defmodule PtcRunner.Lisp.Runtime.Callable do
   defguardp is_keyword(k) when is_atom(k) and k != nil and k != true and k != false
 
   @spec call(term(), [term()]) :: term()
+  def call(%Builtin{binding: {:multi_arity, _name, funs}} = builtin, args) do
+    arity = length(args)
+    min_arity = :erlang.fun_info(elem(funs, 0), :arity) |> elem(1)
+    idx = arity - min_arity
+
+    if idx >= 0 and idx < tuple_size(funs) do
+      Args.validate!(builtin, args)
+    end
+
+    call(Builtin.unwrap(builtin), args)
+  end
+
+  def call(%Builtin{} = builtin, args) do
+    Args.validate!(builtin, args)
+    call(Builtin.unwrap(builtin), args)
+  end
+
   def call(f, args) when is_function(f), do: apply(f, args)
 
   def call(%LispKeyword{} = k, [m]) when is_map(m), do: FlexAccess.flex_get(m, k)

--- a/lib/ptc_runner/lisp/runtime/collection.ex
+++ b/lib/ptc_runner/lisp/runtime/collection.ex
@@ -11,6 +11,7 @@ defmodule PtcRunner.Lisp.Runtime.Collection do
   are implemented in `Collection.Transform`.
   """
 
+  alias PtcRunner.Lisp.Env.Builtin
   alias PtcRunner.Lisp.Eval.Helpers
   alias PtcRunner.Lisp.Keyword, as: LispKeyword
   alias PtcRunner.Lisp.Runtime.Callable
@@ -68,6 +69,15 @@ defmodule PtcRunner.Lisp.Runtime.Collection do
   end
 
   defp wrap_comparator(comp) when is_tuple(comp) do
+    fn a, b ->
+      case Callable.call(comp, [a, b]) do
+        n when is_integer(n) -> n <= 0
+        bool -> bool
+      end
+    end
+  end
+
+  defp wrap_comparator(%Builtin{} = comp) do
     fn a, b ->
       case Callable.call(comp, [a, b]) do
         n when is_integer(n) -> n <= 0

--- a/lib/ptc_runner/lisp/runtime/predicates.ex
+++ b/lib/ptc_runner/lisp/runtime/predicates.ex
@@ -46,6 +46,7 @@ defmodule PtcRunner.Lisp.Runtime.Predicates do
       iex> f.(5)
       6
   """
+  alias PtcRunner.Lisp.Env.Builtin
   alias PtcRunner.Lisp.Keyword, as: LispKeyword
   alias PtcRunner.Lisp.Runtime.Callable
   alias PtcRunner.Lisp.SourceAtoms
@@ -94,6 +95,29 @@ defmodule PtcRunner.Lisp.Runtime.Predicates do
   end
 
   def fnil({:collect, _fun} = callable, default) do
+    {:collect, fn args -> Callable.call(callable, substitute_nil(args, default)) end}
+  end
+
+  def fnil(%Builtin{binding: {:normal, fun}} = callable, default) when is_function(fun) do
+    case :erlang.fun_info(fun, :arity) do
+      {:arity, 1} ->
+        fn
+          nil -> Callable.call(callable, [default])
+          arg -> Callable.call(callable, [arg])
+        end
+
+      {:arity, 2} ->
+        fn
+          nil, arg2 -> Callable.call(callable, [default, arg2])
+          arg1, arg2 -> Callable.call(callable, [arg1, arg2])
+        end
+
+      {:arity, _n} ->
+        {:collect, fn args -> Callable.call(callable, substitute_nil(args, default)) end}
+    end
+  end
+
+  def fnil(%Builtin{} = callable, default) do
     {:collect, fn args -> Callable.call(callable, substitute_nil(args, default)) end}
   end
 
@@ -328,6 +352,7 @@ defmodule PtcRunner.Lisp.Runtime.Predicates do
   def type_of(x) when is_list(x), do: :vector
   def type_of(%MapSet{}), do: :set
   def type_of(%LispKeyword{}), do: :keyword
+  def type_of(%Builtin{}), do: :function
 
   def type_of(x) when is_atom(x) do
     if SpecialValues.special?(x), do: :number, else: :keyword

--- a/priv/functions.exs
+++ b/priv/functions.exs
@@ -2411,7 +2411,7 @@
     %{
       name: "merge",
       description: "Merge maps (later wins)",
-      binding: :variadic,
+      binding: :collect,
       category: :core,
       dispatch: :env,
       signatures: ["(merge m1 m2 ...)"],

--- a/test/ptc_runner/lisp/def_test.exs
+++ b/test/ptc_runner/lisp/def_test.exs
@@ -10,6 +10,7 @@ defmodule PtcRunner.Lisp.DefTest do
 
   alias PtcRunner.Lisp
   alias PtcRunner.Lisp.Analyze
+  alias PtcRunner.Lisp.Env.Builtin
   alias PtcRunner.Lisp.Eval
   alias PtcRunner.Lisp.Format.Var
 
@@ -178,8 +179,8 @@ defmodule PtcRunner.Lisp.DefTest do
       {:ok, value, _} = Eval.eval(ast, %{}, %{}, %{}, &dummy_tool/2)
 
       # count should be a builtin
-      assert is_tuple(value)
-      assert elem(value, 0) == :normal
+      assert Builtin.builtin?(value)
+      assert Builtin.unwrap(value) |> elem(0) == :normal
     end
 
     test "resolution order: locals > user_ns > builtins" do

--- a/test/ptc_runner/lisp/format_test.exs
+++ b/test/ptc_runner/lisp/format_test.exs
@@ -1,6 +1,7 @@
 defmodule PtcRunner.Lisp.FormatTest do
   use ExUnit.Case, async: true
 
+  alias PtcRunner.Lisp.Env.Builtin
   alias PtcRunner.Lisp.Format
 
   doctest PtcRunner.Lisp.Format
@@ -48,6 +49,14 @@ defmodule PtcRunner.Lisp.FormatTest do
     test "formats :multi_arity builtin" do
       assert Format.to_string({:multi_arity, :subs, {&String.slice/2, &String.slice/3}}) ==
                "#<builtin>"
+    end
+
+    test "formats wrapped Env builtins" do
+      normal = Builtin.wrap(:count, {:normal, &Enum.count/1})
+      collect = Builtin.wrap(:merge, {:collect, fn args -> args end})
+
+      assert Format.to_string(normal) == "#<builtin>"
+      assert Format.to_string(collect) == "#fn[...]"
     end
   end
 

--- a/test/ptc_runner/lisp/integration/error_handling_test.exs
+++ b/test/ptc_runner/lisp/integration/error_handling_test.exs
@@ -66,7 +66,7 @@ defmodule PtcRunner.Lisp.Integration.ErrorHandlingTest do
       source = "(filter :x 42)"
 
       assert {:error, %Step{fail: %{reason: :type_error, message: message}}} = Lisp.run(source)
-      assert message =~ "expected a collection, got number 42"
+      assert message =~ "filter: arg 2 expected seqable, got number"
     end
 
     test "filter with arguments swapped returns a clean error, not a raw protocol error" do
@@ -86,7 +86,7 @@ defmodule PtcRunner.Lisp.Integration.ErrorHandlingTest do
       source = "(count 42)"
 
       assert {:error, %Step{fail: %{reason: :type_error, message: message}}} = Lisp.run(source)
-      assert message =~ "invalid argument types"
+      assert message =~ "count: arg 1 expected seqable, got number"
     end
 
     test "take on set returns type error" do
@@ -119,6 +119,45 @@ defmodule PtcRunner.Lisp.Integration.ErrorHandlingTest do
       assert {:error, %Step{fail: %{message: message}}} = Lisp.run("((first filter) 1 2)")
       assert message =~ "function"
       refute message =~ "unknown"
+    end
+
+    test "map builtin type errors include function name and argument position" do
+      assert {:error, %Step{fail: %{reason: :type_error, message: message}}} =
+               Lisp.run("(merge nil [1 2])")
+
+      assert message =~ "merge: arg 2 expected map, got list"
+
+      assert {:error, %Step{fail: %{reason: :type_error, message: message}}} =
+               Lisp.run("(merge [1 2] nil)")
+
+      assert message =~ "merge: arg 1 expected map, got list"
+    end
+
+    test "keyword arguments are reported as keyword in canonical type errors" do
+      assert {:error, %Step{fail: %{reason: :type_error, message: message}}} =
+               Lisp.run("(merge :x {})")
+
+      assert message =~ "merge: arg 1 expected map, got keyword"
+
+      assert {:error, %Step{fail: %{reason: :type_error, message: message}}} =
+               Lisp.run("(take :n [1 2])")
+
+      assert message =~ "take: arg 1 expected integer, got keyword"
+    end
+
+    test "sort-by swapped collection and comparator keeps custom hint" do
+      assert {:error, %Step{fail: %{reason: :type_error, message: message}}} =
+               Lisp.run("(sort-by :k [1 2] >)")
+
+      assert message =~ "sort-by expects (key, comparator, collection)"
+      assert message =~ "got (key, collection, comparator)"
+    end
+
+    test "merge-with without function is an arity error" do
+      assert {:error, %Step{fail: %{reason: :arity_error, message: message}}} =
+               Lisp.run("(merge-with)")
+
+      assert message =~ "merge-with requires at least 1 argument"
     end
   end
 

--- a/test/ptc_runner/lisp/registry_test.exs
+++ b/test/ptc_runner/lisp/registry_test.exs
@@ -3,6 +3,7 @@ defmodule PtcRunner.Lisp.RegistryTest do
 
   alias PtcRunner.Lisp.Analyze
   alias PtcRunner.Lisp.Env
+  alias PtcRunner.Lisp.Env.Builtin
   alias PtcRunner.Lisp.Registry
 
   describe "sync validation" do
@@ -254,6 +255,10 @@ defmodule PtcRunner.Lisp.RegistryTest do
                "#{name} divergences should link to docs/clojure-conformance-gaps.md, got: #{inspect(entry[:divergences])}"
       end
     end
+  end
+
+  defp binding_type(%Builtin{} = builtin) do
+    builtin |> Builtin.unwrap() |> binding_type()
   end
 
   defp binding_type({:normal, _}), do: :normal

--- a/test/ptc_runner/lisp/runtime/callable_test.exs
+++ b/test/ptc_runner/lisp/runtime/callable_test.exs
@@ -1,8 +1,12 @@
 defmodule PtcRunner.Lisp.Runtime.CallableTest do
   use ExUnit.Case, async: true
 
+  alias PtcRunner.Lisp.Env
+  alias PtcRunner.Lisp.Env.Builtin
   alias PtcRunner.Lisp.Runtime.Callable
+  alias PtcRunner.Lisp.Runtime.MapOps
   alias PtcRunner.Lisp.Runtime.Math
+  alias PtcRunner.Lisp.TypeError
 
   describe "call/2 with plain functions" do
     test "calls function with args" do
@@ -100,6 +104,22 @@ defmodule PtcRunner.Lisp.Runtime.CallableTest do
     test "passes args as list to unary function" do
       collect = {:collect, fn args -> Enum.sum(args) end}
       assert Callable.call(collect, [1, 2, 3, 4, 5]) == 15
+    end
+  end
+
+  describe "call/2 with wrapped Env builtins" do
+    test "validates with builtin metadata before calling" do
+      builtin = Builtin.wrap(:merge, {:collect, &MapOps.merge_variadic/1}, {:rest, :map_or_nil})
+
+      assert_raise TypeError, "merge: arg 2 expected map, got list", fn ->
+        Callable.call(builtin, [%{}, [1, 2]])
+      end
+    end
+
+    test "wrapped multi-arity builtin preserves arity errors" do
+      assert_raise ArgumentError, ~r/map arity mismatch: got 0 arguments/, fn ->
+        Callable.call(Env.initial()[:map], [])
+      end
     end
   end
 end

--- a/test/ptc_runner/lisp_test.exs
+++ b/test/ptc_runner/lisp_test.exs
@@ -255,17 +255,16 @@ defmodule PtcRunner.LispTest do
       assert msg =~ "Tool 'kaboom' failed: \"boom\""
     end
 
-    test "unexpected runtime exception reports as runtime_error not tool_error" do
-      # Simulate a built-in function that raises unexpectedly.
-      # We use a tool that returns a non-map value, then call (keys result)
-      # which will raise ArgumentError from Map.keys/1.
-      # This should be classified as :runtime_error, not :tool_error with name "unknown".
+    test "builtin type error after tool result reports as type_error not tool_error" do
+      # A tool can return a value with the wrong shape for a downstream builtin.
+      # This should be classified as a Lisp type error, not a tool_error with
+      # name "unknown".
       tools = %{"get-data" => fn _args -> "not-a-map" end}
 
-      assert {:error, %{fail: %{reason: :runtime_error, message: msg}}} =
+      assert {:error, %{fail: %{reason: :type_error, message: msg}}} =
                Lisp.run(~S|(keys (tool/get-data {}))|, tools: tools)
 
-      assert msg =~ "Runtime error:"
+      assert msg =~ "keys: arg 1 expected map, got string"
       refute msg =~ "unknown"
     end
 


### PR DESCRIPTION
## Summary
- Wrap callable Env builtins with metadata so runtime validation has the public builtin name and argument contract
- Add shared Args validation for selected map and collection builtins with canonical `function: arg n expected type, got type` diagnostics
- Preserve arity precedence, raw runtime callables, formatting, registry classification, and custom swapped-argument hints

## Verification
- `mix format --check-formatted`
- `mix credo --strict`
- `mix test test/ptc_runner/lisp`
- Pre-push hook: root full suite + dialyzer, mcp_server full suite + dialyzer, ptc_viewer full suite

## Fix Automation State
<!-- fix-state: {"attempts":4} -->
Fix attempts: 2/3
