### PR TITLE
feat(subagent): bridge re-enters internal Runner.run (Definition-only) + Phase 1.5 docs/tests

### DIFF
--- a/docs/guides/capability-prelude.md
+++ b/docs/guides/capability-prelude.md
@@ -222,6 +222,14 @@ covers **the agent given the runtime**: a child SubAgent invoked via `as_tool` i
 `requires`-backed prelude is only validated if that child is itself run through
 its own upstream bridge/runtime.
 
+> **Host-supplied side-effect guard (Phase 1).** Fail-closed `requires`
+> validation bounds *which* operations a prelude may reach, but Phase 1 does
+> **not** install a side-effect *continuation* guard by default. Continuation
+> policy — how far a run may keep producing side effects — is **host-supplied**
+> in Phase 1: `mcp_server` installs one; a standalone caller must pass its own
+> `continuation_guard` (to `run_subagent/3`, §7) to bound side effects, until a
+> core default lands in a later phase.
+
 > The prelude does **not** define upstream endpoints or credentials. It only
 > *wraps* operations the host has already configured. Credentials live in
 > host/deployment config and never appear in the artifact, prompts, or traces.
@@ -250,7 +258,7 @@ have no export record and never appear.
 
 ## 7. Attaching a prelude to a run
 
-The same compiled artifact attaches through three seams.
+The same compiled artifact attaches through four seams.
 
 **Direct execution** (`PtcRunner.Lisp.run/2`) — pass a compiled artifact *or*
 source (compiled before user-code analysis):
