### PR TITLE
test(livebooks): parse-smoke + deterministic playground tests

### DIFF
--- a/livebooks/ptc_runner_playground.livemd
+++ b/livebooks/ptc_runner_playground.livemd
@@ -22,7 +22,7 @@ PTC-Lisp is a small, safe subset of Clojure designed for Programmatic Tool Calli
 
 * `->>` threads data through a pipeline (like Elixir's `|>`)
 * `:keyword` accesses map fields (converted to string keys internally)
-* `where` builds predicates for filtering
+* `#(...)` is an anonymous function (`%` is its argument), used to build filter predicates
 * `tool/tool-name` calls external tools
 
 ## Basic Example
@@ -40,7 +40,7 @@ tools = %{
   end
 }
 
-program = ~S|(->> (tool/get-expenses) (filter (where :category = "travel")) (sum-by :amount))|
+program = ~S|(->> (tool/get-expenses) (filter #(= (:category %) "travel")) (sum-by :amount))|
 
 {:ok, step} = PtcRunner.Lisp.run(program, tools: tools)
 
@@ -50,14 +50,14 @@ IO.puts("Travel expenses: #{step.return}")
 ### Step-by-step breakdown
 
 1. `(tool/get-expenses)` - calls the tool, returns list of expense maps
-2. `(filter (where :category = "travel"))` - keeps only travel expenses
+2. `(filter #(= (:category %) "travel"))` - keeps only travel expenses (`#(...)` is an anonymous function; `%` is the item under test)
 3. `(sum-by :amount)` - sums the amount field
 
 ## PTC-Lisp Extensions
 
-The example above uses `where` and `sum-by`, which are PTC-Lisp extensions not found in standard Clojure. These make common filtering and aggregation patterns more concise.
+The example above uses `sum-by`, a PTC-Lisp extension not found in standard Clojure. These extensions make common aggregation patterns more concise.
 
-In standard Clojure, the same logic would be:
+In standard Clojure, the same sum would be written with `map` and `reduce`:
 
 ```elixir
 program = ~S|(->> (tool/get-expenses) (filter #(= (:category %) "travel")) (map :amount) (reduce +))|
@@ -69,15 +69,12 @@ IO.puts("Travel expenses (Clojure style): #{step.return}")
 
 **Key PTC-Lisp extensions:**
 
-| Extension                | Clojure Equivalent             | Purpose                        |
-| ------------------------ | ------------------------------ | ------------------------------ |
-| `(where :field = value)` | `#(= (:field %) value)`        | Build predicates for filtering |
-| `(sum-by :field coll)`   | `(reduce + (map :field coll))` | Sum a field across collection  |
-| `(avg-by :field coll)`   | Manual calculation             | Average a field                |
-| `(all-of pred1 pred2)`   | `#(and (pred1 %) (pred2 %))`   | Combine predicates with AND    |
-| `(any-of pred1 pred2)`   | `#(or (pred1 %) (pred2 %))`    | Combine predicates with OR     |
+| Extension              | Clojure Equivalent             | Purpose                       |
+| ---------------------- | ------------------------------ | ----------------------------- |
+| `(sum-by :field coll)` | `(reduce + (map :field coll))` | Sum a field across collection |
+| `(avg-by :field coll)` | Manual calculation             | Average a field               |
 
-These extensions are designed for LLM code generation - they reduce syntax errors and make intent clearer.
+Filtering uses standard Clojure anonymous functions — `#(= (:field %) value)`, where `%` is the item under test. These aggregation extensions are designed for LLM code generation: they reduce syntax errors and make intent clearer.
 
 ## Key Convention
 
@@ -90,11 +87,11 @@ Tools receive and return **string-keyed maps** (like JSON):
 
 PTC-Lisp's FlexAccess makes `:keyword` access work transparently with string-keyed data:
 
-```elixir
-# These all work on string-keyed maps:
-(:category item)              # => "travel"
-(where :category = "travel")  # matches %{"category" => "travel"}
-(sum-by :amount expenses)     # sums the "amount" field
+```clojure
+; These all work on string-keyed maps (PTC-Lisp, not runnable here):
+(:category item)                 ; => "travel"
+(filter #(= (:category %) ...))  ; matches {"category" "travel"}
+(sum-by :amount expenses)        ; sums the "amount" field
 ```
 
 **Why string keys?**
@@ -110,7 +107,7 @@ Use `let` to bind intermediate results:
 ```elixir
 program = ~S"""
 (let [expenses (tool/get-expenses)
-      travel (filter (where :category = "travel") expenses)]
+      travel (filter #(= (:category %) "travel") expenses)]
   {:count (count travel)
    :total (sum-by :amount travel)
    :avg (avg-by :amount travel)})
@@ -125,8 +122,8 @@ step.return
 PTC-Lisp provides helpful error messages with hints:
 
 ```elixir
-# Missing operator in where clause
-bad_program = ~S|(filter (where :status "active") items)|
+# Calling a tool that wasn't provided
+bad_program = ~S|(tool/get-expenses)|
 
 case PtcRunner.Lisp.run(bad_program, tools: %{}) do
   {:error, error} -> IO.puts("Error: #{inspect(error)}")
@@ -168,10 +165,10 @@ tools = %{
 program = ~S"""
 (let [users (tool/get-users)
       orders (tool/get-orders)
-      high-value (filter (where :total > 100) orders)]
+      high-value (filter #(> (:total %) 100) orders)]
   (->> high-value
        (mapv (fn [order]
-               (let [user (find (where :id = (:user-id order)) users)]
+               (let [user (first (filter #(= (:id %) (:user-id order)) users))]
                  {:customer (:name user)
                   :product (:product order)
                   :total (:total order)})))))

--- a/test/livebooks/livebook_smoke_test.exs
+++ b/test/livebooks/livebook_smoke_test.exs
@@ -1,0 +1,39 @@
+defmodule PtcRunner.LivebookSmokeTest do
+  @moduledoc """
+  Cheap, deterministic guard for every published livebook: assert that each
+  elixir cell still parses as valid Elixir. Catches syntax rot in the tutorials
+  without running them (no LLM, no network). Semantic coverage of the
+  deterministic playground lives in `PtcRunner.LivebookPlaygroundTest`.
+  """
+  use ExUnit.Case, async: true
+
+  alias PtcRunner.Test.LivebookExtractor
+
+  # Generate one test per notebook at compile time.
+  for path <- LivebookExtractor.paths() do
+    name = Path.basename(path)
+
+    test "#{name}: every elixir cell parses" do
+      cells = LivebookExtractor.elixir_cells(unquote(path))
+
+      assert cells != [],
+             "expected at least one elixir cell in #{unquote(name)} — did the format change?"
+
+      for {code, idx} <- Enum.with_index(cells, 1) do
+        case Code.string_to_quoted(code) do
+          {:ok, _ast} ->
+            :ok
+
+          {:error, {meta, message, token}} ->
+            flunk("""
+            Syntax error in #{unquote(name)}, elixir cell ##{idx} (line #{meta[:line] || "?"}):
+            #{message}#{inspect(token)}
+
+            Cell source:
+            #{code}
+            """)
+        end
+      end
+    end
+  end
+end

--- a/test/livebooks/playground_test.exs
+++ b/test/livebooks/playground_test.exs
@@ -1,0 +1,73 @@
+defmodule PtcRunner.LivebookPlaygroundTest do
+  @moduledoc """
+  End-to-end check of `livebooks/ptc_runner_playground.livemd`.
+
+  The playground is fully deterministic — in-memory tool functions, no LLM, no
+  network — so we can evaluate its cells against the real `PtcRunner.Lisp`
+  engine and assert the exact results the tutorial promises. If the public API
+  the playground teaches ever drifts, this test fails.
+  """
+  use ExUnit.Case, async: true
+  import ExUnit.CaptureIO
+
+  alias PtcRunner.Test.LivebookExtractor
+
+  @path Path.join(LivebookExtractor.livebooks_dir(), "ptc_runner_playground.livemd")
+
+  test "playground cells run against the real engine and produce the documented results" do
+    # Drop the Mix.install cell — ptc_runner is already loaded in the test
+    # runtime, and re-installing would be slow and pointless here.
+    cells =
+      @path
+      |> LivebookExtractor.elixir_cells()
+      |> Enum.reject(&String.contains?(&1, "Mix.install"))
+
+    assert cells != [], "no runnable cells found in the playground livebook"
+
+    {values, output} = with_io(fn -> eval_cells(cells) end)
+
+    # Both the PTC-Lisp and plain-Clojure forms of the basic example sum the
+    # two travel expenses (500 + 200) to 700.
+    assert output =~ "Travel expenses: 700"
+    assert output =~ "Travel expenses (Clojure style): 700"
+
+    # The `let` cell returns an aggregate map. Keys come back as a mix of atoms
+    # and strings depending on the builtin, so normalize before matching.
+    assert Enum.any?(values, fn value ->
+             is_map(value) and match?(%{"count" => 2, "total" => 700}, stringify_keys(value))
+           end),
+           "expected the let cell to aggregate 2 travel expenses totalling 700"
+
+    # The grouping cell returns one row per category with per-group totals.
+    assert Enum.any?(values, fn value ->
+             is_list(value) and
+               has_row?(value, %{"category" => "travel", "total" => 700, "count" => 2}) and
+               has_row?(value, %{"category" => "food", "total" => 125, "count" => 2})
+           end),
+           "expected the grouping cell to total travel=700 and food=125"
+  end
+
+  defp has_row?(rows, expected) do
+    Enum.any?(rows, fn row ->
+      is_map(row) and Enum.all?(expected, fn {k, v} -> Map.get(stringify_keys(row), k) == v end)
+    end)
+  end
+
+  defp stringify_keys(map) do
+    Map.new(map, fn {k, v} -> {to_string(k), v} end)
+  end
+
+  # Evaluate cells in sequence, threading the binding so later cells see the
+  # variables earlier ones defined — exactly as Livebook would. Returns the
+  # value of each cell in order. A cell that raises (e.g. a failed `{:ok, step}`
+  # match) fails the test loudly, which is the point.
+  defp eval_cells(cells) do
+    {values, _binding} =
+      Enum.reduce(cells, {[], []}, fn code, {values, binding} ->
+        {value, binding} = Code.eval_string(code, binding)
+        {[value | values], binding}
+      end)
+
+    Enum.reverse(values)
+  end
+end

--- a/test/support/livebook_extractor.ex
+++ b/test/support/livebook_extractor.ex
@@ -1,0 +1,42 @@
+defmodule PtcRunner.Test.LivebookExtractor do
+  @moduledoc """
+  Helpers for testing the `livebooks/*.livemd` notebooks.
+
+  Livebooks are Markdown with fenced ` ```elixir ` code cells. These helpers
+  pull those cells out as plain strings so tests can parse-check or evaluate
+  them, keeping the published tutorials honest against the real engine.
+  """
+
+  # This file lives in test/support; the livebooks dir is two levels up.
+  @livebooks_dir Path.expand("../../livebooks", __DIR__)
+
+  @doc "Absolute path to the `livebooks/` directory."
+  def livebooks_dir, do: @livebooks_dir
+
+  @doc "Sorted list of every `.livemd` notebook under `livebooks/`."
+  def paths do
+    @livebooks_dir
+    |> Path.join("*.livemd")
+    |> Path.wildcard()
+    |> Enum.sort()
+  end
+
+  @doc "Reads a notebook and returns its elixir code cells, in document order."
+  def elixir_cells(path) do
+    path
+    |> File.read!()
+    |> extract_cells()
+  end
+
+  # Matches ```elixir fenced blocks at the start of a line, non-greedily up to
+  # the closing fence. The `m` flag anchors ^ to line starts; `s` lets . span
+  # newlines so multi-line cells are captured whole.
+  @fence ~r/^```elixir\r?\n(.*?)^```/ms
+
+  @doc "Extracts elixir code cells from raw LiveMarkdown content."
+  def extract_cells(content) do
+    @fence
+    |> Regex.scan(content, capture: :all_but_first)
+    |> Enum.map(fn [code] -> code end)
+  end
+end


### PR DESCRIPTION
## What

Adds **Tier-A livebook test coverage** so the published notebooks can't silently rot, and fixes real doc rot the tests immediately caught.

- **`LivebookExtractor`** (`test/support/`) — pulls ` ```elixir ` cells out of `.livemd` files.
- **`livebook_smoke_test`** — asserts every elixir cell in all six livebooks parses as valid Elixir. Cheap, deterministic, no LLM/network. Zero-maintenance guard against syntax rot.
- **`playground_test`** — evaluates `ptc_runner_playground.livemd` end-to-end against the real `PtcRunner.Lisp` engine and asserts the documented results (travel total 700, grouping totals). Key-type-agnostic to tolerate the engine's mixed atom/string map keys.

## Doc rot the tests caught

The playground still taught `where`/`find`, removed in `ec48386d` (#678/#672). Fixed:
- Rewrote those examples to current Clojure idioms: `#(= (:field %) v)`, `(first (filter ...))`.
- Retagged an illustrative PTC-Lisp block as ` ```clojure ` (it was mis-tagged `elixir` and isn't runnable — would error in real Livebook).
- Replaced the obsolete `where`-error example with an unknown-tool one.
- Removed the stale `where` bullet from the intro (caught by codex review).

The other five LLM-dependent livebooks get parse-smoke only (they need `OPENROUTER_API_KEY` + Kino); an `--include e2e` tier for those is a sensible follow-up.

## Verification

- `mix test test/livebooks` — 7/7
- full `mix test` — 5288/0
- `demo/` + `ptc_viewer/` suites green
- codex review — clean (one P3 found and fixed, re-review clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)