### PR TITLE
refactor(lisp): decouple SourceAtoms from Env.initial to leave runtime cycle

### DIFF
--- a/lib/ptc_runner/lisp/builtin_names.ex
+++ b/lib/ptc_runner/lisp/builtin_names.ex
@@ -1,0 +1,37 @@
+defmodule PtcRunner.Lisp.BuiltinNames do
+  @moduledoc """
+  Leaf source of env-dispatched builtin names, loaded from
+  `priv/functions.exs` at compile time.
+
+  Exists so `PtcRunner.Lisp.SourceAtoms` can derive the builtin-name
+  half of its bounded vocabulary without calling
+  `PtcRunner.Lisp.Env.initial/0` — which would pull `SourceAtoms` into
+  the Lisp runtime cycle (issue #1051). This module aliases and calls
+  **no** other `PtcRunner.Lisp.*` runtime module, so it stays a leaf.
+
+  The names returned here equal `Env.initial() |> Map.keys()` exactly;
+  a drift-guard test asserts the two stay in sync.
+  """
+
+  @registry_path "priv/functions.exs"
+
+  # Compile-time loading (no runtime file I/O), mirroring Registry.
+  @external_resource @registry_path
+  @registry Code.eval_file(@registry_path) |> elem(0)
+
+  # Names come from the closed compile-time registry, not user input,
+  # so `String.to_atom/1` is safe and avoids depending on Env being
+  # loaded first (same justification as `Registry.builtins_by_category/1`).
+  @env_names @registry.implemented
+             |> Enum.filter(&(&1.dispatch == :env))
+             |> Enum.map(&String.to_atom(&1.name))
+
+  @doc """
+  Returns the env-dispatched builtin names as atoms.
+
+  Equal to `PtcRunner.Lisp.Env.initial/0` keys, derived from the
+  compile-time registry instead of building the runtime environment.
+  """
+  @spec env_names() :: [atom()]
+  def env_names, do: @env_names
+end

--- a/lib/ptc_runner/lisp/source_atoms.ex
+++ b/lib/ptc_runner/lisp/source_atoms.ex
@@ -17,8 +17,12 @@ defmodule PtcRunner.Lisp.SourceAtoms do
 
   ## What's in the table
 
