### PR TITLE
fix(kernel): enforce standalone REPL session ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Made standalone `PtcRunner.Kernel.ReplSession` values process-affine. Only
+  the process that creates a session may evaluate, close, or abort it; calls
+  from another process now return `:session_owner_mismatch` without mutating
+  the continuation or stopping its owners. Public session values no longer
+  expose continuation values or raw run-state, sink, provider, or configuration
+  capabilities or owner process identifiers. An opaque ID resolves through a
+  creator-private table to one internal owner; closed entries are removed and
+  the owner closes all resources if the creator exits. Evaluation results now
+  use the inert public projection instead of returning native callable
+  continuation authority, preflight errors preserve the committed public memory
+  view, projection failures roll back before commit, owner construction
+  validates the exact run-state/sink/limit binding, and monitor-based watchdogs
+  cancel compile and evaluation workers if the creator exits without changing
+  its trap-exit flag or retaining an unbounded copy of the workload.
 - Redacted `Inspect` output for payload-bearing Lisp results, opaque Kernel
   programs, and runtime callables. Logger messages explicitly built from these
   inspected values now retain only bounded outcome/count/byte metadata, program

--- a/docs/guides/kernel-maintainer.md
+++ b/docs/guides/kernel-maintainer.md
@@ -343,8 +343,29 @@ Subordinate evaluation is serialized because it owns the transactional
 continuation. Reservation returns memory, history, and the lease token in one
 owner operation; commit validates and installs the complete candidate in one
 owner operation. A concurrent attempt receives a recoverable busy result rather
-than waiting in an unbounded queue. ReplSession projects memory and history for
-its caller but does not own a competing copy for evaluation decisions.
+than waiting in an unbounded queue. ReplSession keeps exact memory and history
+only in RunState; evaluation results expose an inert observation projection.
+Projection is validated before commit, so an unrepresentable result rolls back
+the candidate continuation and records an evaluation error.
+
+Standalone `PtcRunner.Kernel.ReplSession` is process-affine. The process that
+constructs it is the only process allowed to call `eval/2`, `close/1`, or
+`abort/2`; a foreign caller receives `:session_owner_mismatch` before any
+continuation, event, provider, or lifecycle operation. Passing the session
+struct in a message does not transfer ownership. The public value contains only
+an opaque ID, one shared creator-private lookup table, and bounded attempt
+counters; it contains no owner PID or token. Closed entries are deleted, while
+the empty private table lasts only for the creator process. Continuation values
+and raw run-state, configuration, sink, and provider capabilities remain inside
+the internal owner. Its non-transferable run state is bound to the configured
+sinks and limits. Preflight failures return the committed public memory
+observation without exposing native continuation authority. Each bounded worker
+starts a small monitor-only watchdog before running the workload, so creator
+shutdown stops compilation and evaluation without changing the creator's
+trap-exit behavior or copying the workload into an unbounded process. Keep
+construction, the input loop, and terminal cleanup in one stable frontend
+process; use a separate supervised session abstraction if a product later
+requires transferable or multi-client ownership.
 
 `evaluation_memory_bytes` continues to charge definitions only.
 `evaluation_history_bytes` independently bounds every exact history value and

--- a/docs/guides/kernel-repl.md
+++ b/docs/guides/kernel-repl.md
@@ -40,6 +40,24 @@ The direct REPL does not accept an ambient capability catalog or arbitrary
 profile configuration. Providers and component sources are selected only by
 the manifest and trusted provider registry.
 
+Elixir hosts using `PtcRunner.Kernel.ReplSession` directly must keep each
+session in the process that created it. That process performs every evaluation
+and the final close or abort. Sending the struct to another process does not
+transfer its continuation or cleanup authority; `eval/2`, `close/1`, and
+`abort/2` return `{:error, :session_owner_mismatch}` without changing the
+session. The public value contains an opaque ID resolved through a shared table
+only the creator can read; closed entries are deleted. It contains no owner PID,
+token, continuation value, or raw run-state, configuration, sink, or provider
+capability. The internal owner binds the run state to the configured event and
+optional inspection sinks. Each `eval/2` result is an inert observation
+projection; its memory is not the authoritative continuation and must not be
+threaded back into the session.
+Preflight errors preserve that committed public memory view, and projection is
+validated before continuation commit. Each bounded worker starts a small
+monitor-only watchdog before running the workload. The watchdog cancels the
+worker when the creator exits, without changing its trap-exit behavior or
+holding an unbounded workload copy, before retained resources are closed.
+
 Every workflow session emits canonical Kernel events. Persist them as bounded,
 append-only JSONL with:
 

--- a/docs/plans/future/kernel-publication-and-boundary-hardening.md
+++ b/docs/plans/future/kernel-publication-and-boundary-hardening.md
@@ -1,10 +1,10 @@
 # Kernel publication and boundary hardening
 
-**Status:** triaged; first four slices implemented
+**Status:** triaged; first five slices implemented
 
 **Origin:** extracted from the Java interop investigation on 2026-07-20
 
-**Last audited:** 2026-07-22 against `origin/main` at `af64a3ea`
+**Last audited:** 2026-07-22 against `origin/main` at `70b3745a`
 
 ## Decision
 
@@ -32,7 +32,7 @@ This plan now separates:
 | Ordinary terminal publication | Runner and standalone REPL now reserve terminal capacity, finalize atomically, and hand one frozen batch to persistence. | Complete. |
 | Drop accounting and inspection | Event loss is bounded. Result, Program, and RuntimeCallable use payload-free custom `Inspect`; owner status is constant-redacted. | Complete for the identified high-value boundaries. |
 | Viewer persistence | SessionTrace owns finalization and retry; TraceLog publication is synced, no-clobber, and byte-identical on retry. | Remove from the active backlog. |
-| Standalone REPL ownership | A transferred ReplSession becomes closed when its creator exits. | Decide whether sessions are process-affine or transferable before changing ownership. |
+| Standalone REPL ownership | ReplSession records its creator and rejects foreign evaluation or teardown before touching owner state. | Complete: sessions are process-affine and run state is bound to its configured sinks. |
 | Oracle supervision | The current subprocess-per-run harness has timeout, output, and temporary-directory bounds. | Keep the reusable service deferred until a leak or throughput problem is measured. |
 
 ## Completed by Java interop
@@ -242,22 +242,46 @@ The durable contract also records that direct Logger struct reports bypass
 status test also retains sensitive continuation values and proves the existing
 constant-redacted `format_status` boundary does not enumerate them.
 
-## Product decision: standalone REPL ownership
+## Completed fifth slice: process-affine standalone REPL
 
-Standalone ReplSession currently contains handles owned by the process that
-created the session. Sending the immutable session value to another process
-does not transfer ownership; when the creator exits, later evaluation returns
-`:session_closed`.
+Standalone ReplSession already contained run-state and event-sink handles tied
+to the process that created the session. Sending the immutable session value to
+another process did not transfer those owners, but while the creator remained
+alive a foreign process could still evaluate against the continuation or close
+and abort the creator's resources.
 
-Choose one contract before implementing a new lifecycle process:
+RunState now retains the canonical creator identity. `eval/2`, `close/1`, and
+`abort/2` compare their actual caller inside that owner before consulting or
+mutating any continuation, event, provider, or lifecycle state. Standalone
+REPL state is non-transferable and bound to the exact configured event and
+optional inspection sinks. The public session value contains only an opaque ID,
+one shared creator-private lookup table, and bounded attempt counters—not an
+owner PID or token. Closed lookup entries are deleted, and the empty table dies
+with the creator. Continuation values and raw run-state, configuration, sink,
+and provider capabilities remain inside that owner. Evaluation results use the
+inert public projection while exact native memory and history stay internal;
+preflight errors preserve the committed public memory view, and projection
+failure rolls back before commit. A foreign caller receives the stable
+`{:error, :session_owner_mismatch}` result, and the creator can continue using
+and terminating the session normally. Construction also rejects a supplied
+config whose event or optional inspection sink belongs to another process
+before claiming either resource. The co-hosted log-analysis construction path
+retains only its owner-only, one-shot transfer. Monitor-based watchdogs couple
+REPL compile and evaluation sandboxes to the creator without changing its
+trap-exit behavior. Each bounded worker starts its own tiny monitor-only
+watchdog, so no unbounded process retains the workload closure; owner death
+cancels in-flight work before the owner closes the remaining resources.
 
-- **Process-affine session:** document the creator/owner constraint and reject
-  use from another process with a stable error.
-- **Transferable session:** add a supervised lifecycle owner independent of the
-  creator and define transfer, close, abort, timeout, and owner-death behavior.
-
-Do not infer the larger transferable design merely because the session is an
-Elixir struct.
+Boundary tests reproduce the former foreign evaluation and teardown, prove the
+public value carries no raw resource handles or owner process identifier, prove
+creator-private resource lookup and every session operation reject a foreign
+process, prove a rejected evaluation commits no definition, reject foreign
+configured sinks without tearing them down, reject mismatched run-state/config
+construction, cancel an in-flight evaluator on owner death, and prove the
+creator retains evaluation and cleanup authority. This intentionally does not
+add a REPL transfer API. If a real multi-client use case appears, it requires a
+separate supervised abstraction with explicit transfer, serialization, close,
+abort, timeout, and owner-death behavior.
 
 ## Deferred investigations
 

