### PR TITLE
fix(kernel): finalize ordinary traces atomically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Ordinary Kernel runs and standalone REPL sessions now reserve terminal event
+  count and measured envelope capacity and atomically freeze one canonical
+  batch for result usage, trace, and inspection persistence. Drop accounting is
+  capped at sixteen event types plus a saturating overflow bucket, each
+  `RunConfig` atomically claims its recorder for one execution, and rejected
+  claimants cannot close resources owned by the winning run or REPL session.
 - Unified direct and Kernel public-value projection. Direct results preserve
   colliding map keys and set members with inert wrappers, while Kernel JSON
   boundaries reject ambiguous projections with

--- a/docs/guides/kernel-maintainer.md
+++ b/docs/guides/kernel-maintainer.md
@@ -402,6 +402,25 @@ Runtime observability has separate planes with separate data contracts:
 `PtcRunner.Kernel.EventSink` owns canonical event sequence numbers, timestamps,
 queue bounds, and loss accounting. Normal policy is lossy and reports dropped
 events. Private policy fails closed when it cannot retain the required event.
+Normal sinks used by `RunConfig` reserve count and measured envelope capacity
+for one `events-dropped` summary and one `run-stopped` event. Construction also
+requires the sink's exact `Limits`, verifies that `run-started` fits outside the
+reserve, and rejects payload ceilings too small for the bounded worst-case loss
+summary. Runner and standalone `ReplSession` close
+their `RunState` first, then finalize the recorder in one owner operation. That
+operation injects the exact drop snapshot into terminal usage, appends both
+terminal events when loss occurred, freezes the event list, and returns the
+same batch used by trace and inspection persistence. Emits after finalization
+cannot change events or loss usage. Loss accounting retains at most sixteen
+individual event-type keys; further types increment the saturating
+`$overflow` bucket, so arbitrary valid event names cannot create unbounded
+owner state. A `RunConfig` is consequently one-shot: reuse after terminal
+publication fails with `:event_sink_error` instead of executing against an old
+frozen recorder. Startup retains `run-started` and claims that one-shot recorder
+in the same owner operation, so concurrent callers cannot both pass a separate
+readiness check and execute. Only the successful claimant owns provider and
+recorder cleanup; a rejected concurrent runner or REPL constructor cannot tear
+down the live winner.
 Run labels and workflow annotations use `PtcRunner.Kernel.SafeMetadata`.
 Caller-supplied `name`, `model`, and `provider` label strings become one-way
 SHA-256 fingerprints. Tags use fixed `environment`, `mode`, `stage`, and
@@ -450,7 +469,7 @@ mission callback is therefore rejected.
 The trace owner is additionally bound to the exact combined runtime/sink,
 limits, sink run/trace identity, and `<run-id>.jsonl` destination at
 construction, and assembly validation rechecks that binding. Construction also
-requires the exact two-event terminal reserve, an unfinalized empty recorder,
+requires the exact two-event measured-envelope reserve, an unfinalized empty recorder,
 and an open `RunState`. The sole session attaches before `run-started` is
 emitted, so replaying a previously attached assembly cannot append a duplicate
 start event.
@@ -478,7 +497,7 @@ closes or reports backend failure and releases the snapshot rather than
 silently evaluating without canonical events.
 
 `PtcRunner.Kernel.SessionTrace` lifecycle-owns the combined runtime and monitors
-the session. The event state's opt-in terminal reserve keeps capacity for one
+the session. The event state's opt-in measured terminal reserve keeps capacity for one
 bounded `events-dropped` summary and exactly one `run-stopped` event inside the
 normal hard count/byte ceilings. One owner call finalizes and returns the
 complete batch before the runtime is stopped; `SessionTrace` then publishes it

--- a/docs/plans/future/kernel-publication-and-boundary-hardening.md
+++ b/docs/plans/future/kernel-publication-and-boundary-hardening.md
@@ -1,10 +1,10 @@
 # Kernel publication and boundary hardening
 
-**Status:** triaged; first two slices implemented
+**Status:** triaged; first three slices implemented
 
 **Origin:** extracted from the Java interop investigation on 2026-07-20
 
-**Last audited:** 2026-07-22 against `origin/main` at `fe10efd9`
+**Last audited:** 2026-07-22 against `origin/main` at `35005bf7`
 
 ## Decision
 
@@ -29,8 +29,8 @@ This plan now separates:
 | --- | --- | --- |
 | Tool cache | Every evaluation now owns an empty, evaluation-local cache. Caller-supplied state is rejected and Results omit cache entries. | Complete. |
 | Public projection | Direct and Kernel results use one collision-aware projection. Direct Elixir results preserve entries; Kernel boundaries reject ambiguity. | Complete. |
-| Ordinary terminal publication | Atomic finalization, terminal reserve, and frozen batch handoff exist, but ordinary Runner and standalone REPL do not use them. | Migrate in a separate lifecycle slice. |
-| Drop accounting and inspection | Drop buckets are unbounded by event-type count, and several payload-bearing structs use derived `Inspect`. | Fix with the owning boundary slices. |
+| Ordinary terminal publication | Runner and standalone REPL now reserve terminal capacity, finalize atomically, and hand one frozen batch to persistence. | Complete. |
+| Drop accounting and inspection | Event loss uses sixteen fixed type buckets plus a saturating overflow count. Several payload-bearing structs still use derived `Inspect`. | Address inspection with each owning boundary. |
 | Viewer persistence | SessionTrace owns finalization and retry; TraceLog publication is synced, no-clobber, and byte-identical on retry. | Remove from the active backlog. |
 | Standalone REPL ownership | A transferred ReplSession becomes closed when its creator exits. | Decide whether sessions are process-affine or transferable before changing ownership. |
 | Oracle supervision | The current subprocess-per-run harness has timeout, output, and temporary-directory bounds. | Keep the reusable service deferred until a leak or throughput problem is measured. |
@@ -176,28 +176,43 @@ Boundary tests cover maps and sets containing distinct callables as well as a
 callable beside its literal display string. The implementation does not add
 generic validation for every host-supplied BEAM term.
 
-## Third slice: ordinary terminal finalization
+## Completed third slice: ordinary terminal finalization
 
-`PtcRunner.Kernel.EventSink.finalize_and_events/3` already performs atomic
+`PtcRunner.Kernel.EventSink.finalize_and_events/2` already performs atomic
 terminal finalization and returns a frozen batch. Log-analysis SessionTrace
 uses a two-event terminal reserve, persists the frozen batch, and retries
 publication without appending another terminal event.
 
-Ordinary Runner and standalone ReplSession still read dropped counts, emit
-`events-dropped`, emit `run-stopped`, and read events in separate operations.
-RunBuilder then reads the mutable sink independently for trace and inspection
-persistence. Existing tests explicitly allow `run-stopped` to be dropped by a
-full normal sink.
+Ordinary Runner and standalone ReplSession previously read dropped counts,
+emitted `events-dropped`, emitted `run-stopped`, and read events in separate
+operations. RunBuilder then read the mutable sink independently for trace and
+inspection persistence. A full normal sink could drop `run-stopped` entirely.
 
-For a system that treats logs as future improvement evidence, ordinary traces
-should have the same terminal integrity as Viewer traces. A separate slice
-should:
+Normal EventSinks now reserve two terminal slots and their worst-case measured
+envelopes by default. RunConfig requires that exact reserve, the sink's exact
+`Limits`, enough ordinary capacity for the assembled `run-started` event, and a
+payload ceiling that can retain the bounded worst-case loss summary.
+The startup operation atomically claims the fresh recorder while retaining
+`run-started`; a focused concurrent-reuse test demonstrated that a separate
+readiness check let two runs execute against one sink, so the claim closes that
+race without introducing a general producer-lease protocol. Only a successful
+claimant owns shared cleanup, so a rejected runner or REPL constructor cannot
+tear down provider or recorder resources used by the winner.
+Runner and ReplSession close RunState before one atomic finalization call. The
+EventSink owner adds the exact frozen loss snapshot to terminal usage, appends
+`events-dropped` when needed and exactly one `run-stopped`, freezes the sink,
+and returns both the events and loss snapshot. Later emits are contained without
+mutating either. RunBuilder passes that returned event list directly to trace
+and inspection persistence rather than rereading the sink.
 
-- reserve terminal capacity for ordinary normal sinks;
-- give Runner and standalone REPL one terminal finalization operation;
-- return one frozen batch for trace and inspection persistence;
-- compute public event-loss usage from that same terminal state; and
-- cap drop accounting to fixed event-type buckets plus an overflow count.
+Drop accounting retains sixteen named event-type buckets. Additional names and
+invalid event types increment one `$overflow` bucket, and every counter
+saturates at the unsigned 32-bit ceiling. This bounds both key cardinality and
+integer growth while preserving useful common loss evidence.
+
+Boundary tests saturate ordinary count capacity for Runner and ReplSession,
+prove terminal events and returned usage agree, prove post-finalization emits
+cannot change the batch, and exercise overflow accounting.
 
 Do not add producer leases or split EventSink capabilities unless a focused
 test first demonstrates that current RunState/provider cleanup permits an

--- a/docs/trace-log-contract.md
+++ b/docs/trace-log-contract.md
@@ -204,7 +204,7 @@ handoff failure explicitly stops the partial session even when the trace owner
 has already died. Session information requests serialize behind an accepted
 evaluation and do not mistake that bounded wait for owner death.
 The trace owner is constructed only when its limits, combined runtime/sink,
-normal fail-closed policy, exact two-event terminal reserve, empty unfinalized
+normal fail-closed policy, exact two-event measured-envelope terminal reserve, empty unfinalized
 recorder, open RunState, sink run/trace identity, and `<run-id>.jsonl`
 destination agree. Assembly validation rechecks the runtime binding. The sole
 session attaches before `run-started`, so rejected assembly replay is side-effect
@@ -237,7 +237,7 @@ Public evaluation prints are projected in one pass under both a 128-entry
 ceiling and a 65,536-byte encoded JSON-array ceiling. The truncation flag is
 authoritative even when omitted entries are empty strings.
 
-The session EventSink opts into a terminal reserve. Ordinary events stop before
+The session EventSink opts into a measured terminal reserve. Ordinary events stop before
 the count and byte ceilings would consume capacity for one bounded
 `events-dropped` summary and exactly one `run-stopped`; atomic finalization also
 returns the frozen terminal batch in that same owner call, without exceeding

