### PR TITLE
fix(llm): preload llm_db catalog outside the bounded provider worker

### DIFF
--- a/lib/ptc_runner/llm.ex
+++ b/lib/ptc_runner/llm.ex
@@ -54,7 +54,17 @@ defmodule PtcRunner.LLM do
   @callback stream(model :: String.t(), request :: map()) ::
               {:ok, Enumerable.t()} | {:error, term()}
 
-  @optional_callbacks [stream: 2]
+  @doc """
+  Preload adapter-owned model metadata into a shared, process-independent store
+  (e.g. a `:persistent_term`/ETS catalog) so the first per-request provider
+  worker does not pay a large one-time load inside its bounded heap.
+
+  Optional. Invoked once at capability-build time in the unbounded builder
+  process; implementations must be idempotent.
+  """
+  @callback ensure_ready() :: :ok
+
+  @optional_callbacks [stream: 2, ensure_ready: 0]
 
   @doc """
   Creates a normalized callback for a configured model.
@@ -67,6 +77,11 @@ defmodule PtcRunner.LLM do
   def callback(model, opts \\ []) do
     {adapter_override, opts} = Keyword.pop(opts, :adapter)
     adapter = adapter_override || adapter!()
+    # Warm adapter-owned model metadata (e.g. the llm_db catalog) here, in the
+    # unbounded builder process, so the first bounded provider worker does not
+    # trigger a large one-time decode and exceed its heap ceiling. No-op for
+    # adapters that do not implement it.
+    if function_exported?(adapter, :ensure_ready, 0), do: adapter.ensure_ready()
     model = PtcRunner.LLM.Registry.resolve!(model)
     merged_opts = Map.new(opts)
 

--- a/lib/ptc_runner/llm/req_llm_adapter.ex
+++ b/lib/ptc_runner/llm/req_llm_adapter.ex
@@ -37,6 +37,23 @@ if Code.ensure_loaded?(ReqLLM) do
     # --- Behaviour Callbacks ---
 
     @impl true
+    @doc """
+    Loads the `llm_db` model catalog into its VM-global `:persistent_term`
+    store so per-request provider workers read it copy-free instead of
+    triggering a large one-time decode inside their bounded heap. Idempotent;
+    called once at capability-build time in the unbounded builder process.
+    """
+    @spec ensure_ready() :: :ok
+    def ensure_ready do
+      if Code.ensure_loaded?(LLMDB.Catalog) and
+           function_exported?(LLMDB.Catalog, :ensure_loaded, 0) do
+        _ = LLMDB.Catalog.ensure_loaded()
+      end
+
+      :ok
+    end
+
+    @impl true
     @spec call(String.t(), map()) :: {:ok, map()} | {:error, term()}
     def call(model, %{schema: schema} = req) when is_map(schema) do
       messages = build_messages(req)

--- a/mix.exs
+++ b/mix.exs
@@ -38,7 +38,7 @@ defmodule PtcRunner.MixProject do
       dialyzer: [
         plt_core_path: "priv/plts",
         plt_file: {:no_warn, "priv/plts/project.plt"},
-        plt_add_apps: [:ex_unit, :mix, :req, :req_llm, :recon],
+        plt_add_apps: [:ex_unit, :mix, :req, :req_llm, :llm_db, :recon],
         ignore_warnings: ".dialyzer_ignore.exs",
         list_unused_filters: true
       ]

--- a/test/ptc_runner/llm_test.exs
+++ b/test/ptc_runner/llm_test.exs
@@ -28,6 +28,20 @@ defmodule PtcRunner.LLMTest do
     end
   end
 
+  # Records whether its ensure_ready/0 warmup ran (build-time preload test).
+  defmodule ReadyProbe do
+    @behaviour PtcRunner.LLM
+
+    @impl true
+    def ensure_ready do
+      Process.put({__MODULE__, :called}, true)
+      :ok
+    end
+
+    @impl true
+    def call(_model, _req), do: {:ok, %{content: "", tokens: %{}}}
+  end
+
   setup do
     prev = Application.get_env(:ptc_runner, :llm_adapter)
     Application.put_env(:ptc_runner, :llm_adapter, MockAdapter)
@@ -39,6 +53,20 @@ defmodule PtcRunner.LLMTest do
     end)
 
     :ok
+  end
+
+  describe "callback/2 adapter warmup" do
+    test "invokes the adapter's ensure_ready/0 at build time, before the request runs" do
+      Process.delete({ReadyProbe, :called})
+      closure = PtcRunner.LLM.callback("ollama:test-model", adapter: ReadyProbe)
+      assert is_function(closure, 1)
+      assert Process.get({ReadyProbe, :called}) == true
+    end
+
+    test "is a no-op for adapters that do not implement ensure_ready/0" do
+      # MockAdapter (installed by setup) defines no ensure_ready/0.
+      assert is_function(PtcRunner.LLM.callback("ollama:test-model"), 1)
+    end
   end
 
   describe "callback/2" do


### PR DESCRIPTION
## The bug (surfaced by running the DeepSeek e2e test)

Every live LLM request on `main` fails in ~0.2s with `:provider_heap_exceeded`. Root cause: **req_llm 1.17.1 / llm_db 2026.7** (bumped in #1107) decodes its model catalog on first use into a VM-global `:persistent_term` store. When that first decode happened **inside the bounded LLM provider worker** (`provider_heap_words: 5_000_000` ≈ 40 MB, `limits.ex:40`), the transient allocation — measured at **~130–190 MB** — blew the heap ceiling and the BEAM killed the worker (`dispatcher.ex:420` maps `:killed` → `:provider_heap_exceeded`).

e2e runs nightly (not on PRs), so the bump merged without catching it.

## Evidence

Bracketing the provider worker's `max_heap_size` against a real DeepSeek call:

| worker heap | result |
|---|---|
| 5M (default) / 6M / 8M / 12M / 16M | ❌ killed (heap) |
| 24M / 32M / 50M | ✅ real 4.4s response |

Retained heap after the call is ~2.7K words — so it's a pure **one-time transient decode**, and llm_db stores the result in `:persistent_term` (off-heap, copy-free reads). Warming the catalog once in an unbounded process makes a subsequent **5M** worker call pass.

## The fix

Preload the catalog **once, outside the worker**:
- Add an optional `ensure_ready/0` callback to the `PtcRunner.LLM` adapter behaviour.
- `PtcRunner.LLM.callback/2` (the unbounded capability builder) invokes `adapter.ensure_ready/0` via `function_exported?/3` before returning the per-request closure.
- `ReqLLMAdapter.ensure_ready/0` triggers the idempotent `LLMDB.Catalog.ensure_loaded/0`.

Per-request workers then read the catalog copy-free from persistent_term. **The 40 MB isolation bound is unchanged** — no loosening of the memory guarantee.

## req_llm stays optional

`ensure_ready/0` lives inside the adapter's existing `if Code.ensure_loaded?(ReqLLM)` module guard (and inner-guards `LLMDB.Catalog`), and `callback/2` calls it only through `function_exported?/3`. With req_llm absent, the adapter module doesn't exist and the call is a no-op — nothing references `ReqLLM`/`LLMDB`.

## Verification

- **DeepSeek e2e now passes at the default 5M provider heap** (`deepseek_e2e_test.exs`): was 0.2s `:provider_heap_exceeded`, now a real **6.8s** round-trip returning `KERNEL_OK`.
- New non-network regression tests in `llm_test.exs` assert `callback/2` calls `ensure_ready` at build time and is a no-op for adapters without it.
- `mix precommit` green — 4340 + 67 tests, credo/xref/spec clean.

https://claude.ai/code/session_01Am6GHNEtJ4GaK5AtwUrqbR