--- a/lib/mix/tasks/ptc.repl.ex
+++ b/lib/mix/tasks/ptc.repl.ex
@@ -55,7 +55,6 @@ defmodule Mix.Tasks.Ptc.Repl do
   use Mix.Task
 
   alias PtcRunner.Kernel.DeterministicJSON
-  alias PtcRunner.Kernel.EventSink
   alias PtcRunner.Kernel.LogAnalysisProfile
   alias PtcRunner.Kernel.LogAnalysisSession
   alias PtcRunner.Kernel.LogAnalysisSessionBuilder
@@ -1040,7 +1039,7 @@ defmodule Mix.Tasks.Ptc.Repl do
   end
 
   defp persist_and_stop(session, trace_path) do
-    private? = EventSink.policy(session.config.event_sink) == :private
+    private? = ReplSession.event_policy(session) == :private
 
     with {:ok, events} <- ReplSession.close(session),
          :ok <- persist_trace(trace_path, events, private?) do

--- a/lib/ptc_runner/kernel/evaluation.ex
+++ b/lib/ptc_runner/kernel/evaluation.ex
@@ -281,7 +281,8 @@ defmodule PtcRunner.Kernel.Evaluation do
       max_program_bytes: limits.subordinate_source_bytes,
       filter_context: false,
       caller: :kernel,
-      preserve_runtime_callables: true
+      preserve_runtime_callables: true,
+      link: true
     ]
 
     mission_calls_before = mission_capability_call_count(state)

--- a/lib/ptc_runner/kernel/event_sink.ex
+++ b/lib/ptc_runner/kernel/event_sink.ex
@@ -166,6 +166,10 @@ defmodule PtcRunner.Kernel.EventSink do
     end
   end
 
+  @doc false
+  @spec owner?(t()) :: boolean()
+  def owner?(sink), do: call(sink, :owner?) == true
+
   @spec stop(t()) :: :ok
   @doc "Stops the sink. Calling it after owner-driven shutdown is harmless."
   def stop(sink) do
@@ -176,10 +180,16 @@ defmodule PtcRunner.Kernel.EventSink do
 
   @impl GenServer
   def init({sink_state, owner}) do
-    {:ok, Map.put(sink_state, :owner_ref, Process.monitor(owner))}
+    {:ok,
+     sink_state
+     |> Map.put(:owner, owner)
+     |> Map.put(:owner_ref, Process.monitor(owner))}
   end
 
   @impl GenServer
+  def handle_call({token, :owner?}, {caller, _tag}, %{token: token} = state),
+    do: {:reply, caller == state.owner, state}
+
   def handle_call(request, _from, state) do
     {reply, next} = EventSinkState.handle(request, state)
     {:reply, reply, next}

--- a/lib/ptc_runner/kernel/inspection_sink.ex
+++ b/lib/ptc_runner/kernel/inspection_sink.ex
@@ -73,6 +73,10 @@ defmodule PtcRunner.Kernel.InspectionSink do
   @doc "Returns retained records in sequence order while the required sink is healthy."
   def records(%__MODULE__{} = sink), do: call(sink, :records)
 
+  @doc false
+  @spec owner?(t()) :: boolean()
+  def owner?(sink), do: call(sink, :owner?) == true
+
   @spec stop(t()) :: :ok
   @doc "Stops the sink; repeated or owner-driven stops are harmless."
   def stop(%__MODULE__{pid: pid}) do