--- a/lib/ptc_runner/kernel.ex
+++ b/lib/ptc_runner/kernel.ex
@@ -45,12 +45,20 @@ defmodule PtcRunner.Kernel do
   in `config`. Calls across the reserved subordinate-evaluation boundary use
   only the mission environment. The run owns its resource counters,
   transactional native evaluation memory/history, deadline, and canonical
-  events.
+  events. Terminal publication is one atomic recorder operation: normal sinks
+  reserve the loss summary and `run-stopped`, and no event can mutate the batch
+  after finalization.
 
   Returns a bounded `PtcRunner.Kernel.Result` or
   `PtcRunner.Kernel.Error`. Capability failures normally remain recoverable
-  Lisp values; workflow policy decides whether to retry, degrade, or fail.
+  Lisp values; workflow policy decides whether to retry, degrade, or fail. The
+  supplied configuration is one-shot because this call finalizes its event
+  sink; construct a fresh configuration for another run.
   """
   @spec run(binary(), RunConfig.t()) :: {:ok, Result.t()} | {:error, Error.t()}
   def run(entry_source, %RunConfig{} = config), do: Runner.run(entry_source, config)
+
+  @doc false
+  def run_and_events(entry_source, %RunConfig{} = config),
+    do: Runner.run_and_events(entry_source, config)
 end

--- a/lib/ptc_runner/kernel/event_sink.ex
+++ b/lib/ptc_runner/kernel/event_sink.ex
@@ -11,8 +11,14 @@ defmodule PtcRunner.Kernel.EventSink do
   Under `:normal` policy, a full or unavailable sink ordinarily records or
   projects loss without changing workflow execution. An internal normal sink
   may opt into fail-closed owner loss so a session cannot continue without its
-  canonical recorder. The sink monitors its owner and exits when the owner
-  terminates.
+  canonical recorder. Normal sinks reserve two measured terminal envelopes by default.
+  Finalization atomically appends the bounded loss summary and `run-stopped`,
+  freezes the recorder, and returns the exact terminal batch and drop snapshot.
+  Runner and session startup atomically claim the recorder while retaining
+  `run-started`, so one configuration cannot execute twice or concurrently.
+  Later emits cannot mutate either snapshot. Drop accounting retains at most
+  sixteen event-type buckets plus a saturating `$overflow` count. The sink
+  monitors its owner and exits when the owner terminates.
 
   Persistent JSONL storage is an explicit `PtcRunner.Kernel.TraceLog` operation
   after collection, not an arbitrary callback in the runtime path.
@@ -21,6 +27,10 @@ defmodule PtcRunner.Kernel.EventSink do
 
   alias PtcRunner.Kernel.EventSinkState
   alias PtcRunner.Kernel.Limits
+  alias PtcRunner.Lisp.RetainedSize
+
+  @drop_count_limit 4_294_967_295
+  @max_drop_type String.duplicate("e", 128)
 
   @enforce_keys [:pid, :token, :policy]
   defstruct [:pid, :token, :policy, fail_closed?: false]
@@ -38,7 +48,8 @@ defmodule PtcRunner.Kernel.EventSink do
   Starts a sink with one policy and the event bounds from `limits`.
 
   Options are `:run_id`, `:trace_id`, `:owner`, and the internal normal-policy
-  `:terminal_reserve` and `:fail_closed`. IDs must be valid UTF-8 binaries from
+  `:terminal_reserve` and `:fail_closed`. Normal sinks default to the standard
+  two-event terminal reserve; private sinks reserve nothing. IDs must be valid UTF-8 binaries from
   1 through 256 bytes; a unique run ID is generated when omitted and is also
   the default trace ID.
   """
@@ -55,18 +66,34 @@ defmodule PtcRunner.Kernel.EventSink do
     token = make_ref()
     run_id = Keyword.get_lazy(opts, :run_id, &default_run_id/0)
     trace_id = Keyword.get(opts, :trace_id, run_id)
-    terminal_reserve = Keyword.get(opts, :terminal_reserve, %{count: 0, bytes: 0})
+    terminal_reserve = Keyword.get(opts, :terminal_reserve, terminal_reserve(policy, limits))
     fail_closed? = Keyword.get(opts, :fail_closed, false)
 
     if Keyword.keys(opts) -- [:run_id, :trace_id, :owner, :terminal_reserve, :fail_closed] == [] and
          valid_id?(run_id) and valid_id?(trace_id) and is_boolean(fail_closed?) and
-         valid_terminal_reserve?(policy, terminal_reserve, limits) do
+         valid_terminal_reserve?(policy, terminal_reserve, limits) and
+         terminal_payload_capacity?(policy, limits, terminal_reserve) do
       state = EventSinkState.new(policy, limits, token, run_id, trace_id, terminal_reserve)
       {:ok, state, %{token: token, policy: policy, fail_closed?: fail_closed?}}
     else
       {:error, :invalid_event_sink}
     end
   end
+
+  @doc false
+  @spec terminal_reserve(policy(), Limits.t()) :: %{
+          count: non_neg_integer(),
+          bytes: non_neg_integer()
+        }
+  def terminal_reserve(:normal, %Limits{} = limits),
+    do: %{
+      count: 2,
+      bytes:
+        limits.event_payload_bytes * 2 + terminal_envelope_bytes("events-dropped") +
+          terminal_envelope_bytes("run-stopped")
+    }
+
+  def terminal_reserve(:private, %Limits{}), do: %{count: 0, bytes: 0}
 
   @spec emit(t(), binary(), map()) :: :ok | {:error, :event_sink_error}
   @doc "Emits one bounded event or applies the sink's loss policy."
@@ -76,6 +103,17 @@ defmodule PtcRunner.Kernel.EventSink do
       result -> result
     end
   end
+
+  @doc false
+  @spec begin(t(), map()) :: :ok | {:error, :event_sink_error}
+  def begin(%__MODULE__{} = sink, data) when is_map(data), do: call(sink, {:begin, data})
+  def begin(_sink, _data), do: {:error, :event_sink_error}
+
+  @doc false
+  def begin_capacity?(%__MODULE__{} = sink, data) when is_map(data),
+    do: call(sink, {:begin_capacity?, data}) == true
+
+  def begin_capacity?(_sink, _data), do: false
 
   @spec events(t()) :: [map()]
   @doc "Returns retained canonical events in sequence order."
@@ -96,22 +134,12 @@ defmodule PtcRunner.Kernel.EventSink do
   end
 
   @doc false
-  @spec finalize(t(), map(), map()) :: :ok | {:error, :event_sink_error}
-  def finalize(%__MODULE__{policy: :normal} = sink, dropped_data, stopped_data)
-      when is_map(dropped_data) and is_map(stopped_data),
-      do: call(sink, {:finalize, dropped_data, stopped_data})
+  @spec finalize_and_events(t(), map()) ::
+          {:ok, %{events: [map()], dropped: map()}} | {:error, :event_sink_error}
+  def finalize_and_events(%__MODULE__{} = sink, stopped_data) when is_map(stopped_data),
+    do: call(sink, {:finalize_and_events, stopped_data})
 
-  def finalize(_sink, _dropped_data, _stopped_data), do: {:error, :event_sink_error}
-
-  @doc false
-  @spec finalize_and_events(t(), map(), map()) ::
-          {:ok, [map()]} | {:error, :event_sink_error}
-  def finalize_and_events(%__MODULE__{policy: :normal} = sink, dropped_data, stopped_data)
-      when is_map(dropped_data) and is_map(stopped_data),
-      do: call(sink, {:finalize_and_events, dropped_data, stopped_data})
-
-  def finalize_and_events(_sink, _dropped_data, _stopped_data),
-    do: {:error, :event_sink_error}
+  def finalize_and_events(_sink, _stopped_data), do: {:error, :event_sink_error}
 
   @spec policy(t()) :: policy() | {:error, :event_sink_error}
   @doc "Returns the configured loss policy."
@@ -130,8 +158,11 @@ defmodule PtcRunner.Kernel.EventSink do
   @doc false
   def session_contract(sink) do
     case call(sink, :session_contract) do
-      %{terminal_reserve: _reserve, ready?: _ready?} = contract -> {:ok, contract}
-      {:error, :event_sink_error} = error -> error
+      %{terminal_reserve: _reserve, ready?: _ready?, begun?: _begun?} = contract ->
+        {:ok, contract}
+
+      {:error, :event_sink_error} = error ->
+        error
     end
   end
 
@@ -163,11 +194,48 @@ defmodule PtcRunner.Kernel.EventSink do
   defp valid_terminal_reserve?(:normal, %{count: count, bytes: bytes}, limits)
        when is_integer(count) and is_integer(bytes) and count >= 0 and bytes >= 0 do
     count <= limits.normal_event_count and bytes <= limits.normal_event_bytes and
-      ((count == 0 and bytes == 0) or (count >= 2 and bytes >= limits.event_payload_bytes * 2))
+      ((count == 0 and bytes == 0) or
+         (count >= 2 and bytes >= terminal_reserve(:normal, limits).bytes))
   end
 
   defp valid_terminal_reserve?(:private, %{count: 0, bytes: 0}, _limits), do: true
   defp valid_terminal_reserve?(_policy, _reserve, _limits), do: false
+
+  defp terminal_payload_capacity?(_policy, _limits, %{count: 0, bytes: 0}), do: true
+  defp terminal_payload_capacity?(:private, _limits, _reserve), do: true
+
+  defp terminal_payload_capacity?(:normal, limits, _reserve) do
+    dropped =
+      1..16
+      |> Map.new(&{"#{@max_drop_type}#{&1}", @drop_count_limit})
+      |> Map.put("$overflow", @drop_count_limit)
+
+    terminal_payloads = [
+      %{counts: dropped},
+      %{outcome: :error, reason: :event_sink_error, usage: %{events_dropped: dropped}}
+    ]
+
+    Enum.all?(terminal_payloads, fn payload ->
+      case RetainedSize.bytes_with_cap(payload, limits.event_payload_bytes) do
+        bytes when is_integer(bytes) -> bytes <= limits.event_payload_bytes
+        :oversized -> false
+      end
+    end)
+  end
+
+  defp terminal_envelope_bytes(type) do
+    envelope = %{
+      schema_version: 1,
+      run_id: String.duplicate("r", 256),
+      trace_id: String.duplicate("t", 256),
+      sequence: @drop_count_limit,
+      timestamp: ~U[9999-12-31 23:59:59.999999Z],
+      type: type,
+      data: nil
+    }
+
+    RetainedSize.bytes(envelope)
+  end
 
   defp valid_id?(value),
     do: is_binary(value) and byte_size(value) in 1..256 and String.valid?(value)

