### PR TITLE
refactor(upstream): extract Eval to break runtime cycle

### DIFF
--- a/lib/mix/tasks/ptc.repl.ex
+++ b/lib/mix/tasks/ptc.repl.ex
@@ -52,7 +52,7 @@ defmodule Mix.Tasks.Ptc.Repl do
   alias PtcRunner.Lisp.Format
   alias PtcRunner.Lisp.Registry
   alias PtcRunner.SubAgent.Loop.ResponseHandler
-  alias PtcRunner.Upstream.RunContext, as: UpstreamRunContext
+  alias PtcRunner.Upstream.Eval, as: UpstreamEval
   alias PtcRunner.Upstream.Runtime, as: UpstreamRuntime
 
   @switches [
@@ -318,7 +318,7 @@ defmodule Mix.Tasks.Ptc.Repl do
   defp run_lisp(source, opts, nil), do: PtcRunner.Lisp.run(source, opts)
 
   defp run_lisp(source, opts, runtime) do
-    UpstreamRuntime.run_lisp(runtime, source, opts)
+    UpstreamEval.run_lisp(runtime, source, opts)
   end
 
   defp with_upstream_runtime(opts, fun) do
@@ -400,8 +400,8 @@ defmodule Mix.Tasks.Ptc.Repl do
 
   defp discovery_once(runtime, operation, args) do
     {result, _records} =
-      UpstreamRuntime.with_run_context(runtime, [], fn context ->
-        exec = UpstreamRunContext.eval_options(context)[:discovery_exec]
+      UpstreamEval.with_run_context(runtime, [], fn context ->
+        exec = UpstreamEval.eval_options(context)[:discovery_exec]
         exec.(operation, args)
       end)
 

--- a/lib/ptc_runner/session.ex
+++ b/lib/ptc_runner/session.ex
@@ -27,7 +27,7 @@ defmodule PtcRunner.Session do
   """
 
   alias PtcRunner.Step
-  alias PtcRunner.Upstream.Runtime, as: UpstreamRuntime
+  alias PtcRunner.Upstream.Eval, as: UpstreamEval
 
   @default_history_depth 3
 
@@ -142,6 +142,6 @@ defmodule PtcRunner.Session do
   end
 
   defp run_lisp(%__MODULE__{upstream_runtime: runtime}, source, opts) do
-    UpstreamRuntime.run_lisp(runtime, source, opts)
+    UpstreamEval.run_lisp(runtime, source, opts)
   end
 end

--- a/lib/ptc_runner/upstream/eval.ex
+++ b/lib/ptc_runner/upstream/eval.ex
@@ -1,0 +1,63 @@
+defmodule PtcRunner.Upstream.Eval do
+  @moduledoc """
+  High-level Lisp orchestration over the upstream runtime.
+
+  Sits above the low-level `PtcRunner.Upstream.Runtime` server: builds a
+  per-run `RunContext`, assembles the eval callbacks (`tools:` /
+  `discovery_exec:`), and runs PTC-Lisp programs against them.
+  """
+
+  alias PtcRunner.Upstream.{CallTool, Discovery, RunContext}
+
+  @context_keys [
+    :max_tool_calls,
+    :max_catalog_ops,
+    :call_timeout_ms,
+    :max_response_bytes,
+    :max_catalog_result_bytes
+  ]
+
+  @spec run_context(struct() | pid(), keyword()) :: {:ok, struct()} | {:error, term()}
+  def run_context(runtime, opts \\ []), do: RunContext.new(runtime, opts)
+
+  @spec eval_options(struct()) :: keyword()
+  def eval_options(%RunContext{} = context) do
+    [
+      tools: CallTool.build(context),
+      discovery_exec: Discovery.build(context)
+    ]
+  end
+
+  @spec with_run_context(struct() | pid(), keyword(), (struct() -> term())) ::
+          {term(), [map()]}
+  def with_run_context(runtime, opts, fun) when is_function(fun, 1) do
+    {:ok, context} = run_context(runtime, opts)
+
+    try do
+      result = fun.(context)
+      records = RunContext.drain_calls(context)
+      {result, records}
+    after
+      RunContext.close(context)
+    end
+  end
+
+  @spec run_lisp(struct() | pid(), String.t(), keyword()) ::
+          {:ok, PtcRunner.Step.t()} | {:error, PtcRunner.Step.t()}
+  def run_lisp(runtime, program, opts \\ []) do
+    {result, _records} = run_lisp_with_records(runtime, program, opts)
+    result
+  end
+
+  @doc false
+  @spec run_lisp_with_records(struct() | pid(), String.t(), keyword()) ::
+          {{:ok, PtcRunner.Step.t()} | {:error, PtcRunner.Step.t()}, [map()]}
+  def run_lisp_with_records(runtime, program, opts \\ []) do
+    context_opts = Keyword.take(opts, @context_keys)
+    lisp_opts = Keyword.drop(opts, @context_keys)
+
+    with_run_context(runtime, context_opts, fn context ->
+      PtcRunner.Lisp.run(program, Keyword.merge(lisp_opts, eval_options(context)))
+    end)
+  end
+end

--- a/lib/ptc_runner/upstream/run_context.ex
+++ b/lib/ptc_runner/upstream/run_context.ex
@@ -1,7 +1,7 @@
 defmodule PtcRunner.Upstream.RunContext do
   @moduledoc false
 
-  alias PtcRunner.Upstream.{CallTool, Collector, Discovery, Runtime}
+  alias PtcRunner.Upstream.{Collector, Runtime}
 
   @type t :: %__MODULE__{}
 
@@ -25,14 +25,6 @@ defmodule PtcRunner.Upstream.RunContext do
          limits: limits(runtime, opts)
        }}
     end
-  end
-
-  @spec eval_options(struct()) :: keyword()
-  def eval_options(%__MODULE__{} = context) do
-    [
-      tools: CallTool.build(context),
-      discovery_exec: Discovery.build(context)
-    ]
   end
 
   @spec drain_calls(struct()) :: [map()]

--- a/lib/ptc_runner/upstream/runtime.ex
+++ b/lib/ptc_runner/upstream/runtime.ex
@@ -5,7 +5,7 @@ defmodule PtcRunner.Upstream.Runtime do
 
   use GenServer
 
-  alias PtcRunner.Upstream.{Catalog, Config, Credentials, OpenAPI, RunContext}
+  alias PtcRunner.Upstream.{Catalog, Config, Credentials, OpenAPI}
   alias PtcRunner.Upstream.Transport.McpHttp
   alias PtcRunner.Upstream.Transport.McpStdio
 
@@ -69,79 +69,6 @@ defmodule PtcRunner.Upstream.Runtime do
       nil -> :ok
       pid -> stop(pid)
     end
-  end
-
-  @spec run_context(struct() | pid(), keyword()) :: {:ok, struct()} | {:error, term()}
-  def run_context(runtime, opts \\ []), do: RunContext.new(runtime, opts)
-
-  @spec with_run_context(struct() | pid(), keyword(), (struct() -> term())) ::
-          {term(), [map()]}
-  def with_run_context(runtime, opts, fun) when is_function(fun, 1) do
-    {:ok, context} = run_context(runtime, opts)
-
-    try do
-      result = fun.(context)
-      records = RunContext.drain_calls(context)
-      {result, records}
-    after
-      RunContext.close(context)
-    end
-  end
-
-  @spec run_lisp(struct() | pid(), String.t(), keyword()) ::
-          {:ok, PtcRunner.Step.t()} | {:error, PtcRunner.Step.t()}
-  def run_lisp(runtime, program, opts \\ []) do
-    context_opts =
-      Keyword.take(opts, [
-        :max_tool_calls,
-        :max_catalog_ops,
-        :call_timeout_ms,
-        :max_response_bytes,
-        :max_catalog_result_bytes
-      ])
-
-    lisp_opts =
-      Keyword.drop(opts, [
-        :max_tool_calls,
-        :max_catalog_ops,
-        :call_timeout_ms,
-        :max_response_bytes,
-        :max_catalog_result_bytes
-      ])
-
-    {result, _records} =
-      with_run_context(runtime, context_opts, fn context ->
-        PtcRunner.Lisp.run(program, Keyword.merge(lisp_opts, RunContext.eval_options(context)))
-      end)
-
-    result
-  end
-
-  @doc false
-  @spec run_lisp_with_records(struct() | pid(), String.t(), keyword()) ::
-          {{:ok, PtcRunner.Step.t()} | {:error, PtcRunner.Step.t()}, [map()]}
-  def run_lisp_with_records(runtime, program, opts \\ []) do
-    context_opts =
-      Keyword.take(opts, [
-        :max_tool_calls,
-        :max_catalog_ops,
-        :call_timeout_ms,
-        :max_response_bytes,
-        :max_catalog_result_bytes
-      ])
-
-    lisp_opts =
-      Keyword.drop(opts, [
-        :max_tool_calls,
-        :max_catalog_ops,
-        :call_timeout_ms,
-        :max_response_bytes,
-        :max_catalog_result_bytes
-      ])
-
-    with_run_context(runtime, context_opts, fn context ->
-      PtcRunner.Lisp.run(program, Keyword.merge(lisp_opts, RunContext.eval_options(context)))
-    end)
   end
 
   @spec defaults(struct() | pid()) :: map()

--- a/mcp_server/lib/ptc_runner_mcp/agentic.ex
+++ b/mcp_server/lib/ptc_runner_mcp/agentic.ex
@@ -4,7 +4,7 @@ defmodule PtcRunnerMcp.Agentic do
   alias PtcRunner.Step
   alias PtcRunner.SubAgent
   alias PtcRunner.SubAgent.Loop.StepAssembler
-  alias PtcRunner.Upstream.{Result, RunContext, Runtime}
+  alias PtcRunner.Upstream.{Eval, Result, Runtime}
 
   alias PtcRunnerMcp.{
     AgenticConfig,
@@ -165,11 +165,11 @@ defmodule PtcRunnerMcp.Agentic do
   defp run_subagent(agent, llm, validated, request_id, ledger) do
     if RootUpstreamRuntime.configured?() do
       {result, _records} =
-        Runtime.with_run_context(
+        Eval.with_run_context(
           RootUpstreamRuntime.runtime(),
           root_context_opts(),
           fn context ->
-            eval_opts = RunContext.eval_options(context)
+            eval_opts = Eval.eval_options(context)
             root_agent = %{agent | tools: root_tools_with_ledger(eval_opts[:tools], ledger)}
 
             SubAgent.run(root_agent,

--- a/mcp_server/lib/ptc_runner_mcp/sessions.ex
+++ b/mcp_server/lib/ptc_runner_mcp/sessions.ex
@@ -9,7 +9,7 @@ defmodule PtcRunnerMcp.Sessions do
 
   import Kernel, except: [inspect: 1]
 
-  alias PtcRunner.Upstream.{RunContext, Runtime}
+  alias PtcRunner.Upstream.{Eval, RunContext}
 
   alias PtcRunnerMcp.{
     CatalogConfig,
@@ -712,7 +712,7 @@ defmodule PtcRunnerMcp.Sessions do
     catalog_config = CatalogConfig.get()
 
     {:ok, context} =
-      Runtime.run_context(RootUpstreamRuntime.runtime(),
+      Eval.run_context(RootUpstreamRuntime.runtime(),
         max_tool_calls: Limits.max_upstream_calls_per_program(),
         max_catalog_ops: catalog_config.max_catalog_ops_per_program,
         call_timeout_ms: Limits.upstream_call_timeout_ms(),
@@ -720,7 +720,7 @@ defmodule PtcRunnerMcp.Sessions do
         max_catalog_result_bytes: catalog_config.max_catalog_result_bytes
       )
 
-    eval_opts = RunContext.eval_options(context)
+    eval_opts = Eval.eval_options(context)
 
     run_opts =
       opts

--- a/mcp_server/lib/ptc_runner_mcp/tools.ex
+++ b/mcp_server/lib/ptc_runner_mcp/tools.ex
@@ -23,7 +23,7 @@ defmodule PtcRunnerMcp.Tools do
   """
 
   alias PtcRunner.SubAgent.Signature
-  alias PtcRunner.Upstream.{Result, RunContext, Runtime}
+  alias PtcRunner.Upstream.{Eval, Result, RunContext}
 
   alias PtcRunnerMcp.{
     Agentic,
@@ -707,7 +707,7 @@ defmodule PtcRunnerMcp.Tools do
     runtime = RootUpstreamRuntime.runtime()
 
     {:ok, run_context} =
-      Runtime.run_context(runtime,
+      Eval.run_context(runtime,
         max_tool_calls: Limits.max_upstream_calls_per_program(),
         max_catalog_ops: CatalogConfig.get().max_catalog_ops_per_program,
         call_timeout_ms: Limits.upstream_call_timeout_ms(),
@@ -716,7 +716,7 @@ defmodule PtcRunnerMcp.Tools do
       )
 
     try do
-      eval_opts = RunContext.eval_options(run_context)
+      eval_opts = Eval.eval_options(run_context)
 
       sandbox_result =
         Sandbox.execute(

--- a/test/ptc_runner/upstream_runtime_test.exs
+++ b/test/ptc_runner/upstream_runtime_test.exs
@@ -2,6 +2,7 @@ defmodule PtcRunner.UpstreamRuntimeTest do
   use ExUnit.Case, async: true
 
   alias PtcRunner.Upstream.Credentials
+  alias PtcRunner.Upstream.Eval
   alias PtcRunner.Upstream.RunContext
   alias PtcRunner.Upstream.Runtime
 
@@ -19,13 +20,13 @@ defmodule PtcRunner.UpstreamRuntimeTest do
     try do
       assert [%{"name" => "observatory", "tool_count" => 2}] = Runtime.catalog_snapshot(runtime)
 
-      assert {:ok, step} = Runtime.run_lisp(runtime, "(tool/servers)")
+      assert {:ok, step} = Eval.run_lisp(runtime, "(tool/servers)")
       assert [%{"name" => "observatory", "tool_count" => 2}] = step.return
 
-      assert {:ok, dir_step} = Runtime.run_lisp(runtime, "(dir 'observatory)")
+      assert {:ok, dir_step} = Eval.run_lisp(runtime, "(dir 'observatory)")
       assert Enum.any?(dir_step.return, &String.contains?(&1, "observatory/list-traces"))
 
-      assert {:ok, doc_step} = Runtime.run_lisp(runtime, "(doc 'observatory/list-traces)")
+      assert {:ok, doc_step} = Eval.run_lisp(runtime, "(doc 'observatory/list-traces)")
       assert doc_step.return =~ "observatory/list-traces"
     after
       Runtime.stop(runtime)
@@ -39,10 +40,10 @@ defmodule PtcRunner.UpstreamRuntimeTest do
 
     try do
       {{:ok, first}, first_records} =
-        Runtime.run_lisp_with_records(runtime, program, max_tool_calls: 0)
+        Eval.run_lisp_with_records(runtime, program, max_tool_calls: 0)
 
       {{:ok, second}, second_records} =
-        Runtime.run_lisp_with_records(runtime, program, max_tool_calls: 0)
+        Eval.run_lisp_with_records(runtime, program, max_tool_calls: 0)
 
       assert first.return == %{ok: false, reason: :cap_exhausted, message: "cap_exhausted"}
       assert second.return == first.return
@@ -63,7 +64,7 @@ defmodule PtcRunner.UpstreamRuntimeTest do
 
     try do
       {{:ok, step}, records} =
-        Runtime.run_lisp_with_records(runtime, program, max_tool_calls: 0)
+        Eval.run_lisp_with_records(runtime, program, max_tool_calls: 0)
 
       assert step.return == %{ok: false, reason: :cap_exhausted, message: "cap_exhausted"}
       assert [%{"server" => "observatory", "tool" => "list-traces"}] = records
@@ -87,7 +88,7 @@ defmodule PtcRunner.UpstreamRuntimeTest do
       ~S|(tool/call {:server "observatory" :tool "list-traces" :args {:org_id "acme" :limit 1}})|
 
     try do
-      {{:ok, step}, records} = Runtime.run_lisp_with_records(runtime, program)
+      {{:ok, step}, records} = Eval.run_lisp_with_records(runtime, program)
 
       assert step.return == %{
                ok: true,
@@ -128,7 +129,7 @@ defmodule PtcRunner.UpstreamRuntimeTest do
       ~S|(tool/call {:server "observatory" :tool "get-trace" :args {:trace_id "org/42" :org_id "acme"}})|
 
     try do
-      {{:ok, step}, records} = Runtime.run_lisp_with_records(runtime, program)
+      {{:ok, step}, records} = Eval.run_lisp_with_records(runtime, program)
 
       assert step.return == %{
                ok: true,
@@ -166,7 +167,7 @@ defmodule PtcRunner.UpstreamRuntimeTest do
       ~S|(tool/call {:server "observatory" :tool "get-trace-cost" :args {:trace_id "org/42"}})|
 
     try do
-      {{:ok, step}, _records} = Runtime.run_lisp_with_records(runtime, program)
+      {{:ok, step}, _records} = Eval.run_lisp_with_records(runtime, program)
 
       assert step.return.ok == true
 
@@ -197,7 +198,7 @@ defmodule PtcRunner.UpstreamRuntimeTest do
       ~S|(tool/call {:server "observatory" :tool "list-trace-steps" :args {:trace_id "trace-42" :summary true}})|
 
     try do
-      {{:ok, step}, _records} = Runtime.run_lisp_with_records(runtime, program)
+      {{:ok, step}, _records} = Eval.run_lisp_with_records(runtime, program)
 
       assert step.return.ok == true
 
@@ -219,7 +220,7 @@ defmodule PtcRunner.UpstreamRuntimeTest do
       ~S|(tool/call {:server "observatory" :tool "list-trace-steps" :args {:trace_id "t1" :summary []}})|
 
     try do
-      {{:ok, step}, _records} = Runtime.run_lisp_with_records(runtime, program)
+      {{:ok, step}, _records} = Eval.run_lisp_with_records(runtime, program)
 
       assert step.return.ok == false
       assert step.return.reason == :upstream_error
@@ -243,7 +244,7 @@ defmodule PtcRunner.UpstreamRuntimeTest do
       ~S|(tool/call {:server "observatory" :tool "get-trace" :args {:trace_id "org/42" :org_id "acme"}})|
 
     try do
-      {{:ok, step}, _records} = Runtime.run_lisp_with_records(runtime, program)
+      {{:ok, step}, _records} = Eval.run_lisp_with_records(runtime, program)
 
       assert step.return.ok == true
 
@@ -264,7 +265,7 @@ defmodule PtcRunner.UpstreamRuntimeTest do
       ~S|(tool/call {:server "observatory" :tool "get-trace" :args {:org_id "acme"}})|
 
     try do
-      {{:error, step}, _records} = Runtime.run_lisp_with_records(runtime, program)
+      {{:error, step}, _records} = Eval.run_lisp_with_records(runtime, program)
 
       assert step.fail.reason == :runtime_error
       assert step.fail.message =~ "missing required args trace_id"
@@ -295,7 +296,7 @@ defmodule PtcRunner.UpstreamRuntimeTest do
 
     try do
       {{:ok, step}, records} =
-        Runtime.run_lisp_with_records(runtime, program, max_response_bytes: 64)
+        Eval.run_lisp_with_records(runtime, program, max_response_bytes: 64)
 
       assert step.return.ok == false
       assert step.return.reason == :response_too_large
@@ -336,7 +337,7 @@ defmodule PtcRunner.UpstreamRuntimeTest do
 
     try do
       {{:ok, step}, records} =
-        Runtime.run_lisp_with_records(runtime, program, max_response_bytes: 64)
+        Eval.run_lisp_with_records(runtime, program, max_response_bytes: 64)
 
       assert step.return.ok == false
       assert step.return.reason == :tool_error
@@ -361,7 +362,7 @@ defmodule PtcRunner.UpstreamRuntimeTest do
     program = ~S|(apropos "list-traces" {:limit 1})|
 
     try do
-      {:ok, step} = Runtime.run_lisp(runtime, program)
+      {:ok, step} = Eval.run_lisp(runtime, program)
 
       # limit 1 -> the single top hit must be the upstream tool, not a local
       # builtin. Match the ref prefix only, so the description text isn't brittle.
@@ -383,7 +384,7 @@ defmodule PtcRunner.UpstreamRuntimeTest do
       assert [%{"name" => "fixture", "tool_count" => 1}] = Runtime.catalog_snapshot(runtime)
 
       program = ~S|(tool/call 'fixture/echo {:message "hello"})|
-      {{:ok, step}, records} = Runtime.run_lisp_with_records(runtime, program)
+      {{:ok, step}, records} = Eval.run_lisp_with_records(runtime, program)
 
       assert step.return == %{
                ok: true,
@@ -408,7 +409,7 @@ defmodule PtcRunner.UpstreamRuntimeTest do
       ~S|(pmap (fn [message] (tool/call 'fixture/echo {:message message})) ["a" "b" "c" "d"])|
 
     try do
-      {{:ok, step}, records} = Runtime.run_lisp_with_records(runtime, program)
+      {{:ok, step}, records} = Eval.run_lisp_with_records(runtime, program)
 
       assert Enum.map(step.return, &get_in(&1, [:value, "echo", "message"])) == [
                "a",
@@ -448,7 +449,7 @@ defmodule PtcRunner.UpstreamRuntimeTest do
       assert [%{"name" => "fixture", "tool_count" => 1}] = Runtime.catalog_snapshot(runtime)
 
       program = ~S|(tool/call 'fixture/echo {:message "hello"})|
-      {{:ok, step}, records} = Runtime.run_lisp_with_records(runtime, program)
+      {{:ok, step}, records} = Eval.run_lisp_with_records(runtime, program)
 
       assert step.return == %{
                ok: true,
@@ -489,7 +490,7 @@ defmodule PtcRunner.UpstreamRuntimeTest do
 
     try do
       program = ~S|(tool/call 'fixture/echo {:message "hello"})|
-      {{:ok, step}, records} = Runtime.run_lisp_with_records(runtime, program)
+      {{:ok, step}, records} = Eval.run_lisp_with_records(runtime, program)
 
       assert step.return == %{
                ok: true,
@@ -581,7 +582,7 @@ defmodule PtcRunner.UpstreamRuntimeTest do
     program = ~S|(tool/call 'fixture/echo {:message "hello"})|
 
     try do
-      {{:ok, step}, records} = Runtime.run_lisp_with_records(runtime, program)
+      {{:ok, step}, records} = Eval.run_lisp_with_records(runtime, program)
 
       assert step.return == %{ok: false, reason: :tool_error, message: "denied [REDACTED]"}
 
@@ -629,7 +630,7 @@ defmodule PtcRunner.UpstreamRuntimeTest do
     program = ~S|(tool/call 'fixture/echo {:message "hello"})|
 
     try do
-      {{:ok, step}, _records} = Runtime.run_lisp_with_records(runtime, program)
+      {{:ok, step}, _records} = Eval.run_lisp_with_records(runtime, program)
 
       assert step.return == %{
                ok: true,
@@ -678,7 +679,7 @@ defmodule PtcRunner.UpstreamRuntimeTest do
     program = ~S|(tool/call 'fixture/echo {:message "hello"})|
 
     try do
-      {{:ok, step}, _records} = Runtime.run_lisp_with_records(runtime, program)
+      {{:ok, step}, _records} = Eval.run_lisp_with_records(runtime, program)
 
       assert step.return.ok == true
       assert get_in(step.return.value, ["echo", "message"]) == "hello"
@@ -716,7 +717,7 @@ defmodule PtcRunner.UpstreamRuntimeTest do
     program = ~S|(tool/call 'fixture/echo {:message "hello"})|
 
     try do
-      {{:ok, step}, _records} = Runtime.run_lisp_with_records(runtime, program)
+      {{:ok, step}, _records} = Eval.run_lisp_with_records(runtime, program)
 
       assert step.return == %{ok: false, reason: :tool_error, message: "boom"}
       refute inspect(step.return) =~ "should-not-win"
@@ -843,7 +844,7 @@ defmodule PtcRunner.UpstreamRuntimeTest do
     {:ok, runtime} = Runtime.start_link(config: config())
 
     try do
-      {:ok, context} = Runtime.run_context(runtime)
+      {:ok, context} = Eval.run_context(runtime)
 
       assert :ok = RunContext.close(context)
       refute Process.alive?(context.collector.pid)
@@ -859,7 +860,7 @@ defmodule PtcRunner.UpstreamRuntimeTest do
 
     try do
       assert_raise RuntimeError, "boom", fn ->
-        Runtime.with_run_context(runtime, [], fn context ->
+        Eval.with_run_context(runtime, [], fn context ->
           send(parent, {:collector, context.collector.pid})
           raise "boom"
         end)
@@ -934,16 +935,16 @@ defmodule PtcRunner.UpstreamRuntimeTest do
       refute catalog_text =~ secret
       assert catalog_text =~ "[REDACTED]"
 
-      assert {:ok, servers_step} = Runtime.run_lisp(runtime, "(tool/servers)")
+      assert {:ok, servers_step} = Eval.run_lisp(runtime, "(tool/servers)")
       refute inspect(servers_step.return) =~ secret
 
-      assert {:ok, dir_step} = Runtime.run_lisp(runtime, "(dir 'observatory)")
+      assert {:ok, dir_step} = Eval.run_lisp(runtime, "(dir 'observatory)")
       refute inspect(dir_step.return) =~ secret
 
-      assert {:ok, doc_step} = Runtime.run_lisp(runtime, "(doc 'observatory/list-traces)")
+      assert {:ok, doc_step} = Eval.run_lisp(runtime, "(doc 'observatory/list-traces)")
       refute doc_step.return =~ secret
 
-      assert {:ok, meta_step} = Runtime.run_lisp(runtime, "(meta 'observatory/list-traces)")
+      assert {:ok, meta_step} = Eval.run_lisp(runtime, "(meta 'observatory/list-traces)")
       refute inspect(meta_step.return) =~ secret
     after
       Runtime.stop(runtime)
@@ -955,7 +956,7 @@ defmodule PtcRunner.UpstreamRuntimeTest do
 
     try do
       assert {:ok, step} =
-               Runtime.run_lisp(runtime, "(dir 'observatory)", max_catalog_result_bytes: 10)
+               Eval.run_lisp(runtime, "(dir 'observatory)", max_catalog_result_bytes: 10)
 
       assert step.return == nil
 


### PR DESCRIPTION
## Summary

Breaks the 4-file upstream compile-time cycle (`call_tool → discovery → run_context → runtime`) by separating the low-level upstream **server** from the high-level Lisp **orchestration**.

The cycle came from `Runtime` playing two roles: it both *was* the GenServer server and *assembled* the eval callbacks (via `RunContext.eval_options`), which transitively depend back on that same server. Relocating only `eval_options` wasn't enough — the orchestration had to move *above* the server.

## Changes

- **New `PtcRunner.Upstream.Eval`** — owns `run_lisp/3`, `run_lisp_with_records/3`, `with_run_context/3`, `run_context/2`, and the eval-callback assembly `eval_options/1`. Sits above the server layer.
- **`Runtime`** — now the pure GenServer (lifecycle + low-level accessors). Dropped the four orchestration functions and the `RunContext` alias; no longer references `RunContext`/`CallTool`/`Discovery`.
- **`RunContext`** — dropped `eval_options/1` and the `CallTool`/`Discovery` aliases. Still owns per-run state, caps, collector lifecycle, and call records.
- **Callers** — `session.ex`, `ptc.repl.ex`, and `upstream_runtime_test.exs` updated to the new module.

`run_lisp/3` now delegates to `run_lisp_with_records/3` instead of duplicating the `context_opts`/`lisp_opts` split — identical behavior.

Resulting DAG:

```text
Eval ─┬─→ Runtime
      ├─→ RunContext ─→ Runtime, Collector
      ├─→ CallTool   ─→ RunContext, Runtime
      └─→ Discovery  ─→ RunContext, Runtime
```

## Test plan

- [x] `mix xref graph --format cycles` no longer reports the upstream cycle (and introduces no new cycle)
- [x] `test/ptc_runner/upstream_runtime_test.exs` — 35 tests, 0 failures
- [x] `mix precommit` passes (format, compile, xref cycles gate, credo, tests, demo + viewer suites)

Closes #1048

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Fix Automation State
<!-- fix-state: {"attempts":2} -->
Fix attempts: 2/3
