### PR TITLE
fix(kernel): harden MCP and inspection boundaries

### DIFF
--- a/docs/guides/host-configuration.md
+++ b/docs/guides/host-configuration.md
@@ -221,10 +221,10 @@ ungranted one stays denied. A manifest may narrow the visible set but never
 extend it beyond what the installation marked visible.
 
 `error_feedback` defaults to `closed`. Setting it to `bounded` exposes at most
-1,024 bytes of exact validated text from an MCP `isError` result as untrusted
-recoverable error detail. Enabling it trusts the installed server not to place
-secrets, paths, or stack traces in that text. Public canonical events stay
-closed either way.
+1,024 bytes of validated text from an MCP `isError` result as untrusted
+recoverable error detail, with terminal control characters replaced. Enabling
+it trusts the installed server not to place secrets, paths, or stack traces in
+that text. Public canonical events stay closed either way.
 
 `snapshot_identity` names one mapped read-only tool and a result field.
 PtcRunner calls it once during assembly with an empty argument object, validates
@@ -409,8 +409,10 @@ workflow  deepseek  llm  model openrouter:deepseek/deepseek-v4-flash  accepts: n
 
 Each line reports the environment, alias, source, resolved non-secret policy,
 accepted data classes, and the provider snapshot hash. That bare-hex
-`snapshot_hash` attests the complete installed provider identity, including its
-policy and ceilings. A frozen-content provider also publishes an
+`snapshot_hash` attests the provider-specific non-secret identity projection,
+including the effective ceilings present in that projection. It does not
+automatically cover the alias, data-class policy, or fields the provider
+deliberately excludes. A frozen-content provider also publishes an
 algorithm-qualified `content_snapshot_hash` covering only the captured bytes;
 the two have deliberately different scopes and are never equal.
 

--- a/docs/guides/kernel-maintainer.md
+++ b/docs/guides/kernel-maintainer.md
@@ -240,7 +240,8 @@ manifest may only select mapped names and narrow visibility or limits.
 `PtcRunner.Kernel.MCPProtocol` owns pure protocol validation and normalization,
 and the transport owners bound and correlate each request. Their module docs
 define the exact behavior. MCP tool errors are closed by default; a host
-mapping may opt into exact validated feedback bounded to 1,024 bytes. Runtime
+mapping may opt into validated feedback bounded to 1,024 bytes, with terminal
+control characters replaced before exposure. Runtime
 calls propagate only a derived W3C `traceparent`, with no baggage or
 operator-supplied trace value crossing the provider boundary. Immutable MCP
 sources may freeze a host-installed content identity during assembly; this is

--- a/docs/guides/manifests-and-capabilities.md
+++ b/docs/guides/manifests-and-capabilities.md
@@ -237,7 +237,13 @@ MCP capability schemas.
 `--output PATH` atomically writes only the validated `Result.value`, never
 clobbers an existing file, and can be passed directly to a later run with
 `--mission`. Use `--private-output` for a private run; it creates a `0600`
-artifact and keeps the value off stdout.
+artifact and keeps the value off stdout. Destination conflicts and
+normal/private class mismatches are rejected before provider acquisition, while
+exclusive creation remains authoritative if the path appears during the run.
+Artifact publication currently requires a Unix host and POSIX-compatible
+`mkdir` and `id` executables on `PATH`. It fails closed if those authority and
+mode-at-create primitives are unavailable, rather than briefly exposing
+content through a wider default mode.
 
 ## Providers are installed authority
 
@@ -281,9 +287,11 @@ but no path. Every query result carries `snapshot_hash`, equal to that
 provider snapshot's `content_snapshot_hash`, so a cited run, sequence, or
 counter page remains bound to the captured catalog. Do not confuse that
 algorithm-qualified content identity with the safe provider snapshot's own
-bare-hex `snapshot_hash`: the latter attests the complete installed provider
-identity, including its policy and ceilings, while `content_snapshot_hash`
-attests only the frozen queried bytes.
+bare-hex `snapshot_hash`: the latter attests its provider-specific non-secret
+identity projection, including the effective ceilings present in that
+projection, while `content_snapshot_hash` attests only the frozen queried
+bytes. The provider hash does not automatically cover the alias, data-class
+policy, or deliberately excluded fields.
 
 Private inspection artifacts use a separate paired native source, installed as
 `ptc_inspection_snapshot`. A manifest selecting such an alias must also select

--- a/docs/guides/running-and-debugging.md
+++ b/docs/guides/running-and-debugging.md
@@ -52,6 +52,14 @@ The command checks this rule after assembly determines the effective run class
 but before workflow execution or model activity. A normal run may not use the
 reserved private suffix.
 
+Configured result, trace, and inspection destinations must be pairwise
+distinct after resolving their existing parent-directory identity; final names
+are Unicode case-folded and normalized so the rule remains safe on
+case-insensitive filesystems. Deterministic destination conflicts and
+filesystem-invalid or deterministically unwritable destinations are rejected
+before provider acquisition; each persistence path still uses its own
+publication checks to close races after preflight.
+
 Snapshot capture failures report the source kind, measured retained bytes, and
 configured retained-byte ceiling when the decoded trace or inspection catalog
 is too large. Workflow timeouts likewise name the effective limit
@@ -60,7 +68,27 @@ whether compilation or execution exhausted it.
 
 `--inspect` is a host opt-in development feature. It writes a separate bounded
 owner-only artifact containing sensitive execution details. Do not publish it
-with normal traces.
+with normal traces. Artifact publication through `--output`,
+`--private-output`, or `--inspect` requires a Unix host and POSIX-compatible
+`mkdir` and `id` executables on `PATH`; it fails closed with
+`result_persistence_failed` or `inspection_persistence_failed` when that
+authority or mode-at-create primitive is unavailable. Publication validates
+both lexical and resolved physical ancestry and rejects an untrusted owner or a
+group/other-writable directory without sticky-directory protection, because
+another tenant could otherwise replace the private temporary directory before
+the artifact is opened. A final parent must also grant create access to the
+effective owner, group, or other permission class.
+
+Private trace creation uses the same host primitives and ancestry checks. A
+missing trace requires both `mkdir` and `id` and is published at mode `0600`
+before use. An existing private trace requires `id`, must already be mode
+`0600`, owned by the current process authority or root, and writable by the
+effective authority; its parent needs traversal but not create access. The
+append retains its permission-checked descriptor. Every trace append also
+requires `sh` and either `lockf` or `flock` for its cross-runtime lease. The
+per-authority lease directory is owner-only; its first creation additionally
+requires `mkdir`, while later appends validate its type, owner, and exact mode
+without changing permissions through an unresolved path.
 
 The current 0.x `--mission PATH` option replaces the manifest input file. Its
 name is historical and is planned to become `--input` without a compatibility

--- a/lib/mix/tasks/ptc.run.ex
+++ b/lib/mix/tasks/ptc.run.ex
@@ -17,6 +17,8 @@ defmodule Mix.Tasks.Ptc.Run do
   `--output` and `--private-output` write the result value as a standalone
   JSON artifact so a later run can consume it without scraping stdout. Both
   refuse to overwrite an existing destination and are mutually exclusive.
+  Deterministic destination and data-class conflicts fail before provider
+  acquisition; exclusive publication still protects against later races.
   `--private-mission` is mutually exclusive with `--mission`, loads the same
   manifest-confined JSON shape, and classifies the entire run before provider
   activity.

--- a/lib/ptc_runner/kernel/analysis_session.ex
+++ b/lib/ptc_runner/kernel/analysis_session.ex
@@ -345,7 +345,7 @@ defmodule PtcRunner.Kernel.AnalysisSession do
       formatted_truncated?: false,
       prints: prints,
       prints_truncated?: prints_truncated?,
-      error: error_projection(detailed),
+      error: error_projection(detailed, state),
       evaluation_id: detailed.evaluation_id,
       duration_ms: detailed.duration_ms,
       usage: usage_projection(state)
@@ -465,21 +465,28 @@ defmodule PtcRunner.Kernel.AnalysisSession do
 
   defp bounded_prints(_prints), do: {[], true}
 
-  defp error_projection(%{outcome: outcome}) when outcome in [:continued, :returned], do: nil
+  defp error_projection(%{outcome: outcome}, _state) when outcome in [:continued, :returned],
+    do: nil
 
-  defp error_projection(result) do
+  defp error_projection(result, state) do
     details = Map.get(result, :details, %{})
 
     %{
       kind: Map.get(result, :kind, result.outcome),
       reason: Map.get(result, :reason),
-      message: bounded_message(Map.get(details, :message)),
+      message: error_message(details, state),
       capability_activity?:
         Map.get(result, :capability_activity?, Map.get(details, :capability_activity?)),
       capability_failure?: Map.get(result, :capability_failure?),
       retryable?: Map.get(result, :retryable?)
     }
   end
+
+  defp error_message(_details, %{profile: %{identity: %{"result_data_class" => class}}})
+       when class != "normal",
+       do: "private evaluation failed"
+
+  defp error_message(details, _state), do: bounded_message(Map.get(details, :message))
 
   defp bounded_message(message) when is_binary(message), do: elem(clip_utf8(message, 4_096), 0)
   defp bounded_message(_message), do: nil

--- a/lib/ptc_runner/kernel/dispatcher.ex
+++ b/lib/ptc_runner/kernel/dispatcher.ex
@@ -291,8 +291,14 @@ defmodule PtcRunner.Kernel.Dispatcher do
           send(pid, go)
           await_provider(state, capability, pid, ref, timeout_ms)
 
+        {:error, :provider_down} ->
+          reason = await_down(pid, ref)
+          RunState.release_provider_slot(state)
+          provider_exit(reason)
+
         {:error, :closed} ->
           await_down(pid, ref)
+          RunState.release_provider_slot(state)
           limit_error(state, nil, :run_closed)
       end
     end
@@ -310,13 +316,7 @@ defmodule PtcRunner.Kernel.Dispatcher do
 
       {:DOWN, ^ref, :process, ^pid, reason} ->
         RunState.release_provider_slot(state)
-
-        %{
-          status: :error,
-          kind: :provider_error,
-          reason: normalize_exit(reason),
-          retryable?: true
-        }
+        provider_exit(reason)
     after
       timeout_ms ->
         Process.exit(pid, :kill)
@@ -328,8 +328,17 @@ defmodule PtcRunner.Kernel.Dispatcher do
 
   defp await_down(pid, ref) do
     receive do
-      {:DOWN, ^ref, :process, ^pid, _reason} -> :ok
+      {:DOWN, ^ref, :process, ^pid, reason} -> reason
     end
+  end
+
+  defp provider_exit(reason) do
+    %{
+      status: :error,
+      kind: :provider_error,
+      reason: normalize_exit(reason),
+      retryable?: true
+    }
   end
 
   defp safely_invoke(callback, arguments, context) do

--- a/lib/ptc_runner/kernel/host_installation.ex
+++ b/lib/ptc_runner/kernel/host_installation.ex
@@ -15,12 +15,15 @@ defmodule PtcRunner.Kernel.HostInstallation do
   private artifacts validate against the exact already-captured canonical
   source without reopening trace paths or exposing owner handles in metadata.
 
-  Every safe provider snapshot's bare-hex `snapshot_hash` attests its complete
-  non-secret provider identity, including policy and ceilings. A frozen-content
-  provider additionally publishes an algorithm-qualified
-  `content_snapshot_hash`; native query results call that content identity
-  `snapshot_hash` so citations can copy the source's own field unchanged. The
-  two hashes deliberately have different scopes and are not equal.
+  Every safe provider snapshot's bare-hex `snapshot_hash` attests the
+  provider-specific non-secret identity projection from which it is calculated,
+  including the effective ceilings present in that projection. It does not
+  automatically cover the provider alias, data-class policy, or fields that a
+  provider deliberately excludes. A frozen-content provider additionally
+  publishes an algorithm-qualified `content_snapshot_hash`; native query
+  results call that content identity `snapshot_hash` so citations can copy the
+  source's own field unchanged. The two hashes deliberately have different
+  scopes and are not equal.
   """
 
   alias PtcRunner.Kernel.ConfinedFile

--- a/lib/ptc_runner/kernel/inspection_artifact.ex
+++ b/lib/ptc_runner/kernel/inspection_artifact.ex
@@ -3,18 +3,34 @@ defmodule PtcRunner.Kernel.InspectionArtifact do
   Persists and loads one immutable private inspection JSONL artifact.
 
   Destinations must end in `.inspection.jsonl`, must not already exist, and are
-  installed atomically with a hard-link create from an exclusive temporary
-  sibling whose permissions are restricted to `0600` before content is
-  written. The create fails when the destination already exists; unlike a
-  rename, it cannot replace an existing artifact. Loading rejects symlinks,
+  installed atomically with a hard-link create from a file inside a mode-0700
+  temporary sibling directory. The file is restricted to `0600` before
+  content is written or the hard link is published. The create fails when the
+  destination already exists; unlike a rename, it cannot replace an existing
+  artifact. Temporary cleanup after the link is best-effort and cannot turn a
+  committed publication into a reported failure. A relative destination is
+  anchored once before validation so a VM-wide working-directory change cannot
+  redirect later filesystem operations. Loading opens a raw descriptor,
+  revalidates its identity, and performs two exact whole-file reads through EOF
+  whose bytes must match. It rejects symlinks,
   changed files, content above 16 MB, any record above 2,000,000 encoded bytes,
-  malformed lines, mixed identities or schema versions, non-contiguous
-  sequences, and records outside the exact V1 or V2 vocabulary. V2 adds paired
-  MCP request/response bodies correlated to an existing capability attempt.
+  excessive structural depth, malformed lines, mixed identities or schema
+  versions, non-contiguous sequences, and records outside the exact V1 or V2
+  vocabulary. V2 adds paired MCP request/response bodies correlated to an
+  existing capability attempt.
+
+  Secure publication is supported on Unix hosts with POSIX-compatible `mkdir`
+  and `id` executables available on `PATH`; persistence fails closed when those
+  authority/mode primitives are unavailable, a physical or lexical ancestor
+  has an untrusted owner, or any ancestor is group/other-writable without
+  sticky-directory protection. Preflight also rejects a final parent whose
+  effective permission class lacks create access. The same structural-depth
+  ceiling applies before in-memory retention, persistence, and loading.
   """
 
   alias Jason.OrderedObject
   alias PtcRunner.Kernel.MCPProtocol
+  alias PtcRunner.Kernel.PrivateDirectory
 
   @max_bytes 16_000_000
   @max_record_bytes 2_000_000
@@ -28,7 +44,8 @@ defmodule PtcRunner.Kernel.InspectionArtifact do
           | {:error,
              :invalid_inspection_path
              | :inspection_destination_exists
-             | :inspection_destination_unavailable}
+             | :inspection_destination_unavailable
+             | :inspection_persistence_failed}
   @doc """
   Read-only destination preflight using the same path rules as `persist/3`.
 
@@ -40,12 +57,9 @@ defmodule PtcRunner.Kernel.InspectionArtifact do
   preflight does not promise the destination stays creatable.
   """
   def preflight_destination(path) when is_binary(path) do
-    with :ok <- valid_path(path) do
-      case File.lstat(path) do
-        {:ok, _stat} -> {:error, :inspection_destination_exists}
-        {:error, :enoent} -> :ok
-        {:error, _reason} -> {:error, :inspection_destination_unavailable}
-      end
+    with :ok <- valid_path(path),
+         {:ok, path} <- anchor_path(path, :invalid_inspection_path) do
+      preflight_anchored(path)
     end
   end
 
@@ -55,13 +69,25 @@ defmodule PtcRunner.Kernel.InspectionArtifact do
   @doc "Validates and atomically persists one previously absent artifact."
   def persist(path, records, canonical_events)
       when is_binary(path) and is_list(records) and is_list(canonical_events) do
-    with :ok <- valid_path(path),
+    persist(path, records, canonical_events, nil)
+  end
+
+  def persist(_path, _records, _events), do: {:error, :invalid_inspection_artifact}
+
+  @doc false
+  @spec persist(binary(), [map()], [map()], nil | (atom() -> term())) ::
+          :ok | {:error, atom()}
+  def persist(path, records, canonical_events, fault_hook)
+      when is_binary(path) and is_list(records) and is_list(canonical_events) do
+    with true <- is_nil(fault_hook) or is_function(fault_hook, 1),
+         :ok <- valid_path(path),
+         {:ok, path} <- anchor_path(path, :invalid_inspection_artifact),
          false <- File.exists?(path),
          :ok <- validate_records(records),
          :ok <- validate_correlations(records, canonical_events),
          {:ok, encoded} <- encode(records),
          true <- byte_size(encoded) <= @max_bytes,
-         :ok <- persist_new(path, encoded) do
+         :ok <- persist_new(path, encoded, fault_hook) do
       :ok
     else
       true -> {:error, :inspection_destination_exists}
@@ -71,13 +97,53 @@ defmodule PtcRunner.Kernel.InspectionArtifact do
     end
   end
 
-  def persist(_path, _records, _events), do: {:error, :invalid_inspection_artifact}
+  def persist(_path, _records, _events, _fault_hook),
+    do: {:error, :invalid_inspection_artifact}
+
+  defp anchor_path(path, error) do
+    case PrivateDirectory.anchor(path) do
+      {:ok, path} -> {:ok, path}
+      {:error, _reason} -> {:error, error}
+    end
+  end
+
+  defp preflight_anchored(path) do
+    case File.lstat(path) do
+      {:ok, _stat} -> {:error, :inspection_destination_exists}
+      {:error, :enoent} -> preflight_private_directory(path)
+      {:error, _reason} -> {:error, :inspection_destination_unavailable}
+    end
+  end
 
   @spec load(binary(), keyword()) :: {:ok, [map()]} | {:error, atom()}
   @doc "Loads one exact fixed artifact with optional lower aggregate and per-record limits."
   def load(path, opts \\ [])
 
   def load(path, opts) when is_binary(path) and is_list(opts) do
+    load(path, opts, nil)
+  end
+
+  def load(_path, _opts), do: {:error, :invalid_inspection_artifact}
+
+  @doc false
+  @spec load(binary(), keyword(), nil | (-> term())) ::
+          {:ok, [map()]} | {:error, atom()}
+  def load(path, opts, verification_hook)
+      when is_binary(path) and is_list(opts) and
+             (is_nil(verification_hook) or is_function(verification_hook, 0)) do
+    load(path, opts, verification_hook, &:file.read/2)
+  end
+
+  def load(_path, _opts, _verification_hook), do: {:error, :invalid_inspection_artifact}
+
+  @doc false
+  @spec load(binary(), keyword(), nil | (-> term()), (:file.io_device(), non_neg_integer() ->
+                                                        {:ok, binary()} | :eof | {:error, term()})) ::
+          {:ok, [map()]} | {:error, atom()}
+  def load(path, opts, verification_hook, reader)
+      when is_binary(path) and is_list(opts) and
+             (is_nil(verification_hook) or is_function(verification_hook, 0)) and
+             is_function(reader, 2) do
     max_bytes = Keyword.get(opts, :max_bytes, @max_bytes)
     max_record_bytes = Keyword.get(opts, :max_record_bytes, @max_record_bytes)
 
@@ -89,8 +155,10 @@ defmodule PtcRunner.Kernel.InspectionArtifact do
          :ok <- valid_path(path),
          {:ok, before} <- regular_file(path),
          :ok <- within_limit(before, max_bytes),
-         {:ok, content} <- File.read(path),
+         {:ok, content, opened} <-
+           read_regular_file(path, before, max_bytes, verification_hook, reader),
          {:ok, after_read} <- regular_file(path),
+         :ok <- unchanged(before, opened),
          :ok <- unchanged(before, after_read),
          {:ok, records} <- decode(content, max_record_bytes),
          :ok <- validate_records(records) do
@@ -102,7 +170,8 @@ defmodule PtcRunner.Kernel.InspectionArtifact do
     end
   end
 
-  def load(_path, _opts), do: {:error, :invalid_inspection_artifact}
+  def load(_path, _opts, _verification_hook, _reader),
+    do: {:error, :invalid_inspection_artifact}
 
   defp valid_path(path) do
     if String.valid?(path) and String.ends_with?(path, @suffix),
@@ -150,7 +219,8 @@ defmodule PtcRunner.Kernel.InspectionArtifact do
   end
 
   defp decode_line(line) do
-    with {:ok, decoded} <- Jason.decode(line, objects: :ordered_objects),
+    with true <- MCPProtocol.within_inspection_document_depth?(line),
+         {:ok, decoded} <- Jason.decode(line, objects: :ordered_objects),
          do: ordered_value(decoded)
   end
 
@@ -319,7 +389,8 @@ defmodule PtcRunner.Kernel.InspectionArtifact do
   end
 
   defp valid_record?(record, run_id, trace_id, schema_version, sequence) do
-    is_map(record) and Map.keys(record) |> Enum.sort() == Enum.sort(@envelope_keys) and
+    MCPProtocol.within_inspection_document_depth?(record) and
+      is_map(record) and Map.keys(record) |> Enum.sort() == Enum.sort(@envelope_keys) and
       schema_version in [1, 2] and record["schema_version"] == schema_version and
       record["run_id"] == run_id and
       record["trace_id"] == trace_id and is_binary(run_id) and is_binary(trace_id) and
@@ -502,21 +573,24 @@ defmodule PtcRunner.Kernel.InspectionArtifact do
   defp string_value(value) when is_binary(value), do: value
   defp string_value(_value), do: nil
 
-  defp persist_new(path, encoded) do
-    temporary = path <> ".tmp-" <> Base.encode16(:crypto.strong_rand_bytes(6), case: :lower)
-    persist_temporary(path, temporary, encoded)
+  defp persist_new(path, encoded, fault_hook) do
+    {temporary_directory, temporary} = PrivateDirectory.temporary_sibling(path, "artifact")
+    persist_temporary(path, temporary_directory, temporary, encoded, fault_hook)
   end
 
-  defp persist_temporary(path, temporary, encoded) do
-    with {:ok, :ok} <-
-           File.open(temporary, [:write, :binary, :exclusive], fn device ->
-             case File.chmod(temporary, 0o600) do
-               :ok -> IO.binwrite(device, encoded)
-               {:error, _reason} = error -> error
-             end
-           end),
-         :ok <- File.ln(temporary, path),
-         :ok <- File.rm(temporary) do
+  defp persist_temporary(path, temporary_directory, temporary, encoded, fault_hook) do
+    case PrivateDirectory.create(temporary_directory) do
+      :ok ->
+        persist_created(path, temporary_directory, temporary, encoded, fault_hook)
+
+      {:error, _reason} ->
+        {:error, :inspection_persistence_failed}
+    end
+  end
+
+  defp persist_created(path, temporary_directory, temporary, encoded, fault_hook) do
+    with {:ok, :ok} <- write_private_file(temporary, encoded, fault_hook),
+         :ok <- File.ln(temporary, path) do
       :ok
     else
       {:error, :eexist} -> {:error, :inspection_destination_exists}
@@ -524,6 +598,48 @@ defmodule PtcRunner.Kernel.InspectionArtifact do
     end
   after
     _ = File.rm(temporary)
+    _ = File.rmdir(temporary_directory)
+  end
+
+  defp preflight_private_directory(path) do
+    case PrivateDirectory.preflight(path) do
+      :ok ->
+        :ok
+
+      {:error, :private_directory_parent_unavailable} ->
+        {:error, :inspection_destination_unavailable}
+
+      {:error, _reason} ->
+        {:error, :inspection_persistence_failed}
+    end
+  end
+
+  defp write_private_file(path, encoded, fault_hook) do
+    case File.open(path, [:write, :binary, :exclusive], fn device ->
+           with :ok <- persistence_fault(fault_hook, :before_chmod),
+                :ok <- File.chmod(path, 0o600),
+                :ok <- persistence_fault(fault_hook, :before_write) do
+             IO.binwrite(device, encoded)
+           end
+         end) do
+      {:ok, :ok} = success -> success
+      {:ok, {:error, _reason}} -> {:error, :inspection_persistence_failed}
+      {:error, _reason} = error -> error
+      _unexpected -> {:error, :inspection_persistence_failed}
+    end
+  end
+
+  defp persistence_fault(nil, _stage), do: :ok
+
+  defp persistence_fault(fault_hook, stage) do
+    case fault_hook.(stage) do
+      :ok -> :ok
+      _failure -> {:error, :inspection_persistence_failed}
+    end
+  rescue
+    _exception -> {:error, :inspection_persistence_failed}
+  catch
+    _kind, _reason -> {:error, :inspection_persistence_failed}
   end
 
   defp regular_file(path) do
@@ -534,13 +650,93 @@ defmodule PtcRunner.Kernel.InspectionArtifact do
     end
   end
 
-  defp stable?(before, after_read),
-    do:
-      before.size == after_read.size and before.mtime == after_read.mtime and
-        before.inode == after_read.inode
+  defp read_regular_file(path, expected, max_bytes, verification_hook, reader) do
+    case :file.open(String.to_charlist(path), [:read, :binary, :raw]) do
+      {:ok, device} ->
+        try do
+          with {:ok, info} <- :file.read_file_info(device, time: :posix),
+               opened = File.Stat.from_record(info),
+               :ok <- same_file(expected, opened),
+               :ok <- within_limit(opened, max_bytes),
+               {:ok, content} <- read_exact(device, opened.size, reader),
+               :ok <- run_verification_hook(verification_hook),
+               {:ok, 0} <- :file.position(device, :bof),
+               {:ok, verification} <- read_exact(device, opened.size, reader),
+               true <- verification == content,
+               {:ok, after_info} <- :file.read_file_info(device, time: :posix),
+               after_read = File.Stat.from_record(after_info),
+               :ok <- unchanged(opened, after_read) do
+            {:ok, content, opened}
+          else
+            false -> {:error, :inspection_source_changed}
+            {:error, _reason} = error -> error
+          end
+        after
+          :file.close(device)
+        end
+
+      {:error, _reason} ->
+        {:error, :inspection_source_unavailable}
+    end
+  end
+
+  defp run_verification_hook(nil), do: :ok
+
+  defp run_verification_hook(verification_hook) do
+    case verification_hook.() do
+      :ok -> :ok
+      _other -> {:error, :inspection_source_unavailable}
+    end
+  rescue
+    _exception -> {:error, :inspection_source_unavailable}
+  catch
+    _kind, _reason -> {:error, :inspection_source_unavailable}
+  end
+
+  defp read_exact(device, expected_bytes, reader),
+    do: read_exact(device, expected_bytes, reader, [])
+
+  defp read_exact(device, 0, reader, chunks) do
+    case reader.(device, 1) do
+      :eof -> {:ok, chunks |> Enum.reverse() |> IO.iodata_to_binary()}
+      {:ok, _unexpected} -> {:error, :inspection_source_changed}
+      {:error, _reason} -> {:error, :inspection_source_unavailable}
+    end
+  end
+
+  defp read_exact(device, remaining, reader, chunks) do
+    case reader.(device, remaining) do
+      {:ok, chunk}
+      when is_binary(chunk) and byte_size(chunk) > 0 and byte_size(chunk) <= remaining ->
+        read_exact(device, remaining - byte_size(chunk), reader, [chunk | chunks])
+
+      :eof ->
+        {:error, :inspection_source_changed}
+
+      {:ok, _unexpected} ->
+        {:error, :inspection_source_changed}
+
+      {:error, _reason} ->
+        {:error, :inspection_source_unavailable}
+    end
+  end
+
+  defp same_file(
+         %File.Stat{major_device: major, minor_device: minor, inode: inode},
+         %File.Stat{major_device: major, minor_device: minor, inode: inode}
+       ),
+       do: :ok
+
+  defp same_file(_expected, _opened), do: {:error, :inspection_source_changed}
 
   defp unchanged(before, after_read) do