@@ -269,12 +277,34 @@ PtcRunner.Lisp.run(program, prelude: prelude, runtime: upstream_runtime)
 %PtcRunner.SubAgent.Definition{runtime_prelude: prelude}
 ```
 
-**Upstream-backed runs** — `PtcRunner.Upstream.Eval.run_lisp/3` forwards its
+**Upstream-backed single program** — `PtcRunner.Upstream.Eval.run_lisp/3` runs
+**one** Lisp program against a selected upstream runtime and forwards that
 runtime into the attach path automatically, so `requires` are validated:
 
 ```elixir
 PtcRunner.Upstream.Eval.run_lisp(runtime, program, prelude: prelude)
 ```
+
+**Upstream-backed multi-turn SubAgent** — `PtcRunner.Upstream.Eval.run_subagent/3`
+is the analogue of `run_lisp/3` for a **multi-turn** agent. It owns a single
+`RunContext` for the whole run, enriches the agent with the upstream-call tool
+**before** prompt generation, and threads the runtime into **every** turn so the
+prelude `requires` validate fail-closed per turn:
+
+```elixir
+PtcRunner.Upstream.Eval.run_subagent(runtime, agent, llm: llm, context: ctx)
+```
+
+The distinction: `run_lisp/3` runs a **single program**; `run_subagent/3` runs a
+**multi-turn agent**. Both forward the same `runtime` into the attach path, so in
+either case `requires` are validated against the selected upstream.
+
+> **Host-supplied side-effect guard (Phase 1).** `run_subagent/3` validates a
+> prelude's `requires` fail-closed per turn, but Phase 1 installs **no**
+> side-effect continuation guard by default. That policy is host-supplied:
+> `mcp_server` installs one; a standalone caller must pass its own
+> `continuation_guard` to `run_subagent/3` to bound side effects, until a core
+> default lands in a later phase. (See §5.)
 
 If no upstream runtime is selected (e.g. a direct `Lisp.run` with a stub
 `tools:` map), `requires` validation is skipped — the artifact still attaches

--- a/docs/plans/subagent-upstream-runtime-integration.md
+++ b/docs/plans/subagent-upstream-runtime-integration.md
@@ -57,22 +57,26 @@ as done):
   malformed `continuation_guard`, per §5.2).
 - **§6 `:e2e` test** — real LLM + the bridge over the dummy upstream is not yet
   written.
-- **Guide docs** — `docs/guides/capability-prelude.md` §7 still documents only
-  `run_lisp/3`, not `run_subagent/3` as the SubAgent↔upstream seam. (§5's
-  cross-turn guarantee wording has already been corrected to *fail-closed before
-  any side-effecting turn*.)
-- **Standalone side-effect honesty gap** — a standalone bridge consumer gets
-  fail-closed `requires` validation but **no** side-effect continuation guard by
-  default (`continuation_guard == nil ⇒ :continue`, `loop.ex:478-480`); the
-  stop-after-side-effect policy is mcp-owned until Phase 3. §8's "safe by default"
-  is a Phase-3 target, not Phase-1 reality, and the guide does not yet say so.
+- **Guide docs (delivered, §9 T4)** — `docs/guides/capability-prelude.md` §7 now
+  documents `run_subagent/3` as the multi-turn SubAgent↔upstream seam alongside
+  `run_lisp/3`. (§5's cross-turn guarantee wording was already corrected to
+  *fail-closed before any side-effecting turn*.)
+- **Standalone side-effect honesty gap (documented, §9 T4; gap stays Phase 3)** —
+  a standalone bridge consumer gets fail-closed `requires` validation but **no**
+  side-effect continuation guard by default (`continuation_guard == nil ⇒
+  :continue`, `loop.ex:478-480`); the stop-after-side-effect policy is mcp-owned
+  until Phase 3. §8's "safe by default" is a Phase-3 target, not Phase-1 reality —
+  the guide §5/§7 now says so (host-supplied-guard caveat). The underlying gap (no
+  core default guard) remains a Phase-3 item.
 
-**Phase 1.5 (do now) — see [§9 Implementation Checklist](#9-phase-15--implementation-checklist-do-now-workflow-executable).**
-A small, behaviour-preserving cleanup batch the 2026-06-05 design review surfaced:
-switch the bridge onto the internal `Runner.run/2` (`Definition`-only), add a
-Definition-contract test + a no-default-guard canary, and close the guide §7/§5 +
-§8 honesty gaps. Architecture unchanged; the Phase-2 facade and Phase-3 record
-surface stay deferred.
+**Phase 1.5 (delivered) — see [§9 Implementation Checklist](#9-phase-15--implementation-checklist-do-now-workflow-executable).**
+A small, behaviour-preserving cleanup batch the 2026-06-05 design review surfaced,
+now shipped: the bridge calls the internal `Runner.run/2` (`Definition`-only — §9
+T1), a Definition-contract test (T2) and a no-default-guard canary (T3) are in
+`test/ptc_runner/upstream/eval_run_subagent_test.exs`, and the guide §7/§5 + §8
+honesty gaps are closed (T4). Architecture unchanged; the Phase-2 facade and
+Phase-3 record surface stay deferred. The §6 raise-through-bridge fault test and
+the `:e2e` test remain outstanding — T2/T3 do not close them.
 
 Sections below preserve the original pre-implementation design record; read
 current-architecture claims there as historical context unless this status
@@ -237,14 +241,15 @@ change).** Three things the facade must get right:
   `PtcRunner.SubAgent.Runner.run/2`, **not** the public `SubAgent.run/2` (as the
   §3.2 lifecycle shows). The bridge passes `runtime:` in its opts and the facade
   keys on `runtime:`, so calling the public entry would recurse (facade → bridge
-  → `SubAgent.run` → facade → …). *Scheduled for **Phase 1.5** (§9 T1): switch the
-  bridge to call `PtcRunner.SubAgent.Runner.run/2` directly — decoupled from the
-  deferred facade, since it is behaviour-preserving today (the `%Definition{}`
-  clause of `SubAgent.run/2` is a pure forward to `Runner.run/2`) and pre-empts the
-  recursion the moment a Phase-2 facade lands. That switch also narrows
-  `run_subagent/3` to **`Definition`-only** (`@spec` → `Definition.t()`; a
-  non-Definition agent has no `:tools` field for `enrich_agent` to merge). The
-  shipped bridge still calls `PtcRunner.SubAgent.run` until T1 lands.*
+  → `SubAgent.run` → facade → …). *Delivered in **Phase 1.5** (§9 T1): the bridge
+  now calls `PtcRunner.SubAgent.Runner.run/2` directly — decoupled from the
+  deferred facade, behaviour-preserving (the `%Definition{}` clause of
+  `SubAgent.run/2` is a pure forward to `Runner.run/2`), and pre-empting the
+  recursion the moment a Phase-2 facade lands. The switch also narrowed
+  `run_subagent/3` to **`Definition`-only** (`@spec` → `Definition.t()`;
+  `enrich_agent/3` matches `%Definition{}` specifically, so a non-Definition fails
+  closed at enrich with `FunctionClauseError` rather than slipping through to raise
+  later in `Runner.run/2`).*
 - *Return shape.* `SubAgent.run(runtime:)` returns only the `SubAgent.run/2`
   result, **dropping** the bridge's `records` — mirroring `run_lisp/3` vs
   `run_lisp_with_records/3`. This keeps the public facade unsurprising and leaves
@@ -559,17 +564,24 @@ are delivered — see `test/ptc_runner/upstream/eval_run_subagent_test.exs`,
 - **mcp_server regression:** `agentic_contract_test.exs` still green after
   `run_subagent` collapses onto the core bridge (the ledger decorator + guard are
   unchanged mcp-side, so its `Ledger`/`root_tools_with_ledger` units still pass).
-- **Definition-only contract (§9 T1/T2, scheduled):** `run_subagent/3` runs a
-  `%Definition{}` and **raises** for a non-Definition agent (a `%CompiledAgent{}`
-  has no `:tools` field; a string is not a struct) — locking the contract that the
-  bridge re-enters the internal `Runner.run/2`, not the public facade.
-- **Standalone no-default-guard canary (§9 T3, scheduled):** a bridge run with a
-  *dispatching* write-effect upstream call and **no** `continuation_guard`
-  **continues** (no `partial_side_effects` stop), pinning today's
-  `continuation_guard == nil ⇒ :continue` so a future Phase-3 core default flips
-  this test loudly. *(Distinct from the still-outstanding raise-through-bridge
-  fault test and `:e2e` test — the canary pins behaviour, it does not exercise a
-  raising path or a real LLM.)*
+- **Definition-only contract (§9 T1/T2, delivered):** `run_subagent/3` runs a
+  `%Definition{}` and **raises** `FunctionClauseError` at `enrich_agent/3` for a
+  non-Definition agent — a bare string, a `%CompiledAgent{}`, and (critically) a
+  bare map that *does* carry a `:tools` field. The map case asserts the raise
+  originates in `enrich_agent/3` specifically, so a loose `%{tools: _}` regression
+  (which would instead raise later in `Runner.run/2`) fails the test. Locks the
+  contract that the bridge re-enters the internal `Runner.run/2`, not the public
+  facade.
+- **Standalone no-default-guard canary (§9 T3, delivered):** a bridge run with a
+  *dispatching* upstream call and **no** `continuation_guard` is **not stopped**
+  between turns — it reaches turn 2 and returns. This pins the observable shape of
+  `continuation_guard == nil ⇒ :continue` (no side-effect bounding by default for a
+  standalone caller). Scope kept honest: the dispatched op is a read-only GET and
+  core is effect-blind, so the test pins *"not stopped"*, **not** behaviour against
+  a future Phase-3 effect-classifying default (which would need a write/unknown
+  dispatch to flip loudly). *(Distinct from the still-outstanding
+  raise-through-bridge fault test and `:e2e` test — the canary pins behaviour, it
+  does not exercise a raising path or a real LLM.)*
 
 ---
 
@@ -594,10 +606,12 @@ are delivered — see `test/ptc_runner/upstream/eval_run_subagent_test.exs`,
    format) into core yet — the *generic* ledger/classification/guard mechanism
    does belong in core; that move is Phase 3 (§4 target boundary).
 
-   **Phase 1.5 (do-now fast-follow, §9):** behaviour-preserving cleanups from the
-   2026-06-05 review — bridge → internal `Runner.run/2` (`Definition`-only),
-   Definition-contract + no-default-guard canary tests, and the guide §7/§5 + §8
-   honesty fixes. No architecture change; does not gate or block Phases 2/3.
+   **Phase 1.5 (delivered, §9):** behaviour-preserving cleanups from the
+   2026-06-05 review, now shipped — bridge → internal `Runner.run/2`
+   (`Definition`-only), Definition-contract + no-default-guard canary tests, and the
+   guide §7/§5 + §8 honesty fixes. No architecture change; did not gate or block
+   Phases 2/3. The §6 raise-through-bridge fault test and the `:e2e` test remain
+   outstanding.
 2. **Phase 2 (convenience):** `upstreams: config` form where core starts/stops a
    runtime for the run's duration (a facade over the bridge — does **not** need
    `runtime:` inside the loop); and the thin `SubAgent.run(runtime:)` delegating
@@ -648,6 +662,14 @@ are delivered — see `test/ptc_runner/upstream/eval_run_subagent_test.exs`,
 ---
 
 ## 9. Phase 1.5 — Implementation Checklist (do now, workflow-executable)
+
+> **Status: T1–T5 delivered.** T1 (bridge → internal `Runner.run/2`, `Definition`-only),
+> T2/T3 (Definition-contract + no-default-guard canary in
+> `test/ptc_runner/upstream/eval_run_subagent_test.exs`), T4 (guide §5/§7 seam +
+> host-guard caveat), and T5 (this reconciliation) shipped together. The
+> verification gate (precommit + mcp `agentic_contract_test.exs` + codex review)
+> passed. The §6 raise-through-bridge fault test and the `:e2e` test stay
+> **outstanding** — they are explicitly *not* closed by T2/T3.
 
 **Scope.** Behaviour-preserving cleanups + honesty/test gaps the 2026-06-05
 design review surfaced. **No architecture change.** The Phase-2 facade and the

--- a/lib/ptc_runner/upstream/eval.ex
+++ b/lib/ptc_runner/upstream/eval.ex
@@ -7,6 +7,7 @@ defmodule PtcRunner.Upstream.Eval do
   `discovery_exec:`), and runs PTC-Lisp programs against them.
   """
 
+  alias PtcRunner.SubAgent.{Definition, Runner}
   alias PtcRunner.Upstream.{CallTool, Discovery, RunContext}
 
   @context_keys [
@@ -100,10 +101,15 @@ defmodule PtcRunner.Upstream.Eval do
 
   `:discovery_exec` and `:runtime` are bridge-owned; any caller-supplied values
   for those keys are ignored.
+
+  The `agent` argument must be a `%PtcRunner.SubAgent.Definition{}` (as built by
+  `SubAgent.new/1`): the bridge merges the upstream `"call"` tool into the
+  agent's `.tools` map and re-enters the internal `PtcRunner.SubAgent.Runner.run/2`
+  rather than the public facade.
   """
   @bridge_keys [:on_upstream_call, :allow_call_override, :discovery_exec, :runtime]
 
-  @spec run_subagent(struct() | pid(), struct(), keyword()) ::
+  @spec run_subagent(struct() | pid(), Definition.t(), keyword()) ::
           {{:ok, PtcRunner.Step.t()} | {:error, PtcRunner.Step.t()}, [map()]}
   def run_subagent(runtime, agent, opts \\ []) do
     context_opts = Keyword.take(opts, @context_keys)
@@ -121,7 +127,11 @@ defmodule PtcRunner.Upstream.Eval do
         |> Keyword.put(:discovery_exec, eval_opts[:discovery_exec])
         |> Keyword.put(:runtime, runtime)
 
-      PtcRunner.SubAgent.run(enriched, run_opts)
+      # Internal runner, not the public facade -- pre-empts facade/bridge recursion
+      # when the Phase-2 SubAgent.run(runtime:) facade lands (plan section 3.1).
+      # Behaviour-preserving today: the %Definition{} clause of SubAgent.run/2 is a
+      # pure forward to Runner.run/2.
+      Runner.run(enriched, run_opts)
     end)
   end
 
@@ -131,12 +141,16 @@ defmodule PtcRunner.Upstream.Eval do
     %{tools | "call" => decorate.(call)}
   end
 
-  # Merge the upstream `"call"` tool into the agent BEFORE SubAgent.run so it is
+  # Merge the upstream `"call"` tool into the agent BEFORE the agent runs so it is
   # visible both in the first-turn prompt and in every per-turn execution surface
   # (both re-derive from `agent.tools`). Reserve `"call"` for the upstream tool: a
   # silent local override would make prelude `requires` validation (against the
   # runtime) disagree with execution (a local fn).
-  defp enrich_agent(%{tools: tools} = agent, call_tool, allow_override) do
+  #
+  # Matches `%Definition{}` specifically (not just any `%{tools: _}`): the bridge
+  # is Definition-only (see `@spec`), so a non-Definition agent fails closed here
+  # with `FunctionClauseError` rather than slipping through enrich to raise later.
+  defp enrich_agent(%Definition{tools: tools} = agent, call_tool, allow_override) do
     cond do
       not Map.has_key?(tools, "call") ->
         %{agent | tools: Map.merge(tools, call_tool)}

--- a/test/ptc_runner/upstream/eval_run_subagent_test.exs
+++ b/test/ptc_runner/upstream/eval_run_subagent_test.exs
@@ -350,11 +350,145 @@ defmodule PtcRunner.Upstream.EvalRunSubagentTest do
   end
 
   # ------------------------------------------------------------------
+  # Definition-only contract (T2)
+  # ------------------------------------------------------------------
+
+  describe "run_subagent/3 is Definition-only" do
+    setup do
+      {:ok, runtime} = Runtime.start_link(config: config())
+      on_exit(fn -> Runtime.stop(runtime) end)
+      %{runtime: runtime}
+    end
+
+    # enrich_agent/3 matches `%Definition{}` specifically, so any non-Definition
+    # agent fails closed at enrich with FunctionClauseError. This pins the
+    # Definition-only contract T1 made explicit: the bridge re-enters the internal
+    # Runner.run/2, NOT the public facade (which also accepts strings and
+    # CompiledAgents). The match is on the struct, not merely the presence of a
+    # `:tools` field (see the third test). A started runtime must be in scope
+    # because run_subagent opens a RunContext before reaching enrich_agent.
+    test "a bare-string agent raises FunctionClauseError at enrich", %{runtime: runtime} do
+      assert_raise FunctionClauseError, fn ->
+        Eval.run_subagent(runtime, "not an agent", llm: stub_llm("1"))
+      end
+    end
+
+    test "a %CompiledAgent{} agent raises FunctionClauseError at enrich", %{runtime: runtime} do
+      # CompiledAgent is not a %Definition{} (and has no :tools field), so
+      # enrich_agent/3's %Definition{} clause does not match.
+      compiled = %PtcRunner.SubAgent.CompiledAgent{source: "(return 1)"}
+
+      assert_raise FunctionClauseError, fn ->
+        Eval.run_subagent(runtime, compiled, llm: stub_llm("1"))
+      end
+    end
+
+    test "a non-Definition that DOES carry a :tools field still raises at enrich",
+         %{runtime: runtime} do
+      # Guards against a looser `%{tools: _}` match: a bare map (or any non-Definition
+      # struct with a :tools field, e.g. %PtcRunner.Context{}) is NOT a Definition.
+      # FunctionClauseError alone is not enough to pin the fix: under a loose head the
+      # map would slip through enrich and raise the *same* error later in Runner.run/2.
+      # So assert the raise originates in enrich_agent/3 specifically — a regression to
+      # `%{tools: _}` would move it to Runner.run/2 and fail these assertions. Locks
+      # "Definition-only" to the struct, not merely the presence of the field.
+      err =
+        assert_raise FunctionClauseError, fn ->
+          Eval.run_subagent(runtime, %{tools: %{}}, llm: stub_llm("1"))
+        end
+
+      assert err.module == PtcRunner.Upstream.Eval
+      assert err.function == :enrich_agent
+      assert err.arity == 3
+    end
+  end
+
+  # ------------------------------------------------------------------
+  # No-default-guard canary (T3)
+  # ------------------------------------------------------------------
+
+  describe "a dispatching upstream call is not stopped between turns without a guard" do
+    # What this asserts (observable): with NO continuation_guard supplied, a turn
+    # that dispatches an upstream call does not stop the run — it proceeds to turn 2
+    # and returns. That is the visible shape of "no side-effect bounding by default"
+    # (capability-prelude guide §5/§7): a standalone caller that passes no
+    # continuation_guard gets no between-turn stop.
+    #
+    # At the code level this is the nil-guard branch of loop.ex
+    # apply_continuation_guard (nil => :continue, ~line 478); run_subagent/3 forwards
+    # only caller opts and adds no guard of its own. CORE is effect-blind here: the
+    # read/write classification + any stop-after-side-effect policy are mcp-owned
+    # (the ledger) and ABSENT in this standalone run.
+    #
+    # Scope (deliberately narrow, to avoid overclaiming): the dispatched op is a
+    # read-only observatory GET, so a "continue" outcome only proves *this dispatch
+    # was not stopped*. It does NOT prove behaviour against a hypothetical default
+    # guard that classifies effects — a read-allowing guard would also let it pass.
+    # Pinning behaviour against the planned Phase-3 write/unknown-stop default would
+    # need a side-effecting dispatch, and is deferred with that default. (Distinct
+    # from the still-outstanding raise-through-bridge fault test and the :e2e test.)
+    test "a dispatched upstream call between turns does not stop the run" do
+      {:ok, server} = start_http_fixture(%{"traces" => [%{"id" => "t-1", "org_id" => "acme"}]})
+      {:ok, runtime} = Runtime.start_link(config: config(base_url: server.base_url))
+
+      agent =
+        SubAgent.new(
+          prompt: "List traces, then return.",
+          runtime_prelude: direct_prelude(),
+          output: :ptc_lisp,
+          max_turns: 2
+        )
+
+      try do
+        # turn 1: a bare value (no `(return ...)`) that dispatches an upstream
+        #         HTTP call => loop Head 5 => {:continue} => between-turn checkpoint
+        # turn 2: explicit (return 42) => Head 1 => {:ok, step}, step.return == 42
+        {result, records} =
+          Eval.run_subagent(runtime, agent,
+            llm:
+              sequenced_llm([
+                ~S|(api/list-traces "acme")|,
+                "(return 42)"
+              ])
+          )
+
+        # Reached turn 2 and completed normally — the run continued.
+        assert {:ok, step} = result
+        assert step.return == 42
+
+        # NOT stopped — no guard fired (e.g. no :partial_side_effects).
+        assert step.fail == nil
+
+        # The between-turn checkpoint did NOT stop the loop after turn 1.
+        assert length(step.turns) == 2
+
+        # Prove the turn-1 upstream call genuinely dispatched through the bridge.
+        assert [%{"server" => "observatory", "tool" => "list-traces", "status" => "ok"}] = records
+        assert_receive {:http_fixture_request, _request}, 1_000
+      after
+        Runtime.stop(runtime)
+      end
+    end
+  end
+
+  # ------------------------------------------------------------------
   # Helpers
   # ------------------------------------------------------------------
 
   defp stub_llm(program) do
     fn _input -> {:ok, "```clojure\n#{program}\n```"} end