@@ -86,6 +90,7 @@ defmodule PtcRunner.Kernel.InspectionSink do
     {:ok,
      %{
        token: token,
+       owner: owner,
        owner_ref: Process.monitor(owner),
        run_id: run_id,
        trace_id: trace_id,
@@ -99,6 +104,9 @@ defmodule PtcRunner.Kernel.InspectionSink do
   end
 
   @impl GenServer
+  def handle_call({token, :owner?}, {caller, _tag}, %{token: token} = state),
+    do: {:reply, caller == state.owner, state}
+
   def handle_call({token, :records}, _from, %{token: token, failed?: false} = state),
     do: {:reply, {:ok, Enum.reverse(state.records)}, state}
 

--- a/lib/ptc_runner/kernel/repl_session.ex
+++ b/lib/ptc_runner/kernel/repl_session.ex
@@ -8,9 +8,21 @@ defmodule PtcRunner.Kernel.ReplSession do
   labels, and event policy from an optional `PtcRunner.Kernel.RunConfig` but
   does not execute the manifest entry function.
 
-  The session owns one internal run state and event sink. Call `close/1` for an
-  atomically frozen terminal batch or `abort/2` when the frontend terminates
-  early. Both paths use the recorder's reserved terminal capacity.
+  A session is process-affine: the process that calls `new/1` is its owner and
+  must perform every `eval/2`, `close/1`, and `abort/2` call. Passing the struct
+  to another process does not transfer ownership; those calls return
+  `{:error, :session_owner_mismatch}` without touching continuation or lifecycle
+  state. The public value contains only an opaque ID, one shared
+  creator-private lookup table, and bounded attempt counters—not an owner PID or
+  token. Closed lookup entries are removed. Continuation values and raw
+  run-state, sink, provider, and configuration capabilities remain inside the
+  internal owner process. Watchdogs couple compilation and evaluation sandboxes
+  to the creator; all owned resources and in-flight work are stopped if it
+  exits.
+
+  Call `close/1` for an atomically frozen terminal batch or `abort/2` when the
+  frontend terminates early. Both paths use the recorder's reserved terminal
+  capacity.
   """
 
   alias PtcRunner.Kernel.Dispatcher
@@ -19,6 +31,7 @@ defmodule PtcRunner.Kernel.ReplSession do
   alias PtcRunner.Kernel.InspectionSink
   alias PtcRunner.Kernel.Limits
   alias PtcRunner.Kernel.MissionEnvironment
+  alias PtcRunner.Kernel.ReplSessionOwner
   alias PtcRunner.Kernel.RunConfig
   alias PtcRunner.Kernel.RunState
   alias PtcRunner.Kernel.RuntimeTools
@@ -28,14 +41,14 @@ defmodule PtcRunner.Kernel.ReplSession do
   alias PtcRunner.Lisp.RetainedSize
   alias PtcRunner.Lisp.TrustedTool
 
-  @enforce_keys [:config, :state, :memory, :history]
-  defstruct [:config, :state, :memory, :history, attempts: 0, errors: 0]
+  @access_table_key {__MODULE__, :access_table}
+
+  @enforce_keys [:access, :id]
+  defstruct [:access, :id, attempts: 0, errors: 0]
 
   @type t :: %__MODULE__{
-          config: RunConfig.t(),
-          state: RunState.t(),
-          memory: map(),
-          history: [term()],
+          access: :ets.tid(),
+          id: reference(),
           attempts: non_neg_integer(),
           errors: non_neg_integer()
         }
@@ -47,6 +60,10 @@ defmodule PtcRunner.Kernel.ReplSession do
   Without a config, the session creates empty environments, default limits,
   and a normal in-memory event sink. Exact native history has the fixed language
   depth of three and is owned by RunState with continuation memory.
+
+  A supplied config's event and optional inspection sinks must belong to the
+  calling process. A mismatch returns `{:error, :session_owner_mismatch}` before
+  the recorder is claimed or a run state is started.
   """
   def new(opts \\ [])
 
@@ -62,13 +79,64 @@ defmodule PtcRunner.Kernel.ReplSession do
 
   def new(_opts), do: {:error, :invalid_repl_session}
 
-  @spec eval(t(), binary()) :: {:ok, Native.t(), t()} | {:error, Native.t(), t()}
-  @doc "Evaluates one bounded source form and returns the updated session."
+  @doc false
+  @spec event_policy(t()) :: EventSink.policy() | {:error, atom()}
+  def event_policy(%__MODULE__{} = session) do
+    with {:ok, owned} <- owned_session(session),
+         do: EventSink.policy(owned.config.event_sink)
+  catch
+    :exit, _reason -> {:error, :session_closed}
+  end
+
+  @doc false
+  @spec evaluation_memory_summary(t()) :: map() | {:error, atom()}
+  def evaluation_memory_summary(%__MODULE__{} = session) do
+    with {:ok, owned} <- owned_session(session),
+         do: RunState.evaluation_memory_summary(owned.state)
+  catch
+    :exit, _reason -> {:error, :session_closed}
+  end
+
+  @doc false
+  @spec usage(t()) :: map() | {:error, atom()}
+  def usage(%__MODULE__{} = session) do
+    with {:ok, owned} <- owned_session(session),
+         do: RunState.usage(owned.state)
+  catch
+    :exit, _reason -> {:error, :session_closed}
+  end
+
+  @spec eval(t(), binary()) ::
+          {:ok, Native.t(), t()}
+          | {:error, Native.t(), t()}
+          | {:error, :session_owner_mismatch}
+  @doc """
+  Evaluates one bounded source form and returns the updated session.
+
+  The returned result is an observation-only public projection. The exact
+  native memory and history used by later forms remain inside the session
+  owner; callers must not thread the result's memory back into the session.
+
+  Returns `{:error, :session_owner_mismatch}` without evaluating when called
+  outside the process that created the session.
+  """
   def eval(%__MODULE__{} = session, source) when is_binary(source) do
-    if sink_alive?(session) and RunState.open?(session.state) do
-      eval_open(session, source)
-    else
-      session_closed(session)
+    case owned_session(session) do
+      {:ok, owned} ->
+        result =
+          if sink_alive?(owned) and RunState.open?(owned.state) do
+            eval_open(owned, source)
+          else
+            session_closed(owned)
+          end
+
+        public_result(result)
+
+      {:error, :session_closed} ->
+        session_closed(session)
+
+      {:error, :session_owner_mismatch} = error ->
+        error
     end
   catch
     :exit, _reason -> session_closed(session)
@@ -76,21 +144,45 @@ defmodule PtcRunner.Kernel.ReplSession do
 
   defp eval_open(session, source) do
     case RunState.reserve_evaluation(session.state) do
-      {:ok, memory, history, lease} -> eval_reserved(session, source, memory, history, lease)
-      {:error, reason} -> evaluation_reservation_failure(session, reason)
+      {:ok, memory, history, lease} ->
+        session = Map.merge(session, %{memory: memory, history: history})
+        eval_reserved(session, source, memory, history, lease)
+
+      {:error, reason} ->
+        evaluation_reservation_failure(session, reason)
     end
   catch
     :exit, _reason -> session_closed(session)
   end
 
   defp session_closed(session) do
-    step = Native.error(:session_closed, "REPL session is closed", session.memory)
+    step = Native.error(:session_closed, "REPL session is closed", observed_memory(session))
     {:error, step, session}
   end
 
-  @spec close(t()) :: {:ok, [map()]} | {:error, :event_sink_error | :session_closed}
-  @doc "Closes a session normally and returns its atomically frozen canonical events."
+  @spec close(t()) ::
+          {:ok, [map()]}
+          | {:error, :event_sink_error | :session_closed | :session_owner_mismatch}
+  @doc """
+  Closes a session normally and returns its atomically frozen canonical events.
+
+  Returns `{:error, :session_owner_mismatch}` without closing anything when
+  called outside the process that created the session.
+  """
   def close(%__MODULE__{} = session) do
+    with {:ok, owned} <- owned_session(session) do
+      try do
+        close_owned(owned)
+      after
+        ReplSessionOwner.release(owned.owner_pid, owned.owner_token)
+        close_access(session)
+      end
+    end
+  catch
+    :exit, _reason -> {:error, :session_closed}
+  end
+
+  defp close_owned(session) do
     if sink_alive?(session) do
       try do
         :ok = RunState.close(session.state)
@@ -103,27 +195,47 @@ defmodule PtcRunner.Kernel.ReplSession do
         end
       catch
         :exit, _reason -> {:error, :session_closed}
-      after
-        stop_owners(session)
       end
     else
       {:error, :session_closed}
     end
   end
 
-  @spec abort(t(), atom()) :: {:ok, [map()]} | :ok
-  @doc "Closes a session with an error reason and returns retained events when available."
-  def abort(%__MODULE__{} = session, reason) when is_atom(reason) do
-    if sink_alive?(session) do
-      try do
-        :ok = RunState.close(session.state)
+  @spec abort(t(), atom()) ::
+          {:ok, [map()]} | :ok | {:error, :session_owner_mismatch}
+  @doc """
+  Closes a session with an error reason and returns retained events when available.
 
-        case finalize(session, :error, reason) do
-          {:ok, events} -> {:ok, events}
-          {:error, :event_sink_error} -> :ok
+  Returns `{:error, :session_owner_mismatch}` without closing anything when
+  called outside the process that created the session.
+  """
+  def abort(%__MODULE__{} = session, reason) when is_atom(reason) do
+    case owned_session(session) do
+      {:ok, owned} ->
+        try do
+          abort_owned(owned, reason)
+        after
+          ReplSessionOwner.release(owned.owner_pid, owned.owner_token)
+          close_access(session)
         end
-      after
-        stop_owners(session)
+
+      {:error, :session_closed} ->
+        :ok
+
+      {:error, :session_owner_mismatch} = error ->
+        error
+    end
+  catch
+    :exit, _reason -> :ok
+  end
+
+  defp abort_owned(session, reason) do
+    if sink_alive?(session) do
+      :ok = RunState.close(session.state)
+
+      case finalize(session, :error, reason) do
+        {:ok, events} -> {:ok, events}
+        {:error, :event_sink_error} -> :ok
       end
     else
       :ok
@@ -155,28 +267,39 @@ defmodule PtcRunner.Kernel.ReplSession do
     end
   end
 
-  defp config(%RunConfig{} = config), do: {:ok, config}
+  defp config(%RunConfig{} = config) do
+    if EventSink.owner?(config.event_sink) and inspection_owner?(config.inspection_sink),
+      do: {:ok, config},
+      else: {:error, :session_owner_mismatch}
+  end
+
   defp config(_config), do: {:error, :invalid_repl_session}
+
+  defp inspection_owner?(nil), do: true
+  defp inspection_owner?(sink), do: InspectionSink.owner?(sink)
 
   defp emit_run_started(config) do
     EventSink.begin(config.event_sink, config.run_started_metadata)
   end
 
   defp start_session(config) do
-    {:ok, state} = RunState.start(config.limits)
-    start_session_with_state(config, state)
+    case RunState.start_repl(config.limits, config.event_sink, config.inspection_sink) do
+      {:ok, state} -> start_session_with_state(config, state)
+      {:error, _reason} = error -> error
+    end
   end
 
   defp start_session_with_state(config, state) do
     case emit_run_started(config) do
       :ok ->
-        {:ok,
-         %__MODULE__{
-           config: config,
-           state: state,
-           memory: %{},
-           history: []
-         }}
+        case ReplSessionOwner.start(config, state, self()) do
+          {:ok, pid, token} ->
+            register_access(pid, token)
+
+          {:error, reason} ->
+            stop_owners(%{config: config, state: state})
+            {:error, reason}
+        end
 
       {:error, :event_sink_error} = error ->
         RunState.close(state)
@@ -253,7 +376,8 @@ defmodule PtcRunner.Kernel.ReplSession do
       max_program_bytes: limits.subordinate_source_bytes,
       max_tool_call_result_bytes: limits.capability_result_bytes,
       preserve_runtime_callables: true,
-      filter_context: false
+      filter_context: false,
+      link: true
     )
   end
 
@@ -366,9 +490,25 @@ defmodule PtcRunner.Kernel.ReplSession do
        ) do
     limits = session.config.limits
 
-    if result_within_limit?(step.return, limits.terminal_result_bytes),
-      do: commit_success(session, step, history, lease, evaluation_id, started_ms),
-      else: reject_success(session, lease, evaluation_id, started_ms, :result_exceeded)
+    if result_within_limit?(step.return, limits.terminal_result_bytes) do
+      case Lisp.project_native_result({:ok, step}) do
+        {:ok, public_step} ->
+          commit_success(
+            session,
+            step,
+            public_step,
+            history,
+            lease,
+            evaluation_id,
+            started_ms
+          )
+
+        {:error, public_error} ->
+          reject_projection(session, public_error, lease, evaluation_id, started_ms)
+      end
+    else
+      reject_success(session, lease, evaluation_id, started_ms, :result_exceeded)
+    end
   end
 
   defp finish_evaluation(
@@ -395,14 +535,27 @@ defmodule PtcRunner.Kernel.ReplSession do
     end
   end
 
-  defp commit_success(session, step, history, lease, evaluation_id, started_ms) do
-    candidate_history = history_after_success(history, step.return)
+  defp commit_success(
+         session,
+         native_step,
+         public_step,
+         history,
+         lease,
+         evaluation_id,
+         started_ms
+       ) do
+    candidate_history = history_after_success(history, native_step.return)
 
-    case RunState.commit_evaluation(session.state, lease, step.memory, candidate_history) do
+    case RunState.commit_evaluation(
+           session.state,
+           lease,
+           native_step.memory,
+           candidate_history
+         ) do
       :ok ->
         next = %{
           session
-          | memory: step.memory,
+          | memory: native_step.memory,
             history: candidate_history
         }
 
@@ -414,12 +567,30 @@ defmodule PtcRunner.Kernel.ReplSession do
                :ok,
                nil
              ) do
-          :ok -> {:ok, step, %{next | attempts: next.attempts + 1}}
+          :ok -> {:ok, public_step, %{next | attempts: next.attempts + 1}}
           {:error, :event_sink_error} -> event_sink_failure(next)
         end
 
       {:error, reason} ->
         reject_committed_failure(session, evaluation_id, started_ms, reason)