-    if stable?(before, after_read), do: :ok, else: {:error, :inspection_source_changed}
+    with :ok <- same_file(before, after_read),
+         true <- before.size == after_read.size and before.mtime == after_read.mtime do
+      :ok
+    else
+      false -> {:error, :inspection_source_changed}
+      {:error, _reason} = error -> error
+    end
   end
 
   defp within_limit(stat, max_bytes) do

--- a/lib/ptc_runner/kernel/inspection_query.ex
+++ b/lib/ptc_runner/kernel/inspection_query.ex
@@ -379,33 +379,72 @@ defmodule PtcRunner.Kernel.InspectionQuery do
   end
 
   defp fit_page(selected, all_items, offset, source_id, query_id, max_result_bytes) do
-    next_offset = offset + length(selected)
-    more? = next_offset < length(all_items)
-
-    result = %{
-      "items" => selected,
-      "next_cursor" => if(more?, do: encode_cursor(next_offset, source_id, query_id), else: nil),
-      "truncated" => more?,
-      "omitted_count" => max(length(all_items) - next_offset, 0)
-    }
+    result = page_result(selected, all_items, offset, source_id, query_id)
 
     cond do
       byte_size(Jason.encode!(result)) <= max_result_bytes ->
         {:ok, result}
 
-      selected != [] ->
-        fit_page(
-          Enum.drop(selected, -1),
-          all_items,
-          offset,
-          source_id,
-          query_id,
-          max_result_bytes
-        )
+      selected == [] ->
+        {:error, :result_limit_exceeded}
 
       true ->
-        {:error, :result_limit_exceeded}
+        context = {all_items, offset, source_id, query_id, max_result_bytes}
+
+        fit_page_prefix(
+          selected,
+          context,
+          1,
+          length(selected) - 1,
+          nil
+        )
     end
+  end
+
+  defp fit_page_prefix(_selected, _context, lower, upper, best)
+       when lower > upper do
+    if best, do: {:ok, best}, else: {:error, :result_limit_exceeded}
+  end
+
+  defp fit_page_prefix(
+         selected,
+         {all_items, offset, source_id, query_id, max_result_bytes} = context,
+         lower,
+         upper,
+         best
+       ) do
+    count = div(lower + upper, 2)
+    result = page_result(Enum.take(selected, count), all_items, offset, source_id, query_id)
+
+    if byte_size(Jason.encode!(result)) <= max_result_bytes do
+      fit_page_prefix(
+        selected,
+        context,
+        count + 1,
+        upper,
+        result
+      )
+    else
+      fit_page_prefix(
+        selected,
+        context,
+        lower,
+        count - 1,
+        best
+      )
+    end
+  end
+
+  defp page_result(selected, all_items, offset, source_id, query_id) do
+    next_offset = offset + length(selected)
+    more? = next_offset < length(all_items)
+
+    %{
+      "items" => selected,
+      "next_cursor" => if(more?, do: encode_cursor(next_offset, source_id, query_id), else: nil),
+      "truncated" => more?,
+      "omitted_count" => max(length(all_items) - next_offset, 0)
+    }
   end
 
   defp encode_cursor(offset, source_id, query_id) do

--- a/lib/ptc_runner/kernel/inspection_sink.ex
+++ b/lib/ptc_runner/kernel/inspection_sink.ex
@@ -188,6 +188,8 @@ defmodule PtcRunner.Kernel.InspectionSink do
 
   defp retain(state, record_type, correlation, payload) do
     with true <- record_type in record_types(state.schema_version),
+         candidate <- record(state, record_type, correlation, payload),
+         true <- MCPProtocol.within_inspection_document_depth?(candidate),
          {:ok, correlation} <- normalize(correlation),
          {:ok, payload} <- normalize(payload),
          :ok <- shape(record_type, correlation, payload),

--- a/lib/ptc_runner/kernel/inspection_snapshot.ex
+++ b/lib/ptc_runner/kernel/inspection_snapshot.ex
@@ -31,6 +31,7 @@ defmodule PtcRunner.Kernel.InspectionSnapshot do
   @max_artifact_bytes 16_000_000
   @listing_timeout_ms 5_000
   @listing_heap_words 1_000_000
+  @capture_heap_words 40_000_000
   @operations [
     :list_runs,
     :model_exchanges,
@@ -74,6 +75,7 @@ defmodule PtcRunner.Kernel.InspectionSnapshot do
       :max_result_bytes,
       :max_directory_entries,
       :max_files,
+      :capture_heap_words,
       :capture_hook,
       :listing_hook
     ]
@@ -93,6 +95,8 @@ defmodule PtcRunner.Kernel.InspectionSnapshot do
            Keyword.get(opts, :max_directory_entries, @default_directory_entries),
          max_files when max_files in 1..@default_files <-
            Keyword.get(opts, :max_files, @default_files),
+         capture_heap_words when capture_heap_words in 233..@capture_heap_words <-
+           Keyword.get(opts, :capture_heap_words, @capture_heap_words),
          capture_hook when is_nil(capture_hook) or is_function(capture_hook, 0) <-
            Keyword.get(opts, :capture_hook),
          listing_hook when is_nil(listing_hook) or is_function(listing_hook, 0) <-
@@ -103,7 +107,7 @@ defmodule PtcRunner.Kernel.InspectionSnapshot do
              __MODULE__,
              {Path.expand(directory), trace_snapshot, owner, token, max_source_bytes,
               max_retained_bytes, max_result_bytes, max_directory_entries, max_files,
-              capture_hook, listing_hook}
+              capture_heap_words, capture_hook, listing_hook}
            ) do
         {:ok, pid} -> {:ok, %__MODULE__{pid: pid, token: token}}
         {:error, {:source_retained_limit_exceeded, _details} = reason} -> {:error, reason}
@@ -160,7 +164,8 @@ defmodule PtcRunner.Kernel.InspectionSnapshot do
   @impl GenServer
   def init(
         {directory, trace_snapshot, owner, token, max_source_bytes, max_retained_bytes,
-         max_result_bytes, max_directory_entries, max_files, capture_hook, listing_hook}
+         max_result_bytes, max_directory_entries, max_files, capture_heap_words, capture_hook,
+         listing_hook}
       ) do
     owner_ref = Process.monitor(owner)
     trace_ref = Process.monitor(trace_snapshot.pid)
@@ -178,7 +183,14 @@ defmodule PtcRunner.Kernel.InspectionSnapshot do
       )
     end
 
-    case capture_for_dependencies(capture, owner, owner_ref, trace_snapshot.pid, trace_ref) do
+    case capture_for_dependencies(
+           capture,
+           owner,
+           owner_ref,
+           trace_snapshot.pid,
+           trace_ref,
+           capture_heap_words
+         ) do
       {:ok, capture} ->
         {:ok, snapshot_state(capture, token, owner_ref, trace_ref, max_result_bytes)}
 
@@ -450,12 +462,31 @@ defmodule PtcRunner.Kernel.InspectionSnapshot do
 
   defp normalize_capture_error(_reason), do: :invalid_snapshot
 
-  defp capture_for_dependencies(capture, owner, owner_ref, trace, trace_ref) do
+  defp capture_for_dependencies(
+         capture,
+         owner,
+         owner_ref,
+         trace,
+         trace_ref,
+         capture_heap_words
+       ) do
     reply_alias = Process.alias()
     reply_ref = make_ref()
 
     {worker, worker_ref} =
-      Process.spawn(fn -> send(reply_alias, {reply_ref, capture.()}) end, [:monitor])
+      Process.spawn(
+        fn -> send(reply_alias, {reply_ref, capture.()}) end,
+        [
+          {:max_heap_size,
+           %{
+             size: capture_heap_words,
+             kill: true,
+             error_logger: false,
+             include_shared_binaries: true
+           }},
+          :monitor
+        ]
+      )
 
     receive do
       {^reply_ref, result} ->
@@ -473,6 +504,10 @@ defmodule PtcRunner.Kernel.InspectionSnapshot do
       {:DOWN, ^trace_ref, :process, ^trace, _reason} ->
         terminate_capture(worker, worker_ref, reply_alias)
         {:error, :snapshot_unavailable}
+
+      {:DOWN, ^worker_ref, :process, ^worker, :killed} ->
+        Process.unalias(reply_alias)
+        {:error, :source_retained_limit_exceeded}
 
       {:DOWN, ^worker_ref, :process, ^worker, _reason} ->
         Process.unalias(reply_alias)

--- a/lib/ptc_runner/kernel/mcp_protocol.ex
+++ b/lib/ptc_runner/kernel/mcp_protocol.ex
@@ -19,11 +19,16 @@ defmodule PtcRunner.Kernel.MCPProtocol do
 
   Structured results require a frozen object-output validator and explicit
   content containing only exact text or embedded text-resource blocks; those
-  companion blocks are validated and discarded. Tools without output schemas
+  companion blocks are validated and discarded. Standard content-block
+  `annotations` and `_meta` fields are validated, accepted, and ignored; other
+  extra block fields are rejected. Tools without output schemas
   return a map containing ordered `"text"` values and, when present, ordered
   embedded text `"resources"`. Binary resources and all other content types
