### PR TITLE
test(http): cover Origin validation matrix for MCP endpoint

### DIFF
--- a/mcp_server/test/ptc_runner_mcp/http/origin_test.exs
+++ b/mcp_server/test/ptc_runner_mcp/http/origin_test.exs
@@ -1,0 +1,64 @@
+defmodule PtcRunnerMcp.Http.OriginTest do
+  use ExUnit.Case, async: true
+  import Plug.Test
+
+  alias PtcRunnerMcp.Http.Origin
+
+  # Loopback bind, no allowlist — loopback origins are permitted.
+  @loopback_cfg %{host: "127.0.0.1", allowed_origins: []}
+  # Non-loopback bind, no allowlist — fail closed for any present Origin.
+  @nonloopback_cfg %{host: "0.0.0.0", allowed_origins: []}
+  # Explicit allowlist — only listed origins are permitted, on any bind.
+  @allowlist_cfg %{host: "0.0.0.0", allowed_origins: ["https://app.example.com"]}
+
+  describe "allowed?/2 header extraction" do
+    test "absent Origin header is allowed" do
+      assert Origin.allowed?(conn(:get, "/mcp"), @nonloopback_cfg)
+    end
+
+    test "present Origin header is delegated to the policy" do
+      conn = %{conn(:get, "/mcp") | req_headers: [{"origin", "http://attacker.example"}]}
+      refute Origin.allowed?(conn, @loopback_cfg)
+    end
+  end
+
+  describe "allowed_origin?/2 allowlist branch" do
+    test "an explicitly allowed origin succeeds" do
+      assert Origin.allowed_origin?("https://app.example.com", @allowlist_cfg)
+    end
+
+    test "an origin outside the allowlist is rejected" do
+      refute Origin.allowed_origin?("https://attacker.example", @allowlist_cfg)
+    end
+
+    test "allowlist match normalises default ports and case" do
+      assert Origin.allowed_origin?("HTTPS://App.Example.com:443", @allowlist_cfg)
+    end
+  end
+
+  describe "allowed_origin?/2 null origin" do
+    test "Origin: null is rejected on a loopback bind" do
+      refute Origin.allowed_origin?("null", @loopback_cfg)
+    end
+
+    test "Origin: null is rejected even with an allowlist" do
+      refute Origin.allowed_origin?("null", @allowlist_cfg)
+    end
+  end
+
+  describe "allowed_origin?/2 fail-closed on non-loopback bind" do
+    test "a present origin without an allowlist is rejected" do
+      refute Origin.allowed_origin?("https://app.example.com", @nonloopback_cfg)
+    end
+  end
+
+  describe "allowed_origin?/2 loopback bind without allowlist" do
+    test "a loopback origin is permitted" do
+      assert Origin.allowed_origin?("http://localhost:3000", @loopback_cfg)
+    end
+
+    test "a non-loopback origin is rejected" do
+      refute Origin.allowed_origin?("https://attacker.example", @loopback_cfg)
+    end
+  end
+end

--- a/mcp_server/test/ptc_runner_mcp/http_router_test.exs
+++ b/mcp_server/test/ptc_runner_mcp/http_router_test.exs
@@ -65,6 +65,18 @@ defmodule PtcRunnerMcp.HttpRouterTest do
     assert conn.resp_body == "forbidden"
   end
 
+  test "GET /mcp with invalid Origin returns 403 before 405" do
+    conn =
+      conn(:get, "/mcp")
+      |> auth()
+      |> with_host("127.0.0.1")
+      |> put_req_header("origin", "http://attacker.example")
+      |> call()
+
+    assert conn.status == 403
+    assert conn.resp_body == "forbidden"
+  end
+
   test "health and ready are unauthenticated" do
     assert call(conn(:get, "/health")).status == 200
     assert call(conn(:get, "/ready")).status == 200


### PR DESCRIPTION
## Summary

Regression test coverage for the shared Host/Origin validation path on the
`/mcp` HTTP endpoint. The behavioral fix (validation runs before method
dispatch for every method) already landed; this fills the test gap for the
security-critical Origin policy branches.

- New `mcp_server/test/ptc_runner_mcp/http/origin_test.exs` unit suite
  (mirrors `host_test.exs`) exercising the previously untested branches of
  `PtcRunnerMcp.Http.Origin`: the `allowed_origins` allowlist, `Origin: null`
  rejection, and the non-loopback fail-closed path. Also covers header
  extraction and the loopback default-allow branch for a coherent matrix.
- Router-level test in `http_router_test.exs`: `GET /mcp` with an invalid
  Origin returns `403` before the `405` method catch-all, complementing the
  existing bad-Host GET test.

No production code change — testing confirmed the existing validation is
correct.

## Test plan

- [x] `mix test test/ptc_runner_mcp/http/origin_test.exs test/ptc_runner_mcp/http_router_test.exs` (49 tests, 0 failures)
- [x] `mix precommit` full suite (653 tests, 0 failures)

Closes #1041

🤖 Generated with [Claude Code](https://claude.com/claude-code)