### PR TITLE
refactor(llm): decouple LLM facades from default implementations

### DIFF
--- a/lib/ptc_runner/llm.ex
+++ b/lib/ptc_runner/llm.ex
@@ -245,17 +245,19 @@ defmodule PtcRunner.LLM do
   """
   @spec adapter!() :: module()
   def adapter! do
-    Application.get_env(:ptc_runner, :llm_adapter) ||
-      if Code.ensure_loaded?(PtcRunner.LLM.ReqLLMAdapter) do
-        PtcRunner.LLM.ReqLLMAdapter
-      else
-        raise """
-        No LLM adapter configured.
+    case Application.get_env(:ptc_runner, :llm_adapter) do
+      nil -> raise_no_adapter()
+      mod -> if Code.ensure_loaded?(mod), do: mod, else: raise_no_adapter()
+    end
+  end
 
-        Either:
-        1. Add {:req_llm, "~> 1.8"} to your deps for the built-in adapter
-        2. Set config :ptc_runner, :llm_adapter, YourAdapter
-        """
-      end
+  defp raise_no_adapter do
+    raise """
+    No LLM adapter configured.
+
+    Either:
+    1. Add {:req_llm, "~> 1.8"} to your deps for the built-in adapter
+    2. Set config :ptc_runner, :llm_adapter, YourAdapter
+    """
   end
 end

--- a/lib/ptc_runner/llm.ex
+++ b/lib/ptc_runner/llm.ex
@@ -246,8 +246,17 @@ defmodule PtcRunner.LLM do
   @spec adapter!() :: module()
   def adapter! do
     case Application.get_env(:ptc_runner, :llm_adapter) do
-      nil -> raise_no_adapter()
-      mod -> if Code.ensure_loaded?(mod), do: mod, else: raise_no_adapter()
+      nil ->
+        raise_no_adapter()
+
+      mod ->
+        if Code.ensure_loaded?(mod),
+          do: mod,
+          else:
+            raise(
+              "Configured LLM adapter #{inspect(mod)} could not be loaded. " <>
+                "Check that the module exists and is compiled."
+            )
     end
   end
 

--- a/lib/ptc_runner/llm.ex
+++ b/lib/ptc_runner/llm.ex
@@ -254,8 +254,9 @@ defmodule PtcRunner.LLM do
           do: mod,
           else:
             raise(
-              "Configured LLM adapter #{inspect(mod)} could not be loaded. " <>
-                "Check that the module exists and is compiled."
+              "LLM adapter #{inspect(mod)} could not be loaded. " <>
+                "If you intended to use the built-in adapter, add {:req_llm, \"~> 1.8\"} to your deps; " <>
+                "otherwise verify that #{inspect(mod)} exists and is compiled, or set config :ptc_runner, :llm_adapter to a valid module."
             )
     end
   end

--- a/lib/ptc_runner/llm/registry.ex
+++ b/lib/ptc_runner/llm/registry.ex
@@ -145,6 +145,6 @@ defmodule PtcRunner.LLM.Registry do
   def validate(model_string), do: impl().validate(model_string)
 
   defp impl do
-    Application.get_env(:ptc_runner, :model_registry, PtcRunner.LLM.DefaultRegistry)
+    Application.get_env(:ptc_runner, :model_registry)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -38,7 +38,11 @@ defmodule PtcRunner.MixProject do
   # Run "mix help compile.app" to learn about applications.
   def application do
     [
-      extra_applications: [:logger]
+      extra_applications: [:logger],
+      env: [
+        model_registry: PtcRunner.LLM.DefaultRegistry,
+        llm_adapter: PtcRunner.LLM.ReqLLMAdapter
+      ]
     ]
   end
 

--- a/test/ptc_runner/llm_test.exs
+++ b/test/ptc_runner/llm_test.exs
@@ -160,10 +160,20 @@ defmodule PtcRunner.LLMTest do
       assert PtcRunner.LLM.adapter!() == MockAdapter
     end
 
-    test "falls back to ReqLLMAdapter when no config" do
-      Application.delete_env(:ptc_runner, :llm_adapter)
+    test "resolves to the packaged ReqLLMAdapter default" do
+      # mix.exs ships :llm_adapter => ReqLLMAdapter; the setup overrides it with
+      # MockAdapter, so restore the packaged default for this assertion.
+      Application.put_env(:ptc_runner, :llm_adapter, PtcRunner.LLM.ReqLLMAdapter)
       # ReqLLM is available in test env (via optional req_llm dep)
       assert PtcRunner.LLM.adapter!() == PtcRunner.LLM.ReqLLMAdapter
+    end
+
+    test "raises when no adapter is configured" do
+      Application.delete_env(:ptc_runner, :llm_adapter)
+
+      assert_raise RuntimeError, ~r/No LLM adapter configured/, fn ->
+        PtcRunner.LLM.adapter!()
+      end
     end
   end
 end

--- a/test/ptc_runner/llm_test.exs
+++ b/test/ptc_runner/llm_test.exs
@@ -175,5 +175,13 @@ defmodule PtcRunner.LLMTest do
         PtcRunner.LLM.adapter!()
       end
     end
+
+    test "raises with actionable message when configured adapter cannot be loaded" do
+      Application.put_env(:ptc_runner, :llm_adapter, NonExistent.Adapter)
+
+      assert_raise RuntimeError, ~r/req_llm/, fn ->
+        PtcRunner.LLM.adapter!()
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

Breaks the two compile↔runtime LLM dependency cycles reported by
`mix xref graph --format cycles`:

- `default_registry.ex` ↔ `registry.ex`
- `llm.ex` ↔ `req_llm_adapter.ex`

The fix moves the `DefaultRegistry` and `ReqLLMAdapter` default-module
literals out of `lib/` and into the library application env in `mix.exs`.
Since `mix.exs` is not part of the `lib/` xref graph, the facade → default
edges disappear while the `@behaviour` edges (default → facade) remain,
leaving an acyclic dependency graph. Public API and resolution semantics are
unchanged.

## Changes

- **`mix.exs`** — add `env: [model_registry: DefaultRegistry, llm_adapter: ReqLLMAdapter]` to `application/0`.
- **`registry.ex`** — `impl/0` reads `:model_registry` without a literal default arg.
- **`llm.ex`** — `adapter!/0` reads `:llm_adapter` and keeps the runtime `Code.ensure_loaded?/1` guard so the helpful "no adapter configured" raise and explicit-config precedence are preserved.
- **`llm_test.exs`** — split the old fallback test into: (1) resolves to the packaged `ReqLLMAdapter` default, and (2) raises when no adapter is configured.

## Verification

- `mix xref graph --format cycles` no longer lists either LLM cycle.
- `mix precommit` green (5286 lib tests + demo + ptc_viewer, 0 failures).

Closes #1047

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Fix Automation State
<!-- fix-state: {"attempts":3} -->
Fix attempts: 2/3