-  remain unsupported. The functions return closed MCP reason atoms and never
-  construct provider errors or expose remote error data.
+  remain unsupported. Inbound documents are rejected before decoding when
+  their raw JSON nesting exceeds the fixed document-depth ceiling. Functions
+  normally return closed MCP reason atoms; the explicitly installed
+  `:bounded` error-feedback policy is the sole exception and returns a bounded
+  validated remote text value for later provider-error construction.
   """
 
   alias PtcRunner.Kernel.DeterministicJSON
@@ -37,7 +42,13 @@ defmodule PtcRunner.Kernel.MCPProtocol do
   @max_header_parameters 24
   @max_header_name_bytes 128
   @max_parameter_header_bytes 16_384
+  @max_annotation_string_bytes 256
+  @rfc3339_datetime ~r/\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})\z/i
   @max_schema_depth 16
+  # A maximum-depth schema in tools/list occupies four envelope containers,
+  # `2 * depth - 1` schema containers, and `depth` const/enum instance
+  # containers: 4 + 31 + 16 = 51 at the configured limits.
+  @max_document_depth @max_schema_depth * 3 + 3
   @schema_instance_keywords ~w(const enum)
   @schema_value_keywords ~w(additionalProperties contains if items not then else)
   @schema_list_keywords ~w(allOf anyOf oneOf prefixItems)
@@ -96,7 +107,8 @@ defmodule PtcRunner.Kernel.MCPProtocol do
   @spec decode_message(binary()) ::
           {:ok, inbound_message()} | {:error, :mcp_protocol_error}
   def decode_message(body) when is_binary(body) do
-    with {:ok, decoded} <- StrictJSON.decode(body),
+    with true <- within_document_depth?(body),
+         {:ok, decoded} <- StrictJSON.decode(body),
          true <- JSONValue.map?(decoded),
          "2.0" <- decoded["jsonrpc"] do
       classify_message(decoded)
@@ -106,6 +118,74 @@ defmodule PtcRunner.Kernel.MCPProtocol do
   end
 
   def decode_message(_body), do: {:error, :mcp_protocol_error}
+
+  @doc false
+  @spec within_document_depth?(term()) :: boolean()
+  def within_document_depth?(body) when is_binary(body),
+    do: scan_document_depth(body, 0, false, false, @max_document_depth)
+
+  def within_document_depth?(value),
+    do: scan_decoded_depth(value, 0, @max_document_depth)
+
+  @doc false
+  @spec within_inspection_document_depth?(term()) :: boolean()
+  def within_inspection_document_depth?(body) when is_binary(body),
+    do: scan_document_depth(body, 0, false, false, @max_document_depth + 2)
+
+  def within_inspection_document_depth?(value),
+    do: scan_decoded_depth(value, 0, @max_document_depth + 2)
+
+  defp scan_document_depth(<<>>, _depth, _string?, _escaped?, _max_depth), do: true
+
+  defp scan_document_depth(<<_byte, rest::binary>>, depth, true, true, max_depth),
+    do: scan_document_depth(rest, depth, true, false, max_depth)
+
+  defp scan_document_depth(<<?\\, rest::binary>>, depth, true, false, max_depth),
+    do: scan_document_depth(rest, depth, true, true, max_depth)
+
+  defp scan_document_depth(<<?", rest::binary>>, depth, true, false, max_depth),
+    do: scan_document_depth(rest, depth, false, false, max_depth)
+
+  defp scan_document_depth(<<_byte, rest::binary>>, depth, true, false, max_depth),
+    do: scan_document_depth(rest, depth, true, false, max_depth)
+
+  defp scan_document_depth(<<?", rest::binary>>, depth, false, false, max_depth),
+    do: scan_document_depth(rest, depth, true, false, max_depth)
+
+  defp scan_document_depth(<<byte, rest::binary>>, depth, false, false, max_depth)
+       when byte in ~c"[{" do
+    next_depth = depth + 1
+
+    if next_depth <= max_depth,
+      do: scan_document_depth(rest, next_depth, false, false, max_depth),
+      else: false
+  end
+
+  defp scan_document_depth(<<byte, rest::binary>>, depth, false, false, max_depth)
+       when byte in ~c"]}" and depth > 0,
+       do: scan_document_depth(rest, depth - 1, false, false, max_depth)
+
+  defp scan_document_depth(<<_byte, rest::binary>>, depth, false, false, max_depth),
+    do: scan_document_depth(rest, depth, false, false, max_depth)
+
+  defp scan_decoded_depth(value, depth, max_depth)
+       when is_map(value) and not is_struct(value) do
+    next_depth = depth + 1
+
+    next_depth <= max_depth and
+      Enum.all?(value, fn {_key, item} ->
+        scan_decoded_depth(item, next_depth, max_depth)
+      end)
+  end
+
+  defp scan_decoded_depth(values, depth, max_depth) when is_list(values) do
+    next_depth = depth + 1
+
+    next_depth <= max_depth and
+      Enum.all?(values, &scan_decoded_depth(&1, next_depth, max_depth))
+  end
+
+  defp scan_decoded_depth(_value, _depth, _max_depth), do: true
 
   @doc false
   @spec valid_exchange_request?(term(), term()) :: boolean()
@@ -120,7 +200,9 @@ defmodule PtcRunner.Kernel.MCPProtocol do
       )
       when is_integer(id) and id > 0 and is_binary(method) and byte_size(method) in 1..128 and
              is_map(params) and not is_struct(params) do
-    Map.keys(request) |> Enum.sort() == ~w(id jsonrpc method params) and JSONValue.map?(request)
+    within_document_depth?(request) and
+      Map.keys(request) |> Enum.sort() == ~w(id jsonrpc method params) and
+      JSONValue.map?(request)
   end
 
   def valid_exchange_request?(_request, _id), do: false
@@ -129,7 +211,8 @@ defmodule PtcRunner.Kernel.MCPProtocol do
   @spec valid_exchange_response?(term(), term()) :: boolean()
   def valid_exchange_response?(response, id)
       when is_map(response) and is_integer(id) and id > 0 do
-    match?({:ok, {:response, ^id, _decoded}}, classify_message(response)) and
+    within_document_depth?(response) and
+      match?({:ok, {:response, ^id, _decoded}}, classify_message(response)) and
       response["jsonrpc"] == "2.0" and JSONValue.map?(response)
   end
 
@@ -468,14 +551,19 @@ defmodule PtcRunner.Kernel.MCPProtocol do
   defp text_result(content) do
     Enum.reduce_while(content, {:ok, [], []}, fn
       %{"type" => "text", "text" => text} = block, {:ok, texts, resources}
-      when is_binary(text) and map_size(block) == 2 ->
-        {:cont, {:ok, [text | texts], resources}}
+      when is_binary(text) ->
+        if valid_content_block?(block, ~w(type text annotations _meta)),
+          do: {:cont, {:ok, [text | texts], resources}},
+          else: {:halt, {:error, :mcp_invalid_result}}
 
-      %{"type" => "resource", "resource" => resource} = block, {:ok, texts, resources}
-      when map_size(block) == 2 ->
-        case text_resource(resource) do
-          {:ok, normalized} -> {:cont, {:ok, texts, [normalized | resources]}}
-          :error -> {:halt, {:error, :mcp_invalid_result}}
+      %{"type" => "resource", "resource" => resource} = block, {:ok, texts, resources} ->
+        if valid_content_block?(block, ~w(type resource annotations _meta)) do
+          case text_resource(resource) do
+            {:ok, normalized} -> {:cont, {:ok, texts, [normalized | resources]}}
+            :error -> {:halt, {:error, :mcp_invalid_result}}
+          end
+        else
+          {:halt, {:error, :mcp_invalid_result}}
         end
 
       _block, _acc ->
@@ -499,14 +587,19 @@ defmodule PtcRunner.Kernel.MCPProtocol do
 
   defp text_resource(%{"uri" => uri, "text" => text} = resource)
        when is_binary(uri) and byte_size(uri) > 0 and is_binary(text) do
-    allowed = ~w(uri mimeType text)
+    allowed = ~w(uri mimeType text _meta)
 
-    case {Map.keys(resource) -- allowed, Map.get(resource, "mimeType")} do
-      {[], nil} ->
-        {:ok, Map.take(resource, allowed)}
+    case {
+      JSONValue.map?(resource),
+      Map.keys(resource) -- allowed,
+      Map.get(resource, "mimeType"),
+      optional_meta?(resource)
+    } do
+      {true, [], nil, true} ->
+        {:ok, Map.take(resource, ~w(uri mimeType text))}
 
-      {[], mime_type} when is_binary(mime_type) and byte_size(mime_type) > 0 ->
-        {:ok, Map.take(resource, allowed)}
+      {true, [], mime_type, true} when is_binary(mime_type) and byte_size(mime_type) > 0 ->
+        {:ok, Map.take(resource, ~w(uri mimeType text))}
 
       _invalid ->
         :error
@@ -518,8 +611,10 @@ defmodule PtcRunner.Kernel.MCPProtocol do
   defp error_feedback(content, policy) do
     Enum.reduce_while(content, {:ok, []}, fn
       %{"type" => "text", "text" => text} = block, {:ok, texts}
-      when is_binary(text) and map_size(block) == 2 ->
-        {:cont, {:ok, [text | texts]}}
+      when is_binary(text) ->
+        if valid_content_block?(block, ~w(type text annotations _meta)),
+          do: {:cont, {:ok, [text | texts]}},
+          else: {:halt, {:error, :mcp_invalid_result}}
 
       _block, _acc ->
         {:halt, {:error, :mcp_invalid_result}}
@@ -531,7 +626,7 @@ defmodule PtcRunner.Kernel.MCPProtocol do
       {:ok, texts} ->
         case texts |> Enum.reverse() |> Enum.join("\n") do
           "" -> {:ok, nil}
-          feedback -> {:ok, truncate_utf8(feedback, 1_024)}
+          feedback -> {:ok, feedback |> sanitize_feedback() |> truncate_utf8(1_024)}
         end
 
       error ->
@@ -545,6 +640,61 @@ defmodule PtcRunner.Kernel.MCPProtocol do
     value
     |> binary_part(0, max_bytes)
     |> valid_utf8_prefix()
+  end
+
+  defp valid_content_block?(block, allowed) do
+    JSONValue.map?(block) and Map.keys(block) -- allowed == [] and
+      optional_annotations?(block) and optional_meta?(block)
+  end
+
+  defp optional_annotations?(block) do
+    case Map.fetch(block, "annotations") do
+      :error -> true
+      {:ok, annotations} -> valid_annotations?(annotations)
+    end
+  end
+
+  defp valid_annotations?(annotations) do
+    JSONValue.map?(annotations) and
+      Map.keys(annotations) -- ~w(audience priority lastModified) == [] and
+      valid_optional_annotation?(annotations, "audience", &valid_audience?/1) and
+      valid_optional_annotation?(annotations, "priority", &valid_priority?/1) and
+      valid_optional_annotation?(annotations, "lastModified", &valid_last_modified?/1)
+  end
+
+  defp valid_optional_annotation?(annotations, key, validator) do
+    case Map.fetch(annotations, key) do
+      :error -> true
+      {:ok, value} -> validator.(value)
+    end
+  end
+
+  defp valid_audience?(audience) when is_list(audience),
+    do: Enum.all?(audience, &(&1 in ["user", "assistant"]))
+
+  defp valid_audience?(_audience), do: false
+
+  defp valid_priority?(priority) when is_number(priority), do: priority >= 0 and priority <= 1
+  defp valid_priority?(_priority), do: false
+
+  defp valid_last_modified?(last_modified) when is_binary(last_modified) do
+    byte_size(last_modified) <= @max_annotation_string_bytes and
+      String.valid?(last_modified) and
+      last_modified =~ @rfc3339_datetime and
+      match?({:ok, _datetime, _offset}, DateTime.from_iso8601(String.upcase(last_modified)))
+  end
+
+  defp valid_last_modified?(_last_modified), do: false
+
+  defp optional_meta?(value) do
+    case Map.fetch(value, "_meta") do
+      :error -> true
+      {:ok, meta} -> JSONValue.map?(meta)
+    end
+  end
+
+  defp sanitize_feedback(feedback) do
+    String.replace(feedback, ~r/[\x00-\x1F\x7F-\x{9F}]/u, "�")
   end
 
   defp valid_utf8_prefix(value) do

--- a/lib/ptc_runner/kernel/mcp_source.ex
+++ b/lib/ptc_runner/kernel/mcp_source.ex
@@ -96,13 +96,15 @@ defmodule PtcRunner.Kernel.MCPSource do
       `%{as: public_name, effect: :read}`. A mapping may also carry a bounded
       host-owned `:description`, `:model_visible` (default `true` for direct
       embedding), and `:error_feedback` (`:closed`, the default, or
-      `:bounded`). Bounded feedback exposes at most 1,024 bytes of exact,
-      validated text from an MCP `isError` result as untrusted recoverable
-      capability-error details. Enabling it trusts the installed server not
-      to place secrets, paths, or stack traces in that text. Public canonical
-      events remain closed. Both names are unique and bounded; only the public
-      name crosses the capability boundary. The host JSON decoder supplies its
-      stricter model-invisible default explicitly.
+      `:bounded`). Bounded feedback exposes at most 1,024 bytes of validated
+      text from an MCP `isError` result as untrusted recoverable
+      capability-error details. C0 controls, including tab, newline, carriage
+      return, ESC, and DEL, are replaced before exposure.
+      Enabling it trusts the installed server not to place secrets, paths, or
+      stack traces in that text. Public canonical events remain closed. Both
+      names are unique and bounded; only the public name crosses the capability
+      boundary. The host JSON decoder supplies its stricter model-invisible
+      default explicitly.
     * `:timeout_ms` - installed end-to-end ceiling for discovery, calls, and
       requests (default `5_000`; stdio maximum `300_000`). A manifest may only
       lower it.
@@ -140,18 +142,20 @@ defmodule PtcRunner.Kernel.MCPSource do
   Discovery produces ordinary read-only `PtcRunner.Kernel.Capability` values.
   An advertised object output schema accepts only schema-valid
   `structuredContent` accompanied by exact text blocks (which are validated
-  and discarded). A tool without an output schema accepts only exact text
-  blocks and returns `%{"text" => [string()]}`.
+  and discarded). Text and embedded text-resource blocks may carry standard
+  `annotations` and `_meta`; other extra block fields are rejected. A tool
+  without an output schema returns exact text as `%{"text" => [string()]}`.
   MCP `isError`, malformed/mixed content, invalid JSON-RPC envelopes, and
   schema failures become bounded `PtcRunner.Kernel.ProviderError` values with
   closed reasons. Authentication, timeout, unsupported-result, invalid-result,
   and transport failures never include remote messages or payloads.
 
   The safe connector snapshot has top-level fields `provider`, `protocol`,
-  `transport`, `server_info_hash`, `snapshot_hash`, and `tools`. When the host
-  installs `snapshot_identity`, it also carries the validated
-  `content_snapshot_hash`; changing that identity changes the overall
-  `snapshot_hash`. Stdio
+  `transport`, selected `timeout_ms`, selected `max_result_bytes`,
+  installed `max_catalog_tools`, installed `max_pages`, `server_info_hash`,
+  `snapshot_hash`, and `tools`. When the host installs `snapshot_identity`, it
+  also carries the validated `content_snapshot_hash`; changing that identity
+  or any effective ceiling changes the overall `snapshot_hash`. Stdio
   snapshots additionally contain the launcher protocol, launcher digest, and
   server-executable digest. The nullable server hash fingerprints bounded self-reported
   implementation identity without exposing its untrusted text. Successful
@@ -724,10 +728,12 @@ defmodule PtcRunner.Kernel.MCPSource do
              tools,
              server.server_info,
              content_snapshot_hash,
-             installed
+             installed,
+             selected
            ) do
       {:ok, capabilities, snapshot}
     else
+      {:error, :mcp_transport_closed} -> {:error, :mcp_transport_error}
       {:error, _reason} = error -> error
       _reason -> {:error, :mcp_protocol_error}
     end
@@ -871,7 +877,7 @@ defmodule PtcRunner.Kernel.MCPSource do
              context
            ) do
         {:ok, result} -> normalize_result(result, output_validator, error_feedback)
-        {:error, reason} -> {:error, provider_error(reason)}
+        {:error, reason} -> {:error, provider_error(reason, transport.type)}
       end
     end
   end
@@ -923,7 +929,8 @@ defmodule PtcRunner.Kernel.MCPSource do
          tools,
          server_info,
          content_snapshot_hash,
-         installed
+         installed,
+         selected
        )
        when is_binary(provider) and type in [:streamable_http, :stdio] do
     transport_name = Atom.to_string(type)
@@ -944,6 +951,10 @@ defmodule PtcRunner.Kernel.MCPSource do
               ) ++
               optional_projection("content_snapshot_hash", content_snapshot_hash) ++
               [
+                {"timeout_ms", selected.timeout_ms},
+                {"max_result_bytes", selected.max_result_bytes},
+                {"max_catalog_tools", installed.max_catalog_tools},
+                {"max_pages", installed.max_pages},
                 {"server_info_hash", server_info_hash},
                 {"tools",
                  Enum.map(tools, fn tool ->
@@ -968,6 +979,10 @@ defmodule PtcRunner.Kernel.MCPSource do
             "provider" => provider,
             "protocol" => "mcp-#{@protocol}",
             "transport" => transport_name,
+            "timeout_ms" => selected.timeout_ms,
+            "max_result_bytes" => selected.max_result_bytes,
+            "max_catalog_tools" => installed.max_catalog_tools,
+            "max_pages" => installed.max_pages,
             "server_info_hash" => server_info_hash,
             "snapshot_hash" => sha256(encoded),
             "tools" => tools
@@ -1089,7 +1104,7 @@ defmodule PtcRunner.Kernel.MCPSource do
           handle,
           method,
           params,
-          request_metadata(nil),
+          request_metadata(context),
           @max_transport_response_bytes,
           timeout_ms
         )
@@ -1104,7 +1119,7 @@ defmodule PtcRunner.Kernel.MCPSource do
         bounded_outcome(body, method, max_bytes)
 
       {:error, :closed} ->
-        {:error, :mcp_transport_error}
+        {:error, :mcp_transport_closed}
 
       {:error, _reason} = error ->
         error
@@ -1167,7 +1182,7 @@ defmodule PtcRunner.Kernel.MCPSource do
         end
 
       {:error, :closed} ->
-        {:error, :mcp_transport_error}
+        {:error, :mcp_transport_closed}
     end
   end
 
@@ -1471,25 +1486,31 @@ defmodule PtcRunner.Kernel.MCPSource do
   defp strip_sse_bom(<<0xEF, 0xBB, 0xBF, rest::binary>>, true), do: rest
   defp strip_sse_bom(event, _at_start?), do: event
 
-  defp provider_error(:mcp_authentication_failed),
+  defp provider_error(:mcp_authentication_failed, _transport),
     do: ProviderError.new(:authentication_failed, "mcp_authentication_failed")
 
-  defp provider_error(:mcp_timeout),
+  defp provider_error(:mcp_timeout, _transport),
     do: ProviderError.new(:timeout, "mcp_timeout", retryable?: true)
 
-  defp provider_error(:mcp_response_exceeded),
+  defp provider_error(:mcp_response_exceeded, _transport),
     do: ProviderError.new(:invalid_result, "mcp_response_exceeded")
 
-  defp provider_error(:mcp_protocol_error),
+  defp provider_error(:mcp_protocol_error, _transport),
     do: ProviderError.new(:invalid_result, "mcp_protocol_error")
 
-  defp provider_error(:mcp_remote_error),
+  defp provider_error(:mcp_remote_error, _transport),
     do: ProviderError.new(:domain_error, "mcp_remote_error")
 
-  defp provider_error(:mcp_unsupported_result),
+  defp provider_error(:mcp_unsupported_result, _transport),
     do: ProviderError.new(:invalid_result, "mcp_unsupported_result")
 
-  defp provider_error(_reason),
+  defp provider_error(:mcp_transport_closed, _transport),
+    do: ProviderError.new(:transport_error, "mcp_transport_closed")
+
+  defp provider_error(:mcp_transport_error, :stdio),
+    do: ProviderError.new(:transport_error, "mcp_transport_error")
+
+  defp provider_error(_reason, _transport),
     do: ProviderError.new(:transport_error, "mcp_transport_error", retryable?: true)
 
   defp sha256(value), do: :crypto.hash(:sha256, value) |> Base.encode16(case: :lower)

--- a/lib/ptc_runner/kernel/mcp_stdio_transport.ex
+++ b/lib/ptc_runner/kernel/mcp_stdio_transport.ex
@@ -20,7 +20,6 @@ defmodule PtcRunner.Kernel.MCPStdioTransport do
   @max_start_timeout_ms 60_000
   @max_request_timeout_ms 300_000
   @max_pending_requests 128
-  @max_cancelled_requests 256
   @finish_drain_timeout_ms 100
   @default_grace_ms 250
   @default_stderr_bytes 65_536
@@ -66,6 +65,7 @@ defmodule PtcRunner.Kernel.MCPStdioTransport do
              | :mcp_protocol_error
              | :mcp_response_exceeded
              | :mcp_timeout
+             | :mcp_transport_busy
              | :mcp_transport_error}
   def request(
         %__MODULE__{pid: pid},
@@ -86,6 +86,7 @@ defmodule PtcRunner.Kernel.MCPStdioTransport do
              | :mcp_protocol_error
              | :mcp_response_exceeded
              | :mcp_timeout
+             | :mcp_transport_busy
              | :mcp_transport_error}
   def request_exchange(
         %__MODULE__{pid: pid},
@@ -139,7 +140,6 @@ defmodule PtcRunner.Kernel.MCPStdioTransport do
          next_ack_id: 1,
          pending: %{},
          monitors: %{},
-         cancelled: MapSet.new(),
          writes: :queue.new(),
          controls: :queue.new(),
          writing: nil,
@@ -179,7 +179,7 @@ defmodule PtcRunner.Kernel.MCPStdioTransport do
         %{pending: pending} = state
       )
       when map_size(pending) >= @max_pending_requests,
-      do: {:reply, {:error, :mcp_transport_error}, state}
+      do: {:reply, {:error, :mcp_transport_busy}, state}
 
   def handle_call(
         {:request, method, params, metadata, max_bytes, timeout_ms, exchange?},
@@ -758,6 +758,8 @@ defmodule PtcRunner.Kernel.MCPStdioTransport do
   defp consume_response(id, response, bytes, state) do
     case Map.fetch(state.pending, id) do
       {:ok, %{sent?: true} = pending} ->
+        state = %{state | unscoped_notification_bytes: 0}
+
         result =
           if pending.response_bytes + bytes <= pending.max_bytes do
             if pending.exchange?,
@@ -773,8 +775,8 @@ defmodule PtcRunner.Kernel.MCPStdioTransport do
         {:error, :mcp_protocol_error, state}
 
       :error ->
-        if MapSet.member?(state.cancelled, id),
-          do: {:ok, %{state | cancelled: MapSet.delete(state.cancelled, id)}},
+        if id < state.next_id,
+          do: charge_unscoped_bytes(state, bytes),
           else: {:error, :mcp_protocol_error, state}
     end
   end
@@ -793,12 +795,16 @@ defmodule PtcRunner.Kernel.MCPStdioTransport do
         {:ok, state}
 
       :unscoped ->
-        bytes = state.unscoped_notification_bytes + bytes
-
-        if bytes <= @max_response_bytes,
-          do: {:ok, %{state | unscoped_notification_bytes: bytes}},
-          else: {:error, :mcp_response_exceeded, state}
+        charge_unscoped_bytes(state, bytes)
     end
+  end
+
+  defp charge_unscoped_bytes(state, frame_bytes) do
+    bytes = state.unscoped_notification_bytes + frame_bytes
+
+    if bytes <= @max_response_bytes,
+      do: {:ok, %{state | unscoped_notification_bytes: bytes}},
+      else: {:error, :mcp_response_exceeded, state}
   end
 
   defp notification_request_id(
@@ -822,7 +828,6 @@ defmodule PtcRunner.Kernel.MCPStdioTransport do
 
         if sent? do
           state
-          |> remember_cancelled(id)
           |> enqueue_write(nil, encode_cancellation(id), write_timeout_ms)
         else
           %{state | writes: reject_write(state.writes, id)}
@@ -838,19 +843,6 @@ defmodule PtcRunner.Kernel.MCPStdioTransport do
     |> :queue.to_list()
     |> Enum.reject(&(&1.request_id == id))
     |> :queue.from_list()
-  end
-
-  defp remember_cancelled(state, id) do
-    cancelled =
-      if MapSet.size(state.cancelled) >= @max_cancelled_requests do
-        state.cancelled
-        |> Enum.min()
-        |> then(&MapSet.delete(state.cancelled, &1))
-      else
-        state.cancelled
-      end
-
-    %{state | cancelled: MapSet.put(cancelled, id)}
   end
 
   defp writing_request?(%{writing: %{request_id: id}}, id) when is_integer(id), do: true

--- a/lib/ptc_runner/kernel/private_directory.ex
+++ b/lib/ptc_runner/kernel/private_directory.ex
@@ -1,0 +1,455 @@
+defmodule PtcRunner.Kernel.PrivateDirectory do
+  @moduledoc false
+
+  @temporary_prefix ".ptc-private-"
+  @temporary_random_bytes 6
+
+  @type error ::
+          :private_directory_unsupported
+          | :private_directory_unavailable
+          | :private_directory_parent_unavailable
+          | :private_directory_parent_unsafe
+          | :private_directory_creation_failed
+
+  @spec anchor(binary()) :: {:ok, binary()} | {:error, :private_directory_parent_unavailable}
+  def anchor(path) when is_binary(path) do
+    case Path.type(path) do
+      :absolute ->
+        {:ok, path}
+
+      :relative ->
+        case File.cwd() do
+          {:ok, cwd} -> anchor(path, cwd)
+          {:error, _reason} -> {:error, :private_directory_parent_unavailable}
+        end
+
+      _other ->
+        {:error, :private_directory_parent_unavailable}
+    end
+  rescue
+    _exception -> {:error, :private_directory_parent_unavailable}
+  end
+
+  def anchor(_path), do: {:error, :private_directory_parent_unavailable}
+
+  @doc false
+  @spec anchor(binary(), binary() | nil) ::
+          {:ok, binary()} | {:error, :private_directory_parent_unavailable}
+  def anchor(path, cwd) when is_binary(path) do
+    case Path.type(path) do
+      :absolute ->
+        {:ok, path}
+
+      :relative when is_binary(cwd) ->
+        {:ok, Path.join(cwd, path)}
+
+      _other ->
+        {:error, :private_directory_parent_unavailable}
+    end
+  rescue
+    _exception -> {:error, :private_directory_parent_unavailable}
+  end
+
+  def anchor(_path, _cwd), do: {:error, :private_directory_parent_unavailable}
+
+  @doc false
+  @spec casefold_name(binary()) :: binary()
+  def casefold_name(name) when is_binary(name) do
+    name
+    |> String.normalize(:nfc)
+    |> String.to_charlist()
+    |> :string.casefold()
+    |> :unicode.characters_to_binary()
+    |> String.normalize(:nfc)
+  end
+
+  @doc false
+  @spec temporary_sibling(binary(), binary()) :: {binary(), binary()}
+  def temporary_sibling(path, leaf) when is_binary(path) and is_binary(leaf) do
+    directory =
+      Path.join(
+        Path.dirname(path),
+        @temporary_prefix <>
+          Base.encode16(:crypto.strong_rand_bytes(@temporary_random_bytes), case: :lower)
+      )
+
+    {directory, Path.join(directory, leaf)}
+  end
+
+  @spec preflight(binary()) :: :ok | {:error, error()}
+  def preflight(path) when is_binary(path) do
+    result =
+      with {:ok, executables} <- creation_executables(),
+           do: preflight_creation_with(path, executables.id)
+
+    case result do
+      {:ok, _uid} -> :ok
+      {:error, _reason} = error -> error
+    end
+  end
+
+  def preflight(_path), do: {:error, :private_directory_parent_unavailable}
+
+  @doc false
+  @spec preflight_owner(binary()) :: {:ok, non_neg_integer()} | {:error, error()}
+  def preflight_owner(path) when is_binary(path) do
+    with {:ok, id} <- authority_executable(),
+         do: preflight_owner_with(path, id)
+  end
+
+  def preflight_owner(_path), do: {:error, :private_directory_parent_unavailable}
+
+  @doc false
+  @spec preflight_writable_parent(binary()) :: :ok | {:error, error()}
+  def preflight_writable_parent(path) when is_binary(path) do
+    with {:ok, id} <- authority_executable(),
+         {:ok, uid} <- read_authority_uid(id),
+         {:ok, groups} <- read_authority_groups(id),
+         {:ok, path} <- anchor(path),
+         :ok <- safe_parent_hierarchy(path, uid),
+         {:ok, %File.Stat{type: :directory} = parent} <-
+           File.stat(Path.dirname(path), time: :posix),
+         :ok <- writable_directory(parent, uid, groups) do
+      :ok
+    else
+      {:error, reason}
+      when reason in [
+             :private_directory_unsupported,
+             :private_directory_unavailable
+           ] ->
+        {:error, reason}
+
+      _unavailable_or_unwritable ->
+        {:error, :private_directory_parent_unavailable}
+    end
+  rescue
+    _exception -> {:error, :private_directory_parent_unavailable}
+  end
+
+  def preflight_writable_parent(_path),
+    do: {:error, :private_directory_parent_unavailable}
+
+  @doc false
+  @spec preflight_writable_file(binary()) :: :ok | {:error, error()}
+  def preflight_writable_file(path) when is_binary(path) do
+    with {:ok, id} <- authority_executable(),
+         {:ok, uid} <- read_authority_uid(id),
+         {:ok, groups} <- read_authority_groups(id) do
+      preflight_writable_file(path, %{uid: uid, groups: groups})
+    end
+  rescue
+    _exception -> {:error, :private_directory_parent_unavailable}
+  end
+
+  def preflight_writable_file(_path),
+    do: {:error, :private_directory_parent_unavailable}
+
+  @doc false
+  @spec preflight_writable_file(binary(), %{uid: non_neg_integer(), groups: MapSet.t()}) ::
+          :ok | {:error, error()}
+  def preflight_writable_file(path, %{uid: uid, groups: %MapSet{} = groups})
+      when is_binary(path) and is_integer(uid) and uid >= 0 do
+    with {:ok, path} <- anchor(path),
+         {:ok, %File.Stat{type: :regular} = file} <- File.stat(path, time: :posix),
+         :ok <- writable_file(file, uid, groups) do
+      :ok
+    else
+      _unavailable_or_unwritable ->
+        {:error, :private_directory_parent_unavailable}
+    end
+  rescue
+    _exception -> {:error, :private_directory_parent_unavailable}
+  end
+
+  def preflight_writable_file(_path, _authority),
+    do: {:error, :private_directory_parent_unavailable}
+
+  defp preflight_owner_with(path, id) do
+    with {:ok, uid} <- read_authority_uid(id),
+         {:ok, path} <- anchor(path),
+         :ok <- safe_parent_hierarchy(path, uid) do
+      {:ok, uid}
+    else
+      {:error, reason}
+      when reason in [
+             :private_directory_unsupported,
+             :private_directory_unavailable,
+             :private_directory_parent_unavailable,
+             :private_directory_parent_unsafe
+           ] ->
+        {:error, reason}
+
+      _missing_or_invalid_parent ->
+        {:error, :private_directory_parent_unavailable}
+    end
+  end
+
+  defp preflight_creation_with(path, id) do
+    with {:ok, uid} <- read_authority_uid(id),
+         {:ok, groups} <- read_authority_groups(id),
+         {:ok, path} <- anchor(path),
+         :ok <- safe_parent_hierarchy(path, uid),
+         {:ok, %File.Stat{type: :directory} = parent} <-
+           File.stat(Path.dirname(path), time: :posix),
+         :ok <- writable_directory(parent, uid, groups),
+         :ok <- temporary_sibling_supported(path) do
+      {:ok, uid}
+    else
+      {:error, reason}
+      when reason in [
+             :private_directory_unsupported,
+             :private_directory_unavailable,
+             :private_directory_parent_unavailable,
+             :private_directory_parent_unsafe
+           ] ->
+        {:error, reason}
+
+      _missing_or_invalid_parent ->
+        {:error, :private_directory_parent_unavailable}
+    end
+  end
+
+  @spec create(binary()) :: :ok | {:error, error()}
+  def create(path) when is_binary(path) do
+    with {:ok, executables} <- creation_executables(),
+         {:ok, uid} <- read_authority_uid(executables.id),
+         {:ok, groups} <- read_authority_groups(executables.id),
+         {:ok, path} <- anchor(path),
+         :ok <- safe_parent_hierarchy(path, uid),
+         {:ok, %File.Stat{type: :directory} = parent} <-
+           File.stat(Path.dirname(path), time: :posix),
+         :ok <- writable_directory(parent, uid, groups),
+         :ok <- create_unix(executables.mkdir, path) do
+      verify_created_directory(path, uid)
+    end
+  end
+
+  def create(_path), do: {:error, :private_directory_creation_failed}
+
+  defp authority_executable do
+    case :os.type() do
+      {:unix, _name} ->
+        case System.find_executable("id") do
+          id when is_binary(id) -> {:ok, id}
+          nil -> {:error, :private_directory_unavailable}
+        end
+
+      _other ->
+        {:error, :private_directory_unsupported}
+    end
+  end
+
+  defp creation_executables do
+    with {:ok, id} <- authority_executable(),
+         mkdir when is_binary(mkdir) <- System.find_executable("mkdir") do
+      {:ok, %{mkdir: mkdir, id: id}}
+    else
+      {:error, _reason} = error -> error
+      nil -> {:error, :private_directory_unavailable}
+    end
+  end
+
+  defp create_unix(executable, path) do
+    path = if Path.type(path) == :relative, do: "./" <> path, else: path
+
+    case System.cmd(executable, ["-m", "700", path], stderr_to_stdout: true) do
+      {_output, 0} -> :ok
+      {_output, _status} -> {:error, :private_directory_creation_failed}
+    end
+  rescue
+    _exception -> {:error, :private_directory_creation_failed}
+  end
+
+  defp read_authority_uid(executable) do
+    case System.cmd(executable, ["-u"], stderr_to_stdout: true) do
+      {output, 0} ->
+        case Integer.parse(String.trim(output)) do
+          {uid, ""} when uid >= 0 -> {:ok, uid}
+          _invalid -> {:error, :private_directory_unavailable}
+        end
+
+      {_output, _status} ->
+        {:error, :private_directory_unavailable}
+    end
+  rescue
+    _exception -> {:error, :private_directory_unavailable}
+  end
+
+  defp read_authority_groups(executable) do
+    case System.cmd(executable, ["-G"], stderr_to_stdout: true) do
+      {output, 0} ->
+        groups =
+          output
+          |> String.split()
+          |> Enum.reduce_while({:ok, MapSet.new()}, fn value, {:ok, groups} ->
+            case Integer.parse(value) do
+              {group, ""} when group >= 0 -> {:cont, {:ok, MapSet.put(groups, group)}}
+              _invalid -> {:halt, {:error, :private_directory_unavailable}}
+            end
+          end)
+
+        case groups do
+          {:ok, groups} ->
+            if MapSet.size(groups) > 0,
+              do: {:ok, groups},
+              else: {:error, :private_directory_unavailable}
+
+          _invalid ->
+            {:error, :private_directory_unavailable}
+        end
+
+      {_output, _status} ->
+        {:error, :private_directory_unavailable}
+    end
+  rescue
+    _exception -> {:error, :private_directory_unavailable}
+  end
+
+  defp safe_parent_hierarchy(path, uid) do
+    with :ok <- validate_directory("/", uid) do
+      parent = Path.dirname(path)
+      resolve_components("/", tl(Path.split(parent)), 0, uid)
+    end
+  rescue
+    _exception -> {:error, :private_directory_parent_unavailable}
+  end
+
+  defp resolve_components(_current, _components, hops, _uid) when hops > 40,
+    do: {:error, :private_directory_parent_unavailable}
+
+  defp resolve_components(current, [], _hops, uid) do
+    case File.lstat(current, time: :posix) do
+      {:ok, %File.Stat{type: :directory} = stat} -> safe_directory(stat, uid)
+      _invalid -> {:error, :private_directory_parent_unavailable}
+    end
+  end
+
+  defp resolve_components(current, ["." | rest], hops, uid),
+    do: resolve_components(current, rest, hops, uid)
+
+  defp resolve_components(current, [".." | rest], hops, uid),
+    do: resolve_components(Path.dirname(current), rest, hops, uid)
+
+  defp resolve_components(current, [component | rest], hops, uid) do
+    candidate = Path.join(current, component)
+
+    case File.lstat(candidate, time: :posix) do
+      {:ok, %File.Stat{type: :directory} = stat} ->
+        with :ok <- safe_directory(stat, uid),
+             do: resolve_components(candidate, rest, hops, uid)
+
+      {:ok, %File.Stat{type: :symlink} = stat} ->
+        with :ok <- safe_symlink(stat, uid),
+             {:ok, target} <- File.read_link(candidate),
+             {:ok, target_root, target_components} <- symlink_target(current, target) do
+          resolve_components(target_root, target_components ++ rest, hops + 1, uid)
+        else
+          {:error, reason}
+          when reason in [
+                 :private_directory_parent_unsafe,
+                 :private_directory_parent_unavailable
+               ] ->
+            {:error, reason}
+
+          _error ->
+            {:error, :private_directory_parent_unavailable}
+        end
+
+      _missing_or_invalid ->
+        {:error, :private_directory_parent_unavailable}
+    end
+  end
+
+  defp symlink_target(current, target) do
+    case Path.type(target) do
+      :absolute -> {:ok, "/", tl(Path.split(target))}
+      :relative -> {:ok, current, Path.split(target)}
+      _other -> {:error, :private_directory_parent_unavailable}
+    end
+  end
+
+  defp validate_directory(path, uid) do
+    case File.lstat(path, time: :posix) do
+      {:ok, %File.Stat{type: :directory} = stat} ->
+        safe_directory(stat, uid)
+
+      _invalid ->
+        {:error, :private_directory_parent_unavailable}
+    end
+  end
+
+  # Sticky semantics protect entries owned by this process authority or root,
+  # but not entries owned by a peer. Requiring trusted ownership for symlinks
+  # closes the remaining replacement window in a trusted sticky directory.
+  defp safe_symlink(%File.Stat{uid: owner}, uid) do
+    if owner in [0, uid],
+      do: :ok,
+      else: {:error, :private_directory_parent_unsafe}
+  end
+
+  # Every controlling directory must be owned by this process authority or
+  # root, as well as non-replaceable by group/other writers.
+  defp safe_directory(%File.Stat{uid: owner, mode: mode}, uid) do
+    owner_safe? = owner in [0, uid]
+    mode_safe? = Bitwise.band(mode, 0o022) == 0 or Bitwise.band(mode, 0o1000) != 0
+
+    if owner_safe? and mode_safe?,
+      do: :ok,
+      else: {:error, :private_directory_parent_unsafe}
+  end
+
+  defp writable_directory(stat, uid, groups),
+    do: writable(stat, uid, groups, 0o300, 0o030, 0o003)
+
+  defp writable_file(stat, uid, groups),
+    do: writable(stat, uid, groups, 0o200, 0o020, 0o002)
+
+  # Publication uses a short sibling name independent of the destination
+  # basename. Probe paths of the exact generated lengths so deterministic
+  # NAME_MAX/PATH_MAX failures are caught during read-only preflight.
+  defp temporary_sibling_supported(path) do
+    {directory, artifact} = temporary_sibling(path, "artifact")
+
+    with :ok <- representable_path(directory),
+         do: representable_path(artifact)
+  end
+
+  defp representable_path(path) do
+    case File.lstat(path) do
+      {:ok, _stat} -> :ok
+      {:error, :enoent} -> :ok
+      {:error, _reason} -> {:error, :private_directory_parent_unavailable}
+    end
+  end
+
+  defp writable(
+         %File.Stat{uid: owner, gid: group, mode: mode},
+         uid,
+         groups,
+         owner_mask,
+         group_mask,
+         other_mask
+       ) do
+    mask =
+      cond do
+        owner == uid -> owner_mask
+        MapSet.member?(groups, group) -> group_mask
+        true -> other_mask
+      end
+
+    if Bitwise.band(mode, mask) == mask,
+      do: :ok,
+      else: {:error, :private_directory_parent_unavailable}
+  end
+
+  defp verify_created_directory(path, uid) do
+    case File.lstat(path, time: :posix) do
+      {:ok, %File.Stat{type: :directory, uid: ^uid, mode: mode}}
+      when Bitwise.band(mode, 0o777) == 0o700 ->
+        :ok
+
+      _changed_or_invalid ->
+        {:error, :private_directory_creation_failed}
+    end
+  end
+end

--- a/lib/ptc_runner/kernel/provider_task_tracker.ex
+++ b/lib/ptc_runner/kernel/provider_task_tracker.ex
@@ -18,9 +18,9 @@ defmodule PtcRunner.Kernel.ProviderTaskTracker do
     end
   end
 
-  @spec attach(t(), pid()) :: :ok | {:error, :closed}
+  @spec attach(t(), pid()) :: :ok | {:error, :closed | :provider_down}
   def attach(tracker, provider) when is_pid(provider),
-    do: call(tracker, {:attach, provider})
+    do: safe_call(tracker, {:attach, provider})
 
   @spec close(t()) :: :ok
   def close(%__MODULE__{pid: pid} = tracker) do
@@ -53,7 +53,7 @@ defmodule PtcRunner.Kernel.ProviderTaskTracker do
       ref = Process.monitor(provider)
       {:reply, :ok, put_in(state.providers[ref], provider)}
     else
-      {:reply, {:error, :closed}, state}
+      {:reply, {:error, :provider_down}, state}
     end
   end
 

--- a/lib/ptc_runner/kernel/result_artifact.ex
+++ b/lib/ptc_runner/kernel/result_artifact.ex
@@ -5,15 +5,28 @@ defmodule PtcRunner.Kernel.ResultArtifact do
   A multi-run application passes values between ordinary runs. Scraping them
   from stdout is not good enough: terminal output interleaves with logs, has no
   atomicity, and cannot express that a value must never be published. This
-  writer gives a run one explicit destination instead.
+  writer gives a run one explicit destination instead. Its read-only preflight
+  validates deterministic destination conflicts before provider acquisition
+  or run execution; exclusive publication remains authoritative against races.
 
   Persistence is atomic and refuses to clobber. Content is deterministic
   canonical JSON: the SHA-256 digest of the exact artifact bytes is therefore a
   stable identity for the successful value. Content is written to an exclusive
-  temporary sibling, linked into place, and the temporary removed, so a reader
-  never observes a partial artifact and an existing destination fails rather
-  than being overwritten. A private artifact is restricted to `0600` before
-  any content is written, never after.
+  file inside a mode-0700 temporary sibling directory, linked into place, and
+  the temporary directory is then cleaned up best-effort, so a reader never
+  observes a partial artifact and an existing destination fails rather than
+  being overwritten. Once the link succeeds, cleanup cannot turn the committed
+  publication into a reported failure. A relative destination is anchored once
+  before validation so a VM-wide working-directory change cannot redirect later
+  filesystem operations. A private artifact is restricted to `0600` before any
+  content is written, never after.
+
+  Secure publication is supported on Unix hosts with POSIX-compatible `mkdir`
+  and `id` executables available on `PATH`; persistence fails closed when those
+  authority/mode primitives are unavailable, a physical or lexical ancestor
+  has an untrusted owner, or any ancestor is group/other-writable without
+  sticky-directory protection. Preflight also rejects a final parent whose
+  effective permission class lacks create access.
 
   The private/normal distinction is authority, not formatting. A private result
   may only reach a private destination; the caller decides the class and this
@@ -21,6 +34,7 @@ defmodule PtcRunner.Kernel.ResultArtifact do
   """
 
   alias PtcRunner.Kernel.DeterministicJSON
+  alias PtcRunner.Kernel.PrivateDirectory
 
   @type class :: :normal | :private
 
@@ -42,24 +56,76 @@ defmodule PtcRunner.Kernel.ResultArtifact do
   def persist(path, value, class, destination)
       when is_binary(path) and class in [:normal, :private] and
              destination in [:normal, :private] do
-    with :ok <- compatible(class, destination),
-         :ok <- validate_destination(path),
-         {:ok, encoded} <- encode(value) do
-      persist_new(path, encoded, destination)
-    end
+    persist(path, value, class, destination, nil)
   end
 
   def persist(_path, _value, _class, _destination), do: {:error, :invalid_result_destination}
 
