### PR TITLE
fix(http): authenticate /mcp before method dispatch

### DIFF
--- a/mcp_server/lib/ptc_runner_mcp/http/router.ex
+++ b/mcp_server/lib/ptc_runner_mcp/http/router.ex
@@ -51,37 +51,37 @@ defmodule PtcRunnerMcp.Http.Router do
     end
   end
 
-  defp route_mcp(%{method: "GET"} = conn, _cfg) do
-    conn
-    |> Plug.Conn.put_resp_header("allow", "POST, DELETE")
-    |> Plug.Conn.send_resp(405, "")
-  end
-
-  defp route_mcp(%{method: "DELETE"} = conn, cfg) do
-    with {:ok, owner} <- authenticate(conn, cfg),
-         {:ok, session_id} <- session_id(conn) do
-      conn =
-        put_http_private(conn,
-          owner_hash: owner.hash,
-          session_hash: Telemetry.hash_id(session_id)
-        )
-
-      case SessionRegistry.delete(session_id, owner) do
-        :ok -> Plug.Conn.send_resp(conn, 202, "")
-        {:error, :not_found} -> Plug.Conn.send_resp(conn, 404, "")
-      end
-    else
+  defp route_mcp(conn, cfg) do
+    case authenticate(conn, cfg) do
+      {:ok, owner} -> dispatch_method(conn, cfg, owner)
       {:error, {:auth, reason}} -> auth_error(conn, reason)
       {:error, {:auth_rate_limited, retry_after_s}} -> rate_limit_error(conn, retry_after_s)
-      {:error, :missing_session} -> Plug.Conn.send_resp(conn, 400, "missing MCP-Session-Id")
       {:error, :origin} -> Plug.Conn.send_resp(conn, 403, "forbidden")
       {:error, :host} -> Plug.Conn.send_resp(conn, 403, "forbidden")
     end
   end
 
-  defp route_mcp(%{method: "POST"} = conn, cfg) do
-    with {:ok, owner} <- authenticate(conn, cfg),
-         :ok <- acceptable_content_type(conn),
+  defp dispatch_method(%{method: "DELETE"} = conn, _cfg, owner) do
+    case session_id(conn) do
+      {:ok, session_id} ->
+        conn =
+          put_http_private(conn,
+            owner_hash: owner.hash,
+            session_hash: Telemetry.hash_id(session_id)
+          )
+
+        case SessionRegistry.delete(session_id, owner) do
+          :ok -> Plug.Conn.send_resp(conn, 202, "")
+          {:error, :not_found} -> Plug.Conn.send_resp(conn, 404, "")
+        end
+
+      {:error, :missing_session} ->
+        Plug.Conn.send_resp(conn, 400, "missing MCP-Session-Id")
+    end
+  end
+
+  defp dispatch_method(%{method: "POST"} = conn, cfg, owner) do
+    with :ok <- acceptable_content_type(conn),
          {:ok, body, conn} <- read_body_capped(conn, cfg),
          {:ok, decoded} <- decode_body(body) do
       if registry_draining?() do
@@ -90,18 +90,6 @@ defmodule PtcRunnerMcp.Http.Router do
         handle_post(conn, cfg, owner, decoded)
       end
     else
-      {:error, {:auth, reason}} ->
-        auth_error(conn, reason)
-
-      {:error, {:auth_rate_limited, retry_after_s}} ->
-        rate_limit_error(conn, retry_after_s)
-
-      {:error, :origin} ->
-        Plug.Conn.send_resp(conn, 403, "forbidden")
-
-      {:error, :host} ->
-        Plug.Conn.send_resp(conn, 403, "forbidden")
-
       {:error, :unsupported_media_type} ->
         Plug.Conn.send_resp(conn, 415, "unsupported media type")
 
@@ -116,7 +104,7 @@ defmodule PtcRunnerMcp.Http.Router do
     end
   end
 
-  defp route_mcp(conn, _cfg) do
+  defp dispatch_method(conn, _cfg, _owner) do
     conn
     |> Plug.Conn.put_resp_header("allow", "POST, DELETE")
     |> Plug.Conn.send_resp(405, "")

--- a/mcp_server/test/ptc_runner_mcp/http_router_test.exs
+++ b/mcp_server/test/ptc_runner_mcp/http_router_test.exs
@@ -42,10 +42,27 @@ defmodule PtcRunnerMcp.HttpRouterTest do
     {:ok, cfg: cfg}
   end
 
-  test "GET /mcp returns 405 with Allow" do
-    conn = call(conn(:get, "/mcp"))
+  test "authenticated GET /mcp returns 405 with Allow" do
+    conn = call(auth(conn(:get, "/mcp")))
     assert conn.status == 405
     assert get_resp_header(conn, "allow") == ["POST, DELETE"]
+  end
+
+  test "unauthenticated GET /mcp returns 401 bearer challenge" do
+    conn = call(conn(:get, "/mcp"))
+    assert conn.status == 401
+    assert get_resp_header(conn, "www-authenticate") == ["Bearer"]
+  end
+
+  test "GET /mcp with bad Host returns 403 before 405" do
+    conn =
+      conn(:get, "/mcp")
+      |> auth()
+      |> with_host("attacker.example")
+      |> call()
+
+    assert conn.status == 403
+    assert conn.resp_body == "forbidden"
   end
 
   test "health and ready are unauthenticated" do


### PR DESCRIPTION
## Summary

- Hoist `authenticate/2` ahead of the HTTP method check in `route_mcp/2` so every `/mcp` request runs the full host → origin → bearer pipeline regardless of method.
- Method-specific handling now lives in a new `dispatch_method/3` that receives the already-resolved `owner` (POST/DELETE bodies unchanged; any other method → 405 + `Allow: POST, DELETE`).
- Centralizes the auth / origin / host / rate-limit error branches in `route_mcp/2`; the inner POST/DELETE clauses keep only their method-specific error branches.

### Behavior change

- Unauthenticated `GET /mcp` → **401** with `WWW-Authenticate: Bearer` (was `405`), so endpoint/method probing now consumes the `AuthRateLimiter`.
- Authenticated `GET /mcp` → still **405** with `Allow: POST, DELETE`.
- GET now also gets host/origin enforcement (bad Host → `403 forbidden` before any 405).
- Authenticated `POST` / `DELETE` → unchanged.

## Test plan

- [x] Updated `"GET /mcp returns 405 with Allow"` → `"authenticated GET /mcp returns 405 with Allow"` (sends auth).
- [x] Added `"unauthenticated GET /mcp returns 401 bearer challenge"`.
- [x] Added `"GET /mcp with bad Host returns 403 before 405"`.
- [x] `mix precommit` from `mcp_server/` (format, compile, credo, 529 tests, 0 failures).

Closes #1069

🤖 Generated with [Claude Code](https://claude.com/claude-code)