+    end
+  end
+
+  defp reject_projection(session, public_error, lease, evaluation_id, started_ms) do
+    _ = RunState.release_evaluation(session.state, lease)
+    public_error = %{public_error | memory: observed_memory(session)}
+    next = increment_error(session)
+
+    case emit_evaluation_stopped(
+           session,
+           session.state,
+           evaluation_id,
+           started_ms,
+           :error,
+           public_error.fail.reason
+         ) do
+      :ok -> {:error, public_error, next}
+      {:error, :event_sink_error} -> event_sink_failure(session)
     end
   end
 
@@ -466,7 +637,10 @@ defmodule PtcRunner.Kernel.ReplSession do
       end
 
     _ = EventSink.emit(session.config.event_sink, "limit-exceeded", %{reason: normalized})
-    step = Native.error(:limit_exceeded, "REPL evaluation limit exceeded", session.memory)
+
+    step =
+      Native.error(:limit_exceeded, "REPL evaluation limit exceeded", observed_memory(session))
+
     {:error, step, increment_error(session)}
   end
 
@@ -505,6 +679,103 @@ defmodule PtcRunner.Kernel.ReplSession do
 
   defp sink_alive?(session),
     do: Process.alive?(session.config.event_sink.pid) and Process.alive?(session.state.pid)
+
+  defp owned_session(session) do
+    with {:ok, pid, token} <- access_resources(session),
+         {:ok, config, state} <- ReplSessionOwner.resources(pid, token) do
+      {:ok,
+       Map.merge(Map.from_struct(session), %{
+         owner_pid: pid,
+         owner_token: token,
+         config: config,
+         state: state,
+         memory: %{},
+         history: []
+       })}
+    end
+  end
+
+  defp register_access(pid, token) do
+    access = access_table()
+    id = make_ref()
+    true = :ets.insert(access, {id, {pid, token}})
+    {:ok, %__MODULE__{access: access, id: id}}
+  rescue
+    exception ->
+      _ = ReplSessionOwner.release(pid, token)
+      {:error, {:session_access_error, Exception.message(exception)}}
+  end
+
+  defp access_resources(%__MODULE__{access: access, id: id}) do
+    case :ets.lookup(access, id) do
+      [{^id, {pid, token}}] when is_pid(pid) and is_reference(token) ->
+        {:ok, pid, token}
+
+      [{^id, :closed}] ->
+        {:error, :session_closed}
+
+      [] ->
+        if :ets.info(access, :owner) == self(),
+          do: {:error, :session_closed},
+          else: {:error, :session_owner_mismatch}
+
+      _other ->
+        {:error, :session_owner_mismatch}
+    end
+  rescue
+    ArgumentError -> {:error, :session_owner_mismatch}
+  end
+
+  defp close_access(%__MODULE__{access: access, id: id}) do
+    :ets.delete(access, id)
+    :ok
+  rescue
+    ArgumentError -> :ok
+  end
+
+  defp access_table do
+    case Process.get(@access_table_key) do
+      nil -> new_access_table()
+      access -> existing_access_table(access)
+    end
+  end
+
+  defp existing_access_table(access) do
+    if :ets.info(access, :owner) == self(), do: access, else: new_access_table()
+  rescue
+    ArgumentError -> new_access_table()
+  end
+
+  defp new_access_table do
+    access = :ets.new(__MODULE__, [:set, :private])
+    Process.put(@access_table_key, access)
+    access
+  end
+
+  defp observed_memory(%{state: state} = session) do
+    case RunState.evaluation_memory_observation(state) do
+      memory when is_map(memory) -> memory
+      {:error, _reason} -> Map.get(session, :memory, %{})
+    end
+  catch
+    :exit, _reason -> Map.get(session, :memory, %{})
+  end
+
+  defp observed_memory(session), do: Map.get(session, :memory, %{})
+
+  defp public_result({status, step, session}) when status in [:ok, :error] do
+    {public_status, public_step} = Lisp.project_native_result({status, step})
+    {public_status, public_step, public_session(session)}
+  end
+
+  defp public_session(session) do
+    %__MODULE__{
+      access: session.access,
+      id: session.id,
+      attempts: session.attempts,
+      errors: session.errors
+    }
+  end
 
   defp prelude(%{bundle: nil}), do: nil
   defp prelude(%{bundle: bundle}), do: bundle.prelude

--- a/lib/ptc_runner/kernel/repl_session_owner.ex
+++ b/lib/ptc_runner/kernel/repl_session_owner.ex
@@ -1,0 +1,114 @@
+defmodule PtcRunner.Kernel.ReplSessionOwner do
+  @moduledoc false
+
+  use GenServer
+
+  alias PtcRunner.Kernel.EventSink
+  alias PtcRunner.Kernel.InspectionSink
+  alias PtcRunner.Kernel.RunConfig
+  alias PtcRunner.Kernel.RunState
+
+  @spec start(RunConfig.t(), RunState.t(), pid()) ::
+          {:ok, pid(), reference()} | {:error, term()}
+  def start(%RunConfig{} = config, %RunState{} = run_state, owner) when is_pid(owner) do
+    with true <- owner == self(),
+         true <-
+           RunState.repl_owner?(
+             run_state,
+             config.event_sink,
+             config.inspection_sink,
+             config.limits
+           ) do
+      token = make_ref()
+
+      case GenServer.start(__MODULE__, {token, owner, config, run_state}) do
+        {:ok, pid} -> {:ok, pid, token}
+        {:error, reason} -> {:error, reason}
+      end
+    else
+      false -> {:error, :session_owner_mismatch}
+    end
+  catch
+    :exit, _reason -> {:error, :session_owner_mismatch}
+  end
+
+  @spec resources(pid(), reference()) ::
+          {:ok, RunConfig.t(), RunState.t()} | {:error, :session_owner_mismatch}
+  def resources(pid, token), do: GenServer.call(pid, {token, :resources})
+
+  @spec release(pid(), reference()) :: :ok | {:error, :session_owner_mismatch}
+  def release(pid, token) do
+    GenServer.call(pid, {token, :release})
+  catch
+    :exit, _reason -> :ok
+  end
+
+  @impl GenServer
+  def init({token, owner, config, run_state}) do
+    {:ok,
+     %{
+       token: token,
+       owner: owner,
+       owner_ref: Process.monitor(owner),
+       config: config,
+       run_state: run_state
+     }}
+  end
+
+  @impl GenServer
+  def handle_call({token, :resources}, {caller, _tag}, %{token: token, owner: caller} = state),
+    do: {:reply, {:ok, state.config, state.run_state}, state}
+
+  def handle_call({token, :release}, {caller, _tag}, %{token: token, owner: caller} = state),
+    do: {:stop, :normal, :ok, state}
+
+  def handle_call(_request, _from, state),
+    do: {:reply, {:error, :session_owner_mismatch}, state}
+
+  @impl GenServer
+  def handle_info({:DOWN, ref, :process, _pid, _reason}, %{owner_ref: ref} = state),
+    do: {:stop, :normal, state}
+
+  def handle_info(_message, state), do: {:noreply, state}
+
+  if {:format_status, 1} in GenServer.behaviour_info(:callbacks) do
+    @impl GenServer
+    def format_status(status), do: redact_status(status)
+  else
+    def format_status(status), do: redact_status(status)
+  end
+
+  @impl GenServer
+  def format_status(_reason, _status), do: [data: [{~c"State", :redacted}]]
+
+  @impl GenServer
+  def terminate(_reason, state) do
+    close_resources(state.config, state.run_state)
+  end
+
+  defp close_resources(config, run_state) do
+    safely(fn -> RunState.close(run_state) end)
+    safely(fn -> RunState.stop(run_state) end)
+    RunConfig.close_provider_resources(config)
+    if config.inspection_sink, do: safely(fn -> InspectionSink.stop(config.inspection_sink) end)
+    safely(fn -> EventSink.stop(config.event_sink) end)
+    :ok
+  end
+
+  defp safely(fun) do
+    fun.()
+    :ok
+  rescue
+    _exception -> :ok
+  catch
+    _kind, _reason -> :ok
+  end
+
+  defp redact_status(status) do
+    Map.new(status, fn
+      {key, _value} when key in [:state, :message, :reason] -> {key, :redacted}
+      {:log, _value} -> {:log, []}
+      key_value -> key_value
+    end)
+  end
+end

--- a/lib/ptc_runner/kernel/run_state.ex
+++ b/lib/ptc_runner/kernel/run_state.ex
@@ -11,7 +11,9 @@ defmodule PtcRunner.Kernel.RunState do
   must not recreate them as separate read and update steps. The opaque token
   prevents messages that did not originate through the returned handle from
   mutating state. The process monitors the run owner and automatically exits
-  with it.
+  with it. Owner checks compare the actual `GenServer.call/3` caller inside this
+  process. Ordinary and standalone-REPL state cannot transfer ownership; only
+  co-hosted session construction receives a one-shot transfer.
 
   Each capability reservation also monitors the dispatching process. If that
   process dies mid-call (heap kill, timeout kill), the reservation is
@@ -27,7 +29,9 @@ defmodule PtcRunner.Kernel.RunState do
 
   alias PtcRunner.Kernel.EventSink
   alias PtcRunner.Kernel.EventSinkState
