### PR TITLE
fix(http): enforce MCP bearer auth on non-loopback binds

### DIFF
--- a/docs/mcp-server-configuration.md
+++ b/docs/mcp-server-configuration.md
@@ -68,11 +68,11 @@ the deployment runbook.
 | Flag | Env var | Default | Meaning |
 |---|---|---|---|
 | `--http` | `PTC_RUNNER_MCP_HTTP` | `false` | Enable the HTTP listener. |
-| `--http-host` | `PTC_RUNNER_MCP_HTTP_HOST` | `127.0.0.1` | Bind IP address or `localhost`. Non-loopback binds require auth unless explicitly unsafe. |
+| `--http-host` | `PTC_RUNNER_MCP_HTTP_HOST` | `127.0.0.1` | Bind IP address or `localhost`. Non-loopback binds always require auth. |
 | `--http-port` | `PTC_RUNNER_MCP_HTTP_PORT` | `7332` | Bind port. |
 | `--http-path` | `PTC_RUNNER_MCP_HTTP_PATH` | `/mcp` | Streamable HTTP MCP endpoint. Must differ from `/health`, `/ready`, and `--http-metrics-path`. |
 | `--http-auth-token` | `PTC_RUNNER_MCP_HTTP_AUTH_TOKEN` | unset | Static bearer token. Must be at least 32 characters; generate it from a CSPRNG. |
-| `--http-disable-auth` | `PTC_RUNNER_MCP_HTTP_DISABLE_AUTH` | `false` | Disable bearer auth. Permitted on loopback with a warning; non-loopback also requires `--http-allow-unsafe-network`. |
+| `--http-disable-auth` | `PTC_RUNNER_MCP_HTTP_DISABLE_AUTH` | `false` | Disable bearer auth. Only permitted on explicit loopback binds; cannot be combined with `--http-allow-unsafe-network`. |
 | `--http-allowed-origin` | `PTC_RUNNER_MCP_HTTP_ALLOWED_ORIGIN` | unset | Browser `Origin` allow-list. May be repeated or comma-separated. This is a DNS-rebinding check, not full CORS support. |
 | `--http-request-timeout-ms` | `PTC_RUNNER_MCP_HTTP_REQUEST_TIMEOUT_MS` | `15000` | HTTP request read timeout. |
 | `--http-shutdown-grace-ms` | `PTC_RUNNER_MCP_HTTP_SHUTDOWN_GRACE_MS` | `10000` | Application-stop drain window before in-flight workers are cancelled. |
@@ -82,7 +82,7 @@ the deployment runbook.
 | `--http-max-sessions` | `PTC_RUNNER_MCP_HTTP_MAX_SESSIONS` | `256` | Global HTTP protocol-session cap. |
 | `--http-max-sessions-per-owner` | `PTC_RUNNER_MCP_HTTP_MAX_SESSIONS_PER_OWNER` | `32` | Per-owner HTTP protocol-session cap. In single-token v1 every client shares one owner. |
 | `--http-max-in-flight-per-session` | `PTC_RUNNER_MCP_HTTP_MAX_IN_FLIGHT_PER_SESSION` | `4` | Non-queueing cap for executing requests in one HTTP protocol session. |
-| `--http-allow-unsafe-network` | `PTC_RUNNER_MCP_HTTP_ALLOW_UNSAFE_NETWORK` | `false` | Allows unauthenticated non-loopback bind only when paired with `--http-disable-auth`. |
+| `--http-allow-unsafe-network` | `PTC_RUNNER_MCP_HTTP_ALLOW_UNSAFE_NETWORK` | `false` | Allows non-loopback bind addresses (network-binding gate only; does not affect auth requirements). |
 | `--http-metrics` | `PTC_RUNNER_MCP_HTTP_METRICS` | `false` | Reserved for the Prometheus endpoint follow-up; core telemetry is emitted regardless. |
 | `--http-metrics-path` | `PTC_RUNNER_MCP_HTTP_METRICS_PATH` | `/metrics` | Reserved metrics path; must not collide with HTTP control paths. |
 | `--http-instance-label` | `PTC_RUNNER_MCP_HTTP_INSTANCE_LABEL` | hostname | Stable instance label stamped into HTTP logs, telemetry, and trace metadata. |

--- a/docs/mcp-server-http-deployment.md
+++ b/docs/mcp-server-http-deployment.md
@@ -64,9 +64,9 @@ TLS should terminate at the load balancer or edge proxy. If traffic from
 the proxy to the BEAM node is plaintext, anything able to observe that
 link can see the bearer token.
 
-Binding to a non-loopback address requires a token unless both
-`--http-disable-auth` and `--http-allow-unsafe-network` are set. That
-pair is for controlled tests only.
+Binding to a non-loopback address always requires a token.
+`--http-disable-auth` is only permitted on loopback binds and cannot be
+combined with `--http-allow-unsafe-network`.
 
 The v1 auth model has one static token. All token holders are the same
 owner, so an `MCP-Session-Id` is a bearer capability inside that trust

