### PR TITLE
feat(kernel): make provider failures effect-aware

### DIFF
--- a/docs/plans/mcp-write-and-surface.md
+++ b/docs/plans/mcp-write-and-surface.md
@@ -1,7 +1,8 @@
 # MCP write support and bounded client surfaces
 
-**Status:** proposed; the protocol baseline is reconciled, but no runtime work
-is approved. Revised 2026-07-28 against the final MCP `2026-07-28` tag at
+**Status:** active; the protocol baseline is reconciled and the effect-aware
+Dispatcher foundation is implemented, but MCP write authority remains
+unapproved. Revised 2026-07-28 against the final MCP `2026-07-28` tag at
 `modelcontextprotocol/modelcontextprotocol@5f5440bb26a62e2cf3440b92da5a667efa03b267`.
 
 PtcRunner installs MCP sources read-only. Every mapped tool must declare
@@ -98,12 +99,13 @@ resolves the effective effect against the installed mission capabilities, and
 Write support must not make the provider-independent compiler depend on a host
 installation.
 
-The remaining retry defect is at the per-call boundary. `MCPSource` marks
-timeouts and transport failures retryable, and `Dispatcher` independently
-marks callback exits and its outer provider timeout retryable without consulting
-`Capability.effect`. Generated mission code can observe that envelope and retry
-inside the same evaluation even though the outer evaluation will later refuse
-to retry as a whole.
+`Dispatcher` now classifies every mission failure produced after callback
+invocation with `Capability.effect` and trusted provider dispatch provenance.
+Read failures retain their provider policy; write and unknown failures after
+possible dispatch are non-retryable and carry the orthogonal
+`mutation_state: :indeterminate` field. Workflow provider policy remains
+independent. The remaining per-call work for MCP writes is to make `MCPSource`
+populate the shared mutation state and provenance from its transport boundary.
 
 ### Read-only MCP installation
 
@@ -191,30 +193,26 @@ Acceptance:
 A timeout, transport loss, or callback-process exit after dispatch does not
 prove whether a write happened. Cancellation does not change that fact.
 
-Make both failure-producing layers effect-aware at the mission boundary:
-
-1. `MCPSource` must classify request failures with the mapped tool's declared
-   effect and trusted transport dispatch provenance.
-2. `Dispatcher` must use `Capability.effect` when it constructs or normalizes
-   a mission capability's post-invocation envelope.
+The Dispatcher mission boundary is already effect-aware. `MCPSource` must now
+classify request failures with the mapped tool's declared effect and trusted
+transport dispatch provenance.
 
 Do not apply this rule blindly to workflow capabilities. In particular,
 `llm-request` deliberately has `effect: :unknown` while its trusted provider
 classifies some availability failures as retryable; the workflow agent owns
-that retry policy. Slice 1 preserves that contract and adds an explicit
-regression for it. A later proposal may replace the LLM's coarse effect with a
-more precise capability semantic, but MCP write support must not change it as a
-side effect.
+that retry policy. The Dispatcher preserves that contract. A later proposal
+may replace the LLM's coarse effect with a more precise capability semantic,
+but MCP write support must not change it as a side effect.
 
 For a read capability, the existing retryable timeout and transport semantics
 remain. For `write` or `unknown`, a failure after remote dispatch may have
 begun is non-retryable and explicitly classified as an indeterminate outcome.
-Represent that state independently from the diagnostic cause: add a bounded
-`mutation_state: :indeterminate` field to `ProviderError` and the public
-Dispatcher envelope while preserving `kind` and `reason` as the specific
-timeout, domain, protocol, validation, or transport diagnosis. Successful calls
-and failures proven to occur before dispatch omit the field. Do not encode
-mutation state as a replacement error kind or only in prose.
+The public Dispatcher envelope represents that state independently from the
+diagnostic cause with the bounded `mutation_state: :indeterminate` field while
+preserving `kind` and `reason` as the specific timeout, domain, protocol,
+validation, or transport diagnosis. Successful calls and failures proven to
+occur before dispatch omit the field. Do not encode mutation state as a
+replacement error kind or only in prose.
 
 Callback entry is not the dispatch boundary. Header-parameter projection,
 outbound-header validation, a request context already being closed, and other
@@ -269,7 +267,8 @@ Acceptance:
 - an export wrapping a write tool reports the installed write effect without
   injecting host knowledge into `Prelude.Compiler`.
 
