### PR TITLE
fix(string): align split-lines empty input

### DIFF
--- a/conformance_inventory.json
+++ b/conformance_inventory.json
@@ -3847,7 +3847,7 @@
     "symbol": "split-lines",
     "namespace": "clojure.string",
     "compatibility_target": "Clojure",
-    "notes": "BUG GAP-S51: empty string currently returns [] instead of [\"\"]"
+    "notes": "GAP-S51 fixed: empty string returns [\"\"]"
   },
   {
     "status": "supported",

--- a/docs/clojure-conformance-gaps.md
+++ b/docs/clojure-conformance-gaps.md
@@ -2456,19 +2456,20 @@ space is not removed by these helpers but EM SPACE is considered whitespace.
 | Field | Value |
 |-------|-------|
 | **Priority** | P2 |
-| **Status** | open |
+| **Status** | fixed |
 | **Source** | Manual conformance case `string/split-lines-empty-bug-001` |
 
 ```clojure
 ;; Clojure
 (clojure.string/split-lines "")   ;=> [""]
 
-;; PTC-Lisp current behavior
-(clojure.string/split-lines "")   ;=> []
+;; PTC-Lisp
+(clojure.string/split-lines "")   ;=> [""]
 ```
 
-**Decision:** BUG. This is a supported Clojure-named string helper on finite
-input, and returning an empty collection loses the single empty line.
+**Fix:** Added an explicit empty-input case so `(clojure.string/split-lines "")`
+returns the single empty line while preserving the existing non-empty line-split
+behavior, including trimming trailing empty lines.
 
 ### GAP-S52: Bit shift/test helpers do not apply JVM index masking
 

--- a/docs/conformance/clojure-string-audit.md
+++ b/docs/conformance/clojure-string-audit.md
@@ -40,7 +40,7 @@ Coverage excludes `not_relevant` entries: `supported / (supported + candidate + 
 | `replace-first` | 🔲 candidate | Replaces first instance of match in s | pure string transformation |
 | `reverse` | 🔲 candidate | Returns s with characters reversed | pure string transformation |
 | `split` | ✅ supported | Splits string on regex | BUG GAP-S15: empty regex currently keeps a trailing empty element; BUG GAP-S25: 3-arity limit form is not implemented; BUG GAP-S74: plain string delimiter is accepted even though Clojure requires a regex; BUG GAP-S95: trailing empty fields and empty input differ from Clojure split. BUG GAP-S116: character delimiters are accepted instead of raising |
-| `split-lines` | ✅ supported | Splits string on \n or \r\n | BUG GAP-S51: empty string currently returns [] instead of [""] |
+| `split-lines` | ✅ supported | Splits string on \n or \r\n | GAP-S51 fixed: empty string returns [""] |
 | `starts-with?` | ✅ supported | True if s starts with substr | BUG GAP-S116: character substring arguments are accepted instead of raising. BUG GAP-S139: numeric receivers raise instead of being stringified |
 | `trim` | ✅ supported | Removes whitespace from both ends of string | BUG GAP-S50: Unicode whitespace classification differs from Clojure for U+00A0 and U+2003 |
 | `trim-newline` | ✅ supported | Removes all trailing newline or return characters | BUG GAP-S116: character inputs are accepted instead of raising |

--- a/lib/ptc_runner/lisp/runtime/string.ex
+++ b/lib/ptc_runner/lisp/runtime/string.ex
@@ -135,6 +135,10 @@ defmodule PtcRunner.Lisp.Runtime.String do
   - (split-lines "line1\nline2\r\nline3") returns ["line1" "line2" "line3"]
   - Does not return trailing empty lines.
   """
+  def split_lines("") do
+    [""]
+  end
+
   def split_lines(s) when is_binary(s) do
     s
     |> String.split(~r/\r?\n/)

--- a/priv/function_audit.exs
+++ b/priv/function_audit.exs
@@ -3325,7 +3325,7 @@
       name: "split-lines",
       status: :supported,
       description: "Splits string on \\n or \\r\\n",
-      notes: "BUG GAP-S51: empty string currently returns [] instead of [\"\"]"
+      notes: "GAP-S51 fixed: empty string returns [\"\"]"
     },
     %{
       name: "starts-with?",

--- a/test/ptc_runner/lisp/runtime/string_split_lines_test.exs
+++ b/test/ptc_runner/lisp/runtime/string_split_lines_test.exs
@@ -26,7 +26,7 @@ defmodule PtcRunner.Lisp.Runtime.StringSplitLinesTest do
     end
 
     test "handles empty string" do
-      assert Runtime.split_lines("") == []
+      assert Runtime.split_lines("") == [""]
     end
 
     test "handles input with only newlines" do

--- a/test/support/lisp_conformance_cases/manual.ex
+++ b/test/support/lisp_conformance_cases/manual.ex
@@ -593,13 +593,13 @@ defmodule PtcRunner.TestSupport.LispConformanceCases.Manual do
         "GAP-S50",
         "Clojure trimr removes trailing EM SPACE; PTC-Lisp currently leaves it unchanged."
       ),
-      bug_case(
+      fixed_bug_case(
         "string/split-lines-empty-bug-001",
         "clojure.string",
         ["split-lines"],
         ~S|(clojure.string/split-lines "")|,
         "GAP-S51",
-        "Clojure split-lines returns one empty string for empty input; PTC-Lisp currently returns an empty vector."
+        "Clojure split-lines returns one empty string for empty input; this guards GAP-S51."
       ),
       c(
         "string/split-lines-001",


### PR DESCRIPTION
## Summary
- Fixes GAP-S51 by returning `[""]` for `(clojure.string/split-lines "")`.
- Converts the manual GAP-S51 case into a fixed regression case.
- Refreshes conformance audit metadata and `conformance_inventory.json`.

## Verification
- `mix test test/ptc_runner/lisp/runtime/string_split_lines_test.exs`
- `MIX_ENV=test mix run -e ...` for `string/split-lines-empty-bug-001` against Babashka: PTC and Clojure both returned `[""]`
- `mix ptc.gen_docs`
- `mix ptc.conformance_report --write-inventory`
- `~/.codex/skills/codex-review/scripts/codex-independent-review review --base main` (high effort): no findings
- `mix precommit`
- pre-push hook passed root tests, root dialyzer, mcp_server tests, mcp_server dialyzer, and ptc_viewer tests

Refs #1030.