+  @doc false
+  @spec persist(binary(), term(), class(), class(), nil | (atom() -> term())) ::
+          :ok | {:error, error()}
+  def persist(path, value, class, destination, fault_hook)
+      when is_binary(path) and class in [:normal, :private] and
+             destination in [:normal, :private] and
+             (is_nil(fault_hook) or is_function(fault_hook, 1)) do
+    with :ok <- compatible(class, destination),
+         :ok <- validate_destination(path),
+         {:ok, path} <- anchor_destination(path),
+         :ok <- preflight_anchored(path),
+         {:ok, encoded} <- encode(value) do
+      persist_new(path, encoded, destination, fault_hook)
+    end
+  end
+
+  def persist(_path, _value, _class, _destination, _fault_hook),
+    do: {:error, :invalid_result_destination}
+
+  @doc "Read-only validation of a result destination before run execution."
+  @spec preflight_destination(term(), class(), class()) :: :ok | {:error, error()}
+  def preflight_destination(path, class, destination)
+      when is_binary(path) and class in [:normal, :private] and
+             destination in [:normal, :private] do
+    with :ok <- compatible(class, destination),
+         :ok <- validate_destination(path),
+         {:ok, path} <- anchor_destination(path) do
+      preflight_anchored(path)
+    end
+  end
+
+  def preflight_destination(_path, _class, _destination),
+    do: {:error, :invalid_result_destination}
+
   defp compatible(:private, :normal), do: {:error, :private_result_requires_private_destination}
   defp compatible(_class, _destination), do: :ok
+
+  defp anchor_destination(path) do
+    case PrivateDirectory.anchor(path) do
+      {:ok, path} -> {:ok, path}
+      {:error, _reason} -> {:error, :invalid_result_destination}
+    end
+  end
+
+  defp preflight_anchored(path) do
+    case File.lstat(path) do
+      {:ok, _stat} -> {:error, :result_destination_exists}
+      {:error, :enoent} -> preflight_private_directory(path)
+      {:error, _reason} -> {:error, :invalid_result_destination}
+    end
+  end
 
   defp validate_destination(path) do
     cond do
       path == "" or String.contains?(path, <<0>>) -> {:error, :invalid_result_destination}
       not String.valid?(path) -> {:error, :invalid_result_destination}
-      File.exists?(path) -> {:error, :result_destination_exists}
       true -> :ok
+    end
+  end
+
+  defp preflight_private_directory(path) do
+    case PrivateDirectory.preflight(path) do
+      :ok -> :ok
+      {:error, :private_directory_parent_unavailable} -> {:error, :invalid_result_destination}
+      {:error, _reason} -> {:error, :result_persistence_failed}
     end
   end
 
@@ -83,30 +149,73 @@ defmodule PtcRunner.Kernel.ResultArtifact do
 
   # `File.ln/2` fails when the destination exists, so the no-clobber guarantee
   # survives a race between the check above and the link.
-  defp persist_new(path, encoded, destination) do
-    temporary = path <> ".tmp-" <> Base.encode16(:crypto.strong_rand_bytes(6), case: :lower)
+  defp persist_new(path, encoded, destination, fault_hook) do
+    {temporary_directory, temporary} = PrivateDirectory.temporary_sibling(path, "artifact")
 
-    try do
-      with {:ok, :ok} <- write_temporary(temporary, encoded, destination),
-           :ok <- File.ln(temporary, path) do
-        :ok
-      else
-        {:error, :eexist} -> {:error, :result_destination_exists}
-        {:error, _reason} -> {:error, :result_persistence_failed}
-      end
-    after
-      _ = File.rm(temporary)
+    case PrivateDirectory.create(temporary_directory) do
+      :ok ->
+        persist_created(
+          path,
+          temporary_directory,
+          temporary,
+          encoded,
+          destination,
+          fault_hook
+        )
+
+      {:error, _reason} ->
+        {:error, :result_persistence_failed}
     end
   end
 
-  defp write_temporary(temporary, encoded, destination) do
-    File.open(temporary, [:write, :binary, :exclusive], fn device ->
-      with :ok <- restrict(temporary, destination) do
-        IO.binwrite(device, encoded)
-      end
-    end)
+  defp persist_created(
+         path,
+         temporary_directory,
+         temporary,
+         encoded,
+         destination,
+         fault_hook
+       ) do
+    with {:ok, :ok} <- write_temporary(temporary, encoded, destination, fault_hook),
+         :ok <- File.ln(temporary, path) do
+      :ok
+    else
+      {:error, :eexist} -> {:error, :result_destination_exists}
+      {:error, _reason} -> {:error, :result_persistence_failed}
+    end
+  after
+    _ = File.rm(temporary)
+    _ = File.rmdir(temporary_directory)
+  end
+
+  defp write_temporary(temporary, encoded, destination, fault_hook) do
+    case File.open(temporary, [:write, :binary, :exclusive], fn device ->
+           with :ok <- persistence_fault(fault_hook, :before_restrict),
+                :ok <- restrict(temporary, destination),
+                :ok <- persistence_fault(fault_hook, :before_write) do
+             IO.binwrite(device, encoded)
+           end
+         end) do
+      {:ok, :ok} = success -> success
+      {:ok, {:error, _reason}} -> {:error, :result_persistence_failed}
+      {:error, _reason} = error -> error
+      _unexpected -> {:error, :result_persistence_failed}
+    end
   end
 
   defp restrict(temporary, :private), do: File.chmod(temporary, 0o600)
   defp restrict(_temporary, :normal), do: :ok
+
+  defp persistence_fault(nil, _stage), do: :ok
+
+  defp persistence_fault(fault_hook, stage) do
+    case fault_hook.(stage) do
+      :ok -> :ok
+      _failure -> {:error, :result_persistence_failed}
+    end
+  rescue
+    _exception -> {:error, :result_persistence_failed}
+  catch
+    _kind, _reason -> {:error, :result_persistence_failed}
+  end
 end

--- a/lib/ptc_runner/kernel/run_builder.ex
+++ b/lib/ptc_runner/kernel/run_builder.ex
@@ -6,7 +6,9 @@ defmodule PtcRunner.Kernel.RunBuilder do
   mission bundles, assembles their environments, starts the configured event
   sink, and produces the same `PtcRunner.Kernel.RunConfig` accepted by direct
   Elixir embedding. Frontends should delegate here instead of creating a
-  second manifest, authority, or event path.
+  second manifest, authority, or event path. Relative artifact destinations are
+  anchored once before preflight and the same absolute paths are retained
+  through post-run persistence.
   """
 
   alias PtcRunner.Kernel
@@ -16,6 +18,7 @@ defmodule PtcRunner.Kernel.RunBuilder do
   alias PtcRunner.Kernel.InspectionSink
   alias PtcRunner.Kernel.Manifest
   alias PtcRunner.Kernel.MissionEnvironment
+  alias PtcRunner.Kernel.PrivateDirectory
   alias PtcRunner.Kernel.ProviderRegistry
   alias PtcRunner.Kernel.ProviderResources
   alias PtcRunner.Kernel.Result
@@ -37,11 +40,15 @@ defmodule PtcRunner.Kernel.RunBuilder do
   def build(manifest, registry, opts \\ [])
 
   def build(%Manifest{} = manifest, %ProviderRegistry{} = registry, opts) when is_list(opts) do
-    input_class = Keyword.get(opts, :input_class, :normal)
+    with {:ok, opts} <- anchor_artifact_options(opts),
+         :ok <- preflight_inspection(opts),
+         :ok <- preflight_artifact_destinations(opts) do
+      input_class = Keyword.get(opts, :input_class, :normal)
 
-    case providers(manifest, registry, input_class) do
-      {:ok, providers} -> build_with_providers(manifest, providers, opts)
-      {:error, _reason} = error -> error
+      case providers(manifest, registry, input_class, opts) do
+        {:ok, providers} -> build_with_providers(manifest, providers, opts)
+        {:error, _reason} = error -> error
+      end
     end
   end
 
@@ -184,13 +191,15 @@ defmodule PtcRunner.Kernel.RunBuilder do
     end)
   end
 
-  defp providers(manifest, registry, input_class)
+  defp providers(manifest, registry, input_class, opts)
        when input_class in [:normal, :private_inspection] do
     with {:ok, prepared} <- prepare_providers(manifest, registry),
          :ok <- validate_provider_dependencies(prepared),
          :ok <- validate_single_workflow_llm(prepared),
          effective_class <- effective_data_class(input_class, prepared),
          :ok <- providers_accept(prepared, effective_class),
+         :ok <- preflight_trace(manifest.events.policy, effective_class, opts),
+         :ok <- preflight_result(manifest.events.policy, effective_class, opts),
          {:ok, preflighted} <- preflight_providers(prepared),
          {:ok, credentials} <-
            ProviderRegistry.resolve_credentials(registry, credential_names(prepared)),
@@ -206,7 +215,7 @@ defmodule PtcRunner.Kernel.RunBuilder do
     end
   end
 
-  defp providers(_manifest, _registry, _input_class), do: {:error, :invalid_input_class}
+  defp providers(_manifest, _registry, _input_class, _opts), do: {:error, :invalid_input_class}
 
   defp sort_snapshots(snapshots), do: Enum.sort_by(snapshots, &Map.get(&1, "provider", ""))
 
@@ -502,21 +511,75 @@ defmodule PtcRunner.Kernel.RunBuilder do
   default for one construction.
   """
   def load_and_build(path, registry, opts \\ []) do
+    case load_and_build_with_options(path, registry, opts) do
+      {:ok, built, _anchored_opts} -> {:ok, built}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp load_and_build_with_options(path, registry, opts) do
     installed_limits = Keyword.get(opts, :installed_limits, registry.installed_limits)
 
     with {:ok, manifest} <- Manifest.load(path, installed_limits),
          {:ok, manifest, input_class} <- maybe_override_input(manifest, opts),
          {:ok, manifest, override} <- maybe_override_component(manifest, opts),
-         :ok <- preflight_inspection(opts) do
-      build(
-        manifest,
-        registry,
-        opts
-        |> Keyword.put(:input_class, input_class)
-        |> Keyword.put(:component_overrides, List.wrap(override))
-      )
+         {:ok, opts} <- anchor_artifact_options(opts),
+         {:ok, built} <-
+           build(
+             manifest,
+             registry,
+             opts
+             |> Keyword.put(:input_class, input_class)
+             |> Keyword.put(:component_overrides, List.wrap(override))
+           ) do
+      {:ok, built, opts}
     end
   end
+
+  defp anchor_artifact_options(opts) do
+    case artifact_anchor_cwd(opts) do
+      {:ok, cwd} ->
+        anchor_artifact_options([:trace, :inspect, :output, :private_output], opts, cwd)
+
+      {:error, _reason} ->
+        invalid_artifact_destination()
+    end
+  end
+
+  defp anchor_artifact_options([], opts, _cwd), do: {:ok, opts}
+
+  defp anchor_artifact_options([key | rest], opts, cwd) do
+    case anchor_artifact_option(opts, key, cwd) do
+      {:ok, opts} -> anchor_artifact_options(rest, opts, cwd)
+      {:error, _reason} -> invalid_artifact_destination()
+    end
+  end
+
+  defp anchor_artifact_option(opts, key, cwd) do
+    case Keyword.fetch(opts, key) do
+      {:ok, path} when is_binary(path) ->
+        with {:ok, path} <- PrivateDirectory.anchor(path, cwd),
+             do: {:ok, Keyword.put(opts, key, path)}
+
+      _missing_or_invalid ->
+        {:ok, opts}
+    end
+  end
+
+  defp artifact_anchor_cwd(opts) do
+    relative? =
+      Enum.any?([:trace, :inspect, :output, :private_output], fn key ->
+        case Keyword.fetch(opts, key) do
+          {:ok, path} when is_binary(path) -> Path.type(path) == :relative
+          _missing_or_invalid -> false
+        end
+      end)
+
+    if relative?, do: File.cwd(), else: {:ok, nil}
+  end
+
+  defp invalid_artifact_destination,
+    do: {:error, {:artifact_preflight_failed, :invalid_destination}}
 
   # Applied after the manifest is loaded and before any bundle is compiled, so
   # the candidate goes through the same dependency, export, signature, and
@@ -553,7 +616,8 @@ defmodule PtcRunner.Kernel.RunBuilder do
 
   # A deterministic destination conflict is reported after manifest and input
   # validation (so a bad output path never masks a more useful error) but
-  # before provider builders — including MCP discovery — or model calls run.
+  # before provider preflight, credential resolution, acquisition, MCP
+  # discovery, or model calls run.
   # The atomic no-clobber creation in `InspectionArtifact.persist/3` remains
   # authoritative for destinations that appear after this check.
   defp preflight_inspection(opts) do
@@ -569,18 +633,91 @@ defmodule PtcRunner.Kernel.RunBuilder do
     end
   end
 
-  defp preflight_trace(sink, opts) do
+  defp preflight_artifact_destinations(opts) do
+    destinations =
+      [:trace, :inspect, :output, :private_output]
+      |> Enum.flat_map(fn key ->
+        case Keyword.fetch(opts, key) do
+          {:ok, path} when is_binary(path) -> [path]
+          _missing_or_invalid -> []
+        end
+      end)
+
+    with {:ok, identities} <- artifact_destination_identities(destinations) do
+      if length(identities) == MapSet.size(MapSet.new(identities)),
+        do: :ok,
+        else: {:error, {:artifact_preflight_failed, :conflicting_destinations}}
+    end
+  end
+
+  defp artifact_destination_identities(destinations) do
+    Enum.reduce_while(destinations, {:ok, []}, fn path, {:ok, identities} ->
+      case artifact_destination_identity(path) do
+        {:ok, identity} -> {:cont, {:ok, [identity | identities]}}
+        {:error, _reason} = error -> {:halt, error}
+      end
+    end)
+  end
+
+  defp artifact_destination_identity(path) do
+    if String.valid?(path) and not String.contains?(path, <<0>>) do
+      parent = Path.dirname(path)
+      basename = path |> Path.basename() |> PrivateDirectory.casefold_name()
+
+      case File.stat(parent, time: :posix) do
+        {:ok,
+         %File.Stat{
+           type: :directory,
+           major_device: major,
+           minor_device: minor,
+           inode: inode
+         }}
+        when is_integer(major) and is_integer(minor) and is_integer(inode) ->
+          {:ok, {:filesystem, major, minor, inode, basename}}
+
+        _unavailable_or_unsupported ->
+          {:ok, {:lexical, PrivateDirectory.casefold_name(path)}}
+      end
+    else
+      {:error, {:artifact_preflight_failed, :invalid_destination}}
+    end
+  rescue
+    _exception -> {:error, {:artifact_preflight_failed, :invalid_destination}}
+  end
+
+  defp preflight_trace(event_policy, provider_class, opts) do
     case Keyword.get(opts, :trace) do
       nil ->
         :ok
 
       path ->
-        private? = result_class(sink) == :private
+        private? = event_policy == :private or provider_class == :private_inspection
 
-        case TraceLog.validate_append_path(path, private?) do
+        case TraceLog.preflight_destination(path, private?) do
           :ok -> :ok
           {:error, reason} -> {:error, {:trace_preflight_failed, reason}}
         end
+    end
+  end
+
+  defp preflight_result(event_policy, provider_class, opts) do
+    class =
+      if event_policy == :private or provider_class == :private_inspection,
+        do: :private,
+        else: :normal
+
+    case result_destination(opts) do
+      {:ok, nil} ->
+        :ok
+
+      {:ok, {path, destination}} ->
+        case ResultArtifact.preflight_destination(path, class, destination) do
+          :ok -> :ok
+          {:error, reason} -> {:error, {:result_preflight_failed, reason}}
+        end
+
+      {:error, reason} ->
+        {:error, {:result_preflight_failed, reason}}
     end
   end
 
@@ -611,17 +748,11 @@ defmodule PtcRunner.Kernel.RunBuilder do
   from the same event sink the run itself used.
   """
   def run_with_class(path, registry, opts \\ []) do
-    with {:ok, built} <- load_and_build(path, registry, opts) do
+    with {:ok, built, opts} <- load_and_build_with_options(path, registry, opts) do
       try do
-        case preflight_trace(built.config.event_sink, opts) do
-          :ok ->
-            case execute_built(built, opts) do
-              {:ok, result} -> {:ok, result, result_class(built.config.event_sink)}
-              other -> other
-            end
-
-          {:error, _reason} = error ->
-            prefer_cleanup_error(error, RunConfig.close_provider_resources(built.config))
+        case execute_built(built, opts) do
+          {:ok, result} -> {:ok, result, result_class(built.config.event_sink)}
+          other -> other
         end
       after
         if built.config.inspection_sink, do: InspectionSink.stop(built.config.inspection_sink)
@@ -809,14 +940,15 @@ defmodule PtcRunner.Kernel.RunBuilder do
 
       path when is_binary(path) ->
         result =
-          with {:ok, identity} <- EventSink.identity(event_sink),
+          with {:ok, path} <- anchor_inspection_path(path),
+               {:ok, identity} <- EventSink.identity(event_sink),
                {:ok, inspection_sink} <-
                  InspectionSink.start(
                    run_id: identity.run_id,
                    trace_id: identity.trace_id,
                    schema_version: 2
                  ) do
-            {:ok, inspection_sink, Path.expand(path)}
+            {:ok, inspection_sink, path}
           end
 
         if match?({:error, _reason}, result), do: EventSink.stop(event_sink)
@@ -825,6 +957,13 @@ defmodule PtcRunner.Kernel.RunBuilder do
       _path ->
         EventSink.stop(event_sink)
         {:error, :invalid_inspection_path}
+    end
+  end
+
+  defp anchor_inspection_path(path) do
+    case PrivateDirectory.anchor(path) do
+      {:ok, path} -> {:ok, path}
+      {:error, _reason} -> {:error, :invalid_inspection_path}
     end
   end
 

--- a/lib/ptc_runner/kernel/run_state.ex
+++ b/lib/ptc_runner/kernel/run_state.ex
@@ -105,18 +105,28 @@ defmodule PtcRunner.Kernel.RunState do
   def reserve_capability(state, environment, name),
     do: call(state, {:reserve_capability, environment, name})
 
-  @spec attach_provider(t(), pid()) :: :ok | {:error, :closed}
+  @spec attach_provider(t(), pid()) :: :ok | {:error, :closed | :provider_down}
   @doc "Attaches the caller's live provider process to its capability reservation."
   def attach_provider(%__MODULE__{} = state, provider) when is_pid(provider) do
-    with :ok <- ProviderTaskTracker.attach(state.provider_tracker, provider) do
-      case call(state, {:attach_provider, provider}) do
-        :ok ->
-          :ok
+    case ProviderTaskTracker.attach(state.provider_tracker, provider) do
+      :ok ->
+        case call(state, {:attach_provider, provider}) do
+          :ok ->
+            :ok
 
-        {:error, :closed} = error ->
-          Process.exit(provider, :kill)
-          error
-      end
+          {:error, :closed} = error ->
+            Process.exit(provider, :kill)
+            error
+        end
+
+      {:error, :closed} = error ->
+        Process.exit(provider, :kill)
+        _ = release_provider_slot(state)
+        error
+
+      {:error, :provider_down} = error ->
+        _ = release_provider_slot(state)
+        error
     end
   end
 
@@ -276,19 +286,24 @@ defmodule PtcRunner.Kernel.RunState do
   end
 
   def handle_call({token, {:attach_provider, provider}}, {caller, _tag}, %{token: token} = state) do
-    case state.reservations do
-      %{^caller => reservation} ->
-        reservation =
-          reservation
-          |> Map.put(:provider, provider)
-          |> Map.put(:provider_ref, Process.monitor(provider))
+    if unavailable?(state) do
+      Process.exit(provider, :kill)
+      {:reply, {:error, :closed}, release_reservation(state, caller)}
+    else
+      case state.reservations do
+        %{^caller => reservation} ->
+          reservation =
+            reservation
+            |> Map.put(:provider, provider)
+            |> Map.put(:provider_ref, Process.monitor(provider))
 
-        reservations = Map.put(state.reservations, caller, reservation)
-        {:reply, :ok, %{state | reservations: reservations}}
+          reservations = Map.put(state.reservations, caller, reservation)
+          {:reply, :ok, %{state | reservations: reservations}}
 
-      _ ->
-        Process.exit(provider, :kill)
-        {:reply, {:error, :closed}, state}
+        _ ->
+          Process.exit(provider, :kill)
+          {:reply, {:error, :closed}, state}
+      end
     end
   end
 

--- a/lib/ptc_runner/kernel/runner.ex
+++ b/lib/ptc_runner/kernel/runner.ex
@@ -218,7 +218,13 @@ defmodule PtcRunner.Kernel.Runner do
          %Error{
            kind: workflow_error_kind(step.fail.reason),
            reason: step.fail.reason,
-           details: workflow_error_details(step.fail, timeout_ms, config.limits),
+           details:
+             workflow_error_details(
+               step.fail,
+               timeout_ms,
+               config.limits,
+               config.event_sink
+             ),
            usage: RunState.usage(state)
          }}
     end
@@ -433,7 +439,7 @@ defmodule PtcRunner.Kernel.Runner do
 
   defp workflow_error_kind(_reason), do: :workflow_failed
 
-  defp workflow_error_details(%{reason: reason}, timeout_ms, limits)
+  defp workflow_error_details(%{reason: reason}, timeout_ms, limits, _sink)
        when reason in [:timeout, :compile_timeout] do
     limit =
       if timeout_ms == limits.workflow_timeout_ms,
@@ -450,7 +456,19 @@ defmodule PtcRunner.Kernel.Runner do
     }
   end
 
-  defp workflow_error_details(fail, _timeout_ms, _limits),
+  defp workflow_error_details(fail, _timeout_ms, _limits, sink)
+       when not is_nil(sink) do
+    case EventSink.policy(sink) do
+      :normal -> :normal
+      _private_or_unavailable -> :private
+    end
+    |> workflow_error_details_for_class(fail)
+  end
+
+  defp workflow_error_details_for_class(:private, _fail),
+    do: %{message: "private workflow failed"}
+
+  defp workflow_error_details_for_class(:normal, fail),
     do: %{message: String.slice(fail.message || "workflow failed", 0, 4_096)}
 
   defp configuration_error(reason, usage),

--- a/lib/ptc_runner/kernel/trace_log.ex
+++ b/lib/ptc_runner/kernel/trace_log.ex
@@ -31,6 +31,7 @@ defmodule PtcRunner.Kernel.TraceLog do
   alias PtcRunner.Kernel.DeterministicJSON
   alias PtcRunner.Kernel.EventSink
   alias PtcRunner.Kernel.JSONValue
+  alias PtcRunner.Kernel.PrivateDirectory
 
   @default_source_bytes 8_000_000
   @default_result_bytes 1_000_000
@@ -47,15 +48,16 @@ defmodule PtcRunner.Kernel.TraceLog do
   @append_lock_timeout_ms 30_000
   @append_lock_helper ~S"""
   set -eu
-  lock_file=$1
+  lock_kind=$1
+  lock_executable=$2
+  shell=$3
+  lock_file=$4
   lock_body='printf "READY\n"; IFS= read -r command; [ "$command" = X ]; printf "DONE\n"'
-  if command -v lockf >/dev/null 2>&1; then
-    exec lockf -k -t 30 "$lock_file" sh -c "$lock_body"
-  elif command -v flock >/dev/null 2>&1; then
-    exec flock -w 30 "$lock_file" sh -c "$lock_body"
-  else
-    exit 1
-  fi
+  case "$lock_kind" in
+    lockf) exec "$lock_executable" -k -t 30 "$lock_file" "$shell" -c "$lock_body" ;;
+    flock) exec "$lock_executable" -w 30 "$lock_file" "$shell" -c "$lock_body" ;;
+    *) exit 1 ;;
+  esac
   """
   @bound_publication_helper ~S"""
   set -eu
@@ -218,26 +220,31 @@ defmodule PtcRunner.Kernel.TraceLog do
 
   @doc """
   Appends canonical events to one admin-selected JSONL file under a total byte
-  cap. `private: true` restricts the empty/new or existing file to mode `0600`
-  before event bytes are appended. An OS-released advisory lease keyed by the
-  existing file's device and inode serializes hard-link aliases across BEAM
-  processes and separate local runtimes.
+  cap. `private: true` requires safe parent ancestry and a mode-`0600` file,
+  owned by the current process authority or root, creating a missing file
+  privately before publication. The permission-checked descriptor is retained
+  through validation and append so pathname replacement cannot redirect private
+  bytes. One OS-released advisory lease keyed by the parent-directory/name
+  identity remains held across first-file creation. A nested device/inode lease
+  serializes hard-link aliases. The fixed path-then-inode acquisition order
+  applies across BEAM processes and separate local runtimes.
   """
   @spec append_jsonl(binary(), [map()], keyword()) :: :ok | {:error, atom()}
   def append_jsonl(path, events, opts \\ [])
 
   def append_jsonl(path, events, opts)
       when is_binary(path) and is_list(events) and is_list(opts) do
-    with true <- Keyword.keys(opts) -- [:max_source_bytes, :private] == [],
+    with true <- Keyword.keys(opts) -- [:max_source_bytes, :private, :append_hook] == [],
          max_bytes when is_integer(max_bytes) and max_bytes > 0 <-
            Keyword.get(opts, :max_source_bytes, @default_source_bytes),
          private? when is_boolean(private?) <- Keyword.get(opts, :private, false),
-         :ok <- validate_append_path(path, private?) do
-      path = Path.expand(path)
-
+         append_hook when is_nil(append_hook) or is_function(append_hook, 1) <-
+           Keyword.get(opts, :append_hook),
+         :ok <- validate_append_path(path, private?),
+         {:ok, path} <- PrivateDirectory.anchor(path) do
       :global.trans({{__MODULE__, {:append, path}}, self()}, fn ->
         with_append_lock(path, fn ->
-          append_locked(path, normalize(events), max_bytes, private?)
+          append_locked(path, normalize(events), max_bytes, private?, append_hook)
         end)
       end)
     else
@@ -271,16 +278,41 @@ defmodule PtcRunner.Kernel.TraceLog do
 
   def validate_append_path(_path, _private?), do: {:error, :invalid_trace_path}
 
+  @doc false
+  @spec preflight_destination(term(), term()) :: :ok | {:error, atom()}
+  def preflight_destination(path, private?)
+      when is_binary(path) and is_boolean(private?) do
+    with :ok <- validate_append_path(path, private?),
+         {:ok, path} <- PrivateDirectory.anchor(path),
+         :ok <- preflight_trace_destination(path, private?),
+         :ok <- preflight_append_lock() do
+      :ok
+    else
+      {:error, reason} when is_atom(reason) -> {:error, reason}
+    end
+  end
+
+  def preflight_destination(_path, _private?), do: {:error, :invalid_trace_path}
+
+  @doc false
+  @spec append_lock_identity(binary()) :: {:ok, term()} | {:error, :source_unavailable}
+  def append_lock_identity(path) when is_binary(path) do
+    with {:ok, path} <- PrivateDirectory.anchor(path),
+         do: append_path_lock_scope(path)
+  end
+
+  def append_lock_identity(_path), do: {:error, :source_unavailable}
+
   defp with_append_lock(path, callback, attempts \\ 3)
 
   defp with_append_lock(_path, _callback, 0), do: {:error, :source_unavailable}
 
   defp with_append_lock(path, callback, attempts) do
-    with {:ok, scope} <- append_lock_scope(path),
+    with {:ok, scope} <- append_path_lock_scope(path),
          {:ok, port} <- start_append_lock(scope) do
       result =
         try do
-          case append_lock_scope(path) do
+          case append_path_lock_scope(path) do
             {:ok, ^scope} -> callback.()
             _changed -> :retry_append_lock
           end
@@ -298,18 +330,26 @@ defmodule PtcRunner.Kernel.TraceLog do
 
   defp start_append_lock(scope) do
     with {:ok, lock_root} <- append_lock_root(),
