### PR TITLE
[codex] harden Claude runner watchdog

### DIFF
--- a/.github/workflows/claude-issue.yml
+++ b/.github/workflows/claude-issue.yml
@@ -35,7 +35,7 @@ jobs:
     if: |
       github.event_name != 'issues' || github.event.label.name == 'impl:queued'
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 75
 
     # The single global implementation lock. Shared with claude-batch-fix and
     # claude-stale-check so main-mutating automation is strictly serialized.
@@ -95,32 +95,99 @@ jobs:
           # Expose to all later steps as $ISSUE_NUMBER / env.ISSUE_NUMBER.
           echo "ISSUE_NUMBER=$NEXT" >> "$GITHUB_ENV"
 
-      - name: Checkout repository
+      - name: Record implementation claim
+        id: claim
         if: steps.pick.outputs.has_work == 'true'
+        continue-on-error: true
+        timeout-minutes: 3
+        env:
+          GH_TOKEN: ${{ secrets.PAT_WORKFLOW_TRIGGER || github.token }}
+        run: |
+          set -euo pipefail
+
+          CLAIMED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          RUN_URL="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          CURRENT_BODY=$(gh issue view "$ISSUE_NUMBER" --json body --jq '.body // ""')
+          CLEAN_BODY=$(printf '%s\n' "$CURRENT_BODY" | sed '/^## Automation Claim/,$d')
+
+          cat > /tmp/issue-body.md << EOF
+          $CLEAN_BODY
+
+          ## Automation Claim
+          <!-- automation-claim: {"status":"RUNNING","issue":${ISSUE_NUMBER},"run_id":${GITHUB_RUN_ID},"run_attempt":${GITHUB_RUN_ATTEMPT},"run_url":"${RUN_URL}","claimed_at":"${CLAIMED_AT}"} -->
+
+          | Field | Value |
+          |-------|-------|
+          | Status | \`RUNNING\` |
+          | Run | [${GITHUB_RUN_ID}](${RUN_URL}) |
+          | Attempt | ${GITHUB_RUN_ATTEMPT} |
+          | Claimed At | ${CLAIMED_AT} |
+          EOF
+
+          gh issue edit "$ISSUE_NUMBER" --body-file /tmp/issue-body.md
+
+      - name: Check issue still needs implementation
+        id: issue-state
+        if: steps.pick.outputs.has_work == 'true' && steps.claim.outcome == 'success'
+        continue-on-error: true
+        timeout-minutes: 3
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          ISSUE_STATE=$(gh issue view "$ISSUE_NUMBER" --json state --jq '.state')
+          if [ "$ISSUE_STATE" != "OPEN" ]; then
+            echo "Issue #$ISSUE_NUMBER is $ISSUE_STATE; skipping implementation."
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            echo "skip_reason=issue-${ISSUE_STATE}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          MERGED_PRS=$(gh pr list \
+            --repo "${{ github.repository }}" \
+            --state merged \
+            --limit 100 \
+            --json number,body \
+            | jq --arg issue "$ISSUE_NUMBER" '[.[] | select((.body // "") | test("(?i)(closes|fixes|resolves)[[:space:]]+#" + $issue + "([^0-9]|$)"))] | length')
+
+          if [ "${MERGED_PRS:-0}" -gt 0 ]; then
+            echo "Issue #$ISSUE_NUMBER already has a merged closing PR; skipping implementation."
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            echo "skip_reason=merged-pr-exists" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "should_run=true" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout repository
+        if: steps.pick.outputs.has_work == 'true' && steps.claim.outcome == 'success' && steps.issue-state.outcome == 'success' && steps.issue-state.outputs.should_run == 'true'
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           token: ${{ secrets.PAT_WORKFLOW_TRIGGER || github.token }}
 
       - name: Install git pre-commit hook
-        if: steps.pick.outputs.has_work == 'true'
+        if: steps.pick.outputs.has_work == 'true' && steps.claim.outcome == 'success' && steps.issue-state.outcome == 'success' && steps.issue-state.outputs.should_run == 'true'
+        timeout-minutes: 3
         run: |
           cp scripts/pre-commit .git/hooks/pre-commit
           chmod +x .git/hooks/pre-commit
 
       - name: Setup Elixir environment
-        if: steps.pick.outputs.has_work == 'true'
+        if: steps.pick.outputs.has_work == 'true' && steps.claim.outcome == 'success' && steps.issue-state.outcome == 'success' && steps.issue-state.outputs.should_run == 'true'
         uses: ./.github/actions/setup-elixir
 
       - name: Setup Claude Code
         id: setup-claude
-        if: steps.pick.outputs.has_work == 'true'
+        if: steps.pick.outputs.has_work == 'true' && steps.claim.outcome == 'success' && steps.issue-state.outcome == 'success' && steps.issue-state.outputs.should_run == 'true'
         uses: ./.github/actions/setup-claude-code
 
       - name: Run tests and capture failures
         id: test-feedback
-        if: steps.pick.outputs.has_work == 'true'
+        if: steps.pick.outputs.has_work == 'true' && steps.claim.outcome == 'success' && steps.issue-state.outcome == 'success' && steps.issue-state.outputs.should_run == 'true'
         continue-on-error: true
+        timeout-minutes: 15
         run: |
           echo "Running tests to capture any failures..."
           FAILURES=""
@@ -154,8 +221,8 @@ jobs:
 
           # Capture output for Claude
           if [ -n "$FAILURES" ]; then
-            echo "has_failures=true" >> $GITHUB_OUTPUT
-            echo "failures=$FAILURES" >> $GITHUB_OUTPUT
+            echo "has_failures=true" >> "$GITHUB_OUTPUT"
+            echo "failures=$FAILURES" >> "$GITHUB_OUTPUT"
 
             # Truncate output if too long (keep last 200 lines)
             tail -200 /tmp/test_output.txt > /tmp/test_output_truncated.txt
@@ -165,17 +232,18 @@ jobs:
               echo 'output<<EOF'
               cat /tmp/test_output_truncated.txt
               echo 'EOF'
-            } >> $GITHUB_OUTPUT
+            } >> "$GITHUB_OUTPUT"
 
             echo "::warning::Test failures detected: $FAILURES"
           else
-            echo "has_failures=false" >> $GITHUB_OUTPUT
+            echo "has_failures=false" >> "$GITHUB_OUTPUT"
             echo "All checks passed"
           fi
 
       - name: Run Claude Code
         id: claude
-        if: steps.pick.outputs.has_work == 'true'
+        if: steps.pick.outputs.has_work == 'true' && steps.claim.outcome == 'success' && steps.issue-state.outcome == 'success' && steps.issue-state.outputs.should_run == 'true'
+        timeout-minutes: 30
         uses: anthropics/claude-code-action@v1
         env:
           GH_TOKEN: ${{ secrets.PAT_WORKFLOW_TRIGGER || github.token }}
@@ -352,30 +420,32 @@ jobs:
 
       # Verify status was updated in issue body
       - name: Verify implementation status
-        if: always() && steps.pick.outputs.has_work == 'true'
+        if: always() && steps.pick.outputs.has_work == 'true' && steps.claim.outcome == 'success' && steps.issue-state.outcome == 'success' && steps.issue-state.outputs.should_run == 'true'
         id: verify-status
+        timeout-minutes: 3
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           # Check if automation state exists in issue body
-          ISSUE_BODY=$(gh issue view $ISSUE_NUMBER --json body --jq '.body')
+          ISSUE_BODY=$(gh issue view "$ISSUE_NUMBER" --json body --jq '.body')
 
           if echo "$ISSUE_BODY" | grep -q "<!-- automation-state:"; then
-            echo "status_posted=true" >> $GITHUB_OUTPUT
+            echo "status_posted=true" >> "$GITHUB_OUTPUT"
 
             # Extract status from JSON
             STATUS_JSON=$(echo "$ISSUE_BODY" | grep -o '<!-- automation-state: {[^}]*}' | sed 's/<!-- automation-state: //')
             RESULT=$(echo "$STATUS_JSON" | grep -o '"status":"[^"]*"' | cut -d'"' -f4)
-            echo "result=$RESULT" >> $GITHUB_OUTPUT
+            echo "result=$RESULT" >> "$GITHUB_OUTPUT"
             echo "Implementation result: $RESULT"
           else
-            echo "status_posted=false" >> $GITHUB_OUTPUT
+            echo "status_posted=false" >> "$GITHUB_OUTPUT"
             echo "::warning::No automation state found in issue body"
           fi
 
       # Post fallback status if Claude didn't update issue body
       - name: Post fallback status
-        if: always() && steps.pick.outputs.has_work == 'true' && steps.verify-status.outputs.status_posted == 'false'
+        if: always() && steps.pick.outputs.has_work == 'true' && steps.claim.outcome == 'success' && steps.issue-state.outcome == 'success' && steps.issue-state.outputs.should_run == 'true' && steps.verify-status.outputs.status_posted == 'false'
+        timeout-minutes: 5
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -390,7 +460,7 @@ jobs:
           fi
 
           # Get current issue body
-          CURRENT_BODY=$(gh issue view $ISSUE_NUMBER --json body --jq '.body')
+          CURRENT_BODY=$(gh issue view "$ISSUE_NUMBER" --json body --jq '.body')
 
           # Remove any partial automation state
           CLEAN_BODY=$(echo "$CURRENT_BODY" | sed '/^## Automation State/,$d')
@@ -414,17 +484,24 @@ jobs:
           **Next Steps:** Re-trigger with \`@claude Please continue implementing this issue.\`
           EOF
 
-          gh issue edit $ISSUE_NUMBER --body-file /tmp/issue-body.md
+          gh issue edit "$ISSUE_NUMBER" --body-file /tmp/issue-body.md
 
           # Add needs-attention label
-          gh issue edit $ISSUE_NUMBER --add-label "needs-attention" || true
+          gh issue edit "$ISSUE_NUMBER" --add-label "needs-attention" || true
 
       # Safety net: push any unpushed commits and remove workflow files
       - name: Push unpushed commits
-        if: always() && steps.pick.outputs.has_work == 'true'
+        if: always() && steps.pick.outputs.has_work == 'true' && steps.claim.outcome == 'success' && steps.issue-state.outcome == 'success' && steps.issue-state.outputs.should_run == 'true'
+        timeout-minutes: 5
         env:
           GH_TOKEN: ${{ secrets.PAT_WORKFLOW_TRIGGER || github.token }}
         run: |
+          ISSUE_STATE=$(gh issue view "$ISSUE_NUMBER" --json state --jq '.state')
+          if [ "$ISSUE_STATE" != "OPEN" ]; then
+            echo "Issue #$ISSUE_NUMBER is $ISSUE_STATE; skipping fallback push."
+            exit 0
+          fi
+
           CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
           [ "$CURRENT_BRANCH" = "main" ] && exit 0
 
@@ -456,21 +533,39 @@ jobs:
             else
               git push -u origin HEAD
             fi
-            echo "branch_pushed=true" >> $GITHUB_OUTPUT
-            echo "branch_name=$CURRENT_BRANCH" >> $GITHUB_OUTPUT
+            echo "branch_pushed=true" >> "$GITHUB_OUTPUT"
+            echo "branch_name=$CURRENT_BRANCH" >> "$GITHUB_OUTPUT"
             echo "::notice::Pushed commits"
           fi
 
       - name: Create PR if branch was pushed but no PR exists
-        if: always() && steps.pick.outputs.has_work == 'true'
+        if: always() && steps.pick.outputs.has_work == 'true' && steps.claim.outcome == 'success' && steps.issue-state.outcome == 'success' && steps.issue-state.outputs.should_run == 'true'
+        timeout-minutes: 5
         env:
           GH_TOKEN: ${{ secrets.PAT_WORKFLOW_TRIGGER || github.token }}
         run: |
+          ISSUE_STATE=$(gh issue view "$ISSUE_NUMBER" --json state --jq '.state')
+          if [ "$ISSUE_STATE" != "OPEN" ]; then
+            echo "Issue #$ISSUE_NUMBER is $ISSUE_STATE; skipping fallback PR creation."
+            exit 0
+          fi
+
           CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
           [ "$CURRENT_BRANCH" = "main" ] && exit 0
 
           # Check if PR already exists for this branch
-          EXISTING_PR=$(gh pr list --head "$CURRENT_BRANCH" --state open --json number --jq '.[0].number')
+          EXISTING_PR=$(gh pr list --head "$CURRENT_BRANCH" --state all --json number --jq '.[0].number')
+          MERGED_CLOSING_PR=$(gh pr list \
+            --repo "${{ github.repository }}" \
+            --state merged \
+            --limit 100 \
+            --json number,body \
+            | jq -r --arg issue "$ISSUE_NUMBER" '[.[] | select((.body // "") | test("(?i)(closes|fixes|resolves)[[:space:]]+#" + $issue + "([^0-9]|$)"))][0].number // empty')
+
+          if [ -n "$MERGED_CLOSING_PR" ]; then
+            echo "Merged closing PR #$MERGED_CLOSING_PR already exists; skipping fallback PR creation."
+            exit 0
+          fi
 
           if [ -z "$EXISTING_PR" ]; then
             echo "No PR exists for branch $CURRENT_BRANCH, creating one..."
@@ -500,12 +595,27 @@ jobs:
       # path; the */10 schedule is the guaranteed backstop.
       - name: Release claim and drain next
         if: always() && steps.pick.outputs.has_work == 'true'
+        timeout-minutes: 5
         env:
           GH_TOKEN: ${{ secrets.PAT_WORKFLOW_TRIGGER || github.token }}
         run: |
           set -euo pipefail
 
-          gh issue edit "$ISSUE_NUMBER" --remove-label "impl:running" 2>/dev/null || true
+          ISSUE_STATE=$(gh issue view "$ISSUE_NUMBER" --json state --jq '.state')
+
+          if [ "${{ steps.claim.outcome }}" != "success" ] || [ "${{ steps.issue-state.outcome }}" != "success" ]; then
+            if [ "$ISSUE_STATE" = "OPEN" ]; then
+              echo "Pre-implementation setup failed; requeueing issue #$ISSUE_NUMBER."
+              gh issue edit "$ISSUE_NUMBER" \
+                --remove-label "impl:running" \
+                --add-label "impl:queued" 2>/dev/null || true
+            else
+              echo "Pre-implementation setup failed, but issue #$ISSUE_NUMBER is $ISSUE_STATE; removing running claim."
+              gh issue edit "$ISSUE_NUMBER" --remove-label "impl:running" 2>/dev/null || true
+            fi
+          else
+            gh issue edit "$ISSUE_NUMBER" --remove-label "impl:running" 2>/dev/null || true
+          fi
 
           REMAINING=$(gh issue list \
             --repo "${{ github.repository }}" \

--- a/.github/workflows/claude-stale-check.yml
+++ b/.github/workflows/claude-stale-check.yml
@@ -1,7 +1,9 @@
 name: Claude Stale Check
 
 on:
-  workflow_dispatch:  # Manual trigger only
+  workflow_dispatch:
+  schedule:
+    - cron: "17 */2 * * *"
 
 jobs:
   detect-issues:
@@ -14,6 +16,7 @@ jobs:
       issues: write  # Need write to add needs-attention label as fallback
       pull-requests: read
       contents: read
+      actions: write
 
     steps:
       - name: Detect stuck issues
@@ -25,6 +28,117 @@ jobs:
           echo "=== Detecting stuck issues ==="
           STUCK_ISSUES=""
           HAS_ISSUES="false"
+          STALE_RUNNING_SECONDS=5400
+
+          # Clean durable queue labels that can no longer produce useful work.
+          CLOSED_QUEUE_ISSUES=$(gh issue list \
+            --repo "${{ github.repository }}" \
+            --label "impl:queued" \
+            --state closed \
+            --json number \
+            --jq '.[].number')
+
+          for ISSUE_NUM in $CLOSED_QUEUE_ISSUES; do
+            echo "CLOSED QUEUED: #$ISSUE_NUM - removing impl:queued"
+            gh issue edit "$ISSUE_NUM" --repo "${{ github.repository }}" --remove-label "impl:queued" 2>/dev/null || true
+          done
+
+          RUNNING_ISSUES=$(gh issue list \
+            --repo "${{ github.repository }}" \
+            --label "impl:running" \
+            --state all \
+            --json number,state,updatedAt \
+            --jq '.[] | "\(.number)|\(.state)|\(.updatedAt)"')
+
+          while IFS='|' read -r ISSUE_NUM ISSUE_STATE UPDATED_AT; do
+            [ -z "$ISSUE_NUM" ] && continue
+
+            ISSUE_BODY=$(gh issue view "$ISSUE_NUM" --repo "${{ github.repository }}" --json body --jq '.body // ""')
+            ISSUE_TITLE=$(gh issue view "$ISSUE_NUM" --repo "${{ github.repository }}" --json title --jq '.title')
+            CLAIM_JSON=$(echo "$ISSUE_BODY" | grep -o '<!-- automation-claim: {[^}]*}' | sed 's/<!-- automation-claim: //' | tail -1 || true)
+            RUN_ID=""
+            CLAIMED_AT="$UPDATED_AT"
+            RUN_VALID="false"
+            RUN_STATUS="unknown"
+            RUN_CONCLUSION=""
+
+            if [ -n "$CLAIM_JSON" ]; then
+              RUN_ID=$(echo "$CLAIM_JSON" | jq -r '.run_id // empty' 2>/dev/null || true)
+              CLAIMED_AT=$(echo "$CLAIM_JSON" | jq -r '.claimed_at // empty' 2>/dev/null || true)
+              CLAIMED_AT=${CLAIMED_AT:-$UPDATED_AT}
+            fi
+
+            if [ -n "$RUN_ID" ]; then
+              RUN_DATA=$(gh api "/repos/${{ github.repository }}/actions/runs/${RUN_ID}" 2>/dev/null || echo "{}")
+              RUN_PATH=$(echo "$RUN_DATA" | jq -r '.path // ""')
+              RUN_DISPLAY_TITLE=$(echo "$RUN_DATA" | jq -r '.display_title // ""')
+              RUN_STATUS=$(echo "$RUN_DATA" | jq -r '.status // "unknown"')
+              RUN_CONCLUSION=$(echo "$RUN_DATA" | jq -r '.conclusion // ""')
+
+              if [ "$RUN_PATH" = ".github/workflows/claude-issue.yml" ] && [ "$RUN_DISPLAY_TITLE" = "$ISSUE_TITLE" ]; then
+                RUN_VALID="true"
+              else
+                echo "::warning::Ignoring untrusted run claim for issue #$ISSUE_NUM: run_id=$RUN_ID path=$RUN_PATH title=$RUN_DISPLAY_TITLE"
+              fi
+            fi
+
+            AGE_SECONDS=$(jq -nr --arg ts "$CLAIMED_AT" 'try (now - ($ts | fromdateiso8601)) catch 0')
+            AUTOMATION_STATUS=$(echo "$ISSUE_BODY" | grep -o '<!-- automation-state: {[^}]*}' | sed 's/<!-- automation-state: //' | jq -r '.status // empty' 2>/dev/null || true)
+
+            if [ "$ISSUE_STATE" = "CLOSED" ]; then
+              echo "CLOSED RUNNING: #$ISSUE_NUM - removing impl:running"
+              gh issue edit "$ISSUE_NUM" --repo "${{ github.repository }}" --remove-label "impl:running" 2>/dev/null || true
+
+              if [ "$RUN_VALID" = "true" ]; then
+                if [ "$RUN_STATUS" = "in_progress" ] || [ "$RUN_STATUS" = "queued" ] || [ "$RUN_STATUS" = "waiting" ]; then
+                  echo "Cancelling recorded run $RUN_ID for closed issue #$ISSUE_NUM"
+                  gh run cancel "$RUN_ID" --repo "${{ github.repository }}" || true
+                fi
+              elif [ -z "$RUN_ID" ]; then
+                echo "::warning::Issue #$ISSUE_NUM has impl:running but no trusted run_id; not cancelling any run."
+              fi
+
+              continue
+            fi
+
+            if awk "BEGIN { exit !($AGE_SECONDS > $STALE_RUNNING_SECONDS) }"; then
+              echo "STALE RUNNING: #$ISSUE_NUM claimed ${AGE_SECONDS}s ago"
+              STUCK_ISSUES="$STUCK_ISSUES #$ISSUE_NUM(stale-running)"
+              HAS_ISSUES="true"
+
+              if [ "$RUN_VALID" = "true" ]; then
+                if [ "$RUN_STATUS" = "in_progress" ] || [ "$RUN_STATUS" = "queued" ] || [ "$RUN_STATUS" = "waiting" ]; then
+                  echo "Cancelling recorded stale run $RUN_ID for issue #$ISSUE_NUM"
+                  if gh run cancel "$RUN_ID" --repo "${{ github.repository }}"; then
+                    echo "Requeueing issue #$ISSUE_NUM after cancelling run $RUN_ID"
+                    gh issue edit "$ISSUE_NUM" \
+                      --repo "${{ github.repository }}" \
+                      --remove-label "impl:running" \
+                      --add-label "impl:queued" 2>/dev/null || true
+                  else
+                    echo "::warning::Could not cancel run $RUN_ID for issue #$ISSUE_NUM; leaving impl:running in place."
+                  fi
+                elif [ "$RUN_STATUS" = "completed" ]; then
+                  if [ "$RUN_CONCLUSION" = "success" ] || [ "$AUTOMATION_STATUS" = "SUCCESS" ]; then
+                    echo "Recorded run $RUN_ID completed successfully; removing stale impl:running for issue #$ISSUE_NUM"
+                    gh issue edit "$ISSUE_NUM" \
+                      --repo "${{ github.repository }}" \
+                      --remove-label "impl:running" 2>/dev/null || true
+                  else
+                    echo "Recorded run $RUN_ID completed with conclusion=${RUN_CONCLUSION:-unknown}; requeueing open issue #$ISSUE_NUM"
+                    gh issue edit "$ISSUE_NUM" \
+                      --repo "${{ github.repository }}" \
+                      --remove-label "impl:running" \
+                      --add-label "impl:queued" 2>/dev/null || true
+                  fi
+                fi
+              else
+                echo "::warning::Issue #$ISSUE_NUM is stale but has no trusted run_id; marking needs-attention only."
+              fi
+
+              gh issue edit "$ISSUE_NUM" --repo "${{ github.repository }}" --add-label "needs-attention" 2>/dev/null || true
+            fi
+          done <<< "$RUNNING_ISSUES"
 
           # Find the active epic
           EPIC_NUMBER=$(gh issue list \
@@ -108,8 +222,8 @@ jobs:
             fi
           done
 
-          echo "has_stuck_issues=$HAS_ISSUES" >> $GITHUB_OUTPUT
-          echo "stuck_issues_summary=$STUCK_ISSUES" >> $GITHUB_OUTPUT
+          echo "has_stuck_issues=$HAS_ISSUES" >> "$GITHUB_OUTPUT"
+          echo "stuck_issues_summary=$STUCK_ISSUES" >> "$GITHUB_OUTPUT"
 
           if [ "$HAS_ISSUES" = "true" ]; then
             echo ""

--- a/docs/guidelines/github-workflows.md
+++ b/docs/guidelines/github-workflows.md
@@ -118,7 +118,7 @@ All Claude workflows have explicit timeouts to prevent runaway jobs:
 
 | Workflow | Timeout |
 |----------|---------|
-| `claude-issue.yml` | 45 minutes |
+| `claude-issue.yml` | 75 minutes |
 | `claude-pr-fix.yml` | 30 minutes |
 | `claude-second-opinion.yml` | 45 minutes |
 
@@ -269,7 +269,11 @@ When implementation discovers prerequisite work:
 - Epic issues with no labels but all blockers resolved
 - Issues with `needs-review` but no review activity after 2 hours
 - Issues with `ready-for-implementation` but no PR/status after 2 hours
+- Closed issues still carrying `impl:queued` or `impl:running`
+- Stale open `impl:running` issues with a recorded workflow run claim
 - Adds `needs-attention` label for visibility
+- Cancels only a recorded stale run ID validated against GitHub run metadata;
+  it never guesses from labels or trusts issue-body metadata alone
 
 **Claude fix (only if issues detected):**
 - Gets the list of stuck issues from detection
@@ -282,6 +286,8 @@ When implementation discovers prerequisite work:
 - Logs stuck PRs with `needs-human-review` for 24+ hours
 
 This design ensures visibility (`needs-attention` label) even if Claude can't run.
+The non-Claude detector may remove stale queue labels and cancel recorded
+workflow runs, but it never pushes branches or creates implementation PRs.
 
 ## Epic-Driven Development
 
@@ -404,12 +410,14 @@ automation will NOT proceed because `needs-human-review` has higher priority.
 ## Concurrency Control
 
 > **Why not one shared group?** A single global `claude-automation` group was
-> the original design, but it has a fatal flaw: a GitHub concurrency group
-> holds at most **one running + one pending** run. When several workflows fire
-> at once, the newest waiting request **evicts and cancels** the older pending
-> one. Read-only reviews competing in the same group could starve an
-> implementation run, and a burst of `@claude` requests could silently drop all
-> but two. (This stranded issue #1039.) The current design replaces the single
+> the original design, but it has a fatal flaw: by default, a GitHub concurrency
+> group holds at most **one running + one pending** run. When several workflows
+> fire at once, the newest waiting request **evicts and cancels** the older
+> pending one. GitHub now supports larger concurrency queues with `queue: max`,
+> but labels remain the durable source of implementation state. Read-only
+> reviews competing in the same group could still starve implementation work,
+> and a burst of `@claude` requests could silently drop work on older default
+> queues. (This stranded issue #1039.) The current design replaces the single
 > group with a durable queue plus purpose-scoped groups.
 
 ### Durable implementation queue
@@ -425,7 +433,9 @@ Issue implementation is split into an **enqueue** front door and a
   picks the oldest `impl:queued` issue, flips it to `impl:running`, implements
   it, then releases the label and re-dispatches itself if the queue is
   non-empty. Triggers: the `labeled` event (fast path), a `*/10` schedule
-  (backstop so the queue can never stall), and `workflow_dispatch`.
+  (backstop so the queue can never stall), and `workflow_dispatch`. When an
+  issue is claimed, the runner records the workflow `run_id`, attempt, run URL,
+  and claim time in the issue body so watchdog cleanup can target only that run.
 
 This guarantees **both** invariants the single group could not:
 - **Never parallel** — `claude-impl` (size 1) lets only one main-mutating run
@@ -532,9 +542,16 @@ gh workflow run claude-issue.yml
 
 If jobs are stuck running:
 ```bash
