### PR TITLE
docs: audit code documentation — remove dangling plan/spec references

### DIFF
--- a/.claude/workflows/code-doc-audit.js
+++ b/.claude/workflows/code-doc-audit.js
@@ -1,0 +1,245 @@
+export const meta = {
+  name: 'code-doc-audit',
+  description:
+    'Audit in-code documentation (@moduledoc/@doc/@typedoc/@shortdoc and doc comments in lib/**) for stale references to specs/plans that no longer exist, broken doc links, and drift from the implementation',
+  phases: [
+    { title: 'Audit', detail: 'one agent per file group' },
+    { title: 'Verify', detail: 'adversarially verify each finding against source/docs' },
+    { title: 'Synthesize', detail: 'systemic patterns and cross-file consistency' },
+  ],
+}
+
+// Ground truth established by scouting before this run:
+const CONTEXT = `Repository: PtcRunner — a BEAM-native Elixir runtime for Programmatic Tool Calling (PTC-Lisp). You run at the repo root.
+You are auditing IN-CODE documentation: \`@moduledoc\`, \`@doc\`, \`@typedoc\`, \`@shortdoc\`, and doc/rationale \`#\` comments in \`lib/**/*.ex\`. (\`@spec\` typespecs are NOT doc prose — never flag them.)
+
+Retained, authoritative references (verify claims against these, on disk):
+- Implementation: \`lib/**\`, \`priv/preludes/**\`, \`priv/*.exs\`, \`mix.exs\`, \`examples/**\`.
+- Language spec: \`docs/ptc-lisp-specification.md\`. Its ONLY top-level sections are 1–16:
+  1 Overview, 2 Lexical Structure, 3 Data Types, 4 Truthiness, 5 Special Forms, 6 Threading Macros,
+  7 Filtering Predicates, 8 Core Functions, 9 Namespaces/Context/Tools, 10 Complete Examples,
+  11 Semantics and Edge Cases, 12 Error Handling, 13 Language Scope and Restrictions, 14 Grammar (EBNF),
+  15 Implementation Notes, 16 Memory Model for Agentic Loops.
+  There is NO JSON section and NO §4.2/§4.3/§4.4 subsections (§4 is "Truthiness", with no subsections).
+  Always confirm a cited §number by grepping headings: \`rg -n '^#{1,4} [0-9]' docs/ptc-lisp-specification.md\`.
+- Conformance IDs (\`DIV-*\`, \`GAP-*\`) live in \`docs/clojure-conformance-gaps.md\`; confirm each cited ID exists: \`rg -n '^### (DIV-13|GAP-S54):' docs/clojure-conformance-gaps.md\`.
+- ExDoc \`:extras\` (the only .md files an ExDoc autolink like \`[x](foo.md)\` resolves to): README.md, LICENSE, docs/ptc-lisp-specification.md, docs/clojure-conformance-gaps.md, docs/function-reference.md, docs/java-interop.md, docs/trace-log-contract.md, docs/conformance/index.md, docs/conformance/*-audit.md, and docs/guides/{capability-prelude,getting-started,building-agents,manifests-and-capabilities,running-and-debugging,embedding-in-elixir,documentation-guidelines,kernel-maintainer,kernel-tutorial,kernel-repl}.md.
+
+Documentation-guidelines rules that bind code docs (docs/guides/documentation-guidelines.md):
+- Code documentation MUST NOT reference implementation plans or planning specifications (anything under docs/plans/). Durable contracts belong in module docs / guides / retained specs.
+- ESTABLISHED FACT for this audit: the code carries ~35 "plan §N" citations (e.g. "(plan §12)", "plan §3 / §6A", "Capability Prelude V1, plan §5"). NO current plan document uses §-numbered sections (the prelude plan uses named "## ..." / "### Phase N" headings), and no retained doc defines "Capability Prelude V1". So every "plan §N" citation is a DANGLING reference to a superseded plan AND a guideline violation. Flag each as category "plan-reference"; the fix is to delete the "(plan §N)" citation while KEEPING the surrounding rationale prose intact and grammatical.
+- Use real, current module/function/option/error names; verify before trusting the doc.
+- No migration narratives or deprecated-alternative descriptions (git history holds removed 0.x designs).`
+
+const FINDINGS_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          file: { type: 'string' },
+          line: { type: 'integer' },
+          category: {
+            type: 'string',
+            enum: [
+              'plan-reference',
+              'stale-spec-reference',
+              'broken-conformance-id',
+              'broken-doc-link',
+              'stale-content',
+              'correctness',
+            ],
+          },
+          severity: { type: 'string', enum: ['high', 'medium', 'low'] },
+          summary: { type: 'string', description: 'one-sentence statement of the defect' },
+          evidence: {
+            type: 'string',
+            description: 'the exact doc text + the source/heading you checked that proves it wrong or missing',
+          },
+          suggested_fix: {
+            type: 'string',
+            description: 'concrete replacement text; for plan-reference give the exact edited sentence',
+          },
+        },
+        required: ['file', 'line', 'category', 'severity', 'summary', 'evidence', 'suggested_fix'],
+      },
+    },
+  },
+  required: ['findings'],
+}
+
+const VERDICT_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    verdict: { type: 'string', enum: ['CONFIRMED', 'REJECTED'] },
+    corrected_severity: { type: 'string', enum: ['high', 'medium', 'low'] },
+    reasoning: { type: 'string' },
+  },
+  required: ['verdict', 'reasoning'],
+}
+
+const SYNTH_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    systemic_patterns: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+          pattern: { type: 'string' },
+          affected_files: { type: 'array', items: { type: 'string' } },
+          recommendation: { type: 'string' },
+        },
+        required: ['pattern', 'affected_files', 'recommendation'],
+      },
+    },
+    notes: { type: 'string' },
+  },
+  required: ['systemic_patterns', 'notes'],
+}
+
+const auditPrompt = (group) => `Audit the in-code documentation in this file group: **${group.name}**.
+
+Files (audit the doc prose in each — read every one, in chunks if long):
+${group.files.map((f) => '- ' + f).join('\n')}
+
+${CONTEXT}
+
+For every \`@moduledoc\`/\`@doc\`/\`@typedoc\`/\`@shortdoc\` string and every explanatory \`#\` comment in these files, check:
+1. PLAN REFERENCES — any "plan §N", "(plan ...)", "plan acceptance", "Prelude V1 ... plan", or similar citation of a planning document. Flag each (category "plan-reference"); the suggested_fix is the sentence rewritten with the citation removed and prose kept.
+2. STALE SPEC REFERENCES — any "§X", "§X.Y", "spec §…", "Section N", or paragraph pointer into the language spec. Grep the spec headings and confirm the number exists AND covers the cited topic. Flag mismatches (category "stale-spec-reference"). Note: "Section 13" (Language Scope) and "§3.5" (Character Literals) DO exist — confirm before flagging. The JSON \`§4.2/§4.3/§4.4\` citations do NOT resolve.
+3. BROKEN CONFORMANCE IDS — any \`DIV-*\`/\`GAP-*\` citation; confirm the ID exists in docs/clojure-conformance-gaps.md (category "broken-conformance-id" if absent).
+4. BROKEN DOC LINKS — any Markdown link or path to a .md/doc file; confirm the target exists on disk and (for ExDoc autolinks) is in :extras (category "broken-doc-link").
+5. STALE CONTENT — references to removed/renamed modules, functions, options, or events; migration narratives; behavior descriptions that no longer match the code (category "stale-content").
+6. CORRECTNESS — moduledoc/@doc claims contradicting the implementation: wrong option keys, error atoms, function names/arities, defaults, ownership, or return shapes (category "correctness"). Verify with grep against the module and its collaborators.
+
+Rules:
+- EVERY finding cites file + line + the exact doc text AND the source/heading you checked. No style nits, no speculation, no prose-polish suggestions.
+- Only report what you verified against disk in this run. Do NOT edit files.
+- If a file's docs are clean, say nothing about it. Return an empty findings array if the whole group is clean.
+
+Return the structured findings object.`
+
+const verifyPrompt = (f) => `Adversarially verify one in-code-documentation finding. Assume it is WRONG until source/docs prove it right; REJECT if you cannot independently substantiate it.
+
+File: ${f.file}
+Line: ${f.line}
+Category: ${f.category}
+Severity: ${f.severity}
+Claim: ${f.summary}
+Evidence given: ${f.evidence}
+Suggested fix: ${f.suggested_fix}
+
+${CONTEXT}
+
+Re-check independently against disk (do not trust the evidence text):
+- plan-reference: open the file at the line and confirm a plan citation is actually present in DOC prose (not a @spec, not unrelated). CONFIRM only if present.
+- stale-spec-reference: grep the spec headings yourself; CONFIRM only if the cited section truly does not exist or does not cover the topic. Remember §3.5, §13, and §16 etc. DO exist.
+- broken-conformance-id: grep docs/clojure-conformance-gaps.md for the exact ID; CONFIRM only if genuinely absent.
+- broken-doc-link: test the target path / :extras membership yourself.
+- stale-content / correctness: grep lib/**, priv/**, mix.exs to confirm the doc truly contradicts the code. A thing defined via macro/metaprogramming still exists.
+
+Return CONFIRMED or REJECTED with reasoning stating exactly what you checked. Optionally set corrected_severity.`
+
+const synthPrompt = (groups, confirmed) => `Synthesize the code-documentation audit. Per-file findings are done; identify systemic patterns and anything cross-file.
+
+Groups audited: ${groups.map((g) => g.name).join(', ')}.
+
+${CONTEXT}
+
+Confirmed findings (for context):
+${JSON.stringify(confirmed.map((f) => ({ file: f.file, line: f.line, category: f.category, summary: f.summary })), null, 2)}
+
+Produce:
+1. SYSTEMIC PATTERNS — issues that recur across many files and deserve one coordinated fix (e.g. the "plan §N" citation sweep, a spec section that was renumbered and is now cited wrong in several places, a repeated stale event/option name). For each, list the affected files and a single recommendation.
+2. NOTES — anything the per-file pass may have missed (a whole module's moduledoc describing removed behavior; a doc contract with no retained home) and a short statement of what came back clean.
+
+Only include patterns backed by the confirmed findings or by evidence you re-checked. Return the structured object.`
+
+// Balanced file groups (~13 files each) covering every lib/**/*.ex. Override by
+// passing an array of {name, files[]} as `args`.
+const DEFAULT_GROUPS = [
+  { name: 'mix/tasks', files: ['lib/mix/tasks/bench.check.ex', 'lib/mix/tasks/ptc.audit_upstream.ex', 'lib/mix/tasks/ptc.clojure_audit.ex', 'lib/mix/tasks/ptc.conformance_report.ex', 'lib/mix/tasks/ptc.gen_docs.ex', 'lib/mix/tasks/ptc.install_babashka.ex', 'lib/mix/tasks/ptc.repl.ex', 'lib/mix/tasks/ptc.run.ex', 'lib/mix/tasks/ptc.smoke.ex', 'lib/mix/tasks/ptc.update_spec_checksums.ex', 'lib/mix/tasks/ptc.validate_spec.ex'] },
+  { name: 'root', files: ['lib/ptc_runner.ex'] },
+  { name: 'ptc_runner', files: ['lib/ptc_runner/dotenv.ex', 'lib/ptc_runner/kernel.ex', 'lib/ptc_runner/lisp.ex', 'lib/ptc_runner/llm.ex', 'lib/ptc_runner/sandbox.ex'] },
+  { name: 'kernel#1', files: ['lib/ptc_runner/kernel/bounded_worker.ex', 'lib/ptc_runner/kernel/bundle_compiler.ex', 'lib/ptc_runner/kernel/capability.ex', 'lib/ptc_runner/kernel/component.ex', 'lib/ptc_runner/kernel/deterministic_json.ex', 'lib/ptc_runner/kernel/dispatcher.ex', 'lib/ptc_runner/kernel/environment.ex', 'lib/ptc_runner/kernel/error.ex', 'lib/ptc_runner/kernel/evaluation.ex', 'lib/ptc_runner/kernel/event_sink.ex', 'lib/ptc_runner/kernel/event_sink_state.ex', 'lib/ptc_runner/kernel/events.ex', 'lib/ptc_runner/kernel/file_capability.ex'] },
+  { name: 'kernel#2', files: ['lib/ptc_runner/kernel/frozen_bundle.ex', 'lib/ptc_runner/kernel/inspection_artifact.ex', 'lib/ptc_runner/kernel/inspection_sink.ex', 'lib/ptc_runner/kernel/json_schema.ex', 'lib/ptc_runner/kernel/json_value.ex', 'lib/ptc_runner/kernel/library.ex', 'lib/ptc_runner/kernel/limits.ex', 'lib/ptc_runner/kernel/llm_capability.ex', 'lib/ptc_runner/kernel/log_analysis_assembly.ex', 'lib/ptc_runner/kernel/log_analysis_profile.ex', 'lib/ptc_runner/kernel/log_analysis_session.ex', 'lib/ptc_runner/kernel/log_analysis_session_builder.ex', 'lib/ptc_runner/kernel/manifest.ex'] },
+  { name: 'kernel#3', files: ['lib/ptc_runner/kernel/mcp_lease.ex', 'lib/ptc_runner/kernel/mcp_source.ex', 'lib/ptc_runner/kernel/mission_environment.ex', 'lib/ptc_runner/kernel/mission_inventory.ex', 'lib/ptc_runner/kernel/model_contract.ex', 'lib/ptc_runner/kernel/program.ex', 'lib/ptc_runner/kernel/provider_error.ex', 'lib/ptc_runner/kernel/provider_registry.ex', 'lib/ptc_runner/kernel/repl_session.ex', 'lib/ptc_runner/kernel/result.ex', 'lib/ptc_runner/kernel/run_builder.ex', 'lib/ptc_runner/kernel/run_config.ex', 'lib/ptc_runner/kernel/run_state.ex'] },
+  { name: 'kernel#4', files: ['lib/ptc_runner/kernel/runner.ex', 'lib/ptc_runner/kernel/runtime_tools.ex', 'lib/ptc_runner/kernel/safe_metadata.ex', 'lib/ptc_runner/kernel/session_trace.ex', 'lib/ptc_runner/kernel/strict_json.ex', 'lib/ptc_runner/kernel/trace_capability.ex', 'lib/ptc_runner/kernel/trace_log.ex', 'lib/ptc_runner/kernel/trace_snapshot.ex', 'lib/ptc_runner/kernel/viewer_adapter.ex', 'lib/ptc_runner/kernel/viewer_repl_adapter.ex', 'lib/ptc_runner/kernel/viewer_repl_backend.ex', 'lib/ptc_runner/kernel/viewer_repl_session_worker.ex', 'lib/ptc_runner/kernel/workflow_environment.ex'] },
+  { name: 'lisp#1', files: ['lib/ptc_runner/lisp/ambiguous_arguments.ex', 'lib/ptc_runner/lisp/analyze.ex', 'lib/ptc_runner/lisp/ast.ex', 'lib/ptc_runner/lisp/builtin_names.ex', 'lib/ptc_runner/lisp/child_result.ex', 'lib/ptc_runner/lisp/clojure_validator.ex', 'lib/ptc_runner/lisp/closure_capture.ex', 'lib/ptc_runner/lisp/context.ex', 'lib/ptc_runner/lisp/core_ast.ex', 'lib/ptc_runner/lisp/core_to_source.ex', 'lib/ptc_runner/lisp/data_keys.ex', 'lib/ptc_runner/lisp/env.ex', 'lib/ptc_runner/lisp/eval.ex'] },
+  { name: 'lisp#2', files: ['lib/ptc_runner/lisp/externalized_map_key.ex', 'lib/ptc_runner/lisp/fast_parser.ex', 'lib/ptc_runner/lisp/format.ex', 'lib/ptc_runner/lisp/formatter.ex', 'lib/ptc_runner/lisp/key_normalizer.ex', 'lib/ptc_runner/lisp/keyword.ex', 'lib/ptc_runner/lisp/metadata.ex', 'lib/ptc_runner/lisp/parser.ex', 'lib/ptc_runner/lisp/prelude.ex', 'lib/ptc_runner/lisp/protected_namespaces.ex', 'lib/ptc_runner/lisp/registry.ex', 'lib/ptc_runner/lisp/result.ex', 'lib/ptc_runner/lisp/retained_size.ex'] },
+  { name: 'lisp#3', files: ['lib/ptc_runner/lisp/runtime.ex', 'lib/ptc_runner/lisp/runtime_callable.ex', 'lib/ptc_runner/lisp/schema.ex', 'lib/ptc_runner/lisp/signature.ex', 'lib/ptc_runner/lisp/source_atoms.ex', 'lib/ptc_runner/lisp/spec_validator.ex', 'lib/ptc_runner/lisp/symbol_counter.ex', 'lib/ptc_runner/lisp/tool.ex', 'lib/ptc_runner/lisp/trusted_tool.ex', 'lib/ptc_runner/lisp/type_extractor.ex', 'lib/ptc_runner/lisp/type_vocabulary.ex', 'lib/ptc_runner/lisp/untrusted_renderer.ex'] },
+  { name: 'lisp/analyze', files: ['lib/ptc_runner/lisp/analyze/conditionals.ex', 'lib/ptc_runner/lisp/analyze/definitions.ex', 'lib/ptc_runner/lisp/analyze/iteration.ex', 'lib/ptc_runner/lisp/analyze/patterns.ex', 'lib/ptc_runner/lisp/analyze/placeholder.ex', 'lib/ptc_runner/lisp/analyze/prelude_scope.ex', 'lib/ptc_runner/lisp/analyze/short_fn.ex'] },
+  { name: 'lisp/env', files: ['lib/ptc_runner/lisp/env/builtin.ex'] },
+  { name: 'lisp/eval', files: ['lib/ptc_runner/lisp/eval/abort.ex', 'lib/ptc_runner/lisp/eval/apply.ex', 'lib/ptc_runner/lisp/eval/capture.ex', 'lib/ptc_runner/lisp/eval/context.ex', 'lib/ptc_runner/lisp/eval/effects.ex', 'lib/ptc_runner/lisp/eval/helpers.ex', 'lib/ptc_runner/lisp/eval/host_context.ex', 'lib/ptc_runner/lisp/eval/outcome.ex', 'lib/ptc_runner/lisp/eval/parallel.ex', 'lib/ptc_runner/lisp/eval/parallel_budget.ex', 'lib/ptc_runner/lisp/eval/parallel_runner.ex', 'lib/ptc_runner/lisp/eval/patterns.ex', 'lib/ptc_runner/lisp/eval/parallel_runner/envelope.ex'] },
+  { name: 'lisp/java', files: ['lib/ptc_runner/lisp/java/surface.ex', 'lib/ptc_runner/lisp/java/surface/validator.ex'] },
+  { name: 'lisp/prelude', files: ['lib/ptc_runner/lisp/prelude/attach.ex', 'lib/ptc_runner/lisp/prelude/attach_context.ex', 'lib/ptc_runner/lisp/prelude/bundle.ex', 'lib/ptc_runner/lisp/prelude/compiler.ex', 'lib/ptc_runner/lisp/prelude/contract.ex', 'lib/ptc_runner/lisp/prelude/export.ex', 'lib/ptc_runner/lisp/prelude/form_scanner.ex', 'lib/ptc_runner/lisp/prelude/spec.ex', 'lib/ptc_runner/lisp/prelude/validation_error.ex'] },
+  { name: 'lisp/runtime#1', files: ['lib/ptc_runner/lisp/runtime/args.ex', 'lib/ptc_runner/lisp/runtime/builtins.ex', 'lib/ptc_runner/lisp/runtime/callable.ex', 'lib/ptc_runner/lisp/runtime/collection.ex', 'lib/ptc_runner/lisp/runtime/describe.ex', 'lib/ptc_runner/lisp/runtime/flex_access.ex', 'lib/ptc_runner/lisp/runtime/interop.ex', 'lib/ptc_runner/lisp/runtime/json.ex', 'lib/ptc_runner/lisp/runtime/map_ops.ex', 'lib/ptc_runner/lisp/runtime/math.ex', 'lib/ptc_runner/lisp/runtime/predicates.ex', 'lib/ptc_runner/lisp/runtime/regex.ex', 'lib/ptc_runner/lisp/runtime/special_values.ex'] },
+  { name: 'lisp/runtime#2', files: ['lib/ptc_runner/lisp/runtime/string.ex', 'lib/ptc_runner/lisp/runtime/collection/normalize.ex', 'lib/ptc_runner/lisp/runtime/collection/select.ex', 'lib/ptc_runner/lisp/runtime/collection/transform.ex'] },
+  { name: 'lisp/signature', files: ['lib/ptc_runner/lisp/signature/coercion.ex', 'lib/ptc_runner/lisp/signature/parser.ex', 'lib/ptc_runner/lisp/signature/parser_helpers.ex', 'lib/ptc_runner/lisp/signature/renderer.ex', 'lib/ptc_runner/lisp/signature/type_resolver.ex', 'lib/ptc_runner/lisp/signature/validator.ex'] },
+  { name: 'lisp/spec_validator', files: ['lib/ptc_runner/lisp/spec_validator/parser.ex'] },
+  { name: 'llm', files: ['lib/ptc_runner/llm/default_registry.ex', 'lib/ptc_runner/llm/registry.ex', 'lib/ptc_runner/llm/req_llm_adapter.ex'] },
+]
+
+// ── Run ────────────────────────────────────────────────────────────────────
+const groups = Array.isArray(args) && args.length ? args : DEFAULT_GROUPS
+log(`Auditing in-code docs across ${groups.length} groups (${groups.reduce((n, g) => n + g.files.length, 0)} files).`)
+
+phase('Audit')
+const perGroup = await pipeline(
+  groups,
+  (g) =>
+    agent(auditPrompt(g), { label: `audit:${g.name}`, phase: 'Audit', schema: FINDINGS_SCHEMA }).then((r) => ({
+      group: g.name,
+      findings: (r && r.findings) || [],
+    })),
+  (audit) =>
+    parallel(
+      audit.findings.map((f) => () =>
+        agent(verifyPrompt(f), { label: `verify:${f.file.split('/').pop()}:${f.line}`, phase: 'Verify', schema: VERDICT_SCHEMA }).then((v) => ({
+          ...f,
+          verdict: v,
+        }))
+      )
+    )
+)
+
+const verified = perGroup.flat().filter(Boolean)
+const confirmed = verified.filter((f) => f.verdict && f.verdict.verdict === 'CONFIRMED')
+const rejected = verified.filter((f) => f.verdict && f.verdict.verdict === 'REJECTED')
+log(`${verified.length} findings raised, ${confirmed.length} confirmed, ${rejected.length} rejected.`)
+
+phase('Synthesize')
+const synthesis = await agent(synthPrompt(groups, confirmed), { label: 'synthesis', phase: 'Synthesize', schema: SYNTH_SCHEMA })
+
+// Sort confirmed by file then line for easy application.
+const bySeverity = { high: 0, medium: 1, low: 2 }
+const sortedConfirmed = confirmed
+  .map((f) => ({
+    file: f.file,
+    line: f.line,
+    category: f.category,
+    severity: (f.verdict && f.verdict.corrected_severity) || f.severity,
+    summary: f.summary,
+    evidence: f.evidence,
+    suggested_fix: f.suggested_fix,
+    verifier_reasoning: f.verdict && f.verdict.reasoning,
+  }))
+  .sort((a, b) => (a.file < b.file ? -1 : a.file > b.file ? 1 : a.line - b.line))
+
+const byCategory = {}
+for (const f of sortedConfirmed) byCategory[f.category] = (byCategory[f.category] || 0) + 1
+
+return {
+  totals: { raised: verified.length, confirmed: confirmed.length, rejected: rejected.length, by_category: byCategory },
+  confirmed: sortedConfirmed,
+  rejected: rejected.map((f) => ({ file: f.file, line: f.line, summary: f.summary, why_rejected: f.verdict && f.verdict.reasoning })),
+  synthesis,
+}

