### PR TITLE
feat(http): rate limit failed MCP bearer authentication

### DIFF
--- a/docs/mcp-server-http-deployment.md
+++ b/docs/mcp-server-http-deployment.md
@@ -72,6 +72,31 @@ The v1 auth model has one static token. All token holders are the same
 owner, so an `MCP-Session-Id` is a bearer capability inside that trust
 boundary. Session ids are random and are never logged raw.
 
+### Failed-auth rate limiting
+
+Repeated failed bearer authentications from the same source are rate
+limited to reduce brute-force risk (`OPLANE_REQ-00080322`). Both missing
+and invalid bearer failures count. Once a source exceeds
+`--http-auth-rate-limit-max-failures` within
+`--http-auth-rate-limit-window-ms`, it is temporarily blocked for
+`--http-auth-rate-limit-block-ms`; blocked requests receive `429` with a
+`Retry-After` header and no `www-authenticate` challenge (so a blocked
+caller is not told whether its token was missing or invalid). A
+successful authentication immediately resets the source's failure state.
+A misconfigured-but-legitimate client can briefly be blocked; it
+self-heals after the block window. The limiter is on by default and is a
+no-op when no token is configured or when `--http-auth-rate-limit` is
+`false`; if the limiter process is unavailable it fails open.
+
+The source is keyed by the peer IP (`conn.remote_ip`). `X-Forwarded-For`
+/ `Forwarded` headers are **not** trusted — behind a reverse proxy every
+request appears to originate from the proxy, so deploy per-source
+limiting at the proxy too (or in addition). `Host`/`Origin` rejections
+are not bearer-auth failures and never count toward the limit. Block
+decisions log a JSON line (`http_auth_rate_limited`) with the raw source
+IP, which is operationally useful for acting on abuse; the bearer token
+itself is never logged.
+
 ### Token generation
 
 The server requires a minimum of 32 bytes but does not programmatically
@@ -104,7 +129,8 @@ instance label, `X-Request-Id`, method, path, status, duration, and
 hashed owner/session ids when known.
 
 The server emits sanitized telemetry under `[:ptc_lisp, :http, ...]`
-for request start/stop, session create/close, auth failures, limit
+for request start/stop, session create/close, auth failures, failed-auth
+rate-limit blocks (`[:ptc_lisp, :http, :auth, :rate_limited]`), limit
 rejections, and cancellations.
 
 When `--trace-dir` is enabled, HTTP tool-call trace events include
@@ -137,6 +163,10 @@ sessions return `404` on later use.
 | `--http-max-sessions` | `256` | Global HTTP protocol-session cap. |
 | `--http-max-sessions-per-owner` | `32` | Per-owner protocol-session cap. |
 | `--http-max-in-flight-per-session` | `4` | Per-session executing request cap. |
+| `--http-auth-rate-limit` | `true` | Rate limit failed bearer auth per source. |
+| `--http-auth-rate-limit-window-ms` | `60000` | Window over which failures accumulate. |
+| `--http-auth-rate-limit-max-failures` | `5` | Failures per window before a source is blocked. |
+| `--http-auth-rate-limit-block-ms` | `60000` | Block duration after the threshold is exceeded (`429` + `Retry-After`). |
 | `--http-session-ttl-ms` | `3600000` | Absolute protocol-session lifetime. |
 | `--http-session-idle-timeout-ms` | `900000` | Idle protocol-session timeout. |
 | `--http-instance-label` | hostname | Label stamped into HTTP logs/telemetry/traces. |

--- a/mcp_server/lib/ptc_runner_mcp/application.ex
+++ b/mcp_server/lib/ptc_runner_mcp/application.ex
@@ -58,7 +58,7 @@ defmodule PtcRunnerMcp.Application do
     TraceHandler
   }
 
-  alias PtcRunnerMcp.Http.{Config, Server}
+  alias PtcRunnerMcp.Http.{AuthRateLimiter, Config, Server}
   alias PtcRunnerMcp.Http.SessionRegistry, as: HttpSessionRegistry
   alias PtcRunnerMcp.Sessions.Config, as: SessionsConfig
 