-         executable when is_binary(executable) <- System.find_executable("sh"),
+         {:ok, shell, lock_kind, lock_executable} <- append_lock_executables(),
          lock_file = Path.join(lock_root, append_lock_name(scope)),
          port <-
            Port.open(
-             {:spawn_executable, executable},
+             {:spawn_executable, shell},
              [
                :binary,
                :exit_status,
                :use_stdio,
                :stderr_to_stdout,
                {:line, 64},
-               args: ["-c", @append_lock_helper, "ptc-trace-append-lock", lock_file]
+               args: [
+                 "-c",
+                 @append_lock_helper,
+                 "ptc-trace-append-lock",
+                 Atom.to_string(lock_kind),
+                 lock_executable,
+                 shell,
+                 lock_file
+               ]
              ]
            ),
          :ok <- await_append_lock(port) do
@@ -319,6 +359,27 @@ defmodule PtcRunner.Kernel.TraceLog do
     end
   rescue
     _exception -> {:error, :source_unavailable}
+  end
+
+  defp append_lock_executables do
+    case System.find_executable("sh") do
+      shell when is_binary(shell) ->
+        cond do
+          lockf = System.find_executable("lockf") -> {:ok, shell, :lockf, lockf}
+          flock = System.find_executable("flock") -> {:ok, shell, :flock, flock}
+          true -> {:error, :source_unavailable}
+        end
+
+      nil ->
+        {:error, :source_unavailable}
+    end
+  end
+
+  defp preflight_append_lock do
+    with {:ok, _root} <- append_lock_root(),
+         {:ok, _shell, _lock_kind, _lock_executable} <- append_lock_executables() do
+      :ok
+    end
   end
 
   defp await_append_lock(port) do
@@ -364,7 +425,50 @@ defmodule PtcRunner.Kernel.TraceLog do
     end
   end
 
-  defp append_lock_scope(path) do
+  defp append_path_lock_scope(path) do
+    case File.stat(Path.dirname(path), time: :posix) do
+      {:ok,
+       %File.Stat{
+         type: :directory,
+         major_device: major,
+         minor_device: minor,
+         inode: inode
+       }} ->
+        name = path |> Path.basename() |> PrivateDirectory.casefold_name()
+        {:ok, {:path, major, minor, inode, name}}
+
+      _ ->
+        {:error, :source_unavailable}
+    end
+  end
+
+  defp with_inode_append_lock(path, callback, attempts \\ 3)
+
+  defp with_inode_append_lock(_path, _callback, 0),
+    do: {:error, :source_unavailable}
+
+  defp with_inode_append_lock(path, callback, attempts) do
+    with {:ok, scope, _stat} <- append_inode_lock_scope(path),
+         {:ok, port} <- start_append_lock(scope) do
+      result =
+        try do
+          case append_inode_lock_scope(path) do
+            {:ok, ^scope, locked_stat} -> callback.(locked_stat)
+            _changed -> :retry_inode_append_lock
+          end
+        after
+          release_append_lock(port)
+        end
+
+      if result == :retry_inode_append_lock,
+        do: with_inode_append_lock(path, callback, attempts - 1),
+        else: result
+    else
+      _ -> {:error, :source_unavailable}
+    end
+  end
+
+  defp append_inode_lock_scope(path) do
     case File.lstat(path) do
       {:ok,
        %File.Stat{
@@ -372,25 +476,8 @@ defmodule PtcRunner.Kernel.TraceLog do
          major_device: major,
          minor_device: minor,
          inode: inode
-       }} ->
-        {:ok, {:inode, major, minor, inode}}
-
-      {:error, :enoent} ->
-        parent = Path.dirname(path)
-
-        case File.lstat(parent) do
-          {:ok,
-           %File.Stat{
-             type: :directory,
-             major_device: major,
-             minor_device: minor,
-             inode: inode
-           }} ->
-            {:ok, {:new_path, major, minor, inode, Path.basename(path)}}
-
-          _ ->
-            {:error, :source_unavailable}
-        end
+       } = stat} ->
+        {:ok, {:inode, major, minor, inode}, stat}
 
       _ ->
         {:error, :source_unavailable}
@@ -398,12 +485,44 @@ defmodule PtcRunner.Kernel.TraceLog do
   end
 
   defp append_lock_root do
-    root = Path.join(System.tmp_dir!(), "ptc-runner-trace-append-locks")
+    base = Path.join(System.tmp_dir!(), "ptc-runner-trace-append-locks")
 
-    with :ok <- File.mkdir_p(root),
-         :ok <- File.chmod(root, 0o700),
-         {:ok, %File.Stat{type: :directory}} <- File.lstat(root) do
+    with {:ok, uid} <- PrivateDirectory.preflight_owner(base),
+         root = base <> "-" <> Integer.to_string(uid),
+         :ok <- ensure_append_lock_root(root, uid) do
       {:ok, root}
+    else
+      _error -> {:error, :source_unavailable}
+    end
+  end
+
+  defp ensure_append_lock_root(root, uid) do
+    case validate_append_lock_root(root, uid) do
+      :ok ->
+        :ok
+
+      {:error, :enoent} ->
+        case PrivateDirectory.create(root) do
+          :ok -> validate_append_lock_root(root, uid)
+          {:error, _reason} -> validate_append_lock_root(root, uid)
+        end
+
+      {:error, _reason} ->
+        {:error, :source_unavailable}
+    end
+  end
+
+  defp validate_append_lock_root(root, uid) do
+    case File.lstat(root, time: :posix) do
+      {:ok, %File.Stat{type: :directory, uid: ^uid, mode: mode}}
+      when Bitwise.band(mode, 0o777) == 0o700 ->
+        :ok
+
+      {:error, :enoent} ->
+        {:error, :enoent}
+
+      _unsafe_or_unavailable ->
+        {:error, :source_unavailable}
     end
   end
 
@@ -426,8 +545,8 @@ defmodule PtcRunner.Kernel.TraceLog do
     with true <-
            Keyword.keys(opts) -- [:max_source_bytes, :fault_hook, :expected_parent_identity] == [],
          true <- String.valid?(path),
-         true <- Path.basename(path) == Path.basename(Path.expand(path)),
          true <- String.ends_with?(path, ".jsonl") and not reserved_path?(path),
+         {:ok, path} <- PrivateDirectory.anchor(path),
          max_bytes when max_bytes in 1..@default_source_bytes <-
            Keyword.get(opts, :max_source_bytes, @default_source_bytes),
          fault_hook when is_nil(fault_hook) or is_function(fault_hook, 1) <-
@@ -439,7 +558,7 @@ defmodule PtcRunner.Kernel.TraceLog do
          :ok <- publication_fault(fault_hook, :after_validation),
          {:ok, encoded} <- encode_jsonl(normalized, max_bytes),
          :ok <- publication_fault(fault_hook, :after_encoding) do
-      publish_encoded(Path.expand(path), encoded, fault_hook, expected_parent_identity)
+      publish_encoded(path, encoded, fault_hook, expected_parent_identity)
     else
       false ->
         {:error, :invalid_trace_log}
@@ -537,14 +656,27 @@ defmodule PtcRunner.Kernel.TraceLog do
     end
   end
 
-  defp append_locked(path, events, max_bytes, private?) do
-    with :ok <- ensure_trace_file(path, private?),
+  defp append_locked(path, events, max_bytes, true, append_hook),
+    do: append_private_locked(path, events, max_bytes, append_hook)
+
+  defp append_locked(path, events, max_bytes, false, append_hook) do
+    with :ok <- ensure_trace_file(path),
+         :ok <- append_fault(append_hook, :after_file_ready) do
+      with_inode_append_lock(path, fn locked_stat ->
+        append_regular_locked(path, events, max_bytes, locked_stat)
+      end)
+    end
+  end
+
+  defp append_regular_locked(path, events, max_bytes, locked_stat) do
+    with {:ok, current_stat} <- File.lstat(path),
+         :ok <- same_file(locked_stat, current_stat),
          {:ok, existing_source} <- read_regular_file(path, max_bytes),
          {:ok, existing_events} <- decode_jsonl(existing_source),
          {:ok, _events, _source_id} <- validate_loaded(existing_events ++ events, max_bytes),
          encoded = Enum.map_join(events, "", &(Jason.encode!(&1) <> "\n")),
          true <- byte_size(existing_source) + byte_size(encoded) <= max_bytes,
-         :ok <- append_regular_file(path, existing_source, encoded, max_bytes) do
+         :ok <- append_regular_file(path, existing_source, encoded, max_bytes, locked_stat) do
       :ok
     else
       false -> {:error, :source_limit_exceeded}
@@ -552,6 +684,49 @@ defmodule PtcRunner.Kernel.TraceLog do
     end
   rescue
     Jason.EncodeError -> {:error, :malformed_source}
+  end
+
+  defp append_private_locked(path, events, max_bytes, append_hook) do
+    with {:ok, uid} <- private_parent_identity(path),
+         :ok <- ensure_private_trace_file(path, uid, append_hook),
+         :ok <- append_fault(append_hook, :after_file_ready) do
+      with_inode_append_lock(path, fn locked_stat ->
+        append_private_inode_locked(path, events, max_bytes, uid, locked_stat)
+      end)
+    end
+  end
+
+  defp append_private_inode_locked(path, events, max_bytes, uid, locked_stat) do
+    with {:ok, device} <- open_private_trace(path, uid, locked_stat) do
+      try do
+        with {:ok, existing_source} <- read_private_device(device, max_bytes),
+             {:ok, existing_events} <- decode_jsonl(existing_source),
+             {:ok, _events, _source_id} <- validate_loaded(existing_events ++ events, max_bytes),
+             encoded = Enum.map_join(events, "", &(Jason.encode!(&1) <> "\n")),
+             true <- byte_size(existing_source) + byte_size(encoded) <= max_bytes,
+             {:ok, _position} <- :file.position(device, :eof),
+             :ok <- :file.write(device, encoded) do
+          :ok
+        else
+          false -> {:error, :source_limit_exceeded}
+          {:error, _reason} = error -> error
+        end
+      after
+        :file.close(device)
+      end
+    end
+  rescue
+    Jason.EncodeError -> {:error, :malformed_source}
+  end
+
+  defp append_fault(nil, _stage), do: :ok
+  defp append_fault(hook, stage), do: hook.(stage)
+
+  defp read_private_device(device, max_bytes) do
+    case :file.position(device, :bof) do
+      {:ok, 0} -> read_device(device, max_bytes)
+      {:error, _reason} -> {:error, :source_unavailable}
+    end
   end
 
   defp encode_jsonl(events, max_bytes) do
@@ -991,46 +1166,204 @@ defmodule PtcRunner.Kernel.TraceLog do
     _kind, _reason -> {:error, :trace_persistence_failed}
   end
 
-  defp ensure_trace_file(path, private?) do
+  defp ensure_trace_file(path) do
     case File.lstat(path) do
-      {:ok, %File.Stat{type: :regular}} -> restrict_trace_file(path, private?)
+      {:ok, %File.Stat{type: :regular}} -> :ok
       {:ok, %File.Stat{}} -> {:error, :malformed_source}
-      {:error, :enoent} -> create_trace_file(path, private?)
+      {:error, :enoent} -> create_trace_file(path)
       {:error, _reason} -> {:error, :source_unavailable}
     end
   end
 
-  defp create_trace_file(path, private?) do
+  defp create_trace_file(path) do
     case File.write(path, "", [:exclusive]) do
       :ok ->
-        case restrict_trace_file(path, private?) do
-          :ok ->
-            :ok
-
-          {:error, _reason} = error ->
-            File.rm(path)
-            error
-        end
+        :ok
 
       {:error, :eexist} ->
-        ensure_trace_file(path, private?)
+        ensure_trace_file(path)
 
       {:error, _reason} ->
         {:error, :source_unavailable}
     end
   end
 
-  defp restrict_trace_file(path, true) do
-    case File.chmod(path, 0o600) do
+  defp preflight_trace_destination(path, private?) do
+    case File.lstat(path, time: :posix) do
+      {:ok, %File.Stat{type: :regular} = stat} ->
+        if private?,
+          do: preflight_private_trace(path, stat),
+          else: preflight_normal_trace(path)
+
+      {:ok, %File.Stat{}} ->
+        {:error, :invalid_trace_path}
+
+      {:error, :enoent} ->
+        preflight_missing_trace(path, private?)
+
+      {:error, _reason} ->
+        {:error, :trace_destination_unavailable}
+    end
+  end
+
+  defp preflight_missing_trace(path, private?) do
+    case File.lstat(Path.dirname(path)) do
+      {:ok, %File.Stat{type: :directory}} ->
+        if private?, do: private_creation_parent(path), else: normal_creation_parent(path)
+
+      _missing_or_invalid ->
+        {:error, :trace_destination_unavailable}
+    end
+  end
+
+  defp preflight_normal_trace(path) do
+    case PrivateDirectory.preflight_writable_file(path) do
+      :ok ->
+        :ok
+
+      {:error, :private_directory_parent_unavailable} ->
+        {:error, :trace_destination_unavailable}
+
+      {:error, _reason} ->
+        {:error, :source_unavailable}
+    end
+  end
+
+  defp normal_creation_parent(path) do
+    case PrivateDirectory.preflight_writable_parent(path) do
+      :ok ->
+        :ok
+
+      {:error, :private_directory_parent_unavailable} ->
+        {:error, :trace_destination_unavailable}
+
+      {:error, _reason} ->
+        {:error, :source_unavailable}
+    end
+  end
+
+  defp preflight_private_trace(path, %File.Stat{mode: mode, uid: owner}) do
+    with {:ok, uid} <- private_parent_identity(path),
+         true <- owner in [0, uid] and Bitwise.band(mode, 0o777) == 0o600,
+         :ok <- PrivateDirectory.preflight_writable_file(path) do
+      :ok
+    else
+      false -> {:error, :trace_destination_unavailable}
+      {:error, _reason} -> {:error, :trace_destination_unavailable}
+    end
+  end
+
+  defp private_creation_parent(path) do
+    case PrivateDirectory.preflight(path) do
       :ok -> :ok
       {:error, _reason} -> {:error, :source_unavailable}
     end
   end
 
-  defp restrict_trace_file(_path, false), do: :ok
+  defp private_parent_identity(path) do
+    case PrivateDirectory.preflight_owner(path) do
+      {:ok, uid} -> {:ok, uid}
+      {:error, _reason} -> {:error, :source_unavailable}
+    end
+  end
 
-  defp append_regular_file(path, existing_source, encoded, max_bytes) do
+  defp ensure_private_trace_file(path, uid, append_hook) do
+    case File.lstat(path) do
+      {:ok, %File.Stat{type: :regular, mode: mode, uid: owner}}
+      when owner in [0, uid] and Bitwise.band(mode, 0o777) == 0o600 ->
+        :ok
+
+      {:ok, %File.Stat{}} ->
+        {:error, :source_unavailable}
+
+      {:error, :enoent} ->
+        publish_empty_private_trace(path, uid, append_hook)
+
+      {:error, _reason} ->
+        {:error, :source_unavailable}
+    end
+  end
+
+  defp publish_empty_private_trace(path, uid, append_hook) do
+    {temporary_directory, temporary} = PrivateDirectory.temporary_sibling(path, "trace")
+
+    case PrivateDirectory.create(temporary_directory) do
+      :ok ->
+        publish_empty_private_trace_created(
+          path,
+          uid,
+          temporary_directory,
+          temporary,
+          append_hook
+        )
+
+      {:error, _reason} ->
+        {:error, :source_unavailable}
+    end
+  end
+
+  defp publish_empty_private_trace_created(
+         path,
+         uid,
+         temporary_directory,
+         temporary,
+         append_hook
+       ) do
+    with {:ok, :ok} <-
+           File.open(temporary, [:write, :binary, :exclusive], fn _device ->
+             with :ok <- append_fault(append_hook, :before_private_chmod),
+                  do: File.chmod(temporary, 0o600)
+           end),
+         :ok <- File.ln(temporary, path) do
+      :ok
+    else
+      {:error, :eexist} -> ensure_private_trace_file(path, uid, append_hook)
+      {:ok, {:error, _reason}} -> {:error, :source_unavailable}
+      {:error, _reason} -> {:error, :source_unavailable}
+    end
+  after
+    _ = File.rm(temporary)
+    _ = File.rmdir(temporary_directory)
+  end
+
+  defp open_private_trace(path, uid, locked_stat) do
+    case :file.open(String.to_charlist(path), [:read, :append, :binary, :raw]) do
+      {:ok, device} ->
+        case validate_open_private_trace(path, device, uid, locked_stat) do
+          :ok ->
+            {:ok, device}
+
+          {:error, _reason} = error ->
+            :file.close(device)
+            error
+        end
+
+      {:error, _reason} ->
+        {:error, :source_unavailable}
+    end
+  end
+
+  defp validate_open_private_trace(path, device, uid, locked_stat) do
+    with {:ok, file_info} <- :file.read_file_info(device, time: :posix),
+         opened = File.Stat.from_record(file_info),
+         :ok <- same_file(locked_stat, opened),
+         true <-
+           opened.type == :regular and opened.uid in [0, uid] and
+             Bitwise.band(opened.mode, 0o777) == 0o600,
+         {:ok, current} <- File.lstat(path, time: :posix),
+         true <-
+           current.type == :regular and current.uid in [0, uid] and
+             Bitwise.band(current.mode, 0o777) == 0o600,
+         :ok <- same_file(opened, current) do
+      :ok
+    else
+      _changed_or_invalid -> {:error, :source_unavailable}
+    end
+  end
+
+  defp append_regular_file(path, existing_source, encoded, max_bytes, locked_stat) do
     with {:ok, %File.Stat{type: :regular} = expected} <- File.lstat(path),
+         :ok <- same_file(locked_stat, expected),
          true <- expected.size == byte_size(existing_source),
          {:ok, device} <-
            :file.open(String.to_charlist(path), [:read, :append, :binary, :raw]) do
@@ -1803,33 +2136,72 @@ defmodule PtcRunner.Kernel.TraceLog do
   end
 
   defp fit_page(selected, all_items, offset, source_id, query_id, max_result_bytes) do
+    result = page_result(selected, all_items, offset, source_id, query_id)
+
+    cond do
+      byte_size(Jason.encode!(result)) <= max_result_bytes ->
+        {:ok, result}
+
+      selected == [] ->
+        {:error, :result_limit_exceeded}
+
+      true ->
+        context = {all_items, offset, source_id, query_id, max_result_bytes}
+
+        fit_page_prefix(
+          selected,
+          context,
+          1,
+          length(selected) - 1,
+          nil
+        )
+    end
+  end
+
+  defp fit_page_prefix(_selected, _context, lower, upper, best)
+       when lower > upper do
+    if best, do: {:ok, best}, else: {:error, :result_limit_exceeded}
+  end
+
+  defp fit_page_prefix(
+         selected,
+         {all_items, offset, source_id, query_id, max_result_bytes} = context,
+         lower,
+         upper,
+         best
+       ) do
+    count = div(lower + upper, 2)
+    result = page_result(Enum.take(selected, count), all_items, offset, source_id, query_id)
+
+    if byte_size(Jason.encode!(result)) <= max_result_bytes do
+      fit_page_prefix(
+        selected,
+        context,
+        count + 1,
+        upper,
+        result
+      )
+    else
+      fit_page_prefix(
+        selected,
+        context,
+        lower,
+        count - 1,
+        best
+      )
+    end
+  end
+
+  defp page_result(selected, all_items, offset, source_id, query_id) do
     next_offset = offset + length(selected)
     more? = next_offset < length(all_items)
 
-    result = %{
+    %{
       "items" => selected,
       "next_cursor" => if(more?, do: encode_cursor(next_offset, source_id, query_id), else: nil),
       "truncated" => more?,
       "omitted_count" => max(length(all_items) - next_offset, 0)
     }
-
-    case within_result_limit(result, max_result_bytes) do
-      :ok ->
-        {:ok, result}
-
-      {:error, :result_limit_exceeded} when selected != [] ->
-        fit_page(
-          Enum.drop(selected, -1),
-          all_items,
-          offset,
-          source_id,
-          query_id,
-          max_result_bytes
-        )
-
-      {:error, :result_limit_exceeded} ->
-        {:error, :result_limit_exceeded}
-    end
   end
 
   defp encode_cursor(offset, source_id, query_id) do

--- a/lib/ptc_runner/kernel/trace_snapshot.ex
+++ b/lib/ptc_runner/kernel/trace_snapshot.ex
@@ -13,6 +13,7 @@ defmodule PtcRunner.Kernel.TraceSnapshot do
   @default_result_bytes 1_000_000
   @default_directory_entries 4_096
   @default_trace_files 1_024
+  @capture_heap_words 10_000_000
   @operations [:list_runs, :get_run, :list_turns, :counters]
 
   @enforce_keys [:pid, :token]
@@ -40,6 +41,7 @@ defmodule PtcRunner.Kernel.TraceSnapshot do
       :max_result_bytes,
       :max_directory_entries,
       :max_trace_files,
+      :capture_heap_words,
       :capture_hook,
       :listing_hook
     ]
@@ -58,6 +60,8 @@ defmodule PtcRunner.Kernel.TraceSnapshot do
            Keyword.get(opts, :max_directory_entries, @default_directory_entries),
          max_trace_files when max_trace_files in 1..@default_trace_files <-
            Keyword.get(opts, :max_trace_files, @default_trace_files),
+         capture_heap_words when capture_heap_words in 233..@capture_heap_words <-
+           Keyword.get(opts, :capture_heap_words, @capture_heap_words),
          capture_hook when is_nil(capture_hook) or is_function(capture_hook, 0) <-
            Keyword.get(opts, :capture_hook),
          listing_hook when is_nil(listing_hook) or is_function(listing_hook, 0) <-
@@ -67,7 +71,8 @@ defmodule PtcRunner.Kernel.TraceSnapshot do
       case GenServer.start(
              __MODULE__,
              {directory, owner, token, max_source_bytes, max_retained_bytes, max_result_bytes,
-              max_directory_entries, max_trace_files, capture_hook, listing_hook}
+              max_directory_entries, max_trace_files, capture_heap_words, capture_hook,
+              listing_hook}
            ) do
         {:ok, pid} -> {:ok, %__MODULE__{pid: pid, token: token}}
         {:error, {:source_retained_limit_exceeded, _details} = reason} -> {:error, reason}
@@ -132,7 +137,7 @@ defmodule PtcRunner.Kernel.TraceSnapshot do
   @impl GenServer
   def init(
         {directory, owner, token, max_source_bytes, max_retained_bytes, max_result_bytes,
-         max_directory_entries, max_trace_files, capture_hook, listing_hook}
+         max_directory_entries, max_trace_files, capture_heap_words, capture_hook, listing_hook}
       ) do
     owner_ref = Process.monitor(owner)
 
@@ -148,7 +153,7 @@ defmodule PtcRunner.Kernel.TraceSnapshot do
       )
     end
 
-    case capture_for_owner(capture, owner, owner_ref) do
+    case capture_for_owner(capture, owner, owner_ref, capture_heap_words) do
       {:ok, capture, retained_bytes} ->
         {:ok, snapshot_state(capture, retained_bytes, token, owner_ref, max_result_bytes)}
 
@@ -276,12 +281,24 @@ defmodule PtcRunner.Kernel.TraceSnapshot do
     end
   end
 
-  defp capture_for_owner(capture, owner, owner_ref) do
+  defp capture_for_owner(capture, owner, owner_ref, capture_heap_words) do
     reply_alias = Process.alias()
     reply_ref = make_ref()
 
     {worker, worker_ref} =
-      Process.spawn(fn -> send(reply_alias, {reply_ref, capture.()}) end, [:monitor])
+      Process.spawn(
+        fn -> send(reply_alias, {reply_ref, capture.()}) end,
+        [
+          {:max_heap_size,
+           %{
+             size: capture_heap_words,
+             kill: true,
+             error_logger: false,
+             include_shared_binaries: true
+           }},
+          :monitor
+        ]
+      )
 
     receive do
       {^reply_ref, result} ->
@@ -295,6 +312,10 @@ defmodule PtcRunner.Kernel.TraceSnapshot do
       {:DOWN, ^owner_ref, :process, ^owner, _reason} ->
         terminate_capture(worker, worker_ref, reply_alias)
         {:error, :snapshot_unavailable}
+
+      {:DOWN, ^worker_ref, :process, ^worker, :killed} ->
+        Process.unalias(reply_alias)
+        {:error, :source_retained_limit_exceeded}
 
       {:DOWN, ^worker_ref, :process, ^worker, _reason} ->
         Process.unalias(reply_alias)

--- a/lib/ptc_runner/kernel/value_contract.ex
+++ b/lib/ptc_runner/kernel/value_contract.ex
@@ -141,9 +141,7 @@ defmodule PtcRunner.Kernel.ValueContract do
 
   # The validator reports which schema keyword failed and where, but its error
   # struct also carries the offending data. Only the structural path and the
-  # keyword travel out; `detail` is emitted for `:required` alone, whose
-  # argument is a list of schema-declared key names. Every other keyword
-  # reports its name and location and nothing more, so a new keyword cannot
+  # keyword travel out. No validator detail is emitted, so a new keyword cannot
   # start disclosing values by default.
   defp violations(validator, value, branch_index, declared) do
     case JSV.validate(value, validator, cast: false) do

--- a/test/ptc_runner/kernel/core_contract_test.exs
+++ b/test/ptc_runner/kernel/core_contract_test.exs
@@ -196,6 +196,57 @@ defmodule PtcRunner.Kernel.CoreContractTest do
              Dispatcher.dispatch(state, :workflow, environment, "malformed-struct", %{}, 100)
   end
 
+  test "provider death before tracker attachment releases every reserved slot" do
+    {:ok, capability} =
+      Capability.new(
+        name: "tiny-heap",
+        input_schema: @input_schema,
+        callback: fn _ -> {:ok, true} end
+      )
+
+    {:ok, environment} = WorkflowEnvironment.new(capabilities: [capability])
+
+    {:ok, limits} =
+      Limits.new(
+        live_provider_tasks: 1,
+        workflow_capability_calls: 5,
+        workflow_capability_calls_per_name: 5,
+        provider_heap_words: 100
+      )
+
+    {:ok, state} = RunState.start(limits)
+
+    for _attempt <- 1..4 do
+      assert %{status: :error, kind: :provider_error, reason: :provider_exit} =
+               Dispatcher.dispatch(state, :workflow, environment, "tiny-heap", %{}, 100)
+    end
+
+    assert :ok = RunState.reserve_capability(state, :workflow, "tiny-heap")
+    assert :ok = RunState.release_provider_slot(state)
+  end
+
+  test "provider attachment after run closure is rejected and releases its reservation" do
+    {:ok, state} = RunState.start(Limits.defaults())
+    assert :ok = RunState.reserve_capability(state, :workflow, "late-provider")
+    assert :ok = RunState.close(state)
+
+    provider =
+      spawn(fn ->
+        receive do
+          :stop -> :ok
+        end
+      end)
+
+    provider_ref = Process.monitor(provider)
+
+    assert {:error, :closed} = RunState.attach_provider(state, provider)
+    assert_receive {:DOWN, ^provider_ref, :process, ^provider, :killed}, 1_000
+
+    internal = :sys.get_state(state.pid)
+    assert internal.provider_tasks == 0
+    assert internal.reservations == %{}
+  end
+
   test "timed-out provider results cannot consume another callback slot after closure" do
     parent = self()
 
@@ -271,6 +322,32 @@ defmodule PtcRunner.Kernel.CoreContractTest do
     assert :ok = RunState.close_and_drain(state)
     assert_receive {:DOWN, ^provider_ref, :process, ^provider, :killed}
     assert %{closed?: true} = RunState.usage(state)