+  end
+
+  # Turn-sequenced LLM: returns a DIFFERENT program per call (head of the list,
+  # popped each invocation), each wrapped in a fenced clojure block exactly like
+  # stub_llm/1. Lets one run drive distinct programs across turns.
+  defp sequenced_llm(programs) do
+    {:ok, agent} = Agent.start_link(fn -> programs end)
+
+    fn _input ->
+      program = Agent.get_and_update(agent, fn [head | rest] -> {head, rest} end)
+      {:ok, "```clojure\n#{program}\n```"}
+    end
   end
 
   defp counting_llm(counter, program) do


### PR DESCRIPTION
Implements **Phase 1.5** of the SubAgent↔upstream plan (`docs/plans/subagent-upstream-runtime-integration.md` §9). Behaviour-preserving cleanups + honesty/test gaps from the 2026-06-05 design review. **No architecture change.**

## What changed (T1–T5)

- **T1 — bridge re-enters the internal runner.** `Upstream.Eval.run_subagent/3` now calls `SubAgent.Runner.run/2` instead of the public `SubAgent.run/2` facade, pre-empting the facade↔bridge recursion the deferred Phase-2 `SubAgent.run(runtime:)` facade would otherwise introduce. Behaviour-preserving today: the `%Definition{}` clause of `SubAgent.run/2` is a pure forward to `Runner.run/2`. `@spec` narrowed to `Definition.t()`, and `enrich_agent/3` now matches `%Definition{}` specifically so the runtime guard matches the spec (a non-Definition fails closed *at enrich*, not later).
- **T2 — Definition-only contract test.** A non-Definition agent (bare string, `%CompiledAgent{}`, or a bare map that *does* carry a `:tools` field) raises `FunctionClauseError` at `enrich_agent/3`. The map case pins the raise *location* specifically, so a regression to a loose `%{tools: _}` head (which would instead raise later in `Runner.run/2`) fails the test.
- **T3 — no-default-guard canary.** With no `continuation_guard` supplied, a dispatching upstream call between turns does **not** stop the run (it reaches turn 2 and returns) — the observable shape of "no side-effect bounding by default" for a standalone caller (`continuation_guard == nil ⇒ :continue`). Scope kept honest: the dispatched op is a read-only GET and core is effect-blind, so it pins *"not stopped"*, not behaviour against a future effect-classifying default.
- **T4 — guide docs.** `capability-prelude.md` §7 documents `run_subagent/3` as the multi-turn upstream seam; §5/§7 add the host-supplied `continuation_guard` caveat.
- **T5 — plan reconciliation.** Flipped the T1–T4 markers in §0/§3.1/§6/§7 from *scheduled* → *delivered*.

## Still outstanding (deferred, not in this PR)

- The §6 **raise-through-bridge** fault test and the **`:e2e`** test — explicitly *not* closed by T2/T3.
- The Phase-2 `SubAgent.run(runtime:)` facade and the Phase-3 record surface stay deferred.

## Verification

- `mix precommit` green: format, `compile --warnings-as-errors`, xref cycles, `credo --strict`, schema.gen, validate_spec, `test` (**5874 tests, 0 failures**), plus sibling suites (demo 200/0, ptc_viewer 9/0).
- `mcp_server` `agentic_contract_test.exs`: **5 tests, 0 failures** (the bridge collapse stays green).
- New `eval_run_subagent_test.exs`: **14 tests, 0 failures**.
- **codex review: clean** — converged over 5 passes (1 review + 4 adversarial). Fixes made along the way: `enrich_agent/3` tightened to truly `%Definition{}`-only, the canary's claim narrowed to the honest read-only "not stopped" scope, and the map-case assertion pinned to `enrich_agent/3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)