@@ -170,6 +170,7 @@ defmodule PtcRunnerMcp.Application do
       session_children_for_http() ++
       [
         {HttpSessionRegistry, [config: http_config]},
+        {AuthRateLimiter, [config: http_config]},
         Server.child_spec(http_config)
       ] ++
       debug_children()
@@ -264,6 +265,10 @@ defmodule PtcRunnerMcp.Application do
           http_max_sessions: :integer,
           http_max_sessions_per_owner: :integer,
           http_max_in_flight_per_session: :integer,
+          http_auth_rate_limit: :boolean,
+          http_auth_rate_limit_window_ms: :integer,
+          http_auth_rate_limit_max_failures: :integer,
+          http_auth_rate_limit_block_ms: :integer,
           http_allow_unsafe_network: :boolean,
           http_metrics: :boolean,
           http_metrics_path: :string,

--- a/mcp_server/lib/ptc_runner_mcp/http/auth_rate_limiter.ex
+++ b/mcp_server/lib/ptc_runner_mcp/http/auth_rate_limiter.ex
@@ -1,0 +1,203 @@
+defmodule PtcRunnerMcp.Http.AuthRateLimiter do
+  @moduledoc """
+  Per-source rate limiter for failed `/mcp` bearer authentication
+  (`OPLANE_REQ-00080322`).
+
+  A `GenServer` owns a named, public ETS table and runs a periodic
+  cleanup sweep. The hot path (`check/2`, `record_failure/2`,
+  `reset/2`) touches ETS directly — atomic `:ets.update_counter/3` for
+  failure increments, plain `:ets.lookup/2` for block checks — so auth
+  is never serialized through a single process.
+
+  Each source (keyed by `conn.remote_ip`) gets one row:
+
+      {source_key, failure_count, window_started_mono, blocked_until_mono}
+
+  Window and block expiry are evaluated lazily on read; the periodic
+  sweep evicts rows whose window has fully expired and that are not
+  currently blocked, bounding table growth under many distinct sources.
+
+  Graceful degradation: when the limiter is disabled (no configured
+  token or `http_auth_rate_limit: false`) or the table is absent, every
+  function is a no-op that fails open — auth proceeds normally.
+  """
+
+  use GenServer
+
+  alias PtcRunnerMcp.Http.Telemetry
+  alias PtcRunnerMcp.Log
+
+  @table __MODULE__.Table
+  @cleanup_interval_ms 60_000
+
+  @type source_key :: :inet.ip_address() | term()
+  @type config :: %{optional(atom()) => term()}
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts) do
+    name = Keyword.get(opts, :name, __MODULE__)
+    GenServer.start_link(__MODULE__, opts, name: name)
+  end
+
+  @doc """
+  Hot-path block check. Returns `:ok` when the source may attempt auth,
+  or `{:blocked, retry_after_s}` when it is currently blocked. Fails
+  open (returns `:ok`) when disabled or the table is absent.
+  """
+  @spec check(source_key(), config()) :: :ok | {:blocked, pos_integer()}
+  def check(source_key, cfg) do
+    if enabled?(cfg) do
+      now = System.monotonic_time(:millisecond)
+
+      case :ets.lookup(@table, source_key) do
+        [{^source_key, _count, _window, blocked_until}] when blocked_until > now ->
+          {:blocked, retry_after_s(blocked_until - now)}
+
+        _ ->
+          :ok
+      end
+    else
+      :ok
+    end
+  rescue
+    _ -> :ok
+  catch
+    _, _ -> :ok
+  end
+
+  @doc """
+  Record one failed bearer auth for `source_key`. Increments the
+  per-source counter (atomically) and arms a block once it reaches
+  `http_auth_rate_limit_max_failures` within the window. No-op when
+  disabled or the table is absent.
+  """
+  @spec record_failure(source_key(), config()) :: :ok
+  def record_failure(source_key, cfg) do
+    if enabled?(cfg) do
+      do_record_failure(source_key, cfg)
+    end
+
+    :ok
+  rescue
+    _ -> :ok
+  catch
+    _, _ -> :ok
+  end
+
+  @doc """
+  Reset a source's failure state after a successful auth. No-op when
+  disabled or the table is absent.
+  """
+  @spec reset(source_key(), config()) :: :ok
+  def reset(source_key, cfg) do
+    if enabled?(cfg), do: :ets.delete(@table, source_key)
+    :ok
+  rescue
+    _ -> :ok
+  catch
+    _, _ -> :ok
+  end
+
+  defp do_record_failure(source_key, cfg) do
+    now = System.monotonic_time(:millisecond)
+    window_ms = window_ms(cfg)
+
+    # `blocked_until` is initialized to `now` (== "not blocked"); using a
+    # fixed sentinel like 0 is unsafe because monotonic time can be
+    # negative, so 0 would read as "blocked far into the future".
+    :ets.insert_new(@table, {source_key, 0, now, now})
+
+    case :ets.lookup(@table, source_key) do
+      [{^source_key, _count, _window, blocked_until}] when blocked_until > now ->
+        :ok
+
+      [{^source_key, _count, window_started, _blocked_until}]
+      when now - window_started >= window_ms ->
+        # Window elapsed: start a fresh window at this failure.
+        :ets.insert(@table, {source_key, 1, now, now})
+        :ok
+
+      _ ->
+        count = :ets.update_counter(@table, source_key, {2, 1})
+
+        if count >= max_failures(cfg) do
+          arm_block(source_key, cfg, now)
+        end
+
+        :ok
+    end
+  end
+
+  defp arm_block(source_key, cfg, now) do
+    block_ms = block_ms(cfg)
+    :ets.update_element(@table, source_key, {4, now + block_ms})
+
+    meta = %{instance: Map.get(cfg, :instance_label), source: source_label(source_key)}
+    Telemetry.emit([:auth, :rate_limited], %{count: 1, block_ms: block_ms}, meta)
+    Log.log(:warn, "http_auth_rate_limited", Map.put(meta, :block_ms, block_ms))
+  end
+
+  @impl GenServer
+  def init(opts) do
+    config = Keyword.fetch!(opts, :config)
+
+    table =
+      :ets.new(@table, [
+        :set,
+        :public,
+        :named_table,
+        read_concurrency: true,
+        write_concurrency: true
+      ])
+
+    ref = Process.send_after(self(), :cleanup, @cleanup_interval_ms)
+    {:ok, %{table: table, config: config, cleanup_ref: ref}}
+  end
+
+  @impl GenServer
+  def handle_info(:cleanup, state) do
+    now = System.monotonic_time(:millisecond)
+    threshold = now - window_ms(state.config)
+
+    # Evict rows that are not currently blocked and whose window has
+    # fully expired: blocked_until <= now AND window_started < threshold.
+    match_spec = [
+      {{:_, :_, :"$1", :"$2"}, [{:andalso, {:"=<", :"$2", now}, {:<, :"$1", threshold}}], [true]}
+    ]
+
+    _ = :ets.select_delete(state.table, match_spec)
+
+    ref = Process.send_after(self(), :cleanup, @cleanup_interval_ms)
+    {:noreply, %{state | cleanup_ref: ref}}
+  end
+
+  @impl GenServer
+  def terminate(_reason, state) do
+    if is_reference(state.cleanup_ref), do: Process.cancel_timer(state.cleanup_ref)
+    :ok
+  end
+
+  defp enabled?(cfg) do
+    Map.get(cfg, :auth_rate_limit, false) and
+      is_binary(Map.get(cfg, :auth_token)) and
+      :ets.whereis(@table) != :undefined
+  end
+
+  defp window_ms(cfg), do: Map.get(cfg, :auth_rate_limit_window_ms, 60_000)
+  defp max_failures(cfg), do: Map.get(cfg, :auth_rate_limit_max_failures, 5)
+  defp block_ms(cfg), do: Map.get(cfg, :auth_rate_limit_block_ms, 60_000)
+
+  defp retry_after_s(remaining_ms) when remaining_ms > 0,
+    do: max(1, div(remaining_ms + 999, 1000))
+
+  defp retry_after_s(_remaining_ms), do: 1
+
+  defp source_label(ip) when is_tuple(ip) do
+    case :inet.ntoa(ip) do
+      {:error, _} -> inspect(ip)
+      charlist -> List.to_string(charlist)
+    end
+  end
+
+  defp source_label(other), do: inspect(other)
+end