--- a/lib/mix/tasks/ptc.gen_docs.ex
+++ b/lib/mix/tasks/ptc.gen_docs.ex
@@ -8,6 +8,7 @@ defmodule Mix.Tasks.Ptc.GenDocs do
   1. `docs/function-reference.md` — all implemented functions grouped by section
   2. `docs/conformance/index.md` — namespace coverage dashboard
   3. `docs/conformance/*-audit.md` — Clojure and Java compatibility audits
+  4. `docs/java-interop.md` — bounded Java interop reference
 
   ## Usage
 

--- a/lib/ptc_runner/kernel/error.ex
+++ b/lib/ptc_runner/kernel/error.ex
@@ -9,8 +9,7 @@ defmodule PtcRunner.Kernel.Error do
   a hard runtime boundary makes them terminal.
 
   Outer kinds currently include `:workflow_failed`, `:limit_exceeded`,
-  `:protocol_error`, `:event_sink_error`, `:configuration_error`, and
-  `:internal_error`.
+  `:event_sink_error`, `:configuration_error`, and `:inspection_sink_error`.
   """
   @enforce_keys [:kind, :reason, :details, :usage]
   defstruct [:kind, :reason, :details, :usage]

--- a/lib/ptc_runner/kernel/inspection_sink.ex
+++ b/lib/ptc_runner/kernel/inspection_sink.ex
@@ -3,11 +3,11 @@ defmodule PtcRunner.Kernel.InspectionSink do
   Required, bounded in-memory owner for sensitive developer inspection records.
 
   Capture is host-enabled and fail-closed. The sink accepts only the version 1
-  capability-input, capability-output, and subordinate evaluation-source
-  shapes. It normalizes atom keys and enum values to JSON strings, assigns the
-  run identity, sequence, and UTC timestamp, and rejects a record before
-  retention when either its retained or encoded size exceeds the installed
-  bounds.
+  capability-input, capability-output, subordinate evaluation-source, and
+  prelude-source shapes. It normalizes atom keys and enum values to JSON
+  strings, assigns the run identity, sequence, and UTC timestamp, and rejects a
+  record before retention when either its retained or encoded size exceeds the
+  installed bounds.
 
   This sink is independent of Logger, Telemetry, EventSink policy, manifests,
   and Lisp. Records remain private until the host explicitly persists them as

--- a/lib/ptc_runner/lisp.ex
+++ b/lib/ptc_runner/lisp.ex
@@ -161,9 +161,9 @@ defmodule PtcRunner.Lisp do
     - `:filter_context` - Filter context to only include accessed data keys (default: true)
     - `:prelude` - A compiled `%PtcRunner.Lisp.Prelude{}` artifact, a prelude
       SOURCE string, or a list of source-bearing selection maps accepted by
-      `PtcRunner.Lisp.Prelude.Bundle.compile/1` to attach before user code
-      (Capability Prelude V1). Source selections are concatenated and compiled
-      once in explicit order after duplicate namespace rejection. The attached
+      `PtcRunner.Lisp.Prelude.Bundle.compile/1` to attach before user code.
+      Source selections are concatenated and compiled once in explicit order
+      after duplicate namespace rejection. The attached
       prelude's protected namespaces and public export table are consulted by
       the analyzer/evaluator so qualified prelude calls (e.g. `crm/get-user`)
       resolve, while private helpers stay user-invisible. Compile/attach
@@ -479,8 +479,8 @@ defmodule PtcRunner.Lisp do
     end
   end
 
-  # Stamp the prelude trace summary (plan §12) onto the result Step so trace
-  # consumers can reproduce the V1 capability environment. Applied to BOTH the
+  # Stamp the prelude trace summary onto the result Step so trace
+  # consumers can reproduce the capability environment. Applied to BOTH the
   # success and error Step; `nil` prelude leaves `prelude_trace` nil.
   defp stamp_prelude_trace(result, nil), do: result
 

--- a/lib/ptc_runner/lisp/analyze.ex
+++ b/lib/ptc_runner/lisp/analyze.ex
@@ -385,7 +385,7 @@ defmodule PtcRunner.Lisp.Analyze do
   defp dispatch_list_form({:symbol, :fail}, rest, _list, tail?), do: analyze_fail(rest, tail?)
   # Qualified definition targets: `(def crm/x ...)` / `(defn crm/get-user ...)`.
   # V1 supports these only to REJECT writes into protected namespaces with a
-  # protection programmer fault (plan §2), not to enable general qualified defs.
+  # protection programmer fault, not to enable general qualified defs.
   defp dispatch_list_form({:symbol, head}, [{:ns_symbol, ns, sym} | _], _list, _tail?)
        when head in [:def, :defonce, :defn] do
     analyze_qualified_definition(head, ns, sym)
@@ -1152,7 +1152,7 @@ defmodule PtcRunner.Lisp.Analyze do
   # Clojure namespace normalization
   # ============================================================
 
-  # Per-namespace lookup tables for namespace-qualified env keys (OQ-5 option (a)).
+  # Per-namespace lookup tables for namespace-qualified env keys.
   # Namespaces listed here use qualified atoms in `Env.initial()` (e.g.
   # `:"json/parse-string"`) rather than aliasing the unqualified name.
   # Tables are computed at compile time from `Env.initial()` so the lookup is
@@ -1234,7 +1234,7 @@ defmodule PtcRunner.Lisp.Analyze do
   # analyze the args, and emit a {:prelude_call, ref, args} node the evaluator
   # resolves from the export table (invoking the captured closure against the
   # captured private prelude env). Private helpers have no export record, so
-  # this path is unreachable for them — they stay user-invisible (plan §5/§8).
+  # this path is unreachable for them — they stay user-invisible.
   # A `def` constant export: `(cfg/answer)` YIELDS the value (it is not applied),
   # even when that value is a function. Calling it with arguments is an error.
   defp analyze_prelude_call(%{ref: ref, kind: :constant}, [], _tail?),
@@ -1274,8 +1274,7 @@ defmodule PtcRunner.Lisp.Analyze do
   # their existing normalization. A KNOWN prelude namespace whose member is not
   # a public export (an unknown export, or a private helper with no export
   # record) becomes an actionable unknown-export programmer fault pointing at
-  # discovery forms (plan acceptance: "Reject Unknown Namespaced Call",
-  # "Private Helper Is Not User-visible"). Everything else keeps the generic
+  # discovery forms. Everything else keeps the generic
   # unknown-namespace message.
   defp prelude_or_clojure_namespace(ns, func, on_success) do
     cond do
@@ -1307,15 +1306,14 @@ defmodule PtcRunner.Lisp.Analyze do
   # A qualified definition target `(def ns/sym ...)` / `(defn ns/sym ...)`.
   # Writing into a PROTECTED namespace (reserved or prelude-declared) or onto a
   # public prelude EXPORT is a protection programmer fault naming the
-  # namespace/symbol (plan §2). A qualified definition outside any protected
+  # namespace/symbol. A qualified definition outside any protected
   # namespace is an explicit unsupported-qualified-definition error (V1 does
   # not support general qualified defs).
   defp analyze_qualified_definition(_head, ns, sym) do
     cond do
       # The target IS a public prelude export: say so explicitly so the user
       # learns they are attempting to shadow a curated capability, not just
-      # writing into a protected namespace (plan §2 "OR the symbol is a public
-      # prelude export").
+      # writing into a protected namespace.
       match?({:ok, _}, PreludeScope.fetch_export(ns, sym)) ->
         {:error,
          {:invalid_form,

--- a/lib/ptc_runner/lisp/analyze/prelude_scope.ex
+++ b/lib/ptc_runner/lisp/analyze/prelude_scope.ex
@@ -1,7 +1,7 @@
 defmodule PtcRunner.Lisp.Analyze.PreludeScope do
   @moduledoc """
   Process-local scope for the compiled prelude consulted during a single