+  end
+
+  test "provider attachment distinguishes a closed run from an already-dead provider" do
+    {:ok, closed_state} = RunState.start(Limits.defaults())
+    assert :ok = RunState.reserve_capability(closed_state, :workflow, "closed")
+    assert :ok = RunState.close_and_drain(closed_state)
+
+    live_provider =
+      spawn(fn ->
+        receive do
+          :stop -> :ok
+        end
+      end)
+
+    live_ref = Process.monitor(live_provider)
+
+    assert {:error, :closed} = RunState.attach_provider(closed_state, live_provider)
+    assert_receive {:DOWN, ^live_ref, :process, ^live_provider, :killed}
+
+    {:ok, live_state} = RunState.start(Limits.defaults())
+    assert :ok = RunState.reserve_capability(live_state, :workflow, "dead")
+    {dead_provider, dead_ref} = spawn_monitor(fn -> :ok end)
+    assert_receive {:DOWN, ^dead_ref, :process, ^dead_provider, :normal}
+
+    assert {:error, :provider_down} = RunState.attach_provider(live_state, dead_provider)
+    assert :ok = RunState.release_provider_slot(live_state)
   end
 
   test "a dispatching process killed mid-call releases its slot and stops its provider" do
@@ -1161,6 +1238,32 @@ defmodule PtcRunner.Kernel.CoreContractTest do
              Kernel.run(~s|(fail "#{private}")|, config)
 
     refute inspect(error) =~ private
+  end
+
+  test "private workflow evaluator failures expose only fixed diagnostics" do
+    {:ok, workflow} = WorkflowEnvironment.new([])
+    {:ok, mission} = MissionEnvironment.new([])
+    {:ok, limits} = Limits.new()
+    {:ok, sink} = EventSink.start(:private, limits, run_id: "private-workflow-error")
+
+    {:ok, config} =
+      RunConfig.new(
+        workflow_environment: workflow,
+        mission_environment: mission,
+        input: %{},
+        limits: limits,
+        event_sink: sink
+      )
+
+    secret = "PRIVATE_NOT_CALLABLE_VALUE"
+
+    assert {:error,
+            %{
+              kind: :workflow_failed,
+              details: %{message: "private workflow failed"}
+            } = error} = Kernel.run(~s|("#{secret}" 1)|, config)
+
+    refute inspect(error) =~ secret
   end
 
   test "explicit workflow failure exposes only bounded safe taxonomy" do

--- a/test/ptc_runner/kernel/inspection_analysis_profile_test.exs
+++ b/test/ptc_runner/kernel/inspection_analysis_profile_test.exs
@@ -237,6 +237,23 @@ defmodule PtcRunner.Kernel.InspectionAnalysisProfileTest do
   end
 
   @tag :tmp_dir
+  test "private analysis evaluator errors expose only fixed diagnostics", %{tmp_dir: root} do
+    fixture = PrivateInspectionFixture.create!(root)
+    {:ok, session, _info} = start_internal_session(fixture)
+    on_exit(fn -> AnalysisSession.stop(session) end)
+
+    secret = "PRIVATE_ANALYSIS_NOT_CALLABLE"
+
+    assert {:ok,
+            %{
+              status: :error,
+              error: %{message: "private evaluation failed"}
+            } = result} = AnalysisSession.evaluate(session, ~s|("#{secret}" 1)|)
+
+    refute inspect(result) =~ secret
+  end
+
+  @tag :tmp_dir
   test "session owner death closes both captures and persists an aborted canonical trace", %{
     tmp_dir: root
   } do

--- a/test/ptc_runner/kernel/inspection_preflight_test.exs
+++ b/test/ptc_runner/kernel/inspection_preflight_test.exs
@@ -1,9 +1,15 @@
 defmodule PtcRunner.Kernel.InspectionPreflightTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
+  alias PtcRunner.Kernel.Capability
   alias PtcRunner.Kernel.InspectionArtifact
+  alias PtcRunner.Kernel.InspectionSink
+  alias PtcRunner.Kernel.Manifest
+  alias PtcRunner.Kernel.PrivateDirectory
   alias PtcRunner.Kernel.ProviderRegistry
+  alias PtcRunner.Kernel.ResultArtifact
   alias PtcRunner.Kernel.RunBuilder
+  alias PtcRunner.Kernel.TraceLog
 
   describe "InspectionArtifact.preflight_destination/1" do
     @tag :tmp_dir
@@ -36,8 +42,81 @@ defmodule PtcRunner.Kernel.InspectionPreflightTest do
       assert {:error, :inspection_destination_unavailable} =
                InspectionArtifact.preflight_destination(under_file)
 
+      assert {:error, :inspection_destination_unavailable} =
+               InspectionArtifact.preflight_destination(
+                 Path.join([dir, "missing", "run.inspection.jsonl"])
+               )
+
       assert :ok =
                InspectionArtifact.preflight_destination(Path.join(dir, "free.inspection.jsonl"))
+    end
+
+    @tag :tmp_dir
+    test "rejects publication through a replaceable parent directory", %{tmp_dir: dir} do
+      replaceable = Path.join(dir, "replaceable")
+      File.mkdir!(replaceable)
+      File.chmod!(replaceable, 0o777)
+
+      assert {:error, :inspection_persistence_failed} =
+               InspectionArtifact.preflight_destination(
+                 Path.join(replaceable, "run.inspection.jsonl")
+               )
+    end
+
+    @tag :tmp_dir
+    test "rejects a symlink that hides a replaceable physical ancestor", %{tmp_dir: dir} do
+      replaceable = Path.join(dir, "replaceable")
+      protected_child = Path.join(replaceable, "protected")
+      alias_path = Path.join(dir, "alias")
+
+      File.mkdir!(replaceable)
+      File.chmod!(replaceable, 0o777)
+      File.mkdir!(protected_child)
+      File.chmod!(protected_child, 0o700)
+      File.ln_s!(protected_child, alias_path)
+
+      assert {:error, :inspection_persistence_failed} =
+               InspectionArtifact.preflight_destination(
+                 Path.join(alias_path, "run.inspection.jsonl")
+               )
+    end
+
+    @tag :tmp_dir
+    test "resolves parent components after following symlinks", %{tmp_dir: dir} do
+      replaceable = Path.join(dir, "replaceable")
+      protected_child = Path.join(replaceable, "protected")
+      alias_path = Path.join(dir, "alias")
+
+      File.mkdir!(replaceable)
+      File.chmod!(replaceable, 0o777)
+      File.mkdir!(protected_child)
+      File.chmod!(protected_child, 0o700)
+      File.ln_s!(protected_child, alias_path)
+
+      assert {:error, :inspection_persistence_failed} =
+               InspectionArtifact.preflight_destination(
+                 Path.join([alias_path, "..", "run.inspection.jsonl"])
+               )
+    end
+
+    @tag :tmp_dir
+    test "rejects every replaceable controller traversed by a symlink chain", %{tmp_dir: dir} do
+      replaceable = Path.join(dir, "replaceable")
+      protected_child = Path.join(dir, "protected")
+      hop = Path.join(replaceable, "hop")
+      alias_path = Path.join(dir, "alias")
+
+      File.mkdir!(replaceable)
+      File.chmod!(replaceable, 0o777)
+      File.mkdir!(protected_child)
+      File.chmod!(protected_child, 0o700)
+      File.ln_s!(protected_child, hop)
+      File.ln_s!(hop, alias_path)
+
+      assert {:error, :inspection_persistence_failed} =
+               InspectionArtifact.preflight_destination(
+                 Path.join(alias_path, "run.inspection.jsonl")
+               )
     end
   end
 
@@ -93,6 +172,706 @@ defmodule PtcRunner.Kernel.InspectionPreflightTest do
 
       refute match?({:inspection_preflight_failed, _reason}, reason)
     end
+
+    @tag :tmp_dir
+    test "an occupied result destination is rejected before provider acquisition", %{tmp_dir: dir} do
+      parent = self()
+
+      builder = fn _config, _context ->
+        send(parent, :provider_builder_invoked)
+        {:error, :should_not_run}
+      end
+
+      {:ok, registry} = ProviderRegistry.new(%{"probe" => builder})
+
+      manifest_path =
+        write_manifest(dir, %{"workflow" => [%{"name" => "probe", "config" => %{}}]})
+
+      occupied = Path.join(dir, "result.json")
+      File.write!(occupied, "occupied")
+
+      assert {:error, {:result_preflight_failed, :result_destination_exists}} =
+               RunBuilder.run(manifest_path, registry, output: occupied)
+
+      refute_received :provider_builder_invoked
+      assert File.read!(occupied) == "occupied"
+    end
+
+    @tag :tmp_dir
+    test "a result destination with a missing parent is rejected before provider acquisition", %{
+      tmp_dir: dir
+    } do
+      parent = self()
+
+      builder = fn _config, _context ->
+        send(parent, :provider_builder_invoked)
+        {:error, :should_not_run}
+      end
+
+      {:ok, registry} = ProviderRegistry.new(%{"probe" => builder})
+
+      manifest_path =
+        write_manifest(dir, %{"workflow" => [%{"name" => "probe", "config" => %{}}]})
+
+      destination = Path.join([dir, "missing", "result.json"])
+
+      assert {:error, {:result_preflight_failed, :invalid_result_destination}} =
+               RunBuilder.run(manifest_path, registry, output: destination)
+
+      refute_received :provider_builder_invoked
+    end
+
+    @tag :tmp_dir
+    test "colliding artifact destinations are rejected before provider acquisition", %{
+      tmp_dir: dir
+    } do
+      parent = self()
+
+      builder = fn _config, _context ->
+        send(parent, :provider_builder_invoked)
+        {:error, :should_not_run}
+      end
+
+      {:ok, registry} = ProviderRegistry.new(%{"probe" => builder})
+
+      manifest_path =
+        write_manifest(dir, %{"workflow" => [%{"name" => "probe", "config" => %{}}]})
+
+      real_parent = Path.join(dir, "real")
+      alias_parent = Path.join(dir, "alias")
+      File.mkdir!(real_parent)
+      File.ln_s!(real_parent, alias_parent)
+
+      for options <- [
+            [
+              output: Path.join(dir, "same.jsonl"),
+              trace: Path.join(dir, "same.jsonl")
+            ],
+            [
+              output: Path.join(dir, "same.inspection.jsonl"),
+              inspect: Path.join(dir, "same.inspection.jsonl")
+            ],
+            [
+              output: Path.join(real_parent, "same.jsonl"),
+              trace: Path.join(alias_parent, "same.jsonl")
+            ],
+            [
+              output: Path.join(real_parent, "Case.jsonl"),
+              trace: Path.join(real_parent, "case.jsonl")
+            ],
+            [
+              output: Path.join(real_parent, "σ.jsonl"),
+              trace: Path.join(real_parent, "ς.jsonl")
+            ]
+          ] do
+        assert {:error, {:artifact_preflight_failed, :conflicting_destinations}} =
+                 RunBuilder.run(manifest_path, registry, options)
+
+        refute_received :provider_builder_invoked
+      end
+    end
+
+    @tag :tmp_dir
+    test "an inspection destination with a missing parent is rejected before provider acquisition",
+         %{tmp_dir: dir} do
+      parent = self()
+
+      builder = fn _config, _context ->
+        send(parent, :provider_builder_invoked)
+        {:error, :should_not_run}
+      end
+
+      {:ok, registry} = ProviderRegistry.new(%{"probe" => builder})
+
+      manifest_path =
+        write_manifest(dir, %{"workflow" => [%{"name" => "probe", "config" => %{}}]})
+
+      destination = Path.join([dir, "missing", "run.inspection.jsonl"])
+
+      assert {:error, {:inspection_preflight_failed, :inspection_destination_unavailable}} =
+               RunBuilder.run(manifest_path, registry, inspect: destination)
+
+      refute_received :provider_builder_invoked
+    end
+
+    @tag :tmp_dir
+    test "unwritable artifact parents are rejected before provider acquisition", %{tmp_dir: dir} do
+      parent = self()
+
+      builder = fn _config, _context ->
+        send(parent, :provider_builder_invoked)
+        {:error, :should_not_run}
+      end
+
+      {:ok, registry} = ProviderRegistry.new(%{"probe" => builder})
+
+      manifest_path =
+        write_manifest(dir, %{"workflow" => [%{"name" => "probe", "config" => %{}}]})
+
+      unwritable = Path.join(dir, "unwritable")
+      File.mkdir!(unwritable)
+      File.chmod!(unwritable, 0o500)
+      on_exit(fn -> File.chmod(unwritable, 0o700) end)
+
+      cases = [
+        {[output: Path.join(unwritable, "result.json")],
+         {:result_preflight_failed, :invalid_result_destination}},
+        {[inspect: Path.join(unwritable, "run.inspection.jsonl")],
+         {:inspection_preflight_failed, :inspection_destination_unavailable}},
+        {[trace: Path.join(unwritable, "run.jsonl")],
+         {:trace_preflight_failed, :trace_destination_unavailable}}
+      ]
+
+      for {options, reason} <- cases do
+        assert {:error, ^reason} = RunBuilder.run(manifest_path, registry, options)
+        refute_received :provider_builder_invoked
+      end
+    end
+
+    @tag :tmp_dir
+    test "an invalid trace destination is rejected before provider acquisition", %{tmp_dir: dir} do
+      parent = self()
+
+      builder = fn _config, _context ->
+        send(parent, :provider_builder_invoked)
+        {:error, :should_not_run}
+      end
+
+      {:ok, registry} = ProviderRegistry.new(%{"probe" => builder})
+
+      manifest_path =
+        write_manifest(dir, %{"workflow" => [%{"name" => "probe", "config" => %{}}]})
+
+      assert {:error, {:trace_preflight_failed, :normal_trace_requires_normal_suffix}} =
+               RunBuilder.run(manifest_path, registry, trace: Path.join(dir, "run.private.jsonl"))
+
+      refute_received :provider_builder_invoked
+    end
+
+    @tag :tmp_dir
+    test "missing trace lock dependencies are rejected before provider acquisition", %{
+      tmp_dir: dir
+    } do
+      parent = self()
+      original_path = System.get_env("PATH")
+      sh = System.find_executable("sh") || flunk("sh is required for this test")
+      fake_bin = Path.join(dir, "trace-shell-only-bin")
+
+      on_exit(fn ->
+        System.put_env("PATH", original_path)
+      end)
+
+      File.mkdir!(fake_bin)
+      File.ln_s!(sh, Path.join(fake_bin, "sh"))
+      System.put_env("PATH", fake_bin)
+
+      builder = fn _config, _context ->
+        send(parent, :provider_builder_invoked)
+        {:error, :should_not_run}
+      end
+
+      {:ok, registry} = ProviderRegistry.new(%{"probe" => builder})
+
+      manifest_path =
+        write_manifest(dir, %{"workflow" => [%{"name" => "probe", "config" => %{}}]})
+
+      assert {:error, {:trace_preflight_failed, :source_unavailable}} =
+               RunBuilder.run(manifest_path, registry, trace: Path.join(dir, "run.jsonl"))
+
+      refute_received :provider_builder_invoked
+    end
+
+    @tag :tmp_dir
+    test "filesystem-invalid trace destinations are rejected before provider acquisition", %{
+      tmp_dir: dir
+    } do
+      parent = self()
+
+      builder = fn _config, _context ->
+        send(parent, :provider_builder_invoked)
+        {:error, :should_not_run}
+      end
+
+      {:ok, registry} = ProviderRegistry.new(%{"probe" => builder})
+
+      manifest_path =
+        write_manifest(dir, %{"workflow" => [%{"name" => "probe", "config" => %{}}]})
+
+      missing_parent = Path.join([dir, "missing", "run.jsonl"])
+      directory = Path.join(dir, "directory.jsonl")
+      target = Path.join(dir, "target.jsonl")
+      symlink = Path.join(dir, "symlink.jsonl")
+      File.mkdir!(directory)
+      File.write!(target, "")
+      File.ln_s!(target, symlink)
+
+      assert {:error, {:trace_preflight_failed, :trace_destination_unavailable}} =
+               RunBuilder.run(manifest_path, registry, trace: missing_parent)
+
+      refute_received :provider_builder_invoked
+
+      for destination <- [directory, symlink] do
+        assert {:error, {:trace_preflight_failed, :invalid_trace_path}} =
+                 RunBuilder.run(manifest_path, registry, trace: destination)
+
+        refute_received :provider_builder_invoked
+      end
+    end
+
+    @tag :tmp_dir
+    test "direct build applies inspection and cross-artifact preflights before providers", %{
+      tmp_dir: dir
+    } do
+      parent = self()
+
+      prepare = fn _config, _context ->
+        send(parent, :provider_prepared)
+        {:error, :should_not_run}
+      end
+
+      {:ok, registry} =
+        ProviderRegistry.new(%{"probe" => ProviderRegistry.staged(prepare)})
+
+      manifest_path =
+        write_manifest(dir, %{"workflow" => [%{"name" => "probe", "config" => %{}}]})
+
+      {:ok, manifest} = Manifest.load(manifest_path)
+      occupied = Path.join(dir, "occupied.inspection.jsonl")
+      File.write!(occupied, "occupied")
+
+      assert {:error, {:inspection_preflight_failed, :inspection_destination_exists}} =
+               RunBuilder.build(manifest, registry, inspect: occupied)
+
+      refute_received :provider_prepared
+
+      shared = Path.join(dir, "shared.inspection.jsonl")
+
+      assert {:error, {:artifact_preflight_failed, :conflicting_destinations}} =
+               RunBuilder.build(manifest, registry, inspect: shared, output: shared)
+
+      refute_received :provider_prepared
+    end
+
+    @tag :tmp_dir
+    test "a relative result destination keeps its preflight working directory", %{tmp_dir: dir} do
+      original_cwd = File.cwd!()
+      changed_cwd = Path.join(dir, "changed")
+      File.mkdir!(changed_cwd)
+      on_exit(fn -> File.cd!(original_cwd) end)
+
+      {:ok, capability} =
+        Capability.new(
+          name: "probe.unused",
+          input_schema: %{"type" => "object", "additionalProperties" => false},
+          callback: fn _arguments -> {:ok, %{}} end
+        )
+
+      builder = fn _config, _context ->
+        File.cd!(changed_cwd)
+        {:ok, %{capabilities: [capability], snapshot: nil, close: nil}}
+      end
+
+      {:ok, registry} = ProviderRegistry.new(%{"probe" => builder})
+
+      manifest_path =
+        write_manifest(dir, %{"workflow" => [%{"name" => "probe", "config" => %{}}]})
+
+      File.cd!(dir)
+
+      assert {:ok, %{value: 42}} =
+               RunBuilder.run(manifest_path, registry, output: "result.json")
+
+      assert File.regular?(Path.join(dir, "result.json"))
+      refute File.exists?(Path.join(changed_cwd, "result.json"))
+    end
+
+    @tag :tmp_dir
+    test "relative artifact destinations share one captured working directory", %{tmp_dir: dir} do
+      original_cwd = File.cwd!()
+      changed_cwd = Path.join(dir, "changed")
+      File.mkdir!(changed_cwd)
+      on_exit(fn -> File.cd!(original_cwd) end)
+
+      {:ok, capability} =
+        Capability.new(
+          name: "probe.unused",
+          input_schema: %{"type" => "object", "additionalProperties" => false},
+          callback: fn _arguments -> {:ok, %{}} end
+        )
+
+      builder = fn _config, _context ->
+        File.cd!(changed_cwd)
+        {:ok, %{capabilities: [capability], snapshot: nil, close: nil}}
+      end
+
+      {:ok, registry} = ProviderRegistry.new(%{"probe" => builder})
+
+      manifest_path =
+        write_manifest(dir, %{"workflow" => [%{"name" => "probe", "config" => %{}}]})
+
+      File.cd!(dir)
+
+      assert {:ok, %{value: 42}} =
+               RunBuilder.run(manifest_path, registry,
+                 output: "result.json",
+                 trace: "trace.jsonl",
+                 inspect: "run.inspection.jsonl"
+               )
+
+      for name <- ["result.json", "trace.jsonl", "run.inspection.jsonl"] do
+        assert File.regular?(Path.join(dir, name))
+        refute File.exists?(Path.join(changed_cwd, name))
+      end
+    end
+  end
+
+  describe "TraceLog private destination ownership" do
+    @tag :tmp_dir
+    test "accepts an appendable existing private trace in a non-creatable parent", %{
+      tmp_dir: dir
+    } do
+      parent = Path.join(dir, "read-only-parent")
+      path = Path.join(parent, "existing.private.jsonl")
+
+      File.mkdir!(parent)
+      File.write!(path, "")
+      File.chmod!(path, 0o600)
+      File.chmod!(parent, 0o500)
+
+      on_exit(fn -> File.chmod(parent, 0o700) end)
+
+      assert :ok = TraceLog.preflight_destination(path, true)
+    end
+
+    @tag :tmp_dir
+    test "file preflight rejects a trusted-owner trace without authority write access", %{
+      tmp_dir: dir
+    } do
+      path = Path.join(dir, "root-owned.private.jsonl")
+      File.write!(path, "")
+      File.chmod!(path, 0o600)
+
+      foreign_authority = %{
+        uid: current_uid() + 1,
+        groups: MapSet.new([File.stat!(path).gid + 1])
+      }
+
+      assert {:error, :private_directory_parent_unavailable} =
+               PrivateDirectory.preflight_writable_file(path, foreign_authority)
+    end
+
+    @tag :tmp_dir
+    test "preflights an existing private trace without the creation executable", %{
+      tmp_dir: dir
+    } do
+      original_path = System.get_env("PATH")
+      id = System.find_executable("id") || flunk("id is required for this test")
+      sh = System.find_executable("sh") || flunk("sh is required for this test")
+      lock = System.find_executable("lockf") || System.find_executable("flock")
+      lock = lock || flunk("lockf or flock is required for this test")
+      fake_bin = Path.join(dir, "trace-runtime-bin")
+      path = Path.join(dir, "existing.private.jsonl")
+
+      on_exit(fn ->
+        System.put_env("PATH", original_path)
+      end)
+
+      File.mkdir!(fake_bin)
+      File.ln_s!(id, Path.join(fake_bin, "id"))
+      File.ln_s!(sh, Path.join(fake_bin, "sh"))
+      File.ln_s!(lock, Path.join(fake_bin, Path.basename(lock)))
+      File.write!(path, "")
+      File.chmod!(path, 0o600)
+
+      # Initialize and validate the per-authority append-lock directory while
+      # the first-creation executable is still available. The assertion below
+      # then proves that an existing trace and lease root do not need it.
+      assert :ok = TraceLog.preflight_destination(path, true)
+
+      System.put_env("PATH", fake_bin)
+
+      assert :ok = TraceLog.preflight_destination(path, true)
+    end
+
+    @tag :tmp_dir
+    test "rejects a trace destination when no append locking utility is available", %{
+      tmp_dir: dir
+    } do
+      original_path = System.get_env("PATH")
+      sh = System.find_executable("sh") || flunk("sh is required for this test")
+      fake_bin = Path.join(dir, "shell-only-bin")
+
+      on_exit(fn ->
+        System.put_env("PATH", original_path)
+      end)
+
+      File.mkdir!(fake_bin)
+      File.ln_s!(sh, Path.join(fake_bin, "sh"))
+      System.put_env("PATH", fake_bin)
+
+      assert {:error, :source_unavailable} =
+               TraceLog.preflight_destination(Path.join(dir, "run.jsonl"), false)
+    end
+
+    @tag :tmp_dir
+    test "rejects precreated append-lock roots without changing their targets", %{tmp_dir: dir} do
+      uid = current_uid()
+      victim = Path.join(dir, "victim")
+      legacy_root = Path.join(dir, "ptc-runner-trace-append-locks")
+      authority_root = Path.join(dir, "ptc-runner-trace-append-locks-#{uid}")
+
+      File.mkdir!(victim)
+      File.chmod!(victim, 0o755)
+      File.ln_s!(victim, legacy_root)
+      File.ln_s!(victim, authority_root)
+
+      assert "{:error, :source_unavailable}" =
+               trace_preflight_in_fresh_runtime(dir, Path.join(dir, "run.jsonl"))
+
+      assert Bitwise.band(File.stat!(victim).mode, 0o777) == 0o755
+    end
+
+    @tag :tmp_dir
+    test "missing artifact destinations still require the creation executable", %{
+      tmp_dir: dir
+    } do
+      original_path = System.get_env("PATH")
+      id = System.find_executable("id") || flunk("id is required for this test")
+      fake_bin = Path.join(dir, "id-only-creation-bin")
+
+      on_exit(fn ->
+        System.put_env("PATH", original_path)
+      end)
+
+      File.mkdir!(fake_bin)
+      File.ln_s!(id, Path.join(fake_bin, "id"))
+      System.put_env("PATH", fake_bin)
+
+      assert {:error, :result_persistence_failed} =
+               ResultArtifact.preflight_destination(
+                 Path.join(dir, "result.json"),
+                 :normal,
+                 :normal
+               )
+
+      assert {:error, :inspection_persistence_failed} =
+               InspectionArtifact.preflight_destination(Path.join(dir, "run.inspection.jsonl"))
+
+      assert {:error, :source_unavailable} =
+               TraceLog.preflight_destination(
+                 Path.join(dir, "run.private.jsonl"),
+                 true
+               )
+    end
+
+    @tag :tmp_dir
+    test "rejects a mode-0600 trace owned outside the validated process authority", %{
+      tmp_dir: dir
+    } do
+      original_path = System.get_env("PATH")
+      actual_uid = current_uid()
+
+      path =
+        Path.join(
+          "/tmp",
+          "ptc-private-owner-#{System.unique_integer([:positive])}.private.jsonl"
+        )
+
+      on_exit(fn ->
+        System.put_env("PATH", original_path)
+        File.rm(path)
+      end)
+
+      fake_bin = Path.join(dir, "bin")
+      File.mkdir!(fake_bin)
+      fake_id = Path.join(fake_bin, "id")
+      owner_uid = if actual_uid == 0, do: 1, else: actual_uid
+      authority_uid = owner_uid + 1
+      File.write!(fake_id, "#!/bin/sh\nprintf '%s\\n' '#{authority_uid}'\n")
+      File.chmod!(fake_id, 0o755)
+      System.put_env("PATH", fake_bin <> ":" <> original_path)
+
+      File.write!(path, "")
+      File.chmod!(path, 0o600)
+      if actual_uid == 0, do: :ok = :file.change_owner(String.to_charlist(path), owner_uid)
+
+      assert {:error, :trace_destination_unavailable} =
+               TraceLog.preflight_destination(path, true)
+
+      assert {:error, :source_unavailable} =
+               TraceLog.append_jsonl(path, [], private: true)
+    end
+  end
+
+  describe "temporary sibling path bounds" do
+    @tag :tmp_dir
+    test "near-NAME_MAX destinations preflight and publish through every private path", %{
+      tmp_dir: dir
+    } do
+      result_path = Path.join(dir, near_name_limit(".private.json"))
+      inspection_path = Path.join(dir, near_name_limit(".inspection.jsonl"))
+      trace_path = Path.join(dir, near_name_limit(".private.jsonl"))
+
+      {:ok, inspection_sink} =
+        InspectionSink.start(run_id: "long-path-run", trace_id: "long-path-trace")
+
+      assert :ok =
+               InspectionSink.emit(
+                 inspection_sink,
+                 "capability-input",
+                 %{capability_id: "long-path-capability"},
+                 %{environment: :mission, name: "read", arguments: %{}}
+               )
+
+      assert {:ok, inspection_records} = InspectionSink.records(inspection_sink)
+      assert :ok = InspectionSink.stop(inspection_sink)
+
+      canonical_events = [
+        %{
+          run_id: "long-path-run",
+          trace_id: "long-path-trace",
+          type: "capability-started",
+          data: %{
+            capability_id: "long-path-capability",
+            environment: :mission,
+            name: "read"
+          }
+        }
+      ]
+
+      trace_events = [
+        %{
+          "schema_version" => 1,
+          "run_id" => "long-path-run",
+          "trace_id" => "long-path-trace",
+          "sequence" => 1,
+          "timestamp" => "2026-07-28T12:00:00Z",
+          "type" => "run-started",
+          "data" => %{}
+        }
+      ]
+
+      assert :ok =
+               ResultArtifact.preflight_destination(
+                 result_path,
+                 :private,
+                 :private
+               )
+
+      assert :ok =
+               ResultArtifact.persist(
+                 result_path,
+                 %{"ok" => true},
+                 :private,
+                 :private
+               )
+
+      assert :ok = InspectionArtifact.preflight_destination(inspection_path)
+
+      assert :ok =
+               InspectionArtifact.persist(
+                 inspection_path,
+                 inspection_records,
+                 canonical_events
+               )
+
+      assert :ok = TraceLog.preflight_destination(trace_path, true)
+      assert :ok = TraceLog.append_jsonl(trace_path, trace_events, private: true)
+
+      assert Enum.all?([result_path, inspection_path, trace_path], &File.regular?/1)
+    end
+  end
+
+  describe "temporary-directory cleanup authority" do
+    @tag :tmp_dir
+    test "a failed symlink collision cannot delete through any persistence path", %{tmp_dir: dir} do
+      original_path = System.get_env("PATH")
+      original_ln = System.get_env("PTC_TEST_REAL_LN")
+      fake_bin = install_collision_bin!(dir)
+
+      on_exit(fn ->
+        System.put_env("PATH", original_path)
+        System.delete_env("PTC_TEST_COLLISION_TARGET")
+        restore_env("PTC_TEST_REAL_LN", original_ln)
+      end)
+
+      System.put_env("PATH", fake_bin)
+
+      {:ok, inspection_sink} =
+        InspectionSink.start(run_id: "collision-run", trace_id: "collision-trace")
+
+      assert :ok =
+               InspectionSink.emit(
+                 inspection_sink,
+                 "capability-input",
+                 %{capability_id: "collision-capability"},
+                 %{environment: :mission, name: "read", arguments: %{}}
+               )
+
+      assert {:ok, inspection_records} = InspectionSink.records(inspection_sink)
+      assert :ok = InspectionSink.stop(inspection_sink)
+
+      canonical_events = [
+        %{
+          run_id: "collision-run",
+          trace_id: "collision-trace",
+          type: "capability-started",
+          data: %{
+            capability_id: "collision-capability",
+            environment: :mission,
+            name: "read"
+          }
+        }
+      ]
+
+      trace_events = [
+        %{
+          "schema_version" => 1,
+          "run_id" => "collision-run",
+          "trace_id" => "collision-trace",
+          "sequence" => 1,
+          "timestamp" => "2026-07-28T12:00:00Z",
+          "type" => "run-started",
+          "data" => %{}
+        }
+      ]
+
+      cases = [
+        {"result", "artifact",
+         fn path ->
+           ResultArtifact.persist(path, %{"ok" => true}, :private, :private)
+         end},
+        {"inspection", "artifact",
+         fn path ->
+           InspectionArtifact.persist(path, inspection_records, canonical_events)
+         end},
+        {"trace", "trace",
+         fn path ->
+           TraceLog.append_jsonl(path, trace_events, private: true)
+         end}
+      ]
+
+      for {name, leaf, persist} <- cases do
+        target = Path.join(dir, "#{name}-collision-target")
+
+        destination =
+          Path.join(
+            dir,
+            if(name == "trace",
+              do: "#{name}.private.jsonl",
+              else: "#{name}.inspection.jsonl"
+            )
+          )
+
+        File.mkdir!(target)
+        protected = Path.join(target, leaf)
+        File.write!(protected, "must-survive")
+        System.put_env("PTC_TEST_COLLISION_TARGET", target)
+
+        assert {:error, _reason} = persist.(destination)
+        assert File.read!(protected) == "must-survive"
+      end
+    end
   end
 
   defp write_manifest(dir, providers) do
