### PR TITLE
feat(subagent): first-class upstream bridge + fail-closed prelude requires

### DIFF
--- a/docs/guides/capability-prelude.md
+++ b/docs/guides/capability-prelude.md
@@ -207,6 +207,14 @@ runs**. If a required upstream operation is not configured/granted, attachment
 fails fast with `:prelude_attach_failed` — so a missing backing can never cause
 a partial run with side effects.
 
+This holds across execution surfaces: direct `Lisp.run`, the multi-turn SubAgent
+loop, and the single-shot fast path. On the multi-turn path a
+`:prelude_attach_failed` is a **hard stop**, never a recoverable retry turn, so
+the guarantee survives across turns. The validation covers **the agent given the
+runtime**: a child SubAgent invoked via `as_tool` is **upstream-blind** — it does
+not inherit the parent's runtime, so its own `requires`-backed prelude is only
+validated if that child is itself constructed with a runtime.
+
 > The prelude does **not** define upstream endpoints or credentials. It only
 > *wraps* operations the host has already configured. Credentials live in
 > host/deployment config and never appear in the artifact, prompts, or traces.

--- a/lib/ptc_runner/sub_agent/loop.ex
+++ b/lib/ptc_runner/sub_agent/loop.ex
@@ -158,6 +158,11 @@ defmodule PtcRunner.SubAgent.Loop do
     # Caller-owned, not inherited by child SubAgents.
     discovery_exec = Keyword.get(opts, :discovery_exec)
 
+    # Optional upstream runtime handle. Opaque passthrough for attach-time
+    # prelude `requires` validation only; the bridge (`Upstream.Eval.run_subagent/3`)
+    # owns the RunContext lifecycle. Caller-owned, not inherited by children.
+    runtime = Keyword.get(opts, :runtime)
+
     # Extract Lisp.run resource limits (propagated to child agents)
     max_heap = Keyword.get(opts, :max_heap)
 
@@ -205,6 +210,7 @@ defmodule PtcRunner.SubAgent.Loop do
           journal: journal,
           tool_cache: tool_cache,
           discovery_exec: discovery_exec,
+          runtime: runtime,
           on_chunk: on_chunk,
           initial_messages: initial_messages,
           initial_memory: initial_memory
@@ -304,6 +310,7 @@ defmodule PtcRunner.SubAgent.Loop do
       journal: run_opts.journal,
       tool_cache: run_opts.tool_cache,
       discovery_exec: run_opts.discovery_exec,
+      runtime: run_opts.runtime,
       agent_name: agent.name,
       agent_id: run_opts.agent_id,
       on_chunk: run_opts.on_chunk,
@@ -841,8 +848,6 @@ defmodule PtcRunner.SubAgent.Loop do
       {:error, lisp_step} ->
         # Emit pmap/pcalls telemetry events even on error
         emit_pmap_telemetry(state, lisp_step)
-        # Build error message for LLM
-        error_message = ResponseHandler.format_error_for_llm(lisp_step.fail)
 
         # Build Turn struct (failure turn) with turn type
         turn =
@@ -854,21 +859,51 @@ defmodule PtcRunner.SubAgent.Loop do
             type: state.current_turn_type
           )
 
-        # Build feedback with appropriate turn info
-        feedback = TurnFeedback.build_error_feedback(error_message, agent, state)
+        if Shared.terminal_lisp_failure?(lisp_step.fail) do
+          # Fail closed: a prelude attach failure (a missing upstream backing) is
+          # NOT a program error the LLM can repair by rewriting, and treating it
+          # as a recoverable retry turn would let earlier side-effecting turns
+          # stand (plan §3.5 #2). Stop the run immediately.
+          duration_ms = System.monotonic_time(:millisecond) - state.start_time
 
-        # Deferred step-done: discard current turn's summaries on error
-        new_state =
-          build_continuation_state(state, turn, response, feedback,
-            memory: lisp_step.memory,
-            journal: lisp_step.journal,
-            tool_cache: lisp_step.tool_cache,
-            child_steps: state.child_steps ++ lisp_step.child_steps,
-            last_fail: lisp_step.fail,
-            last_return_error: error_message
-          )
+          # Preserve the assistant response that triggered the failure (for
+          # collect_messages) and this turn's tokens (for turn-stop telemetry),
+          # parity with the explicit-fail terminal path and the :tool_call hard
+          # stop. A pre-execution attach step carries no usage, so memory_bytes
+          # defaults to 0.
+          final_messages =
+            state.messages ++
+              [%{role: :assistant, content: ResponseHandler.strip_thinking(response)}]
 
-        {:continue, new_state, turn}
+          final_step =
+            StepAssembler.finalize(lisp_step, state,
+              duration_ms: duration_ms,
+              is_error: true,
+              final_turn: turn,
+              final_messages: final_messages,
+              journal: lisp_step.journal,
+              child_steps: state.child_steps ++ lisp_step.child_steps
+            )
+
+          {:stop, {:error, final_step}, turn, state.turn_tokens}
+        else
+          # Build feedback with appropriate turn info
+          error_message = ResponseHandler.format_error_for_llm(lisp_step.fail)
+          feedback = TurnFeedback.build_error_feedback(error_message, agent, state)
+
+          # Deferred step-done: discard current turn's summaries on error
+          new_state =
+            build_continuation_state(state, turn, response, feedback,
+              memory: lisp_step.memory,
+              journal: lisp_step.journal,
+              tool_cache: lisp_step.tool_cache,
+              child_steps: state.child_steps ++ lisp_step.child_steps,
+              last_fail: lisp_step.fail,
+              last_return_error: error_message
+            )
+
+          {:continue, new_state, turn}
+        end
     end
   end
 

--- a/lib/ptc_runner/sub_agent/loop/lisp_opts.ex
+++ b/lib/ptc_runner/sub_agent/loop/lisp_opts.ex
@@ -47,6 +47,9 @@ defmodule PtcRunner.SubAgent.Loop.LispOpts do
     |> maybe_put(:max_tool_calls, agent.max_tool_calls)
     |> maybe_put(:discovery_exec, Map.get(state, :discovery_exec))
     |> maybe_put(:prelude, Map.get(agent, :runtime_prelude))
+    # Opaque upstream runtime handle, forwarded only so `Lisp.run/2`'s
+    # attach-time prelude `requires` validation runs against it. `nil` is inert.
+    |> maybe_put(:runtime, Map.get(state, :runtime))
   end
 
   defp maybe_put(opts, _key, nil), do: opts