-Sections 1 and 2 are one atomic write-support slice.
+The remaining MCP changes in sections 1 and 2 are one atomic write-support
+slice.
 
 ## 3. Complete Streamable HTTP cancellation
 
@@ -399,47 +398,7 @@ correctness and authority findings, and runs the slice's focused tests plus
 fix changes behavior. Dependent slices do not begin from an unreviewed
 authority or wire contract.
 
-### Slice 1 — effect-aware failure foundation
-
-**Scope**
-
-- Add one orthogonal, bounded `mutation_state` field to `ProviderError` and the
-  public Dispatcher envelope without replacing the existing diagnostic
-  `kind`/`reason`.
-- Make every mission Dispatcher outcome produced after callback invocation
-  consult `Capability.effect` and trusted dispatch provenance: timeout,
-  callback exit/crash, forwarded `ProviderError`, oversized or schema-invalid
-  result, arbitrary callback return, run closure, and inspection-output
-  replacement.
-- Preserve retryability for reads and make write or unknown outcomes
-  non-retryable when dispatch may have occurred.
-- Preserve the existing workflow `llm-request` contract, including its trusted
-  retryable availability errors despite its deliberately unknown effect.
-- Update the `ProviderError` and `Dispatcher` module documentation for the new
-  public error contract in this slice.
-- Add focused regressions before enabling write mappings in host configuration.
-
-This slice is protocol-independent and may land by itself.
-
-**Review checkpoint**
-
-- Review the public error shape once; reject parallel encodings of
-  indeterminacy in `kind`, `reason`, and free text.
-- Verify deterministic pre-dispatch failures retain their existing specific
-  classifications and carry trusted `not_dispatched` provenance through the
-  mission boundary without a public mutation-state claim.
-- Verify every post-callback Dispatcher normalization and replacement path has
-  read, write, and unknown tests, including provider errors, result bounds,
-  schema mismatch, invalid return, run closure, and inspection failure.
-- Confirm existing read-capability retry behavior is unchanged and unknown
-  remains unsafe.
-- Confirm a workflow `llm-request` retryable provider failure remains retryable;
-  this slice must not reinterpret workflow provider policy as mission mutation
-  state.
-
-### Slice 2 — MCP write authority end to end
-
-**Depends on:** Slice 1.
+### Slice 1 — MCP write authority end to end
 
 **Scope**
 
@@ -486,7 +445,7 @@ is one atomic merge even if developed as several commits.
 - Run one local stdio write fixture and one independent third-party read server
   to catch regressions outside synthetic unit paths.
 
-### Slice 3 — Streamable HTTP cancellation
+### Slice 2 — Streamable HTTP cancellation
 
 **Scope**
 
@@ -512,9 +471,9 @@ indeterminate classification of an abandoned write.
 - Verify cancellation races cannot turn an indeterminate write into a retryable
   failure.
 
-### Slice 4 — MRTR validation and policy refusal
+### Slice 3 — MRTR validation and policy refusal
 
-**Depends on:** Slice 2.
+**Depends on:** Slice 1.
 
 **Scope**
 
@@ -541,7 +500,7 @@ the centralized result classifier.
 - Confirm empty client capabilities never lead to fulfilling an input request
   or automatically retrying a state-only response.
 
-### Slice 5 — exact-resource authority design
+### Slice 4 — exact-resource authority design
 
 **Trigger:** a concrete first-party application that needs MCP resources.
 
@@ -567,9 +526,9 @@ This is a specification slice. It changes no runtime code.
 - Reject the slice if its consumer could instead use an ordinary mapped MCP
   tool without losing an important capability.
 
-### Slice 6 — exact-resource mappings
+### Slice 5 — exact-resource mappings
 
-**Depends on:** approved Slice 5.
+**Depends on:** approved Slice 4.
 
 **Scope**
 

--- a/lib/ptc_runner/kernel/dispatcher.ex
+++ b/lib/ptc_runner/kernel/dispatcher.ex
@@ -7,6 +7,14 @@ defmodule PtcRunner.Kernel.Dispatcher do
   events, runs the trusted callback in a monitored heap-limited process, and
   constructs the uniform Lisp result envelope. Completion is checked against
   run closure so late results cannot re-enter Lisp.
