### PR TITLE
fix: batch quick-fixes (3 issues)

### DIFF
--- a/docs/mcp-server-http-deployment.md
+++ b/docs/mcp-server-http-deployment.md
@@ -84,7 +84,10 @@ and invalid bearer failures count. Once a source exceeds
 caller is not told whether its token was missing or invalid). A
 successful authentication immediately resets the source's failure state.
 A misconfigured-but-legitimate client can briefly be blocked; it
-self-heals after the block window. The limiter is on by default and is a
+self-heals after the failure *window* elapses (not just the block window
+— if `block_ms < window_ms`, the failure count persists across block
+expiry until the window resets, so the effective recovery time is
+`window_ms`). The limiter is on by default and is a
 no-op when no token is configured or when `--http-auth-rate-limit` is
 `false`; if the limiter process is unavailable it fails open.
 

--- a/mcp_server/lib/ptc_runner_mcp/application.ex
+++ b/mcp_server/lib/ptc_runner_mcp/application.ex
@@ -165,14 +165,19 @@ defmodule PtcRunnerMcp.Application do
   @spec build_http_children([map()], %{String.t() => Credentials.Binding.t()}, map()) ::
           [Supervisor.child_spec() | {module(), term()}]
   def build_http_children(_upstreams, bindings, http_config, root_runtime_opts \\ nil) do
+    rate_limiter_children =
+      if http_config.auth_rate_limit,
+        do: [{AuthRateLimiter, [config: http_config]}],
+        else: []
+
     [{Credentials, [bindings: bindings]}] ++
       root_runtime_children(root_runtime_opts) ++
       session_children_for_http() ++
       [
-        {HttpSessionRegistry, [config: http_config]},
-        {AuthRateLimiter, [config: http_config]},
-        Server.child_spec(http_config)
+        {HttpSessionRegistry, [config: http_config]}
       ] ++
+      rate_limiter_children ++
+      [Server.child_spec(http_config)] ++
       debug_children()
   end
 

--- a/mcp_server/lib/ptc_runner_mcp/http/config.ex
+++ b/mcp_server/lib/ptc_runner_mcp/http/config.ex
@@ -263,17 +263,17 @@ defmodule PtcRunnerMcp.Http.Config do
       value when is_binary(value) ->
         case Integer.parse(value) do
           {n, _} when n > 0 -> {:ok, n}
-          _ -> {:error, invalid_int_message(key, value)}
+          _ -> {:error, invalid_int_message(key, env, value)}
         end
 
       value ->
-        {:error, invalid_int_message(key, value)}
+        {:error, invalid_int_message(key, env, value)}
     end
   end
 
-  defp invalid_int_message(key, value) do
+  defp invalid_int_message(key, env, value) do
     flag = "--" <> (key |> Atom.to_string() |> String.replace("_", "-"))
-    "#{flag} must be a positive integer, got: #{inspect(value)}"
+    "#{flag} / #{env} must be a positive integer, got: #{inspect(value)}"
   end
 
   defp read_bool(args, key, env, default) do

--- a/mcp_server/test/ptc_runner_mcp/http_config_test.exs
+++ b/mcp_server/test/ptc_runner_mcp/http_config_test.exs
@@ -176,6 +176,7 @@ defmodule PtcRunnerMcp.HttpConfigTest do
              Config.resolve(%{http: true, http_auth_token: String.duplicate("a", 32)})
 
     assert message =~ "--http-port"
+    assert message =~ "PTC_RUNNER_MCP_HTTP_PORT"
     assert message =~ "must be a positive integer"
   end
 


### PR DESCRIPTION
## Summary
Batch fix for quick-fix issues.

## Issues Fixed
- Closes #1073: Error message names CLI flag even when value came from env var
- Closes #1066: AuthRateLimiter: skip child_spec when auth_rate_limit is disabled
- Closes #1065: AuthRateLimiter doc caveat: self-heal claim inaccurate when window_ms > block_ms

## Issues Skipped
- #1076: Split http_router_test.exs by concern — the shared `setup` block and several helper functions (`auth/1`, `call/1`, `bad_auth_post/1`, etc.) are used across all test groups; splitting without a shared support module would require duplicating ~50 lines of boilerplate per file. This is not a quick mechanical split.
- #1078: Consider extracting auth/host/origin gate tests from http_router_test.exs — duplicate of #1076; the issue body itself records the decision as "Deferred."

## Changes
- `mcp_server/lib/ptc_runner_mcp/http/config.ex`: `invalid_int_message/3` now takes the env-var name and emits `--http-port / PTC_RUNNER_MCP_HTTP_PORT must be a positive integer, got: …` so operators who set an env var aren't pointed at a CLI flag they didn't use.
- `mcp_server/test/ptc_runner_mcp/http_config_test.exs`: updated "rejects invalid integer config supplied via env var" test to assert the env-var name appears in the message.
- `mcp_server/lib/ptc_runner_mcp/application.ex`: `build_http_children/4` now only adds `AuthRateLimiter` to the supervision tree when `http_config.auth_rate_limit == true`, matching how other optional components are conditionally supervised.
- `docs/mcp-server-http-deployment.md`: clarified that self-healing happens after the *window* elapses (`window_ms`), not just after the block window (`block_ms`), to avoid misleading operators who configure `block_ms < window_ms`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)