### PR TITLE
test: add boundary integration coverage

### DIFF
--- a/test/ptc_runner/lisp/prelude/tool_requires_test.exs
+++ b/test/ptc_runner/lisp/prelude/tool_requires_test.exs
@@ -276,6 +276,77 @@ defmodule PtcRunner.Lisp.Prelude.ToolRequiresTest do
       assert [%{private: true, origin: %{ref: "cap/fetch"}}] = step.tool_calls
     end
 
+    test "private prelude tool ledgers redact source and metadata at the public boundary" do
+      input_source = "PRIVATE_INPUT_SOURCE"
+      result_source = "PRIVATE_RESULT_SOURCE"
+
+      prelude =
+        compile!("""
+        (ns cap "Cap." {:visibility :prompt})
+        (defn fetch "doc" []
+          (do
+            (tool/private_fetch
+              {"source" "#{input_source}"
+               "metadata"
+               {"reason" "sync"
+                "requires_preludes" ["base" 7]
+                "prelude_deps"
+                [{"id" "base" "version" 2 "checksum" "checksum-base"}
+                 {"id" "invalid" "version" 0 "checksum" "ignored"}]
+                "nested" {"token" "PRIVATE_INPUT_SECRET"}}})
+            "ok"))
+        """)
+
+      tools = %{
+        "private_fetch" =>
+          {fn _args ->
+             %{
+               "source" => result_source,
+               "metadata" => %{
+                 "created_by" => "prelude",
+                 "api_key" => "PRIVATE_RESULT_SECRET"
+               }
+             }
+           end, visibility: :private}
+      }
+
+      assert {:ok, %Step{} = step} = Lisp.run(~S|(cap/fetch)|, prelude: prelude, tools: tools)
+      assert step.return == "ok"
+
+      assert [
+               %{
+                 private: true,
+                 origin: %{type: :prelude_export, ref: "cap/fetch"},
+                 args: %{"source" => input_summary, "metadata" => input_metadata},
+                 result: %{"source" => result_summary, "metadata" => result_metadata}
+               }
+             ] = step.tool_calls
+
+      assert %{"redacted" => true, "bytes" => input_bytes, "sha256" => input_hash} = input_summary
+      assert input_bytes == byte_size(input_source)
+      assert input_hash =~ ~r/\A[0-9a-f]{64}\z/
+
+      assert %{"redacted" => true, "bytes" => result_bytes, "sha256" => result_hash} =
+               result_summary
+
+      assert result_bytes == byte_size(result_source)
+      assert result_hash =~ ~r/\A[0-9a-f]{64}\z/
+      refute input_hash == result_hash
+
+      assert input_metadata == %{
+               "reason" => "sync",
+               "requires_preludes" => ["base"],
+               "prelude_deps" => [
+                 %{"id" => "base", "version" => 2, "checksum" => "checksum-base"}
+               ]
+             }
+
+      assert result_metadata == %{"created_by" => "prelude"}
+
+      encoded_ledger = inspect(step.tool_calls)
+      refute encoded_ledger =~ "PRIVATE_"
+    end
+
     test "a value-position HOF use of an export may call its declared private tools" do
       tools = %{
         "private_fetch" =>

--- a/test/ptc_runner/llm/req_llm_adapter_test.exs
+++ b/test/ptc_runner/llm/req_llm_adapter_test.exs
@@ -2,8 +2,65 @@ defmodule PtcRunner.LLM.ReqLLMAdapterTest do
   use ExUnit.Case, async: true
 
   alias PtcRunner.LLM.ReqLLMAdapter
+  alias PtcRunner.TestSupport.MCPHTTPFixture
   alias ReqLLM.Message
   alias ReqLLM.ToolCall
+
+  describe "OpenAI-compatible HTTP integration" do
+    test "sends the production request over HTTP and decodes the provider response" do
+      parent = self()
+
+      fixture =
+        MCPHTTPFixture.start(fn request ->
+          send(parent, {:openai_compat_request, request})
+
+          response = %{
+            "choices" => [%{"message" => %{"content" => "loopback response"}}],
+            "usage" => %{"prompt_tokens" => 13, "completion_tokens" => 5}
+          }
+
+          {200, [{"content-type", "application/json"}], Jason.encode!(response)}
+        end)
+
+      on_exit(fixture.close)
+
+      assert {:ok, response} =
+               ReqLLMAdapter.generate_text(
+                 "openai-compat:#{fixture.endpoint}|loopback-model",
+                 [
+                   %{role: :system, content: "Be concise."},
+                   %{role: :user, content: "Summarize this."}
+                 ],
+                 max_tokens: 32,
+                 temperature: 0.25,
+                 receive_timeout: 1_000
+               )
+
+      assert response == %{
+               content: "loopback response",
+               tokens: %{
+                 input: 13,
+                 output: 5,
+                 cache_read: 0,
+                 cache_creation: 0
+               }
+             }
+
+      assert_receive {:openai_compat_request, request}
+      assert request.method == "POST"
+      assert request.path == "/mcp/chat/completions"
+
+      assert request.body == %{
+               "model" => "loopback-model",
+               "messages" => [
+                 %{"role" => "system", "content" => "Be concise."},
+                 %{"role" => "user", "content" => "Summarize this."}
+               ],
+               "max_tokens" => 32,
+               "temperature" => 0.25
+             }
+    end
+  end
 
   describe "generate_object/4" do
     test "returns structured_output_not_supported for ollama" do


### PR DESCRIPTION
## Summary

- add a loopback HTTP integration test for OpenAI-compatible text generation
- verify private prelude tool ledgers redact source and non-public metadata

## Why

These tests exercise two production boundaries that previously lacked successful end-to-end coverage: provider request/response handling and private tool ledger projection.

## Validation

- `mix precommit` (root checks and 4,399 root tests)
- `mix test` in `ptc_viewer` (67 tests)
- `mix test --cover --warnings-as-errors` (4,399 tests; 82.95% total coverage)
- repository pre-push gate, including Dialyzer