+
+  Mission failures after callback entry are classified with the capability's
+  declared effect. Read failures keep their provider retry policy. Write and
+  unknown failures are non-retryable and carry
+  `mutation_state: :indeterminate` when invocation may have reached external
+  state. A trusted `ProviderError` with `dispatch_provenance: :not_dispatched`
+  preserves its specific pre-dispatch policy without exposing that internal
+  provenance. Workflow capabilities retain their provider-owned retry policy.
   """
 
   alias PtcRunner.Kernel.Capability
@@ -160,7 +168,7 @@ defmodule PtcRunner.Kernel.Dispatcher do
                ) do
             :ok ->
               context = invocation_context(event_sink, inspection_sink, capability_id)
-              {invoke(state, capability, arguments, timeout_ms, context), true}
+              {invoke(state, capability, arguments, timeout_ms, context, environment), true}
 
             {:error, :inspection_sink_error} ->
               {inspection_failure(state), false}
@@ -175,8 +183,13 @@ defmodule PtcRunner.Kernel.Dispatcher do
                    capability.name,
                    result
                  ) do
-              :ok -> result
-              {:error, :inspection_sink_error} -> inspection_failure(state)
+              :ok ->
+                result
+
+              {:error, :inspection_sink_error} ->
+                state
+                |> inspection_failure()
+                |> post_invocation_failure(environment, capability)
             end
           else
             result
@@ -248,7 +261,7 @@ defmodule PtcRunner.Kernel.Dispatcher do
     }
   end
 
-  defp invoke(state, capability, arguments, requested_timeout_ms, context) do
+  defp invoke(state, capability, arguments, requested_timeout_ms, context, environment) do
     remaining = RunState.usage(state).remaining_ms
     timeout_ms = min(requested_timeout_ms, remaining)
     limits = state_limits(state)
@@ -289,7 +302,7 @@ defmodule PtcRunner.Kernel.Dispatcher do
       case RunState.attach_provider(state, pid) do
         :ok ->
           send(pid, go)
-          await_provider(state, capability, pid, ref, timeout_ms)
+          await_provider(state, capability, pid, ref, timeout_ms, environment)
 
         {:error, :closed} ->
           await_down(pid, ref)
@@ -298,31 +311,45 @@ defmodule PtcRunner.Kernel.Dispatcher do
     end
   end
 
-  defp await_provider(state, capability, pid, ref, timeout_ms) do
+  defp await_provider(state, capability, pid, ref, timeout_ms, environment) do
     receive do
       {:provider_result, ^pid, result} ->
         await_down(pid, ref)
 
         case RunState.finish_provider(state) do
-          :ok -> normalize_result(state, capability, result)
-          {:error, :run_closed} -> limit_error(state, nil, :run_closed)
+          :ok ->
+            normalize_result(state, environment, capability, result)
+
+          {:error, :run_closed} ->
+            state
+            |> limit_error(nil, :run_closed)
+            |> post_invocation_failure(environment, capability)
         end
 
       {:DOWN, ^ref, :process, ^pid, reason} ->
         RunState.release_provider_slot(state)
 
-        %{
-          status: :error,
-          kind: :provider_error,
-          reason: normalize_exit(reason),
-          retryable?: true
-        }
+        post_invocation_failure(
+          %{
+            status: :error,
+            kind: :provider_error,
+            reason: normalize_exit(reason),
+            retryable?: true
+          },
+          environment,
+          capability
+        )
     after
       timeout_ms ->
         Process.exit(pid, :kill)
         await_down(pid, ref)
         RunState.release_provider_slot(state)
-        %{status: :error, kind: :timeout, reason: :provider_timeout, retryable?: true}
+
+        post_invocation_failure(
+          %{status: :error, kind: :timeout, reason: :provider_timeout, retryable?: true},
+          environment,
+          capability
+        )
     end
   end
 
@@ -341,52 +368,109 @@ defmodule PtcRunner.Kernel.Dispatcher do
     _kind, _reason -> {:raised, :throw}
   end
 
-  defp normalize_result(state, capability, {:ok, value}) do
+  defp normalize_result(state, environment, capability, {:ok, value}) do
     cap = capability_result_limit(state)
     bytes = RetainedSize.bytes_with_cap(value, cap)
 
     cond do
       not (json_value?(value) and is_integer(bytes) and bytes <= cap) ->
-        %{
-          status: :error,
-          kind: :result_exceeded,
-          reason: :provider_result_limit,
-          retryable?: false
-        }
+        post_invocation_failure(
+          %{
+            status: :error,
+            kind: :result_exceeded,
+            reason: :provider_result_limit,
+            retryable?: false
+          },
+          environment,
+          capability
+        )
 
       not valid_output?(capability, value) ->
-        %{
-          status: :error,
-          kind: :invalid_result,
-          reason: :output_schema_mismatch,
-          retryable?: false
-        }
+        post_invocation_failure(
+          %{
+            status: :error,
+            kind: :invalid_result,
+            reason: :output_schema_mismatch,
+            retryable?: false
+          },
+          environment,
+          capability
+        )
 
       true ->
         %{status: :ok, value: RetainedSize.detach_binaries(value)}
     end
   end
 
-  defp normalize_result(_state, _capability, {:error, %ProviderError{} = error}) do
-    %{
-      status: :error,
-      kind: :provider_error,
-      reason: error.kind,
-      details: error.details,
-      retryable?: error.retryable?
-    }
+  defp normalize_result(
+         _state,
+         environment,
+         capability,
+         {:error, %ProviderError{} = error}
+       ) do
+    if ProviderError.valid?(error) do
+      %{
+        status: :error,
+        kind: :provider_error,
+        reason: error.kind,
+        details: error.details,
+        retryable?: error.retryable?
+      }
+      |> maybe_put_mutation_state(error.mutation_state)
+      |> post_invocation_failure(environment, capability, error.dispatch_provenance)
+    else
+      invalid_provider_result(environment, capability)
+    end
   end
 
-  defp normalize_result(_state, _capability, {:raised, reason}),
-    do: %{status: :error, kind: :provider_error, reason: reason, retryable?: true}
+  defp normalize_result(_state, environment, capability, {:raised, reason}) do
+    post_invocation_failure(
+      %{status: :error, kind: :provider_error, reason: reason, retryable?: true},
+      environment,
+      capability
+    )
+  end
 
-  defp normalize_result(_state, _capability, _result),
-    do: %{
-      status: :error,
-      kind: :invalid_result,
-      reason: :invalid_provider_return,
-      retryable?: false
-    }
+  defp normalize_result(_state, environment, capability, _result),
+    do: invalid_provider_result(environment, capability)
+
+  defp invalid_provider_result(environment, capability) do
+    post_invocation_failure(
+      %{
+        status: :error,
+        kind: :invalid_result,
+        reason: :invalid_provider_return,
+        retryable?: false
+      },
+      environment,
+      capability
+    )
+  end
+
+  defp post_invocation_failure(result, environment, capability, provenance \\ nil)
+
+  defp post_invocation_failure(
+         result,
+         :mission,
+         %Capability{effect: effect},
+         provenance
+       )
+       when effect in [:write, :unknown] and provenance != :not_dispatched do
+    result
+    |> Map.put(:retryable?, false)
+    |> Map.put(:mutation_state, :indeterminate)
+  end
+
+  defp post_invocation_failure(result, _environment, _capability, _provenance) do
+    if Map.get(result, :mutation_state) == :indeterminate,
+      do: Map.put(result, :retryable?, false),
+      else: result
+  end
+
+  defp maybe_put_mutation_state(result, :indeterminate),
+    do: Map.put(result, :mutation_state, :indeterminate)
+
+  defp maybe_put_mutation_state(result, nil), do: result
 
   defp validate(%Capability{} = capability, arguments) do
     if JSONSchema.valid?(capability.input_validator, arguments),

--- a/lib/ptc_runner/kernel/provider_error.ex
+++ b/lib/ptc_runner/kernel/provider_error.ex
@@ -6,10 +6,31 @@ defmodule PtcRunner.Kernel.ProviderError do
   dispatcher converts it into the uniform Lisp capability error envelope.
   `details` is truncated to 1,024 characters and must not contain credentials,
   BEAM exceptions, stack traces, or other host-private data.
+
+  `mutation_state: :indeterminate` is orthogonal to the diagnostic `kind`: it
+  means a non-successful call may already have changed external state and is
+  therefore never retryable. `dispatch_provenance` is trusted, internal
+  evidence for the mission dispatcher. Providers may set it to
+  `:not_dispatched` only when no invocation could have reached the underlying
+  transport; it is never copied into the public Lisp envelope. Missing
+  provenance is treated conservatively after callback entry.
   """
 