--- a/lib/ptc_runner/kernel/event_sink_state.ex
+++ b/lib/ptc_runner/kernel/event_sink_state.ex
@@ -5,6 +5,9 @@ defmodule PtcRunner.Kernel.EventSinkState do
   alias PtcRunner.Lisp.RetainedSize
 
   @event_type ~r/\A[a-z][a-z0-9-]{0,127}\z/
+  @drop_type_buckets 16
+  @drop_overflow "$overflow"
+  @drop_count_limit 4_294_967_295
 
   @doc false
   def new(policy, limits, token, run_id, trace_id, terminal_reserve) do
@@ -19,11 +22,31 @@ defmodule PtcRunner.Kernel.EventSinkState do
       events: [],
       dropped: %{},
       terminal_reserve: terminal_reserve,
+      begun?: false,
       finalized?: false
     }
   end
 
   @doc false
+  def handle(
+        {token, {:begin, data}},
+        %{token: token, begun?: false, finalized?: false} = state
+      ) do
+    with {:ok, event, bytes} <- event_with_bytes(state, "run-started", data),
+         true <- ordinary_capacity?(state, bytes) do
+      next = retain_event(%{state | begun?: true}, event, bytes)
+      {:ok, next}
+    else
+      _error -> {{:error, :event_sink_error}, state}
+    end
+  end
+
+  def handle(
+        {token, {:emit, _type, _data}},
+        %{token: token, finalized?: true} = state
+      ),
+      do: {{:error, :event_sink_error}, state}
+
   def handle({token, {:emit, type, data}}, %{token: token} = state) do
     case event_with_bytes(state, type, data) do
       {:ok, event, bytes} -> enqueue(state, event, bytes)
@@ -32,22 +55,16 @@ defmodule PtcRunner.Kernel.EventSinkState do
   end
 
   def handle(
-        {token, {:finalize, dropped_data, stopped_data}},
-        %{token: token, policy: :normal} = state
+        {token, {:finalize_and_events, stopped_data}},
+        %{token: token} = state
       ) do
-    case finalize_state(state, dropped_data, stopped_data) do
-      {:ok, next} -> {:ok, next}
-      :error -> {{:error, :event_sink_error}, state}
-    end
-  end
+    case finalize_state(state, stopped_data) do
+      {:ok, next} ->
+        batch = %{events: Enum.reverse(next.events), dropped: next.dropped}
+        {{:ok, batch}, next}
 
-  def handle(
-        {token, {:finalize_and_events, dropped_data, stopped_data}},
-        %{token: token, policy: :normal} = state
-      ) do
-    case finalize_state(state, dropped_data, stopped_data) do
-      {:ok, next} -> {{:ok, Enum.reverse(next.events)}, next}
-      :error -> {{:error, :event_sink_error}, state}
+      :error ->
+        {{:error, :event_sink_error}, state}
     end
   end
 
@@ -60,12 +77,21 @@ defmodule PtcRunner.Kernel.EventSinkState do
   def handle({token, :identity}, %{token: token} = state),
     do: {%{run_id: state.run_id, trace_id: state.trace_id}, state}
 
+  def handle({token, {:begin_capacity?, data}}, %{token: token} = state) do
+    fits? =
+      match?({:ok, _event, _bytes}, event_with_ordinary_capacity(state, "run-started", data))
+
+    {fits?, state}
+  end
+
   def handle({token, :session_contract}, %{token: token} = state) do
     contract = %{
       terminal_reserve: state.terminal_reserve,
+      limits: state.limits,
       ready?: ready?(state),
       event_count: length(state.events),
       event_bytes: state.bytes,
+      begun?: state.begun?,
       dropped?: map_size(state.dropped) != 0
     }
 
@@ -78,33 +104,64 @@ defmodule PtcRunner.Kernel.EventSinkState do
   def ready?(state), do: not state.finalized?
 
   defp enqueue(state, event, bytes) do
+    if ordinary_capacity?(state, bytes) do
+      {:ok, retain_event(state, event, bytes)}
+    else
+      sink_failure(state, event.type)
+    end
+  end
+
+  defp event_with_ordinary_capacity(state, type, data) do
+    with {:ok, event, bytes} <- event_with_bytes(state, type, data),
+         true <- ordinary_capacity?(state, bytes) do
+      {:ok, event, bytes}
+    else
+      _ -> :error
+    end
+  end
+
+  defp ordinary_capacity?(state, bytes) do
     reserve = state.terminal_reserve
 
-    full? =
-      state.finalized? or
-        length(state.events) >= state.limits.normal_event_count - reserve.count or
-        state.bytes + bytes > state.limits.normal_event_bytes - reserve.bytes
+    not state.finalized? and
+      length(state.events) < state.limits.normal_event_count - reserve.count and
+      state.bytes + bytes <= state.limits.normal_event_bytes - reserve.bytes
+  end
 
-    if full? do
-      sink_failure(state, event.type)
-    else
-      {:ok,
-       %{
-         state
-         | sequence: state.sequence + 1,
-           bytes: state.bytes + bytes,
-           events: [event | state.events]
-       }}
-    end
+  defp retain_event(state, event, bytes) do
+    %{
+      state
+      | sequence: state.sequence + 1,
+        bytes: state.bytes + bytes,
+        events: [event | state.events]
+    }
   end
 
   defp sink_failure(%{policy: :private} = state, _type),
     do: {{:error, :event_sink_error}, state}
 
   defp sink_failure(state, type) do
-    dropped = Map.update(state.dropped, type, 1, &(&1 + 1))
+    bucket = drop_bucket(state.dropped, type)
+    dropped = Map.update(state.dropped, bucket, 1, &increment_drop_count/1)
     {:ok, %{state | dropped: dropped}}
   end
+
+  defp drop_bucket(dropped, type) do
+    cond do
+      Map.has_key?(dropped, type) -> type
+      valid_drop_type?(type) and drop_type_bucket_count(dropped) < @drop_type_buckets -> type
+      true -> @drop_overflow
+    end
+  end
+
+  defp valid_drop_type?(type), do: is_binary(type) and type =~ @event_type
+
+  defp drop_type_bucket_count(dropped) do
+    map_size(dropped) - if(Map.has_key?(dropped, @drop_overflow), do: 1, else: 0)
+  end
+
+  defp increment_drop_count(count) when count < @drop_count_limit, do: count + 1
+  defp increment_drop_count(_count), do: @drop_count_limit
 
   defp event_with_bytes(state, type, data) do
     payload_cap = state.limits.event_payload_bytes
@@ -127,27 +184,40 @@ defmodule PtcRunner.Kernel.EventSinkState do
     end
   end
 
-  defp finalize_state(%{finalized?: true} = state, _dropped_data, _stopped_data),
+  defp finalize_state(%{finalized?: true} = state, _stopped_data),
     do: {:ok, state}
 
-  defp finalize_state(state, dropped_data, stopped_data) do
-    terminal =
-      if map_size(state.dropped) == 0 do
-        [{"run-stopped", stopped_data}]
-      else
-        [
-          {"events-dropped", Map.put(dropped_data, :counts, state.dropped)},
-          {"run-stopped", stopped_data}
-        ]
-      end
-
-    with true <- length(terminal) <= state.terminal_reserve.count,
+  defp finalize_state(state, stopped_data) do
+    with {:ok, stopped_data} <- put_dropped_usage(stopped_data, state.dropped),
+         terminal = terminal_events(stopped_data, state.dropped),
+         true <- terminal_capacity?(state, terminal),
          {:ok, next} <- enqueue_terminal_events(%{state | finalized?: true}, terminal) do
       {:ok, next}
     else
       _ -> :error
     end
   end
+
+  defp put_dropped_usage(stopped_data, dropped) do
+    case Map.get(stopped_data, :usage, %{}) do
+      usage when is_map(usage) and not is_struct(usage) ->
+        {:ok, Map.put(stopped_data, :usage, Map.put(usage, :events_dropped, dropped))}
+
+      _invalid ->
+        :error
+    end
+  end
+
+  defp terminal_events(stopped_data, dropped) when map_size(dropped) == 0,
+    do: [{"run-stopped", stopped_data}]
+
+  defp terminal_events(stopped_data, dropped),
+    do: [{"events-dropped", %{counts: dropped}}, {"run-stopped", stopped_data}]
+
+  defp terminal_capacity?(%{policy: :normal} = state, terminal),
+    do: length(terminal) <= state.terminal_reserve.count
+
+  defp terminal_capacity?(%{policy: :private}, _terminal), do: true
 
   defp enqueue_terminal_events(state, []), do: {:ok, state}
 

--- a/lib/ptc_runner/kernel/log_analysis_session.ex
+++ b/lib/ptc_runner/kernel/log_analysis_session.ex
@@ -98,9 +98,8 @@ defmodule PtcRunner.Kernel.LogAnalysisSession do
              assembly.snapshot
            ),
          :ok <-