+  alias PtcRunner.Kernel.InspectionSink
   alias PtcRunner.Kernel.Limits
+  alias PtcRunner.Lisp
   alias PtcRunner.Lisp.RetainedSize
 
   @history_depth 3
@@ -43,8 +47,25 @@ defmodule PtcRunner.Kernel.RunState do
   def start(%Limits{} = limits, opts \\ []) do
     token = make_ref()
     owner = Keyword.get(opts, :owner, self())
-    {:ok, pid} = GenServer.start(__MODULE__, {limits, token, owner, nil})
+    {:ok, pid} = GenServer.start(__MODULE__, {limits, token, owner, nil, false, nil})
     {:ok, %__MODULE__{pid: pid, token: token}}
+  end
+
+  @doc false
+  def start_repl(%Limits{} = limits, %EventSink{} = event_sink, inspection_sink) do
+    with true <- EventSink.owner?(event_sink),
+         true <- inspection_owner?(inspection_sink),
+         token = make_ref(),
+         owner = self(),
+         {:ok, pid} <-
+           GenServer.start(
+             __MODULE__,
+             {limits, token, owner, nil, false, {event_sink, inspection_sink}}
+           ) do
+      {:ok, %__MODULE__{pid: pid, token: token}}
+    else
+      _ -> {:error, :session_owner_mismatch}
+    end
   end
 
   @doc false
@@ -54,7 +75,8 @@ defmodule PtcRunner.Kernel.RunState do
 
     with true <- Keyword.keys(opts) -- [:owner] == [],
          {:ok, event_sink, handle} <- EventSink.prepare(:normal, limits, sink_opts),
-         {:ok, pid} <- GenServer.start(__MODULE__, {limits, token, owner, event_sink}) do
+         {:ok, pid} <-
+           GenServer.start(__MODULE__, {limits, token, owner, event_sink, true, nil}) do
       {:ok, %__MODULE__{pid: pid, token: token}, struct!(EventSink, Map.put(handle, :pid, pid))}
     else
       _ -> {:error, :invalid_run_state}
@@ -129,22 +151,39 @@ defmodule PtcRunner.Kernel.RunState do
   @doc "Returns whether the run is open and its deadline has not elapsed."
   def open?(state), do: call(state, :open?)
 
+  @doc false
+  @spec owner?(t()) :: boolean()
+  def owner?(state), do: call(state, :owner?) == true
+
+  @doc false
+  @spec repl_owner?(t(), EventSink.t(), InspectionSink.t() | nil, Limits.t()) :: boolean()
+  def repl_owner?(state, event_sink, inspection_sink, limits),
+    do: call(state, {:repl_owner?, event_sink, inspection_sink, limits}) == true
+
   @spec evaluation_memory_summary(t()) :: map()
   @doc "Returns bounded definition, history, and retained continuation byte counts."
   def evaluation_memory_summary(state), do: call(state, :evaluation_memory_summary)
 
   @doc false
+  @spec evaluation_memory_observation(t()) ::
+          map() | {:error, :session_owner_mismatch | {:java_projection_error, term()}}
+  def evaluation_memory_observation(state), do: call(state, :evaluation_memory_observation)
+
+  @doc false
   def transfer_owner(state, owner) when is_pid(owner), do: call(state, {:transfer_owner, owner})
 
   @impl GenServer