-# Cancel running workflows
-gh run list --workflow=claude-issue.yml --status in_progress --json databaseId \
-  | jq -r '.[].databaseId' | xargs -I {} gh run cancel {}
+# Prefer the recorded run ID in the issue's Automation Claim.
+gh issue view ISSUE_NUMBER --json body --jq '.body'
+gh run cancel RUN_ID
+```
+
+For closed issues, do not requeue. Remove stale queue labels after cancelling
+any recorded active run:
+
+```bash
+gh issue edit ISSUE_NUMBER --remove-label "impl:running" --remove-label "impl:queued"
 ```
 
 ## Fork PR Handling


### PR DESCRIPTION
## Summary

Hardens the serialized Claude issue runner against stuck implementation runs.

## Changes

- Records a validated issue-runner claim with run metadata before implementation starts.
- Adds bounded timeouts around Claude execution and cleanup paths.
- Adds scheduled stale-check recovery for stale `impl:queued` / `impl:running` labels.
- Ensures the watchdog only cancels recorded runs after validating GitHub run metadata.
- Updates workflow documentation for the scheduled watchdog and 75-minute issue runner timeout.

## Verification

- `actionlint .github/workflows/claude-issue.yml .github/workflows/claude-stale-check.yml`
- YAML parse for both modified workflow files
- `git diff --check`
- Pre-push hook: root tests + Dialyzer, `mcp_server` tests + Dialyzer, `ptc_viewer` tests
