### PR TITLE
fix(ci): stabilize Viewer checks on Elixir 1.20.2

### DIFF
--- a/.github/actions/setup-elixir/action.yml
+++ b/.github/actions/setup-elixir/action.yml
@@ -8,7 +8,7 @@ runs:
       id: setup-beam
       uses: erlef/setup-beam@v1
       with:
-        elixir-version: '1.20.0'
+        elixir-version: '1.20.2'
         otp-version: '28.5.0.1'
 
     - name: Cache deps and _build
@@ -18,9 +18,9 @@ runs:
         path: |
           deps
           _build
-        key: ${{ runner.os }}-mix-otp28.5.0.1-elixir1.20.0-${{ hashFiles('**/mix.lock') }}
+        key: ${{ runner.os }}-mix-otp28.5.0.1-elixir1.20.2-${{ hashFiles('**/mix.lock') }}
         restore-keys: |
-          ${{ runner.os }}-mix-otp28.5.0.1-elixir1.20.0-
+          ${{ runner.os }}-mix-otp28.5.0.1-elixir1.20.2-
 
     - name: Get dependencies
       run: mix deps.get
@@ -30,9 +30,9 @@ runs:
       uses: actions/cache@v5
       with:
         path: priv/plts
-        key: plt-${{ runner.os }}-otp28.5.0.1-elixir1.20.0-${{ hashFiles('**/mix.lock') }}
+        key: plt-${{ runner.os }}-otp28.5.0.1-elixir1.20.2-${{ hashFiles('**/mix.lock') }}
         restore-keys: |
-          plt-${{ runner.os }}-otp28.5.0.1-elixir1.20.0-
+          plt-${{ runner.os }}-otp28.5.0.1-elixir1.20.2-
 
     - name: Cache Babashka
       uses: actions/cache@v5

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,3 @@
+[tools]
+erlang = "28.5.0.1"
+elixir = "1.20.2-otp-28"

--- a/ptc_viewer/lib/ptc_viewer/repl_store.ex
+++ b/ptc_viewer/lib/ptc_viewer/repl_store.ex
@@ -179,7 +179,10 @@ defmodule PtcViewer.ReplStore do
   def handle_call(_request, _from, state), do: {:reply, {:error, :adapter_failure}, state}
 
   @impl GenServer
-  def handle_info({ref, result}, %{foreground: %{task: %{ref: ref}} = foreground} = state) do
+  def handle_info(
+        {ref, result},
+        %{foreground: %{task: %{task: %{ref: ref}}} = foreground} = state
+      ) do
     observe_task_down(foreground.task)
     state = %{state | foreground: nil}
     {:noreply, finish_foreground(state, foreground, result)}
@@ -187,7 +190,7 @@ defmodule PtcViewer.ReplStore do
 
   def handle_info(
         {:DOWN, ref, :process, _pid, reason},
-        %{foreground: %{task: %{ref: ref}}} = state
+        %{foreground: %{task: %{task: %{ref: ref}}}} = state
       ) do
     if reason == :normal do
       {:noreply, state}
@@ -196,7 +199,10 @@ defmodule PtcViewer.ReplStore do
     end
   end
 
-  def handle_info({:foreground_timeout, ref}, %{foreground: %{task: %{ref: ref}}} = state) do
+  def handle_info(
+        {:foreground_timeout, ref},
+        %{foreground: %{task: %{task: %{ref: ref}}}} = state
+      ) do
     terminate_task(state.foreground.task)
     {:noreply, recover_or_fail_foreground(state, :timeout)}
   end
@@ -209,7 +215,10 @@ defmodule PtcViewer.ReplStore do
     {:noreply, %{state | recovery: %{recovery | task: task, retry_timer: nil}}}
   end
 
-  def handle_info({ref, result}, %{recovery: %{task: %{ref: ref}} = recovery} = state) do
+  def handle_info(
+        {ref, result},
+        %{recovery: %{task: %{task: %{ref: ref}}} = recovery} = state
+      ) do
     observe_task_down(recovery.task)
 
     foreground =
@@ -224,7 +233,7 @@ defmodule PtcViewer.ReplStore do
 
   def handle_info(
         {:DOWN, ref, :process, _pid, reason},
-        %{recovery: %{task: %{ref: ref}} = recovery} = state
+        %{recovery: %{task: %{task: %{ref: ref}}} = recovery} = state
       ) do
     if reason == :normal do
       {:noreply, state}
