### PR TITLE
refactor(sub_agent): route nested agent execution through internal Runner

### DIFF
--- a/lib/ptc_runner/sub_agent/loop/tool_normalizer.ex
+++ b/lib/ptc_runner/sub_agent/loop/tool_normalizer.ex
@@ -28,9 +28,9 @@ defmodule PtcRunner.SubAgent.Loop.ToolNormalizer do
   """
 
   alias PtcRunner.Lisp.ExecutionError
-  alias PtcRunner.SubAgent
   alias PtcRunner.SubAgent.Definition
   alias PtcRunner.SubAgent.{LLMTool, SubAgentTool, Telemetry}
+  alias PtcRunner.SubAgent.Runner
 
   @doc """
   Normalize tools map to convert SubAgentTool instances into executable functions.
@@ -440,7 +440,7 @@ defmodule PtcRunner.SubAgent.Loop.ToolNormalizer do
     # Execute within a new trace session - this creates the physical trace file
     {:ok, result, _trace_path} =
       TraceLog.with_trace(
-        fn -> SubAgent.run(agent, run_opts_with_trace) end,
+        fn -> Runner.run(agent, run_opts_with_trace) end,
         trace_opts
       )
 
@@ -467,7 +467,7 @@ defmodule PtcRunner.SubAgent.Loop.ToolNormalizer do
   # Execute SubAgentTool without tracing
   # Still wraps result with __child_step__ so TraceTree can show the hierarchy
   defp execute_without_trace(name, agent, run_opts) do
-    case SubAgent.run(agent, run_opts) do
+    case Runner.run(agent, run_opts) do
       {:ok, step} ->
         %{__child_step__: prune_child_step(step), value: step.return}
 


### PR DESCRIPTION
## Summary

Routes `ToolNormalizer`'s shared nested-agent execution helpers through the
internal `PtcRunner.SubAgent.Runner` (introduced by #1049) instead of the
public `PtcRunner.SubAgent` facade. This removes the
`tool_normalizer.ex → sub_agent.ex` edge of the 7-module SubAgent cycle.

- `execute_with_trace/4` and `execute_without_trace/3` now call
  `Runner.run/2` (`tool_normalizer.ex:443`, `:470`).
- Dropped the now-unused `alias PtcRunner.SubAgent`; added
  `alias PtcRunner.SubAgent.Runner`.

`Runner.run/2` encapsulates the full `%Definition{}` execution pipeline
(trace-context injection, `:self` resolution, llm/registry validation,
context prep, single-shot vs `Loop.run` dispatch), so nested-agent behavior
— child tracing, child-step propagation, LLM inheritance, `_remaining_turns`,
`_mission_deadline`, `_nesting_depth` — is preserved unchanged.

Note: this removes one edge only. Other edges (`chaining.ex`, `loop.ex`,
`ptc_tool_call.ex`, `text_mode.ex`) remain, so the cycle does not fully
disappear with this change alone, as the issue states.

## Verification

- `mix xref trace lib/ptc_runner/sub_agent/loop/tool_normalizer.ex` — both
  call sites now resolve to `PtcRunner.SubAgent.Runner.run/2`; **zero** edges
  to `lib/ptc_runner/sub_agent.ex`.
- `mix precommit` passes (format, compile --warnings-as-errors, xref cycles,
  credo --strict, full test suite, demo + ptc_viewer tests).

## Test plan

- [x] Existing nested SubAgentTool / LLMTool / trace tests pass
- [x] xref trace shows no facade dependency

Closes #1052