### PR TITLE
feat(sub_agent): add mission_log_in format option for prompt caching

### DIFF
--- a/docs/guides/subagent-advanced.md
+++ b/docs/guides/subagent-advanced.md
@@ -129,6 +129,7 @@ Large results are automatically truncated at different stages to manage context 
 | `result_limit` | 50 | Inspect `:limit` for final result formatting |
 | `result_max_chars` | 500 | Max chars in final result string |
 | `max_print_length` | 2000 | Max chars per `println` call |
+| `mission_log_in` | `:system_prompt` | Where to inject the mission log: `:system_prompt` or `:user_message` (use `:user_message` to keep the system prompt static for prompt caching) |
 
 Configure via `format_options`:
 
@@ -141,6 +142,8 @@ SubAgent.new(
   ]
 )
 ```
+
+To enable prompt caching with providers that cache the system prompt, set `mission_log_in: :user_message` — this keeps the system prompt static across turns while the mission log updates in the first user message.
 
 When data is truncated in turn feedback, the system appends:
 > *"... (truncated)"*

--- a/lib/ptc_runner/sub_agent/definition.ex
+++ b/lib/ptc_runner/sub_agent/definition.ex
@@ -151,6 +151,7 @@ defmodule PtcRunner.SubAgent.Definition do
   - `result_limit` - Inspect `:limit` for final result (default: 50)
   - `result_max_chars` - Final string truncation (default: 500)
   - `max_print_length` - Max chars per `println` call (default: 2000)
+  - `mission_log_in` - Where to inject the mission log: `:system_prompt` (default) or `:user_message`
   """
   @type format_options :: [
           feedback_limit: pos_integer(),
@@ -158,7 +159,8 @@ defmodule PtcRunner.SubAgent.Definition do
           history_max_bytes: pos_integer(),
           result_limit: pos_integer(),
           result_max_chars: pos_integer(),
-          max_print_length: pos_integer()
+          max_print_length: pos_integer(),
+          mission_log_in: :system_prompt | :user_message
         ]
 
   @typedoc """

--- a/lib/ptc_runner/sub_agent/loop.ex
+++ b/lib/ptc_runner/sub_agent/loop.ex
@@ -558,6 +558,7 @@ defmodule PtcRunner.SubAgent.Loop do
     # Build messages: pressure-triggered compaction trims older turns when
     # the threshold is reached; otherwise the raw accumulated history is sent.
     {messages, compaction_stats} = build_llm_messages(agent, state)
+    messages = maybe_inject_mission_log_in_messages(agent, state.journal, messages)
 
     state = maybe_put_state(state, :compaction_stats, compaction_stats)
 
@@ -1170,8 +1171,9 @@ defmodule PtcRunner.SubAgent.Loop do
         base
       end
 
-    # Only append mission log when journaling is enabled on the agent
-    if agent.journaling do
+    mission_log_in = Keyword.get(agent.format_options, :mission_log_in, :system_prompt)
+
+    if agent.journaling and mission_log_in == :system_prompt do
       case journal do
         %{} = j when map_size(j) > 0 ->
           mission_log = SystemPrompt.render_mission_log(journal)
@@ -1182,6 +1184,33 @@ defmodule PtcRunner.SubAgent.Loop do
       end
     else
       base
+    end
+  end
+
+  # When mission_log_in: :user_message, prepend the rendered mission log to
+  # the first user message in the message list. Called each turn so the log
+  # reflects the current journal without polluting state.messages.
+  defp maybe_inject_mission_log_in_messages(agent, journal, messages) do
+    mission_log_in = Keyword.get(agent.format_options, :mission_log_in, :system_prompt)
+
+    with true <- agent.journaling,
+         :user_message <- mission_log_in,
+         %{} = j when map_size(j) > 0 <- journal do
+      mission_log = SystemPrompt.render_mission_log(journal)
+      inject_into_first_user_message(messages, mission_log)
+    else
+      _ -> messages
+    end
+  end
+
+  defp inject_into_first_user_message(messages, prefix) do
+    case Enum.split_while(messages, &(&1.role != :user)) do
+      {before, [first_user | rest]} ->
+        updated = %{first_user | content: prefix <> "\n\n" <> first_user.content}
+        before ++ [updated | rest]
+
+      _ ->
+        messages
     end
   end
 

--- a/test/ptc_runner/sub_agent/journal_test.exs
+++ b/test/ptc_runner/sub_agent/journal_test.exs
@@ -175,4 +175,133 @@ defmodule PtcRunner.SubAgent.JournalTest do
       assert step2.journal == %{"charge_100" => "tx_100"}
     end
   end
+
+  describe "mission_log_in: :user_message" do
+    test "mission log appears in first user message instead of system prompt" do
+      agent =
+        test_agent(
+          max_turns: 2,
+          journaling: true,
+          format_options: [mission_log_in: :user_message]
+        )
+
+      llm = fn %{system: system, messages: messages, turn: 1} ->
+        refute system =~ "<mission_log>"
+
+        first_user = Enum.find(messages, &(&1.role == :user))
+        assert first_user.content =~ "<mission_log>"
+        assert first_user.content =~ "[done] order_1: \"tx_123\""
+
+        {:ok, ~S|```clojure
+(return "ok")
+```|}
+      end
+
+      {:ok, _step} = SubAgent.run(agent, llm: llm, journal: %{"order_1" => "tx_123"})
+    end
+
+    test "system prompt stays static across turns" do
+      agent =
+        test_agent(
+          max_turns: 3,
+          journaling: true,
+          format_options: [mission_log_in: :user_message]
+        )
+
+      system_prompts = :ets.new(:system_prompts, [:set, :public])
+
+      llm = fn %{system: system, turn: turn} ->
+        :ets.insert(system_prompts, {turn, system})
+
+        case turn do
+          1 ->
+            {:ok, ~S|```clojure
+(task "step-1" (+ 1 2))
+```|}
+
+          2 ->
+            {:ok, ~S|```clojure
+(return "done")
+```|}
+        end
+      end
+
+      {:ok, _step} = SubAgent.run(agent, llm: llm, journal: %{})
+
+      [{1, sys1}] = :ets.lookup(system_prompts, 1)
+      [{2, sys2}] = :ets.lookup(system_prompts, 2)
+      assert sys1 == sys2
+      :ets.delete(system_prompts)
+    end
+
+    test "mission log updates in user message on turn 2 after task completion" do
+      tools = %{"lookup" => fn %{"id" => id} -> "user_#{id}" end}
+
+      agent =
+        test_agent(
+          max_turns: 3,
+          tools: tools,
+          journaling: true,
+          format_options: [mission_log_in: :user_message]
+        )
+
+      llm = fn %{messages: messages, turn: turn} ->
+        case turn do
+          1 ->
+            {:ok, ~S|```clojure
+(task "fetch_user_42" (tool/lookup {:id 42}))
+```|}
+
+          2 ->
+            first_user = Enum.find(messages, &(&1.role == :user))
+            assert first_user.content =~ "[done] fetch_user_42: \"user_42\""
+
+            {:ok, ~S|```clojure
+(return "ok")
+```|}
+        end
+      end
+
+      {:ok, _step} = SubAgent.run(agent, llm: llm, journal: %{})
+    end
+
+    test "empty journal produces no injection in either mode" do
+      for mode <- [:system_prompt, :user_message] do
+        agent =
+          test_agent(
+            max_turns: 2,
+            journaling: true,
+            format_options: [mission_log_in: mode]
+          )
+
+        llm = fn %{system: system, messages: messages, turn: 1} ->
+          refute system =~ "<mission_log>"
+
+          first_user = Enum.find(messages, &(&1.role == :user))
+          refute first_user.content =~ "<mission_log>"
+
+          {:ok, ~S|```clojure
+(return "ok")
+```|}
+        end
+
+        {:ok, _step} = SubAgent.run(agent, llm: llm, journal: %{})
+      end
+    end
+
+    test "default mode :system_prompt preserves existing behavior" do
+      agent = test_agent(max_turns: 2, journaling: true)
+
+      llm = fn %{system: system, turn: 1} ->
+        assert system =~ "<mission_log>"
+        assert system =~ "[done] task_a"
+
+        {:ok, ~S|```clojure
+(return "ok")
+```|}
+      end
+
+      {:ok, _step} = SubAgent.run(agent, llm: llm, journal: %{"task_a" => "result"})
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- Add `format_options: [mission_log_in: :user_message]` to control where the mission log is injected
- When `:user_message`, the system prompt stays static across turns, enabling LLM prompt caching
- Default `:system_prompt` preserves existing behavior — no breaking change

Closes #785

## Changes

**`lib/ptc_runner/sub_agent/definition.ex`**
- Add `:mission_log_in` to `format_options` typespec (`:system_prompt | :user_message`)

**`lib/ptc_runner/sub_agent/loop.ex`**
- `build_system_prompt/6`: Skip mission log when `mission_log_in: :user_message`
- `maybe_inject_mission_log_in_messages/3`: Inject mission log into the first user message each turn (after compaction, so state.messages stays clean and compaction can't discard it)

**`test/ptc_runner/sub_agent/journal_test.exs`**
- Mission log appears in user message, not system prompt
- System prompt is identical across turns (proves cacheability)
- Mission log updates after task completion on turn 2
- Empty journal produces no injection in either mode
- Default `:system_prompt` mode preserves existing behavior

## Test plan
- [x] All 5135 existing tests pass
- [x] 5 new tests covering `:user_message` mode
- [x] Existing journal/mission log tests pass unchanged
- [x] `mix precommit` passes (format + compile + credo + tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Fix Automation State
<!-- fix-state: {"attempts":2} -->
Fix attempts: 2/3