@@ -233,12 +242,18 @@ defmodule PtcViewer.ReplStore do
     end
   end
 
-  def handle_info({:recovery_timeout, ref}, %{recovery: %{task: %{ref: ref}} = recovery} = state) do
+  def handle_info(
+        {:recovery_timeout, ref},
+        %{recovery: %{task: %{task: %{ref: ref}}} = recovery} = state
+      ) do
     terminate_task(recovery.task)
     {:noreply, schedule_recovery(%{state | recovery: %{recovery | task: nil}})}
   end
 
-  def handle_info({ref, result}, %{info_task: %{task: %{ref: ref}} = info_task} = state) do
+  def handle_info(
+        {ref, result},
+        %{info_task: %{task: %{task: %{ref: ref}}} = info_task} = state
+      ) do
     observe_task_down(info_task.task)
     state = %{state | info_task: nil}
 
@@ -254,11 +269,14 @@ defmodule PtcViewer.ReplStore do
 
   def handle_info(
         {:DOWN, ref, :process, _pid, _reason},
-        %{info_task: %{task: %{ref: ref}}} = state
+        %{info_task: %{task: %{task: %{ref: ref}}}} = state
       ),
       do: {:noreply, %{state | info_task: nil}}
 
-  def handle_info({:info_timeout, ref}, %{info_task: %{task: %{ref: ref}}} = state) do
+  def handle_info(
+        {:info_timeout, ref},
+        %{info_task: %{task: %{task: %{ref: ref}}}} = state
+      ) do
     terminate_task(state.info_task.task)
     {:noreply, %{state | info_task: nil}}
   end
@@ -876,13 +894,13 @@ defmodule PtcViewer.ReplStore do
   defp launch_task(state, timeout_ms, function) do
     task = Task.Supervisor.async_nolink(state.task_supervisor, function)
     timer = Process.send_after(self(), {:foreground_timeout, task.ref}, timeout_ms)
-    Map.put(task, :timer, timer)
+    %{task: task, timer: timer}
   end
 
   defp launch_info_task(state, function) do
     task = Task.Supervisor.async_nolink(state.task_supervisor, function)
     timer = Process.send_after(self(), {:info_timeout, task.ref}, @short_timeout_ms)
-    Map.put(task, :timer, timer)
+    %{task: task, timer: timer}
   end
 
   defp launch_reconciliation_task(state, foreground) do
@@ -899,11 +917,8 @@ defmodule PtcViewer.ReplStore do
         ])
       end)
 
-    Map.put(
-      task,
-      :timer,
-      Process.send_after(self(), {:recovery_timeout, task.ref}, @short_timeout_ms)
-    )
+    timer = Process.send_after(self(), {:recovery_timeout, task.ref}, @short_timeout_ms)
+    %{task: task, timer: timer}
   end
 
   defp launch_recovery_task(state, recovery) do
@@ -912,11 +927,8 @@ defmodule PtcViewer.ReplStore do
         reconciliation_result(state, recovery)
       end)
 
-    Map.put(
-      task,
-      :timer,
-      Process.send_after(self(), {:recovery_timeout, task.ref}, @operation_timeout_ms)
-    )
+    timer = Process.send_after(self(), {:recovery_timeout, task.ref}, @operation_timeout_ms)
+    %{task: task, timer: timer}
   end
 
   defp reconciliation_result(state, foreground) do
@@ -960,12 +972,12 @@ defmodule PtcViewer.ReplStore do
 
   defp preserve_recovery_failure_state(state, _foreground), do: state
 
-  defp terminate_task(task) do
-    cancel_timer(task.timer)
+  defp terminate_task(%{task: task, timer: timer}) do
+    cancel_timer(timer)
     Task.shutdown(task, :brutal_kill)
   end
 
-  defp observe_task_down(%{pid: pid, ref: ref, timer: timer}) do
+  defp observe_task_down(%{task: %{pid: pid, ref: ref}, timer: timer}) do
     cancel_timer(timer)
 
     receive do

--- a/ptc_viewer/lib/ptc_viewer/router.ex
+++ b/ptc_viewer/lib/ptc_viewer/router.ex
@@ -462,8 +462,12 @@ defmodule PtcViewer.Router do
   defp allowed_methods("/api/repl"), do: "GET, DELETE"
   defp allowed_methods(_path), do: "POST"
 
