### PR TITLE
fix(http): register bearer token with credential redaction

### DIFF
--- a/docs/mcp-server-http-deployment.md
+++ b/docs/mcp-server-http-deployment.md
@@ -72,6 +72,31 @@ The v1 auth model has one static token. All token holders are the same
 owner, so an `MCP-Session-Id` is a bearer capability inside that trust
 boundary. Session ids are random and are never logged raw.
 
+### Token generation
+
+The server requires a minimum of 32 bytes but does not programmatically
+verify entropy quality. Generate tokens with a cryptographically secure
+source:
+
+```bash
+# Recommended — 32 random bytes, base64-encoded (44 characters)
+openssl rand -base64 32
+
+# Alternative
+python3 -c "import secrets; print(secrets.token_urlsafe(32))"
+```
+
+Do not use low-entropy strings (repeated characters, dictionary words,
+predictable patterns). Entropy quality is the caller's responsibility.
+
+### Redaction
+
+The bearer token is registered with the credential redaction system at
+startup. If the raw token value accidentally appears in a log line or
+trace payload, the redactor replaces it with `[REDACTED]`. This is a
+defense-in-depth measure — the primary protection is that request logs
+and traces use hashed owner identifiers, never the raw token.
+
 ## Observability
 
 HTTP request logs are JSON lines on stderr. Each request log includes an

--- a/mcp_server/lib/ptc_runner_mcp/http/session_registry.ex
+++ b/mcp_server/lib/ptc_runner_mcp/http/session_registry.ex
@@ -3,8 +3,8 @@ defmodule PtcRunnerMcp.Http.SessionRegistry do
 
   use GenServer
 
+  alias PtcRunnerMcp.{Credentials, Log, Sessions}
   alias PtcRunnerMcp.Http.{Session, Telemetry}
-  alias PtcRunnerMcp.{Log, Sessions}
   alias PtcRunnerMcp.Sessions.Owner, as: PtcOwner
 
   defstruct sessions: %{},
@@ -25,6 +25,7 @@ defmodule PtcRunnerMcp.Http.SessionRegistry do
   def init(opts) do
     Process.flag(:trap_exit, true)
     config = Keyword.fetch!(opts, :config)
+    register_auth_token_redaction(config)
     ref = Process.send_after(self(), :cleanup, @cleanup_interval_ms)
     {:ok, %__MODULE__{config: config, cleanup_ref: ref}}
   end
@@ -317,4 +318,11 @@ defmodule PtcRunnerMcp.Http.SessionRegistry do
   end
 
   defp session_age_ms(_meta), do: 0
+
+  defp register_auth_token_redaction(%{auth_token: token})
+       when is_binary(token) and byte_size(token) > 0 do
+    Credentials.register_redaction_secrets([token])
+  end
+
+  defp register_auth_token_redaction(_config), do: :ok
 end

--- a/mcp_server/test/ptc_runner_mcp/http_auth_redaction_test.exs
+++ b/mcp_server/test/ptc_runner_mcp/http_auth_redaction_test.exs
@@ -1,0 +1,47 @@
+defmodule PtcRunnerMcp.HttpAuthRedactionTest do
+  use ExUnit.Case, async: false
+
+  alias PtcRunnerMcp.Credentials
+  alias PtcRunnerMcp.Credentials.Redactor
+  alias PtcRunnerMcp.Http.SessionRegistry
+
+  @token "test-bearer-token-" <> String.duplicate("x", 32)
+
+  setup do
+    start_supervised!({Credentials, [bindings: %{}]})
+    :ok
+  end
+
+  defp unique_registry_name do
+    :"registry_#{:erlang.unique_integer([:positive])}"
+  end
+
+  defp minimal_http_config(token) do
+    %{
+      auth_token: token,
+      session_ttl_ms: 3_600_000,
+      session_idle_timeout_ms: 900_000,
+      max_sessions: 256,
+      max_sessions_per_owner: 32,
+      max_in_flight_per_session: 4,
+      instance_label: "test"
+    }
+  end
+
+  test "HTTP bearer token is redacted after session registry starts" do
+    start_supervised!(
+      {SessionRegistry, [name: unique_registry_name(), config: minimal_http_config(@token)]}
+    )
+
+    assert Redactor.scrub("Authorization: Bearer #{@token}") ==
+             "Authorization: Bearer [REDACTED]"
+  end
+
+  test "redaction handles nil auth_token (auth disabled)" do
+    start_supervised!(
+      {SessionRegistry, [name: unique_registry_name(), config: minimal_http_config(nil)]}
+    )
+
+    assert Redactor.scrub("no token here") == "no token here"
+  end
+end


### PR DESCRIPTION
## Summary

Closes #1040

- Register the HTTP bearer auth token with the `Credentials` redaction ETS table so `Redactor.scrub/1` replaces it with `[REDACTED]` if it accidentally leaks into logs or traces
- Add regression test proving the token is scrubbed after `HttpSessionRegistry` starts
- Document token entropy guidance (caller responsibility) and the redaction defense-in-depth layer in deployment docs

## Changes

- **`mcp_server/lib/ptc_runner_mcp/http/session_registry.ex`** — Call `Credentials.register_redaction_secrets/1` in `init/1`. This runs after `Credentials` starts (child ordering in `:rest_for_one` supervisor) and before the HTTP server accepts requests. Re-registers correctly on `Credentials` crash/restart since `HttpSessionRegistry` is also restarted by `:rest_for_one`.
- **`mcp_server/test/ptc_runner_mcp/http_auth_redaction_test.exs`** — New test proving the token is redacted, plus nil-token case (auth disabled).
- **`docs/mcp-server-http-deployment.md`** — Added "Token generation" section with `openssl rand` / `secrets.token_urlsafe` guidance, and "Redaction" section explaining the defense-in-depth behavior.

## Test plan

- [x] `mix precommit` passes (format, compile, credo, dialyzer, 513 tests, 0 failures)
- [x] New test: bearer token is redacted after session registry starts
- [x] New test: nil auth_token (auth disabled) handled gracefully
- [x] Existing HTTP config tests still pass (32-byte minimum, non-loopback auth requirement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)