### PR TITLE
build(ci): upgrade to OTP 29

### DIFF
--- a/.github/actions/setup-elixir/action.yml
+++ b/.github/actions/setup-elixir/action.yml
@@ -9,7 +9,7 @@ runs:
       uses: erlef/setup-beam@v1
       with:
         elixir-version: '1.20.2'
-        otp-version: '28.5.0.1'
+        otp-version: '29.0.3'
 
     - name: Cache deps and _build
       uses: actions/cache@v5
@@ -18,9 +18,9 @@ runs:
         path: |
           deps
           _build
-        key: ${{ runner.os }}-mix-otp28.5.0.1-elixir1.20.2-${{ hashFiles('**/mix.lock') }}
+        key: ${{ runner.os }}-mix-otp29.0.3-elixir1.20.2-${{ hashFiles('**/mix.lock') }}
         restore-keys: |
-          ${{ runner.os }}-mix-otp28.5.0.1-elixir1.20.2-
+          ${{ runner.os }}-mix-otp29.0.3-elixir1.20.2-
 
     - name: Get dependencies
       run: mix deps.get
@@ -30,9 +30,9 @@ runs:
       uses: actions/cache@v5
       with:
         path: priv/plts
-        key: plt-${{ runner.os }}-otp28.5.0.1-elixir1.20.2-${{ hashFiles('**/mix.lock') }}
+        key: plt-${{ runner.os }}-otp29.0.3-elixir1.20.2-${{ hashFiles('**/mix.lock') }}
         restore-keys: |
-          plt-${{ runner.os }}-otp28.5.0.1-elixir1.20.2-
+          plt-${{ runner.os }}-otp29.0.3-elixir1.20.2-
 
     - name: Cache Babashka
       uses: actions/cache@v5

--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,3 @@
 [tools]
-erlang = "28.5.0.1"
-elixir = "1.20.2-otp-28"
+erlang = "29.0.3"
+elixir = "1.20.2-otp-29"


### PR DESCRIPTION
## Summary

Upgrade the managed Erlang/OTP runtime from 28.5.0.1 to 29.0.3.

- Pin local Mise to Elixir 1.20.2 compiled for OTP 29.
- Pin the shared GitHub Actions setup action to OTP 29.0.3.
- Version dependency and Dialyzer cache keys by the new toolchain so OTP 28 artifacts are not reused.

## Why

Local development was already using OTP 29 while CI remained on OTP 28. This aligns the checked-in local and CI toolchains.

## Validation

- `mise exec -- mix precommit`
- `mise exec -- mix prepush`
- Full pre-push hook: 4,338 root tests, Dialyzer, and 67 PtcViewer tests under OTP 29.