+  @kinds [
+    :denied,
+    :not_found,
+    :unavailable,
+    :invalid_request,
+    :internal,
+    :domain_error,
+    :invalid_result,
+    :authentication_failed,
+    :timeout,
+    :transport_error
+  ]
+  @options [:retryable?, :mutation_state, :dispatch_provenance]
   @enforce_keys [:kind]
-  defstruct [:kind, :details, retryable?: false]
+  defstruct [:kind, :details, :mutation_state, :dispatch_provenance, retryable?: false]
 
   @type kind ::
           :denied
@@ -22,31 +43,78 @@ defmodule PtcRunner.Kernel.ProviderError do
           | :authentication_failed
           | :timeout
           | :transport_error
-  @type t :: %__MODULE__{kind: kind(), details: binary() | nil, retryable?: boolean()}
+  @type mutation_state :: :indeterminate
+  @type dispatch_provenance :: :not_dispatched | :possibly_dispatched
+  @type t :: %__MODULE__{
+          kind: kind(),
+          details: binary() | nil,
+          retryable?: boolean(),
+          mutation_state: mutation_state() | nil,
+          dispatch_provenance: dispatch_provenance() | nil
+        }
 
   @spec new(kind(), binary() | nil, keyword()) :: t()
   @doc """
   Constructs a provider failure with optional bounded details and
-  `:retryable?` metadata.
+  `:retryable?`, `:mutation_state`, and internal `:dispatch_provenance`
+  metadata.
+
+  Mutation state accepts only `:indeterminate`, and dispatch provenance accepts
+  only `:not_dispatched` or `:possibly_dispatched`. An indeterminate failure is
+  always constructed as non-retryable.
   """
   def new(kind, details \\ nil, opts \\ [])