@@ -115,4 +894,65 @@ defmodule PtcRunner.Kernel.InspectionPreflightTest do
     File.write!(path, Jason.encode!(manifest))
     path
   end
+
+  defp current_uid do
+    {uid, 0} = System.cmd("id", ["-u"])
+    uid |> String.trim() |> String.to_integer()
+  end
+
+  defp near_name_limit(suffix) do
+    String.duplicate("x", 250 - byte_size(suffix)) <> suffix
+  end
+
+  defp trace_preflight_in_fresh_runtime(tmp_dir, path) do
+    executable = System.find_executable("elixir") || flunk("elixir is required for this test")
+
+    code =
+      "IO.puts(inspect(PtcRunner.Kernel.TraceLog.preflight_destination(" <>
+        inspect(path) <> ", false)))"
+
+    code_paths =
+      :code.get_path()
+      |> Enum.flat_map(fn path -> ["-pa", List.to_string(path)] end)
+
+    {output, 0} =
+      System.cmd(executable, code_paths ++ ["-e", code],
+        env: [{"TMPDIR", tmp_dir}],
+        stderr_to_stdout: true
+      )
+
+    String.trim(output)
+  end
+
+  defp install_collision_bin!(dir) do
+    id = System.find_executable("id") || flunk("id is required for this test")
+    sh = System.find_executable("sh") || flunk("sh is required for this test")
+    ln = System.find_executable("ln") || flunk("ln is required for this test")
+    lock = System.find_executable("lockf") || System.find_executable("flock")
+    lock = lock || flunk("lockf or flock is required for this test")
+    bin = Path.join(dir, "collision-bin")
+
+    File.mkdir!(bin)
+    File.ln_s!(id, Path.join(bin, "id"))
+    File.ln_s!(sh, Path.join(bin, "sh"))
+    File.ln_s!(lock, Path.join(bin, Path.basename(lock)))
+
+    mkdir = Path.join(bin, "mkdir")
+
+    File.write!(
+      mkdir,
+      """
+      #!/bin/sh
+      "$PTC_TEST_REAL_LN" -s "$PTC_TEST_COLLISION_TARGET" "$3"
+      exit 1
+      """
+    )
+
+    File.chmod!(mkdir, 0o700)
+    System.put_env("PTC_TEST_REAL_LN", ln)
+    bin
+  end
+
+  defp restore_env(name, nil), do: System.delete_env(name)
+  defp restore_env(name, value), do: System.put_env(name, value)
 end

--- a/test/ptc_runner/kernel/inspection_sink_test.exs
+++ b/test/ptc_runner/kernel/inspection_sink_test.exs
@@ -308,6 +308,25 @@ defmodule PtcRunner.Kernel.InspectionSinkTest do
              )
   end
 
+  test "rejects a non-MCP record above the artifact document-depth ceiling" do
+    {:ok, sink} = InspectionSink.start(run_id: "run-1", trace_id: "trace-1")
+    nested = Enum.reduce(1..64, true, fn _level, value -> [value] end)
+
+    assert {:error, :inspection_sink_error} =
+             InspectionSink.emit(
+               sink,
+               "capability-input",
+               %{capability_id: "cap-1"},
+               %{
+                 environment: :mission,
+                 name: "remote.read",
+                 arguments: %{"nested" => nested}
+               }
+             )
+
+    assert {:error, :inspection_sink_error} = InspectionSink.records(sink)
+  end
+
   @tag :tmp_dir
   test "persists one exclusive 0600 artifact and validates immutable loading", %{tmp_dir: dir} do
     {:ok, sink} = InspectionSink.start(run_id: "run-1", trace_id: "trace-1")
@@ -322,6 +341,27 @@ defmodule PtcRunner.Kernel.InspectionSinkTest do
         data: %{capability_id: "cap-1", environment: :mission, name: "read"}
       }
     ]
+
+    for failure_stage <- [:before_chmod, :before_write] do
+      failed_path = Path.join(dir, "#{failure_stage}.inspection.jsonl")
+
+      hook = fn
+        ^failure_stage -> {:error, :simulated_write_failure}
+        _stage -> :ok
+      end
+
+      assert {:error, :inspection_persistence_failed} =
+               InspectionArtifact.persist(failed_path, records, events, hook)
+
+      refute File.exists?(failed_path)
+    end
+
+    File.cd!(dir, fn ->
+      relative_path = "-run.inspection.jsonl"
+
+      assert :ok = InspectionArtifact.persist(relative_path, records, events)
+      assert File.regular?(relative_path)
+    end)
 
     path = Path.join(dir, "run.inspection.jsonl")
 
@@ -475,6 +515,70 @@ defmodule PtcRunner.Kernel.InspectionSinkTest do
     assert_receive {:bandit_telemetry, [:bandit, :request, :stop], stop_metadata}
     refute inspect(start_metadata) =~ private_marker
     refute inspect(stop_metadata) =~ private_marker
+  end
+
+  @tag :tmp_dir
+  test "loading rejects a same-size rewrite between bounded reads", %{tmp_dir: dir} do
+    path = Path.join(dir, "changing.inspection.jsonl")
+    replacement_path = Path.join(dir, "replacement.inspection.jsonl")
+    _records = persisted_records(path, "AAAA")
+    _replacement_records = persisted_records(replacement_path, "BBBB")
+    replacement = File.read!(replacement_path)
+
+    assert byte_size(File.read!(path)) == byte_size(replacement)
+
+    assert {:error, :inspection_source_changed} =
+             InspectionArtifact.load(path, [], fn -> File.write!(path, replacement) end)
+  end
+
+  @tag :tmp_dir
+  test "loading rejects an incomplete short read instead of parsing its prefix", %{tmp_dir: dir} do
+    path = Path.join(dir, "short-read.inspection.jsonl")
+    _records = persisted_records(path, "PRIVATE_SUFFIX")
+    valid_prefix_bytes = path |> File.read!() |> byte_size()
+    File.write!(path, File.read!(path) <> String.duplicate(" ", 64))
+    read_key = {__MODULE__, make_ref()}
+
+    short_reader = fn device, requested ->
+      case Process.get(read_key, :first) do
+        :first ->
+          Process.put(read_key, :done)
+          :file.read(device, min(requested, valid_prefix_bytes))
+
+        :done ->
+          :eof
+      end
+    end
+
+    assert {:error, :inspection_source_changed} =
+             InspectionArtifact.load(path, [], nil, short_reader)
+  end
+
+  @tag :tmp_dir
+  test "loading rejects excessive raw document depth before recursive normalization", %{
+    tmp_dir: dir
+  } do
+    path = Path.join(dir, "deep.inspection.jsonl")
+    nested = Enum.reduce(1..64, true, fn _level, value -> [value] end)
+
+    record = %{
+      "schema_version" => 1,
+      "run_id" => "deep",
+      "trace_id" => "deep",
+      "sequence" => 1,
+      "timestamp" => "2026-07-28T12:00:00Z",
+      "record_type" => "capability-input",
+      "correlation" => %{"capability_id" => "deep-capability"},
+      "payload" => %{
+        "environment" => "mission",
+        "name" => "read",
+        "arguments" => %{"nested" => nested}
+      }
+    }
+
+    File.write!(path, Jason.encode!(record) <> "\n")
+
+    assert {:error, :malformed_inspection_artifact} = InspectionArtifact.load(path)
   end
 
   @tag :tmp_dir

--- a/test/ptc_runner/kernel/inspection_snapshot_test.exs
+++ b/test/ptc_runner/kernel/inspection_snapshot_test.exs
@@ -569,6 +569,42 @@ defmodule PtcRunner.Kernel.InspectionSnapshotTest do
   end
 
   @tag :tmp_dir
+  test "capture heap exhaustion has the stable retained-limit error", %{tmp_dir: root} do
+    {trace, inspection} = source_directories(root)
+    write_run(trace, inspection, "heap-bounded", 1)
+    {:ok, trace_snapshot} = TraceSnapshot.start({:directory, trace}, owner: self())
+    on_exit(fn -> TraceSnapshot.stop(trace_snapshot) end)
+
+    assert {:error, :source_retained_limit_exceeded} =
+             InspectionSnapshot.start({:directory, inspection}, trace_snapshot,
+               capture_heap_words: 233
+             )
+  end
+
+  @tag :tmp_dir
+  test "an individually oversized query item fails instead of returning a stalled cursor", %{
+    tmp_dir: root
+  } do
+    {trace, inspection} = source_directories(root)
+    write_run(trace, inspection, "oversized", 1)
+    {:ok, trace_snapshot} = TraceSnapshot.start({:directory, trace}, owner: self())
+
+    {:ok, snapshot} =
+      InspectionSnapshot.start({:directory, inspection}, trace_snapshot, max_result_bytes: 256)
+
+    on_exit(fn ->
+      InspectionSnapshot.stop(snapshot)
+      TraceSnapshot.stop(trace_snapshot)
+    end)
+
+    assert {:error, :result_limit_exceeded} =
+             InspectionSnapshot.query(snapshot, :model_exchanges, %{
+               "run_id" => "oversized",
+               "limit" => 1
+             })
+  end
+
+  @tag :tmp_dir
   test "safe metadata and owner lifecycle retain no private paths or payloads", %{tmp_dir: root} do
     {trace, inspection} = source_directories(root)
     write_run(trace, inspection, "owned", 2)

--- a/test/ptc_runner/kernel/mcp_protocol_test.exs
+++ b/test/ptc_runner/kernel/mcp_protocol_test.exs
@@ -100,6 +100,62 @@ defmodule PtcRunner.Kernel.MCPProtocolTest do
     end
   end
 