-  analysis pass (Capability Prelude V1, plan §4 / §2).
+  analysis pass.
 
   The analyzer's `do_analyze/2` is deeply mutually-recursive across ~80
   clauses; threading the prelude artifact through every clause would be a
@@ -14,15 +14,15 @@ defmodule PtcRunner.Lisp.Analyze.PreludeScope do
 
   Two questions this module answers for qualified names like `crm/get-user`,
   where `ns`/`symbol` arrive STRING-backed (unknown namespaces are not in
-  `SourceAtoms` so they intern as `{:ns_symbol, "crm", "get-user"}` — fact #1):
+  `SourceAtoms` so they intern as `{:ns_symbol, "crm", "get-user"}`):
 
     * `fetch_export/2` — is `ns/symbol` a PUBLIC prelude export, and what is its
       arity? Private helpers (`defn-`) have no export record, so they are
-      absent here and stay unreachable by qualified user calls (plan §5 / §8).
+      absent here and stay unreachable by qualified user calls.
     * `protected_namespace?/1` — is `ns` a protected namespace (a reserved host
       namespace or one declared by the attached prelude)? Used to reject
       `(def ns/x ...)` / `(defn ns/f ...)` writes with a protection fault rather
-      than a generic invalid-qualified-name syntax error (plan §2).
+      than a generic invalid-qualified-name syntax error.
   """
 
   alias PtcRunner.Lisp.Prelude
@@ -95,7 +95,7 @@ defmodule PtcRunner.Lisp.Analyze.PreludeScope do
   @doc """
   Whether `ns` is a protected namespace for the current analysis pass: a
   reserved host namespace, or one declared by the attached prelude. Used to
