### PR TITLE
fix(actions): block duplicate batch PRs

### DIFF
--- a/.github/workflows/claude-batch-fix.yml
+++ b/.github/workflows/claude-batch-fix.yml
@@ -65,6 +65,24 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          # Only one batch-fix PR may be open at a time. The job-level
+          # concurrency lock serializes running jobs, but it does not protect
+          # the period after a run has opened a PR and exited.
+          OPEN_BATCH_PRS=$(gh pr list \
+            --repo "${{ github.repository }}" \
+            --state open \
+            --json number,title,headRefName \
+            --jq '[.[] | select(.headRefName | startswith("batch-fix/"))]')
+
+          OPEN_BATCH_COUNT=$(echo "$OPEN_BATCH_PRS" | jq length)
+          if [ "$OPEN_BATCH_COUNT" -gt 0 ]; then
+            echo "Open batch-fix PR already exists; skipping new batch:"
+            echo "$OPEN_BATCH_PRS" | jq -r '.[] | "- #\(.number): \(.title) (\(.headRefName))"'
+            echo "issue_count=0" >> "$GITHUB_OUTPUT"
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           # Get open quick-fix issues that are NOT already in a batch
           # Exclude issues with batch-pending label
           ISSUES=$(gh issue list \
@@ -76,20 +94,20 @@ jobs:
             | jq '[.[] | select(.labels | map(.name) | index("batch-pending") | not)]')
 
           COUNT=$(echo "$ISSUES" | jq length)
-          echo "issue_count=$COUNT" >> $GITHUB_OUTPUT
+          echo "issue_count=$COUNT" >> "$GITHUB_OUTPUT"
 
           echo "Found $COUNT available quick-fix issues (excluding batch-pending)"
 
           # Threshold: 5 issues for auto-trigger, always run for manual if any exist
           if [ "${{ github.event_name }}" == "workflow_dispatch" ] && [ "$COUNT" -gt 0 ]; then
             echo "Manual trigger with $COUNT issues - proceeding"
-            echo "should_run=true" >> $GITHUB_OUTPUT
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
           elif [ "$COUNT" -ge 5 ]; then
             echo "Threshold reached ($COUNT >= 5) - proceeding"
-            echo "should_run=true" >> $GITHUB_OUTPUT
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
           else
             echo "Below threshold ($COUNT < 5) - skipping"
-            echo "should_run=false" >> $GITHUB_OUTPUT
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
           fi
 
   batch-fix:
@@ -114,20 +132,47 @@ jobs:
       MIX_ENV: test
 
     steps:
+      - name: Check for open batch PR after lock
+        id: batch_guard
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Re-check after acquiring the claude-impl concurrency lock. Multiple
+          # queued runs can pass the preflight before the first run opens a PR.
+          OPEN_BATCH_PRS=$(gh pr list \
+            --repo "${{ github.repository }}" \
+            --state open \
+            --json number,title,headRefName \
+            --jq '[.[] | select(.headRefName | startswith("batch-fix/"))]')
+
+          OPEN_BATCH_COUNT=$(echo "$OPEN_BATCH_PRS" | jq length)
+          if [ "$OPEN_BATCH_COUNT" -gt 0 ]; then
+            echo "Open batch-fix PR already exists; skipping new batch:"
+            echo "$OPEN_BATCH_PRS" | jq -r '.[] | "- #\(.number): \(.title) (\(.headRefName))"'
+            echo "should_continue=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "should_continue=true" >> "$GITHUB_OUTPUT"
+
       - name: Checkout repository
+        if: steps.batch_guard.outputs.should_continue == 'true'
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           token: ${{ secrets.PAT_WORKFLOW_TRIGGER || github.token }}
 
       - name: Setup Elixir environment
+        if: steps.batch_guard.outputs.should_continue == 'true'
         uses: ./.github/actions/setup-elixir
 
       - name: Setup Claude Code
+        if: steps.batch_guard.outputs.should_continue == 'true'
         id: setup-claude
         uses: ./.github/actions/setup-claude-code
 
       - name: Prepare issue list and mark as pending
+        if: steps.batch_guard.outputs.should_continue == 'true'
         id: issues
         env:
           GH_TOKEN: ${{ github.token }}
@@ -145,11 +190,11 @@ jobs:
           COUNT=$(jq length /tmp/quick-fix-issues.json)
           if [ "$COUNT" -eq 0 ]; then
             echo "No issues to fix (all may have batch-pending)"