-  def init({limits, token, owner, event_sink}) do
+  def init({limits, token, owner, event_sink, owner_transferable?, repl_resources}) do
     now = System.monotonic_time(:millisecond)
 
     {:ok,
      %{
        token: token,
+       owner: owner,
        owner_ref: Process.monitor(owner),
+       owner_transferable?: owner_transferable?,
        event_sink: event_sink,
+       repl_resources: repl_resources,
        limits: limits,
        deadline_ms: now + limits.run_duration_ms,
        closed?: false,
@@ -162,6 +201,13 @@ defmodule PtcRunner.Kernel.RunState do
   end
 
   @impl GenServer
+  def handle_call(
+        {event_token, :owner?},
+        {caller, _tag},
+        %{event_sink: %{token: event_token}, owner: owner} = state
+      ),
+      do: {:reply, caller == owner, state}
+
   def handle_call(
         {event_token, _request} = request,
         _from,
@@ -344,20 +390,64 @@ defmodule PtcRunner.Kernel.RunState do
   def handle_call({token, :open?}, _from, %{token: token} = state),
     do: {:reply, not unavailable?(state), state}
 
+  def handle_call({token, :owner?}, {caller, _tag}, %{token: token} = state),
+    do: {:reply, caller == state.owner, state}
+
+  def handle_call(
+        {token, {:repl_owner?, event_sink, inspection_sink, limits}},
+        {caller, _tag},
+        %{token: token} = state
+      ) do
+    owner? =
+      caller == state.owner and
+        state.repl_resources === {event_sink, inspection_sink} and
+        state.limits === limits
+
+    {:reply, owner?, state}
+  end
+
   def handle_call({token, :evaluation_memory_summary}, _from, %{token: token} = state),
     do: {:reply, continuation_summary(state), state}
 
-  def handle_call({token, {:transfer_owner, owner}}, _from, %{token: token} = state)
+  def handle_call(
+        {token, :evaluation_memory_observation},
+        {caller, _tag},
+        %{token: token, owner: caller} = state
+      ),
+      do: {:reply, Lisp.externalize_memory(state.memory), state}
+
+  def handle_call(
+        {token, :evaluation_memory_observation},
+        _from,
+        %{token: token} = state
+      ),
+      do: {:reply, {:error, :session_owner_mismatch}, state}
+
+  def handle_call(
+        {token, {:transfer_owner, owner}},
+        {caller, _tag},
+        %{token: token, owner: caller, owner_transferable?: true} = state
+      )
       when is_pid(owner) do
     if Process.alive?(owner) do
       Process.demonitor(state.owner_ref, [:flush])
-      {:reply, :ok, %{state | owner_ref: Process.monitor(owner)}}
+
+      {:reply, :ok,
+       %{
+         state
+         | owner: owner,
+           owner_ref: Process.monitor(owner),
+           owner_transferable?: false
+       }}
     else
       {:reply, {:error, :closed}, state}
     end
   end
 
   def handle_call(_request, _from, state), do: {:reply, {:error, :closed}, state}
+
+  defp inspection_owner?(nil), do: true
+  defp inspection_owner?(sink), do: InspectionSink.owner?(sink)
 
   @impl GenServer
   def handle_cast(_request, state), do: {:noreply, state}

--- a/lib/ptc_runner/lisp.ex
+++ b/lib/ptc_runner/lisp.ex
@@ -133,6 +133,19 @@ defmodule PtcRunner.Lisp do
     end
   end
 
+  @doc false
+  @spec project_native_result({:ok | :error, Step.t()}) ::
+          {:ok | :error, Step.t()}
+  def project_native_result({tag, %Step{} = step}) when tag in [:ok, :error] do
+    case externalize_memory(step.memory) do
+      memory when is_map(memory) ->
+        public_result({tag, %{step | memory: memory}})
+
+      {:error, {:java_projection_error, reason}} ->
+        {:error, java_projection_error_step(%{step | memory: %{}}, reason)}
+    end
+  end
+
   @doc """
   Converts a PTC-Lisp memory map into the public memory representation.
 
@@ -251,8 +264,10 @@ defmodule PtcRunner.Lisp do
        runtime callables as labels. Do not serialize `step.memory` (JSON,
        ETF-to-disk, database) between evals —
        serialization silently converts native values such as keywords into
-       plain strings. For persistent or cross-process REPL state, use
-       `PtcRunner.Kernel.ReplSession`, which owns continuation memory.
+       plain strings. For a bounded persistent REPL continuation, use
+       `PtcRunner.Kernel.ReplSession` from one stable owner process. It is
+       process-affine; a separate supervised abstraction must serialize any
+       multi-process frontend.
      - `step.usage`: Execution metrics (`duration_ms`, `memory_bytes`,
        `eval_reductions`)
 
@@ -804,7 +819,11 @@ defmodule PtcRunner.Lisp do
     compile_max_heap =
       Application.get_env(:ptc_runner, :default_max_heap, 1_250_000)
 
-    compile_opts = [timeout: compile_timeout, max_heap: compile_max_heap]
+    compile_opts = [
+      timeout: compile_timeout,
+      max_heap: compile_max_heap,
+      link: Map.get(opts, :link, false)
+    ]
 
     case PtcRunner.Sandbox.run_bounded(compile_fn, compile_opts) do
       {:ok, {:ok, core_ast}} ->

--- a/lib/ptc_runner/sandbox.ex
+++ b/lib/ptc_runner/sandbox.ex
@@ -159,11 +159,9 @@ defmodule PtcRunner.Sandbox do
     max_heap = Keyword.get(opts, :max_heap, default_max_heap)
     setup_max_heap = Keyword.get(opts, :setup_max_heap, 4 * max_heap)
     eval_fn = Keyword.fetch!(opts, :eval_fn)
-    # When `link: true`, the spawned sandbox process is linked to the caller in
-    # addition to being monitored. If a disposable caller is killed, the link
-    # terminates the sandbox child promptly instead of leaving it to run until
-    # its own heap or timeout limit fires. The default is `false` for callers
-    # whose lifetime is independent of the sandbox worker.
+    # When `link: true`, the bounded worker starts a tiny watchdog that monitors
+    # both worker and caller. Caller shutdown therefore kills the sandbox
+    # without changing the caller's trap-exit behavior.
     link? = Keyword.get(opts, :link, false)
 
     # Spawn isolated process with resource limits
@@ -171,25 +169,13 @@ defmodule PtcRunner.Sandbox do
 
     parent = self()
 
-    spawn_opts =
-      [
-        {:max_heap_size,
-         %{size: setup_max_heap, kill: true, error_logger: false, include_shared_binaries: true}},
-        :monitor
-      ] ++
-        if link?, do: [:link], else: []
-
-    # When linking, the parent must trap exits so that an abnormal
-    # child termination (heap_kill, eval_fn raise, etc.) is delivered
-    # as a `{:EXIT, _, _}` message — already handled by the existing
-    # `{:DOWN, ...}` monitor clause — instead of taking the parent
-    # down via the link. We restore the prior trap-exit flag before
-    # returning so this is invisible to non-linking callers.
-    prior_trap_exit =
-      if link?, do: Process.flag(:trap_exit, true), else: nil
+    spawn_opts = [
+      {:max_heap_size,
+       %{size: setup_max_heap, kill: true, error_logger: false, include_shared_binaries: true}}
+    ]
 
     {pid, ref} =
-      Process.spawn(
+      spawn_worker(
         fn ->
           # Set process priority to normal within the process
           Process.flag(:priority, :normal)
@@ -207,7 +193,8 @@ defmodule PtcRunner.Sandbox do
           memory = get_process_memory()
           send(parent, {:result, self(), result, memory, eval_reductions})
         end,
-        spawn_opts
+        spawn_opts,
+        link?
       )
 
     await = %{
@@ -216,29 +203,12 @@ defmodule PtcRunner.Sandbox do
       deadline: start_time + timeout,
       start_time: start_time,
       timeout: timeout,
-      link?: link?,
       max_heap: max_heap,
       setup_max_heap: setup_max_heap,
       baseline_words: nil
     }
 
-    try do
-      await_result(await)
-    after
-      if link? do
-        # Defense-in-depth: even with `unlink/1` above, we may have
-        # been linked but not yet killed (success / DOWN paths). Flush
-        # any straggler `{:EXIT, pid, _}` signal that may have arrived
-        # before we restore `trap_exit`.
-        receive do
-          {:EXIT, ^pid, _} -> :ok
-        after
-          0 -> :ok
-        end
-
-        Process.flag(:trap_exit, prior_trap_exit)
-      end
-    end
+    await_result(await)
   end
 
   # Wait for the sandbox child: consumes the `{:baseline, _, _}` message the
@@ -286,13 +256,7 @@ defmodule PtcRunner.Sandbox do
         {:error, {:execution_error, "Process terminated: #{inspect(reason)}"}}
     after
       remaining ->
-        # Timeout path: kill the child WITHOUT letting its link signal
-        # race with the trap_exit restore (codex review of 0fe4c78).
-        # `Process.unlink/1` atomically discards any pending exit
-        # signal from `pid` on the link, so the EXIT message cannot
-        # reach our mailbox after we restore the prior `trap_exit`.
         Process.demonitor(ref, [:flush])
-        if await.link?, do: Process.unlink(pid)
         Process.exit(pid, :kill)
 
         # Flush stragglers the child may have sent right as the timeout
@@ -386,6 +350,9 @@ defmodule PtcRunner.Sandbox do
 
     * `:timeout` - Timeout in milliseconds (default: 1000)
     * `:max_heap` - Max heap size in words (default: 1_250_000)
+    * `:link` - Couple the bounded worker to its caller through a linked
+      watchdog (default: false). Caller shutdown cancels the worker without
+      changing the caller's trap-exit flag.
 
   ## Returns
 
@@ -414,21 +381,24 @@ defmodule PtcRunner.Sandbox do
 
     timeout = Keyword.get(opts, :timeout, default_timeout)
     max_heap = Keyword.get(opts, :max_heap, default_max_heap)
+    link? = Keyword.get(opts, :link, false)
 
     parent = self()
 
+    spawn_opts = [
+      {:max_heap_size,
+       %{size: max_heap, kill: true, error_logger: false, include_shared_binaries: true}}
+    ]
+
     {pid, ref} =
-      Process.spawn(
+      spawn_worker(
         fn ->
           Process.flag(:priority, :normal)
           result = fun.()
           send(parent, {:bounded_result, self(), result})
         end,
-        [
-          {:max_heap_size,
-           %{size: max_heap, kill: true, error_logger: false, include_shared_binaries: true}},
-          :monitor
-        ]
+        spawn_opts,
+        link?
       )
 
     receive do
@@ -454,6 +424,44 @@ defmodule PtcRunner.Sandbox do
 
         {:error, {:timeout, timeout}}
     end
+  end
+
+  defp spawn_worker(fun, spawn_opts, false),
+    do: Process.spawn(fun, [:monitor | spawn_opts])
+
+  defp spawn_worker(fun, spawn_opts, true) do
+    owner = self()
+
+    worker_fun = fn ->
+      worker = self()
+      ready = make_ref()
+
+      {watchdog, watchdog_ref} =
+        spawn_monitor(fn ->
+          owner_ref = Process.monitor(owner)
+          worker_ref = Process.monitor(worker)
+          send(worker, {ready, self()})
+
+          receive do
+            {:DOWN, ^owner_ref, :process, ^owner, _reason} ->
+              Process.exit(worker, :kill)
+
+            {:DOWN, ^worker_ref, :process, ^worker, _reason} ->
+              Process.demonitor(owner_ref, [:flush])
+          end
+        end)
+
+      receive do
+        {^ready, ^watchdog} ->
+          Process.demonitor(watchdog_ref, [:flush])
+          fun.()
+
+        {:DOWN, ^watchdog_ref, :process, ^watchdog, reason} ->
+          exit({:watchdog_start_failed, reason})
+      end
+    end
+
+    Process.spawn(worker_fun, [:monitor | spawn_opts])
   end
 
   defp get_process_memory do

--- a/test/ptc_runner/kernel/repl_session_test.exs
+++ b/test/ptc_runner/kernel/repl_session_test.exs
@@ -4,11 +4,13 @@ defmodule PtcRunner.Kernel.ReplSessionTest do
   alias PtcRunner.Kernel
   alias PtcRunner.Kernel.Capability
   alias PtcRunner.Kernel.EventSink
+  alias PtcRunner.Kernel.InspectionSink
   alias PtcRunner.Kernel.Library
   alias PtcRunner.Kernel.Limits
   alias PtcRunner.Kernel.LLMCapability
   alias PtcRunner.Kernel.MissionEnvironment
   alias PtcRunner.Kernel.ReplSession
+  alias PtcRunner.Kernel.ReplSessionOwner
   alias PtcRunner.Kernel.RunConfig
   alias PtcRunner.Kernel.RunState
   alias PtcRunner.Kernel.WorkflowEnvironment
@@ -72,9 +74,246 @@ defmodule PtcRunner.Kernel.ReplSessionTest do
     assert third.return == 43
 
     assert %{history_count: 3, history_bytes: history_bytes} =
-             RunState.evaluation_memory_summary(session.state)
+             ReplSession.evaluation_memory_summary(session)
 
     assert history_bytes > 0
+  end
+
+  test "sessions reject evaluation and teardown outside their creating process" do
+    {:ok, eval_session} = ReplSession.new()
+    refute Enum.any?(Map.values(Map.from_struct(eval_session)), &is_pid/1)
+    refute Map.has_key?(eval_session, :pid)
+    refute Map.has_key?(eval_session, :token)
+    refute Map.has_key?(eval_session, :owner)
+    refute Map.has_key?(eval_session, :state)
+    refute Map.has_key?(eval_session, :config)
+    refute Map.has_key?(eval_session, :memory)
+    refute Map.has_key?(eval_session, :history)
+
+    assert :private = :ets.info(eval_session.access, :protection)
+
+    assert {:error, ArgumentError} =
+             from_other_process(fn ->
+               try do
+                 :ets.lookup(eval_session.access, eval_session.id)
+               rescue
+                 exception -> {:error, exception.__struct__}
+               end
+             end)
+
+    assert {:error, :session_owner_mismatch} =
+             from_other_process(fn -> ReplSession.eval(eval_session, "(def leaked 1)") end)
+
+    assert {:error, %{fail: %{reason: :unbound_var}}, _session} =
+             ReplSession.eval(eval_session, "leaked")
+
+    assert %{defined_count: 0} = ReplSession.evaluation_memory_summary(eval_session)
+
+    assert {:ok, _events} = ReplSession.close(eval_session)
+
+    {:ok, close_session} = ReplSession.new()
+
+    malformed = %{close_session | id: make_ref()}
+
+    assert {:error, :session_owner_mismatch} =
+             from_other_process(fn -> ReplSession.close(malformed) end)
+
+    assert {:error, :session_owner_mismatch} =
+             from_other_process(fn -> ReplSession.close(close_session) end)
+
+    assert {:ok, %{return: 42}, close_session} = ReplSession.eval(close_session, "42")
+    assert {:ok, _events} = ReplSession.close(close_session)
+
+    {:ok, abort_session} = ReplSession.new()
+
+    assert {:error, :session_owner_mismatch} =
+             from_other_process(fn -> ReplSession.abort(abort_session, :frontend_exit) end)
+
+    assert {:ok, %{return: 42}, abort_session} = ReplSession.eval(abort_session, "42")
+    assert {:ok, _events} = ReplSession.abort(abort_session, :frontend_exit)
+  end
+
+  test "configured sessions require event and inspection sinks owned by their creator" do
+    parent = self()
+
+    config_owner =
+      Task.async(fn ->
+        {:ok, workflow} = WorkflowEnvironment.new([])
+        {:ok, mission} = MissionEnvironment.new([])
+        limits = Limits.defaults()
+        {:ok, sink} = EventSink.start(:normal, limits, run_id: "foreign-repl-config")
+
+        {:ok, config} =
+          RunConfig.new(
+            workflow_environment: workflow,
+            mission_environment: mission,
+            input: %{},
+            limits: limits,
+            event_sink: sink
+          )
+
+        send(parent, {:foreign_config, config})
+        receive do: (:finish -> :ok)
+      end)
+
+    assert_receive {:foreign_config, foreign_config}, 2_000
+    foreign_sink_ref = Process.monitor(foreign_config.event_sink.pid)
+    assert {:error, :session_owner_mismatch} = ReplSession.new(config: foreign_config)
+    assert Process.alive?(foreign_config.event_sink.pid)
+    send(config_owner.pid, :finish)
+    assert :ok = Task.await(config_owner)
+    assert_receive {:DOWN, ^foreign_sink_ref, :process, _, _reason}, 2_000
+
+    inspection_owner =
+      Task.async(fn ->
+        {:ok, sink} =
+          InspectionSink.start(run_id: "foreign-inspection", trace_id: "foreign-inspection")
+
+        send(parent, {:foreign_inspection_sink, sink})
+        receive do: (:finish -> :ok)
+      end)
+
+    assert_receive {:foreign_inspection_sink, foreign_inspection}, 2_000
+    inspection_ref = Process.monitor(foreign_inspection.pid)
+
+    {:ok, workflow} = WorkflowEnvironment.new([])
+    {:ok, mission} = MissionEnvironment.new([])
+    limits = Limits.defaults()
+    {:ok, local_sink} = EventSink.start(:normal, limits, run_id: "local-repl-config")
+
+    {:ok, mixed_config} =
+      RunConfig.new(
+        workflow_environment: workflow,
+        mission_environment: mission,
+        input: %{},
+        limits: limits,
+        event_sink: local_sink,
+        inspection_sink: foreign_inspection,
+        inspection_path: "foreign.inspection.jsonl"
+      )
+
+    assert {:error, :session_owner_mismatch} = ReplSession.new(config: mixed_config)
+    assert Process.alive?(local_sink.pid)
+    assert :ok = EventSink.stop(local_sink)
+    send(inspection_owner.pid, :finish)
+    assert :ok = Task.await(inspection_owner)
+    assert_receive {:DOWN, ^inspection_ref, :process, _, _reason}, 2_000
+  end
+
+  test "owner exit closes hidden session resources" do
+    parent = self()
+
+    creator =
+      Task.async(fn ->
+        {:ok, workflow} = WorkflowEnvironment.new([])
+        {:ok, mission} = MissionEnvironment.new([])
+        limits = Limits.defaults()
+        {:ok, sink} = EventSink.start(:normal, limits, run_id: "owner-exit-repl")
+
+        {:ok, config} =
+          RunConfig.new(
+            workflow_environment: workflow,
+            mission_environment: mission,
+            input: %{},
+            limits: limits,
+            event_sink: sink,
+            provider_resources: [fn -> send(parent, :owner_exit_resource_closed) end]
+          )
+
+        {:ok, _session} = ReplSession.new(config: config)
+        send(parent, {:owner_exit_session, sink.pid, self()})
+        receive do: (:finish -> :ok)
+        :ok
+      end)
+
+    assert_receive {:owner_exit_session, sink_pid, creator_pid}
+    sink_ref = Process.monitor(sink_pid)
+    send(creator_pid, :finish)
+    assert :ok = Task.await(creator)
+    assert_receive {:DOWN, ^sink_ref, :process, ^sink_pid, :normal}
+    assert_receive :owner_exit_resource_closed
+  end
+
+  test "owner exit cancels an in-flight evaluation sandbox" do
+    parent = self()
+
+    {creator, creator_ref} =
+      spawn_monitor(fn ->
+        {:ok, workflow} = WorkflowEnvironment.new([])
+        {:ok, mission} = MissionEnvironment.new([])
+
+        {:ok, limits} =
+          Limits.new(
+            evaluation_timeout_ms: 30_000,
+            evaluation_heap_words: 1_250_000,
+            run_duration_ms: 30_000
+          )
+
+        {:ok, sink} = EventSink.start(:normal, limits, run_id: "owner-exit-evaluation")
+
+        {:ok, config} =
+          RunConfig.new(
+            workflow_environment: workflow,
+            mission_environment: mission,
+            input: %{},
+            limits: limits,
+            event_sink: sink
+          )
+
+        {:ok, session} = ReplSession.new(config: config)
+        send(parent, {:owner_exit_evaluation_ready, self()})
+
+        receive do
+          :evaluate -> ReplSession.eval(session, "(loop [x 0] (recur (inc x)))")
+        end
+      end)
+
+    assert_receive {:owner_exit_evaluation_ready, ^creator}, 2_000
+    assert {:trap_exit, false} = Process.info(creator, :trap_exit)
+    assert 1 = :erlang.trace(creator, true, [:procs])
+    send(creator, :evaluate)
+
+    assert_receive {:trace, ^creator, :spawn, compile_worker, _mfa}, 2_000
+    compile_ref = Process.monitor(compile_worker)
+    assert_receive {:DOWN, ^compile_ref, :process, ^compile_worker, _reason}, 2_000
+
+    assert_receive {:trace, ^creator, :spawn, evaluation_worker, _mfa}, 2_000
+    evaluation_ref = Process.monitor(evaluation_worker)
+    assert Process.alive?(evaluation_worker)
+    assert {:trap_exit, false} = Process.info(creator, :trap_exit)
+
+    on_exit(fn ->
+      if Process.alive?(evaluation_worker), do: Process.exit(evaluation_worker, :kill)
+    end)
+
+    Process.exit(creator, :shutdown)
+    assert_receive {:DOWN, ^creator_ref, :process, ^creator, :shutdown}, 2_000
+    assert_receive {:DOWN, ^evaluation_ref, :process, ^evaluation_worker, _reason}, 2_000
+  end
+
+  test "session owner rejects a run state not bound to its configured sinks" do
+    {:ok, workflow} = WorkflowEnvironment.new([])
+    {:ok, mission} = MissionEnvironment.new([])
+    limits = Limits.defaults()
+    {:ok, sink} = EventSink.start(:normal, limits, run_id: "repl-owner-binding")
+
+    {:ok, config} =
+      RunConfig.new(
+        workflow_environment: workflow,
+        mission_environment: mission,
+        input: %{},
+        limits: limits,
+        event_sink: sink
+      )
+
+    {:ok, ordinary_state} = RunState.start(limits)
+
+    assert {:error, :session_owner_mismatch} =
+             ReplSessionOwner.start(config, ordinary_state, self())
+
+    :ok = RunState.close(ordinary_state)
+    :ok = RunState.stop(ordinary_state)
+    :ok = EventSink.stop(sink)
   end
 
   test "history has a separate ceiling and rejects a candidate continuation atomically" do
@@ -97,18 +336,18 @@ defmodule PtcRunner.Kernel.ReplSessionTest do
 
     {:ok, session} = ReplSession.new(config: config)
     assert {:ok, _step, session} = ReplSession.eval(session, "(def retained 42)")
-    retained_history = session.history
+    retained = ReplSession.evaluation_memory_summary(session)
 
     source = ~s|"#{String.duplicate("x", 512)}"|
 
     assert {:error, %{fail: %{reason: :history_exceeded}}, session} =
              ReplSession.eval(session, source)
 
-    assert session.history == retained_history
+    assert ReplSession.evaluation_memory_summary(session) == retained
 
     assert {:ok, step, session} = ReplSession.eval(session, "retained")
     assert step.return == 42
-    assert session.history == retained_history ++ [42]
+    assert %{history_count: 2} = ReplSession.evaluation_memory_summary(session)
   end
 
   test "failed evaluations roll back continuation memory and emit canonical status" do
@@ -140,12 +379,10 @@ defmodule PtcRunner.Kernel.ReplSessionTest do
     assert {:error, %{fail: %{reason: :event_sink_error}}, returned} =
              ReplSession.eval(session, "(def committed 42)")
 
-    assert returned.memory == %{"committed" => 42}
-    assert length(returned.history) == 1
     assert %{attempts: 1, errors: 1} = returned
 
     assert %{defined_count: 1, history_count: 1} =
-             RunState.evaluation_memory_summary(returned.state)
+             ReplSession.evaluation_memory_summary(returned)
 
     assert {:error, %{fail: %{reason: :session_closed}}, ^returned} =
              ReplSession.eval(returned, "committed")
@@ -154,12 +391,12 @@ defmodule PtcRunner.Kernel.ReplSessionTest do
   test "explicit failure rolls back memory and turn history" do
     {:ok, session} = ReplSession.new()
     assert {:ok, _step, session} = ReplSession.eval(session, "(def retained 42)")
-    retained_history = session.history
+    retained = ReplSession.evaluation_memory_summary(session)
 
     assert {:error, %{fail: %{reason: :explicit_failure}}, session} =
              ReplSession.eval(session, ~s|(do (def leaked 1) (fail "stop"))|)
 
-    assert session.history == retained_history
+    assert ReplSession.evaluation_memory_summary(session) == retained
     assert {:ok, %{return: 42}, session} = ReplSession.eval(session, "retained")
     assert {:error, _step, _session} = ReplSession.eval(session, "leaked")
   end
@@ -227,23 +464,44 @@ defmodule PtcRunner.Kernel.ReplSessionTest do
       )
 
     {:ok, session} = ReplSession.new(config: config)
-    assert {:ok, _step, session} = ReplSession.eval(session, "41")
+    assert {:ok, _step, session} = ReplSession.eval(session, "(def retained 41)")
 
-    assert {:error, %{fail: %{reason: :limit_exceeded}}, _session} =
+    assert {:error, %{fail: %{reason: :limit_exceeded}, memory: memory}, _session} =
              ReplSession.eval(session, "42")
+
+    assert memory["retained"] == 41
   end
 
   test "closed and constructor-failed sessions leave no live sink" do
-    {:ok, session} = ReplSession.new()
-    sink_pid = session.config.event_sink.pid
+    {:ok, workflow} = WorkflowEnvironment.new([])
+    {:ok, mission} = MissionEnvironment.new([])
+    limits = Limits.defaults()
+    {:ok, sink} = EventSink.start(:normal, limits, run_id: "closed-repl")
+
+    {:ok, config} =
+      RunConfig.new(
+        workflow_environment: workflow,
+        mission_environment: mission,
+        input: %{},
+        limits: limits,
+        event_sink: sink
+      )
+
+    {:ok, session} = ReplSession.new(config: config)
+    sink_pid = sink.pid
     ref = Process.monitor(sink_pid)
     assert {:ok, _events} = ReplSession.close(session)
     assert_receive {:DOWN, ^ref, :process, ^sink_pid, :normal}
+    assert :ets.lookup(session.access, session.id) == []
 
     assert {:error, %{fail: %{reason: :session_closed}}, ^session} =
              ReplSession.eval(session, "42")
 
     assert {:error, :session_closed} = ReplSession.close(session)
+
+    {:ok, replacement} = ReplSession.new()
+    assert replacement.access == session.access
+    assert {:ok, _events} = ReplSession.close(replacement)
 
     # Build-time validation now rejects a payload the configured sink could
     # not accept, so the runtime constructor failure is triggered by a full
@@ -407,6 +665,73 @@ defmodule PtcRunner.Kernel.ReplSessionTest do
            ] == Enum.map(events, & &1.type)
   end
 
+  test "evaluation results do not expose callable continuation authority" do
+    {:ok, echo} =
+      Capability.new(
+        name: "echo",
+        input_schema: @input_schema,
+        callback: fn args -> {:ok, args} end
+      )
+
+    {:ok, workflow} = WorkflowEnvironment.new(capabilities: [echo])
+    {:ok, mission} = MissionEnvironment.new([])
+    limits = Limits.defaults()
+    {:ok, sink} = EventSink.start(:normal, limits, run_id: "repl-result-boundary")
+
+    {:ok, config} =
+      RunConfig.new(
+        workflow_environment: workflow,
+        mission_environment: mission,
+        input: %{},
+        limits: limits,
+        event_sink: sink
+      )
+
+    {:ok, session} = ReplSession.new(config: config)
+
+    assert {:ok, first, session} = ReplSession.eval(session, "(def saved tool/echo)")
+    refute Map.has_key?(first.memory, "saved")
+
+    assert {:ok, second, session} =
+             ReplSession.eval(session, ~S|(saved {"value" 42})|)
+
+    assert second.return == %{status: :ok, value: %{"value" => 42}}
+
+    assert {:ok, third, session} = ReplSession.eval(session, "tool/echo")
+    assert third.return == "tool/echo"
+    assert {:ok, _events} = ReplSession.close(session)
+  end
+
+  test "public projection failure rolls back continuation and records an error" do
+    {:ok, session} = ReplSession.new()
+    assert {:ok, _step, session} = ReplSession.eval(session, "(def retained 42)")
+
+    source =
+      ~S|(do (def leaked 1) {(Integer/parseInt "1") :int (Long/parseLong "1") :long})|
+
+    assert {:error, %{fail: %{reason: :java_projection_error}, memory: memory}, session} =
+             ReplSession.eval(session, source)
+
+    assert memory["retained"] == 42
+    refute Map.has_key?(memory, "leaked")
+
+    assert %{defined_count: 1, history_count: 1} =
+             ReplSession.evaluation_memory_summary(session)
+
+    assert {:error, %{fail: %{reason: :unbound_var}}, session} =
+             ReplSession.eval(session, "leaked")
+
+    assert {:ok, events} = ReplSession.close(session)
+
+    assert Enum.any?(events, fn event ->
+             event.type == "evaluation-stopped" and
+               event.data.status == :error and
+               event.data.reason == :java_projection_error
+           end)
+
+    assert List.last(events).data.outcome == :error
+  end
+
   test "ambiguous capability arguments are counted without REPL provider dispatch" do
     parent = self()
 
@@ -439,7 +764,13 @@ defmodule PtcRunner.Kernel.ReplSessionTest do
     assert {:ok, %{return: %{kind: :protocol_error, reason: :ambiguous_arguments}}, session} =
              ReplSession.eval(session, ~S|(tool/capture {"path" "a" :path "b"})|)
 
-    assert %{protocol_errors: 1} = RunState.usage(session.state)
+    assert %{protocol_errors: 1} = ReplSession.usage(session)
     refute_receive {:repl_provider_called, _arguments}
+  end
+
+  defp from_other_process(fun) do
+    fun
+    |> Task.async()
+    |> Task.await()
   end
 end

--- a/test/ptc_runner/sandbox_test.exs
+++ b/test/ptc_runner/sandbox_test.exs
@@ -153,6 +153,32 @@ defmodule PtcRunner.SandboxTest do
     end
   end
 
+  describe "Sandbox.run_bounded/2 - linked cancellation" do
+    test "linked workers stop when their caller exits" do
+      parent = self()
+
+      {owner, owner_ref} =
+        spawn_monitor(fn ->
+          PtcRunner.Sandbox.run_bounded(
+            fn ->
+              send(parent, {:bounded_worker, self()})
+              receive do: (:finish -> :ok)
+            end,
+            link: true,
+            timeout: 30_000
+          )
+        end)
+
+      assert_receive {:bounded_worker, worker}, 2_000
+      worker_ref = Process.monitor(worker)
+      assert {:trap_exit, false} = Process.info(owner, :trap_exit)
+
+      Process.exit(owner, :shutdown)
+      assert_receive {:DOWN, ^owner_ref, :process, ^owner, :shutdown}, 2_000
+      assert_receive {:DOWN, ^worker_ref, :process, ^worker, _reason}, 2_000
+    end
+  end
+
   # Regression tests for #993: binary-heavy programs must respect max_heap
   describe "shared binary memory accounting (#993)" do
     test "run_bounded kills binary-heavy function under tight heap cap" do


### PR DESCRIPTION
## What changed

- make standalone `ReplSession` handles process-affine and reject foreign evaluation or teardown
- keep native continuation, configuration, sink, and provider authority behind a creator-private opaque lookup
- return inert public result projections while preserving committed memory observations on failures
- bind REPL run state to its exact sinks and limits and clean all hidden resources on creator exit
- cancel compile and evaluation sandboxes with a monitor-only watchdog that neither changes `trap_exit` nor retains an unbounded workload copy
- update the REPL and maintainer guides plus the boundary-hardening record

## Why

The public session struct previously carried raw continuation and owner handles. Passing it to another process could therefore evaluate or tear down state that still belonged to the creator. Evaluation results could also expose callable continuation authority.

This slice makes the existing process ownership contract explicit and enforceable without introducing transferable-session compatibility machinery.

## Validation

- `mix precommit`
- `mix prepush`
- focused REPL, sandbox, core-contract, and parallel-runner tests: 128 passed
- independent Codex review, including a clean follow-up on committed-memory projection and ETS entry reclamation