-  reject writes (`def`/`defn`) into protected namespaces (plan §2).
+  reject writes (`def`/`defn`) into protected namespaces.
   """
   @spec protected_namespace?(term()) :: boolean()
   def protected_namespace?(ns) do

--- a/lib/ptc_runner/lisp/core_ast.ex
+++ b/lib/ptc_runner/lisp/core_ast.ex
@@ -53,7 +53,7 @@ defmodule PtcRunner.Lisp.CoreAST do
           | {:fail, t()}
           # Tool invocation via tool/ namespace: (tool/name args...)
           | {:tool_call, name(), [t()]}
-          # Public prelude export reference / call (Capability Prelude V1).
+          # Public prelude export reference / call.
           # `ref` is the host-boundary string ref, e.g. "crm/get-user". The
           # evaluator resolves it from the attached prelude's export table and
           # invokes the captured closure against the captured private prelude

--- a/lib/ptc_runner/lisp/env.ex
+++ b/lib/ptc_runner/lisp/env.ex
@@ -106,7 +106,8 @@ defmodule PtcRunner.Lisp.Env do
   @doc """
   Get the category for a Clojure-style namespace.
 
-  Returns `:string`, `:set`, or `:core`.
+  Returns the category atom for the namespace (e.g. `:string`, `:set`,
+  `:core`, `:walk`, `:regex`, `:json`), or `nil` if the namespace is unknown.
 
   ## Examples
 