-      when kind in [
-             :denied,
-             :not_found,
-             :unavailable,
-             :invalid_request,
-             :internal,
-             :domain_error,
-             :invalid_result,
-             :authentication_failed,
-             :timeout,
-             :transport_error
-           ] and
-             (is_binary(details) or is_nil(details)) do
-    %__MODULE__{
-      kind: kind,
-      details: details && String.slice(details, 0, 1_024),
-      retryable?: Keyword.get(opts, :retryable?, false)
-    }
+      when kind in @kinds and (is_binary(details) or is_nil(details)) and is_list(opts) do
+    with true <- Keyword.keyword?(opts),
+         [] <- Keyword.keys(opts) -- @options,
+         retryable? when is_boolean(retryable?) <- Keyword.get(opts, :retryable?, false),
+         mutation_state when mutation_state in [nil, :indeterminate] <-
+           Keyword.get(opts, :mutation_state),
+         dispatch_provenance
+         when dispatch_provenance in [nil, :not_dispatched, :possibly_dispatched] <-
+           Keyword.get(opts, :dispatch_provenance),
+         {:ok, details} <- bounded_details(details) do
+      %__MODULE__{
+        kind: kind,
+        details: details,
+        retryable?: retryable? and is_nil(mutation_state),
+        mutation_state: mutation_state,
+        dispatch_provenance: dispatch_provenance
+      }
+    else
+      _invalid_option -> raise ArgumentError, "invalid provider error options"
+    end
   end
+
+  @doc false
+  @spec valid?(term()) :: boolean()
+  def valid?(%__MODULE__{
+        kind: kind,
+        details: details,
+        retryable?: retryable?,
+        mutation_state: mutation_state,
+        dispatch_provenance: dispatch_provenance
+      }) do
+    kind in @kinds and valid_details?(details) and is_boolean(retryable?) and
+      mutation_state in [nil, :indeterminate] and
+      dispatch_provenance in [nil, :not_dispatched, :possibly_dispatched] and
+      not (mutation_state == :indeterminate and retryable?)
+  end
+
+  def valid?(_error), do: false
+
+  defp bounded_details(nil), do: {:ok, nil}
+
+  defp bounded_details(details) when is_binary(details) do
+    if String.valid?(details),
+      do: {:ok, String.slice(details, 0, 1_024)},
+      else: :error
+  end
+
+  defp valid_details?(nil), do: true
+
+  defp valid_details?(details) when is_binary(details),
+    do: String.valid?(details) and String.length(details) <= 1_024
+
+  defp valid_details?(_details), do: false
 end

