### PR TITLE
fix(lisp): close GAP-S128 threading nil conformance

### DIFF
--- a/conformance_inventory.json
+++ b/conformance_inventory.json
@@ -46,14 +46,14 @@
     "symbol": "->",
     "namespace": "clojure.core",
     "compatibility_target": "Clojure",
-    "notes": "BUG GAP-S128: nil thread form returns nil instead of raising"
+    "notes": "GAP-S128 fixed: nil thread targets raise as not callable"
   },
   {
     "status": "supported",
     "symbol": "->>",
     "namespace": "clojure.core",
     "compatibility_target": "Clojure",
-    "notes": "BUG GAP-S128: nil thread form returns nil instead of raising"
+    "notes": "GAP-S128 fixed: nil thread targets raise as not callable"
   },
   {
     "status": "not_relevant",
@@ -704,14 +704,14 @@
     "symbol": "cond->",
     "namespace": "clojure.core",
     "compatibility_target": "Clojure",
-    "notes": "BUG GAP-S123: trailing unmatched test raises instead of acting as a no-op. BUG GAP-S128: truthy nil thread form returns nil instead of raising"
+    "notes": "BUG GAP-S123: trailing unmatched test raises instead of acting as a no-op"
   },
   {
     "status": "supported",
     "symbol": "cond->>",
     "namespace": "clojure.core",
     "compatibility_target": "Clojure",
-    "notes": "BUG GAP-S123: trailing unmatched test raises instead of acting as a no-op. BUG GAP-S128: truthy nil thread form returns nil instead of raising"
+    "notes": "BUG GAP-S123: trailing unmatched test raises instead of acting as a no-op"
   },
   {
     "status": "supported",
@@ -3035,14 +3035,14 @@
     "symbol": "some->",
     "namespace": "clojure.core",
     "compatibility_target": "Clojure",
-    "notes": "BUG GAP-S128: nil thread form returns nil instead of raising"
+    "notes": "GAP-S128 fixed: nil thread targets raise once reached"
   },
   {
     "status": "supported",
     "symbol": "some->>",
     "namespace": "clojure.core",
     "compatibility_target": "Clojure",
-    "notes": "BUG GAP-S128: nil thread form returns nil instead of raising"
+    "notes": "GAP-S128 fixed: nil thread targets raise once reached"
   },
   {
     "status": "supported",

--- a/docs/clojure-conformance-gaps.md
+++ b/docs/clojure-conformance-gaps.md
@@ -4723,7 +4723,7 @@ finite forms during analysis.
 | Field | Value |
 |-------|-------|
 | **Priority** | P1 |
-| **Status** | open |
+| **Status** | **fixed** |
 | **Source** | Manual conformance cases `core/thread-first-nil-form-bug-001`, `core/thread-last-nil-form-bug-001`, `core/some-thread-nil-form-bug-001`, `core/some-thread-last-nil-form-bug-001`, `core/cond-thread-true-nil-form-bug-001`, `core/cond-thread-last-true-nil-form-bug-001` |
 
 ```clojure
@@ -4735,19 +4735,21 @@ finite forms during analysis.
 (cond-> 1 true nil)   ;=> NullPointerException
 (cond->> 1 true nil)  ;=> NullPointerException
 
-;; PTC-Lisp current behavior
-(-> 1 nil)   ;=> nil
-(->> 1 nil)  ;=> nil
-(some-> 1 nil)   ;=> nil
-(some->> 1 nil)  ;=> nil
-(cond-> 1 true nil)   ;=> nil
-(cond->> 1 true nil)  ;=> nil
+;; PTC-Lisp (fixed)
+(-> 1 nil)   ;=> not_callable
+(->> 1 nil)  ;=> not_callable
+(some-> 1 nil)   ;=> not_callable
+(some->> 1 nil)  ;=> not_callable
+(cond-> 1 true nil)   ;=> not_callable
+(cond->> 1 true nil)  ;=> not_callable
 ```
 
-**Decision:** BUG. These are supported Clojure-named threading macros. A nil
-thread target is invalid program structure once the threaded value reaches that
-form; returning nil silently can mask a malformed pipeline as a valid absent
-value.
+**Decision:** BUG, fixed. These are supported Clojure-named threading macros.
+A nil thread target is invalid program structure once the threaded value
+reaches that form. PTC-Lisp now treats the rewritten call target as not
+callable instead of silently returning nil, while `some->`/`some->>` still
+short-circuit when the threaded value itself is nil and `cond->`/`cond->>` still
+skip forms whose tests are falsey.
 
 ### GAP-S115: `if-let`/`if-some` no-else arity is unsupported
 

--- a/docs/conformance/clojure-core-audit.md
+++ b/docs/conformance/clojure-core-audit.md
@@ -32,8 +32,8 @@ Coverage excludes `not_relevant` entries: `supported / (supported + candidate + 
 | `+'` | ✅ supported | Adds numbers with arbitrary precision | alias for +; BEAM integers are already arbitrary precision |
 | `-` | ✅ supported | Subtracts numbers or negates single argument |  |
 | `-'` | ✅ supported | Subtracts numbers with arbitrary precision | alias for -; BEAM integers are already arbitrary precision |
-| `->` | ✅ supported | Threads expression as second argument through forms | BUG GAP-S128: nil thread form returns nil instead of raising |
-| `->>` | ✅ supported | Threads expression as last argument through forms | BUG GAP-S128: nil thread form returns nil instead of raising |
+| `->` | ✅ supported | Threads expression as second argument through forms | GAP-S128 fixed: nil thread targets raise as not callable |
+| `->>` | ✅ supported | Threads expression as last argument through forms | GAP-S128 fixed: nil thread targets raise as not callable |
 | `.` | ❌ not_relevant | Java member access and method calls | Java interop |
 | `..` | ❌ not_relevant | Chains member access operations | Java interop |
 | `/` | ✅ supported | Divides numbers |  |
@@ -127,8 +127,8 @@ Coverage excludes `not_relevant` entries: `supported / (supported + candidate + 
 | `completing` | 🔲 candidate | Returns reducing function with completion | pure function for reducing transformations |
 | `concat` | ✅ supported | Returns lazy seq concatenating collections | BUG GAP-S57: string inputs currently raise instead of being treated as seqable |
 | `cond` | ✅ supported | Multi-way conditional | The zero-clause form returns nil, matching Clojure |
-| `cond->` | ✅ supported | Threads through forms where tests true | BUG GAP-S123: trailing unmatched test raises instead of acting as a no-op. BUG GAP-S128: truthy nil thread form returns nil instead of raising |
-| `cond->>` | ✅ supported | Threads as last arg where tests true | BUG GAP-S123: trailing unmatched test raises instead of acting as a no-op. BUG GAP-S128: truthy nil thread form returns nil instead of raising |
+| `cond->` | ✅ supported | Threads through forms where tests true | BUG GAP-S123: trailing unmatched test raises instead of acting as a no-op |
+| `cond->>` | ✅ supported | Threads as last arg where tests true | BUG GAP-S123: trailing unmatched test raises instead of acting as a no-op |
 | `condp` | ✅ supported | Predicate dispatch against expression | BUG GAP-S38: :>> result-function clauses are unsupported. BUG GAP-S103: no-match/no-default form currently returns nil instead of raising |
 | `conj` | ✅ supported | Returns collection with items added | BUG GAP-S76: conjoining a map into a map currently raises instead of merging entries. The zero-arity form returns an empty vector (Clojure's conj identity). BUG GAP-S137: list pairs are treated as map entries instead of raising. DIV-25: nil/list targets use vector append semantics |
 | `conj!` | ❌ not_relevant | Adds item to transient collection | operates on transient collections (mutable) |
@@ -459,8 +459,8 @@ Coverage excludes `not_relevant` entries: `supported / (supported + candidate + 
 | `simple-symbol?` | ❌ not_relevant | Returns true if symbol has no ns | symbols are not supported as runtime values |
 | `slurp` | ❌ not_relevant | Reads entire contents of file/URL | involves file/network I/O |
 | `some` | ✅ supported | Returns first truthy result or nil | BUG GAP-S71: map/vector callables are rejected in function position. BUG GAP-S130: character literals are treated as one-character strings instead of raising |
-| `some->` | ✅ supported | Threads through forms while non-nil | BUG GAP-S128: nil thread form returns nil instead of raising |
-| `some->>` | ✅ supported | Threads as last arg while non-nil | BUG GAP-S128: nil thread form returns nil instead of raising |
+| `some->` | ✅ supported | Threads through forms while non-nil | GAP-S128 fixed: nil thread targets raise once reached |
+| `some->>` | ✅ supported | Threads as last arg while non-nil | GAP-S128 fixed: nil thread targets raise once reached |
 | `some-fn` | ✅ supported | Returns pred true if any fn truthy | BUG GAP-S71: map/set/vector callables are rejected in predicate position |
 | `some?` | ✅ supported | Returns true if not nil |  |
 | `sort` | ✅ supported | Returns sorted sequence | DIV-30: uses PTC's recoverable total term ordering for nil and mixed values; BUG GAP-S20: nil input currently raises instead of returning an empty seq; BUG GAP-S46: nil comparator currently raises instead of using default compare; BUG GAP-S107: boolean comparator functions are not honored with Clojure ordering semantics |

--- a/priv/function_audit.exs
+++ b/priv/function_audit.exs
@@ -40,13 +40,13 @@
       name: "->",
       status: :supported,
       description: "Threads expression as second argument through forms",
-      notes: "BUG GAP-S128: nil thread form returns nil instead of raising"
+      notes: "GAP-S128 fixed: nil thread targets raise as not callable"
     },
     %{
       name: "->>",
       status: :supported,
       description: "Threads expression as last argument through forms",
-      notes: "BUG GAP-S128: nil thread form returns nil instead of raising"
+      notes: "GAP-S128 fixed: nil thread targets raise as not callable"
     },
     %{
       name: ".",
@@ -616,15 +616,13 @@
       name: "cond->",
       status: :supported,
       description: "Threads through forms where tests true",
-      notes:
-        "BUG GAP-S123: trailing unmatched test raises instead of acting as a no-op. BUG GAP-S128: truthy nil thread form returns nil instead of raising"
+      notes: "BUG GAP-S123: trailing unmatched test raises instead of acting as a no-op"
     },
     %{
       name: "cond->>",
       status: :supported,
       description: "Threads as last arg where tests true",
-      notes:
-        "BUG GAP-S123: trailing unmatched test raises instead of acting as a no-op. BUG GAP-S128: truthy nil thread form returns nil instead of raising"
+      notes: "BUG GAP-S123: trailing unmatched test raises instead of acting as a no-op"
     },
     %{
       name: "condp",
@@ -2617,13 +2615,13 @@
       name: "some->",
       status: :supported,
       description: "Threads through forms while non-nil",
-      notes: "BUG GAP-S128: nil thread form returns nil instead of raising"
+      notes: "GAP-S128 fixed: nil thread targets raise once reached"
     },
     %{
       name: "some->>",
       status: :supported,
       description: "Threads as last arg while non-nil",
-      notes: "BUG GAP-S128: nil thread form returns nil instead of raising"
+      notes: "GAP-S128 fixed: nil thread targets raise once reached"
     },
     %{
       name: "some-fn",

--- a/test/ptc_runner/lisp/analyze_operations_test.exs
+++ b/test/ptc_runner/lisp/analyze_operations_test.exs
@@ -1,6 +1,7 @@
 defmodule PtcRunner.Lisp.AnalyzeOperationsTest do
   use ExUnit.Case, async: true
 
+  alias PtcRunner.Lisp
   alias PtcRunner.Lisp.Analyze
 
   describe "threading desugars to nested calls" do
@@ -63,6 +64,16 @@ defmodule PtcRunner.Lisp.AnalyzeOperationsTest do
       raw = {:list, [{:symbol, :->}]}
       assert {:error, {:invalid_thread_form, :->, msg}} = Analyze.analyze(raw)
       assert msg =~ "at least one"
+    end
+
+    test "thread-first nil step raises instead of returning nil" do
+      assert {:error, %{fail: %{reason: :not_callable, message: "not callable: nil"}}} =
+               Lisp.run("(-> 1 nil)")
+    end
+
+    test "thread-last nil step raises instead of returning nil" do
+      assert {:error, %{fail: %{reason: :not_callable, message: "not callable: nil"}}} =
+               Lisp.run("(->> 1 nil)")
     end
   end
 

--- a/test/ptc_runner/lisp/threading_extensions_test.exs
+++ b/test/ptc_runner/lisp/threading_extensions_test.exs
@@ -60,6 +60,15 @@ defmodule PtcRunner.Lisp.ThreadingExtensionsTest do
     test "error on odd number of forms" do
       assert {:error, _} = Lisp.run("(cond-> 1 true)")
     end
+
+    test "truthy nil step raises instead of returning nil" do
+      assert {:error, %{fail: %{reason: :not_callable, message: "not callable: nil"}}} =
+               Lisp.run("(cond-> 1 true nil)")
+    end
+
+    test "falsey nil step remains skipped" do
+      assert {:ok, %{return: 1}} = Lisp.run("(cond-> 1 false nil)")
+    end
   end
 
   describe "cond->>" do
@@ -70,6 +79,11 @@ defmodule PtcRunner.Lisp.ThreadingExtensionsTest do
     test "applies steps conditionally" do
       assert {:ok, %{return: [2, 3, 4]}} =
                Lisp.run("(cond->> [1 2 3] true (map inc) false (filter odd?))")
+    end
+
+    test "truthy nil step raises instead of returning nil" do
+      assert {:error, %{fail: %{reason: :not_callable, message: "not callable: nil"}}} =
+               Lisp.run("(cond->> 1 true nil)")
     end
   end
 
@@ -102,6 +116,15 @@ defmodule PtcRunner.Lisp.ThreadingExtensionsTest do
     test "threads as first argument" do
       assert {:ok, %{return: 5}} = Lisp.run("(some-> 10 (- 5))")
     end
+
+    test "nil step raises after non-nil value" do
+      assert {:error, %{fail: %{reason: :not_callable, message: "not callable: nil"}}} =
+               Lisp.run("(some-> 1 nil)")
+    end
+
+    test "nil step is not reached after nil value" do
+      assert {:ok, %{return: nil}} = Lisp.run("(some-> nil nil)")
+    end
   end
 
   describe "some->>" do
@@ -115,6 +138,11 @@ defmodule PtcRunner.Lisp.ThreadingExtensionsTest do
 
     test "threads through non-nil" do
       assert {:ok, %{return: [2, 3, 4]}} = Lisp.run("(some->> [1 2 3] (map inc))")
+    end
+
+    test "nil step raises after non-nil value" do
+      assert {:error, %{fail: %{reason: :not_callable, message: "not callable: nil"}}} =
+               Lisp.run("(some->> 1 nil)")
     end
   end
 

--- a/test/support/lisp_conformance_cases/manual.ex
+++ b/test/support/lisp_conformance_cases/manual.ex
@@ -4495,53 +4495,53 @@ defmodule PtcRunner.TestSupport.LispConformanceCases.Manual do
         "GAP-S123",
         "Clojure cond->> treats a trailing unmatched test as a no-op; PTC-Lisp currently raises."
       ),
-      bug_case(
+      fixed_bug_case(
         "core/thread-first-nil-form-bug-001",
         "clojure.core",
         ["->"],
         "(-> 1 nil)",
         "GAP-S128",
-        "Clojure threading through nil raises; PTC-Lisp currently returns nil."
+        "Clojure threading through nil raises; this guards GAP-S128."
       ),
-      bug_case(
+      fixed_bug_case(
         "core/thread-last-nil-form-bug-001",
         "clojure.core",
         ["->>"],
         "(->> 1 nil)",
         "GAP-S128",
-        "Clojure threading through nil raises; PTC-Lisp currently returns nil."
+        "Clojure threading through nil raises; this guards GAP-S128."
       ),
-      bug_case(
+      fixed_bug_case(
         "core/some-thread-nil-form-bug-001",
         "clojure.core",
         ["some->"],
         "(some-> 1 nil)",
         "GAP-S128",
-        "Clojure some-> threading through a nil form raises once the value is non-nil; PTC-Lisp currently returns nil."
+        "Clojure some-> threading through a nil form raises once the value is non-nil; this guards GAP-S128."
       ),
-      bug_case(
+      fixed_bug_case(
         "core/some-thread-last-nil-form-bug-001",
         "clojure.core",
         ["some->>"],
         "(some->> 1 nil)",
         "GAP-S128",
-        "Clojure some->> threading through a nil form raises once the value is non-nil; PTC-Lisp currently returns nil."
+        "Clojure some->> threading through a nil form raises once the value is non-nil; this guards GAP-S128."
       ),
-      bug_case(
+      fixed_bug_case(
         "core/cond-thread-true-nil-form-bug-001",
         "clojure.core",
         ["cond->"],
         "(cond-> 1 true nil)",
         "GAP-S128",
-        "Clojure cond-> threading through a nil form raises when the condition is truthy; PTC-Lisp currently returns nil."
+        "Clojure cond-> threading through a nil form raises when the condition is truthy; this guards GAP-S128."
       ),
-      bug_case(
+      fixed_bug_case(
         "core/cond-thread-last-true-nil-form-bug-001",
         "clojure.core",
         ["cond->>"],
         "(cond->> 1 true nil)",
         "GAP-S128",
-        "Clojure cond->> threading through a nil form raises when the condition is truthy; PTC-Lisp currently returns nil."
+        "Clojure cond->> threading through a nil form raises when the condition is truthy; this guards GAP-S128."
       ),
       bug_case(
         "core/if-let-no-else-bug-001",


### PR DESCRIPTION
## Summary
- Closes GAP-S128 by converting nil-thread-target manual cases into fixed regression cases.
- Adds runtime regression coverage for `->`, `->>`, `some->`, `some->>`, `cond->`, and `cond->>` when a nil thread target is reached.
- Updates GAP/audit/conformance metadata so threading macros no longer carry stale `BUG GAP-S128` notes.

## Verification
- `mix test test/ptc_runner/lisp/analyze_operations_test.exs test/ptc_runner/lisp/threading_extensions_test.exs`
- `mix ptc.gen_docs`
- `mix ptc.conformance_report --write-inventory`
- `mix precommit`
- `~/.codex/skills/codex-review/scripts/codex-independent-review review --base main` (no actionable findings)
- Push hook reruns:
  - root full test suite passed under hook: 371 doctests, 3 properties, 5261 tests, 0 failures
  - root dialyzer passed under hook
  - `mcp_server`: `mix test test/ptc_runner_mcp/http_router_test.exs` passed after a transient registry test failure in the hook
  - `mcp_server`: full `mix test` passed: 5 doctests, 511 tests, 0 failures

Babashka-backed `:clojure` conformance cases were not run locally because Babashka is not installed in this worktree.

Fixes GAP-S128.