--- a/lib/ptc_runner/lisp/eval.ex
+++ b/lib/ptc_runner/lisp/eval.ex
@@ -565,7 +565,7 @@ defmodule PtcRunner.Lisp.Eval do
   # Public prelude export call: `(crm/get-user id)`. Resolve the captured
   # closure from the export table and invoke it with the captured PRIVATE
   # prelude env as its `user_ns` layer so the export body's private sibling
-  # helpers resolve (plan §5). Side-effecting accumulators (tool_calls/ledger,
+  # helpers resolve. Side-effecting accumulators (tool_calls/ledger,
   # prints, cache, ...) are carried IN from and OUT to the caller's context so
   # the wrapped `(tool/call ...)` records exactly once in the existing ledger.
   defp do_eval({:prelude_call, ref, arg_asts}, %EvalContext{prelude_exports: exports} = eval_ctx) do
@@ -1123,7 +1123,7 @@ defmodule PtcRunner.Lisp.Eval do
          origin,
          private_tool?
        ) do
-    # Tier 3.5 Fix 3d: only compute the canonical cache key when the call
+    # Only compute the canonical cache key when the call
     # is actually cacheable. Avoids the cost of canonicalization for
     # every non-cacheable tool call.
     cache_key = if cacheable?, do: KeyNormalizer.canonical_cache_key(tool_name, args_map)

--- a/lib/ptc_runner/lisp/eval/context.ex
+++ b/lib/ptc_runner/lisp/eval/context.ex
@@ -101,9 +101,9 @@ defmodule PtcRunner.Lisp.Eval.Context do
     direct_namespaces: MapSet.new(),
     transitive_namespace_requirers: %{},
     prelude_export_mask: nil,
-    # Capability Prelude V1 (plan §5): the attached compiled prelude's PUBLIC
+    # The attached compiled prelude's PUBLIC
     # export table, a map from string ref (e.g. "crm/get-user") to a
-    # `{callable, ns_env}` tuple — the callable captured from `private_env` plus
+    # `{callable, ns_env, export}` tuple — the callable captured from `private_env` plus
     # its OWN namespace's private env. Qualified prelude calls
     # (`{:prelude_call, ref, args}`) resolve here — inserted in resolver order
     # AFTER the mutable `user` namespace and BEFORE builtins. The paired
@@ -534,7 +534,7 @@ defmodule PtcRunner.Lisp.Eval.Context do
 
   Sub-contexts built with `new/6` for closure/thunk evaluation start with empty
   prelude tables; this re-installs them so a qualified prelude call made from
-  inside a user closure still resolves (Capability Prelude V1, plan §5).
+  inside a user closure still resolves.
   """
   @spec inherit_prelude(t(), t()) :: t()
   def inherit_prelude(%__MODULE__{} = context, %__MODULE__{} = source) do

--- a/lib/ptc_runner/lisp/key_normalizer.ex
+++ b/lib/ptc_runner/lisp/key_normalizer.ex
@@ -78,7 +78,7 @@ defmodule PtcRunner.Lisp.KeyNormalizer do
 
   This function intentionally widens equivalence classes vs naive
   `{tool_name, args}` keying. It is the single source of truth for cache
-  identity across Tier 2b native calls and PTC-Lisp's `(tool/...)` cache
+  identity across native app-tool calls and PTC-Lisp's `(tool/...)` cache
   path; both layers reach the same cache entry whenever the call is
   semantically identical.
 
@@ -109,7 +109,7 @@ defmodule PtcRunner.Lisp.KeyNormalizer do
      unchanged for values. Atom-keyed maps are converted by rule 1; atom
      **values** stay atoms.
 
-  ## Non-map args (Tier 3.5 Fix 3b)
+  ## Non-map args
 
   When `args` is not a map (e.g., a list or scalar from a misbehaving
   tool plumbing path), the result is `{tool_name, {:non_map, args}}`.
@@ -161,7 +161,7 @@ defmodule PtcRunner.Lisp.KeyNormalizer do
     {tool_name, canonicalize(args)}
   end
 
-  # Tier 3.5 Fix 3b: non-map args (list, scalar, nil, etc.) get a sentinel
+  # Non-map args (list, scalar, nil, etc.) get a sentinel
   # cache key rather than raising. Keeps the cache path chaos-resilient.
   def canonical_cache_key(tool_name, args) when is_binary(tool_name) do
     {tool_name, {:non_map, args}}
@@ -177,7 +177,7 @@ defmodule PtcRunner.Lisp.KeyNormalizer do
     Enum.map(value, &canonicalize/1)
   end
 
-  # Tier 3.5 Fix 3c: tuples canonicalize to lists for PTC-Lisp parity.
+  # Tuples canonicalize to lists for PTC-Lisp parity.
   # PTC-Lisp's `[1 2]` vector evaluates to a list; a native cache write
   # using `{1, 2}` would otherwise miss when PTC-Lisp follows the
   # cache_hint.
@@ -201,7 +201,7 @@ defmodule PtcRunner.Lisp.KeyNormalizer do
 
   defp canonicalize(value), do: value
 
-  # Tier 3.5 Fix 3a: re-use `normalize_key/1` so hyphenated and underscored
+  # Re-use `normalize_key/1` so hyphenated and underscored
   # keys collapse together, matching `Lisp.Eval.stringify_key/1` at the
   # PTC-Lisp tool boundary. Without this, a native cache write with
   # `"was-improved"` and a PTC-Lisp lookup with `"was_improved"` miss.

--- a/lib/ptc_runner/lisp/prelude.ex
+++ b/lib/ptc_runner/lisp/prelude.ex
@@ -1,6 +1,6 @@
 defmodule PtcRunner.Lisp.Prelude do
   @moduledoc """
-  Compiled, stateless deployment prelude artifact (Capability Prelude V1).
+  Compiled, stateless deployment prelude artifact.
 
   A deployment loads curated PTC-Lisp prelude source that declares protected
   namespaces (e.g. `crm`) and exports functions/constants. The compiler
@@ -20,13 +20,12 @@ defmodule PtcRunner.Lisp.Prelude do
       definitions in different namespaces distinct (e.g. `crm/who` vs
       `hr/who`). Public exports call their own namespace's private helpers
       through this env; user code cannot resolve private helpers by qualified
-      symbol (plan §5). The CALLABLE values are the contract slice 2
-      (evaluator threading) depends on.
-    * `source_hash` — sha256 hex digest of the prelude source (plan §12
-      traceability).
+      symbol. The CALLABLE values are what evaluator threading depends on.
+    * `source_hash` — sha256 hex digest of the prelude source, for
+      traceability.
     * `form_graph` — `%{namespace => %{symbol => entry}}`, the compiled