--- a/test/ptc_runner/kernel/dispatcher_effect_test.exs
+++ b/test/ptc_runner/kernel/dispatcher_effect_test.exs
@@ -1,0 +1,387 @@
+defmodule PtcRunner.Kernel.DispatcherEffectTest do
+  use ExUnit.Case, async: true
+
+  alias PtcRunner.Kernel.Capability
+  alias PtcRunner.Kernel.Dispatcher
+  alias PtcRunner.Kernel.InspectionSink
+  alias PtcRunner.Kernel.Limits
+  alias PtcRunner.Kernel.LLMCapability
+  alias PtcRunner.Kernel.MissionEnvironment
+  alias PtcRunner.Kernel.ProviderError
+  alias PtcRunner.Kernel.RunState
+  alias PtcRunner.Kernel.WorkflowEnvironment
+
+  @effects [:read, :write, :unknown]
+  @input_schema %{"type" => "object", "additionalProperties" => false}
+
+  test "mission provider errors become indeterminate only after possible non-read dispatch" do
+    for effect <- @effects do
+      result =
+        dispatch_mission(effect, fn ->
+          {:error, ProviderError.new(:unavailable, "try later", retryable?: true)}
+        end)
+
+      assert_effect_failure(
+        result,
+        effect,
+        %{kind: :provider_error, reason: :unavailable, details: "try later"},
+        true
+      )
+    end
+  end
+
+  test "trusted not-dispatched provider errors preserve their retry policy and omit mutation state" do
+    for effect <- @effects do
+      result =
+        dispatch_mission(effect, fn ->
+          {:error,
+           ProviderError.new(:invalid_request, "local validation",
+             retryable?: true,
+             dispatch_provenance: :not_dispatched
+           )}
+        end)
+
+      assert %{
+               status: :error,
+               kind: :provider_error,
+               reason: :invalid_request,
+               details: "local validation",
+               retryable?: true
+             } = result
+
+      refute Map.has_key?(result, :mutation_state)
+      refute Map.has_key?(result, :dispatch_provenance)
+    end
+  end
+
+  test "mission result normalization is effect-aware after callback invocation" do
+    cases = [
+      {
+        fn -> {:ok, String.duplicate("x", 256)} end,
+        [limits: [capability_result_bytes: 64]],
+        %{kind: :result_exceeded, reason: :provider_result_limit}
+      },
+      {
+        fn -> {:ok, %{"ok" => "not-boolean"}} end,
+        [
+          output_schema: %{
+            "type" => "object",
+            "properties" => %{"ok" => %{"type" => "boolean"}},
+            "required" => ["ok"]
+          }
+        ],
+        %{kind: :invalid_result, reason: :output_schema_mismatch}
+      },
+      {
+        fn -> :unexpected end,
+        [],
+        %{kind: :invalid_result, reason: :invalid_provider_return}
+      }
+    ]
+
+    for {callback, opts, expected} <- cases,
+        effect <- @effects do
+      result = dispatch_mission(effect, callback, opts)
+      assert_effect_failure(result, effect, expected, false)
+    end
+  end
+
+  test "mission callback raises, exits, and process deaths are effect-aware" do
+    cases = [
+      {fn -> raise "private failure" end, :exception},
+      {fn -> exit(:private_failure) end, :exit},
+      {fn -> Process.exit(self(), :kill) end, :provider_heap_exceeded}
+    ]
+
+    for {callback, reason} <- cases,
+        effect <- @effects do
+      result = dispatch_mission(effect, callback)
+      assert_effect_failure(result, effect, %{kind: :provider_error, reason: reason}, true)
+    end
+  end
+
+  test "mission timeouts are effect-aware after callback invocation" do
+    parent = self()
+
+    for effect <- @effects do
+      task =
+        Task.async(fn ->
+          dispatch_mission(
+            effect,
+            fn ->
+              send(parent, {:callback_started, effect})
+
+              receive do
+                :never -> {:ok, nil}
+              end
+            end,
+            timeout_ms: 50
+          )
+        end)
+
+      assert_receive {:callback_started, ^effect}
+
+      assert_effect_failure(
+        Task.await(task),
+        effect,
+        %{kind: :timeout, reason: :provider_timeout},
+        true
+      )
+    end
+  end
+
+  test "run closure after callback completion is effect-aware" do
+    parent = self()
+
+    for effect <- @effects do
+      {:ok, state} = RunState.start(Limits.defaults())
+
+      {:ok, capability} =
+        capability(effect, fn ->
+          send(parent, {:callback_started, effect, self()})
+
+          receive do
+            :finish -> {:ok, %{"ok" => true}}
+          end
+        end)
+
+      {:ok, environment} = MissionEnvironment.new(capabilities: [capability])
+
+      task =
+        Task.async(fn ->
+          Dispatcher.dispatch(state, :mission, environment, capability.name, %{}, 1_000)
+        end)
+
+      assert_receive {:callback_started, ^effect, provider}
+      assert :ok = RunState.close(state)
+      send(provider, :finish)
+
+      assert_effect_failure(
+        Task.await(task),
+        effect,
+        %{kind: :limit_exceeded, reason: :run_closed},
+        false
+      )
+    end
+  end
+
+  test "inspection output replacement is effect-aware after callback completion" do
+    for effect <- @effects do
+      {:ok, inspection_sink} =
+        InspectionSink.start(
+          run_id: "dispatcher-effect-run",
+          trace_id: "dispatcher-effect-trace",
+          max_record_bytes: 4_000,
+          max_total_bytes: 10_000
+        )
+
+      result =
+        dispatch_mission(
+          effect,
+          fn -> {:ok, String.duplicate("x", 5_000)} end,
+          inspection_sink: inspection_sink
+        )
+
+      assert_effect_failure(
+        result,
+        effect,
+        %{kind: :inspection_sink_error, reason: :inspection_sink_error},
+        false
+      )
+    end
+  end
+
+  test "failures proven to precede callback invocation omit mutation state" do
+    parent = self()
+
+    for effect <- @effects do
+      {:ok, capability} =
+        Capability.new(
+          name: "effect-fixture",
+          input_schema: %{
+            "type" => "object",
+            "properties" => %{"required" => %{"type" => "boolean"}},
+            "required" => ["required"]
+          },
+          effect: effect,
+          callback: fn _arguments ->
+            send(parent, {:unexpected_callback, effect})
+            {:ok, nil}
+          end
+        )
+
+      {:ok, environment} = MissionEnvironment.new(capabilities: [capability])
+      {:ok, state} = RunState.start(Limits.defaults())
+
+      assert %{status: :error, kind: :protocol_error, reason: :invalid_arguments} =
+               result =
+               Dispatcher.dispatch(state, :mission, environment, capability.name, %{}, 100)
+
+      refute Map.has_key?(result, :mutation_state)
+      refute_received {:unexpected_callback, ^effect}
+    end
+  end
+
+  test "inspection input failure precedes callback invocation and omits mutation state" do
+    parent = self()
+
+    for effect <- @effects do
+      {:ok, inspection_sink} =
+        InspectionSink.start(
+          run_id: "dispatcher-input-run",
+          trace_id: "dispatcher-input-trace"
+        )
+
+      assert {:error, :inspection_sink_error} =
+               InspectionSink.emit(inspection_sink, "unsupported", %{}, %{})
+
+      result =
+        dispatch_mission(
+          effect,
+          fn ->
+            send(parent, {:unexpected_callback, effect})
+            {:ok, nil}
+          end,
+          inspection_sink: inspection_sink
+        )
+
+      assert %{
+               status: :error,
+               kind: :inspection_sink_error,
+               reason: :inspection_sink_error,
+               retryable?: false
+             } = result
+
+      refute Map.has_key?(result, :mutation_state)
+      refute_received {:unexpected_callback, ^effect}
+    end
+  end
+
+  test "successful mission calls omit mutation state for every effect" do
+    for effect <- @effects do
+      assert %{status: :ok, value: %{"ok" => true}} =
+               result =
+               dispatch_mission(effect, fn -> {:ok, %{"ok" => true}} end)
+
+      refute Map.has_key?(result, :mutation_state)
+    end
+  end
+
+  test "workflow llm-request keeps trusted retryable availability failures" do
+    {:ok, capability} = LLMCapability.new(requester: fn _request -> {:error, :unavailable} end)
+    {:ok, environment} = WorkflowEnvironment.new(capabilities: [capability])
+    {:ok, state} = RunState.start(Limits.defaults())
+
+    assert %{
+             status: :error,
+             kind: :provider_error,
+             reason: :unavailable,
+             retryable?: true
+           } =
+             result =
+             Dispatcher.dispatch(state, :workflow, environment, "llm-request", %{}, 100)
+
+    refute Map.has_key?(result, :mutation_state)
+  end
+
+  test "provider-declared mutation state reaches the public envelope without provenance" do
+    result =
+      dispatch_mission(:read, fn ->
+        {:error,
+         ProviderError.new(:transport_error, "connection lost",
+           mutation_state: :indeterminate,
+           dispatch_provenance: :possibly_dispatched
+         )}
+      end)
+
+    assert %{
+             status: :error,
+             kind: :provider_error,
+             reason: :transport_error,
+             details: "connection lost",
+             retryable?: false,
+             mutation_state: :indeterminate
+           } = result
+
+    refute Map.has_key?(result, :dispatch_provenance)
+  end
+
+  test "directly constructed malformed provider errors stay inside the bounded envelope" do
+    malformed_errors = [
+      %ProviderError{kind: :unavailable, mutation_state: :invalid},
+      %ProviderError{kind: :unavailable, dispatch_provenance: :invalid},
+      %ProviderError{kind: :unavailable, retryable?: :invalid},
+      %ProviderError{kind: :invalid},
+      %ProviderError{kind: :unavailable, details: String.duplicate("x", 1_025)}
+    ]
+
+    for error <- malformed_errors,
+        effect <- @effects do
+      result = dispatch_mission(effect, fn -> {:error, error} end)
+
+      assert_effect_failure(
+        result,
+        effect,
+        %{kind: :invalid_result, reason: :invalid_provider_return},
+        false
+      )
+    end
+  end
+
+  test "provider error construction truncates long valid details before validation" do
+    details = String.duplicate("å", 1_025)
+
+    assert %ProviderError{details: bounded} =
+             ProviderError.new(:unavailable, details)
+
+    assert String.length(bounded) == 1_024
+    assert String.valid?(bounded)
+  end
+
+  defp dispatch_mission(effect, callback, opts \\ []) do
+    limits =
+      opts
+      |> Keyword.get(:limits, [])
+      |> Limits.new()
+      |> then(fn {:ok, limits} -> limits end)
+
+    {:ok, state} = RunState.start(limits)
+    {:ok, capability} = capability(effect, callback, opts)
+    {:ok, environment} = MissionEnvironment.new(capabilities: [capability])
+
+    Dispatcher.dispatch(
+      state,
+      :mission,
+      environment,
+      capability.name,
+      %{},
+      Keyword.get(opts, :timeout_ms, 100),
+      nil,
+      Keyword.get(opts, :inspection_sink)
+    )
+  end
+
+  defp capability(effect, callback, opts \\ []) do
+    Capability.new(
+      name: "effect-fixture",
+      input_schema: @input_schema,
+      output_schema: Keyword.get(opts, :output_schema),
+      effect: effect,
+      callback: fn _arguments -> callback.() end
+    )
+  end
+
+  defp assert_effect_failure(result, effect, expected, read_retryable?) do
+    assert %{status: :error} = result
+    assert Map.take(result, Map.keys(expected)) == expected
+    refute Map.has_key?(result, :dispatch_provenance)
+
+    if effect == :read do
+      assert result.retryable? == read_retryable?
+      refute Map.has_key?(result, :mutation_state)
+    else
+      assert result.retryable? == false
+      assert result.mutation_state == :indeterminate
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- build on the complete MCP protocol and delivery-plan reconciliation merged in #1147
- classify every post-callback mission failure using the declared read, write, or unknown capability effect
- make potentially dispatched write and unknown failures non-retryable with bounded indeterminate mutation state
- preserve trusted pre-dispatch provider provenance without leaking transport internals into public envelopes
- add an integration-level failure matrix covering provider errors, malformed returns, bounds, schemas, crashes, exits, process death, timeouts, run closure, and inspection failures

## Scope

This PR is rebased onto main at the #1147 merge commit, so its effective state includes the previous PR and this next reviewed slice. Its diff is intentionally one new commit because #1147 is already merged. MCP capability assembly remains read-only; write authority and MCP transport provenance are reserved for the next slice.

## Verification

- 102 focused kernel tests passed
- focused timing-sensitive regression passed 20 consecutive reruns after one unrelated full-suite load timeout
- MIX_ENV=test mix precommit passed
- pre-push root suite: 4,736 passed, 349 excluded
- upstream API audit passed
- Dialyzer: 0 errors
- PtcViewer: 70 passed
- adversarial independent challenge findings fixed and re-reviewed
- fresh cumulative independent review: no actionable findings