### PR TITLE
fix(runtime): redact payload-bearing inspection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Redacted `Inspect` output for payload-bearing Lisp results, opaque Kernel
+  programs, and runtime callables. Logger messages explicitly built from these
+  inspected values now retain only bounded outcome/count/byte metadata, program
+  digest identity, and callable bound state instead of source, prompts, memory,
+  tool payloads, child steps, or evaluator context.
 - Ordinary Kernel runs and standalone REPL sessions now reserve terminal event
   count and measured envelope capacity and atomically freeze one canonical
   batch for result usage, trace, and inspection persistence. Drop accounting is

--- a/docs/guides/kernel-maintainer.md
+++ b/docs/guides/kernel-maintainer.md
@@ -399,6 +399,18 @@ Runtime observability has separate planes with separate data contracts:
   run-owned inspection sink; Logger, Telemetry, and canonical events never
   receive them.
 
+Payload-bearing values follow the same boundary when explicitly inspected for
+operator output. Custom `Inspect`
+implementations for `PtcRunner.Lisp.Result`, `PtcRunner.Kernel.Program`, and
+`PtcRunner.Lisp.RuntimeCallable` expose only safe outcome, count, byte, digest,
+label, and bound-state metadata. They do not enumerate result values,
+continuation memory, prompts, messages, tool records, child steps, program
+source, evaluator context, or callbacks. Owner `format_status` callbacks remain
+constant-redacted rather than relying on nested value inspection. Passing a
+struct directly to Logger as a report bypasses Elixir's `Inspect` protocol and
+is prohibited in runtime code; log only sparse diagnostics or a value already
+rendered through its redacted inspection boundary.
+
 `PtcRunner.Kernel.EventSink` owns canonical event sequence numbers, timestamps,
 queue bounds, and loss accounting. Normal policy is lossy and reports dropped
 events. Private policy fails closed when it cannot retain the required event.

--- a/docs/plans/future/kernel-publication-and-boundary-hardening.md
+++ b/docs/plans/future/kernel-publication-and-boundary-hardening.md
@@ -1,10 +1,10 @@
 # Kernel publication and boundary hardening
 
-**Status:** triaged; first three slices implemented
+**Status:** triaged; first four slices implemented
 
 **Origin:** extracted from the Java interop investigation on 2026-07-20
 
-**Last audited:** 2026-07-22 against `origin/main` at `35005bf7`
+**Last audited:** 2026-07-22 against `origin/main` at `af64a3ea`
 
 ## Decision
 
@@ -30,7 +30,7 @@ This plan now separates:
 | Tool cache | Every evaluation now owns an empty, evaluation-local cache. Caller-supplied state is rejected and Results omit cache entries. | Complete. |
 | Public projection | Direct and Kernel results use one collision-aware projection. Direct Elixir results preserve entries; Kernel boundaries reject ambiguity. | Complete. |
 | Ordinary terminal publication | Runner and standalone REPL now reserve terminal capacity, finalize atomically, and hand one frozen batch to persistence. | Complete. |
-| Drop accounting and inspection | Event loss uses sixteen fixed type buckets plus a saturating overflow count. Several payload-bearing structs still use derived `Inspect`. | Address inspection with each owning boundary. |
+| Drop accounting and inspection | Event loss is bounded. Result, Program, and RuntimeCallable use payload-free custom `Inspect`; owner status is constant-redacted. | Complete for the identified high-value boundaries. |
 | Viewer persistence | SessionTrace owns finalization and retry; TraceLog publication is synced, no-clobber, and byte-identical on retry. | Remove from the active backlog. |
 | Standalone REPL ownership | A transferred ReplSession becomes closed when its creator exits. | Decide whether sessions are process-affine or transferable before changing ownership. |
 | Oracle supervision | The current subprocess-per-run harness has timeout, output, and temporary-directory bounds. | Keep the reusable service deferred until a leak or throughput problem is measured. |
@@ -218,21 +218,29 @@ Do not add producer leases or split EventSink capabilities unless a focused
 test first demonstrates that current RunState/provider cleanup permits an
 event after finalization begins.
 
-## Inspection and redaction follow-up
+## Completed fourth slice: payload-free inspection
 