-           EventSink.emit(
+           EventSink.begin(
              assembly.config.event_sink,
-             "run-started",
              assembly.config.run_started_metadata
            ),
          :ok <-

--- a/lib/ptc_runner/kernel/log_analysis_session_builder.ex
+++ b/lib/ptc_runner/kernel/log_analysis_session_builder.ex
@@ -14,6 +14,7 @@ defmodule PtcRunner.Kernel.LogAnalysisSessionBuilder do
   owner rather than in a disposable request task.
   """
 
+  alias PtcRunner.Kernel.EventSink
   alias PtcRunner.Kernel.LogAnalysisAssembly
   alias PtcRunner.Kernel.LogAnalysisProfile
   alias PtcRunner.Kernel.LogAnalysisSession
@@ -123,7 +124,7 @@ defmodule PtcRunner.Kernel.LogAnalysisSessionBuilder do
     limits = LogAnalysisProfile.limits()
     run_id = "log-analysis-" <> Base.encode16(:crypto.strong_rand_bytes(8), case: :lower)
     destination = Path.join(trace_directory, run_id <> ".jsonl")
-    terminal_reserve = %{count: 2, bytes: limits.event_payload_bytes * 2}
+    terminal_reserve = EventSink.terminal_reserve(:normal, limits)
 
     case RunState.start_with_event_sink(
            limits,

--- a/lib/ptc_runner/kernel/repl_session.ex
+++ b/lib/ptc_runner/kernel/repl_session.ex
@@ -8,8 +8,9 @@ defmodule PtcRunner.Kernel.ReplSession do
   labels, and event policy from an optional `PtcRunner.Kernel.RunConfig` but
   does not execute the manifest entry function.
 
-  The session owns one internal run state and event sink. Call `close/1` for a
-  normal terminal event or `abort/2` when the frontend terminates early.
+  The session owns one internal run state and event sink. Call `close/1` for an
+  atomically frozen terminal batch or `abort/2` when the frontend terminates
+  early. Both paths use the recorder's reserved terminal capacity.
   """
 
   alias PtcRunner.Kernel.Dispatcher
@@ -88,24 +89,16 @@ defmodule PtcRunner.Kernel.ReplSession do
   end
 
   @spec close(t()) :: {:ok, [map()]} | {:error, :event_sink_error | :session_closed}
-  @doc "Closes a session normally and returns its retained canonical events."
+  @doc "Closes a session normally and returns its atomically frozen canonical events."
   def close(%__MODULE__{} = session) do
     if sink_alive?(session) do
       try do
         :ok = RunState.close(session.state)
-        _ = emit_dropped_summary(session)
+        outcome = if session.errors == 0, do: :ok, else: :error
+        reason = if session.errors == 0, do: nil, else: :repl_evaluation_error
 
-        result =
-          emit_run_stopped(
-            session,
-            if(session.errors == 0, do: :ok, else: :error),
-            if(session.errors == 0, do: nil, else: :repl_evaluation_error)
-          )
-
-        events = if result == :ok, do: EventSink.events(session.config.event_sink), else: []
-
-        case result do
-          :ok -> {:ok, events}
+        case finalize(session, outcome, reason) do
+          {:ok, events} -> {:ok, events}
           {:error, :event_sink_error} -> {:error, :event_sink_error}
         end
       catch
@@ -124,9 +117,11 @@ defmodule PtcRunner.Kernel.ReplSession do
     if sink_alive?(session) do
       try do
         :ok = RunState.close(session.state)
-        _ = emit_dropped_summary(session)
-        _ = emit_run_stopped(session, :error, reason)
-        {:ok, EventSink.events(session.config.event_sink)}
+
+        case finalize(session, :error, reason) do
+          {:ok, events} -> {:ok, events}
+          {:error, :event_sink_error} -> :ok
+        end
       after
         stop_owners(session)
       end
@@ -164,7 +159,7 @@ defmodule PtcRunner.Kernel.ReplSession do
   defp config(_config), do: {:error, :invalid_repl_session}
 
   defp emit_run_started(config) do
-    EventSink.emit(config.event_sink, "run-started", config.run_started_metadata)
+    EventSink.begin(config.event_sink, config.run_started_metadata)
   end
 
   defp start_session(config) do
@@ -186,27 +181,26 @@ defmodule PtcRunner.Kernel.ReplSession do
       {:error, :event_sink_error} = error ->
         RunState.close(state)
         RunState.stop(state)
-        RunConfig.close_provider_resources(config)
-        if config.inspection_sink, do: InspectionSink.stop(config.inspection_sink)
-        EventSink.stop(config.event_sink)
         error
     end
   end
 
-  defp emit_run_stopped(session, outcome, reason) do
+  defp finalize(session, outcome, reason) do
     errors = max(session.errors, observed_errors(session))
 
     usage =
       session.state
       |> RunState.usage()
       |> Map.put(:errors, errors)
-      |> Map.put(:events_dropped, EventSink.dropped(session.config.event_sink))
 
-    EventSink.emit(session.config.event_sink, "run-stopped", %{
-      outcome: outcome,
-      reason: reason,
-      usage: usage
-    })
+    case EventSink.finalize_and_events(session.config.event_sink, %{
+           outcome: outcome,
+           reason: reason,
+           usage: usage
+         }) do
+      {:ok, %{events: events}} -> {:ok, events}
+      {:error, :event_sink_error} = error -> error
+    end
   end
 
   defp observed_errors(session) do
@@ -497,13 +491,6 @@ defmodule PtcRunner.Kernel.ReplSession do
     case RetainedSize.bytes_with_cap(value, limit) do
       bytes when is_integer(bytes) and bytes <= limit -> true
       _ -> false
-    end
-  end
-
-  defp emit_dropped_summary(session) do
-    case EventSink.dropped(session.config.event_sink) do
-      dropped when map_size(dropped) == 0 -> :ok
-      dropped -> EventSink.emit(session.config.event_sink, "events-dropped", %{counts: dropped})
     end
   end
 

--- a/lib/ptc_runner/kernel/run_builder.ex
+++ b/lib/ptc_runner/kernel/run_builder.ex
@@ -216,20 +216,26 @@ defmodule PtcRunner.Kernel.RunBuilder do
     :ok
   end
 
-  # Provider resources are already closed by `Kernel.run/2`; the event sink
-  # remains live long enough for optional post-run canonical trace persistence.
+  # Provider resources are already closed by `Kernel.run_and_events/2`; the
+  # returned terminal batch is the sole input to both persistence paths.
   defp execute_built(built, opts) do
-    result = Kernel.run(built.entry_source, built.config)
+    {result, terminal_batch} = Kernel.run_and_events(built.entry_source, built.config)
 
-    with :ok <- persist_trace(Keyword.get(opts, :trace), built.config.event_sink),
-         :ok <- persist_inspection(built.config) do
-      result
-    else
-      {:error, {:trace, reason}} ->
-        {:error, {:trace_persistence_failed, reason, result}}
+    case terminal_batch do
+      {:ok, events} ->
+        with :ok <- persist_trace(Keyword.get(opts, :trace), built.config.event_sink, events),
+             :ok <- persist_inspection(built.config, events) do
+          result
+        else
+          {:error, {:trace, reason}} ->
+            {:error, {:trace_persistence_failed, reason, result}}
 
-      {:error, {:inspection, reason}} ->
-        {:error, {:inspection_persistence_failed, reason, result}}
+          {:error, {:inspection, reason}} ->
+            {:error, {:inspection_persistence_failed, reason, result}}
+        end
+
+      {:error, _reason} ->
+        result
     end
   end
 
@@ -298,28 +304,28 @@ defmodule PtcRunner.Kernel.RunBuilder do
     end
   end
 
-  defp persist_trace(nil, _sink), do: :ok
+  defp persist_trace(nil, _sink, _events), do: :ok
 
-  defp persist_trace(path, sink) when is_binary(path) do
+  defp persist_trace(path, sink, events) when is_binary(path) do
     private? = EventSink.policy(sink) == :private
 
-    case TraceLog.append_jsonl(path, EventSink.events(sink), private: private?) do
+    case TraceLog.append_jsonl(path, events, private: private?) do
       :ok -> :ok
       {:error, reason} -> {:error, {:trace, reason}}
     end
   end
 
-  defp persist_trace(_path, _sink), do: {:error, {:trace, :invalid_trace_log}}
+  defp persist_trace(_path, _sink, _events), do: {:error, {:trace, :invalid_trace_log}}
 
-  defp persist_inspection(%RunConfig{inspection_sink: nil}), do: :ok
+  defp persist_inspection(%RunConfig{inspection_sink: nil}, _events), do: :ok
 
-  defp persist_inspection(%RunConfig{} = config) do
+  defp persist_inspection(%RunConfig{} = config, events) do
     with {:ok, records} <- InspectionSink.records(config.inspection_sink),
          :ok <-
            InspectionArtifact.persist(
              config.inspection_path,
              records,
-             EventSink.events(config.event_sink)
+             events
            ) do
       :ok
     else

--- a/lib/ptc_runner/kernel/run_config.ex
+++ b/lib/ptc_runner/kernel/run_config.ex
@@ -2,6 +2,10 @@ defmodule PtcRunner.Kernel.RunConfig do
   @moduledoc """
   The complete host-constructed configuration for one Kernel run.
 
+  A configuration is one-shot: terminal publication finalizes its event sink,
+  and a later `PtcRunner.Kernel.run/2` with the same value fails with
+  `:event_sink_error`. Build a fresh configuration and sink for every run.
+
   The required fields are:
 
   - `workflow_environment` — trusted outer workflow code and capabilities;
@@ -9,6 +13,11 @@ defmodule PtcRunner.Kernel.RunConfig do
   - `input` — a JSON-like map exposed as the workflow evaluation context;
   - `limits` — normalized positive runtime ceilings;
   - `event_sink` — the bounded owner of canonical run events.
+
+  An event sink must be open and use these exact limits. A normal sink carries
+  the standard two-event measured terminal reserve, must leave room for the
+  assembled `run-started` event, and must have a payload ceiling large enough
+  for the bounded loss summary. Private sinks reserve no lossy terminal slots.
 
   Construction derives and freezes `mission_inventory` from the mission
   environment and limits. It contains both the authoritative versioned
@@ -26,8 +35,9 @@ defmodule PtcRunner.Kernel.RunConfig do
   `session_profile` is an optional closed profile ID and SHA-256 digest used by
   server-owned interactive mission sessions; it grants no authority and is
   copied only into safe `run-started` metadata.
-  Constructing a config validates shape and ownership objects but performs no
-  execution and grants no authority beyond the supplied environments.
+  Constructing a config validates shape, recorder readiness, and ownership
+  objects but performs no execution and grants no authority beyond the supplied
+  environments.
   """
 
   alias PtcRunner.Kernel.EventSink
@@ -110,6 +120,7 @@ defmodule PtcRunner.Kernel.RunConfig do
          true <- JSONValue.map?(Keyword.get(opts, :input)),
          %Limits{} = limits <- Keyword.get(opts, :limits),
          %EventSink{} = sink <- Keyword.get(opts, :event_sink),
+         true <- valid_event_sink_contract?(sink, limits),
          true <-
            inspection?(Keyword.get(opts, :inspection_sink), Keyword.get(opts, :inspection_path)),
          true <- provider_resources?(Keyword.get(opts, :provider_resources, [])),
@@ -126,7 +137,8 @@ defmodule PtcRunner.Kernel.RunConfig do
              session_profile,
              labels,
              limits
-           ) do
+           ),
+         true <- EventSink.begin_capacity?(sink, run_started_metadata) do
       {:ok,
        %__MODULE__{
          workflow_environment: workflow,
@@ -148,6 +160,41 @@ defmodule PtcRunner.Kernel.RunConfig do
       {:error, :run_started_metadata_exceeded} = error -> error
       _ -> {:error, :invalid_run_config}
     end
+  end
+
+  defp valid_event_sink_contract?(%EventSink{policy: :normal} = sink, limits) do
+    reserve = EventSink.terminal_reserve(:normal, limits)
+
+    limits.normal_event_count > reserve.count and limits.normal_event_bytes > reserve.bytes and
+      match?(
+        {:ok,
+         %{
+           terminal_reserve: ^reserve,
+           limits: ^limits,
+           ready?: true,
+           begun?: false,
+           event_count: 0,
+           event_bytes: 0,
+           dropped?: false
+         }},
+        EventSink.session_contract(sink)
+      )
+  end
+
+  defp valid_event_sink_contract?(%EventSink{policy: :private} = sink, limits) do
+    match?(
+      {:ok,
+       %{
+         terminal_reserve: %{count: 0, bytes: 0},
+         limits: ^limits,
+         ready?: true,
+         begun?: false,
+         event_count: 0,
+         event_bytes: 0,
+         dropped?: false
+       }},
+      EventSink.session_contract(sink)
+    )
   end
 
   # One owner assembles the complete static `run-started` payload — labels,

--- a/lib/ptc_runner/kernel/runner.ex
+++ b/lib/ptc_runner/kernel/runner.ex
@@ -22,6 +22,14 @@ defmodule PtcRunner.Kernel.Runner do
   @spec run(binary(), RunConfig.t()) :: {:ok, Result.t()} | {:error, Error.t()}
   @doc "Executes one validated run configuration and always tears down run state."
   def run(entry_source, %RunConfig{} = config) when is_binary(entry_source) do
+    {result, _terminal_batch} = run_and_events(entry_source, config)
+    result
+  end
+
+  @doc false
+  @spec run_and_events(binary(), RunConfig.t()) ::
+          {{:ok, Result.t()} | {:error, Error.t()}, {:ok, [map()]} | {:error, atom()}}
+  def run_and_events(entry_source, %RunConfig{} = config) when is_binary(entry_source) do
     with :ok <- entry_source_within_limit(entry_source, config.limits),
          {:ok, state} <- RunState.start(config.limits) do
       try do
@@ -31,34 +39,45 @@ defmodule PtcRunner.Kernel.Runner do
         RunState.stop(state)
       end
     else
-      {:error, reason} -> configuration_error(reason, %{})
+      {:error, reason} ->
+        {configuration_error(reason, %{}), {:error, :terminal_batch_unavailable}}
     end
-  after
-    RunConfig.close_provider_resources(config)
   end
 
   defp run_with_events(entry_source, config, state) do
-    case Events.emit(state, config.event_sink, "run-started", config.run_started_metadata) do
+    case EventSink.begin(config.event_sink, config.run_started_metadata) do
       :ok ->
-        result = run_workflow(entry_source, config, state)
-        result = apply_terminal_failure(result, state)
-        _ = emit_dropped_summary(state, config.event_sink)
-        usage = usage_with_events(state, config.event_sink)
-
-        case Events.emit(state, config.event_sink, "run-stopped", %{
-               outcome: outcome(result),
-               reason: terminal_reason(result),
-               usage: usage
-             }) do
-          :ok ->
-            put_result_usage(result, usage_with_events(state, config.event_sink))
-
-          {:error, :event_sink_error} ->
-            event_sink_error(usage_with_events(state, config.event_sink))
+        try do
+          result = run_workflow(entry_source, config, state)
+          result = apply_terminal_failure(result, state)
+          :ok = RunState.close(state)
+          finalize_run(result, state, config.event_sink)
+        after
+          RunConfig.close_provider_resources(config)
         end
 
       {:error, :event_sink_error} ->
-        event_sink_error(RunState.usage(state))
+        {event_sink_error(RunState.usage(state)), {:error, :event_sink_error}}
+    end
+  end
+
+  defp finalize_run(result, state, sink) do
+    usage = RunState.usage(state)
+
+    stopped_data = %{
+      outcome: outcome(result),
+      reason: terminal_reason(result),
+      usage: usage
+    }
+
+    case EventSink.finalize_and_events(sink, stopped_data) do
+      {:ok, %{events: events, dropped: dropped}} ->
+        final_usage = Map.put(usage, :events_dropped, dropped)
+        {put_result_usage(result, final_usage), {:ok, events}}
+
+      {:error, :event_sink_error} ->
+        failed_usage = Map.put(usage, :events_dropped, %{"event-sink" => 1})
+        {event_sink_error(failed_usage), {:error, :event_sink_error}}
     end
   end
 
@@ -252,9 +271,6 @@ defmodule PtcRunner.Kernel.Runner do
   defp terminal_reason({:ok, _result}), do: nil
   defp terminal_reason({:error, %Error{reason: reason}}), do: reason
 
-  defp usage_with_events(state, sink),
-    do: Map.put(RunState.usage(state), :events_dropped, EventSink.dropped(sink))
-
   defp put_result_usage({:ok, %Result{} = result}, usage), do: {:ok, %{result | usage: usage}}
   defp put_result_usage({:error, %Error{} = error}, usage), do: {:error, %{error | usage: usage}}
 
@@ -284,13 +300,6 @@ defmodule PtcRunner.Kernel.Runner do
            details: %{},
            usage: RunState.usage(state)
          }}
