### PR TITLE
fix: batch quick-fixes (3 issues)

### DIFF
--- a/lib/ptc_runner/lisp/runtime/string.ex
+++ b/lib/ptc_runner/lisp/runtime/string.ex
@@ -5,7 +5,6 @@ defmodule PtcRunner.Lisp.Runtime.String do
   Provides string concatenation, substring, join, split, and parsing functions.
   """
 
-  alias PtcRunner.Lisp.ExecutionError
   alias PtcRunner.Lisp.Format
   alias PtcRunner.Lisp.Keyword, as: LispKeyword
   alias PtcRunner.Lisp.Runtime.Interop.Duration
@@ -140,10 +139,7 @@ defmodule PtcRunner.Lisp.Runtime.String do
     if String.length(separator) == 1 do
       String.split(s, separator)
     else
-      raise ExecutionError,
-        reason: :type_error,
-        message:
-          "split: delimiter must be a regex pattern, got plain string #{inspect(separator)}"
+      raise "type_error: split: delimiter must be a regex pattern, got plain string #{inspect(separator)}"
     end
   end
 

--- a/lib/ptc_runner/llm/registry.ex
+++ b/lib/ptc_runner/llm/registry.ex
@@ -145,6 +145,12 @@ defmodule PtcRunner.LLM.Registry do
   def validate(model_string), do: impl().validate(model_string)
 
   defp impl do
-    Application.get_env(:ptc_runner, :model_registry)
+    case Application.get_env(:ptc_runner, :model_registry) do
+      nil ->
+        raise "No model registry configured. Set config :ptc_runner, :model_registry, MyRegistry"
+
+      mod ->
+        mod
+    end
   end
 end

--- a/lib/ptc_runner/sub_agent/validator.ex
+++ b/lib/ptc_runner/sub_agent/validator.ex
@@ -330,8 +330,27 @@ defmodule PtcRunner.SubAgent.Validator do
 
   defp validate_format_options!(opts) do
     case Keyword.fetch(opts, :format_options) do
-      {:ok, fo} when is_list(fo) -> :ok
-      {:ok, _} -> raise ArgumentError, "format_options must be a keyword list"
+      {:ok, fo} when is_list(fo) ->
+        validate_format_option_values!(fo)
+
+      {:ok, _} ->
+        raise ArgumentError, "format_options must be a keyword list"
+
+      :error ->
+        :ok
+    end
+  end
+
+  defp validate_format_option_values!(fo) do
+    case Keyword.fetch(fo, :mission_log_in) do
+      {:ok, v} when v in [:system_prompt, :user_message] -> :ok
+      {:ok, _} -> raise ArgumentError, "mission_log_in must be :system_prompt or :user_message"
+      :error -> :ok
+    end
+
+    case Keyword.fetch(fo, :context_in_system) do
+      {:ok, v} when is_boolean(v) -> :ok
+      {:ok, _} -> raise ArgumentError, "context_in_system must be true or false"
       :error -> :ok
     end
   end

--- a/test/ptc_runner/sub_agent/validator_test.exs
+++ b/test/ptc_runner/sub_agent/validator_test.exs
@@ -590,4 +590,43 @@ defmodule PtcRunner.SubAgent.ValidatorTest do
       end
     end
   end
+
+  describe "format_options validation" do
+    test "accepts valid mission_log_in: :system_prompt" do
+      agent = SubAgent.new(prompt: "Test", format_options: [mission_log_in: :system_prompt])
+      assert Keyword.get(agent.format_options, :mission_log_in) == :system_prompt
+    end
+
+    test "accepts valid mission_log_in: :user_message" do
+      agent = SubAgent.new(prompt: "Test", format_options: [mission_log_in: :user_message])
+      assert Keyword.get(agent.format_options, :mission_log_in) == :user_message
+    end
+
+    test "rejects invalid mission_log_in value" do
+      assert_raise ArgumentError,
+                   ~r/mission_log_in must be :system_prompt or :user_message/,
+                   fn ->
+                     SubAgent.new(
+                       prompt: "Test",
+                       format_options: [mission_log_in: :user_messages]
+                     )
+                   end
+    end
+
+    test "accepts valid context_in_system: true" do
+      agent = SubAgent.new(prompt: "Test", format_options: [context_in_system: true])
+      assert Keyword.get(agent.format_options, :context_in_system) == true
+    end
+
+    test "accepts valid context_in_system: false" do
+      agent = SubAgent.new(prompt: "Test", format_options: [context_in_system: false])
+      assert Keyword.get(agent.format_options, :context_in_system) == false
+    end
+
+    test "rejects invalid context_in_system value" do
+      assert_raise ArgumentError, ~r/context_in_system must be true or false/, fn ->
+        SubAgent.new(prompt: "Test", format_options: [context_in_system: :yes])
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary
Batch fix for quick-fix issues.

## Issues Fixed
- Closes #1023: Validate format_options values (mission_log_in, context_in_system)
- Closes #1038: Unify error-raising pattern for type errors (RuntimeError vs ExecutionError)
- Closes #1060: Add nil guard in LLM Registry.impl/0 for symmetry with adapter!/0

## Issues Skipped
- #1062: Rate-limit tests don't exist on `main` yet — the `describe "failed auth rate limiting"` block lives on the unmerged `origin/claude/1042-http-auth-rate-limit` branch. Fix should be applied there before it merges.
- #1037: `.claude/workflows/conformance-batch.js` was already deleted from `main` in commit `1143b948` (fix(conformance): clean up review drift) — the hardcoded paths are gone.

## Changes
- `lib/ptc_runner/sub_agent/validator.ex`: Extended `validate_format_options!/1` to validate `mission_log_in` (must be `:system_prompt` or `:user_message`) and `context_in_system` (must be a boolean). Prevents silent failures from typos like `mission_log_in: :user_messages`.
- `lib/ptc_runner/lisp/runtime/string.ex`: Changed `raise ExecutionError, reason: :type_error` in `split/2` to `raise "type_error: ..."` to match the pattern used throughout `collection.ex`. Removed now-unused `ExecutionError` alias.
- `lib/ptc_runner/llm/registry.ex`: Added nil guard in `impl/0` matching the pattern from `adapter!/0`. Raises an actionable message instead of `UndefinedFunctionError: function nil.resolve!/1` when `model_registry` is nil.
- `test/ptc_runner/sub_agent/validator_test.exs`: Added 6 tests for the new format_options validation (written as failing tests before the fix).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)