-    1. Every key of `PtcRunner.Lisp.Env.initial/0` — all builtin
-       functions (`map`, `filter`, `+`, `str`, etc.).
+    1. Every env-dispatched builtin name from
+       `PtcRunner.Lisp.BuiltinNames.env_names/0` — all builtin
+       functions (`map`, `filter`, `+`, `str`, etc.). These equal the
+       keys of `PtcRunner.Lisp.Env.initial/0` but are derived from the
+       compile-time registry so `SourceAtoms` stays out of the Lisp
+       runtime cycle (issue #1051).
     2. Analyzer special forms — `let`, `fn`, `def`, `if`, `case`, etc.
        Only forms that the analyzer currently dispatches on. No
        aspirational Clojure entries.
@@ -45,7 +49,7 @@ defmodule PtcRunner.Lisp.SourceAtoms do
   Read cost after first call is one `:persistent_term.get/1` (no copy).
   """
 
-  alias PtcRunner.Lisp.Env
+  alias PtcRunner.Lisp.BuiltinNames
 
   @doc """
   Returns the atom for `name` if it's in the bounded vocabulary,
@@ -78,7 +82,7 @@ defmodule PtcRunner.Lisp.SourceAtoms do
   end
 
   # ============================================================
-  # Bounded vocabulary (in addition to Env.initial keys)
+  # Bounded vocabulary (in addition to BuiltinNames.env_names)
   # ============================================================
 
   # Special forms that the analyzer dispatches via atom-literal
@@ -151,9 +155,7 @@ defmodule PtcRunner.Lisp.SourceAtoms do
   # here, but included for documentation completeness.
 
   defp build_table do
-    builtins =
-      Env.initial()
-      |> Map.keys()
+    builtins = BuiltinNames.env_names()
 
     explicit =
       @special_forms ++

--- a/test/ptc_runner/lisp/source_atoms_test.exs
+++ b/test/ptc_runner/lisp/source_atoms_test.exs
@@ -16,6 +16,8 @@ defmodule PtcRunner.Lisp.SourceAtomsTest do
   """
   use ExUnit.Case, async: true
 
+  alias PtcRunner.Lisp.BuiltinNames
+  alias PtcRunner.Lisp.Env
   alias PtcRunner.Lisp.SourceAtoms
 
   describe "intern/1" do
@@ -182,10 +184,26 @@ defmodule PtcRunner.Lisp.SourceAtomsTest do
                "(#953) would break dispatch unless they're added."
     end
 
-    test "table is non-trivially populated from Env.initial" do
+    test "table is non-trivially populated from BuiltinNames" do
       # Sanity: the builtin vocabulary should contribute hundreds of
       # entries. If this drops to <100 someone broke `build_table/0`.
       assert map_size(SourceAtoms.table()) > 100
+    end
+  end
+
+  describe "BuiltinNames drift guard" do
+    test "leaf env_names equals Env.initial keys" do
+      # `SourceAtoms` derives builtin names from the compile-time
+      # registry via `BuiltinNames` instead of `Env.initial/0` (issue
+      # #1051). If a builtin is added to one source but not the other,
+      # this fails so the bounded vocabulary can't silently drift.
+      leaf = MapSet.new(BuiltinNames.env_names())
+      env = MapSet.new(Map.keys(Env.initial()))
+
+      assert leaf == env,
+             "BuiltinNames.env_names/0 drifted from Env.initial/0 keys.\n" <>
+               "Only in BuiltinNames: #{inspect(MapSet.to_list(MapSet.difference(leaf, env)))}\n" <>
+               "Only in Env.initial: #{inspect(MapSet.to_list(MapSet.difference(env, leaf)))}"
     end
   end
 end


### PR DESCRIPTION
## Summary

Decouples `PtcRunner.Lisp.SourceAtoms` from `PtcRunner.Lisp.Env.initial/0` so the bounded-vocabulary table no longer requires building the full builtin environment — and so `SourceAtoms` leaves the 15-file Lisp runtime cycle.

- Adds `PtcRunner.Lisp.BuiltinNames`, a **leaf** module that loads `priv/functions.exs` at compile time (`@external_resource` + `Code.eval_file/1`, mirroring `Registry`), filters `dispatch == :env`, and exposes the resulting atom list. It calls no other `PtcRunner.Lisp.*` runtime module, so it stays outside the cycle.
- `source_atoms.ex` drops `alias PtcRunner.Lisp.Env`; `build_table/0` now uses `BuiltinNames.env_names()` instead of `Env.initial() |> Map.keys()`. Explicit special-form / namespace / keyword / short-fn lists are unchanged.
- Updates the `@moduledoc` to point at the new leaf source.

## Verification

- `mix xref trace lib/ptc_runner/lisp/source_atoms.ex` — only outgoing call is `BuiltinNames.env_names/0` (no `Env`, no `Registry`).
- `mix xref graph --format cycles` — largest Lisp cycle shrinks 15 → 14; `source_atoms.ex` no longer appears in any cycle.
- Behavior preserved exactly: the 272 `dispatch == :env` names equal `Env.initial/0` keys. New **drift-guard test** asserts `BuiltinNames.env_names/0 == Env.initial/0` keys, so a builtin added to one source but not the other fails CI.
- Renamed the now-misnamed test `"table is non-trivially populated from Env.initial"` → `"... from BuiltinNames"`.
- Source atom, keyword-representation, and atom-leak soak tests pass (no atom-table growth). Full `mix precommit` green.

## Test plan

- [x] `mix test test/ptc_runner/lisp/source_atoms_test.exs test/ptc_runner/lisp/keyword_representation_test.exs`
- [x] `mix test test/soak/atom_leak_soak_test.exs --include soak`
- [x] Drift-guard test (`BuiltinNames` vs `Env.initial`)
- [x] `mix xref trace lib/ptc_runner/lisp/source_atoms.ex`
- [x] `mix xref graph --format cycles`
- [x] `mix precommit`

Closes #1051

🤖 Generated with [Claude Code](https://claude.com/claude-code)