-    end
-  end
-
-  defp emit_dropped_summary(state, sink) do
-    case EventSink.dropped(sink) do
-      dropped when map_size(dropped) == 0 -> :ok
-      dropped -> Events.emit(state, sink, "events-dropped", %{counts: dropped})
     end
   end
 

--- a/lib/ptc_runner/kernel/session_trace.ex
+++ b/lib/ptc_runner/kernel/session_trace.ex
@@ -307,8 +307,8 @@ defmodule PtcRunner.Kernel.SessionTrace do
   defp finalize_state(%{persistence: :open} = state, outcome, reason, usage) do
     stopped = %{outcome: outcome, reason: reason, usage: usage}
 
-    case EventSink.finalize_and_events(state.sink, %{}, stopped) do
-      {:ok, events} when events != [] ->
+    case EventSink.finalize_and_events(state.sink, stopped) do
+      {:ok, %{events: events}} when events != [] ->
         {:ok,
          %{
            state
@@ -328,7 +328,7 @@ defmodule PtcRunner.Kernel.SessionTrace do
   defp finalize_state(state, _outcome, _reason, _usage), do: {:ok, state}
 
   defp valid_trace_contract?(limits, destination, run_id, run_state, sink) do
-    expected_reserve = %{count: 2, bytes: limits.event_payload_bytes * 2}
+    expected_reserve = EventSink.terminal_reserve(:normal, limits)
 
     String.valid?(destination) and String.valid?(run_id) and run_id != "" and
       Path.basename(destination) == run_id <> ".jsonl" and sink.policy == :normal and
@@ -339,7 +339,9 @@ defmodule PtcRunner.Kernel.SessionTrace do
         {:ok,
          %{
            terminal_reserve: expected_reserve,
+           limits: limits,
            ready?: true,
+           begun?: false,
            event_count: 0,
            event_bytes: 0,
            dropped?: false

--- a/test/ptc_runner/kernel/agent_library_test.exs
+++ b/test/ptc_runner/kernel/agent_library_test.exs
@@ -59,7 +59,6 @@ defmodule PtcRunner.Kernel.AgentLibraryTest do
     {:ok, workflow} = WorkflowEnvironment.new(bundle: bundle)
     {:ok, mission} = MissionEnvironment.new([])
     {:ok, limits} = Limits.new()
-    {:ok, sink} = EventSink.start(:normal, limits, run_id: "native-action")
 
     valid = %{
       "content" => nil,
@@ -78,7 +77,9 @@ defmodule PtcRunner.Kernel.AgentLibraryTest do
        "wrong-tool-name"}
     ]
 
-    for {response, expected_kind, expected_reason} <- cases do
+    for {{response, expected_kind, expected_reason}, index} <- Enum.with_index(cases) do
+      {:ok, sink} = EventSink.start(:normal, limits, run_id: "native-action-#{index}")
+
       {:ok, config} =
         RunConfig.new(
           workflow_environment: workflow,

--- a/test/ptc_runner/kernel/core_contract_test.exs
+++ b/test/ptc_runner/kernel/core_contract_test.exs
@@ -287,7 +287,13 @@ defmodule PtcRunner.Kernel.CoreContractTest do
 
   test "normal event sinks drop while private event sinks fail closed" do
     {:ok, limits} = Limits.new(normal_event_count: 1, normal_event_bytes: 10_000)
-    {:ok, normal} = EventSink.start(:normal, limits, run_id: "normal")
+
+    {:ok, normal} =
+      EventSink.start(:normal, limits,
+        run_id: "normal",
+        terminal_reserve: %{count: 0, bytes: 0}
+      )
+
     {:ok, private} = EventSink.start(:private, limits, run_id: "private")
 
     assert :ok = EventSink.emit(normal, "run-started", %{"safe" => true})
@@ -316,7 +322,7 @@ defmodule PtcRunner.Kernel.CoreContractTest do
 
     EventSink.stop(normal)
 
-    assert {:ok, %{value: 42, usage: %{events_dropped: %{"event-sink" => 1}}}} =
+    assert {:error, %{kind: :event_sink_error, reason: :event_sink_error}} =
              Kernel.run("(return 42)", normal_config)
 
     {:ok, private} = EventSink.start(:private, limits, run_id: "stopped-private")
@@ -355,10 +361,17 @@ defmodule PtcRunner.Kernel.CoreContractTest do
              Kernel.run("(return 42)", config)
   end
 
-  test "normal sink terminal drops are included in returned usage" do
+  test "normal Runner finalization reserves and freezes the terminal envelope" do
     {:ok, workflow} = WorkflowEnvironment.new([])
     {:ok, mission} = MissionEnvironment.new([])
-    {:ok, limits} = Limits.new(normal_event_count: 1, normal_event_bytes: 10_000)
+
+    {:ok, limits} =
+      Limits.new(
+        normal_event_count: 4,
+        normal_event_bytes: 100_000,
+        event_payload_bytes: 5_000
+      )
+
     {:ok, sink} = EventSink.start(:normal, limits, run_id: "normal-run")
 
     {:ok, config} =
@@ -371,7 +384,153 @@ defmodule PtcRunner.Kernel.CoreContractTest do
       )
 
     assert {:ok, %{usage: %{events_dropped: dropped}}} = Kernel.run("(return 42)", config)
-    assert dropped["run-stopped"] == 1
+    assert dropped == %{"evaluation-stopped" => 1}
+
+    events = EventSink.events(sink)
+
+    assert Enum.map(events, & &1.type) ==
+             ["run-started", "evaluation-started", "events-dropped", "run-stopped"]
+
+    assert List.last(events).data.usage.events_dropped == dropped
+
+    assert :ok = EventSink.emit(sink, "late-event", %{})
+    assert EventSink.events(sink) == events
+    assert EventSink.dropped(sink) == dropped
+  end
+
+  test "run configuration rejects a normal sink without terminal capacity" do
+    {:ok, workflow} = WorkflowEnvironment.new([])
+    {:ok, mission} = MissionEnvironment.new([])
+
+    {:ok, limits} =
+      Limits.new(
+        normal_event_count: 4,
+        normal_event_bytes: 20_000,
+        event_payload_bytes: 1_000
+      )
+
+    {:ok, sink} =
+      EventSink.start(:normal, limits,
+        run_id: "missing-terminal-reserve",
+        terminal_reserve: %{count: 0, bytes: 0}
+      )
+
+    assert {:error, :invalid_run_config} =
+             RunConfig.new(
+               workflow_environment: workflow,
+               mission_environment: mission,
+               input: %{},
+               limits: limits,
+               event_sink: sink
+             )
+  end
+
+  test "run configuration requires exact sink limits and room for run-started" do
+    {:ok, workflow} = WorkflowEnvironment.new([])
+    {:ok, mission} = MissionEnvironment.new([])
+    sink_limits = Limits.defaults()
+    {:ok, normal} = EventSink.start(:normal, sink_limits, run_id: "mismatched-normal")
+    {:ok, private} = EventSink.start(:private, sink_limits, run_id: "mismatched-private")
+    config_limits = %{sink_limits | run_duration_ms: sink_limits.run_duration_ms + 1}
+
+    for sink <- [normal, private] do
+      assert {:error, :invalid_run_config} =
+               RunConfig.new(
+                 workflow_environment: workflow,
+                 mission_environment: mission,
+                 input: %{},
+                 limits: config_limits,
+                 event_sink: sink
+               )
+    end
+
+    {:ok, base_limits} = Limits.new(normal_event_count: 3, event_payload_bytes: 5_000)
+    reserve = EventSink.terminal_reserve(:normal, base_limits)
+
+    {:ok, tight_limits} =
+      Limits.new(
+        normal_event_count: 3,
+        normal_event_bytes: reserve.bytes + 1,
+        event_payload_bytes: 5_000
+      )
+
+    {:ok, tight} = EventSink.start(:normal, tight_limits, run_id: "tight-run-started")
+
+    assert {:error, :invalid_run_config} =
+             RunConfig.new(
+               workflow_environment: workflow,
+               mission_environment: mission,
+               input: %{},
+               limits: tight_limits,
+               event_sink: tight
+             )
+  end
+
+  test "a finalized run configuration is one-shot" do
+    {:ok, workflow} = WorkflowEnvironment.new([])
+    {:ok, mission} = MissionEnvironment.new([])
+    limits = Limits.defaults()
+    {:ok, sink} = EventSink.start(:normal, limits, run_id: "one-shot-config")
+
+    {:ok, config} =
+      RunConfig.new(
+        workflow_environment: workflow,
+        mission_environment: mission,
+        input: %{},
+        limits: limits,
+        event_sink: sink
+      )
+
+    assert {:ok, %{value: 42}} = Kernel.run("(return 42)", config)
+
+    assert {:error, %{kind: :event_sink_error, reason: :event_sink_error}} =
+             Kernel.run("(return 43)", config)
+  end
+
+  test "a shared run configuration is claimed atomically before execution" do
+    parent = self()
+
+    {:ok, blocking} =
+      Capability.new(
+        name: "blocking",
+        input_schema: @input_schema,
+        callback: fn _arguments ->
+          send(parent, {:provider_started, self()})
+
+          receive do
+            :continue -> {:ok, 42}
+          end
+        end
+      )
+
+    {:ok, workflow} = WorkflowEnvironment.new(capabilities: [blocking])
+    {:ok, mission} = MissionEnvironment.new([])
+    limits = Limits.defaults()
+    {:ok, sink} = EventSink.start(:normal, limits, run_id: "atomic-run-claim")
+
+    {:ok, config} =
+      RunConfig.new(
+        workflow_environment: workflow,
+        mission_environment: mission,
+        input: %{},
+        limits: limits,
+        event_sink: sink,
+        provider_resources: [fn -> send(parent, :resource_closed) end]
+      )
+
+    first = Task.async(fn -> Kernel.run("(return (tool/blocking {}))", config) end)
+    assert_receive {:provider_started, provider}
+
+    assert {:error, %{kind: :event_sink_error, reason: :event_sink_error}} =
+             Kernel.run("(return 43)", config)
+
+    refute_receive :resource_closed
+
+    send(provider, :continue)
+    assert {:ok, %{value: %{status: :ok, value: 42}}} = Task.await(first)
+    assert_receive :resource_closed
+
+    assert Enum.count(EventSink.events(sink), &(&1.type == "run-started")) == 1
   end
 
   test "run owners provide explicit teardown and stop with their creating process" do
@@ -1180,8 +1339,19 @@ defmodule PtcRunner.Kernel.CoreContractTest do
 
     assert {:ok, %{value: %{outcome: :returned, value: 42}}} = Kernel.run(source, config)
 
+    {:ok, second_sink} = EventSink.start(:normal, limits, run_id: "kernel-library-invalid")
+
+    {:ok, second_config} =
+      RunConfig.new(
+        workflow_environment: workflow,
+        mission_environment: mission,
+        input: %{},
+        limits: limits,
+        event_sink: second_sink
+      )
+
     assert {:ok, %{value: %{kind: :protocol_error, reason: :invalid_kernel_eval_request}}} =
-             Kernel.run("(return (kernel/eval \"(return 42)\"))", config)
+             Kernel.run("(return (kernel/eval \"(return 42)\"))", second_config)
   end
 
   test "runtime discovery and workflow annotation helpers expose bounded host facts" do
@@ -1228,26 +1398,47 @@ defmodule PtcRunner.Kernel.CoreContractTest do
     assert %{type: "workflow-annotation", data: %{annotation_type: "progress"}} =
              Enum.find(EventSink.events(sink), &(&1.type == "workflow-annotation"))
 
+    config_for = fn run_id ->
+      {:ok, next_sink} = EventSink.start(:normal, limits, run_id: run_id)
+
+      {:ok, next_config} =
+        RunConfig.new(
+          workflow_environment: workflow,
+          mission_environment: mission,
+          input: %{},
+          limits: limits,
+          event_sink: next_sink
+        )
+
+      {next_config, next_sink}
+    end
+
     private = "PRIVATE_GENERATED_SOURCE_(return_42)"
+    {private_config, private_sink} = config_for.("runtime-library-private")
 
     assert {:ok, %{value: %{status: :error, reason: :invalid_workflow_annotation}}} =
              Kernel.run(
                ~s|(return (workflow.event/annotate "progress" {"source" "#{private}"}))|,
-               config
+               private_config
              )
 
     prompt = "SECRET_PROMPT"
     session = "session-123"
+    {prompt_config, prompt_sink} = config_for.("runtime-library-prompt")
 
     assert {:ok, %{value: %{status: :error, reason: :invalid_workflow_annotation}}} =
              Kernel.run(
                ~s|(return (workflow.event/annotate "progress" {"prompt" "#{prompt}" "session_id" "#{session}"}))|,
-               config
+               prompt_config
              )
 
-    refute EventSink.events(sink) |> Jason.encode!() |> String.contains?(private)
-    refute EventSink.events(sink) |> Jason.encode!() |> String.contains?(prompt)
-    refute EventSink.events(sink) |> Jason.encode!() |> String.contains?(session)
+    public_events =
+      EventSink.events(sink) ++ EventSink.events(private_sink) ++ EventSink.events(prompt_sink)
+
+    encoded_events = Jason.encode!(public_events)
+    refute String.contains?(encoded_events, private)
+    refute String.contains?(encoded_events, prompt)
+    refute String.contains?(encoded_events, session)
   end
 
   test "terminal workflow results and retained mission memory use Kernel limits and state" do

--- a/test/ptc_runner/kernel/event_sink_test.exs
+++ b/test/ptc_runner/kernel/event_sink_test.exs
@@ -10,7 +10,9 @@ defmodule PtcRunner.Kernel.EventSinkTest do
 
     ids =
       for _ <- 1..64 do
-        {:ok, sink} = EventSink.start(:normal, limits)
+        {:ok, sink} =
+          EventSink.start(:normal, limits, terminal_reserve: %{count: 0, bytes: 0})
+
         :ok = EventSink.emit(sink, "run-started", %{})
         [event] = EventSink.events(sink)
         event.run_id
@@ -20,18 +22,55 @@ defmodule PtcRunner.Kernel.EventSinkTest do
     assert Enum.all?(ids, &Regex.match?(~r/\Arun-[0-9a-f]{12}\z/, &1))
   end
 
+  test "normal sinks reserve the ordinary terminal envelope by default" do
+    limits = Limits.defaults()
+    {:ok, sink} = EventSink.start(:normal, limits, run_id: "default-terminal-reserve")
+
+    assert {:ok, %{terminal_reserve: reserve, ready?: true}} =
+             EventSink.session_contract(sink)
+
+    assert reserve == EventSink.terminal_reserve(:normal, limits)
+    assert reserve.bytes > limits.event_payload_bytes * 2
+  end
+
+  test "drop accounting has fixed type buckets and one saturating overflow bucket" do
+    {:ok, limits} =
+      Limits.new(
+        normal_event_count: 2,
+        normal_event_bytes: 2_000,
+        event_payload_bytes: 100
+      )
+
+    {:ok, sink} =
+      EventSink.start(:normal, limits,
+        run_id: "bounded-drops",
+        terminal_reserve: %{count: 0, bytes: 0}
+      )
+
+    assert :ok = EventSink.emit(sink, "seed-one", %{})
+    assert :ok = EventSink.emit(sink, "seed-two", %{})
+
+    for index <- 1..40 do
+      assert :ok = EventSink.emit(sink, "custom-#{index}", %{})
+    end
+
+    dropped = EventSink.dropped(sink)
+    assert map_size(dropped) == 17
+    assert dropped["$overflow"] == 24
+  end
+
   test "terminal reserve retains one dropped summary and one run-stopped event" do
     {:ok, limits} =
       Limits.new(
         normal_event_count: 4,
         normal_event_bytes: 20_000,
-        event_payload_bytes: 1_000
+        event_payload_bytes: 5_000
       )
 
     {:ok, sink} =
       EventSink.start(:normal, limits,
         run_id: "reserved",
-        terminal_reserve: %{count: 2, bytes: 2_000}
+        terminal_reserve: EventSink.terminal_reserve(:normal, limits)
       )
 
     assert :ok = EventSink.emit(sink, "run-started", %{})
@@ -39,16 +78,16 @@ defmodule PtcRunner.Kernel.EventSinkTest do
     assert :ok = EventSink.emit(sink, "evaluation-stopped", %{})
     assert %{"evaluation-stopped" => 1} = EventSink.dropped(sink)
 
-    assert :ok =
-             EventSink.finalize(sink, %{}, %{
+    assert {:ok, first_batch} =
+             EventSink.finalize_and_events(sink, %{
                outcome: :ok,
                reason: nil,
                usage: %{}
              })
 
-    assert :ok = EventSink.finalize(sink, %{}, %{outcome: :error})
+    assert {:ok, ^first_batch} = EventSink.finalize_and_events(sink, %{outcome: :error})
 
-    events = EventSink.events(sink)
+    events = first_batch.events
 
     assert Enum.map(events, & &1.type) ==
              ["run-started", "evaluation-started", "events-dropped", "run-stopped"]
@@ -60,26 +99,29 @@ defmodule PtcRunner.Kernel.EventSinkTest do
     {:ok, limits} =
       Limits.new(
         normal_event_count: 10,
-        normal_event_bytes: 4_000,
-        event_payload_bytes: 1_000
+        normal_event_bytes: 20_000,
+        event_payload_bytes: 5_000
       )
 
     {:ok, sink} =
       EventSink.start(:normal, limits,
         run_id: "byte-reserved",
-        terminal_reserve: %{count: 2, bytes: 2_000}
+        terminal_reserve: EventSink.terminal_reserve(:normal, limits)
       )
 
-    assert :ok = EventSink.emit(sink, "run-started", %{value: String.duplicate("x", 800)})
+    assert :ok = EventSink.emit(sink, "run-started", %{value: String.duplicate("x", 3_500)})
 
     assert :ok =
-             EventSink.emit(sink, "evaluation-started", %{value: String.duplicate("x", 800)})
+             EventSink.emit(sink, "evaluation-started", %{
+               value: String.duplicate("x", 3_500)
+             })
 
     assert %{"evaluation-started" => 1} = EventSink.dropped(sink)
 
-    assert :ok = EventSink.finalize(sink, %{}, %{outcome: :ok, usage: %{}})
+    assert {:ok, %{events: events}} =
+             EventSink.finalize_and_events(sink, %{outcome: :ok, usage: %{}})
 
-    assert Enum.map(EventSink.events(sink), & &1.type) ==
+    assert Enum.map(events, & &1.type) ==
              ["run-started", "events-dropped", "run-stopped"]
   end
 
@@ -88,20 +130,20 @@ defmodule PtcRunner.Kernel.EventSinkTest do
       Limits.new(
         normal_event_count: 4,
         normal_event_bytes: 20_000,
-        event_payload_bytes: 1_000
+        event_payload_bytes: 5_000
       )
 
     {:ok, sink} =
       EventSink.start(:normal, limits,
         run_id: "atomic-finalize",
         fail_closed: true,
-        terminal_reserve: %{count: 2, bytes: limits.event_payload_bytes * 2}
+        terminal_reserve: EventSink.terminal_reserve(:normal, limits)
       )
 
     assert :ok = EventSink.emit(sink, "run-started", %{})
 
-    assert {:ok, events} =
-             EventSink.finalize_and_events(sink, %{}, %{outcome: :ok, reason: nil})
+    assert {:ok, %{events: events}} =
+             EventSink.finalize_and_events(sink, %{outcome: :ok, reason: nil})
 
     EventSink.stop(sink)
 
@@ -117,6 +159,16 @@ defmodule PtcRunner.Kernel.EventSinkTest do
     EventSink.stop(sink)
     assert_receive {:DOWN, ^ref, :process, _pid, :normal}
     assert {:error, :event_sink_error} = EventSink.emit(sink, "evaluation-started", %{})
+  end
+
+  test "invalid terminal usage is contained without destroying the recorder" do
+    limits = Limits.defaults()
+    {:ok, sink} = EventSink.start(:normal, limits, run_id: "invalid-terminal")
+
+    assert :ok = EventSink.begin(sink, %{})
+    assert {:error, :event_sink_error} = EventSink.finalize_and_events(sink, %{usage: nil})
+    assert Process.alive?(sink.pid)
+    assert Enum.map(EventSink.events(sink), & &1.type) == ["run-started"]
   end
 
   test "canonical identifiers and event values are validated before retention" do

--- a/test/ptc_runner/kernel/file_capability_test.exs
+++ b/test/ptc_runner/kernel/file_capability_test.exs
@@ -32,9 +32,10 @@ defmodule PtcRunner.Kernel.FileCapabilityTest do
     {:ok, workflow} = WorkflowEnvironment.new(bundle: workflow_bundle)
     {:ok, mission} = MissionEnvironment.new(bundle: mission_bundle, capabilities: [capability])
     {:ok, limits} = Limits.new(evaluation_timeout_ms: 5_000)
-    {:ok, sink} = EventSink.start(:normal, limits, run_id: "file-capability")
 
-    {:ok, config} =
+    config_for = fn run_id ->
+      {:ok, sink} = EventSink.start(:normal, limits, run_id: run_id)
+
       RunConfig.new(
         workflow_environment: workflow,
         mission_environment: mission,
@@ -42,6 +43,9 @@ defmodule PtcRunner.Kernel.FileCapabilityTest do
         limits: limits,
         event_sink: sink
       )
+    end
+
+    {:ok, read_config} = config_for.("file-capability-read")
 
     source = "(return (kernel/eval (program (return (fs/read \"inside.txt\")))))"
 
@@ -51,15 +55,18 @@ defmodule PtcRunner.Kernel.FileCapabilityTest do
                 outcome: :returned,
                 value: %{"bytes" => 15, "content" => "bounded fixture", "path" => "inside.txt"}
               }
-            }} = Kernel.run(source, config)
+            }} = Kernel.run(source, read_config)
+
+    {:ok, workflow_config} = config_for.("file-capability-workflow")
 
     assert {:error, %{kind: :workflow_failed}} =