-            echo "has_issues=false" >> $GITHUB_OUTPUT
+            echo "has_issues=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          echo "has_issues=true" >> $GITHUB_OUTPUT
+          echo "has_issues=true" >> "$GITHUB_OUTPUT"
 
           # Create summary for prompt
           jq -r '.[] | "- #\(.number): \(.title)"' /tmp/quick-fix-issues.json > /tmp/issue-summary.txt
@@ -159,16 +204,16 @@ jobs:
 
           # Get issue numbers
           ISSUE_NUMBERS=$(jq -r '.[].number' /tmp/quick-fix-issues.json | tr '\n' ' ')
-          echo "issue_numbers=$ISSUE_NUMBERS" >> $GITHUB_OUTPUT
+          echo "issue_numbers=$ISSUE_NUMBERS" >> "$GITHUB_OUTPUT"
 
           # Mark issues as batch-pending to prevent duplicate processing
           echo "Marking issues as batch-pending..."
-          for issue in $ISSUE_NUMBERS; do
+          while IFS= read -r issue; do
             echo "Adding batch-pending to issue #$issue"
             gh issue edit "$issue" \
               --repo "${{ github.repository }}" \
               --add-label "batch-pending" || true
-          done
+          done < <(jq -r '.[].number' /tmp/quick-fix-issues.json)
 
       - name: Run Claude Batch Fix
         if: steps.issues.outputs.has_issues == 'true'

--- a/docs/guidelines/github-workflows.md
+++ b/docs/guidelines/github-workflows.md
@@ -447,7 +447,7 @@ This guarantees **both** invariants the single group could not:
 
 | Group | Workflows | `cancel-in-progress` | Rationale |
 |-------|-----------|----------------------|-----------|
-| `claude-impl` | `claude-issue.yml` (runner), `claude-batch-fix.yml`, `claude-stale-check.yml` | `false` | All branch off `main` / open PRs → strictly serialized so they never produce conflicting changes. |
+| `claude-impl` | `claude-issue.yml` (runner), `claude-batch-fix.yml`, `claude-stale-check.yml` | `false` | All branch off `main` / open PRs → strictly serialized while jobs run. Batch fix skips when an open `batch-fix/*` PR already exists, including after queued runs acquire the lock. |
 | `claude-enqueue-<issue>` | `claude-issue-enqueue.yml` | `false` | Cheap, idempotent; per-issue so it's never evicted and only collapses duplicate `@claude` comments on the same issue. |
 | `claude-pr-<pr>` | `claude-pr-fix.yml`, `claude-second-opinion.yml` | `false` | Push to a PR's *own* branch, not `main`; serialized per-PR but parallel across different PRs. |
 | `claude-review-pr-<pr>` | `claude-code-review.yml` | `true` | Read-only; a newer push supersedes an in-flight review. |
@@ -460,7 +460,10 @@ never block or evict implementation work.
 
 This ensures:
 - Only one main-mutating Claude operation runs at a time (`claude-impl`)
-- No race conditions on `main`; no conflicting branches/PRs
+- Batch-fix automation opens at most one batch PR at a time; later runs skip
+  while an existing `batch-fix/*` PR is open
+- No concurrent race conditions on `main`; reduced risk of conflicting
+  branches/PRs
 - Implementation requests queue durably in labels instead of being cancelled
 
 ## Security Gates


### PR DESCRIPTION
## Summary

Adds a post-lock guard to the Claude batch-fix workflow so queued runs re-check for an open `batch-fix/*` PR after acquiring the `claude-impl` concurrency lock. Keeps the existing preflight skip for cheap early exits.

## Why

The workflow-level threshold check can run before the serialized `batch-fix` job. Multiple queued runs could pass that preflight before the first run opened its PR, then later create duplicate batch PRs.

## Changes

- Re-check open `batch-fix/*` PRs inside the locked `batch-fix` job.
- Skip checkout, setup, and issue marking when a batch PR is already open.
- Update workflow docs to describe skip behavior instead of wait behavior.

## Verification

- YAML parse check
- `actionlint .github/workflows/claude-batch-fix.yml`
- `git diff --check main...HEAD`
- Pre-push hook: root tests/dialyzer, `mcp_server` tests/dialyzer, `ptc_viewer` tests