+  test "rejects inbound JSON above the fixed document depth before decoding" do
+    nested = String.duplicate("[", 64) <> "0" <> String.duplicate("]", 64)
+    body = ~s({"jsonrpc":"2.0","id":7,"result":#{nested}})
+
+    assert {:error, :mcp_protocol_error} = MCPProtocol.decode_message(body)
+  end
+
+  test "rejects decoded inspection exchanges above the fixed document depth" do
+    nested = Enum.reduce(1..64, true, fn _level, value -> [value] end)
+
+    request = %{
+      "jsonrpc" => "2.0",
+      "id" => 7,
+      "method" => "tools/call",
+      "params" => %{"arguments" => %{"nested" => nested}}
+    }
+
+    response = %{
+      "jsonrpc" => "2.0",
+      "id" => 7,
+      "result" => %{"nested" => nested}
+    }
+
+    refute MCPProtocol.valid_exchange_request?(request, 7)
+    refute MCPProtocol.valid_exchange_response?(response, 7)
+  end
+
+  test "accepts a complete tools response containing a supported depth-16 schema" do
+    instance =
+      Enum.reduce(1..15, %{}, fn index, child ->
+        %{"level_#{index}" => child}
+      end)
+
+    schema =
+      Enum.reduce(1..15, %{"type" => "string", "const" => instance}, fn index, child ->
+        %{
+          "type" => "object",
+          "properties" => %{"level_#{index}" => child},
+          "additionalProperties" => false
+        }
+      end)
+
+    body =
+      Jason.encode!(%{
+        "jsonrpc" => "2.0",
+        "id" => 7,
+        "result" => %{
+          "resultType" => "complete",
+          "tools" => [%{"name" => "vendor.deep", "inputSchema" => schema}]
+        }
+      })
+
+    assert {:ok, {:response, 7, %{"result" => %{"tools" => [_tool]}}}} =
+             MCPProtocol.decode_message(body)
+  end
+
   test "accepts exactly one valid JSON-RPC outcome" do
     assert {:ok, %{"resultType" => "complete", "tools" => []}} =
              MCPProtocol.outcome(
@@ -167,6 +223,174 @@ defmodule PtcRunner.Kernel.MCPProtocolTest do
              MCPProtocol.outcome(
                %{"result" => %{"resultType" => "complete", "tools" => []}},
                "tools/list"
+             )
+  end
+
+  test "accepts standard content annotations and metadata but rejects unknown block fields" do
+    content = [
+      %{
+        "type" => "text",
+        "text" => "hello",
+        "annotations" => %{
+          "audience" => ["assistant"],
+          "lastModified" => "2026-07-28T10:00:00+02:00"
+        },
+        "_meta" => %{"vendor" => true}
+      }
+    ]
+
+    assert {:ok, %{"text" => ["hello"]}} =
+             MCPProtocol.normalize_tool_result(
+               %{"content" => content, "isError" => false},
+               nil,
+               :closed
+             )
+
+    for timestamp <- [
+          "2026-07-28t10:00:00z",
+          "2026-07-28t10:00:00.123z",
+          "2026-07-28t10:00:00+02:00"
+        ] do
+      annotated = [
+        %{
+          "type" => "text",
+          "text" => "hello",
+          "annotations" => %{"lastModified" => timestamp}
+        }
+      ]
+
+      assert {:ok, %{"text" => ["hello"]}} =
+               MCPProtocol.normalize_tool_result(
+                 %{"content" => annotated, "isError" => false},
+                 nil,
+                 :closed
+               )
+    end
+
+    for timestamp <- [
+          "yesterday",
+          "20260728T100000+0200",
+          "2026-07-28T10:00:00+0200",
+          "2026-07-28T10:00:00+02"
+        ] do
+      assert {:error, :mcp_invalid_result} =
+               MCPProtocol.normalize_tool_result(
+                 %{
+                   "content" => [
+                     %{
+                       "type" => "text",
+                       "text" => "hello",
+                       "annotations" => %{"lastModified" => timestamp}
+                     }
+                   ],
+                   "isError" => false
+                 },
+                 nil,
+                 :closed
+               )
+    end
+
+    assert {:error, :mcp_invalid_result} =
+             MCPProtocol.normalize_tool_result(
+               %{
+                 "content" => [
+                   %{"type" => "text", "text" => "hello", "unexpected" => true}
+                 ],
+                 "isError" => false
+               },
+               nil,
+               :closed
+             )
+
+    for malformed <- [
+          [%{"type" => "text", "text" => "hello", "annotations" => 42}],
+          [%{"type" => "text", "text" => "hello", "_meta" => []}],
+          [%{"type" => "text", "text" => "hello", "annotations" => %{"audience" => nil}}],
+          [%{"type" => "text", "text" => "hello", "annotations" => %{"priority" => nil}}],
+          [%{"type" => "text", "text" => "hello", "annotations" => %{"lastModified" => nil}}],
+          [
+            %{
+              "type" => "text",
+              "text" => "hello",
+              "annotations" => %{"lastModified" => String.duplicate("x", 257)}
+            }
+          ],
+          [
+            %{
+              "type" => "resource",
+              "resource" => %{"uri" => "repo://x", "text" => "hello"},
+              "annotations" => "assistant"
+            }
+          ]
+        ] do
+      assert {:error, :mcp_invalid_result} =
+               MCPProtocol.normalize_tool_result(
+                 %{"content" => malformed, "isError" => false},
+                 nil,
+                 :closed
+               )
+    end
+
+    assert {:ok,
+            %{
+              "resources" => [
+                %{"uri" => "repo://x", "text" => "hello"}
+              ]
+            }} =
+             MCPProtocol.normalize_tool_result(
+               %{
+                 "content" => [
+                   %{
+                     "type" => "resource",
+                     "resource" => %{
+                       "uri" => "repo://x",
+                       "text" => "hello",
+                       "_meta" => %{"vendor.example/checksum" => "safe-to-drop"}
+                     },
+                     "_meta" => %{"vendor.example/display" => true}
+                   }
+                 ],
+                 "isError" => false
+               },
+               nil,
+               :closed
+             )
+  end
+
+  test "bounded error feedback replaces terminal control characters" do
+    assert {:error, {:mcp_domain_error, feedback}} =
+             MCPProtocol.normalize_tool_result(
+               %{
+                 "content" => [
+                   %{
+                     "type" => "text",
+                     "text" => "bad\e[31mred\u009B32mgreen\rforged\tfield\nline"
+                   }
+                 ],
+                 "isError" => true
+               },
+               nil,
+               :bounded
+             )
+
+    refute feedback =~ "\e"
+    refute feedback =~ "\u009B"
+    refute feedback =~ "\r"
+    refute feedback =~ "\t"
+    refute feedback =~ "\n"
+    assert feedback =~ "bad�[31mred"
+    assert feedback =~ "green�forged�field�line"
+  end
+
+  test "bounded error feedback rejects invalid UTF-8 without raising" do
+    assert {:error, :mcp_invalid_result} =
+             MCPProtocol.normalize_tool_result(
+               %{
+                 "content" => [%{"type" => "text", "text" => <<0xFF>>}],
+                 "isError" => true
+               },
+               nil,
+               :bounded
              )
   end
 
@@ -563,7 +787,7 @@ defmodule PtcRunner.Kernel.MCPProtocolTest do
     assert {:error, :mcp_domain_error} =
              MCPProtocol.normalize_tool_result(%{"isError" => true, "content" => []}, validator)
 
-    assert {:error, {:mcp_domain_error, "unknown path\ntry another path"}} =
+    assert {:error, {:mcp_domain_error, "unknown path�try another path"}} =
              MCPProtocol.normalize_tool_result(
                %{
                  "isError" => true,
@@ -591,7 +815,7 @@ defmodule PtcRunner.Kernel.MCPProtocolTest do
     assert byte_size(bounded_feedback) == 1_024
     assert String.valid?(bounded_feedback)
 
-    assert {:error, :mcp_invalid_result} =
+    assert {:error, {:mcp_domain_error, "not exact"}} =
              MCPProtocol.normalize_tool_result(
                %{
                  "isError" => true,

--- a/test/ptc_runner/kernel/mcp_source_test.exs
+++ b/test/ptc_runner/kernel/mcp_source_test.exs
@@ -425,15 +425,23 @@ defmodule PtcRunner.Kernel.MCPSourceTest do
                  outcome: :returned,
                  value: %{
                    "structured" => structured,
-                   "text" => %{status: :error, reason: :transport_error},
-                   "failed" => %{status: :error, reason: :transport_error}
+                   "text" => %{
+                     status: :error,
+                     reason: :transport_error,
+                     retryable?: false
+                   },
+                   "failed" => %{
+                     status: :error,
+                     reason: :transport_error,
+                     retryable?: false
+                   }
                  }
                }
              } = result.value
 
       case mode do
         "exit-before-response" ->
-          assert %{status: :error, reason: :transport_error} = structured
+          assert %{status: :error, reason: :transport_error, retryable?: false} = structured
 
         "exit-after-response" ->
           assert %{status: :ok, value: %{"value" => 42}} = structured
@@ -537,6 +545,55 @@ defmodule PtcRunner.Kernel.MCPSourceTest do
     assert first_tool["upstream_name_hash"] != second_tool["upstream_name_hash"]
     assert first_tool["description_hash"] != second_tool["description_hash"]
     assert first_snapshot["snapshot_hash"] != second_snapshot["snapshot_hash"]
+  end
+
+  @tag :tmp_dir
+  test "snapshot identity attests selected timeout and result ceilings", %{tmp_dir: dir} do
+    fixture = fixture(self())
+    on_exit(fixture.close)
+    registry = registry(fixture.endpoint)
+
+    {:ok, first} =
+      dir
+      |> manifest(["remote.structured"], timeout_ms: 900, max_result_bytes: 31_000)
+      |> RunBuilder.load_and_build(registry)
+
+    [first_snapshot] = first.config.connector_snapshots
+    assert first_snapshot["timeout_ms"] == 900
+    assert first_snapshot["max_result_bytes"] == 31_000
+    assert :ok = RunBuilder.close(first)
+
+    {:ok, second} =
+      dir
+      |> manifest(["remote.structured"], timeout_ms: 800, max_result_bytes: 30_000)
+      |> RunBuilder.load_and_build(registry)
+
+    [second_snapshot] = second.config.connector_snapshots
+    assert second_snapshot["timeout_ms"] == 800
+    assert second_snapshot["max_result_bytes"] == 30_000
+    assert second_snapshot["snapshot_hash"] != first_snapshot["snapshot_hash"]
+    assert :ok = RunBuilder.close(second)
+  end
+
+  @tag :tmp_dir
+  test "a closed request context produces a terminal provider error", %{tmp_dir: dir} do
+    fixture = fixture(self())
+    on_exit(fixture.close)
+
+    {:ok, built} =
+      dir
+      |> manifest(["remote.structured"])
+      |> RunBuilder.load_and_build(registry(fixture.endpoint))
+
+    capability = built.config.mission_environment.capabilities["remote.structured"]
+    assert :ok = RunBuilder.close(built)
+
+    assert {:error,
+            %{
+              kind: :transport_error,
+              details: "mcp_transport_closed",
+              retryable?: false
+            }} = capability.callback.(%{"query" => "x"}, nil)
   end
 
   @tag :tmp_dir
@@ -1130,8 +1187,12 @@ defmodule PtcRunner.Kernel.MCPSourceTest do
     sink_ref = Process.monitor(abandoned.config.event_sink.pid)
     assert_receive {:DOWN, ^owner_ref, :process, ^owner, :normal}, @owner_lifecycle_timeout_ms
 
-    assert_receive {:DOWN, ^sink_ref, :process, _sink_pid, :normal},
+    assert_receive {:DOWN, ^sink_ref, :process, _sink_pid, sink_reason},
                    @owner_lifecycle_timeout_ms
+
+    # Monitoring can race with the owner-linked sink's normal shutdown. A
+    # monitor installed after that shutdown correctly reports :noproc.
+    assert sink_reason in [:normal, :noproc]
   end
 
   @tag :tmp_dir

--- a/test/ptc_runner/kernel/mcp_stdio_transport_test.exs
+++ b/test/ptc_runner/kernel/mcp_stdio_transport_test.exs
@@ -27,6 +27,32 @@ defmodule PtcRunner.Kernel.MCPStdioTransportTest do
   end
 
   @tag :tmp_dir
+  test "pending request saturation is recoverable rather than terminal", %{tmp_dir: tmp_dir} do
+    transport = start_transport(tmp_dir)
+
+    requests =
+      for _request <- 1..128 do
+        Task.async(fn ->
+          MCPStdioTransport.request(transport, "never", %{}, %{}, 8_192, 5_000)
+        end)
+      end
+
+    assert_eventually(fn ->
+      match?(%{pending: pending} when map_size(pending) == 128, safe_state(transport.pid))
+    end)
+
+    assert {:error, :mcp_transport_busy} =
+             MCPStdioTransport.request(transport, "overflow", %{}, %{}, 8_192, 1_000)
+
+    assert Process.alive?(transport.pid)
+    assert MCPStdioTransport.close(transport) in [:ok, {:error, :mcp_transport_error}]
+
+    assert Enum.all?(requests, fn request ->
+             Task.await(request, 5_000) == {:error, :mcp_transport_error}
+           end)
+  end
+
+  @tag :tmp_dir
   test "returns the exact decoded request and response for private capture", %{tmp_dir: tmp_dir} do
     transport = start_transport(tmp_dir)
 
@@ -70,6 +96,57 @@ defmodule PtcRunner.Kernel.MCPStdioTransportTest do
 
     assert {:ok, %{"result" => %{"method" => "notify"}}} = request(transport, "notify")
     assert :ok = MCPStdioTransport.close(transport)
+  end
+
+  @tag :tmp_dir
+  test "unscoped notification accounting resets after each response", %{tmp_dir: tmp_dir} do
+    transport = start_transport(tmp_dir)
+
+    for _request <- 1..4 do
+      assert {:ok, %{"result" => %{"method" => "unscoped-notify"}}} =
+               request(transport, "unscoped-notify")
+    end
+
+    assert :ok = MCPStdioTransport.close(transport)
+  end
+
+  @tag :tmp_dir
+  test "a stale response for a retired request cannot tear down the transport", %{
+    tmp_dir: tmp_dir
+  } do
+    transport = start_transport(tmp_dir)
+
+    assert {:ok, %{"result" => %{"method" => "stale-response"}}} =
+             request(transport, "stale-response")
+
+    assert {:ok, %{"result" => %{"method" => "after-stale"}}} =
+             request(transport, "after-stale")
+
+    assert :ok = MCPStdioTransport.close(transport)
+  end
+
+  @tag :tmp_dir
+  test "a stale response cannot reset unscoped notification accounting", %{
+    tmp_dir: tmp_dir
+  } do
+    transport = start_transport(tmp_dir)
+
+    assert {:ok, %{"result" => %{"method" => "warmup"}}} = request(transport, "warmup")
+
+    assert {:error, :mcp_response_exceeded} = request(transport, "stale-reset-flood")
+    assert {:error, :closed} = request(transport, "after-flood")
+  end
+
+  @tag :tmp_dir
+  test "repeated stale responses remain subject to the unscoped byte ceiling", %{
+    tmp_dir: tmp_dir
+  } do
+    transport = start_transport(tmp_dir)
+
+    assert {:ok, %{"result" => %{"method" => "warmup"}}} = request(transport, "warmup")
+
+    assert {:error, :mcp_response_exceeded} = request(transport, "stale-response-flood")
+    assert {:error, :closed} = request(transport, "after-stale-response-flood")
   end
 
   @tag :tmp_dir

--- a/test/ptc_runner/kernel/provider_lifecycle_test.exs
+++ b/test/ptc_runner/kernel/provider_lifecycle_test.exs
@@ -489,42 +489,39 @@ defmodule PtcRunner.Kernel.ProviderLifecycleTest do
   end
 
   @tag :tmp_dir
-  test "trace preflight failure closes acquired provider resources", %{tmp_dir: dir} do
+  test "trace preflight failure happens before provider preflight or acquisition", %{tmp_dir: dir} do
     parent = self()
     File.write!(Path.join(dir, "workflow.clj"), "(ns app) (defn run [x] (return x))")
 
-    manifest = manifest(dir, [provider("owned", %{"id" => "trace-preflight"})], [])
-    {:ok, registry} = registry_with_close(parent)
-
-    assert {:error, {:trace_preflight_failed, :normal_trace_requires_normal_suffix}} =
-             RunBuilder.run(manifest, registry, trace: Path.join(dir, "wrong.private.jsonl"))
-
-    assert_receive {:closed, "trace-preflight"}
-    refute_receive {:closed, "trace-preflight"}
-
-    failing_builder = fn %{}, _context ->
-      {:ok, capability} = capability("provided.cleanup-failure")
+    builder = fn %{}, _context ->
+      send(parent, :trace_provider_prepared)
 
       {:ok,
        %{
-         capabilities: [capability],
-         close: fn ->
-           send(parent, :trace_preflight_cleanup_attempted)
-           {:error, :fixture_cleanup_failed}
+         credential_names: [],
+         preflight: fn ->
+           send(parent, :trace_provider_preflighted)
+
+           {:ok,
+            fn %{} ->
+              send(parent, :trace_provider_acquired)
+              capability("provided.trace-preflight")
+            end}
          end
        }}
     end
 
-    {:ok, failing_registry} = ProviderRegistry.new(%{"cleanup-fails" => failing_builder})
-    failing_manifest = manifest(dir, [provider("cleanup-fails", %{})], [])
+    {:ok, registry} =
+      ProviderRegistry.new(%{"staged" => ProviderRegistry.staged(builder)})
 
-    assert {:error, :provider_cleanup_failed} =
-             RunBuilder.run(failing_manifest, failing_registry,
-               trace: Path.join(dir, "also-wrong.private.jsonl")
-             )
+    manifest = manifest(dir, [provider("staged", %{})], [])
 
-    assert_receive :trace_preflight_cleanup_attempted
-    refute_receive :trace_preflight_cleanup_attempted
+    assert {:error, {:trace_preflight_failed, :normal_trace_requires_normal_suffix}} =
+             RunBuilder.run(manifest, registry, trace: Path.join(dir, "wrong.private.jsonl"))
+
+    assert_receive :trace_provider_prepared
+    refute_receive :trace_provider_preflighted
+    refute_receive :trace_provider_acquired
   end
 
   @tag :tmp_dir

--- a/test/ptc_runner/kernel/result_artifact_test.exs
+++ b/test/ptc_runner/kernel/result_artifact_test.exs
@@ -1,5 +1,5 @@
 defmodule PtcRunner.Kernel.ResultArtifactTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   alias PtcRunner.Kernel.DeterministicJSON
   alias PtcRunner.Kernel.ResultArtifact
@@ -13,4 +13,139 @@ defmodule PtcRunner.Kernel.ResultArtifactTest do
     assert {:ok, canonical} = DeterministicJSON.encode(value)
     assert File.read!(path) == canonical
   end
+
+  @tag :tmp_dir
+  test "callback write failures return the persistence error without raising", %{tmp_dir: dir} do
+    path = Path.join(dir, "write-failure.json")
+
+    assert {:error, :result_persistence_failed} =
+             ResultArtifact.persist(
+               path,
+               %{"ok" => true},
+               :normal,
+               :normal,
+               fn
+                 :before_write -> {:error, :simulated_write_failure}
+                 _stage -> :ok
+               end
+             )
+
+    refute File.exists?(path)
+  end
+
+  @tag :tmp_dir
+  test "persists a dash-prefixed relative destination", %{tmp_dir: dir} do
+    File.cd!(dir, fn ->
+      assert :ok =
+               ResultArtifact.persist("-result.json", %{"ok" => true}, :normal, :normal)
+
+      assert File.regular?("-result.json")
+    end)
+  end
+
+  @tag :tmp_dir
+  test "resolves the secure directory creator from PATH", %{tmp_dir: dir} do
+    mkdir = System.find_executable("mkdir")
+    id = System.find_executable("id")
+    bin = Path.join(dir, "bin")
+    wrapper = Path.join(bin, "mkdir")
+    id_wrapper = Path.join(bin, "id")
+    marker = Path.join(dir, "mkdir-invoked")
+    original_path = System.get_env("PATH")
+    original_marker = System.get_env("PTC_TEST_MKDIR_MARKER")
+    original_mkdir = System.get_env("PTC_TEST_REAL_MKDIR")
+
+    assert is_binary(mkdir)
+    assert is_binary(id)
+
+    File.mkdir!(bin)
+    File.ln_s!(id, id_wrapper)
+
+    File.write!(
+      wrapper,
+      """
+      #!/bin/sh
+      printf '%s\\n' "$3" > "$PTC_TEST_MKDIR_MARKER"
+      exec "$PTC_TEST_REAL_MKDIR" "$@"
+      """
+    )
+
+    File.chmod!(wrapper, 0o700)
+    System.put_env("PATH", bin)
+    System.put_env("PTC_TEST_MKDIR_MARKER", marker)
+    System.put_env("PTC_TEST_REAL_MKDIR", mkdir)
+
+    on_exit(fn ->
+      restore_env("PATH", original_path)
+      restore_env("PTC_TEST_MKDIR_MARKER", original_marker)
+      restore_env("PTC_TEST_REAL_MKDIR", original_mkdir)
+    end)
+
+    File.cd!(dir, fn ->
+      assert :ok =
+               ResultArtifact.persist(
+                 "result.json",
+                 %{"ok" => true},
+                 :normal,
+                 :normal
+               )
+    end)
+
+    assert File.regular?(marker)
+    assert marker |> File.read!() |> String.trim() |> Path.type() == :absolute
+  end
+
+  @tag :tmp_dir
+  test "preflight fails when the secure directory creator is unavailable", %{tmp_dir: dir} do
+    original_path = System.get_env("PATH")
+    System.put_env("PATH", "")
+    on_exit(fn -> restore_env("PATH", original_path) end)
+
+    assert {:error, :result_persistence_failed} =
+             ResultArtifact.preflight_destination(
+               Path.join(dir, "result.json"),
+               :normal,
+               :normal
+             )
+  end
+
+  @tag :tmp_dir
+  test "private preflight rejects a replaceable parent directory", %{tmp_dir: dir} do
+    replaceable = Path.join(dir, "replaceable")
+    File.mkdir!(replaceable)
+    File.chmod!(replaceable, 0o777)
+
+    assert {:error, :result_persistence_failed} =
+             ResultArtifact.preflight_destination(
+               Path.join(replaceable, "result.json"),
+               :private,
+               :private
+             )
+  end
+
+  @tag :tmp_dir
+  test "private preflight rejects ancestry outside the process authority", %{tmp_dir: dir} do
+    mkdir = System.find_executable("mkdir")
+    bin = Path.join(dir, "authority-bin")
+    id_wrapper = Path.join(bin, "id")
+    original_path = System.get_env("PATH")
+
+    assert is_binary(mkdir)
+    File.mkdir!(bin)
+    File.ln_s!(mkdir, Path.join(bin, "mkdir"))
+    File.write!(id_wrapper, "#!/bin/sh\nprintf '4294967294\\n'\n")
+    File.chmod!(id_wrapper, 0o700)
+    System.put_env("PATH", bin)
+    on_exit(fn -> restore_env("PATH", original_path) end)
+
+    assert {:error, :result_persistence_failed} =
+             ResultArtifact.preflight_destination(
+               Path.join(dir, "result.json"),
+               :private,
+               :private
+             )
+  end
+
+  defp restore_env(name, nil), do: System.delete_env(name)
+  defp restore_env(name, value), do: System.put_env(name, value)
 end

--- a/test/ptc_runner/kernel/trace_capability_test.exs
+++ b/test/ptc_runner/kernel/trace_capability_test.exs
@@ -221,6 +221,84 @@ defmodule PtcRunner.Kernel.TraceCapabilityTest do
   end
 
   @tag :tmp_dir
+  test "trace publication preserves symlink-sensitive parent components", %{tmp_dir: directory} do
+    physical_parent = Path.join(directory, "physical")
+    nested = Path.join(physical_parent, "nested")
+    alias_path = Path.join(directory, "alias")
+    File.mkdir_p!(nested)
+    File.ln_s!(nested, alias_path)
+
+    event = decoded_event("component-path", 1, "run-started")
+    append_path = Path.join([alias_path, "..", "append.jsonl"])
+    publish_path = Path.join([alias_path, "..", "publish.jsonl"])
+
+    assert :ok = TraceLog.append_jsonl(append_path, [event])
+    assert File.regular?(Path.join(physical_parent, "append.jsonl"))
+    refute File.exists?(Path.join(directory, "append.jsonl"))
+
+    assert :ok = TraceLog.publish_jsonl(publish_path, [event])
+    assert File.regular?(Path.join(physical_parent, "publish.jsonl"))
+    refute File.exists?(Path.join(directory, "publish.jsonl"))
+  end
+
+  @tag :tmp_dir
+  test "trace append follows a direct symlink to its physical parent", %{tmp_dir: directory} do
+    physical_parent = Path.join(directory, "physical-parent")
+    alias_parent = Path.join(directory, "alias-parent")
+    File.mkdir!(physical_parent)
+    File.ln_s!(physical_parent, alias_parent)
+
+    event = decoded_event("direct-parent-link", 1, "run-started")
+    path = Path.join(alias_parent, "trace.jsonl")
+
+    assert :ok = TraceLog.append_jsonl(path, [event])
+    assert File.regular?(Path.join(physical_parent, "trace.jsonl"))
+  end
+
+  @tag :tmp_dir
+  test "missing case-fold aliases share one append-lock identity", %{tmp_dir: directory} do
+    upper = Path.join(directory, "Run.jsonl")
+    lower = Path.join(directory, "run.jsonl")
+    sigma = Path.join(directory, "σ.jsonl")
+    final_sigma = Path.join(directory, "ς.jsonl")
+
+    assert {:ok, identity} = TraceLog.append_lock_identity(upper)
+    assert {:ok, ^identity} = TraceLog.append_lock_identity(lower)
+
+    assert {:ok, sigma_identity} = TraceLog.append_lock_identity(sigma)
+    assert {:ok, ^sigma_identity} = TraceLog.append_lock_identity(final_sigma)
+  end
+
+  @tag :tmp_dir
+  @tag :slow
+  test "a first-file append retains one cross-runtime lease after creation", %{
+    tmp_dir: directory
+  } do
+    path = Path.join(directory, "first-file.jsonl")
+    first = decoded_event("first-runtime", 1, "run-started")
+    second = decoded_event("second-runtime", 1, "run-started")
+    port = start_paused_append_runtime(path, first)
+
+    on_exit(fn ->
+      if Port.info(port), do: Port.close(port)
+    end)
+
+    assert_receive {^port, {:data, {:eol, "APPEND_READY"}}}, 10_000
+
+    second_append = Task.async(fn -> TraceLog.append_jsonl(path, [second]) end)
+    assert Task.yield(second_append, 250) == nil
+
+    assert true = Port.command(port, "X\n")
+    assert_receive {^port, {:data, {:eol, "APPEND_RESULT=:ok"}}}, 10_000
+    assert_receive {^port, {:exit_status, 0}}, 10_000
+    assert Task.await(second_append, 10_000) == :ok
+
+    assert {:ok, trace_log} = TraceLog.new(source: {:file, path})
+    assert {:ok, %{"items" => runs}} = TraceLog.query(trace_log, :list_runs, %{"limit" => 100})
+    assert Enum.sort(Enum.map(runs, & &1["run_id"])) == ["first-runtime", "second-runtime"]
+  end
+
+  @tag :tmp_dir
   @tag :slow
   test "concurrent same-path appends retain every canonical batch", %{tmp_dir: directory} do
     path = Path.join(directory, "concurrent.jsonl")
@@ -302,6 +380,44 @@ defmodule PtcRunner.Kernel.TraceCapabilityTest do
     refute_receive {_port, {:exit_status, _status}}, 100
   end
 
+  defp start_paused_append_runtime(path, event) do
+    executable = System.find_executable("elixir") || flunk("elixir is required for this test")
+
+    code =
+      """
+      path = #{inspect(path)}
+      [event] = :erlang.binary_to_term(Base.decode64!(#{inspect(encode_term([event]))}))
+      hook = fn :after_file_ready ->
+        IO.puts("APPEND_READY")
+        "X\\n" = IO.gets("")
+        :ok
+      end
+      result =
+        PtcRunner.Kernel.TraceLog.append_jsonl(path, [event], append_hook: hook)
+      IO.puts("APPEND_RESULT=" <> inspect(result))
+      """
+
+    code_paths =
+      :code.get_path()
+      |> Enum.flat_map(fn path -> ["-pa", List.to_string(path)] end)
+
+    args = Enum.concat(code_paths, ["-e", code])
+
+    Port.open(
+      {:spawn_executable, executable},
+      [
+        :binary,
+        :exit_status,
+        :use_stdio,
+        :stderr_to_stdout,
+        {:line, 1_024},
+        args: args
+      ]
+    )
+  end
+
+  defp encode_term(term), do: term |> :erlang.term_to_binary() |> Base.encode64()
+
   @tag :tmp_dir
   test "atomic publication is no-clobber, retry-safe, and cleans partial temporaries", %{
     tmp_dir: directory
@@ -333,7 +449,7 @@ defmodule PtcRunner.Kernel.TraceCapabilityTest do
         )
       end)
 
-    assert_receive {:publication_read_ready, publisher}
+    assert_receive {:publication_read_ready, publisher}, 1_000
     oversized = Path.join(directory, "oversized-replacement")
     File.write!(oversized, String.duplicate("x", byte_size(first) + 1))
     File.rm!(path)
@@ -367,7 +483,7 @@ defmodule PtcRunner.Kernel.TraceCapabilityTest do
         )
       end)
 
-    assert_receive {:temporary_synced, temporary_publisher}
+    assert_receive {:temporary_synced, temporary_publisher}, 1_000
 
     [temporary] =
       directory
@@ -527,6 +643,53 @@ defmodule PtcRunner.Kernel.TraceCapabilityTest do
 
     assert {:ok, %{"items" => [%{"run_id" => "private", "source" => "private"}]}} =
              TraceLog.query(private_directory_log, :list_runs, %{})
+  end
+
+  @tag :tmp_dir
+  test "private trace creation reports chmod failures without raising", %{tmp_dir: directory} do
+    path = Path.join(directory, "chmod-failure.private.jsonl")
+    event = decoded_event("private-chmod", 1, "run-started")
+
+    hook = fn
+      :before_private_chmod -> {:error, :simulated_chmod_failure}
+      _stage -> :ok
+    end
+
+    assert {:error, :source_unavailable} =
+             TraceLog.append_jsonl(path, [event], private: true, append_hook: hook)
+
+    refute File.exists?(path)
+  end
+
+  @tag :tmp_dir
+  test "private appends reject a replaceable parent directory", %{tmp_dir: directory} do
+    replaceable = Path.join(directory, "replaceable")
+    File.mkdir!(replaceable)
+    File.chmod!(replaceable, 0o777)
+
+    path = Path.join(replaceable, "secret.private.jsonl")
+    event = decoded_event("private-parent", 1, "run-started")
+
+    assert {:error, :source_unavailable} =
+             TraceLog.append_jsonl(path, [event], private: true)
+
+    refute File.exists?(path)
+  end
+
+  @tag :tmp_dir
+  test "private appends reject an existing file that is not already owner-only", %{
+    tmp_dir: directory
+  } do
+    path = Path.join(directory, "wide.private.jsonl")
+    File.write!(path, "")
+    File.chmod!(path, 0o644)
+    event = decoded_event("private-mode", 1, "run-started")
+
+    assert {:error, :source_unavailable} =
+             TraceLog.append_jsonl(path, [event], private: true)
+
+    assert File.read!(path) == ""
+    assert Bitwise.band(File.stat!(path).mode, 0o777) == 0o644
   end
 
   @tag :tmp_dir

--- a/test/ptc_runner/kernel/trace_snapshot_test.exs
+++ b/test/ptc_runner/kernel/trace_snapshot_test.exs
@@ -107,6 +107,29 @@ defmodule PtcRunner.Kernel.TraceSnapshotTest do
   end
 
   @tag :tmp_dir
+  test "an individually oversized trace item fails instead of returning a stalled cursor", %{
+    tmp_dir: directory
+  } do
+    oversized =
+      "oversized"
+      |> event(1, "run-started")
+      |> put_in(["data", "labels"], %{"name" => String.duplicate("x", 1_024)})
+
+    write_events(Path.join(directory, "trace.jsonl"), [oversized])
+
+    assert {:ok, snapshot} =
+             TraceSnapshot.start({:directory, directory},
+               owner: self(),
+               max_result_bytes: 512
+             )
+
+    on_exit(fn -> TraceSnapshot.stop(snapshot) end)
+
+    assert {:error, :result_limit_exceeded} =
+             TraceSnapshot.query(snapshot, :list_runs, %{"limit" => 1})
+  end
+
+  @tag :tmp_dir
   test "safe metadata is bounded and contains no source path", %{tmp_dir: directory} do
     path = Path.join(directory, "trace.jsonl")
     write_events(path, [event("visible", 1, "run-started")])
@@ -182,6 +205,17 @@ defmodule PtcRunner.Kernel.TraceSnapshotTest do
   end
 
   @tag :tmp_dir
+  test "capture heap exhaustion returns a stable retained-limit error", %{tmp_dir: directory} do
+    write_events(Path.join(directory, "trace.jsonl"), [event("bounded", 1, "run-started")])
+
+    assert {:error, :source_retained_limit_exceeded} =
+             TraceSnapshot.start({:directory, directory},
+               owner: self(),
+               capture_heap_words: 233
+             )
+  end
+
+  @tag :tmp_dir
   test "construction limits may be lowered but not raised", %{tmp_dir: directory} do
     write_events(Path.join(directory, "trace.jsonl"), [event("bounded", 1, "run-started")])
 
@@ -190,7 +224,8 @@ defmodule PtcRunner.Kernel.TraceSnapshotTest do
       max_retained_bytes: 32_000_001,
       max_result_bytes: 1_000_001,
       max_directory_entries: 4_097,
-      max_trace_files: 1_025
+      max_trace_files: 1_025,
+      capture_heap_words: 10_000_001
     ]
 
     for {option, value} <- raised_limits do

--- a/test/support/mcp_stdio_fixture.exs
+++ b/test/support/mcp_stdio_fixture.exs
@@ -47,44 +47,83 @@ defmodule PtcRunner.TestSupport.MCPStdioFixture do
   end
 
   defp handle_line(line, marker) do
-    case {extract_id(line), extract_method(line)} do
-      {nil, "notifications/cancelled"} ->
-        File.write!(marker, line, [:append])
-
-      {id, "slow"} when is_integer(id) ->
-        respond_after(id, "slow", 75)
-
-      {id, "fast"} when is_integer(id) ->
-        respond_after(id, "fast", 5)
-
-      {id, "never"} when is_integer(id) ->
-        :ok
-
-      {id, "junk"} when is_integer(id) ->
-        IO.write(:stdio, "not-json\n")
-
-      {id, "large"} when is_integer(id) ->
-        respond(id, "large", String.duplicate("x", 2_048))
-
-      {id, "exact"} when is_integer(id) ->
-        body = response_body(id, "exact", "")
-        respond(id, "exact", String.duplicate("x", 1_048_576 - byte_size(body)))
-
-      {id, "exact-crlf"} when is_integer(id) ->
-        body = response_body(id, "exact-crlf", "")
-        padding = String.duplicate("x", 1_048_576 - byte_size(body))
-        IO.write(:stdio, [response_body(id, "exact-crlf", padding), "\r\n"])
-
-      {id, method} when is_integer(id) and method in ["notify", "notify-flood"] ->
-        emit_notifications(id, method, line)
-
-      {id, method} when is_integer(id) and is_binary(method) ->
-        respond(id, method)
-
-      _invalid ->
-        IO.write(:stdio, "invalid request\n")
-    end
+    handle_request(extract_id(line), extract_method(line), line, marker)
   end
+
+  defp handle_request(nil, "notifications/cancelled", line, marker),
+    do: File.write!(marker, line, [:append])
+
+  defp handle_request(id, "slow", _line, _marker) when is_integer(id),
+    do: respond_after(id, "slow", 75)
+
+  defp handle_request(id, "fast", _line, _marker) when is_integer(id),
+    do: respond_after(id, "fast", 5)
+
+  defp handle_request(id, "never", _line, _marker) when is_integer(id), do: :ok
+
+  defp handle_request(id, "junk", _line, _marker) when is_integer(id),
+    do: IO.write(:stdio, "not-json\n")
+
+  defp handle_request(id, "large", _line, _marker) when is_integer(id),
+    do: respond(id, "large", String.duplicate("x", 2_048))
+
+  defp handle_request(id, "exact", _line, _marker) when is_integer(id) do
+    body = response_body(id, "exact", "")
+    respond(id, "exact", String.duplicate("x", 1_048_576 - byte_size(body)))
+  end
+
+  defp handle_request(id, "exact-crlf", _line, _marker) when is_integer(id) do
+    body = response_body(id, "exact-crlf", "")
+    padding = String.duplicate("x", 1_048_576 - byte_size(body))
+    IO.write(:stdio, [response_body(id, "exact-crlf", padding), "\r\n"])
+  end
+
+  defp handle_request(id, method, line, _marker)
+       when is_integer(id) and method in ["notify", "notify-flood"],
+       do: emit_notifications(id, method, line)
+
+  defp handle_request(id, "unscoped-notify", _line, _marker) when is_integer(id) do
+    padding = String.duplicate("x", 600_000)
+
+    IO.write(
+      :stdio,
+      ~s({"jsonrpc":"2.0","method":"notifications/message","params":{"data":"#{padding}"}}\n)
+    )
+
+    respond(id, "unscoped-notify")
+  end
+
+  defp handle_request(id, "stale-response", _line, _marker)
+       when is_integer(id) and id > 1 do
+    respond(id - 1, "late")
+    respond(id, "stale-response")
+  end
+
+  defp handle_request(id, "stale-reset-flood", _line, _marker)
+       when is_integer(id) and id > 1 do
+    emit_unscoped_notifications(3)
+    respond(id - 1, "late")
+    emit_unscoped_notifications(1)
+    respond(id, "stale-reset-flood")
+  end
+
+  defp handle_request(id, "stale-response-flood", _line, _marker)
+       when is_integer(id) and id > 1 do
+    padding = String.duplicate("x", 600_000)
+
+    for _response <- 1..4 do
+      respond(id - 1, "late", padding)
+    end
+
+    respond(id, "stale-response-flood")
+  end
+
+  defp handle_request(id, method, _line, _marker)
+       when is_integer(id) and is_binary(method),
+       do: respond(id, method)
+
+  defp handle_request(_id, _method, _line, _marker),
+    do: IO.write(:stdio, "invalid request\n")
 
   defp extract_id(line) do
     case Regex.run(~r/"id"\s*:\s*([1-9][0-9]*)/, line, capture: :all_but_first) do
@@ -120,6 +159,17 @@ defmodule PtcRunner.TestSupport.MCPStdioFixture do
     end
 
     respond(id, method)
+  end
+
+  defp emit_unscoped_notifications(count) do
+    padding = String.duplicate("x", 600_000)
+
+    for _notification <- 1..count do
+      IO.write(
+        :stdio,
+        ~s({"jsonrpc":"2.0","method":"notifications/message","params":{"data":"#{padding}"}}\n)
+      )
+    end
   end
 
   defp respond_after(id, method, delay_ms) do

--- a/test/support/mcp_stdio_source_fixture.sh
+++ b/test/support/mcp_stdio_source_fixture.sh
@@ -37,6 +37,15 @@ do
     *) exit 65 ;;
   esac
 
+  case "$line" in
+    *'"method":"tools/call"'*)
+      case "$line" in
+        *'"traceparent":"00-'*) ;;
+        *) exit 65 ;;
+      esac
+      ;;
+  esac
+
   case "$seen_ids" in
     *" $id "*) exit 65 ;;
     *) seen_ids="${seen_ids}${id} " ;;


### PR DESCRIPTION
## Summary
- release provider reservations and slots on tracker/attachment refusal and close races
- sanitize private evaluator failures before terminal and analysis sinks
- make inspection and trace pagination progress or fail on oversized records with bounded capture heaps
- harden inspection, result, and private-trace artifact path anchoring, ancestry validation, publication, reads, and preflight access checks
- bound MCP JSON depth, correct terminal transport retry semantics, reset notification budgets, tolerate stale responses, and propagate trace metadata
- accept and validate spec-defined MCP content metadata and attest effective connector ceilings
- preflight result, trace, and inspection destinations before provider acquisition
- align module and guide documentation with actual contracts

## Verification
- `mix precommit`
- full pre-push hook (`mix prepush`, root and Viewer tests, Dialyzer, upstream audit, docs)
- clean fresh independent Codex review