-             Kernel.run("(return (tool/fs-read {:path \"inside.txt\"}))", config)
+             Kernel.run("(return (tool/fs-read {:path \"inside.txt\"}))", workflow_config)
 
     discovery_source = "(return (kernel/eval (program (return (cap/list)))))"
+    {:ok, discovery_config} = config_for.("file-capability-discovery")
 
     assert {:ok, %{value: %{outcome: :returned, value: [%{name: "fs-read"}]}}} =
-             Kernel.run(discovery_source, config)
+             Kernel.run(discovery_source, discovery_config)
   end
 
   @tag :tmp_dir
@@ -169,43 +176,46 @@ defmodule PtcRunner.Kernel.FileCapabilityTest do
     {:ok, mission} =
       MissionEnvironment.new(bundle: mission_bundle, capabilities: [capability])
 
-    {:ok, sink} = EventSink.start(:normal, limits, run_id: "hidden-file-authority")
+    config_for = fn selected_mission, run_id ->
+      {:ok, sink} = EventSink.start(:normal, limits, run_id: run_id)
 
-    {:ok, config} =
       RunConfig.new(
         workflow_environment: workflow,
-        mission_environment: mission,
+        mission_environment: selected_mission,
         input: %{},
         limits: limits,
         event_sink: sink
       )