--- a/mcp_server/lib/ptc_runner_mcp/http/auth_rate_limiter.ex
+++ b/mcp_server/lib/ptc_runner_mcp/http/auth_rate_limiter.ex
@@ -171,12 +171,6 @@ defmodule PtcRunnerMcp.Http.AuthRateLimiter do
     {:noreply, %{state | cleanup_ref: ref}}
   end
 
-  @impl GenServer
-  def terminate(_reason, state) do
-    if is_reference(state.cleanup_ref), do: Process.cancel_timer(state.cleanup_ref)
-    :ok
-  end
-
   defp enabled?(cfg) do
     Map.get(cfg, :auth_rate_limit, false) and
       is_binary(Map.get(cfg, :auth_token)) and

--- a/mcp_server/lib/ptc_runner_mcp/http/config.ex
+++ b/mcp_server/lib/ptc_runner_mcp/http/config.ex
@@ -13,6 +13,9 @@ defmodule PtcRunnerMcp.Http.Config do
   @default_max_sessions 256
   @default_max_sessions_per_owner 32
   @default_max_in_flight_per_session 4
+  @default_auth_rate_limit_window_ms 60_000
+  @default_auth_rate_limit_max_failures 5
+  @default_auth_rate_limit_block_ms 60_000
   @token_min_bytes 32
 
   @type t :: %{
@@ -31,6 +34,10 @@ defmodule PtcRunnerMcp.Http.Config do
           max_sessions: pos_integer(),
           max_sessions_per_owner: pos_integer(),
           max_in_flight_per_session: pos_integer(),
+          auth_rate_limit: boolean(),
+          auth_rate_limit_window_ms: pos_integer(),
+          auth_rate_limit_max_failures: pos_integer(),
+          auth_rate_limit_block_ms: pos_integer(),
           allow_unsafe_network: boolean(),
           metrics?: boolean(),
           metrics_path: String.t(),
@@ -106,6 +113,34 @@ defmodule PtcRunnerMcp.Http.Config do
           :http_max_in_flight_per_session,
           "PTC_RUNNER_MCP_HTTP_MAX_IN_FLIGHT_PER_SESSION",
           @default_max_in_flight_per_session
+        ),
+      auth_rate_limit:
+        read_bool(
+          args,
+          :http_auth_rate_limit,
+          "PTC_RUNNER_MCP_HTTP_AUTH_RATE_LIMIT",
+          true
+        ),
+      auth_rate_limit_window_ms:
+        read_int(
+          args,
+          :http_auth_rate_limit_window_ms,
+          "PTC_RUNNER_MCP_HTTP_AUTH_RATE_LIMIT_WINDOW_MS",
+          @default_auth_rate_limit_window_ms
+        ),
+      auth_rate_limit_max_failures:
+        read_int(
+          args,
+          :http_auth_rate_limit_max_failures,
+          "PTC_RUNNER_MCP_HTTP_AUTH_RATE_LIMIT_MAX_FAILURES",
+          @default_auth_rate_limit_max_failures
+        ),
+      auth_rate_limit_block_ms:
+        read_int(
+          args,
+          :http_auth_rate_limit_block_ms,
+          "PTC_RUNNER_MCP_HTTP_AUTH_RATE_LIMIT_BLOCK_MS",
+          @default_auth_rate_limit_block_ms
         ),
       allow_unsafe_network:
         read_bool(

--- a/mcp_server/lib/ptc_runner_mcp/http/router.ex
+++ b/mcp_server/lib/ptc_runner_mcp/http/router.ex
@@ -3,7 +3,16 @@ defmodule PtcRunnerMcp.Http.Router do
 
   use Plug.Router
 
-  alias PtcRunnerMcp.Http.{Auth, Host, Origin, Session, SessionRegistry, Telemetry}
+  alias PtcRunnerMcp.Http.{
+    Auth,
+    AuthRateLimiter,
+    Host,
+    Origin,
+    Session,
+    SessionRegistry,
+    Telemetry
+  }
+
   alias PtcRunnerMcp.{JsonRpc, Limits, Log, Version}
 
   plug(:match)
@@ -63,6 +72,7 @@ defmodule PtcRunnerMcp.Http.Router do
       end
     else
       {:error, {:auth, reason}} -> auth_error(conn, reason)
+      {:error, {:auth_rate_limited, retry_after_s}} -> rate_limit_error(conn, retry_after_s)
       {:error, :missing_session} -> Plug.Conn.send_resp(conn, 400, "missing MCP-Session-Id")
       {:error, :origin} -> Plug.Conn.send_resp(conn, 403, "forbidden")
       {:error, :host} -> Plug.Conn.send_resp(conn, 403, "forbidden")
@@ -82,6 +92,9 @@ defmodule PtcRunnerMcp.Http.Router do
     else
       {:error, {:auth, reason}} ->
         auth_error(conn, reason)
+
+      {:error, {:auth_rate_limited, retry_after_s}} ->
+        rate_limit_error(conn, retry_after_s)
 
       {:error, :origin} ->
         Plug.Conn.send_resp(conn, 403, "forbidden")
@@ -247,11 +260,29 @@ defmodule PtcRunnerMcp.Http.Router do
         {:error, :host}
 
       Origin.allowed?(conn, cfg) ->
+        authenticate_bearer(conn, cfg)
+
+      true ->
+        {:error, :origin}
+    end
+  end
+
+  defp authenticate_bearer(conn, cfg) do
+    source = conn.remote_ip
+
+    case AuthRateLimiter.check(source, cfg) do
+      {:blocked, retry_after_s} ->
+        {:error, {:auth_rate_limited, retry_after_s}}
+
+      :ok ->
         case Auth.authenticate(conn, cfg) do
           {:ok, owner} ->
+            AuthRateLimiter.reset(source, cfg)
             {:ok, owner}
 
           {:error, reason} ->
+            AuthRateLimiter.record_failure(source, cfg)
+
             Telemetry.emit(
               [:auth, :failure],
               %{count: 1},
@@ -260,9 +291,6 @@ defmodule PtcRunnerMcp.Http.Router do
 
             {:error, {:auth, reason}}
         end
-
-      true ->
-        {:error, :origin}
     end
   end
 
@@ -294,6 +322,14 @@ defmodule PtcRunnerMcp.Http.Router do
     conn
     |> Plug.Conn.put_resp_header("www-authenticate", header)
     |> Plug.Conn.send_resp(status, "")
+  end
+
+  # No `www-authenticate` here: a blocked source must not be told whether
+  # its token was missing or invalid.
+  defp rate_limit_error(conn, retry_after_s) do
+    conn
+    |> Plug.Conn.put_resp_header("retry-after", Integer.to_string(retry_after_s))
+    |> Plug.Conn.send_resp(429, "")
   end
 
   defp read_body_capped(conn, cfg) do

--- a/mcp_server/test/ptc_runner_mcp/http_config_test.exs
+++ b/mcp_server/test/ptc_runner_mcp/http_config_test.exs
@@ -85,6 +85,31 @@ defmodule PtcRunnerMcp.HttpConfigTest do
     assert args.http_allowed_origin == ["http://a.test", "http://b.test"]
   end
 
+  test "auth rate limit defaults are enabled with sane thresholds" do
+    assert {:ok, cfg} = Config.resolve(%{http: true, http_auth_token: String.duplicate("a", 32)})
+    assert cfg.auth_rate_limit == true
+    assert cfg.auth_rate_limit_window_ms == 60_000
+    assert cfg.auth_rate_limit_max_failures == 5
+    assert cfg.auth_rate_limit_block_ms == 60_000
+  end
+
+  test "auth rate limit honors CLI overrides" do
+    assert {:ok, cfg} =
+             Config.resolve(%{
+               http: true,
+               http_auth_token: String.duplicate("a", 32),
+               http_auth_rate_limit: false,
+               http_auth_rate_limit_window_ms: 1_000,
+               http_auth_rate_limit_max_failures: 2,
+               http_auth_rate_limit_block_ms: 5_000
+             })
+
+    assert cfg.auth_rate_limit == false
+    assert cfg.auth_rate_limit_window_ms == 1_000
+    assert cfg.auth_rate_limit_max_failures == 2
+    assert cfg.auth_rate_limit_block_ms == 5_000
+  end
+
   test "default body limit follows the applied max frame limit" do
     on_exit(fn -> PtcRunnerMcp.Limits.set(PtcRunnerMcp.Limits.defaults()) end)
 

--- a/mcp_server/test/ptc_runner_mcp/http_router_test.exs
+++ b/mcp_server/test/ptc_runner_mcp/http_router_test.exs
@@ -6,6 +6,7 @@ defmodule PtcRunnerMcp.HttpRouterTest do
 
   alias PtcRunnerMcp.ConcurrencyGate
   alias PtcRunnerMcp.Http.Auth
+  alias PtcRunnerMcp.Http.AuthRateLimiter
   alias PtcRunnerMcp.Http.Config, as: HttpConfig
   alias PtcRunnerMcp.Http.Router
   alias PtcRunnerMcp.Http.SessionRegistry
@@ -662,6 +663,131 @@ defmodule PtcRunnerMcp.HttpRouterTest do
 
     File.rm_rf!(dir)
   end
+
+  describe "failed auth rate limiting" do
+    setup %{cfg: cfg} do
+      cfg = %{
+        cfg
+        | auth_rate_limit: true,
+          auth_rate_limit_window_ms: 60_000,
+          auth_rate_limit_max_failures: 3,
+          auth_rate_limit_block_ms: 60_000
+      }
+
+      Application.put_env(:ptc_runner_mcp, :http_config, cfg)
+      start_supervised!({AuthRateLimiter, [config: cfg]})
+      {:ok, cfg: cfg}
+    end
+
+    test "repeated invalid bearer attempts from the same source return 429 with Retry-After" do
+      for _ <- 1..3, do: assert(bad_auth_post().status == 401)
+
+      conn = bad_auth_post()
+      assert conn.status == 429
+      [retry_after] = get_resp_header(conn, "retry-after")
+      assert String.to_integer(retry_after) > 0
+      # A blocked source must not be told whether its token was invalid.
+      assert get_resp_header(conn, "www-authenticate") == []
+    end
+
+    test "a different source is unaffected while the first is blocked" do
+      for _ <- 1..4, do: bad_auth_post({1, 2, 3, 4})
+      assert bad_auth_post({1, 2, 3, 4}).status == 429
+
+      # A distinct source still gets the normal 401 challenge.
+      conn = bad_auth_post({5, 6, 7, 8})
+      assert conn.status == 401
+      assert get_resp_header(conn, "www-authenticate") == [~s(Bearer error="invalid_token")]
+    end
+
+    test "valid auth below threshold is not blocked" do
+      assert bad_auth_post().status == 401
+      assert valid_initialize().status == 200
+    end
+
+    test "successful auth resets prior failed state" do
+      for _ <- 1..2, do: assert(bad_auth_post().status == 401)
+      assert valid_initialize().status == 200
+      # Counter was reset: two more failures stay below the threshold.
+      for _ <- 1..2, do: assert(bad_auth_post().status == 401)
+    end
+
+    test "missing Authorization failures are counted" do
+      for _ <- 1..3 do
+        conn =
+          conn(:post, "/mcp", "{}")
+          |> put_req_header("content-type", "application/json")
+          |> call()
+
+        assert conn.status == 401
+      end
+
+      conn =
+        conn(:post, "/mcp", "{}")
+        |> put_req_header("content-type", "application/json")
+        |> call()
+
+      assert conn.status == 429
+    end
+
+    test "Host rejections do not increment the failure counter" do
+      for _ <- 1..5 do
+        conn =
+          conn(:post, "/mcp", "{}")
+          |> put_req_header("content-type", "application/json")
+          |> put_req_header("authorization", "Bearer nope")
+          |> with_host("attacker.example")
+          |> Router.call([])
+
+        assert conn.status == 403
+      end
+
+      # No bearer failures were recorded, so a valid auth still succeeds.
+      assert valid_initialize().status == 200
+    end
+
+    test "Origin rejections do not increment the failure counter" do
+      for _ <- 1..5 do
+        conn =
+          conn(:post, "/mcp", "{}")
+          |> put_req_header("content-type", "application/json")
+          |> put_req_header("authorization", "Bearer nope")
+          |> with_host("127.0.0.1")
+          |> put_req_header("origin", "http://attacker.example")
+          |> Router.call([])
+
+        assert conn.status == 403
+      end
+
+      assert valid_initialize().status == 200
+    end
+  end
+
+  test "rate limiting disabled: no blocking even after many failures", %{cfg: cfg} do
+    cfg = %{cfg | auth_rate_limit: false, auth_rate_limit_max_failures: 3}
+    Application.put_env(:ptc_runner_mcp, :http_config, cfg)
+    start_supervised!({AuthRateLimiter, [config: cfg]})
+
+    for _ <- 1..10, do: assert(bad_auth_post().status == 401)
+  end
+
+  defp bad_auth_post(remote_ip \\ {127, 0, 0, 1}) do
+    conn(:post, "/mcp", "{}")
+    |> put_req_header("content-type", "application/json")
+    |> put_req_header("authorization", "Bearer nope")
+    |> with_remote_ip(remote_ip)
+    |> call()
+  end
+
+  defp valid_initialize do
+    init = %{"jsonrpc" => "2.0", "id" => 1, "method" => "initialize"}
+
+    conn(:post, "/mcp", Jason.encode!(init))
+    |> auth()
+    |> call()
+  end
+
+  defp with_remote_ip(conn, ip), do: %{conn | remote_ip: ip}
 
   defp auth(conn), do: put_req_header(conn, "authorization", "Bearer " <> @token)
 


### PR DESCRIPTION
## Summary

Implements per-source rate limiting for failed `/mcp` bearer authentication (`OPLANE_REQ-00080322`). Repeated missing/invalid bearer failures from the same source trigger a temporary block returning `429` + `Retry-After`; successful auth resets the source's failure state.

- New `PtcRunnerMcp.Http.AuthRateLimiter`: a `GenServer` owns a named, public ETS table and a periodic cleanup sweep. The hot path (`check/2`, `record_failure/2`, `reset/2`) uses atomic `:ets.update_counter/3` and direct lookups — no `GenServer.call` serializing auth. Fails open when disabled or absent.
- Wired into `Application.build_http_children/4` before `Server.child_spec/1`.
- `Router.authenticate/2` now short-circuits blocked sources with `{:error, {:auth_rate_limited, retry_after_s}}` → `429` with `Retry-After` and **no** `www-authenticate` (avoids signaling). `Host`/`Origin` rejections are not counted.
- Source keyed by `conn.remote_ip`; forwarded headers are not trusted (documented).
- Config: `--http-auth-rate-limit` (default `true`), `--http-auth-rate-limit-window-ms` (60000), `--http-auth-rate-limit-max-failures` (5), `--http-auth-rate-limit-block-ms` (60000), each with a matching `PTC_RUNNER_MCP_HTTP_*` env var.
- Block decisions emit `[:ptc_lisp, :http, :auth, :rate_limited]` and log `http_auth_rate_limited` (raw source IP; never the token).

### Implementation note
`blocked_until` is initialized to `now` (not `0`) as the "not blocked" sentinel: `System.monotonic_time/1` can be negative, so a `0` sentinel would read as "blocked far in the future". This was caught by the tests.

## Test plan

- [x] `mix precommit` (format, compile, credo, dialyzer, full suite) — 523 tests, 0 failures
- [x] Router integration tests: threshold → `429` + `Retry-After`; distinct source unaffected; valid auth below threshold OK; success resets counter; missing-auth counted; `Host`/`Origin` rejections not counted; disabled → no blocking
- [x] Config tests: defaults and CLI overrides
- [ ] Note: `Plug.Test` requests share `{127,0,0,1}`; tests override `remote_ip` to simulate distinct sources

Closes #1042

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Fix Automation State
<!-- fix-state: {"attempts":2} -->
Fix attempts: 2/3