-      per-namespace sibling call graph (prelude form-edit/introspection plan,
-      Phase 1). Each entry carries `visibility` (`:public`/`:private`, this
+      per-namespace sibling call graph. Each entry carries `visibility`
+      (`:public`/`:private`, this
       form's own definition kind — distinct from `Export.visibility`'s
       `:prompt`/`:discoverable`), `kind`, `arity`, `doc`, direct `calls` (sibling
       symbol references only), and `requires`/`tool_refs` each split into
@@ -37,20 +36,20 @@ defmodule PtcRunner.Lisp.Prelude do
     * `metadata` — small map of namespace-level facts for traces/debugging,
       e.g. per-namespace docstring and default visibility.
 
-  ## Private-env capture seam (fact #6)
+  ## Private-env capture seam
 
   `defn`/`defn-` in the prelude desugar through the existing analyze+eval
   pipeline to `{:closure, params, body, captured_env, turn_history, meta}`
   tuples stored under their bare symbol in a `user_ns`-shaped map. The
   compiler captures that whole map as `private_env`. Sibling helpers are NOT
   folded into each closure's `captured_env` — they resolve by name through
-  `user_ns` at call time, and `private_env` is exactly that namespace. P2
-  therefore threads `private_env` as the user_ns layer (resolver position
+  `user_ns` at call time, and `private_env` is exactly that namespace. The
+  runtime therefore threads `private_env` as the user_ns layer (resolver position
   between the mutable `user` namespace and built-ins) when invoking exports:
   a public export resolves qualified (`crm/get-user`) to
   `private_env[symbol]` and runs its body against `private_env`, so private
   helpers resolve, while private symbols stay absent from `exports` and so
-  are unreachable by qualified user calls. Proven end-to-end during P0.
+  are unreachable by qualified user calls.
 
   ## Validation errors
 
@@ -61,7 +60,7 @@ defmodule PtcRunner.Lisp.Prelude do
   alias PtcRunner.Lisp.Prelude.Export
 
   @typedoc """
-  A `form_graph` entry: one compiled top-level definition (plan Phase 1).
+  A `form_graph` entry: one compiled top-level definition.
 
   `calls` is DIRECT same-namespace references only; `requires`/`tool_refs`/`effects`
   split `direct` (this form's own body) from `transitive` (the closure over
@@ -123,7 +122,7 @@ defmodule PtcRunner.Lisp.Prelude do
   helpers), or `[]` when `ref` is not a public export.
 
   The pre-execution tool guard unions these in so a prelude-wrapped
-  `(tool/call ...)` is validated before any side effect runs (plan §6/§7).
+  `(tool/call ...)` is validated before any side effect runs.
   """
   @spec export_tool_refs(t(), String.t()) :: [String.t()]
   def export_tool_refs(%__MODULE__{exports: exports}, ref) when is_binary(ref) do
@@ -134,7 +133,7 @@ defmodule PtcRunner.Lisp.Prelude do
   end
 
   @typedoc """
-  Trace/debug summary of a compiled prelude (plan §12 Traceability).
+  Trace/debug summary of a compiled prelude, for traceability.
 
   String/atom/list-only, JSON-serializable, and credential-free: it carries
   enough to REPRODUCE the V1 capability environment without leaking captured
@@ -178,7 +177,7 @@ defmodule PtcRunner.Lisp.Prelude do
         }
 
   @doc """
-  Builds the trace/debug summary for `prelude` (plan §12).
+  Builds the trace/debug summary for `prelude`.
 
   Returns `nil` for `nil` (no prelude attached). The result is JSON-serializable
   and contains NO captured closures, private prelude env, or credentials — only

--- a/lib/ptc_runner/lisp/prelude/compiler.ex
+++ b/lib/ptc_runner/lisp/prelude/compiler.ex
@@ -1,7 +1,7 @@
 defmodule PtcRunner.Lisp.Prelude.Compiler do
   @moduledoc """
   Compiles deployment prelude SOURCE into a `%PtcRunner.Lisp.Prelude{}`
-  artifact (Capability Prelude V1, plan §1 / §3).
+  artifact.
 
   ## What this does
 
@@ -24,10 +24,9 @@ defmodule PtcRunner.Lisp.Prelude.Compiler do
        evaluator's lexical closure capture does NOT fold sibling top-level
        defs into each closure's `captured_env` — sibling helpers resolve by
        name through `user_ns` at CALL time. The whole `private_env` map IS
-       that namespace, so P2 must thread `private_env` as the user_ns layer
-       when invoking an export for siblings to resolve (fact #6 capture seam,
-       proven end-to-end during P0).
-    6. Computes a sha256 source hash (plan §12).
+       that namespace, so `private_env` must be threaded as the user_ns layer
+       when invoking an export for siblings to resolve (the capture seam).
+    6. Computes a sha256 source hash.
 
   Attach-time `requires` validation against granted tools is a separate phase.
   """
@@ -286,7 +285,7 @@ defmodule PtcRunner.Lisp.Prelude.Compiler do
   # evaluate at prelude COMPILE time in a bare context with a no-op tool
   # executor (`eval_runtime/1`), where a dep call would fail as unbound — or
   # worse, silently compute garbage if it were made resolvable. Fail closed;
-  # `defn` bodies cover composition (plan decision 3).
+  # `defn` bodies cover composition.
   defp reject_dep_refs_in_defs(specs, dep_ctx) do
     specs
     |> Enum.filter(&(&1.params_form == nil))
@@ -770,7 +769,7 @@ defmodule PtcRunner.Lisp.Prelude.Compiler do
 
   defp build_export(%Spec{} = spec, ns_meta, form_graph, dep_lookup) do
     # Visibility precedence: explicit export metadata, then the declaring
-    # namespace's default, then the global default (plan §10).
+    # namespace's default, then the global default.
     ns_default =
       ns_meta
       |> Map.get(spec.namespace, %{})
@@ -791,7 +790,7 @@ defmodule PtcRunner.Lisp.Prelude.Compiler do
         })
 
       # Union the referenced dep exports' FINAL requires/tool_refs into this
-      # export's transitive sets (the fail-open fix, plan Phase 1 item 6):
+      # export's transitive sets (the fail-open fix):
       # without it, pre-execution surfaces (`check_undefined_tools`,
       # capability grants) would silently omit everything reached through the
       # dep. Refs that miss the lookup (a private or nonexistent dep symbol)
@@ -1033,15 +1032,14 @@ defmodule PtcRunner.Lisp.Prelude.Compiler do
   end
 
   # ============================================================
-  # Form graph — shared per-namespace sibling call graph (plan Phase 1)
+  # Form graph — shared per-namespace sibling call graph
   # ============================================================
 
   # `%{namespace => %{symbol => entry}}`, ONE construction pass over the
   # scope-aware sibling call graph (`collect_refs`, direct tool
   # literals) shared by export validation and bundle compilation. Stored on
-  # `%Prelude{}` as `form_graph` (plan §Phase
-  # 1) so it is guaranteed consistent with write-time validation instead of
-  # being an inline idiom recomputed ad hoc.
+  # `%Prelude{}` as `form_graph` so it is guaranteed consistent with
+  # write-time validation instead of being an inline idiom recomputed ad hoc.
   defp build_form_graph(specs, dep_ctx) do
     specs
     |> Enum.group_by(& &1.namespace)
@@ -1406,7 +1404,7 @@ defmodule PtcRunner.Lisp.Prelude.Compiler do
   end
 
   # ============================================================
-  # Metadata normalization (host boundary, plan §3)
+  # Metadata normalization (host boundary)
   # ============================================================
 
   # Normalize a parsed metadata map's keyword keys to binary strings and
@@ -1518,7 +1516,7 @@ defmodule PtcRunner.Lisp.Prelude.Compiler do
   end
 
   # Explicit `:requires` metadata must be a list of canonical string ids. Invalid
-  # entries FAIL compilation (plan §10: bad export metadata fails fast at load
+  # entries FAIL compilation (bad export metadata fails fast at load
   # time) rather than being silently dropped — a silently-emptied `requires`
   # would skip attach-time validation and hide a missing/typo'd backing id.
   defp validate_requires(nil), do: {:ok, nil}
@@ -1550,7 +1548,7 @@ defmodule PtcRunner.Lisp.Prelude.Compiler do
   defp valid_tool_requirement?(_other), do: false
 
   # ============================================================
-  # Private env capture (fact #6)
+  # Private env capture
   # ============================================================
 
   # Build the captured runtime tables, namespace by namespace. Each namespace is
@@ -1588,7 +1586,7 @@ defmodule PtcRunner.Lisp.Prelude.Compiler do
   # this compile — the fold guarantees sibling exports are final). The scope
   # EXCLUDES the namespace itself, preserving the qualified-self-reference
   # rejection, and excludes undeclared siblings, so an undeclared
-  # cross-namespace ref keeps failing `unknown namespace` (plan decision 5).
+  # cross-namespace ref keeps failing `unknown namespace`.
   # With no declared deps the scope is nil — exactly today's behavior.
   defp dep_scope_prelude(ns, exports_by_ns, dep_ctx) do
     case declared_deps(dep_ctx, ns) do
@@ -1693,7 +1691,7 @@ defmodule PtcRunner.Lisp.Prelude.Compiler do
   end
 
   # ============================================================
-  # Source hash (plan §12)
+  # Source hash
   # ============================================================
 
   defp source_hash(source) do

--- a/lib/ptc_runner/lisp/prelude/export.ex
+++ b/lib/ptc_runner/lisp/prelude/export.ex
@@ -5,19 +5,19 @@ defmodule PtcRunner.Lisp.Prelude.Export do
 
   An export record is **derived** from compiled prelude facts plus host
   policy. It is not an independent source of authority — host policy and
-  runtime facts win (see plan §10 Metadata Precedence). Only `:prompt` and
+  runtime facts win. Only `:prompt` and
   `:discoverable` exports get records here; private prelude helpers
-  (`defn-`) do not (plan §8).
+  (`defn-`) do not.
 
   ## Host-boundary string-backing
 
   `ref`, `namespace`, and `symbol` are kept as binaries to avoid leaking