+    end
+
+    {:ok, inventory_config} = config_for.(mission, "hidden-file-inventory")
 
     assert {:ok, %{value: %{outcome: :returned, value: []}}} =
-             Kernel.run("(return (kernel/eval-source \"(return (cap/list))\"))", config)
+             Kernel.run(
+               "(return (kernel/eval-source \"(return (cap/list))\"))",
+               inventory_config
+             )
+
+    {:ok, library_config} = config_for.(mission, "hidden-file-library")
 
     assert {:ok, %{value: %{outcome: :returned, value: %{"content" => "still callable"}}}} =
              Kernel.run(
                ~S|(return (kernel/eval-source "(return (fs/read \"visible.txt\"))"))|,
-               config
+               library_config
              )
+
+    {:ok, tool_config} = config_for.(mission, "hidden-file-tool")
 
     assert {:ok, %{value: %{outcome: :returned, value: %{status: :ok}}}} =
              Kernel.run(
                ~S|(return (kernel/eval-source "(return (tool/fs-read {\"path\" \"visible.txt\"}))"))|,
-               config
+               tool_config
              )
 
     {:ok, empty_mission_bundle} = Kernel.compile_bundle([cap_component])
     {:ok, empty_mission} = MissionEnvironment.new(bundle: empty_mission_bundle)
 
-    {:ok, missing_config} =
-      RunConfig.new(
-        workflow_environment: workflow,
-        mission_environment: empty_mission,
-        input: %{},
-        limits: limits,
-        event_sink: sink
-      )
+    {:ok, missing_config} = config_for.(empty_mission, "hidden-file-missing")
 
     assert {:ok, %{value: %{outcome: :evaluation_error, kind: :unknown_tool}}} =
              Kernel.run(

--- a/test/ptc_runner/kernel/log_analysis_session_test.exs
+++ b/test/ptc_runner/kernel/log_analysis_session_test.exs
@@ -9,7 +9,6 @@ defmodule PtcRunner.Kernel.LogAnalysisSessionTest do
   alias PtcRunner.Kernel.LogAnalysisSession
   alias PtcRunner.Kernel.LogAnalysisSessionBuilder
   alias PtcRunner.Kernel.MissionEnvironment
-  alias PtcRunner.Kernel.RunConfig
   alias PtcRunner.Kernel.RunState
   alias PtcRunner.Kernel.RuntimeTools
   alias PtcRunner.Kernel.SessionTrace
@@ -128,22 +127,7 @@ defmodule PtcRunner.Kernel.LogAnalysisSessionTest do
                data: %{}
              )
 
-    assert {:ok, config} =
-             RunConfig.new(
-               workflow_environment: state.config.workflow_environment,
-               mission_environment: mission,
-               input: %{},
-               limits: state.config.limits,
-               event_sink: state.config.event_sink,
-               labels: %{
-                 "name" => "ptc.log-analysis.repl",
-                 "tags" => %{"mode" => "repl"}
-               },
-               session_profile: %{
-                 "id" => state.profile.id,
-                 "digest" => state.profile.digest
-               }
-             )
+    config = %{state.config | mission_environment: mission}
 
     assembly =
       LogAnalysisAssembly.seal(
@@ -196,7 +180,7 @@ defmodule PtcRunner.Kernel.LogAnalysisSessionTest do
     tmp_dir: directory
   } do
     limits = LogAnalysisProfile.limits()