-Review payload-bearing structs when their owning boundary changes. The current
-high-value candidates are:
+Derived inspection of `PtcRunner.Lisp.Result`, `PtcRunner.Kernel.Program`, and
+`PtcRunner.Lisp.RuntimeCallable` reproduced direct disclosure of return and
+failure values, continuation memory, prompts, messages, tool arguments and
+results, child steps, program source, evaluator context, and callback identity.
+Logger messages explicitly constructed from derived inspection copied the same
+retained payloads.
 
-- `PtcRunner.Lisp.Result`, which can retain memory, tool calls, prompts,
-  messages, and child steps;
-- `PtcRunner.Kernel.Program`, which retains source; and
-- `PtcRunner.Lisp.RuntimeCallable`, which can retain evaluator context and a
-  function.
+Each owning type now has a custom `Inspect` implementation:
 
-Custom `Inspect` implementations should show safe identity, counts, and byte
-metadata without enumerating payloads. Tests should use unique sentinels in
-success, failure, memory, prompt, tool, and child-result fields. Logger and
-`format_status` paths must not expose those sentinels.
+- Result shows only outcome, field counts, and retained memory bytes;
+- Program shows only source byte size and its validated SHA-256 digest; and
+- RuntimeCallable shows only its qualified label and whether it is bound.
+
+The implementations never recursively inspect the retained payload fields.
+Boundary tests place unique sentinels in success, failure, memory, prompt,
+message, tool, child-result, source, and evaluator-context fields, then prove
+that direct inspection and Logger messages built from it contain none of them.
+The durable contract also records that direct Logger struct reports bypass
+`Inspect` and are prohibited in runtime code. A RunState
+status test also retains sensitive continuation values and proves the existing
+constant-redacted `format_status` boundary does not enumerate them.
 
 ## Product decision: standalone REPL ownership
 

--- a/lib/ptc_runner/kernel/program.ex
+++ b/lib/ptc_runner/kernel/program.ex
@@ -6,6 +6,9 @@ defmodule PtcRunner.Kernel.Program do
   evaluating it in the workflow environment. Only bounded identity metadata is
   projected through public results; the source is evaluated later against the
   mission environment and current native evaluation continuation.