-  defp scrub_bandit_response(%{adapter: {Bandit.Adapter, _adapter}} = conn),
-    do: %{conn | resp_body: nil, req_headers: []}
+  defp scrub_bandit_response(%{adapter: {Bandit.Adapter, _adapter}} = conn) do
+    resp_headers =
+      Enum.reject(conn.resp_headers, fn {name, _value} -> name == "x-ptc-viewer-session" end)
+
+    %{conn | resp_body: nil, req_headers: [], resp_headers: resp_headers}
+  end
 
   defp scrub_bandit_response(conn), do: conn
 

--- a/ptc_viewer/lib/ptc_viewer/server.ex
+++ b/ptc_viewer/lib/ptc_viewer/server.ex
@@ -217,8 +217,6 @@ defmodule PtcViewer.Server do
 
   defp connect_repl(_adapter, _config), do: {:error, :invalid_repl_config}
 
-  defp start_repl_store(nil, nil, _task_supervisor), do: {:ok, nil}
-
   defp start_repl_store(%ReplConnection{} = connection, adapter, task_supervisor) do
     ReplStore.start_link(
       owner: self(),

--- a/test/mix/tasks/ptc_repl_test.exs
+++ b/test/mix/tasks/ptc_repl_test.exs
@@ -521,10 +521,10 @@ defmodule Mix.Tasks.Ptc.ReplTest do
           "(count (get (log/runs {}) \"items\"))"
         ],
         cd: File.cwd!(),
-        env: [{"MIX_ENV", "test"}]
+        env: [{"MIX_ENV", "test"}, {"MIX_QUIET", "1"}]
       )
 
-    records = decode_jsonl(output)
+    records = decode_mix_jsonl(output)
     assert Enum.map(records, & &1["type"]) == ["session-started", "evaluation", "session-closed"]
     assert Enum.at(records, 1)["result"]["value"] == 1
     assert File.regular?(List.last(records)["trace_path"])
@@ -544,6 +544,13 @@ defmodule Mix.Tasks.Ptc.ReplTest do
   defp decode_jsonl(output) do
     output
     |> String.split("\n", trim: true)
+    |> Enum.map(&Jason.decode!/1)
+  end
+
+  defp decode_mix_jsonl(output) do
+    output
+    |> String.split("\n", trim: true)
+    |> Enum.reject(&String.starts_with?(&1, "==> "))
     |> Enum.map(&Jason.decode!/1)
   end
 

--- a/test/ptc_runner/lisp/eval_sets_test.exs
+++ b/test/ptc_runner/lisp/eval_sets_test.exs
@@ -245,7 +245,6 @@ defmodule PtcRunner.Lisp.EvalSetsTest do
     case PtcRunner.Lisp.run(source) do
       {:ok, %Step{return: result}} -> {:ok, result, %{}}
       {:error, %Step{} = step} -> {:error, step}
-      {:error, reason} -> {:error, reason}
     end
   end
 end


### PR DESCRIPTION
## Summary

- scrub the private `x-ptc-viewer-session` response header from the post-send Bandit telemetry projection while preserving it for the HTTP client
- represent Viewer task timers outside `Task` structs and remove an unreachable server clause, resolving Elixir 1.20 compiler warnings
- make the JSONL subprocess test tolerate only Mix application banners while continuing to decode every command-output line as JSON
- pin local mise and GitHub Actions to Elixir 1.20.2 with OTP 28.5.0.1, including fresh cache keys

## CI failures addressed

- PR #1109 CI attempt 1 exposed the REPL session identifier in Bandit's stop telemetry
- PR #1109 CI attempt 2 emitted `==> ptc_viewer` before JSONL records and failed under `--warnings-as-errors` on two Viewer warnings
- Elixir 1.20.2 additionally identified an unreachable fallback in the set-evaluation test helper

These failures are unrelated to the Java interop changes in #1109 and are fixed separately here so that branch can rebase after merge.

## Verification

- `mise exec -- elixir --version` → Elixir 1.20.2 / Erlang/OTP 28
- `mise exec -- mix test test/ptc_runner/kernel/viewer_repl_http_test.exs test/mix/tasks/ptc_repl_test.exs:500 --trace --warnings-as-errors`
- `cd ptc_viewer && mise exec -- mix test test/ptc_viewer/repl_router_test.exs test/ptc_viewer/repl_store_test.exs test/ptc_viewer/server_test.exs --warnings-as-errors`
- `mise exec -- mix precommit`
- `mise exec -- mix prepush`
- `actionlint .github/workflows/test.yml .github/workflows/e2e.yml .github/workflows/release.yml`

The repository commit and push hooks also passed.