--- a/mcp_server/README.md
+++ b/mcp_server/README.md
@@ -315,8 +315,7 @@ Defaults:
 - liveness: `GET /health`
 - readiness: `GET /ready`
 
-For non-loopback binds, auth is required unless you explicitly opt into
-unsafe networking. Use
+Non-loopback binds always require a bearer token. Use
 [`docs/mcp-server-http-deployment.md`](../docs/mcp-server-http-deployment.md)
 as the deployment runbook.
 

--- a/mcp_server/lib/ptc_runner_mcp/http/config.ex
+++ b/mcp_server/lib/ptc_runner_mcp/http/config.ex
@@ -175,7 +175,8 @@ defmodule PtcRunnerMcp.Http.Config do
     {:error, "HTTP auth token must be at least #{@token_min_bytes} characters"}
   end
 
-  defp validate_auth(%{auth_disabled: true, allow_unsafe_network: true}), do: :ok
+  defp validate_auth(%{auth_disabled: true, allow_unsafe_network: true}),
+    do: {:error, "--http-disable-auth cannot be combined with --http-allow-unsafe-network"}
 
   defp validate_auth(%{auth_disabled: true, host: host}) when is_binary(host),
     do: auth_disabled_loopback(host)
@@ -195,7 +196,7 @@ defmodule PtcRunnerMcp.Http.Config do
       Log.log(:warn, "http_auth_disabled_loopback")
       :ok
     else
-      {:error, "non-loopback unauthenticated HTTP requires --http-allow-unsafe-network"}
+      {:error, "--http-disable-auth is only permitted on loopback binds"}
     end
   end
 

--- a/mcp_server/test/ptc_runner_mcp/http_config_test.exs
+++ b/mcp_server/test/ptc_runner_mcp/http_config_test.exs
@@ -33,17 +33,49 @@ defmodule PtcRunnerMcp.HttpConfigTest do
     assert message =~ "at least 32"
   end
 
-  test "requires auth for non-loopback binds unless explicitly unsafe" do
+  test "requires auth for non-loopback binds" do
     assert {:error, message} = Config.resolve(%{http: true, http_host: "0.0.0.0"})
     assert message =~ "required"
+  end
 
-    assert {:ok, cfg} =
+  test "rejects disable-auth on non-loopback even with allow-unsafe-network" do
+    assert {:error, message} =
              Config.resolve(%{
                http: true,
                http_host: "0.0.0.0",
                http_disable_auth: true,
                http_allow_unsafe_network: true
              })
+
+    assert message =~ "cannot be combined"
+  end
+
+  test "rejects disable-auth with allow-unsafe-network on loopback" do
+    assert {:error, message} =
+             Config.resolve(%{
+               http: true,
+               http_host: "127.0.0.1",
+               http_disable_auth: true,
+               http_allow_unsafe_network: true
+             })
+
+    assert message =~ "cannot be combined"
+  end
+
+  test "rejects disable-auth on non-loopback without allow-unsafe-network" do
+    assert {:error, message} =
+             Config.resolve(%{
+               http: true,
+               http_host: "0.0.0.0",
+               http_disable_auth: true
+             })
+
+    assert message =~ "only permitted on loopback"
+  end
+
+  test "allows disable-auth on loopback without allow-unsafe-network" do
+    assert {:ok, cfg} =
+             Config.resolve(%{http: true, http_host: "127.0.0.1", http_disable_auth: true})
 
     assert cfg.auth_disabled
   end


### PR DESCRIPTION
## Summary
- Reject `--http-disable-auth` + `--http-allow-unsafe-network` on all bind addresses (previously allowed as an unsafe opt-in)
- Non-loopback binds now unconditionally require a bearer token
- Updated error message in `auth_disabled_loopback` to no longer suggest `--http-allow-unsafe-network` as a workaround

## Changes
- `config.ex:178`: changed permissive `:ok` clause to return an error when both flags are set
- `config.ex:198`: updated error message for non-loopback `auth_disabled` to `"--http-disable-auth is only permitted on loopback binds"`
- `http_config_test.exs`: replaced single permissive test with 5 focused tests covering all flag combinations
- Updated docs in `mcp-server-http-deployment.md`, `mcp-server-configuration.md`, and `mcp_server/README.md`

## Test plan
- [x] `mix test test/ptc_runner_mcp/http_config_test.exs` — 11 tests, 0 failures
- [x] `mix test test/ptc_runner_mcp/http_router_test.exs` — 28 tests, 0 failures
- [x] `mix precommit` — 517 tests, 0 failures, credo clean, dialyzer clean

Closes #1039

🤖 Generated with [Claude Code](https://claude.com/claude-code)