-    reserve = %{count: 2, bytes: limits.event_payload_bytes * 2}
+    reserve = EventSink.terminal_reserve(:normal, limits)
 
     assert {:ok, run_state, sink} =
              RunState.start_with_event_sink(
@@ -253,13 +237,15 @@ defmodule PtcRunner.Kernel.LogAnalysisSessionTest do
     tmp_dir: directory
   } do
     limits = LogAnalysisProfile.limits()
-    reserve = %{count: 2, bytes: limits.event_payload_bytes * 2}
+    reserve = EventSink.terminal_reserve(:normal, limits)
 
     starts = [
-      {"zero-reserve", [fail_closed: true], fn _run_state, _sink -> :ok end},
+      {"zero-reserve", [fail_closed: true, terminal_reserve: %{count: 0, bytes: 0}],
+       fn _run_state, _sink -> :ok end},
       {"finalized", [fail_closed: true, terminal_reserve: reserve],
        fn _run_state, sink ->
-         EventSink.finalize(sink, %{}, %{outcome: :error})
+         assert {:ok, _batch} = EventSink.finalize_and_events(sink, %{outcome: :error})
+         :ok
        end},
       {"closed", [fail_closed: true, terminal_reserve: reserve],
        fn run_state, _sink ->

--- a/test/ptc_runner/kernel/mission_inventory_test.exs
+++ b/test/ptc_runner/kernel/mission_inventory_test.exs
@@ -45,24 +45,28 @@ defmodule PtcRunner.Kernel.MissionInventoryTest do
     {:ok, kernel_component} = Library.component("kernel")
     {:ok, workflow_bundle} = Kernel.compile_bundle([kernel_component])
     {:ok, workflow} = WorkflowEnvironment.new(bundle: workflow_bundle)
-    {:ok, sink} = EventSink.start(:normal, limits, run_id: "mission-inventory")
 
-    {:ok, config} =
-      RunConfig.new(
-        workflow_environment: workflow,
-        mission_environment: mission,
-        input: %{},
-        limits: limits,
-        event_sink: sink
-      )
+    config_for = fn run_id ->
+      {:ok, sink} = EventSink.start(:normal, limits, run_id: run_id)
+
+      {:ok, config} =
+        RunConfig.new(
+          workflow_environment: workflow,
+          mission_environment: mission,
+          input: %{},
+          limits: limits,
+          event_sink: sink
+        )
+
+      {config, sink}
+    end
+
+    {config, sink} = config_for.("mission-inventory")
 
     assert config.mission_inventory.rendered == @expected
 
     assert {:ok, %{value: @expected}} =
              Kernel.run("(return (kernel/mission-inventory))", config)
-
-    assert {:ok, %{value: @expected_model}} =
-             Kernel.run("(return (kernel/mission-model-context))", config)
 
     started = Enum.find(EventSink.events(sink), &(&1.type == "run-started"))
     assert started.data.mission_inventory_hash == config.mission_inventory.hash
@@ -80,7 +84,13 @@ defmodule PtcRunner.Kernel.MissionInventoryTest do
 
     assert started.data == config.run_started_metadata
 
-    {:ok, repl} = ReplSession.new(config: config)
+    {model_config, _model_sink} = config_for.("mission-model-context")
+
+    assert {:ok, %{value: @expected_model}} =
+             Kernel.run("(return (kernel/mission-model-context))", model_config)
+
+    {repl_config, _repl_sink} = config_for.("mission-inventory-repl")
+    {:ok, repl} = ReplSession.new(config: repl_config)
 
     assert {:ok, %{return: @expected}, repl} =
              ReplSession.eval(repl, "(kernel/mission-inventory)")

--- a/test/ptc_runner/kernel/repl_session_test.exs
+++ b/test/ptc_runner/kernel/repl_session_test.exs
@@ -256,23 +256,51 @@ defmodule PtcRunner.Kernel.ReplSessionTest do
     failed_ref = Process.monitor(failed_pid)
     :ok = EventSink.emit(private_sink, "run-started", %{})
 
+    assert {:error, :invalid_run_config} =
+             RunConfig.new(
+               workflow_environment: workflow,
+               mission_environment: mission,
+               input: %{},
+               limits: limits,
+               event_sink: private_sink
+             )
+
+    EventSink.stop(private_sink)
+    assert_receive {:DOWN, ^failed_ref, :process, ^failed_pid, :normal}
+  end
+
+  test "a rejected reused config cannot tear down the live session" do
+    parent = self()
+    {:ok, workflow} = WorkflowEnvironment.new([])
+    {:ok, mission} = MissionEnvironment.new([])
+    limits = Limits.defaults()
+    {:ok, sink} = EventSink.start(:normal, limits, run_id: "repl-one-shot-owner")
+
     {:ok, config} =
       RunConfig.new(
         workflow_environment: workflow,
         mission_environment: mission,
         input: %{},
         limits: limits,
-        event_sink: private_sink
+        event_sink: sink,
+        provider_resources: [fn -> send(parent, :resource_closed) end]
       )
 
+    {:ok, session} = ReplSession.new(config: config)
     assert {:error, :event_sink_error} = ReplSession.new(config: config)
-    assert_receive {:DOWN, ^failed_ref, :process, ^failed_pid, :normal}
+    refute_receive :resource_closed
+    assert Process.alive?(sink.pid)
+
+    assert {:ok, %{return: 42}, session} = ReplSession.eval(session, "42")
+    assert {:ok, _events} = ReplSession.close(session)
+    assert_receive :resource_closed
   end
 
   test "configuration assembly rejects a run-started payload above the event ceiling" do
     {:ok, workflow} = WorkflowEnvironment.new([])
     {:ok, mission} = MissionEnvironment.new([])
-    {:ok, limits} = Limits.new(event_payload_bytes: 1)
+    {:ok, limits} = Limits.new(event_payload_bytes: 5_000)
+    connector_snapshots = [%{"value" => String.duplicate("x", 10_000)}]
     {:ok, sink} = EventSink.start(:normal, limits, run_id: "repl-metadata-ceiling")
 
     assert {:error, :run_started_metadata_exceeded} =
@@ -281,21 +309,20 @@ defmodule PtcRunner.Kernel.ReplSessionTest do
                mission_environment: mission,
                input: %{},
                limits: limits,
-               event_sink: sink
+               event_sink: sink,
+               connector_snapshots: connector_snapshots
              )
 
-    {:ok, private_limits} = Limits.new(event_payload_bytes: 1)
-
-    {:ok, private_sink} =
-      EventSink.start(:private, private_limits, run_id: "repl-private-ceiling")
+    {:ok, private_sink} = EventSink.start(:private, limits, run_id: "repl-private-ceiling")
 
     assert {:error, :run_started_metadata_exceeded} =
              RunConfig.new(
                workflow_environment: workflow,
                mission_environment: mission,
                input: %{},
-               limits: private_limits,
-               event_sink: private_sink
+               limits: limits,
+               event_sink: private_sink,
+               connector_snapshots: connector_snapshots
              )
 
     EventSink.stop(sink)
@@ -309,6 +336,38 @@ defmodule PtcRunner.Kernel.ReplSessionTest do
     stopped = List.last(events)
     assert stopped.type == "run-stopped"
     assert stopped.data.usage.errors == 1
+  end
+
+  test "close atomically returns a reserved terminal batch and exact drop usage" do
+    {:ok, workflow} = WorkflowEnvironment.new([])
+    {:ok, mission} = MissionEnvironment.new([])
+
+    {:ok, limits} =
+      Limits.new(
+        normal_event_count: 4,
+        normal_event_bytes: 100_000,
+        event_payload_bytes: 5_000
+      )
+
+    {:ok, sink} = EventSink.start(:normal, limits, run_id: "repl-terminal-reserve")
+
+    {:ok, config} =
+      RunConfig.new(
+        workflow_environment: workflow,
+        mission_environment: mission,
+        input: %{},
+        limits: limits,
+        event_sink: sink
+      )
+
+    {:ok, session} = ReplSession.new(config: config)
+    assert {:ok, %{return: 42}, session} = ReplSession.eval(session, "42")
+    assert {:ok, events} = ReplSession.close(session)
+
+    assert Enum.map(events, & &1.type) ==
+             ["run-started", "evaluation-started", "events-dropped", "run-stopped"]
+
+    assert List.last(events).data.usage.events_dropped == %{"evaluation-stopped" => 1}
   end
 
   test "configured workflow capabilities use the bounded dispatcher and canonical events" do

--- a/test/ptc_runner/kernel/trace_capability_test.exs
+++ b/test/ptc_runner/kernel/trace_capability_test.exs
@@ -146,8 +146,20 @@ defmodule PtcRunner.Kernel.TraceCapabilityTest do
 
     assert metadata["run_id"] == "source-run"
 
+    {:ok, workflow_only_sink} =
+      EventSink.start(:normal, limits, run_id: "query-run-workflow-only")
+
+    {:ok, workflow_only_config} =
+      RunConfig.new(
+        workflow_environment: workflow,
+        mission_environment: mission,
+        input: %{},
+        limits: limits,
+        event_sink: workflow_only_sink
+      )
+
     assert {:error, %{kind: :workflow_failed}} =
-             Kernel.run("(return (tool/trace-list-runs {}))", config)
+             Kernel.run("(return (tool/trace-list-runs {}))", workflow_only_config)
   end
 
   @tag :tmp_dir


### PR DESCRIPTION
## Summary

- reserve measured terminal count and byte capacity for ordinary Runner and REPL traces
- atomically claim each EventSink once, finalize one frozen batch, and persist that exact batch
- bound drop-accounting cardinality and counters, with exact drop usage in the terminal result
- require exact sink limits and validated run-started capacity in RunConfig
- keep provider and recorder cleanup with the winning claimant

## Review

An independent Codex review found and this branch fixes: losing claimants tearing down winner resources, incomplete envelope-byte reservation, mismatched sink/config limits, malformed finalizer input killing the sink, and stale documentation arity.

## Verification

- mix precommit
- mix prepush
- focused EventSink, Runner, ReplSession, provider lifecycle, and log-analysis session tests
- push hook: 4,380 root tests and 67 Viewer tests passed; Dialyzer passed