--- a/lib/ptc_runner/sub_agent/loop/ptc_tool_call.ex
+++ b/lib/ptc_runner/sub_agent/loop/ptc_tool_call.ex
@@ -546,22 +546,49 @@ defmodule PtcRunner.SubAgent.Loop.PtcToolCall do
         type: state.current_turn_type
       )
 
-    new_state =
-      build_continuation_state(
-        state,
-        turn,
-        assistant_content,
-        native_call,
-        tool_result_json,
-        memory: lisp_step.memory,
-        journal: lisp_step.journal,
-        tool_cache: lisp_step.tool_cache,
-        child_steps: state.child_steps ++ lisp_step.child_steps,
-        last_fail: fail,
-        last_return_error: message
-      )
+    if Shared.terminal_lisp_failure?(fail) do
+      # Fail closed (§3.5 #2): a prelude attach failure must terminate, never
+      # retry — parity with the `:content` transport. The tool call is still
+      # paired with its error result so the message log stays coherent.
+      duration_ms = System.monotonic_time(:millisecond) - state.start_time
 
-    {:continue, new_state, turn}
+      final_messages =
+        state.messages ++
+          assistant_with_tool_calls_messages(assistant_content, [native_call], [
+            {Map.get(native_call, :id) || Map.get(native_call, "id"), tool_result_json}
+          ])
+
+      # A pre-execution attach failure carries no `usage`, so `memory_bytes`
+      # defaults to 0 (parity with the `:content` transport hard stop).
+      final_step =
+        StepAssembler.finalize(lisp_step, state,
+          duration_ms: duration_ms,
+          is_error: true,
+          final_turn: turn,
+          final_messages: final_messages,
+          journal: lisp_step.journal,
+          child_steps: state.child_steps ++ lisp_step.child_steps
+        )
+
+      {:stop, {:error, final_step}, turn, state.turn_tokens}
+    else
+      new_state =
+        build_continuation_state(
+          state,
+          turn,
+          assistant_content,
+          native_call,
+          tool_result_json,
+          memory: lisp_step.memory,
+          journal: lisp_step.journal,
+          tool_cache: lisp_step.tool_cache,
+          child_steps: state.child_steps ++ lisp_step.child_steps,
+          last_fail: fail,
+          last_return_error: message
+        )
+
+      {:continue, new_state, turn}
+    end
   end
 
   defp handle_return_validation_error(

--- a/lib/ptc_runner/sub_agent/loop/shared.ex
+++ b/lib/ptc_runner/sub_agent/loop/shared.ex
@@ -62,6 +62,21 @@ defmodule PtcRunner.SubAgent.Loop.Shared do
     end
   end
 
+  @doc """
+  Whether a `Lisp.run` failure must terminate the SubAgent run rather than become
+  a recoverable retry turn — consulted by every Lisp-running transport (`:content`
+  and `:tool_call`).
+
+  A `:prelude_attach_failed` means a public capability-prelude export's required
+  upstream backing is missing. That is not a program error the LLM can repair by
+  rewriting, and feeding it back as a retry turn would let earlier side-effecting
+  turns stand. Failing closed here preserves the prelude guarantee on every
+  multi-turn path (plan §3.5 #2).
+  """
+  @spec terminal_lisp_failure?(map() | nil) :: boolean()
+  def terminal_lisp_failure?(%{reason: :prelude_attach_failed}), do: true
+  def terminal_lisp_failure?(_fail), do: false
+
   # ----------------------------------------------------------------
   # Final-text parsing
   # ----------------------------------------------------------------

--- a/lib/ptc_runner/sub_agent/loop/state.ex
+++ b/lib/ptc_runner/sub_agent/loop/state.ex
@@ -104,6 +104,14 @@ defmodule PtcRunner.SubAgent.Loop.State do
     # across child SubAgents.
     discovery_exec: nil,
 
+    # Optional upstream runtime handle (`%Upstream.Runtime{}`/pid). Threaded
+    # through to each turn's `Lisp.run/2` solely so attach-time prelude
+    # `requires` validation runs against it (`PreludeAttach.attach`). It is an
+    # opaque handle — this loop opens no `RunContext` and resets no counters;
+    # the bridge (`Upstream.Eval.run_subagent/3`) owns that lifecycle. Like
+    # `discovery_exec`, it is caller-owned and NOT inherited by child SubAgents.
+    runtime: nil,
+
     # Pluggable progress renderer state (opaque, owned by progress_fn)
     progress_state: nil,
 
@@ -197,6 +205,8 @@ defmodule PtcRunner.SubAgent.Loop.State do
           tool_cache: map() | nil,
           # Optional discovery executor closure
           discovery_exec: (atom(), list() -> term()) | nil,
+          # Optional upstream runtime handle (opaque; attach-time validation only)
+          runtime: struct() | pid() | nil,
           # Pluggable progress renderer state
           progress_state: term(),
           # Child steps

--- a/lib/ptc_runner/sub_agent/loop/text_mode.ex
+++ b/lib/ptc_runner/sub_agent/loop/text_mode.ex
@@ -703,17 +703,37 @@ defmodule PtcRunner.SubAgent.Loop.TextMode do
     if fatal_step do
       duration_ms = System.monotonic_time(:millisecond) - state.start_time
 
+      # Preserve the halting turn for traces/collected messages (parity with the
+      # :content and :tool_call hard stops): the assistant tool call, the tool
+      # results accumulated up to the fatal call, and a failure turn.
+      assistant_msg = combined_assistant_message(assistant_content, tool_calls_with_ids)
+      tool_results = Enum.reverse(tool_results_rev)
+      final_messages = state.messages ++ [assistant_msg | tool_results]
+
+      turn =
+        Metrics.build_turn(state, inspect(tool_calls_with_ids), nil, fatal_step.fail,
+          success?: false,
+          prints: [],
+          tool_calls: Enum.reverse(current_turn_calls),
+          memory: %{}
+        )
+
       step_with_metrics = %{
         fatal_step
         | usage: Metrics.build_final_usage(state, duration_ms, 0),
-          turns: Metrics.apply_trace_filter(Enum.reverse(state.turns), state.trace_mode, true),
-          messages: Shared.build_collected_messages(state, state.messages),
+          turns:
+            Metrics.apply_trace_filter(
+              Enum.reverse([turn | state.turns]),
+              state.trace_mode,
+              true
+            ),
+          messages: Shared.build_collected_messages(state, final_messages),
           prompt: state.expanded_prompt,
           original_prompt: state.original_prompt,
           tools: state.normalized_tools
       }
 
-      {:stop, {:error, step_with_metrics}, nil, state.turn_tokens}
+      {:stop, {:error, step_with_metrics}, turn, state.turn_tokens}
     else
       tool_results = Enum.reverse(tool_results_rev)
 
@@ -738,22 +758,7 @@ defmodule PtcRunner.SubAgent.Loop.TextMode do
           tool_results
         end
 
-      assistant_msg = %{
-        role: :assistant,
-        content: assistant_content || "",
-        tool_calls:
-          Enum.map(tool_calls_with_ids, fn tc ->
-            %{
-              id: tc.id,
-              type: "function",
-              function: %{
-                name: tc.name,
-                arguments:
-                  if(is_binary(tc.args), do: tc.args, else: Jason.encode!(tc.args || %{}))
-              }
-            }
-          end)
-      }
+      assistant_msg = combined_assistant_message(assistant_content, tool_calls_with_ids)
 
       turn =
         Metrics.build_turn(state, inspect(tool_calls_with_ids), nil, nil,
@@ -799,8 +804,12 @@ defmodule PtcRunner.SubAgent.Loop.TextMode do
             tool_result_msg = %{role: :tool, tool_call_id: tool_id, content: result_str}
             {:cont, {[tool_result_msg | results_acc], [step_entry | calls_acc], st_next, nil}}
 
-          {:fatal, error_step} ->
-            {:halt, {results_acc, calls_acc, st, error_step}}
+          {:fatal, error_step, result_str, step_entry} ->
+            # Terminal Lisp failure (`:prelude_attach_failed` or a strict
+            # memory-limit exit): keep the paired tool result + step entry for
+            # observability, then halt the reduce.
+            tool_result_msg = %{role: :tool, tool_call_id: tool_id, content: result_str}
+            {:halt, {[tool_result_msg | results_acc], [step_entry | calls_acc], st, error_step}}
         end
 
       # Tier 3.5 Fix 4: unknown_tool wins over args_error in combined
@@ -832,6 +841,27 @@ defmodule PtcRunner.SubAgent.Loop.TextMode do
         tool_result_msg = %{role: :tool, tool_call_id: tool_id, content: result_str}
         {:cont, {[tool_result_msg | results_acc], [step_entry | calls_acc], st_next, nil}}
     end
+  end
+
+  # Build the combined-mode assistant message carrying the turn's tool calls.
+  # Shared by the normal continue path and the fatal hard-stop path so their
+  # message shapes can't drift.
+  defp combined_assistant_message(assistant_content, tool_calls_with_ids) do
+    %{
+      role: :assistant,
+      content: assistant_content || "",
+      tool_calls:
+        Enum.map(tool_calls_with_ids, fn tc ->
+          %{
+            id: tc.id,
+            type: "function",
+            function: %{
+              name: tc.name,
+              arguments: if(is_binary(tc.args), do: tc.args, else: Jason.encode!(tc.args || %{}))
+            }
+          }
+        end)
+    }
   end
 
   defp simple_step_entry(tool_name, tool_args, error_msg) do
@@ -1050,8 +1080,8 @@ defmodule PtcRunner.SubAgent.Loop.TextMode do
   #   - `:args_error` paths render through `PtcToolProtocol.render_error/3`.
 
   # Returns one of:
-  #   {:ok, result_json, step_entry, new_state}   — continue
-  #   {:fatal, error_step}                          — terminate run with error
+  #   {:ok, result_json, step_entry, new_state}            — continue
+  #   {:fatal, error_step, result_json, step_entry}        — terminate run, paired result
   defp dispatch_lisp_eval(call, agent, state) do
     start = System.monotonic_time(:millisecond)
 
@@ -1191,22 +1221,39 @@ defmodule PtcRunner.SubAgent.Loop.TextMode do
 
   defp handle_lisp_runtime_error(lisp_step, program, call, _agent, state, duration_ms) do
     fail = lisp_step.fail
-    reason_atom = Shared.classify_lisp_error(fail)
-    message = fail.message
 
-    result_json = PtcToolProtocol.render_error(reason_atom, message)
+    if Shared.terminal_lisp_failure?(fail) do
+      # Fail closed (§3.5 #2): a prelude attach failure must terminate the run,
+      # never become a recoverable `lisp_eval` tool error that the LLM retries —
+      # parity with the `:content` and `:tool_call` transports. Render the paired
+      # tool error + step entry so the halting turn stays observable, then signal
+      # fatal: the 4-tuple `{:fatal, step, result_json, step_entry}` halts the
+      # combined-mode reduce while preserving the assistant call + tool result.
+      reason_atom = Shared.classify_lisp_error(fail)
+      message = fail.message
+      result_json = PtcToolProtocol.render_error(reason_atom, message)
+      emit_ptc_lisp_telemetry(state, duration_ms, true)
+      step_entry = ptc_lisp_step_entry(call, lisp_step, duration_ms, message)
+      _ = program
+      {:fatal, lisp_step, result_json, step_entry}
+    else
+      reason_atom = Shared.classify_lisp_error(fail)
+      message = fail.message
 
-    state_next =
-      thread_lisp_step_state(state, lisp_step,
-        advance_turn_history: false,
-        last_fail: fail,
-        last_return_error: message
-      )
+      result_json = PtcToolProtocol.render_error(reason_atom, message)
 
-    emit_ptc_lisp_telemetry(state, duration_ms, true)
-    step_entry = ptc_lisp_step_entry(call, lisp_step, duration_ms, message)
-    _ = program
-    {:ok, result_json, step_entry, state_next}
+      state_next =
+        thread_lisp_step_state(state, lisp_step,
+          advance_turn_history: false,
+          last_fail: fail,
+          last_return_error: message
+        )
+
+      emit_ptc_lisp_telemetry(state, duration_ms, true)
+      step_entry = ptc_lisp_step_entry(call, lisp_step, duration_ms, message)
+      _ = program
+      {:ok, result_json, step_entry, state_next}
+    end
   end
 
   defp handle_memory_limit_exceeded(
@@ -1232,7 +1279,11 @@ defmodule PtcRunner.SubAgent.Loop.TextMode do
     else
       emit_ptc_lisp_telemetry(state, duration_ms, true)
       error_step = Step.error(:memory_limit_exceeded, error_msg, lisp_step.memory)
-      {:fatal, error_step}
+      # Pair a tool result so the fatal finalizer's assistant tool call has its
+      # matching `role: :tool` response (valid transcript under collect_messages).
+      result_json = PtcToolProtocol.render_error(:memory_limit, error_msg)
+      step_entry = ptc_lisp_step_entry(call, lisp_step, duration_ms, error_msg)
+      {:fatal, error_step, result_json, step_entry}
     end
   end
 

--- a/lib/ptc_runner/sub_agent/runner.ex
+++ b/lib/ptc_runner/sub_agent/runner.ex
@@ -84,7 +84,8 @@ defmodule PtcRunner.SubAgent.Runner do
           # PTC-Lisp single-shot (max_turns == 1, no tools) uses run_single_shot for efficiency
           if agent.completion_mode == :implicit and agent.output == :ptc_lisp and
                agent.max_turns == 1 and map_size(agent.tools) == 0 and agent.retry_turns == 0 and
-               not prelude_tool_backed?(agent.runtime_prelude) do
+               not prelude_tool_backed?(agent.runtime_prelude) and
+               not prelude_requires_backed?(agent.runtime_prelude) do
             # PTC-Lisp single-shot mode
             run_single_shot(
               agent,
@@ -123,6 +124,22 @@ defmodule PtcRunner.SubAgent.Runner do
 
   defp prelude_tool_backed?(%PtcRunner.Lisp.Prelude{exports: exports}),
     do: Enum.any?(exports, &(&1.tool_refs != []))
+
+  # A prelude whose exports declare upstream `requires` must have those
+  # `requires` validated against the selected runtime at attach time
+  # (`PreludeAttach.attach`). The single-shot fast path runs `Lisp.run` with no
+  # `:runtime` (runner.ex single-shot), so attach skips validation there. Route
+  # any requires-carrying prelude through `Loop.run/2`, where the bridge's
+  # `:runtime` handle reaches the attach path — making fail-closed validation
+  # independent of which execution surface the agent selects (plan §3.5 #1).
+  # `tool_refs` (AST-derived) and `requires` (explicit metadata is merged in)
+  # diverge: an explicit-`:requires` export with no literal `(tool/...)` body has
+  # `tool_refs == []` but `requires != []`, so `prelude_tool_backed?/1` alone
+  # would leave it on the fast path.
+  defp prelude_requires_backed?(nil), do: false
+
+  defp prelude_requires_backed?(%PtcRunner.Lisp.Prelude{exports: exports}),
+    do: Enum.any?(exports, &(&1.requires != []))
 
   @doc """
   Resolves `:self` sentinels in a tools map to `SubAgentTool` structs.

--- a/lib/ptc_runner/upstream/eval.ex
+++ b/lib/ptc_runner/upstream/eval.ex
@@ -69,4 +69,87 @@ defmodule PtcRunner.Upstream.Eval do
       PtcRunner.Lisp.run(program, opts)
     end)
   end
+
+  @doc """
+  Run a multi-turn `PtcRunner.SubAgent` over an upstream runtime.
+
+  This is the first-class SubAgent↔upstream bridge. It owns **one**
+  `RunContext` spanning the entire multi-turn run (so the ledger, caps, and
+  discovery cache aggregate across all turns), derives the upstream `"call"`
+  tool + discovery hook from it, enriches the agent's tool map **before** prompt
+  generation so the capability is prompt-visible, and threads the runtime handle
+  into every turn so attach-time prelude `requires` validation runs fail-closed.
+  The SubAgent loop never opens a `RunContext`; this function does.
+
+  Returns `{result, records}` where `result` is the `SubAgent.run/2` result and
+  `records` are the drained upstream call records (mirrors
+  `run_lisp_with_records/3`).
+
+  ## Options
+
+  All `SubAgent.run/2` opts are forwarded, plus:
+
+    * the upstream context-limit keys (`:max_tool_calls`, `:max_catalog_ops`,
+      `:call_timeout_ms`, `:max_response_bytes`, `:max_catalog_result_bytes`) —
+      consumed to build the `RunContext`, not forwarded to `SubAgent.run`.
+    * `:on_upstream_call` — optional `((args -> result) -> (args -> result))`
+      decorator wrapping the upstream `"call"` fn, e.g. a server-side ledger
+      that records attempts before dispatch. The mcp ledger lives here.
+    * `:allow_call_override` — when `true`, a local `"call"` tool on the agent is
+      kept instead of raising on the collision (tests/stubs only).
+
+  `:discovery_exec` and `:runtime` are bridge-owned; any caller-supplied values
+  for those keys are ignored.
+  """
+  @bridge_keys [:on_upstream_call, :allow_call_override, :discovery_exec, :runtime]
+
+  @spec run_subagent(struct() | pid(), struct(), keyword()) ::
+          {{:ok, PtcRunner.Step.t()} | {:error, PtcRunner.Step.t()}, [map()]}
+  def run_subagent(runtime, agent, opts \\ []) do
+    context_opts = Keyword.take(opts, @context_keys)
+    decorate = Keyword.get(opts, :on_upstream_call)
+    allow_override = Keyword.get(opts, :allow_call_override, false)
+    sub_opts = Keyword.drop(opts, @context_keys ++ @bridge_keys)
+
+    with_run_context(runtime, context_opts, fn context ->
+      eval_opts = eval_options(context)
+      call_tool = maybe_decorate(eval_opts[:tools], decorate)
+      enriched = enrich_agent(agent, call_tool, allow_override)
+
+      run_opts =
+        sub_opts
+        |> Keyword.put(:discovery_exec, eval_opts[:discovery_exec])
+        |> Keyword.put(:runtime, runtime)
+
+      PtcRunner.SubAgent.run(enriched, run_opts)
+    end)
+  end
+
+  defp maybe_decorate(tools, nil), do: tools
+
+  defp maybe_decorate(%{"call" => call} = tools, decorate) when is_function(decorate, 1) do
+    %{tools | "call" => decorate.(call)}
+  end
+
+  # Merge the upstream `"call"` tool into the agent BEFORE SubAgent.run so it is
+  # visible both in the first-turn prompt and in every per-turn execution surface
+  # (both re-derive from `agent.tools`). Reserve `"call"` for the upstream tool: a
+  # silent local override would make prelude `requires` validation (against the
+  # runtime) disagree with execution (a local fn).
+  defp enrich_agent(%{tools: tools} = agent, call_tool, allow_override) do
+    cond do
+      not Map.has_key?(tools, "call") ->
+        %{agent | tools: Map.merge(tools, call_tool)}
+
+      allow_override ->
+        # Caller explicitly keeps its local "call" (tests/stubs).
+        %{agent | tools: Map.merge(call_tool, tools)}
+
+      true ->
+        raise ArgumentError,
+              "agent defines a local \"call\" tool that collides with the upstream " <>
+                "call tool; pass `allow_call_override: true` to keep the local one " <>
+                "(tests/stubs only)"
+    end
+  end
 end

--- a/mcp_server/lib/ptc_runner_mcp/agentic.ex
+++ b/mcp_server/lib/ptc_runner_mcp/agentic.ex
@@ -164,22 +164,23 @@ defmodule PtcRunnerMcp.Agentic do
 
   defp run_subagent(agent, llm, validated, request_id, ledger) do
     if RootUpstreamRuntime.configured?() do
+      # Core owns the lifecycle + `:runtime` threading (so prelude `requires`
+      # validate fail-closed); mcp keeps only the side-effect *policy* — the
+      # ledger (wrapped around the upstream `"call"` fn before dispatch) and the
+      # continuation guard. The bridge enriches the agent's tools with `"call"`
+      # before prompt generation, so it is prompt-visible and routes through the
+      # loop without any fast-path special-casing.
       {result, _records} =
-        Eval.with_run_context(
+        Eval.run_subagent(
           RootUpstreamRuntime.runtime(),
-          root_context_opts(),
-          fn context ->
-            eval_opts = Eval.eval_options(context)
-            root_agent = %{agent | tools: root_tools_with_ledger(eval_opts[:tools], ledger)}
-
-            SubAgent.run(root_agent,
-              llm: llm,
-              context: validated.context,
-              continuation_guard: continuation_guard(ledger),
-              trace_context: %{request_id: request_id},
-              discovery_exec: eval_opts[:discovery_exec]
-            )
-          end
+          agent,
+          [
+            llm: llm,
+            context: validated.context,
+            continuation_guard: continuation_guard(ledger),
+            trace_context: %{request_id: request_id},
+            on_upstream_call: fn call -> fn args -> call_with_ledger(call, ledger, args) end end
+          ] ++ root_context_opts()
         )
 
       result

--- a/test/ptc_runner/sub_agent/loop/lisp_opts_test.exs
+++ b/test/ptc_runner/sub_agent/loop/lisp_opts_test.exs
@@ -91,5 +91,17 @@ defmodule PtcRunner.SubAgent.Loop.LispOptsTest do
       agent = agent_fixture(%{format_options: [max_print_length: 80]})
       assert LispOpts.build(agent, state_fixture(), %{}, %{})[:max_print_length] == 80
     end
+
+    test "appends :runtime when state.runtime is set, omits when nil" do
+      agent = agent_fixture()
+
+      # nil by default → omitted, so the base key list (and the nil-runtime,
+      # tools-only path) is unchanged.
+      refute Keyword.has_key?(LispOpts.build(agent, state_fixture(), %{}, %{}), :runtime)
+
+      runtime = %{fake: :runtime_handle}
+      with_runtime = state_fixture(%{runtime: runtime})
+      assert LispOpts.build(agent, with_runtime, %{}, %{})[:runtime] == runtime
+    end
   end
 end

--- a/test/ptc_runner/upstream/eval_run_subagent_test.exs
+++ b/test/ptc_runner/upstream/eval_run_subagent_test.exs
@@ -143,6 +143,41 @@ defmodule PtcRunner.Upstream.EvalRunSubagentTest do
       assert Agent.get(counter, & &1) == 1
     end
 
+    test "fails closed and hard-stops in combined text mode too", %{runtime: runtime} do
+      # output: :text + ptc_transport: :tool_call is combined mode, which has its
+      # OWN lisp_eval error handler (text_mode.ex) that otherwise renders a
+      # recoverable tool error and retries.
+      prelude = literal_prelude("crm", "get_user")
+      {:ok, counter} = Agent.start_link(fn -> 0 end)
+
+      agent =
+        SubAgent.new(
+          prompt: "Do the thing.",
+          runtime_prelude: prelude,
+          output: :text,
+          ptc_transport: :tool_call,
+          max_turns: 3
+        )
+
+      {result, _records} =
+        Eval.run_subagent(runtime, agent,
+          llm: counting_tool_call_llm(counter, ~S|(crm/list-traces "o")|),
+          collect_messages: true
+        )
+
+      assert {:error, step} = result
+      assert step.fail.reason == :prelude_attach_failed
+      assert Agent.get(counter, & &1) == 1
+
+      # Observability parity: the halting turn is preserved (not an empty trace),
+      # carries the failure reason (so error-breakdown metrics count it), and the
+      # assistant tool call survives under collect_messages.
+      assert [turn] = step.turns
+      refute turn.success?
+      assert turn.result == step.fail
+      assert Enum.any?(step.messages, &(&1.role == :assistant))
+    end
+
     test "a satisfied requires does not block (validation passes)", %{runtime: runtime} do
       prelude = literal_prelude("observatory", "list-traces")
 

--- a/test/ptc_runner/upstream/eval_run_subagent_test.exs
+++ b/test/ptc_runner/upstream/eval_run_subagent_test.exs
@@ -1,0 +1,462 @@
+defmodule PtcRunner.Upstream.EvalRunSubagentTest do
+  use ExUnit.Case, async: true
+
+  @moduledoc """
+  The core SubAgent↔upstream bridge: `Upstream.Eval.run_subagent/3`.
+
+  Covers the two goals and the three Phase-1 correctness requirements from
+  `private/Plans/subagent-upstream-runtime-integration.md`:
+
+    * the bridge owns one RunContext, enriches the agent with the upstream
+      `"call"` tool, threads the runtime, and round-trips end-to-end;
+    * prelude `requires` validates fail-closed on the multi-turn loop path
+      (§3.3); a missing backing is a HARD STOP, not a recoverable retry turn
+      (§3.5 #2);
+    * collision policy reserves `"call"` (§3.4).
+
+  The single-shot fast-path fix (§3.5 #1) and child upstream-blindness (§3.5 #3)
+  live in their own tests below.
+  """
+
+  alias PtcRunner.Lisp.Prelude.Compiler
+  alias PtcRunner.SubAgent
+  alias PtcRunner.Upstream.Eval
+  alias PtcRunner.Upstream.Runtime
+
+  @schema Path.expand(
+            "../../../mcp_server/test/fixtures/openapi/observatory.openapi.json",
+            __DIR__
+          )
+  @fixture_recv_timeout_ms 15_000
+
+  # ------------------------------------------------------------------
+  # Bridge lifecycle + round-trip
+  # ------------------------------------------------------------------
+
+  describe "round-trip through the bridge against a reachable upstream" do
+    test "enriches the agent with the upstream call, validates requires, and round-trips" do
+      {:ok, server} = start_http_fixture(%{"traces" => [%{"id" => "t-1", "org_id" => "acme"}]})
+      {:ok, runtime} = Runtime.start_link(config: config(base_url: server.base_url))
+
+      agent =
+        SubAgent.new(
+          prompt: "List traces.",
+          runtime_prelude: direct_prelude(),
+          output: :ptc_lisp,
+          max_turns: 1
+        )
+
+      try do
+        {result, records} =
+          Eval.run_subagent(runtime, agent, llm: stub_llm(~S|(api/list-traces "acme")|))
+
+        assert {:ok, step} = result
+
+        # SubAgent normalizes return-map keys to strings (KeyNormalizer); the
+        # recoverable result map round-trips with string keys on this path.
+        assert step.return == %{
+                 "ok" => true,
+                 "value" => %{"traces" => [%{"id" => "t-1", "org_id" => "acme"}]},
+                 "value_kind" => :json
+               }
+
+        # One RunContext spanned the run and drained the single upstream call.
+        assert [%{"server" => "observatory", "tool" => "list-traces", "status" => "ok"}] = records
+
+        # It genuinely hit HTTP through the bridge-enriched "call" tool.
+        assert_receive {:http_fixture_request, request}, 1_000
+        assert request =~ "org_id=acme"
+      after
+        Runtime.stop(runtime)
+      end
+    end
+  end
+
+  # ------------------------------------------------------------------
+  # Prelude requires — fail closed on the multi-turn loop path (§3.3 + §3.5 #2)
+  # ------------------------------------------------------------------
+
+  describe "prelude requires validation on the multi-turn SubAgent path" do
+    setup do
+      {:ok, runtime} = Runtime.start_link(config: config())
+      on_exit(fn -> Runtime.stop(runtime) end)
+      %{runtime: runtime}
+    end
+
+    test "an unsatisfied requires fails closed before any user code AND hard-stops the loop",
+         %{runtime: runtime} do
+      # crm/get_user is NOT configured on this observatory-only runtime.
+      prelude = literal_prelude("crm", "get_user")
+      {:ok, counter} = Agent.start_link(fn -> 0 end)
+
+      agent =
+        SubAgent.new(
+          prompt: "Do the thing.",
+          runtime_prelude: prelude,
+          output: :ptc_lisp,
+          # 3 turns: a recoverable error would retry up to here; a hard stop runs once.
+          max_turns: 3
+        )
+
+      {result, _records} =
+        Eval.run_subagent(runtime, agent,
+          llm: counting_llm(counter, ~S|(crm/list-traces "o")|),
+          collect_messages: true
+        )
+
+      assert {:error, step} = result
+      assert step.fail.reason == :prelude_attach_failed
+      assert step.fail.message =~ "upstream:crm/get_user"
+
+      # Hard stop (§3.5 #2): the loop did not feed the attach failure back as a
+      # retry turn — the planner was consulted exactly once and one turn ran.
+      assert Agent.get(counter, & &1) == 1
+      assert length(step.turns) == 1
+
+      # Observability parity: the assistant response that triggered the failure
+      # is preserved under collect_messages.
+      assert Enum.any?(step.messages, &(&1.role == :assistant))
+    end
+
+    test "fails closed and hard-stops on the :tool_call transport too", %{runtime: runtime} do
+      # Codex [P2]: the :tool_call transport has its own Lisp error handler; the
+      # hard stop must apply there as well, not only on :content.
+      prelude = literal_prelude("crm", "get_user")
+      {:ok, counter} = Agent.start_link(fn -> 0 end)
+
+      agent =
+        SubAgent.new(
+          prompt: "Do the thing.",
+          runtime_prelude: prelude,
+          output: :ptc_lisp,
+          ptc_transport: :tool_call,
+          max_turns: 3
+        )
+
+      {result, _records} =
+        Eval.run_subagent(runtime, agent,
+          llm: counting_tool_call_llm(counter, ~S|(crm/list-traces "o")|)
+        )
+
+      assert {:error, step} = result
+      assert step.fail.reason == :prelude_attach_failed
+      assert Agent.get(counter, & &1) == 1
+    end
+
+    test "a satisfied requires does not block (validation passes)", %{runtime: runtime} do
+      prelude = literal_prelude("observatory", "list-traces")
+
+      agent =
+        SubAgent.new(
+          prompt: "List.",
+          runtime_prelude: prelude,
+          output: :ptc_lisp,
+          max_turns: 1
+        )
+
+      # observatory.example is unreachable, so the call itself may error — but
+      # that is a runtime tool error, NOT a prelude attach failure.
+      {result, _records} =
+        Eval.run_subagent(runtime, agent, llm: stub_llm(~S|(crm/list-traces "o")|))
+
+      case result do
+        {:ok, _step} -> :ok
+        {:error, step} -> refute step.fail.reason == :prelude_attach_failed
+      end
+    end
+  end
+
+  # ------------------------------------------------------------------
+  # Collision policy (§3.4)
+  # ------------------------------------------------------------------
+
+  describe "collision policy reserves the upstream \"call\" tool" do
+    setup do
+      {:ok, runtime} = Runtime.start_link(config: config())
+      on_exit(fn -> Runtime.stop(runtime) end)
+      %{runtime: runtime}
+    end
+
+    test "a local \"call\" tool plus a runtime raises by default", %{runtime: runtime} do
+      agent =
+        SubAgent.new(
+          prompt: "x",
+          tools: %{"call" => fn _args -> %{ok: true, value: "local"} end},
+          output: :ptc_lisp,
+          max_turns: 1
+        )
+
+      assert_raise ArgumentError, ~r/local "call" tool/, fn ->
+        Eval.run_subagent(runtime, agent, llm: stub_llm("1"))
+      end
+    end
+
+    test "allow_call_override: true keeps the local tool instead of raising", %{runtime: runtime} do
+      agent =
+        SubAgent.new(
+          prompt: "x",
+          tools: %{"call" => fn _args -> %{ok: true, value: "local"} end},
+          output: :ptc_lisp,
+          max_turns: 1
+        )
+
+      {result, _records} =
+        Eval.run_subagent(runtime, agent,
+          llm: stub_llm(~S|(tool/call {:server "s" :tool "t" :args {}})|),
+          allow_call_override: true
+        )
+
+      assert {:ok, step} = result
+      assert step.return == %{"ok" => true, "value" => "local"}
+    end
+  end
+
+  # ------------------------------------------------------------------
+  # §3.5 #1 — single-shot path must not skip requires validation
+  # ------------------------------------------------------------------
+
+  describe "single-shot fast path and prelude requires (§3.5 #1)" do
+    setup do
+      {:ok, runtime} = Runtime.start_link(config: config())
+      on_exit(fn -> Runtime.stop(runtime) end)
+      %{runtime: runtime}
+    end
+
+    test "a requires-backed prelude with no literal tool/call still validates against a runtime",
+         %{runtime: runtime} do
+      # requires != [] (explicit metadata) but tool_refs == [] (no literal
+      # (tool/call ...) in the body) — the exact divergence that left this on the
+      # single-shot path, which threads no :runtime and skips validation.
+      prelude = requires_only_prelude("crm", "do_write")
+      [export] = prelude.exports
+      assert export.requires == ["upstream:crm/do_write"]
+      assert export.tool_refs == []
+
+      agent =
+        SubAgent.new(
+          prompt: "x",
+          runtime_prelude: prelude,
+          output: :ptc_lisp,
+          max_turns: 1,
+          retry_turns: 0
+        )
+
+      # Facade form: pass the runtime directly. The fix routes this off the
+      # fast path into Loop.run, where the runtime reaches prelude attach.
+      assert {:error, step} = SubAgent.run(agent, llm: stub_llm("1"), runtime: runtime)
+      assert step.fail.reason == :prelude_attach_failed
+      assert step.fail.message =~ "upstream:crm/do_write"
+    end
+
+    test "a pure prelude (no requires, no tool_refs) still uses the single-shot fast path" do
+      {:ok, prelude} =
+        Compiler.compile("""
+        (ns util "Pure helpers." {:visibility :prompt})
+        (defn add-one [x] (+ x 1))
+        """)
+
+      agent =
+        SubAgent.new(
+          prompt: "x",
+          runtime_prelude: prelude,
+          output: :ptc_lisp,
+          max_turns: 1,
+          retry_turns: 0
+        )
+
+      assert {:ok, step} = SubAgent.run(agent, llm: stub_llm(~S|(util/add-one 41)|))
+      assert step.return == 42
+    end
+  end
+
+  # ------------------------------------------------------------------
+  # §3.5 #3 — child agents are upstream-blind (no runtime inheritance)
+  # ------------------------------------------------------------------
+
+  describe "child agents do not inherit the parent runtime (§3.5 #3)" do
+    test "a child's own requires-backed prelude is not validated against the parent runtime" do
+      {:ok, runtime} = Runtime.start_link(config: config())
+
+      # The child requires crm/do_write (unconfigured). Its body is the constant
+      # 777, but prelude attach runs per-turn before user code regardless. If the
+      # child INHERITED the parent's runtime, that attach would fail closed
+      # (:prelude_attach_failed); because children are upstream-blind, the child
+      # has no runtime, attach skips validation, the child returns 777, and the
+      # parent's (child) call yields it.
+      child =
+        SubAgent.new(
+          prompt: "CHILD_MARKER",
+          runtime_prelude: requires_only_prelude("crm", "do_write"),
+          output: :ptc_lisp,
+          max_turns: 1,
+          signature: "() -> :int",
+          description: "Child that returns a number."
+        )
+
+      parent =
+        SubAgent.new(
+          prompt: "PARENT_MARKER",
+          tools: %{"child" => SubAgent.as_tool(child)},
+          output: :ptc_lisp,
+          max_turns: 1
+        )
+
+      llm = routing_llm([{"CHILD_MARKER", "777"}, {"PARENT_MARKER", "(tool/child {})"}])
+
+      try do
+        {result, _records} = Eval.run_subagent(runtime, parent, llm: llm)
+
+        assert {:ok, step} = result
+        assert step.return == 777
+      after
+        Runtime.stop(runtime)
+      end
+    end
+  end
+
+  # ------------------------------------------------------------------
+  # Helpers
+  # ------------------------------------------------------------------
+
+  defp stub_llm(program) do
+    fn _input -> {:ok, "```clojure\n#{program}\n```"} end
+  end
+
+  defp counting_llm(counter, program) do
+    fn _input ->
+      Agent.update(counter, &(&1 + 1))
+      {:ok, "```clojure\n#{program}\n```"}
+    end
+  end
+
+  # Native tool-call transport: the LLM returns a `lisp_eval` tool call rather
+  # than a fenced content block.
+  defp counting_tool_call_llm(counter, program) do
+    fn _input ->
+      Agent.update(counter, &(&1 + 1))
+
+      {:ok,
+       %{
+         content: nil,
+         tool_calls: [%{id: "c1", name: "lisp_eval", args: %{"program" => program}}],
+         tokens: %{input: 0, output: 0}
+       }}
+    end
+  end
+
+  # Returns different programs per caller, keyed by a marker substring present in
+  # the LLM input (each agent's prompt). Lets a parent call a child while the
+  # child returns its own program.
+  defp routing_llm(routes) do
+    fn input ->
+      text = inspect(input, limit: :infinity)
+
+      program =
+        Enum.find_value(routes, "nil", fn {marker, prog} ->
+          if String.contains?(text, marker), do: prog
+        end)
+
+      {:ok, "```clojure\n#{program}\n```"}
+    end
+  end
+
+  # Literal upstream tool/call: the compiler INFERS requires from the body.
+  defp literal_prelude(server, tool) do
+    {:ok, prelude} =
+      Compiler.compile("""
+      (ns crm "CRM helpers." {:visibility :prompt})
+
+      (defn list-traces "doc" [org-id]
+        (tool/call {:server "#{server}" :tool "#{tool}" :args {:org_id org-id}}))
+      """)
+
+    prelude
+  end
+
+  # A reachable observatory export (literal), used for the round-trip.
+  defp direct_prelude do
+    {:ok, prelude} =
+      Compiler.compile("""
+      (ns api "Observatory API." {:visibility :prompt})
+
+      (defn list-traces "List traces for an org." [org-id]
+        (tool/call {:server "observatory" :tool "list-traces"
+                    :args {:org_id org-id :limit 1}}))
+      """)
+
+    prelude
+  end
+
+  # Explicit :requires metadata with NO literal (tool/call ...) in the body, so
+  # requires != [] but tool_refs == [] (the §3.5 #1 divergence).
+  defp requires_only_prelude(server, tool) do
+    {:ok, prelude} =
+      Compiler.compile("""
+      (ns crm "CRM helpers." {:visibility :prompt})
+
+      (defn do-write
+        "Perform a write."
+        {:provider-ref "upstream:#{server}/#{tool}" :effect :write
+         :requires ["upstream:#{server}/#{tool}"]}
+        []
+        42)
+      """)
+
+    prelude
+  end
+
+  defp config(opts \\ []) do
+    base_url = Keyword.get(opts, :base_url, "https://observatory.example")
+
+    %{
+      "upstreams" => %{
+        "observatory" => %{
+          "transport" => "openapi",
+          "base_url" => base_url,
+          "schema_file" => @schema,
+          "include_operations" => ["list_traces", "get_trace"],
+          "allow_insecure_http" => true
+        }
+      }
+    }
+  end
+
+  # Ephemeral one-shot HTTP server (mirrors upstream_roundtrip_test.exs).
+  defp start_http_fixture(response_body) do
+    parent = self()
+    response_json = Jason.encode!(response_body)
+
+    {:ok, listen_socket} =
+      :gen_tcp.listen(0, [
+        :binary,
+        packet: :raw,
+        active: false,
+        reuseaddr: true,
+        ip: {127, 0, 0, 1}
+      ])
+
+    {:ok, port} = :inet.port(listen_socket)
+
+    pid =
+      spawn_link(fn ->
+        {:ok, socket} = :gen_tcp.accept(listen_socket)
+        {:ok, request} = :gen_tcp.recv(socket, 0, @fixture_recv_timeout_ms)
+        send(parent, {:http_fixture_request, request})
+
+        response = [
+          "HTTP/1.1 200 OK\r\n",
+          "content-type: application/json\r\n",
+          "content-length: #{byte_size(response_json)}\r\n",
+          "connection: close\r\n",
+          "\r\n",
+          response_json
+        ]
+
+        :ok = :gen_tcp.send(socket, response)
+        :gen_tcp.close(socket)
+        :gen_tcp.close(listen_socket)
+      end)
+
+    {:ok, %{pid: pid, base_url: "http://127.0.0.1:#{port}"}}
+  end
+end


### PR DESCRIPTION
## What & why

Moves the multi-turn SubAgent↔upstream glue out of `mcp_server` into core `ptc_runner`, and restores the capability-prelude **fail-closed `requires`** guarantee on the SubAgent path. Implements Phase 1 of `private/Plans/subagent-upstream-runtime-integration.md`.

Two problems this closes:
1. **Misplaced layer** — agent-over-upstream orchestration lived in `PtcRunnerMcp.Agentic`, so a `ptc_runner`-only consumer had no supported way to run a multi-turn agent over MCP/HTTP/OpenAPI upstreams.
2. **Weakened prelude safety** — the multi-turn loop never threaded `:runtime` into prelude attach, so `requires` validation was silently skipped; the guide §5 "a missing backing can never cause a partial run with side effects" guarantee degraded to "attempted, then rejected."

## Design

Rather than make `Loop.run` own the upstream `RunContext` lifecycle, a thin core **bridge** owns it from *outside* the loop (the shape `agentic.ex` already proved). `runtime` and `RunContext` are different things: passing `:runtime` to `Lisp.run` only enables attach-time `PreludeAttach` validation; it opens no context and resets no counters.

- **`PtcRunner.Upstream.Eval.run_subagent/3`** — opens one `RunContext` spanning the run, enriches `agent.tools` with the upstream `"call"` before prompt generation, threads the runtime, drains records. Accepts `on_upstream_call` (tool decorator) + `continuation_guard` so the mcp ledger/side-effect policy stays server-side.
- **`:runtime` passthrough** — `State` → `Loop.run` → `LispOpts.build` (one `maybe_put`). Opaque handle, `nil` is inert. Not inherited by child SubAgents.

## Three Phase-1 correctness fixes

1. **Single-shot** — `prelude_requires_backed?/1` routes any requires-carrying prelude off the fast path so validation can't be skipped by execution-path choice.
2. **Hard-stop** — `Shared.terminal_lisp_failure?/1`; `:prelude_attach_failed` terminates instead of becoming a recoverable retry turn, on **both** the `:content` and `:tool_call` transports.
3. **Child upstream-blind** — children don't inherit the parent runtime (matches `discovery_exec` ownership); documented + tested.

## mcp_server collapse

`agentic.run_subagent/5` now calls the bridge, passing the ledger wrapper as `on_upstream_call` and keeping `Ledger`/`Projection`/effect-classification/`continuation_guard` server-side. `agentic_contract_test.exs` unchanged and green.

## Verification

- ptc_runner `mix precommit`: 5867 tests + 389 doctests + 3 properties, 0 failures (format/credo/spec green).
- mcp_server: 815 tests, 0 failures.
- New `test/ptc_runner/upstream/eval_run_subagent_test.exs` (9): real-HTTP round-trip, fail-closed + hard-stop on both transports, single-shot fix, collision policy, child-blind.
- **codex review: clean.** Round 1 caught that the hard-stop initially missed the `:tool_call` transport ([P2]); fixed by lifting the predicate into `Shared`. Round 2 flagged content-path observability parity ([P3]); fixed. Round 3 clean.

## Deferred (not in this PR)

- Phase 2: `upstreams:` config convenience (core starts/stops a runtime).
- Phase 3: validate `requires` once against a frozen-for-the-run snapshot (removes per-turn redundancy + the `:live`-catalog mid-run hazard).