+
+  `Inspect` exposes only the source byte size and SHA-256 digest. It never
+  renders the retained source.
   """
   @enforce_keys [:source, :byte_size, :digest]
   defstruct [:source, :byte_size, :digest]

--- a/lib/ptc_runner/kernel/program_inspect.ex
+++ b/lib/ptc_runner/kernel/program_inspect.ex
@@ -1,0 +1,19 @@
+defimpl Inspect, for: PtcRunner.Kernel.Program do
+  def inspect(program, _opts) do
+    "#PtcRunner.Kernel.Program<byte_size: #{safe_byte_size(program)}, " <>
+      "digest: #{safe_digest(program)}>"
+  end
+
+  defp safe_byte_size(%{byte_size: byte_size}) when is_integer(byte_size) and byte_size >= 0,
+    do: byte_size
+
+  defp safe_byte_size(_program), do: "unknown"
+
+  defp safe_digest(%{digest: digest}) when is_binary(digest) and byte_size(digest) == 64 do
+    if String.valid?(digest) and digest =~ ~r/\A[0-9a-f]{64}\z/,
+      do: "sha256:" <> digest,
+      else: "invalid"
+  end
+
+  defp safe_digest(_program), do: "invalid"
+end

--- a/lib/ptc_runner/lisp/result.ex
+++ b/lib/ptc_runner/lisp/result.ex
@@ -3,7 +3,9 @@ defmodule PtcRunner.Lisp.Result do
   Native continuation result returned by the neutral PTC-Lisp evaluator.
 
   Evaluation-local tool cache entries are private evaluator state and are not
-  retained in this result.
+  retained in this result. `Inspect` reports only the outcome, bounded field
+  counts, and retained memory size; it never renders return/failure values,
+  memory, prompts, messages, tool records, or child steps.
   """
 
   defstruct [

--- a/lib/ptc_runner/lisp/result_inspect.ex
+++ b/lib/ptc_runner/lisp/result_inspect.ex
@@ -1,0 +1,49 @@
+defimpl Inspect, for: PtcRunner.Lisp.Result do
+  alias PtcRunner.Lisp.RetainedSize
+
+  @count_limit 10_000
+
+  def inspect(result, _opts) do
+    "#PtcRunner.Lisp.Result<" <>
+      Enum.join(
+        [
+          field("outcome", outcome(result)),
+          field("memory_entries", map_count(result.memory)),
+          field("memory_bytes", retained_bytes(result.memory)),
+          field("turns", list_count(result.turns)),
+          field("prints", list_count(result.prints)),
+          field("tool_calls", list_count(result.tool_calls)),
+          field("pmap_calls", list_count(result.pmap_calls)),
+          field("child_traces", list_count(result.child_traces)),
+          field("child_steps", list_count(result.child_steps)),
+          field("messages", list_count(result.messages)),
+          field("prelude_calls", map_count(result.prelude_call_counts))
+        ],
+        ", "
+      ) <> ">"
+  end
+
+  defp outcome(%{fail: nil}), do: "ok"
+  defp outcome(%{}), do: "error"
+
+  defp map_count(value) when is_map(value), do: map_size(value)
+  defp map_count(_value), do: "unknown"
+
+  defp list_count(value) when is_list(value), do: bounded_list_count(value, 0)
+  defp list_count(nil), do: 0
+  defp list_count(_value), do: "unknown"
+
+  defp bounded_list_count([], count), do: count
+  defp bounded_list_count(_rest, @count_limit), do: "#{@count_limit}+"
+  defp bounded_list_count([_item | rest], count), do: bounded_list_count(rest, count + 1)
+  defp bounded_list_count(_improper, _count), do: "unknown"
+
+  defp retained_bytes(value) do
+    case RetainedSize.bytes(value) do
+      bytes when is_integer(bytes) -> bytes
+      :oversized -> "unknown"
+    end
+  end
+
+  defp field(name, value), do: name <> ": " <> to_string(value)
+end

--- a/lib/ptc_runner/lisp/runtime_callable.ex
+++ b/lib/ptc_runner/lisp/runtime_callable.ex
@@ -6,6 +6,9 @@ defmodule PtcRunner.Lisp.RuntimeCallable do
   context to enforce limits, record traces, and call the configured runtime
   executor. The persisted value only carries the qualified name. A short-lived
   bound form is created at application time for higher-order runtime calls.
+
+  `Inspect` exposes only the qualified label and whether the callable is bound.
+  It never renders the evaluator context or callback.
   """
 
   alias PtcRunner.Lisp.Eval.Abort
@@ -18,14 +21,14 @@ defmodule PtcRunner.Lisp.RuntimeCallable do
   @type namespace :: :tool
   @type t :: %__MODULE__{
           namespace: namespace(),
-          name: atom(),
+          name: atom() | binary(),
           eval_ctx: EvalContext.t() | nil,
           do_eval:
             (term(), EvalContext.t() -> {:ok, term(), EvalContext.t()} | {:error, term()})
             | nil
         }
 
-  @spec new(namespace(), atom()) :: t()
+  @spec new(namespace(), atom() | binary()) :: t()
   def new(namespace, name) do
     %__MODULE__{namespace: namespace, name: name}
   end

--- a/lib/ptc_runner/lisp/runtime_callable_inspect.ex
+++ b/lib/ptc_runner/lisp/runtime_callable_inspect.ex
@@ -1,0 +1,29 @@
+defimpl Inspect, for: PtcRunner.Lisp.RuntimeCallable do
+  alias PtcRunner.Lisp.Eval.Context, as: EvalContext
+
+  @tool_name ~r|\A[a-z][a-z0-9._/-]{0,127}\z|
+
+  def inspect(callable, _opts) do
+    "#PtcRunner.Lisp.RuntimeCallable<label: #{safe_label(callable)}, " <>
+      "bound?: #{bound?(callable)}>"
+  end
+
+  defp safe_label(%{namespace: :tool, name: name}) when is_atom(name),
+    do: safe_tool_label(Atom.to_string(name))
+
+  defp safe_label(%{namespace: :tool, name: name}) when is_binary(name),
+    do: safe_tool_label(name)
+
+  defp safe_label(_callable), do: "invalid"
+
+  defp safe_tool_label(name) do
+    if byte_size(name) in 1..128 and String.valid?(name) and name =~ @tool_name,
+      do: "tool/" <> name,
+      else: "invalid"
+  end
+
+  defp bound?(%{eval_ctx: %EvalContext{}, do_eval: do_eval}) when is_function(do_eval, 2),
+    do: true
+
+  defp bound?(_callable), do: false
+end

--- a/test/ptc_runner/inspection_redaction_test.exs
+++ b/test/ptc_runner/inspection_redaction_test.exs
@@ -1,0 +1,166 @@
+defmodule PtcRunner.InspectionRedactionTest do
+  use ExUnit.Case, async: true
+
+  import ExUnit.CaptureLog
+  require Logger
+
+  alias PtcRunner.Kernel.Limits
+  alias PtcRunner.Kernel.Program
+  alias PtcRunner.Kernel.RunState
+  alias PtcRunner.Lisp.Analyze
+  alias PtcRunner.Lisp.Eval
+  alias PtcRunner.Lisp.Eval.Context, as: EvalContext
+  alias PtcRunner.Lisp.Parser
+  alias PtcRunner.Lisp.Result
+  alias PtcRunner.Lisp.RuntimeCallable
+
+  @sentinels [
+    "RETURN_SECRET_7f31",
+    "FAIL_SECRET_a92c",
+    "MEMORY_SECRET_18de",
+    "PROMPT_SECRET_f650",
+    "TOOL_SECRET_63b1",
+    "CHILD_SECRET_b48a",
+    "SOURCE_SECRET_d227",
+    "CONTEXT_SECRET_914e"
+  ]
+
+  test "payload-bearing structs inspect as bounded metadata without retained values" do
+    result = sensitive_result()
+    program = Program.new("(return \"SOURCE_SECRET_d227\")")
+    callable = sensitive_callable("search")
+
+    rendered = Enum.map_join([result, program, callable], "\n", &inspect/1)
+
+    assert rendered =~ "#PtcRunner.Lisp.Result<"
+    assert rendered =~ "memory_entries: 1"
+    assert rendered =~ "tool_calls: 1"
+    assert rendered =~ "child_steps: 1"
+    assert rendered =~ "#PtcRunner.Kernel.Program<"
+    assert rendered =~ "byte_size:"
+    assert rendered =~ program.digest
+    assert rendered =~ "#PtcRunner.Lisp.RuntimeCallable<"
+    assert rendered =~ "label: tool/search"
+    assert rendered =~ "bound?: true"
+
+    refute_sentinels(rendered)
+  end
+
+  test "Logger messages built from Inspect use the same redacted boundary" do
+    values = [
+      sensitive_result(),
+      Program.new("SOURCE_SECRET_d227"),
+      sensitive_callable("search")
+    ]
+
+    log =
+      capture_log([level: :debug], fn ->
+        Logger.critical(fn -> Enum.map_join(values, " ", &inspect/1) end)
+      end)
+
+    assert log =~ "#PtcRunner.Lisp.Result<"
+    assert log =~ "#PtcRunner.Kernel.Program<"
+    assert log =~ "#PtcRunner.Lisp.RuntimeCallable<"
+    refute_sentinels(log)
+  end
+
+  test "runtime callable inspection accepts parsed binary tool names only when valid" do
+    assert {:ok, parsed} = Parser.parse("tool/custom-search")
+    assert {:ok, core} = Analyze.analyze(parsed)
+    assert {:ok, callable, %{}} = Eval.eval(core, %{}, %{}, %{}, fn _, _ -> nil end)
+
+    assert inspect(callable) =~
+             "label: tool/custom-search, bound?: false"
+
+    invalid = RuntimeCallable.new(:tool, "CONTEXT_SECRET_914e")
+    assert inspect(invalid) =~ "label: invalid"
+    refute_sentinels(inspect(invalid))
+  end
+
+  test "redacted inspection contains malformed struct fields without raising" do
+    malformed_result = %Result{memory: nil, turns: [1 | 2], prints: "PROMPT_SECRET_f650"}
+
+    malformed_program = %Program{
+      source: "SOURCE_SECRET_d227",
+      byte_size: -1,
+      digest: :binary.copy(<<255>>, 64)
+    }
+
+    malformed_callable = %RuntimeCallable{namespace: :tool, name: <<255>>}
+
+    rendered =
+      Enum.map_join([malformed_result, malformed_program, malformed_callable], &inspect/1)
+
+    assert rendered =~ "unknown"
+    assert rendered =~ "digest: invalid"
+    assert rendered =~ "label: invalid"
+    refute_sentinels(rendered)
+  end
+
+  test "owner format_status does not enumerate continuation payloads" do
+    {:ok, state} = RunState.start(Limits.defaults())
+    {:ok, _memory, _history, lease} = RunState.reserve_evaluation(state)
+
+    assert :ok =
+             RunState.commit_evaluation(
+               state,
+               lease,
+               %{"value" => "MEMORY_SECRET_18de"},
+               ["CHILD_SECRET_b48a"]
+             )
+
+    status = state.pid |> :sys.get_status() |> inspect()
+    refute_sentinels(status)
+  end
+
+  defp sensitive_result do
+    %Result{
+      return: "RETURN_SECRET_7f31",
+      fail: %{
+        reason: :runtime_error,
+        message: "FAIL_SECRET_a92c",
+        details: %{"prompt" => "PROMPT_SECRET_f650"}
+      },
+      memory: %{"MEMORY_SECRET_18de" => "RETURN_SECRET_7f31"},
+      signature: "PROMPT_SECRET_f650",
+      usage: %{tool_calls: 1},
+      turns: ["RETURN_SECRET_7f31"],
+      trace_id: "PROMPT_SECRET_f650",
+      parent_trace_id: "FAIL_SECRET_a92c",
+      name: "RETURN_SECRET_7f31",
+      field_descriptions: %{"value" => "PROMPT_SECRET_f650"},
+      prints: ["PROMPT_SECRET_f650"],
+      tool_calls: [%{args: "TOOL_SECRET_63b1", result: "RETURN_SECRET_7f31"}],
+      pmap_calls: [%{child_steps: ["CHILD_SECRET_b48a"]}],
+      child_traces: ["PROMPT_SECRET_f650"],
+      child_steps: [%Result{return: "CHILD_SECRET_b48a"}],
+      messages: [%{"content" => "PROMPT_SECRET_f650"}],
+      prompt: "PROMPT_SECRET_f650",
+      original_prompt: "PROMPT_SECRET_f650",
+      tools: %{"TOOL_SECRET_63b1" => fn _ -> :ok end},
+      prelude_trace: %{component_ids: ["PROMPT_SECRET_f650"]},
+      prelude_call_counts: %{"TOOL_SECRET_63b1" => 1}
+    }
+  end
+
+  defp sensitive_callable(name) do
+    eval_ctx =
+      EvalContext.new(
+        %{"CONTEXT_SECRET_914e" => true},
+        %{},
+        %{},
+        fn _, _, _ -> "TOOL_SECRET_63b1" end,
+        ["CHILD_SECRET_b48a"]
+      )
+
+    :tool
+    |> RuntimeCallable.new(name)
+    |> RuntimeCallable.bind(eval_ctx, fn _, _ -> {:ok, "RETURN_SECRET_7f31", eval_ctx} end)
+  end
+
+  defp refute_sentinels(rendered) do
+    Enum.each(@sentinels, fn sentinel ->
+      refute rendered =~ sentinel
+    end)
+  end
+end


### PR DESCRIPTION
## What changed

- add custom, payload-free `Inspect` implementations for Lisp results, Kernel programs, and runtime callables
- retain only bounded outcome/count/byte metadata, validated program identity, and callable label/bound state
- cover success, failure, memory, prompt, message, tool, child-result, source, evaluator-context, malformed-value, Logger-message, and owner-status boundaries with unique sentinels
- update the maintainer guide, changelog, and boundary-hardening record

## Why

The default derived inspection recursively exposed retained program source, prompts, results, memory, tool records, child steps, evaluator context, and callback identity. These structs can reach operator output and explicitly rendered Logger messages, so their owning types now define sparse inspection contracts.

Direct Logger struct reports are deliberately called out as prohibited: Logger treats them as report maps and bypasses the Elixir `Inspect` protocol. Runtime logging must use sparse diagnostics or a value already rendered through the redacted inspection boundary.

## Review

An independent Codex review found and prompted fixes for:

- the direct Logger report bypass, now accurately documented instead of overclaiming protocol coverage
- parsed runtime tool names being binaries, now preserved when they meet the bounded safe-label grammar

Malformed structs and invalid UTF-8 metadata are also handled without raising or exposing retained payloads.

## Verification

- `mix test test/ptc_runner/inspection_redaction_test.exs test/ptc_runner/lisp/runtime_callable_test.exs` — 28 passed
- `mix precommit` — 4,385 root tests and 67 viewer tests passed; format, compile, Credo, schema/spec, and generated-doc checks passed
- `mix prepush` — upstream audit, Dialyzer, and unused-dependency checks passed
- push hook — repeated 4,385 root tests, 67 viewer tests, and Dialyzer successfully