-  atoms from deployment-authored prelude source (plan §3, Implementation
-  Notes). Each `requires` entry is a canonical tool id (also a binary).
+  atoms from deployment-authored prelude source. Each `requires` entry is a
+  canonical tool id (also a binary).
   Only the curated, bounded fields `visibility` and
   `effect` are atoms.
 
-  ## Minimal shape (plan §3)
+  ## Minimal shape
 
     * `ref` — Lisp-facing export ref, e.g. `"crm/get-user"`.
     * `namespace` — declaring namespace, e.g. `"crm"`.

--- a/lib/ptc_runner/lisp/prelude/spec.ex
+++ b/lib/ptc_runner/lisp/prelude/spec.ex
@@ -7,7 +7,7 @@ defmodule PtcRunner.Lisp.Prelude.Spec do
 
   Not part of the public prelude artifact — it carries the raw parser forms
   (`params_form`, `body_form`) that the compiler needs to both build export
-  metadata and reconstruct definition forms for env capture (fact #6).
+  metadata and reconstruct definition forms for env capture.
 
   `metadata_form` is the **raw** `{:map, pairs}` parser node captured from a
   `def`, `defn`, or `defn-` before `normalize_meta/1` flattens it into the (lossy,

--- a/lib/ptc_runner/lisp/prelude/validation_error.ex
+++ b/lib/ptc_runner/lisp/prelude/validation_error.ex
@@ -1,7 +1,6 @@
 defmodule PtcRunner.Lisp.Prelude.ValidationError do
   @moduledoc """
-  Compile-time validation failure for a deployment prelude (Capability
-  Prelude V1, plan §3 / §10).
+  Compile-time validation failure for a deployment prelude.
 
   Returned as `{:error, %ValidationError{}}` from
   `PtcRunner.Lisp.Prelude.Compiler.compile/1` when the prelude SOURCE is
@@ -10,27 +9,27 @@ defmodule PtcRunner.Lisp.Prelude.ValidationError do
   invalid arity/signature metadata, and similar facts), and from
   `PtcRunner.Lisp.Prelude.Attach.validate_requires/2` with the
   `:prelude_attach_failed` reason when a public export requires a tool
-  operation the selected runtime does not provide (plan §3 / §6A).
+  operation the selected runtime does not provide.
 
   ## Fields
 
     * `reason` — a stable, matchable atom. Compile-time reasons:
-      `:reserved_namespace`, `:reserved_name`, `:duplicate_ref`,
+      `:reserved_namespace`, `:duplicate_ref`,
       `:invalid_visibility`, `:invalid_requires`, `:invalid_metadata`,
       `:qualified_self_reference`, `:missing_namespace`, `:invalid_namespace`,
-      `:invalid_signature`, `:parse_error`, `:compile_error`. Dependency
+      `:invalid_signature`, `:parse_error`, `:compile_error`,
+      `:unrecognized_node`. Dependency
       reasons (declared prelude-to-prelude deps): `:unknown_dependency`,
       `:dep_ref_in_def`, `:dependency_cycle`. Attach-time reason:
       `:prelude_attach_failed`.
     * `message` — human-readable detail naming the offending namespace,
-      symbol, or value. Must not contain secrets (plan §12).
+      symbol, or value. Must not contain secrets.
     * `namespace` — the declaring namespace when known, else `nil`.
     * `ref` — the offending export ref when known, else `nil`.
   """
 
   @type reason ::
           :reserved_namespace
-          | :reserved_name
           | :duplicate_ref
           | :invalid_visibility
           | :invalid_requires

--- a/lib/ptc_runner/lisp/protected_namespaces.ex
+++ b/lib/ptc_runner/lisp/protected_namespaces.ex
@@ -1,14 +1,14 @@
 defmodule PtcRunner.Lisp.ProtectedNamespaces do
   @moduledoc """
-  Single consult point for namespace protection in Capability Prelude V1.
+  Single consult point for namespace protection for deployment preludes.
 
   Reserved namespaces are host-owned and may never be declared by a
   deployment prelude, redefined by user code, or shadowed. V1 reserves
-  exactly: `tool`, `data`, and `ptc.core` (plan §2). The future
+  exactly: `tool`, `data`, and `ptc.core`. The future
   "catalog" namespace name is deliberately deferred.
 
-  Namespace names are string-backed at the host boundary (plan §3,
-  Implementation Notes), so this module operates on binaries.
+  Namespace names are string-backed at the host boundary, so this
+  module operates on binaries.
 
   `protected/1` unions the reserved set with a compiled prelude's declared
   namespaces — the full set of namespace names that user code must not write
@@ -18,11 +18,11 @@ defmodule PtcRunner.Lisp.ProtectedNamespaces do
 
   alias PtcRunner.Lisp.Prelude
 
-  # Reserved host namespace NAMES (plan §2). Kept as a plain list and turned
+  # Reserved host namespace NAMES. Kept as a plain list and turned
   # into a MapSet at runtime so the public functions return a `MapSet.t()`
   # (an opaque type), not a compile-time literal with a concrete internal
   # shape. String-backed; NOT added to SourceAtoms @bounded_namespaces —
-  # that would leak atoms and broaden the global vocabulary (plan §4).
+  # that would leak atoms and broaden the global vocabulary.
   #
   @reserved_names ~w(tool data ptc.core)
 

--- a/lib/ptc_runner/lisp/runtime/collection/normalize.ex
+++ b/lib/ptc_runner/lisp/runtime/collection/normalize.ex
@@ -44,8 +44,8 @@ defmodule PtcRunner.Lisp.Runtime.Collection.Normalize do
   @doc """
   Normalize a predicate to a 1-arity function.
 
-  Mode `:truthy` returns a boolean-coercing function (for filter, remove, find,
-  every?, not_any?, take_while, drop_while).
+  Mode `:truthy` returns a boolean-coercing function (for filter, remove,
+  every?, not_any?, not_every?, take_while, drop_while).
   Mode `:value` returns a value-extracting function (for some, keep).
   """
   def normalize_pred(key, :truthy) when is_atom(key),

--- a/lib/ptc_runner/lisp/runtime/collection/select.ex
+++ b/lib/ptc_runner/lisp/runtime/collection/select.ex
@@ -1,7 +1,7 @@
 defmodule PtcRunner.Lisp.Runtime.Collection.Select do
   @moduledoc """
   Selection operations for PTC-Lisp collections: filter, remove, find,
-  some, every?, not_any?, take_while, drop_while.
+  some, every?, not_any?, not_every?, take_while, drop_while.
 
   Each function is collapsed from ~10 type-dispatch clauses to 2-3 by
   delegating predicate/collection normalization to `Collection.Normalize`.

--- a/lib/ptc_runner/lisp/runtime/collection/transform.ex
+++ b/lib/ptc_runner/lisp/runtime/collection/transform.ex
@@ -1,7 +1,7 @@
 defmodule PtcRunner.Lisp.Runtime.Collection.Transform do
   @moduledoc """
   Transformation operations for PTC-Lisp collections: map, mapv, mapcat,
-  keep, map_indexed.
+  keep, map_indexed, keep_indexed.
 
   Each function is collapsed from many type-dispatch clauses to 2-4 by
   delegating normalization to `Collection.Normalize`.

--- a/lib/ptc_runner/lisp/runtime/json.ex
+++ b/lib/ptc_runner/lisp/runtime/json.ex
@@ -48,7 +48,7 @@ defmodule PtcRunner.Lisp.Runtime.Json do
     end
   rescue
     # Defensive: Jason.decode/1 should not raise on string input, but
-    # the sandbox boundary requires a hard guarantee per DIV-23 / §4.4.
+    # the sandbox boundary requires a hard guarantee per DIV-23.
     _ -> nil
   end
 
@@ -91,14 +91,14 @@ defmodule PtcRunner.Lisp.Runtime.Json do
   Encode an Elixir value as a JSON string.
 
   Returns the encoded string on success; `nil` on any failure
-  (non-encodable input). Encoder pre-validation (per spec §4.4) runs
+  (non-encodable input). Encoder pre-validation runs
   *before* `Jason.encode/1` is invoked — without it, `Jason` would
   silently coerce non-boolean atoms (e.g. PTC-Lisp keywords like
   `:fs`) into JSON strings, eroding the wire-boundary type signal.
 
   Map keys are restricted to strings and integers — atoms (including
   `true` / `false` / `nil`), floats, and other key types fail the
-  walk and produce `nil` (§4.2 / §4.3).
+  walk and produce `nil`.
 
   ## Examples
 
@@ -140,7 +140,7 @@ defmodule PtcRunner.Lisp.Runtime.Json do
   end
 
   # ----------------------------------------------------------------
-  # Pre-validation walk (§4.4)
+  # Pre-validation walk
   #
   # Map-key validation is STRICTER than value validation: JSON only
   # accepts string keys, so atoms (including true/false/nil), floats,

--- a/lib/ptc_runner/lisp/signature/coercion.ex
+++ b/lib/ptc_runner/lisp/signature/coercion.ex
@@ -56,15 +56,6 @@ defmodule PtcRunner.Lisp.Signature.Coercion do
 
   Output validation is strict - no coercion applied.
 
-  ## Coercion Modes
-
-  | Mode | Input Coercion | Output Validation | Use Case |
-  |------|----------------|-------------------|----------|
-  | `:enabled` (default) | Apply with warnings | Strict | Production |
-  | `:warn_only` | Apply with warnings | Log warnings only | Development |
-  | `:strict` | No coercion | Strict, reject extra fields | Testing |
-  | `:disabled` | Skip | Skip | Debugging |
-
   ## Examples
 
       iex> PtcRunner.Lisp.Signature.Coercion.coerce("42", :int)
@@ -108,9 +99,6 @@ defmodule PtcRunner.Lisp.Signature.Coercion do
 
   @doc """
   Coerce a value to the expected type with options.
-
-  Options:
-  - `:nested` - whether this is a nested coercion (default: false)
 
   Returns `{:ok, coerced_value, warnings}` or `{:error, reason}`.
   """

--- a/lib/ptc_runner/lisp/signature/parser.ex
+++ b/lib/ptc_runner/lisp/signature/parser.ex
@@ -3,7 +3,7 @@ defmodule PtcRunner.Lisp.Signature.Parser do
   NimbleParsec-based parser for signature strings.
 
   Transforms signature syntax into AST:
-  - Primitives: :string, :int, :float, :bool, :keyword, :any
+  - Primitives: :string, :int, :float, :bool (alias :boolean), :keyword, :datetime, :any
   - Collections: [:type], {field :type}, :map
   - Optional fields: :type?
   - Full format: (params) -> output or shorthand: output

--- a/lib/ptc_runner/lisp/signature/type_resolver.ex
+++ b/lib/ptc_runner/lisp/signature/type_resolver.ex
@@ -3,7 +3,7 @@ defmodule PtcRunner.Lisp.Signature.TypeResolver do
   Resolve paths against parsed signature types.
 
   Given a parsed signature and a path (like ["items", "name"]), determines the expected
-  type at that path. Used for validating section fields in Mustache templates.
+  type at that path.
   """
 
   @doc """
@@ -73,7 +73,7 @@ defmodule PtcRunner.Lisp.Signature.TypeResolver do
   end
 
   @doc """
-  Check if a type is a scalar (can be used with {{.}} in sections).
+  Check if a type is a scalar.
 
   ## Examples
 
@@ -95,15 +95,14 @@ defmodule PtcRunner.Lisp.Signature.TypeResolver do
   def scalar_type?(:keyword), do: true
   def scalar_type?(:any), do: true
   # `:datetime` is scalar from the LLM's perspective even though it carries a
-  # `%DateTime{}` struct in Elixir. Without this, Mustache would try to walk
-  # into it as nested data (same shape as the silent-prompt-failure bug we
-  # fixed earlier in `PromptExpander`).
+  # `%DateTime{}` struct in Elixir; without this a consumer would try to walk
+  # into it as nested data.
   def scalar_type?(:datetime), do: true
   def scalar_type?({:optional, inner}), do: scalar_type?(inner)
   def scalar_type?(_), do: false
 
   @doc """
-  Check if a type is iterable (can be used with {{#section}}).
+  Check if a type is iterable.
 
   ## Examples
 

--- a/lib/ptc_runner/lisp/source_atoms.ex
+++ b/lib/ptc_runner/lisp/source_atoms.ex
@@ -29,8 +29,8 @@ defmodule PtcRunner.Lisp.SourceAtoms do
     3. Bounded keyword modifiers used by `for`/`doseq`/destructuring —
        `:else`, `:keys`, `:as`, `:or`, etc.
     4. Bounded namespaces — `data`, `tool`, `json`, plus Clojure aliases (`clojure.string`),
-       and fully-qualified Java namespaces from `Env.clojure_namespaces`
-       (`java.time.LocalDate`, etc.).
+       and fully-qualified Java namespaces from `BuiltinNames.java_namespace_atoms/0`
+       (projected from `priv/java_interop.exs`) (`java.time.LocalDate`, etc.).
     5. Qualified analyzer keys such as JSON member names plus atom-named Java
        namespace members projected from `priv/java_interop.exs`.
     6. Short-fn param atoms `:p1`..`:p20` synthesized by the

--- a/lib/ptc_runner/lisp/type_extractor.ex
+++ b/lib/ptc_runner/lisp/type_extractor.ex
@@ -226,8 +226,7 @@ defmodule PtcRunner.Lisp.TypeExtractor do
     end
   end
 
-  # Convert Elixir type to Signature type
-  # Based on type-coercion-matrix.md mapping
+  # Convert Elixir typespec AST to a PTC Signature type string
   # depth: current recursion depth for custom type expansion (max 3)
   # module: module context for resolving user types
   defp convert_type(type_ast, depth, module)

--- a/lib/ptc_runner/llm/registry.ex
+++ b/lib/ptc_runner/llm/registry.ex
@@ -3,7 +3,7 @@ defmodule PtcRunner.LLM.Registry do
   Resolves trusted model aliases to provider model identifiers.
 
   The standard Kernel LLM provider builder uses this registry while assembling
-  an explicit `llm/request` capability. Manifests cannot replace the registry
+  an explicit `llm-request` capability. Manifests cannot replace the registry
   or name adapter modules.
   """
 


### PR DESCRIPTION
Audits in-code documentation (`@moduledoc`/`@doc`/`@typedoc`/`@shortdoc` and doc comments across `lib/**`) and fixes what the audit confirmed. Companion to the public-docs audit; independent of it.

## What's here

**`.claude/workflows/code-doc-audit.js`** — a reusable multi-agent workflow (21 file-group auditors → adversarial verifiers → cross-file synthesis). Per file it checks: dangling planning citations, stale spec `§`-references, broken `DIV-*`/`GAP-*`/doc links, and drift from the implementation. Re-run with `Workflow({name: "code-doc-audit"})`.

**Fixes** — 79 confirmed findings (1 false positive rejected: "V2 Simplified Model" *is* a real retained spec §16.3):

- **~55 dangling planning citations removed** from doc prose — `plan §N`, `plan Phase/decision N`, `plan acceptance`, `OQ-5`, `Tier 3.5 Fix`, `fact #6`, `P0`/`P2`, and the `(Capability Prelude V1)` version label. None resolve to any retained doc (the prelude plan uses named sections, not `§`-numbers), and the guidelines forbid plan references in code docs. Rationale prose kept intact.
- **Stale spec references** — `json.ex` cited spec `§4.2/§4.3/§4.4`, but §4 is "Truthiness" with no subsections and the spec has no JSON section. Citations dropped.
- **Drifted enumerations reconciled with code** — `Kernel.Error` outer kinds (−`:protocol_error`/`:internal_error`, +`:inspection_sink_error`), `InspectionSink` accepted shapes (+`prelude-source`), `ValidationError` reasons (−`:reserved_name`, +`:unrecognized_node`), collection/signature op lists, `gen_docs` outputs, `Env.namespace_category` return set.
- **Removed-feature narratives** — Mustache/`PromptExpander` references in `type_resolver`; a coercion-mode/option system `coercion` never implemented; `eval/context` prelude-table tuple shape (2-tuple → 3-tuple); `source_atoms` Java-namespace source; `llm/request` → `llm-request`; a dead `type-coercion-matrix.md` link.

## Naming decision to confirm

The `(Capability Prelude V1)` label was stripped from code docs (say "prelude" / "compiled prelude artifact") because it has no retained definition and the version tag drifts. The feature *is* named "Capability Preludes (V1)" in `CHANGELOG.md`'s 0.13.0 entry — if you'd rather keep that name in the module docs, say so and I'll restore it with a canonical home.

Left untouched by design: `java/surface.ex` "Phase 0" (maps to real `@phase0_attestations` code, not a plan).

## Verification

`mix precommit` green — format, compile (warnings-as-errors), xref, credo --strict, spec, `ptc.gen_docs --check`, conformance report, tests (4336 `ptc_runner` incl. 125 doctests + 67 `ptc_viewer`). Post-edit grep confirms zero surviving `plan §` / spec-`§4.x` / removed-feature strings in `lib/`.

https://claude.ai/code/session_01Am6GHNEtJ4GaK5AtwUrqbR