### PR TITLE
refactor(lisp): extract placeholder detection into leaf module

### DIFF
--- a/lib/ptc_runner/lisp/analyze.ex
+++ b/lib/ptc_runner/lisp/analyze.ex
@@ -14,6 +14,7 @@ defmodule PtcRunner.Lisp.Analyze do
   alias PtcRunner.Lisp.Analyze.Definitions
   alias PtcRunner.Lisp.Analyze.Iteration
   alias PtcRunner.Lisp.Analyze.Patterns
+  alias PtcRunner.Lisp.Analyze.Placeholder
   alias PtcRunner.Lisp.Analyze.ShortFn
   alias PtcRunner.Lisp.CoreAST
   alias PtcRunner.Lisp.Env
@@ -232,7 +233,7 @@ defmodule PtcRunner.Lisp.Analyze do
   # ============================================================
 
   defp do_analyze({:symbol, name}, _tail?) do
-    if placeholder?(name) do
+    if Placeholder.placeholder?(name) do
       {:error, {:invalid_placeholder, name}}
     else
       {:ok, {:var, name}}
@@ -1417,16 +1418,6 @@ defmodule PtcRunner.Lisp.Analyze do
   # ============================================================
   # Placeholder detection
   # ============================================================
-
-  # Check if a symbol name is a placeholder (%, %1, %2, etc.)
-  @doc false
-  def placeholder?(name) do
-    case to_string(name) do
-      "%" -> true
-      "%" <> rest -> String.match?(rest, ~r/^(\d+|&)$/)
-      _ -> false
-    end
-  end
 
   # ============================================================
   # Local shadowing of special form names (GAP-S06)

--- a/lib/ptc_runner/lisp/analyze/placeholder.ex
+++ b/lib/ptc_runner/lisp/analyze/placeholder.ex
@@ -1,0 +1,14 @@
+defmodule PtcRunner.Lisp.Analyze.Placeholder do
+  @moduledoc false
+
+  # Detects short-function placeholders: %, %1..%N, %&.
+  # Leaf helper with no dependencies, so both Analyze and ShortFn can use it
+  # without forming a compile-time cycle.
+  def placeholder?(name) do
+    case to_string(name) do
+      "%" -> true
+      "%" <> rest -> String.match?(rest, ~r/^(\d+|&)$/)
+      _ -> false
+    end
+  end
+end

--- a/lib/ptc_runner/lisp/analyze/short_fn.ex
+++ b/lib/ptc_runner/lisp/analyze/short_fn.ex
@@ -6,7 +6,7 @@ defmodule PtcRunner.Lisp.Analyze.ShortFn do
   by extracting placeholders (%, %1, %2, %&, etc.) and generating parameters.
   """
 
-  alias PtcRunner.Lisp.Analyze
+  alias PtcRunner.Lisp.Analyze.Placeholder
   alias PtcRunner.Lisp.SourceAtoms
 
   @max_short_fn_arity 20
@@ -39,7 +39,7 @@ defmodule PtcRunner.Lisp.Analyze.ShortFn do
           # Literals like #(42) are kept as-is (will error at runtime like Clojure)
           case single_form do
             {:symbol, name} ->
-              if Analyze.placeholder?(name), do: single_form, else: {:list, [single_form]}
+              if Placeholder.placeholder?(name), do: single_form, else: {:list, [single_form]}
 
             _ ->
               single_form
@@ -91,7 +91,7 @@ defmodule PtcRunner.Lisp.Analyze.ShortFn do
 
   # Recursively find all placeholder symbols in an AST node
   defp find_all_placeholders({:symbol, name}) do
-    if Analyze.placeholder?(name) do
+    if Placeholder.placeholder?(name) do
       [name]
     else
       []
@@ -204,7 +204,7 @@ defmodule PtcRunner.Lisp.Analyze.ShortFn do
   defp transform_body({:symbol, name}, _placeholders) when is_atom(name) or is_binary(name) do
     name_str = to_string(name)
 
-    case Analyze.placeholder?(name) do
+    case Placeholder.placeholder?(name) do
       true ->
         param_name = placeholder_to_param(name_str)
         {:symbol, param_name}


### PR DESCRIPTION
## Summary

Breaks the `analyze.ex` ⇄ `analyze/short_fn.ex` compile-time cycle by moving short-function placeholder detection into a new dependency-free leaf module, `PtcRunner.Lisp.Analyze.Placeholder`.

- New leaf `PtcRunner.Lisp.Analyze.Placeholder.placeholder?/1` holds the detection logic (byte-for-byte identical: `"%"` special case + `~r/^(\d+|&)$/`).
- `Analyze` now calls `Placeholder.placeholder?/1` at `:235`; the `@doc false` `Analyze.placeholder?/1` is removed (no external callers, so no shim per 0.x policy).
- The three `ShortFn` call sites (`:42`, `:94`, `:207`) call the leaf instead of `Analyze`.

Both modules now depend on the leaf, which depends on nothing — breaking the cycle.

## Verification

- `mix xref graph --format cycles` no longer reports the `analyze.ex` / `analyze/short_fn.ex` cycle.
- `mix precommit` green: format, compile (warnings-as-errors), xref (`--fail-above 0`), credo --strict, schema, spec, tests (5285, 0 failures); demo (200, 0) and ptc_viewer (9, 0) suites pass.

## Test plan

- [x] `mix xref graph --format cycles` — short_fn cycle gone
- [x] `mix precommit` — all gates green
- [x] Existing analyzer + short-function tests pass unchanged

Closes #1046

🤖 Generated with [Claude Code](https://claude.com/claude-code)