### PR TITLE
fix(mcp): refuse input-required results

### DIFF
--- a/docs/guides/building-agents.md
+++ b/docs/guides/building-agents.md
@@ -440,6 +440,13 @@ dispatched, every non-success remains non-retryable and carries
 Cancellation does not prove rollback. Deterministic failures that prove no
 transport send was attempted omit mutation state.
 
+Some read-side provider failures are terminal even though repeating an ordinary
+read would otherwise be effect-safe. In particular, the MCP adapter never asks
+the model to correct or repeat an `input_required` exchange: policy refusal,
+unsupported capability negotiation, and malformed protocol data close the
+agent evaluation. The Kernel retains that terminal classification outside the
+killable evaluator, so a later program error or resource kill cannot erase it.
+
 An explicit `(fail value)` remains terminal by default because it is also the
 application's deliberate failure signal. There is one narrower correction
 case: a direct capability call, its exact response retained in a simple lexical

--- a/docs/guides/kernel-maintainer.md
+++ b/docs/guides/kernel-maintainer.md
@@ -263,6 +263,20 @@ sends `notifications/cancelled`; stdio retains its protocol notification.
 Cancellation remains advisory and cannot make a possibly dispatched write
 retryable.
 
+The client advertises no MCP elicitation, sampling, or roots capabilities and
+never retries an `input_required` result. On `tools/call`, `prompts/get`, or
+`resources/read`, a structurally valid state-only result, including an empty
+load-shedding request map accompanied by `requestState`, is a closed denied
+policy refusal; a schema-valid non-empty request map is a
+capability-negotiation error. Malformed request entries and
+`input_required` on any other method are protocol errors. Provider denial is
+terminal at the agent correction boundary, as are the capability-negotiation
+and protocol classifications. The provider owner records that terminal
+classification before publishing the result, so a later evaluator error,
+timeout, or heap kill cannot trigger a correction turn. Once a tool call may
+have been dispatched, all three causes preserve the operator-declared effect,
+so a write remains indeterminate.
+
 PtcRunner-owned canonical traces remain native rather than passing through
 MCP. A host-installed `ptc_trace_snapshot` uses `TraceSnapshot` to capture one
 directory and `TraceCapability` to expose the same four canonical `TraceLog`

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -18,9 +18,9 @@ belongs in guides or retained specifications.
 
 ## Active MCP work
 
-- [`mcp-write-and-surface.md`](mcp-write-and-surface.md) tracks MRTR refusal
-  hardening, records the authority design required before exact-resource
-  access, and keeps server-initiated model access refused.
+- [`mcp-write-and-surface.md`](mcp-write-and-surface.md) records the authority
+  design required before exact-resource access and keeps server-initiated
+  model access refused.
 
 ## Future, trigger-gated
 

--- a/docs/plans/mcp-write-and-surface.md
+++ b/docs/plans/mcp-write-and-surface.md
@@ -1,24 +1,23 @@
 # MCP bounded client surfaces
 
-**Status:** active; MCP write authority, effect-aware failures, and Streamable
-HTTP cancellation are implemented. MRTR validation and policy refusal is the
-next delivery slice. Revised 2026-07-28 against the final MCP `2026-07-28` tag at
+**Status:** active; MCP write authority, effect-aware failures, Streamable
+HTTP cancellation, and MRTR refusal are implemented. Exact-resource authority
+design is the next delivery slice. Revised 2026-07-28 against the final MCP
+`2026-07-28` tag at
 `modelcontextprotocol/modelcontextprotocol@5f5440bb26a62e2cf3440b92da5a667efa03b267`.
 
 PtcRunner supports operator-declared read and write MCP tools while keeping
 write selection explicit and post-dispatch failure outcomes conservative. This
-plan tracks MRTR refusal hardening and the authority decision required before
-adding other MCP client surfaces.
+plan tracks the authority decision required before adding other MCP client
+surfaces.
 
 Backward compatibility is not a constraint. PtcRunner is a 0.x library and
 should delete obsolete restrictions rather than preserve compatibility shims.
-The remaining hard parts are semantic: refusing server-initiated authority
-with precise protocol diagnoses and freezing operator authority over
+The remaining hard part is semantic: freezing operator authority over
 server-owned resource namespaces.
 
 ## Goals
 
-- Harden method-sensitive validation and refusal of Multi Round-Trip Requests.
 - Record a bounded authority model for MCP resources before adding that runtime
   surface.
 - Keep server-initiated model access permanently unavailable.
@@ -52,46 +51,13 @@ the official Go SDK `v1.7.0`.
 
 The post-RC protocol details relevant to remaining work are:
 
-- `InputRequiredResult` permits `requestState` without `inputRequests`;
 - every page of one list operation must use the same `cacheScope`, although
   page `ttlMs` values may differ;
 - `Mcp-Name` uses the same Base64 sentinel encoding as `Mcp-Param-*`; and
 - server identity is optional result metadata and client identity remains
   valid on each request.
 
-## 1. Keep server-initiated authority refused
-
-The `2026-07-28` protocol replaces server-initiated roots, sampling, and
-elicitation requests with Multi Round-Trip Requests. A server can answer
-`tools/call`, `prompts/get`, or `resources/read` with
-`InputRequiredResult`.
-
-Supporting a model request would let an MCP server reached through mission code
-invoke the workflow's LLM. That violates the two-environment authority split.
-Elicitation requires a human while missions are deliberately non-interactive,
-and roots presume ambient filesystem scope that PtcRunner replaces with
-explicit grants.
-
-PtcRunner declares empty client capabilities and already rejects
-`InputRequiredResult`. Harden the classifier:
-
-- a structurally valid state-only `InputRequiredResult` on one of its permitted
-  methods is an explicit, non-retryable policy refusal;
-- any `inputRequests` value is a protocol capability-negotiation error while
-  PtcRunner declares no elicitation, sampling, or roots capability;
-- `InputRequiredResult` on any other method is a protocol error;
-- a malformed MRTR result is a protocol error; and
-- state-only MRTR is never automatically retried, especially after a write.
-
-Validate the final schema requirements before distinguishing policy refusal
-from malformed input. Tests must use schema-derived valid examples rather than
-an empty result object.
-
-Trigger to revisit: a first-party need for host-mediated elicitation, where the
-*host*—never mission code and never the model—supplies the response. Sampling
-has no trigger.
-
-## 2. Authority gate for exact resources
+## 1. Authority gate for exact resources
 
 Prompts, resources, and completion are not interchangeable with tools:
 
@@ -140,23 +106,11 @@ Review each complete slice against its invariants, resolve every correctness
 and authority finding, and run focused tests plus `mix precommit`. Dependent
 slices do not begin from an unreviewed authority or wire contract.
 
-### Slice 1 — MRTR validation and policy refusal
-
-Harden section 1's rejection into method-sensitive structural validation and
-policy classification. Use schema-derived valid examples with `inputRequests`,
-`requestState`, and both together.
-
-Cover all three permitted methods and at least one forbidden method.
-Distinguish malformed protocol data, an input-bearing capability-negotiation
-violation, and a valid state-only result refused by policy. For `tools/call`,
-exercise each classification through read and write mappings; retain the
-specific cause and indeterminate mutation state for a write after dispatch.
-
-### Slice 2 — exact-resource authority design
+### Slice 1 — exact-resource authority design
 
 **Trigger:** a concrete first-party application that needs MCP resources.
 
-Decide section 2's operator-owned exact-URI grammar, public capability
+Decide section 1's operator-owned exact-URI grammar, public capability
 projection, resource-only installation rule, frozen catalog semantics, and
 safe snapshot identity. Keep URI templates, prompts, and completion out.
 
@@ -167,9 +121,9 @@ use an ordinary mapped MCP tool without losing an important capability.
 
 This is a specification slice and changes no runtime code.
 
-### Slice 3 — exact-resource mappings
+### Slice 2 — exact-resource mappings
 
-**Depends on:** approved Slice 2.
+**Depends on:** approved Slice 1.
 
 Discover and validate operator-granted exact resources during assembly. Expose
 each as a bounded zero-argument read capability. Implement `resources/read`,

--- a/lib/ptc_runner/kernel/dispatcher.ex
+++ b/lib/ptc_runner/kernel/dispatcher.ex
@@ -15,6 +15,9 @@ defmodule PtcRunner.Kernel.Dispatcher do
   state. A trusted `ProviderError` with `dispatch_provenance: :not_dispatched`
   preserves its specific pre-dispatch policy without exposing that internal
   provenance. Workflow capabilities retain their provider-owned retry policy.
+  Before a mission provider publishes a terminal policy failure, its monitored
+  callback records that classification in RunState so a subsequent evaluator
+  kill cannot make the agent repeat the call.
   """
 
   alias PtcRunner.Kernel.Capability
@@ -289,10 +292,12 @@ defmodule PtcRunner.Kernel.Dispatcher do
 
           receive do
             ^go ->
-              send(
-                parent,
-                {:provider_result, self(), safely_invoke(capability.callback, arguments, context)}
-              )
+              result = safely_invoke(capability.callback, arguments, context)
+
+              if terminal_provider_failure?(result),
+                do: RunState.mark_evaluation_terminal_provider_failure(state)
+
+              send(parent, {:provider_result, self(), result})
 
             {:DOWN, ^parent_ref, :process, _parent, _reason} ->
               :ok
@@ -471,6 +476,15 @@ defmodule PtcRunner.Kernel.Dispatcher do
     do: Map.put(result, :mutation_state, :indeterminate)
 
   defp maybe_put_mutation_state(result, nil), do: result
+
+  defp terminal_provider_failure?({:error, %ProviderError{} = error}) do
+    ProviderError.valid?(error) and
+      (error.kind == :denied or
+         (error.kind == :invalid_result and
+            error.details in ["mcp_capability_negotiation_error", "mcp_protocol_error"]))
+  end
+
+  defp terminal_provider_failure?(_result), do: false
 
   defp validate(%Capability{} = capability, arguments) do
     if JSONSchema.valid?(capability.input_validator, arguments),

--- a/lib/ptc_runner/kernel/evaluation.ex
+++ b/lib/ptc_runner/kernel/evaluation.ex
@@ -14,6 +14,10 @@ defmodule PtcRunner.Kernel.Evaluation do
   call, and whether correcting the program is effect-safe. The latter says only
   that the evaluation performed no write or unknown effect; callers combine all
   three facts with the bounded failure shape before requesting a correction.
+  Terminal provider-policy provenance is reported separately. It is derived
+  from the private tool ledger for normal outcomes and from the evaluation
+  owner for sandbox hard stops, so a later expression failure, timeout, or heap
+  kill cannot erase it.
 
   Continued and returned evaluations atomically commit native memory and exact
   bounded history before exposing only an inert public value. Continued results
@@ -304,12 +308,15 @@ defmodule PtcRunner.Kernel.Evaluation do
           mission_calls_before,
           projection_boundary
         )
+        |> put_terminal_provider_failure(step)
 
       {:ok, step} ->
         commit_result(state, lease, history, step, projection_boundary)
+        |> put_terminal_provider_failure(step)
 
       {:error, step} ->
         release_failure(state, environment, lease, step, mission_calls_before)
+        |> put_terminal_provider_failure(step)
     end
   end
 
@@ -466,7 +473,7 @@ defmodule PtcRunner.Kernel.Evaluation do
     {capability_activity?, unsafe_activity?} =
       evaluation_activity(state, environment, step, mission_calls_before)
 
-    :ok = RunState.release_evaluation(state, lease)
+    {:ok, evaluation_status} = RunState.release_evaluation_status(state, lease)
 
     details =
       step.fail
@@ -482,10 +489,15 @@ defmodule PtcRunner.Kernel.Evaluation do
       continuation_effect: :preserved
     }
 
-    case evaluation_retryable(step, unsafe_activity?) do
-      retryable? when is_boolean(retryable?) -> Map.put(result, :retryable?, retryable?)
-      nil -> result
-    end
+    result =
+      case evaluation_retryable(step, unsafe_activity?) do
+        retryable? when is_boolean(retryable?) -> Map.put(result, :retryable?, retryable?)
+        nil -> result
+      end
+
+    if evaluation_status.terminal_provider_failure?,
+      do: Map.put(result, :terminal_provider_failure?, true),
+      else: result
   end
 
   defp evaluation_activity(state, environment, step, mission_calls_before) do
@@ -566,6 +578,36 @@ defmodule PtcRunner.Kernel.Evaluation do
         %{error: nil, result: result} -> result === value
         _other -> false
       end
+  end
+
+  defp put_terminal_provider_failure(result, step) do
+    if terminal_provider_failure?(step),
+      do: Map.put(result, :terminal_provider_failure?, true),
+      else: result
+  end
+
+  defp terminal_provider_failure?(step) do
+    step
+    |> Map.get(:tool_calls, [])
+    |> List.wrap()
+    |> Enum.any?(fn
+      %{result: %{status: :error, kind: :provider_error, reason: :denied}} ->
+        true
+
+      %{
+        result: %{
+          status: :error,
+          kind: :provider_error,
+          reason: :invalid_result,
+          details: details
+        }
+      }
+      when details in ["mcp_capability_negotiation_error", "mcp_protocol_error"] ->
+        true
+
+      _call ->
+        false
+    end)
   end
 
   defp mission_capability_call_count(state), do: call_total(mission_capability_calls(state))

--- a/lib/ptc_runner/kernel/mcp_base64_format.ex
+++ b/lib/ptc_runner/kernel/mcp_base64_format.ex
@@ -1,0 +1,25 @@
+defmodule PtcRunner.Kernel.MCPBase64Format do
+  @moduledoc false
+
+  @behaviour JSV.FormatValidator
+
+  @impl true
+  def supported_formats, do: ["byte"]
+
+  @impl true
+  def applies_to_type?("byte", value), do: is_binary(value)
+
+  @impl true
+  def validate_cast("byte", value) do
+    case Base.decode64(value) do
+      {:ok, _decoded} ->
+        {:ok, value}
+
+      :error ->
+        case Base.decode64(value, padding: false) do
+          {:ok, _decoded} -> {:ok, value}
+          :error -> {:error, :invalid_base64}
+        end
+    end
+  end
+end

--- a/lib/ptc_runner/kernel/mcp_protocol.ex
+++ b/lib/ptc_runner/kernel/mcp_protocol.ex
@@ -22,15 +22,42 @@ defmodule PtcRunner.Kernel.MCPProtocol do
   companion blocks are validated and discarded. Tools without output schemas
   return a map containing ordered `"text"` values and, when present, ordered
   embedded text `"resources"`. Binary resources and all other content types
-  remain unsupported. The functions return closed MCP reason atoms and never
-  construct provider errors or expose remote error data.
+  remain unsupported.
+
+  Multi-round-trip `input_required` results are legal only for `tools/call`,
+  `prompts/get`, and `resources/read`. A schema-valid state-only result,
+  including an empty load-shedding `inputRequests` map accompanied by
+  `requestState`, is refused by policy. A schema-valid, non-empty request map is
+  a capability-negotiation error because the client advertises no elicitation,
+  sampling, or roots capability. Input requests are validated against those
+  three method schemas only to distinguish malformed protocol data; they are
+  never interpreted or fulfilled. Malformed results and results on other
+  methods are protocol errors. This module never retries either form. The
+  functions return closed MCP reason atoms and never construct provider errors
+  or expose remote error data.
   """
 
   alias PtcRunner.Kernel.DeterministicJSON
   alias PtcRunner.Kernel.JSONSchema
   alias PtcRunner.Kernel.JSONValue
+  alias PtcRunner.Kernel.MCPBase64Format
   alias PtcRunner.Kernel.StrictJSON
 
+  @input_request_schema_path Path.expand(
+                               "../../../priv/schemas/mcp-input-request-2026-07-28.schema.json",
+                               __DIR__
+                             )
+  @external_resource @input_request_schema_path
+  @input_request_validator @input_request_schema_path
+                           |> File.read!()
+                           |> Jason.decode!()
+                           |> JSV.build!(
+                             atoms: false,
+                             formats: [
+                               MCPBase64Format | JSV.default_format_validator_modules()
+                             ],
+                             warnings: :silent
+                           )
   @upstream_name ~r/\A[^\s\x00-\x1f\x7f]{1,128}\z/u
   @header_token ~r/\A[!#$%&'*+\-.^_`|~0-9A-Za-z]+\z/
   @max_safe_integer 9_007_199_254_740_991
@@ -38,6 +65,7 @@ defmodule PtcRunner.Kernel.MCPProtocol do
   @max_header_name_bytes 128
   @max_parameter_header_bytes 16_384
   @max_schema_depth 16
+  @input_required_methods ~w(tools/call prompts/get resources/read)
   @schema_instance_keywords ~w(const enum)
   @schema_value_keywords ~w(additionalProperties contains if items not then else)
   @schema_list_keywords ~w(allOf anyOf oneOf prefixItems)
@@ -168,7 +196,12 @@ defmodule PtcRunner.Kernel.MCPProtocol do
 
   @spec outcome(map(), binary()) ::
           {:ok, map()}
-          | {:error, :mcp_protocol_error | :mcp_remote_error | :mcp_unsupported_result}
+          | {:error,
+             :mcp_capability_negotiation_error
+             | :mcp_input_required_refused
+             | :mcp_protocol_error
+             | :mcp_remote_error
+             | :mcp_unsupported_result}
   def outcome(body, method) when is_map(body) and is_binary(method) do
     case {Map.fetch(body, "result"), Map.fetch(body, "error")} do
       {{:ok, result}, :error} when is_map(result) ->
@@ -559,9 +592,11 @@ defmodule PtcRunner.Kernel.MCPProtocol do
     if cacheable_method?(method), do: validate_cache_hints(result), else: {:ok, result}
   end
 
-  defp classify_result(%{"resultType" => type}, _method)
-       when type in ["input_required", "task"],
-       do: {:error, :mcp_unsupported_result}
+  defp classify_result(%{"resultType" => "input_required"} = result, method),
+    do: classify_input_required(result, method)
+
+  defp classify_result(%{"resultType" => "task"}, _method),
+    do: {:error, :mcp_unsupported_result}
 
   defp classify_result(result, _method) when not is_map_key(result, "resultType"),
     do: {:error, :mcp_protocol_error}
@@ -570,6 +605,60 @@ defmodule PtcRunner.Kernel.MCPProtocol do
     do: {:error, :mcp_unsupported_result}
 
   defp classify_result(_result, _method), do: {:error, :mcp_protocol_error}
+
+  defp classify_input_required(result, method) when method in @input_required_methods do
+    input_requests = Map.fetch(result, "inputRequests")
+    request_state = Map.fetch(result, "requestState")
+
+    with true <- JSONValue.map?(result),
+         true <- valid_optional_result_meta?(result),
+         true <- valid_optional_request_state?(request_state) do
+      case {input_requests, request_state} do
+        {{:ok, requests}, {:ok, _state}}
+        when is_map(requests) and not is_struct(requests) and map_size(requests) == 0 ->
+          {:error, :mcp_input_required_refused}
+
+        {{:ok, requests}, _request_state}
+        when is_map(requests) and not is_struct(requests) and map_size(requests) > 0 ->
+          if valid_input_requests?(requests),
+            do: {:error, :mcp_capability_negotiation_error},
+            else: {:error, :mcp_protocol_error}
+
+        {:error, {:ok, _state}} ->
+          {:error, :mcp_input_required_refused}
+
+        _malformed ->
+          {:error, :mcp_protocol_error}
+      end
+    else
+      false -> {:error, :mcp_protocol_error}
+    end
+  end
+
+  defp classify_input_required(_result, _method), do: {:error, :mcp_protocol_error}
+
+  defp valid_input_requests?(requests) do
+    Enum.all?(requests, fn
+      {id, request} when is_binary(id) -> valid_input_request?(request)
+      _entry -> false
+    end)
+  end
+
+  defp valid_input_request?(request) do
+    match?({:ok, _validated}, JSV.validate(request, @input_request_validator, cast: false))
+  rescue
+    _exception -> false
+  end
+
+  defp valid_optional_result_meta?(result) do
+    case Map.fetch(result, "_meta") do
+      :error -> true
+      {:ok, meta} -> is_map(meta) and not is_struct(meta)
+    end
+  end
+
+  defp valid_optional_request_state?(:error), do: true
+  defp valid_optional_request_state?({:ok, state}), do: is_binary(state)
 
   defp validate_cache_hints(%{"ttlMs" => ttl, "cacheScope" => scope} = result)
        when is_integer(ttl) and ttl >= 0 and scope in ["public", "private"],

--- a/lib/ptc_runner/kernel/mcp_source.ex
+++ b/lib/ptc_runner/kernel/mcp_source.ex
@@ -148,7 +148,8 @@ defmodule PtcRunner.Kernel.MCPSource do
   stable atom error: `:mcp_authentication_failed`, `:mcp_timeout`,
   `:mcp_transport_error`, `:mcp_protocol_error`, `:mcp_remote_error`,
   `:mcp_response_exceeded`, `:mcp_catalog_exceeded`, `:mcp_invalid_catalog`,
-  `:mcp_invalid_tool_schema`, `:mcp_unsupported_result`,
+  `:mcp_invalid_tool_schema`, `:mcp_capability_negotiation_error`,
+  `:mcp_input_required_refused`, `:mcp_unsupported_result`,
   `:mcp_mapped_tool_missing`, or `:mcp_invalid_snapshot_identity`.
 
   ## Frozen result and snapshot contracts
@@ -163,6 +164,12 @@ defmodule PtcRunner.Kernel.MCPSource do
   schema failures become bounded `PtcRunner.Kernel.ProviderError` values with
   closed reasons. Authentication, timeout, unsupported-result, invalid-result,
   and transport failures never include remote messages or payloads.
+  `InputRequiredResult` is never retried: valid state-only results, including
+  empty load-shedding request maps accompanied by `requestState`, become the denied
+  `mcp_input_required_refused` policy cause, valid non-empty input-bearing
+  results become `mcp_capability_negotiation_error` because this client
+  advertises no input capabilities, and malformed or method-inapplicable
+  results remain `mcp_protocol_error`.
   Parameter-header projection, outbound-header validation, and a closed HTTP
   request context are trusted `:not_dispatched` failures. Once an HTTP request
   begins or a stdio request may have been written, failures carry internal
@@ -1615,6 +1622,26 @@ defmodule PtcRunner.Kernel.MCPSource do
 
   defp provider_error(:mcp_protocol_error, effect, provenance),
     do: provider_error(:invalid_result, "mcp_protocol_error", false, effect, provenance)
+
+  defp provider_error(:mcp_capability_negotiation_error, effect, provenance),
+    do:
+      provider_error(
+        :invalid_result,
+        "mcp_capability_negotiation_error",
+        false,
+        effect,
+        provenance
+      )
+
+  defp provider_error(:mcp_input_required_refused, effect, provenance),
+    do:
+      provider_error(
+        :denied,
+        "mcp_input_required_refused",
+        false,
+        effect,
+        provenance
+      )
 
   defp provider_error(:mcp_remote_error, effect, provenance),
     do: provider_error(:domain_error, "mcp_remote_error", false, effect, provenance)

--- a/lib/ptc_runner/kernel/run_state.ex
+++ b/lib/ptc_runner/kernel/run_state.ex
@@ -27,7 +27,10 @@ defmodule PtcRunner.Kernel.RunState do
   terminates. A process holds at most one reservation at a time: dispatch is
   sequential per process, so a second reserve while one is active is a protocol
   violation and is rejected rather than silently replacing the tracked
-  reservation.
+  reservation. A provider process atomically records terminal policy
+  classification against the active evaluation before publishing its result;
+  that evaluation-scoped bit therefore survives a later sandbox timeout or heap
+  kill and is cleared with the lease.
   """
   use GenServer
 
@@ -128,6 +131,11 @@ defmodule PtcRunner.Kernel.RunState do
   @doc "Releases a provider slot and accepts completion only while the run is open."
   def finish_provider(state), do: call(state, :finish_provider)
 
+  @doc false
+  @spec mark_evaluation_terminal_provider_failure(t()) :: :ok
+  def mark_evaluation_terminal_provider_failure(state),
+    do: call(state, :mark_evaluation_terminal_provider_failure)
+
   @spec reserve_evaluation(t()) :: {:ok, map(), [term()], reference()} | {:error, atom()}
   @doc "Atomically reserves and returns native subordinate memory and turn history."
   def reserve_evaluation(state), do: call(state, :reserve_evaluation)
@@ -141,6 +149,12 @@ defmodule PtcRunner.Kernel.RunState do
   @spec release_evaluation(t(), reference()) :: :ok | {:error, atom()}
   @doc "Releases the caller's evaluation lease without changing committed memory."
   def release_evaluation(state, lease), do: call(state, {:release_evaluation, lease})
+
+  @doc false
+  @spec release_evaluation_status(t(), reference()) ::
+          {:ok, %{terminal_provider_failure?: boolean()}} | {:error, atom()}
+  def release_evaluation_status(state, lease),
+    do: call(state, {:release_evaluation_status, lease})
 
   @spec protocol_error(t()) :: :ok | {:error, :protocol_error_limit}
   @doc "Records one protocol error and closes the run when its ceiling is exceeded."
@@ -235,6 +249,8 @@ defmodule PtcRunner.Kernel.RunState do
        memory: %{},
        history: [],
        evaluation_lease: nil,
+       evaluation_release_waiter: nil,
+       evaluation_terminal_provider_failure?: false,
        reservations: %{}
      }}
   end
@@ -302,6 +318,35 @@ defmodule PtcRunner.Kernel.RunState do
     {:reply, reply, state}
   end
 
+  def handle_call(
+        {token, :mark_evaluation_terminal_provider_failure},
+        {provider, _tag},
+        %{token: token} = state
+      ) do
+    reservation_lease =
+      Enum.find_value(state.reservations, fn
+        {_caller,
+         %{environment: :mission, provider: ^provider, evaluation_lease: evaluation_lease}} ->
+          evaluation_lease
+
+        _reservation ->
+          nil
+      end)
+
+    current_lease? =
+      case state.evaluation_lease do
+        {^reservation_lease, _owner, _monitor_ref} when is_reference(reservation_lease) -> true
+        _other -> false
+      end
+
+    state =
+      if current_lease?,
+        do: %{state | evaluation_terminal_provider_failure?: true},
+        else: state
+
+    {:reply, :ok, state}
+  end
+
   def handle_call({token, :reserve_evaluation}, {caller, _tag}, %{token: token} = state) do
     cond do
       state.closed? ->
@@ -320,7 +365,13 @@ defmodule PtcRunner.Kernel.RunState do
         lease = {make_ref(), caller, Process.monitor(caller)}
 
         {:reply, {:ok, state.memory, state.history, elem(lease, 0)},
-         %{state | evaluations: state.evaluations + 1, evaluation_lease: lease}}
+         %{
+           state
+           | evaluations: state.evaluations + 1,
+             evaluation_lease: lease,
+             evaluation_release_waiter: nil,
+             evaluation_terminal_provider_failure?: false
+         }}
     end
   end
 
@@ -353,7 +404,7 @@ defmodule PtcRunner.Kernel.RunState do
 
         cond do
           unavailable?(state) ->
-            {:reply, {:error, :run_closed}, %{state | evaluation_lease: nil}}
+            {:reply, {:error, :run_closed}, clear_evaluation(state)}
 
           not event_sink_ready?(state.event_sink) ->
             failure =
@@ -362,28 +413,29 @@ defmodule PtcRunner.Kernel.RunState do
             next = %{
               state
               | closed?: true,
-                terminal_failure: failure,
-                evaluation_lease: nil
+                terminal_failure: failure
             }
+
+            next = clear_evaluation(next)
 
             {:reply, {:error, :run_closed}, next}
 
           not (is_integer(memory_bytes) and
                    memory_bytes <= state.limits.evaluation_memory_bytes) ->
-            {:reply, {:error, :memory_exceeded}, %{state | evaluation_lease: nil}}
+            {:reply, {:error, :memory_exceeded}, clear_evaluation(state)}
 
           not (history_values_valid? and is_integer(history_bytes) and
                    history_bytes <= state.limits.evaluation_history_bytes) ->
-            {:reply, {:error, :history_exceeded}, %{state | evaluation_lease: nil}}
+            {:reply, {:error, :history_exceeded}, clear_evaluation(state)}
 
           true ->
             {:reply, :ok,
              %{
                state
                | memory: RetainedSize.detach_binaries(memory),
-                 history: RetainedSize.detach_binaries(history),
-                 evaluation_lease: nil
-             }}
+                 history: RetainedSize.detach_binaries(history)
+             }
+             |> clear_evaluation()}
         end
 
       _ ->
@@ -395,7 +447,26 @@ defmodule PtcRunner.Kernel.RunState do
     case state.evaluation_lease do
       {^lease, ^caller, monitor_ref} ->
         Process.demonitor(monitor_ref, [:flush])
-        {:reply, :ok, %{state | evaluation_lease: nil}}
+        {:reply, :ok, clear_evaluation(state)}
+
+      _ ->
+        {:reply, {:error, :stale_lease}, state}
+    end
+  end
+
+  def handle_call(
+        {token, {:release_evaluation_status, lease}},
+        {caller, _tag} = from,
+        %{token: token} = state
+      ) do
+    case state.evaluation_lease do
+      {^lease, ^caller, monitor_ref} ->
+        if evaluation_reservations?(state, lease) do
+          {:noreply, %{state | evaluation_release_waiter: {from, lease}}}
+        else
+          Process.demonitor(monitor_ref, [:flush])
+          {:reply, {:ok, evaluation_status(state)}, clear_evaluation(state)}
+        end
 
       _ ->
         {:reply, {:error, :stale_lease}, state}
@@ -515,7 +586,7 @@ defmodule PtcRunner.Kernel.RunState do
         {:DOWN, ref, :process, _pid, _reason},
         %{evaluation_lease: {_lease, _caller, ref}} = state
       ),
-      do: {:noreply, %{state | evaluation_lease: nil}}
+      do: {:noreply, clear_evaluation(state)}
 
   def handle_info({:DOWN, ref, :process, pid, _reason}, state) do
     case state.reservations do
@@ -590,6 +661,7 @@ defmodule PtcRunner.Kernel.RunState do
     end)
 
     %{state | closed?: true, provider_tasks: 0, reservations: %{}}
+    |> maybe_complete_evaluation_release()
   end
 
   defp redact_status(status) do
@@ -631,6 +703,8 @@ defmodule PtcRunner.Kernel.RunState do
 
       true ->
         reservation = %{
+          environment: environment,
+          evaluation_lease: active_evaluation_lease(state, environment),
           caller_ref: Process.monitor(caller),
           provider: nil,
           provider_ref: nil
@@ -663,11 +737,61 @@ defmodule PtcRunner.Kernel.RunState do
         :ok
     end
 
-    if reservation do
-      %{state | provider_tasks: max(state.provider_tasks - 1, 0), reservations: reservations}
-    else
-      state
+    next =
+      if reservation do
+        %{state | provider_tasks: max(state.provider_tasks - 1, 0), reservations: reservations}
+      else
+        state
+      end
+
+    maybe_complete_evaluation_release(next)
+  end
+
+  defp active_evaluation_lease(state, :mission) do
+    case state.evaluation_lease do
+      {lease, _owner, _monitor_ref} -> lease
+      nil -> nil
     end
+  end
+
+  defp active_evaluation_lease(_state, :workflow), do: nil
+
+  defp evaluation_reservations?(state, lease) do
+    Enum.any?(state.reservations, fn
+      {_caller, %{evaluation_lease: ^lease}} -> true
+      _reservation -> false
+    end)
+  end
+
+  defp evaluation_status(state) do
+    %{terminal_provider_failure?: state.evaluation_terminal_provider_failure?}
+  end
+
+  defp maybe_complete_evaluation_release(%{evaluation_release_waiter: nil} = state), do: state
+
+  defp maybe_complete_evaluation_release(%{evaluation_release_waiter: {from, lease}} = state) do
+    case state.evaluation_lease do
+      {^lease, _owner, monitor_ref} ->
+        if evaluation_reservations?(state, lease) do
+          state
+        else
+          Process.demonitor(monitor_ref, [:flush])
+          GenServer.reply(from, {:ok, evaluation_status(state)})
+          clear_evaluation(state)
+        end
+
+      _other ->
+        clear_evaluation(state)
+    end
+  end
+
+  defp clear_evaluation(state) do
+    %{
+      state
+      | evaluation_lease: nil,
+        evaluation_release_waiter: nil,
+        evaluation_terminal_provider_failure?: false
+    }
   end
 
   defp reservation_by_provider_ref(reservations, ref) do

--- a/priv/preludes/kernel/agent.core.clj
+++ b/priv/preludes/kernel/agent.core.clj
@@ -104,64 +104,74 @@
             (case (get action :kind)
               :tool-call
               (let [evaluation (kernel/eval-source (get action :program))]
-                (case (get evaluation :outcome)
-                  :returned
-                  (returned-outcome (get evaluation :value))
-                  :failed
-                  (if (and (correctable-capability-failure? evaluation)
-                           (agent.retry/retry? turn max-turns))
-                    (let [event (completed-event :evaluation-error turn max-turns)
-                          next-prompt-state (transition-prompt prompt-state event)]
-                      (recur (inc turn)
-                             (append-correlated
-                               messages
-                               action
-                               (agent.feedback/capability-error evaluation))
-                             next-prompt-state
-                             closing?))
-                    (subject-failure :model-program-failed (get evaluation :value)))
-                  :continued
-                  (if (agent.retry/retry? turn max-turns)
-                    (let [event (completed-event :evaluation-success turn max-turns)
-                          next-prompt-state (transition-prompt prompt-state event)
-                          observation (agent.feedback/success evaluation max-observation-chars)]
-                      (recur (inc turn)
-                             (append-correlated messages action observation)
-                             next-prompt-state
-                             closing?))
-                    (subject-failure :turn-limit :intermediate-result))
-                  (if (false? (get evaluation :retryable?))
-                    ;; An unsafe failure forbids repeating the program, not
-                    ;; salvaging the run. Spend one closing turn asking for a
-                    ;; decision from evidence already gathered rather than
-                    ;; discarding every prior evaluation; a second unsafe
-                    ;; failure ends it.
-                    (if (or closing? (not (agent.retry/retry? turn max-turns)))
-                      (subject-failure :non-retryable-evaluation (get evaluation :kind))
-                      (let [next-prompt-state
-                            (transition-prompt
-                              prompt-state
-                              (completed-event :evaluation-error turn max-turns))]
+                ;; Host policy and malformed/provider-initiated MCP exchanges
+                ;; are not argument mistakes the model can correct. The Kernel
+                ;; derives this provenance from the private capability ledger,
+                ;; so it applies even when a later expression fails.
+                (if (true? (get evaluation :terminal-provider-failure?))
+                  (subject-failure
+                    :model-program-failed
+                    (if (= :failed (get evaluation :outcome))
+                      (get evaluation :value)
+                      :terminal-provider-failure))
+                  (case (get evaluation :outcome)
+                    :returned
+                    (returned-outcome (get evaluation :value))
+                    :failed
+                    (if (and (correctable-capability-failure? evaluation)
+                             (agent.retry/retry? turn max-turns))
+                      (let [event (completed-event :evaluation-error turn max-turns)
+                            next-prompt-state (transition-prompt prompt-state event)]
                         (recur (inc turn)
                                (append-correlated
                                  messages
                                  action
-                                 (agent.feedback/non-retryable evaluation))
-                               next-prompt-state
-                               true)))
-                    (if (agent.retry/retry? turn max-turns)
-                      (let [next-prompt-state
-                            (transition-prompt
-                              prompt-state
-                              (completed-event :evaluation-error turn max-turns))]
-                        (recur (inc turn)
-                               (append-correlated
-                                 messages
-                                 action
-                                 (agent.feedback/evaluation-error evaluation))
+                                 (agent.feedback/capability-error evaluation))
                                next-prompt-state
                                closing?))
-                      (subject-failure :turn-limit :evaluation-error)))))
+                      (subject-failure :model-program-failed (get evaluation :value)))
+                    :continued
+                    (if (agent.retry/retry? turn max-turns)
+                      (let [event (completed-event :evaluation-success turn max-turns)
+                            next-prompt-state (transition-prompt prompt-state event)
+                            observation (agent.feedback/success evaluation max-observation-chars)]
+                        (recur (inc turn)
+                               (append-correlated messages action observation)
+                               next-prompt-state
+                               closing?))
+                      (subject-failure :turn-limit :intermediate-result))
+                    (if (false? (get evaluation :retryable?))
+                      ;; An unsafe failure forbids repeating the program, not
+                      ;; salvaging the run. Spend one closing turn asking for a
+                      ;; decision from evidence already gathered rather than
+                      ;; discarding every prior evaluation; a second unsafe
+                      ;; failure ends it.
+                      (if (or closing? (not (agent.retry/retry? turn max-turns)))
+                        (subject-failure :non-retryable-evaluation (get evaluation :kind))
+                        (let [next-prompt-state
+                              (transition-prompt
+                                prompt-state
+                                (completed-event :evaluation-error turn max-turns))]
+                          (recur (inc turn)
+                                 (append-correlated
+                                   messages
+                                   action
+                                   (agent.feedback/non-retryable evaluation))
+                                 next-prompt-state
+                                 true)))
+                      (if (agent.retry/retry? turn max-turns)
+                        (let [next-prompt-state
+                              (transition-prompt
+                                prompt-state
+                                (completed-event :evaluation-error turn max-turns))]
+                          (recur (inc turn)
+                                 (append-correlated
+                                   messages
+                                   action
+                                   (agent.feedback/evaluation-error evaluation))
+                                 next-prompt-state
+                                 closing?))
+                        (subject-failure :turn-limit :evaluation-error))))))
 
               :protocol-error
               (if (agent.retry/retry? turn max-turns)

--- a/priv/schemas/mcp-input-request-2026-07-28.schema.json
+++ b/priv/schemas/mcp-input-request-2026-07-28.schema.json
@@ -1,0 +1,1190 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$comment": "InputRequest dependency closure extracted from modelcontextprotocol/modelcontextprotocol@5f5440bb26a62e2cf3440b92da5a667efa03b267 schema/2026-07-28/schema.json. JSONValue restores number and null from the canonical TypeScript definition because the generated JSON Schema narrows number to integer and omits null.",
+  "$defs": {
+    "Annotations": {
+      "description": "Optional annotations for the client. The client can use annotations to inform how objects are used or displayed",
+      "properties": {
+        "audience": {
+          "description": "Describes who the intended audience of this object or data is.\n\nIt can include multiple entries to indicate content useful for multiple audiences (e.g., `[\"user\", \"assistant\"]`).",
+          "items": {
+            "$ref": "#/$defs/Role"
+          },
+          "type": "array"
+        },
+        "lastModified": {
+          "description": "The moment the resource was last modified, as an ISO 8601 formatted string.\n\nShould be an ISO 8601 formatted string (e.g., \"2025-01-12T15:00:58Z\").\n\nExamples: last activity timestamp in an open file, timestamp when the resource\nwas attached, etc.",
+          "type": "string"
+        },
+        "priority": {
+          "description": "Describes how important this data is for operating the server.\n\nA value of 1 means \"most important,\" and indicates that the data is\neffectively required, while 0 means \"least important,\" and indicates that\nthe data is entirely optional.",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        }
+      },
+      "type": "object"
+    },
+    "AudioContent": {
+      "description": "Audio provided to or from an LLM.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "annotations": {
+          "$ref": "#/$defs/Annotations",
+          "description": "Optional annotations for the client."
+        },
+        "data": {
+          "description": "The base64-encoded audio data.",
+          "format": "byte",
+          "type": "string"
+        },
+        "mimeType": {
+          "description": "The MIME type of the audio. Different providers may support different audio types.",
+          "type": "string"
+        },
+        "type": {
+          "const": "audio",
+          "type": "string"
+        }
+      },
+      "required": [
+        "data",
+        "mimeType",
+        "type"
+      ],
+      "type": "object"
+    },
+    "BlobResourceContents": {
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "blob": {
+          "description": "A base64-encoded string representing the binary data of the item.",
+          "format": "byte",
+          "type": "string"
+        },
+        "mimeType": {
+          "description": "The MIME type of this resource, if known.",
+          "type": "string"
+        },
+        "uri": {
+          "description": "The URI of this resource.",
+          "format": "uri",
+          "type": "string"
+        }
+      },
+      "required": [
+        "blob",
+        "uri"
+      ],
+      "type": "object"
+    },
+    "BooleanSchema": {
+      "properties": {
+        "default": {
+          "type": "boolean"
+        },
+        "description": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "type": {
+          "const": "boolean",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "ContentBlock": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/TextContent"
+        },
+        {
+          "$ref": "#/$defs/ImageContent"
+        },
+        {
+          "$ref": "#/$defs/AudioContent"
+        },
+        {
+          "$ref": "#/$defs/ResourceLink"
+        },
+        {
+          "$ref": "#/$defs/EmbeddedResource"
+        }
+      ]
+    },
+    "CreateMessageRequest": {
+      "description": "A request from the server to sample an LLM via the client. The client has full discretion over which model to select. The client should also inform the user before beginning sampling, to allow them to inspect the request (human in the loop) and decide whether to approve it.",
+      "properties": {
+        "method": {
+          "const": "sampling/createMessage",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/CreateMessageRequestParams"
+        }
+      },
+      "required": [
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "CreateMessageRequestParams": {
+      "description": "Parameters for a `sampling/createMessage` request.",
+      "properties": {
+        "includeContext": {
+          "description": "A request to include context from one or more MCP servers (including the caller), to be attached to the prompt.\nThe client MAY ignore this request.\n\nDefault is `\"none\"`. The values `\"thisServer\"` and `\"allServers\"` are deprecated (SEP-2596): servers SHOULD\nomit this field or use `\"none\"`, and SHOULD only use the deprecated values if the client declares\n{@link ClientCapabilities.sampling.context}.",
+          "enum": [
+            "allServers",
+            "none",
+            "thisServer"
+          ],
+          "type": "string"
+        },
+        "maxTokens": {
+          "description": "The requested maximum number of tokens to sample (to prevent runaway completions).\n\nThe client MAY choose to sample fewer tokens than the requested maximum.",
+          "type": "integer"
+        },
+        "messages": {
+          "items": {
+            "$ref": "#/$defs/SamplingMessage"
+          },
+          "type": "array"
+        },
+        "metadata": {
+          "$ref": "#/$defs/JSONObject",
+          "description": "Optional metadata to pass through to the LLM provider. The format of this metadata is provider-specific."
+        },
+        "modelPreferences": {
+          "$ref": "#/$defs/ModelPreferences",
+          "description": "The server's preferences for which model to select. The client MAY ignore these preferences."
+        },
+        "stopSequences": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "systemPrompt": {
+          "description": "An optional system prompt the server wants to use for sampling. The client MAY modify or omit this prompt.",
+          "type": "string"
+        },
+        "temperature": {
+          "type": "number"
+        },
+        "toolChoice": {
+          "$ref": "#/$defs/ToolChoice",
+          "description": "Controls how the model uses tools.\nThe client MUST return an error if this field is provided but {@link ClientCapabilities.sampling.tools} is not declared.\nDefault is `{ mode: \"auto\" }`."
+        },
+        "tools": {
+          "description": "Tools that the model may use during generation.\nThe client MUST return an error if this field is provided but {@link ClientCapabilities.sampling.tools} is not declared.",
+          "items": {
+            "$ref": "#/$defs/Tool"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "maxTokens",
+        "messages"
+      ],
+      "type": "object"
+    },
+    "ElicitRequest": {
+      "description": "A request from the server to elicit additional information from the user via the client.",
+      "properties": {
+        "method": {
+          "const": "elicitation/create",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/ElicitRequestParams"
+        }
+      },
+      "required": [
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "ElicitRequestFormParams": {
+      "description": "The parameters for a request to elicit non-sensitive information from the user via a form in the client.",
+      "properties": {
+        "message": {
+          "description": "The message to present to the user describing what information is being requested.",
+          "type": "string"
+        },
+        "mode": {
+          "const": "form",
+          "description": "The elicitation mode.",
+          "type": "string"
+        },
+        "requestedSchema": {
+          "description": "A restricted subset of JSON Schema.\nOnly top-level properties are allowed, without nesting.",
+          "properties": {
+            "$schema": {
+              "type": "string"
+            },
+            "properties": {
+              "additionalProperties": {
+                "$ref": "#/$defs/PrimitiveSchemaDefinition"
+              },
+              "type": "object"
+            },
+            "required": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "type": {
+              "const": "object",
+              "type": "string"
+            }
+          },
+          "required": [
+            "properties",
+            "type"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "message",
+        "requestedSchema"
+      ],
+      "type": "object"
+    },
+    "ElicitRequestParams": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/ElicitRequestFormParams"
+        },
+        {
+          "$ref": "#/$defs/ElicitRequestURLParams"
+        }
+      ],
+      "description": "The parameters for a request to elicit additional information from the user via the client."
+    },
+    "ElicitRequestURLParams": {
+      "description": "The parameters for a request to elicit information from the user via a URL in the client.",
+      "properties": {
+        "message": {
+          "description": "The message to present to the user explaining why the interaction is needed.",
+          "type": "string"
+        },
+        "mode": {
+          "const": "url",
+          "description": "The elicitation mode.",
+          "type": "string"
+        },
+        "url": {
+          "description": "The URL that the user should navigate to.",
+          "format": "uri",
+          "type": "string"
+        }
+      },
+      "required": [
+        "message",
+        "mode",
+        "url"
+      ],
+      "type": "object"
+    },
+    "EmbeddedResource": {
+      "description": "The contents of a resource, embedded into a prompt or tool call result.\n\nIt is up to the client how best to render embedded resources for the benefit\nof the LLM and/or the user.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "annotations": {
+          "$ref": "#/$defs/Annotations",
+          "description": "Optional annotations for the client."
+        },
+        "resource": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TextResourceContents"
+            },
+            {
+              "$ref": "#/$defs/BlobResourceContents"
+            }
+          ]
+        },
+        "type": {
+          "const": "resource",
+          "type": "string"
+        }
+      },
+      "required": [
+        "resource",
+        "type"
+      ],
+      "type": "object"
+    },
+    "Icon": {
+      "description": "An optionally-sized icon that can be displayed in a user interface.",
+      "properties": {
+        "mimeType": {
+          "description": "Optional MIME type override if the source MIME type is missing or generic.\nFor example: `\"image/png\"`, `\"image/jpeg\"`, or `\"image/svg+xml\"`.",
+          "type": "string"
+        },
+        "sizes": {
+          "description": "Optional array of strings that specify sizes at which the icon can be used.\nEach string should be in WxH format (e.g., `\"48x48\"`, `\"96x96\"`) or `\"any\"` for scalable formats like SVG.\n\nIf not provided, the client should assume that the icon can be used at any size.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "src": {
+          "description": "A standard URI pointing to an icon resource. May be an HTTP/HTTPS URL or a\n`data:` URI with Base64-encoded image data.\n\nConsumers SHOULD take steps to ensure URLs serving icons are from the\nsame domain as the client/server or a trusted domain.\n\nConsumers SHOULD take appropriate precautions when consuming SVGs as they can contain\nexecutable JavaScript.",
+          "format": "uri",
+          "type": "string"
+        },
+        "theme": {
+          "description": "Optional specifier for the theme this icon is designed for. `\"light\"` indicates\nthe icon is designed to be used with a light background, and `\"dark\"` indicates\nthe icon is designed to be used with a dark background.\n\nIf not provided, the client should assume the icon can be used with any theme.",
+          "enum": [
+            "dark",
+            "light"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "src"
+      ],
+      "type": "object"
+    },
+    "ImageContent": {
+      "description": "An image provided to or from an LLM.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "annotations": {
+          "$ref": "#/$defs/Annotations",
+          "description": "Optional annotations for the client."
+        },
+        "data": {
+          "description": "The base64-encoded image data.",
+          "format": "byte",
+          "type": "string"
+        },
+        "mimeType": {
+          "description": "The MIME type of the image. Different providers may support different image types.",
+          "type": "string"
+        },
+        "type": {
+          "const": "image",
+          "type": "string"
+        }
+      },
+      "required": [
+        "data",
+        "mimeType",
+        "type"
+      ],
+      "type": "object"
+    },
+    "InputRequest": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/CreateMessageRequest"
+        },
+        {
+          "$ref": "#/$defs/ListRootsRequest"
+        },
+        {
+          "$ref": "#/$defs/ElicitRequest"
+        }
+      ]
+    },
+    "JSONObject": {
+      "additionalProperties": {
+        "$ref": "#/$defs/JSONValue"
+      },
+      "type": "object"
+    },
+    "JSONValue": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/JSONObject"
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/JSONValue"
+          },
+          "type": "array"
+        },
+        {
+          "type": [
+            "string",
+            "number",
+            "integer",
+            "boolean",
+            "null"
+          ]
+        }
+      ]
+    },
+    "LegacyTitledEnumSchema": {
+      "description": "Use {@link TitledSingleSelectEnumSchema} instead.\nThis interface will be removed in a future version.",
+      "properties": {
+        "default": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "enum": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "enumNames": {
+          "description": "(Legacy) Display names for enum values.\nNon-standard according to JSON schema 2020-12.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "title": {
+          "type": "string"
+        },
+        "type": {
+          "const": "string",
+          "type": "string"
+        }
+      },
+      "required": [
+        "enum",
+        "type"
+      ],
+      "type": "object"
+    },
+    "ListRootsRequest": {
+      "description": "Sent from the server to request a list of root URIs from the client. Roots allow\nservers to ask for specific directories or files to operate on. A common example\nfor roots is providing a set of repositories or directories a server should operate\non.\n\nThis request is typically used when the server needs to understand the file system\nstructure or access specific locations that the client has permission to read from.",
+      "properties": {
+        "method": {
+          "const": "roots/list",
+          "type": "string"
+        },
+        "params": {
+          "properties": {
+            "_meta": {
+              "$ref": "#/$defs/MetaObject"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "required": [
+        "method"
+      ],
+      "type": "object"
+    },
+    "MetaObject": {
+      "description": "Represents the contents of a `_meta` field, which clients and servers use to attach additional metadata to their interactions.\n\nCertain key names are reserved by MCP for protocol-level metadata; implementations MUST NOT make assumptions about values at these keys. Additionally, specific schema definitions may reserve particular names for purpose-specific metadata, as declared in those definitions.\n\nValid keys have two segments:\n\n**Prefix:**\n- Optional — if specified, MUST be a series of _labels_ separated by dots (`.`), followed by a slash (`/`).\n- Labels MUST start with a letter and end with a letter or digit. Interior characters may be letters, digits, or hyphens (`-`).\n- Implementations SHOULD use reverse DNS notation (e.g., `com.example/` rather than `example.com/`).\n- Any prefix where the second label is `modelcontextprotocol` or `mcp` is **reserved** for MCP use. For example: `io.modelcontextprotocol/`, `dev.mcp/`, `org.modelcontextprotocol.api/`, and `com.mcp.tools/` are all reserved. However, `com.example.mcp/` is NOT reserved, as the second label is `example`.\n\n**Name:**\n- Unless empty, MUST start and end with an alphanumeric character (`[a-z0-9A-Z]`).\n- Interior characters may be alphanumeric, hyphens (`-`), underscores (`_`), or dots (`.`).",
+      "type": "object"
+    },
+    "ModelHint": {
+      "description": "Hints to use for model selection.\n\nKeys not declared here are currently left unspecified by the spec and are up\nto the client to interpret.",
+      "properties": {
+        "name": {
+          "description": "A hint for a model name.\n\nThe client SHOULD treat this as a substring of a model name; for example:\n - `claude-3-5-sonnet` should match `claude-3-5-sonnet-20241022`\n - `sonnet` should match `claude-3-5-sonnet-20241022`, `claude-3-sonnet-20240229`, etc.\n - `claude` should match any Claude model\n\nThe client MAY also map the string to a different provider's model name or a different model family, as long as it fills a similar niche; for example:\n - `gemini-1.5-flash` could match `claude-3-haiku-20240307`",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ModelPreferences": {
+      "description": "The server's preferences for model selection, requested of the client during sampling.\n\nBecause LLMs can vary along multiple dimensions, choosing the \"best\" model is\nrarely straightforward.  Different models excel in different areas—some are\nfaster but less capable, others are more capable but more expensive, and so\non. This interface allows servers to express their priorities across multiple\ndimensions to help clients make an appropriate selection for their use case.\n\nThese preferences are always advisory. The client MAY ignore them. It is also\nup to the client to decide how to interpret these preferences and how to\nbalance them against other considerations.",
+      "properties": {
+        "costPriority": {
+          "description": "How much to prioritize cost when selecting a model. A value of 0 means cost\nis not important, while a value of 1 means cost is the most important\nfactor.",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        },
+        "hints": {
+          "description": "Optional hints to use for model selection.\n\nIf multiple hints are specified, the client MUST evaluate them in order\n(such that the first match is taken).\n\nThe client SHOULD prioritize these hints over the numeric priorities, but\nMAY still use the priorities to select from ambiguous matches.",
+          "items": {
+            "$ref": "#/$defs/ModelHint"
+          },
+          "type": "array"
+        },
+        "intelligencePriority": {
+          "description": "How much to prioritize intelligence and capabilities when selecting a\nmodel. A value of 0 means intelligence is not important, while a value of 1\nmeans intelligence is the most important factor.",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        },
+        "speedPriority": {
+          "description": "How much to prioritize sampling speed (latency) when selecting a model. A\nvalue of 0 means speed is not important, while a value of 1 means speed is\nthe most important factor.",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        }
+      },
+      "type": "object"
+    },
+    "NumberSchema": {
+      "properties": {
+        "default": {
+          "type": "number"
+        },
+        "description": {
+          "type": "string"
+        },
+        "maximum": {
+          "type": "number"
+        },
+        "minimum": {
+          "type": "number"
+        },
+        "title": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "integer",
+            "number"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "PrimitiveSchemaDefinition": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/StringSchema"
+        },
+        {
+          "$ref": "#/$defs/NumberSchema"
+        },
+        {
+          "$ref": "#/$defs/BooleanSchema"
+        },
+        {
+          "$ref": "#/$defs/UntitledSingleSelectEnumSchema"
+        },
+        {
+          "$ref": "#/$defs/TitledSingleSelectEnumSchema"
+        },
+        {
+          "$ref": "#/$defs/UntitledMultiSelectEnumSchema"
+        },
+        {
+          "$ref": "#/$defs/TitledMultiSelectEnumSchema"
+        },
+        {
+          "$ref": "#/$defs/LegacyTitledEnumSchema"
+        }
+      ],
+      "description": "Restricted schema definitions that only allow primitive types\nwithout nested objects or arrays."
+    },
+    "ResourceLink": {
+      "description": "A resource that the server is capable of reading, included in a prompt or tool call result.\n\nNote: resource links returned by tools are not guaranteed to appear in the results of {@link ListResourcesRequestresources/list} requests.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "annotations": {
+          "$ref": "#/$defs/Annotations",
+          "description": "Optional annotations for the client."
+        },
+        "description": {
+          "description": "A description of what this resource represents.\n\nThis can be used by clients to improve the LLM's understanding of available resources. It can be thought of like a \"hint\" to the model.",
+          "type": "string"
+        },
+        "icons": {
+          "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
+          "items": {
+            "$ref": "#/$defs/Icon"
+          },
+          "type": "array"
+        },
+        "mimeType": {
+          "description": "The MIME type of this resource, if known.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+          "type": "string"
+        },
+        "size": {
+          "description": "The size of the raw resource content, in bytes (i.e., before base64 encoding or any tokenization), if known.\n\nThis can be used by Hosts to display file sizes and estimate context window usage.",
+          "type": "integer"
+        },
+        "title": {
+          "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for {@link Tool},\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+          "type": "string"
+        },
+        "type": {
+          "const": "resource_link",
+          "type": "string"
+        },
+        "uri": {
+          "description": "The URI of this resource.",
+          "format": "uri",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "type",
+        "uri"
+      ],
+      "type": "object"
+    },
+    "Role": {
+      "description": "The sender or recipient of messages and data in a conversation.",
+      "enum": [
+        "assistant",
+        "user"
+      ],
+      "type": "string"
+    },
+    "SamplingMessage": {
+      "description": "Describes a message issued to or received from an LLM API.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "content": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TextContent"
+            },
+            {
+              "$ref": "#/$defs/ImageContent"
+            },
+            {
+              "$ref": "#/$defs/AudioContent"
+            },
+            {
+              "$ref": "#/$defs/ToolUseContent"
+            },
+            {
+              "$ref": "#/$defs/ToolResultContent"
+            },
+            {
+              "items": {
+                "$ref": "#/$defs/SamplingMessageContentBlock"
+              },
+              "type": "array"
+            }
+          ]
+        },
+        "role": {
+          "$ref": "#/$defs/Role"
+        }
+      },
+      "required": [
+        "content",
+        "role"
+      ],
+      "type": "object"
+    },
+    "SamplingMessageContentBlock": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/TextContent"
+        },
+        {
+          "$ref": "#/$defs/ImageContent"
+        },
+        {
+          "$ref": "#/$defs/AudioContent"
+        },
+        {
+          "$ref": "#/$defs/ToolUseContent"
+        },
+        {
+          "$ref": "#/$defs/ToolResultContent"
+        }
+      ]
+    },
+    "StringSchema": {
+      "properties": {
+        "default": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "format": {
+          "enum": [
+            "date",
+            "date-time",
+            "email",
+            "uri"
+          ],
+          "type": "string"
+        },
+        "maxLength": {
+          "type": "integer"
+        },
+        "minLength": {
+          "type": "integer"
+        },
+        "title": {
+          "type": "string"
+        },
+        "type": {
+          "const": "string",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "TextContent": {
+      "description": "Text provided to or from an LLM.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "annotations": {
+          "$ref": "#/$defs/Annotations",
+          "description": "Optional annotations for the client."
+        },
+        "text": {
+          "description": "The text content of the message.",
+          "type": "string"
+        },
+        "type": {
+          "const": "text",
+          "type": "string"
+        }
+      },
+      "required": [
+        "text",
+        "type"
+      ],
+      "type": "object"
+    },
+    "TextResourceContents": {
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "mimeType": {
+          "description": "The MIME type of this resource, if known.",
+          "type": "string"
+        },
+        "text": {
+          "description": "The text of the item. This must only be set if the item can actually be represented as text (not binary data).",
+          "type": "string"
+        },
+        "uri": {
+          "description": "The URI of this resource.",
+          "format": "uri",
+          "type": "string"
+        }
+      },
+      "required": [
+        "text",
+        "uri"
+      ],
+      "type": "object"
+    },
+    "TitledMultiSelectEnumSchema": {
+      "description": "Schema for multiple-selection enumeration with display titles for each option.",
+      "properties": {
+        "default": {
+          "description": "Optional default value.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "description": {
+          "description": "Optional description for the enum field.",
+          "type": "string"
+        },
+        "items": {
+          "description": "Schema for array items with enum options and display labels.",
+          "properties": {
+            "anyOf": {
+              "description": "Array of enum options with values and display labels.",
+              "items": {
+                "properties": {
+                  "const": {
+                    "description": "The constant enum value.",
+                    "type": "string"
+                  },
+                  "title": {
+                    "description": "Display title for this option.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "const",
+                  "title"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "anyOf"
+          ],
+          "type": "object"
+        },
+        "maxItems": {
+          "description": "Maximum number of items to select.",
+          "type": "integer"
+        },
+        "minItems": {
+          "description": "Minimum number of items to select.",
+          "type": "integer"
+        },
+        "title": {
+          "description": "Optional title for the enum field.",
+          "type": "string"
+        },
+        "type": {
+          "const": "array",
+          "type": "string"
+        }
+      },
+      "required": [
+        "items",
+        "type"
+      ],
+      "type": "object"
+    },
+    "TitledSingleSelectEnumSchema": {
+      "description": "Schema for single-selection enumeration with display titles for each option.",
+      "properties": {
+        "default": {
+          "description": "Optional default value.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Optional description for the enum field.",
+          "type": "string"
+        },
+        "oneOf": {
+          "description": "Array of enum options with values and display labels.",
+          "items": {
+            "properties": {
+              "const": {
+                "description": "The enum value.",
+                "type": "string"
+              },
+              "title": {
+                "description": "Display label for this option.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "const",
+              "title"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "title": {
+          "description": "Optional title for the enum field.",
+          "type": "string"
+        },
+        "type": {
+          "const": "string",
+          "type": "string"
+        }
+      },
+      "required": [
+        "oneOf",
+        "type"
+      ],
+      "type": "object"
+    },
+    "Tool": {
+      "description": "Definition for a tool the client can call.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "annotations": {
+          "$ref": "#/$defs/ToolAnnotations",
+          "description": "Optional additional tool information.\n\nDisplay name precedence order is: `title`, `annotations.title`, then `name`."
+        },
+        "description": {
+          "description": "A human-readable description of the tool.\n\nThis can be used by clients to improve the LLM's understanding of available tools. It can be thought of like a \"hint\" to the model.",
+          "type": "string"
+        },
+        "icons": {
+          "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
+          "items": {
+            "$ref": "#/$defs/Icon"
+          },
+          "type": "array"
+        },
+        "inputSchema": {
+          "additionalProperties": {},
+          "description": "A JSON Schema object defining the expected parameters for the tool.\n\nTool arguments are always JSON objects, so `type: \"object\"` is required at the root.\nBeyond that, any JSON Schema 2020-12 keyword may appear alongside `type` — including\ncomposition keywords (`oneOf`, `anyOf`, `allOf`, `not`), conditional keywords\n(`if`/`then`/`else`), reference keywords (`$ref`, `$defs`, `$anchor`), and any other\nstandard validation or annotation keywords.\n\nProperty schemas may carry an `x-mcp-header` annotation to mirror the\nargument value into an HTTP header on the Streamable HTTP transport. See\nthe Streamable HTTP transport specification for the validity and\nextraction rules.\n\nDefaults to JSON Schema 2020-12 when no explicit `$schema` is provided.",
+          "properties": {
+            "$schema": {
+              "type": "string"
+            },
+            "type": {
+              "const": "object",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object"
+        },
+        "name": {
+          "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+          "type": "string"
+        },
+        "outputSchema": {
+          "additionalProperties": {},
+          "description": "An optional JSON Schema object defining the structure of the tool's output returned in\nthe structuredContent field of a {@link CallToolResult}. This can be any valid JSON Schema 2020-12.\n\nDefaults to JSON Schema 2020-12 when no explicit `$schema` is provided.",
+          "properties": {
+            "$schema": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "title": {
+          "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for {@link Tool},\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+          "type": "string"
+        }
+      },
+      "required": [
+        "inputSchema",
+        "name"
+      ],
+      "type": "object"
+    },
+    "ToolAnnotations": {
+      "description": "Additional properties describing a {@link Tool} to clients.\n\nNOTE: all properties in `ToolAnnotations` are **hints**.\nThey are not guaranteed to provide a faithful description of\ntool behavior (including descriptive properties like `title`).\n\nClients should never make tool use decisions based on `ToolAnnotations`\nreceived from untrusted servers.",
+      "properties": {
+        "destructiveHint": {
+          "description": "If true, the tool may perform destructive updates to its environment.\nIf false, the tool performs only additive updates.\n\n(This property is meaningful only when `readOnlyHint == false`)\n\nDefault: true",
+          "type": "boolean"
+        },
+        "idempotentHint": {
+          "description": "If true, calling the tool repeatedly with the same arguments\nwill have no additional effect on its environment.\n\n(This property is meaningful only when `readOnlyHint == false`)\n\nDefault: false",
+          "type": "boolean"
+        },
+        "openWorldHint": {
+          "description": "If true, this tool may interact with an \"open world\" of external\nentities. If false, the tool's domain of interaction is closed.\nFor example, the world of a web search tool is open, whereas that\nof a memory tool is not.\n\nDefault: true",
+          "type": "boolean"
+        },
+        "readOnlyHint": {
+          "description": "If true, the tool does not modify its environment.\n\nDefault: false",
+          "type": "boolean"
+        },
+        "title": {
+          "description": "A human-readable title for the tool.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ToolChoice": {
+      "description": "Controls tool selection behavior for sampling requests.",
+      "properties": {
+        "mode": {
+          "description": "Controls the tool use ability of the model:\n- `\"auto\"`: Model decides whether to use tools (default)\n- `\"required\"`: Model MUST use at least one tool before completing\n- `\"none\"`: Model MUST NOT use any tools",
+          "enum": [
+            "auto",
+            "none",
+            "required"
+          ],
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ToolResultContent": {
+      "description": "The result of a tool use, provided by the user back to the assistant.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject",
+          "description": "Optional metadata about the tool result. Clients SHOULD preserve this field when\nincluding tool results in subsequent sampling requests to enable caching optimizations."
+        },
+        "content": {
+          "description": "The unstructured result content of the tool use.\n\nThis has the same format as {@link CallToolResult.content} and can include text, images,\naudio, resource links, and embedded resources.",
+          "items": {
+            "$ref": "#/$defs/ContentBlock"
+          },
+          "type": "array"
+        },
+        "isError": {
+          "description": "Whether the tool use resulted in an error.\n\nIf true, the content typically describes the error that occurred.\nDefault: false",
+          "type": "boolean"
+        },
+        "structuredContent": {
+          "description": "An optional structured result value.\n\nThis can be any JSON value (object, array, string, number, boolean, or null).\nIf the tool defined an {@link Tool.outputSchema}, this SHOULD conform to that schema."
+        },
+        "toolUseId": {
+          "description": "The ID of the tool use this result corresponds to.\n\nThis MUST match the ID from a previous {@link ToolUseContent}.",
+          "type": "string"
+        },
+        "type": {
+          "const": "tool_result",
+          "type": "string"
+        }
+      },
+      "required": [
+        "content",
+        "toolUseId",
+        "type"
+      ],
+      "type": "object"
+    },
+    "ToolUseContent": {
+      "description": "A request from the assistant to call a tool.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject",
+          "description": "Optional metadata about the tool use. Clients SHOULD preserve this field when\nincluding tool uses in subsequent sampling requests to enable caching optimizations."
+        },
+        "id": {
+          "description": "A unique identifier for this tool use.\n\nThis ID is used to match tool results to their corresponding tool uses.",
+          "type": "string"
+        },
+        "input": {
+          "additionalProperties": {},
+          "description": "The arguments to pass to the tool, conforming to the tool's input schema.",
+          "type": "object"
+        },
+        "name": {
+          "description": "The name of the tool to call.",
+          "type": "string"
+        },
+        "type": {
+          "const": "tool_use",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "input",
+        "name",
+        "type"
+      ],
+      "type": "object"
+    },
+    "UntitledMultiSelectEnumSchema": {
+      "description": "Schema for multiple-selection enumeration without display titles for options.",
+      "properties": {
+        "default": {
+          "description": "Optional default value.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "description": {
+          "description": "Optional description for the enum field.",
+          "type": "string"
+        },
+        "items": {
+          "description": "Schema for the array items.",
+          "properties": {
+            "enum": {
+              "description": "Array of enum values to choose from.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "type": {
+              "const": "string",
+              "type": "string"
+            }
+          },
+          "required": [
+            "enum",
+            "type"
+          ],
+          "type": "object"
+        },
+        "maxItems": {
+          "description": "Maximum number of items to select.",
+          "type": "integer"
+        },
+        "minItems": {
+          "description": "Minimum number of items to select.",
+          "type": "integer"
+        },
+        "title": {
+          "description": "Optional title for the enum field.",
+          "type": "string"
+        },
+        "type": {
+          "const": "array",
+          "type": "string"
+        }
+      },
+      "required": [
+        "items",
+        "type"
+      ],
+      "type": "object"
+    },
+    "UntitledSingleSelectEnumSchema": {
+      "description": "Schema for single-selection enumeration without display titles for options.",
+      "properties": {
+        "default": {
+          "description": "Optional default value.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Optional description for the enum field.",
+          "type": "string"
+        },
+        "enum": {
+          "description": "Array of enum values to choose from.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "title": {
+          "description": "Optional title for the enum field.",
+          "type": "string"
+        },
+        "type": {
+          "const": "string",
+          "type": "string"
+        }
+      },
+      "required": [
+        "enum",
+        "type"
+      ],
+      "type": "object"
+    }
+  },
+  "$ref": "#/$defs/InputRequest"
+}

--- a/test/ptc_runner/kernel/core_contract_test.exs
+++ b/test/ptc_runner/kernel/core_contract_test.exs
@@ -87,6 +87,64 @@ defmodule PtcRunner.Kernel.CoreContractTest do
     assert combined_bytes == memory_bytes + history_bytes
   end
 
+  test "evaluation status waits for its provider and cannot leak into the next lease" do
+    parent = self()
+    {:ok, state} = RunState.start(Limits.defaults())
+
+    evaluation_owner =
+      spawn_link(fn ->
+        {:ok, %{}, [], lease} = RunState.reserve_evaluation(state)
+        send(parent, {:evaluation_ready, self()})
+
+        receive do
+          :release ->
+            status = RunState.release_evaluation_status(state, lease)
+            send(parent, {:evaluation_released, status})
+        end
+      end)
+
+    assert_receive {:evaluation_ready, ^evaluation_owner}
+
+    {:ok, blocked} =
+      Capability.new(
+        name: "blocked",
+        effect: :read,
+        input_schema: @input_schema,
+        callback: fn _ ->
+          send(parent, {:provider_ready, self()})
+
+          receive do
+            :finish ->
+              {:error,
+               ProviderError.new(:denied, "mcp_input_required_refused", retryable?: false)}
+          end
+        end
+      )
+
+    {:ok, mission} = MissionEnvironment.new(capabilities: [blocked])
+
+    dispatch =
+      Task.async(fn ->
+        Dispatcher.dispatch(state, :mission, mission, "blocked", %{}, 2_000)
+      end)
+
+    assert_receive {:provider_ready, provider}
+    send(evaluation_owner, :release)
+    refute_receive {:evaluation_released, _status}, 50
+
+    send(provider, :finish)
+
+    assert %{status: :error, kind: :provider_error, reason: :denied} =
+             Task.await(dispatch, 2_000)
+
+    assert_receive {:evaluation_released, {:ok, %{terminal_provider_failure?: true}}}
+
+    assert {:ok, %{}, [], next_lease} = RunState.reserve_evaluation(state)
+
+    assert {:ok, %{terminal_provider_failure?: false}} =
+             RunState.release_evaluation_status(state, next_lease)
+  end
+
   test "continuation commit applies separate memory and exact-history ceilings atomically" do
     memory = %{"retained" => String.duplicate("m", 64)}
     history_value = String.duplicate("h", 64)
@@ -1805,6 +1863,41 @@ defmodule PtcRunner.Kernel.CoreContractTest do
 
     assert %{outcome: :evaluation_error, details: %{capability_activity?: false}} =
              Evaluation.evaluate_source(state, mission, "leaked", 100)
+  end
+
+  test "sandbox kills retain terminal provider-failure provenance outside the evaluator" do
+    {:ok, blocked} =
+      Capability.new(
+        name: "blocked",
+        effect: :read,
+        input_schema: @input_schema,
+        callback: fn _ ->
+          {:error, ProviderError.new(:denied, "mcp_input_required_refused", retryable?: false)}
+        end
+      )
+
+    {:ok, mission} = MissionEnvironment.new(capabilities: [blocked])
+
+    {:ok, limits} =
+      Limits.new(
+        evaluation_timeout_ms: 500,
+        evaluation_heap_words: 100_000_000
+      )
+
+    {:ok, state} = RunState.start(limits)
+
+    assert %{
+             outcome: :evaluation_error,
+             kind: :timeout,
+             retryable?: true,
+             terminal_provider_failure?: true
+           } =
+             Evaluation.evaluate_source(
+               state,
+               mission,
+               ~S|(do (tool/blocked {}) (reduce + (range 0 100000000)))|,
+               500
+             )
   end
 
   test "workflow kernel-eval routes source into the mission environment" do

--- a/test/ptc_runner/kernel/mcp_protocol_test.exs
+++ b/test/ptc_runner/kernel/mcp_protocol_test.exs
@@ -147,12 +147,6 @@ defmodule PtcRunner.Kernel.MCPProtocolTest do
     end
 
     assert {:error, :mcp_unsupported_result} =
-             MCPProtocol.outcome(
-               %{"result" => %{"resultType" => "input_required"}},
-               "tools/call"
-             )
-
-    assert {:error, :mcp_unsupported_result} =
              MCPProtocol.outcome(%{"result" => %{"resultType" => "future"}}, "tools/call")
 
     for malformed <- [nil, 42, %{}, []] do
@@ -168,6 +162,173 @@ defmodule PtcRunner.Kernel.MCPProtocolTest do
                %{"result" => %{"resultType" => "complete", "tools" => []}},
                "tools/list"
              )
+  end
+
+  test "classifies input-required outcomes by method, structure, and client policy" do
+    state_only = %{
+      "resultType" => "input_required",
+      "requestState" => "eyJwcm9ncmVzcyI6IjUwJSJ9"
+    }
+
+    input_requests = %{
+      "resultType" => "input_required",
+      "inputRequests" => %{
+        "github_login" => %{
+          "method" => "elicitation/create",
+          "params" => %{
+            "message" => "Please provide your GitHub username",
+            "requestedSchema" => %{
+              "type" => "object",
+              "properties" => %{"name" => %{"type" => "string"}},
+              "required" => ["name"]
+            }
+          }
+        },
+        "capital_of_france" => %{
+          "method" => "sampling/createMessage",
+          "params" => %{
+            "messages" => [
+              %{
+                "role" => "user",
+                "content" => %{"type" => "text", "text" => "What is the capital of France?"}
+              }
+            ],
+            "maxTokens" => 100,
+            "metadata" => %{"threshold" => 0.5, "fallback" => nil}
+          }
+        }
+      }
+    }
+
+    for method <- ["tools/call", "prompts/get", "resources/read"] do
+      assert {:error, :mcp_input_required_refused} =
+               MCPProtocol.outcome(%{"result" => state_only}, method)
+
+      assert {:error, :mcp_protocol_error} =
+               MCPProtocol.outcome(
+                 %{"result" => %{"resultType" => "input_required", "inputRequests" => %{}}},
+                 method
+               )
+
+      assert {:error, :mcp_input_required_refused} =
+               MCPProtocol.outcome(
+                 %{
+                   "result" => %{
+                     "resultType" => "input_required",
+                     "inputRequests" => %{},
+                     "requestState" => "load-shed"
+                   }
+                 },
+                 method
+               )
+
+      assert {:error, :mcp_capability_negotiation_error} =
+               MCPProtocol.outcome(%{"result" => input_requests}, method)
+
+      assert {:error, :mcp_capability_negotiation_error} =
+               MCPProtocol.outcome(
+                 %{"result" => Map.put(input_requests, "requestState", "opaque")},
+                 method
+               )
+    end
+
+    assert {:error, :mcp_protocol_error} =
+             MCPProtocol.outcome(%{"result" => state_only}, "tools/list")
+
+    assert {:error, :mcp_capability_negotiation_error} =
+             MCPProtocol.outcome(
+               %{
+                 "result" => %{
+                   "resultType" => "input_required",
+                   "inputRequests" => %{
+                     "roots" => %{"method" => "roots/list"}
+                   }
+                 }
+               },
+               "tools/call"
+             )
+
+    for malformed <- [
+          %{"resultType" => "input_required"},
+          %{"resultType" => "input_required", "requestState" => 42},
+          %{"resultType" => "input_required", "inputRequests" => []},
+          %{
+            "resultType" => "input_required",
+            "inputRequests" => %{},
+            "requestState" => nil
+          },
+          %{
+            "resultType" => "input_required",
+            "requestState" => "opaque",
+            "_meta" => []
+          },
+          %{
+            "resultType" => "input_required",
+            "inputRequests" => %{
+              "future" => %{"method" => "future/request", "params" => %{}}
+            }
+          },
+          %{
+            "resultType" => "input_required",
+            "inputRequests" => %{
+              "sampling" => %{
+                "method" => "sampling/createMessage",
+                "params" => %{"messages" => [], "maxTokens" => "many"}
+              }
+            }
+          },
+          %{
+            "resultType" => "input_required",
+            "inputRequests" => %{
+              "elicitation" => %{
+                "method" => "elicitation/create",
+                "params" => %{"message" => "Missing schema"}
+              }
+            }
+          },
+          %{
+            "resultType" => "input_required",
+            "inputRequests" => %{
+              "elicitation" => %{
+                "method" => "elicitation/create",
+                "params" => %{
+                  "message" => "Choose values",
+                  "requestedSchema" => %{
+                    "type" => "object",
+                    "properties" => %{
+                      "choices" => %{"type" => "array", "items" => %{}}
+                    }
+                  }
+                }
+              }
+            }
+          },
+          %{
+            "resultType" => "input_required",
+            "inputRequests" => %{
+              "sampling" => %{
+                "method" => "sampling/createMessage",
+                "params" => %{
+                  "messages" => [
+                    %{
+                      "role" => "user",
+                      "content" => %{
+                        "type" => "image",
+                        "data" => "not base64!",
+                        "mimeType" => "image/png",
+                        "annotations" => %{"priority" => "high"}
+                      }
+                    }
+                  ],
+                  "maxTokens" => 100
+                }
+              }
+            }
+          }
+        ] do
+      assert {:error, :mcp_protocol_error} =
+               MCPProtocol.outcome(%{"result" => malformed}, "tools/call")
+    end
   end
 
   test "reduces catalog pages without interpreting unmapped tool contracts" do

--- a/test/ptc_runner/kernel/mcp_source_test.exs
+++ b/test/ptc_runner/kernel/mcp_source_test.exs
@@ -11,11 +11,16 @@ defmodule PtcRunner.Kernel.MCPSourceTest do
   alias PtcRunner.Kernel.Dispatcher
   alias PtcRunner.Kernel.EventSink
   alias PtcRunner.Kernel.InspectionArtifact
+  alias PtcRunner.Kernel.Library
   alias PtcRunner.Kernel.Limits
+  alias PtcRunner.Kernel.LLMCapability
   alias PtcRunner.Kernel.MCPSource
+  alias PtcRunner.Kernel.MissionEnvironment
   alias PtcRunner.Kernel.ProviderRegistry
   alias PtcRunner.Kernel.RunBuilder
+  alias PtcRunner.Kernel.RunConfig
   alias PtcRunner.Kernel.RunState
+  alias PtcRunner.Kernel.WorkflowEnvironment
   alias PtcRunner.TestSupport.MCPHTTPFixture
 
   @owner_lifecycle_timeout_ms 30_000
@@ -652,16 +657,33 @@ defmodule PtcRunner.Kernel.MCPSourceTest do
     tmp_dir: dir
   } do
     cases = [
-      {"structured", [rpc_error_tool: "structured"], :domain_error, []},
-      {"structured", [structured_value: "wrong"], :invalid_result, []},
-      {"structured", [result_and_error?: true], :invalid_result, []},
-      {"structured", [result_type: "input_required"], :invalid_result, []},
-      {"fail", [], :domain_error, []},
-      {"text", [large_text?: true], :invalid_result, [max_result_bytes: 1_000]}
+      {"structured", [rpc_error_tool: "structured"], :domain_error, "mcp_remote_error", []},
+      {"structured", [structured_value: "wrong"], :invalid_result, "mcp_invalid_result", []},
+      {"structured", [result_and_error?: true], :invalid_result, "mcp_protocol_error", []},
+      {"structured", [structured_result: input_required_state_only()], :denied,
+       "mcp_input_required_refused", []},
+      {"structured",
+       [
+         structured_result: %{
+           "resultType" => "input_required",
+           "inputRequests" => %{},
+           "requestState" => "load-shed"
+         }
+       ], :denied, "mcp_input_required_refused", []},
+      {"structured",
+       [structured_result: %{"resultType" => "input_required", "inputRequests" => %{}}],
+       :invalid_result, "mcp_protocol_error", []},
+      {"structured", [structured_result: input_required_with_requests()], :invalid_result,
+       "mcp_capability_negotiation_error", []},
+      {"structured", [structured_result: %{"resultType" => "input_required"}], :invalid_result,
+       "mcp_protocol_error", []},
+      {"fail", [], :domain_error, "mcp_domain_error", []},
+      {"text", [large_text?: true], :invalid_result, "mcp_response_exceeded",
+       [max_result_bytes: 1_000]}
     ]
 
     for effect <- [:read, :write],
-        {upstream, fixture_opts, reason, manifest_opts} <- cases do
+        {upstream, fixture_opts, reason, details, manifest_opts} <- cases do
       fixture = fixture(self(), fixture_opts)
       on_exit(fixture.close)
       tools = mappings_with_effect(upstream, effect)
@@ -690,11 +712,116 @@ defmodule PtcRunner.Kernel.MCPSourceTest do
                status: :error,
                kind: :provider_error,
                reason: ^reason,
+               details: ^details,
                retryable?: false
              } = failure
 
       assert_effect_state(failure, effect)
       assert :ok = RunBuilder.close(built)
+    end
+  end
+
+  test "agent correction does not repeat any MCP input-required classification" do
+    programs = [
+      {~S|(fail (tool/remote.structured {"query" "x"}))|, [evaluation_timeout_ms: 5_000]},
+      {~S|(do (tool/remote.structured {"query" "x"}) (+ {} 1))|, [evaluation_timeout_ms: 5_000]},
+      {~S|(do (tool/remote.structured {"query" "x"}) (reduce + (range 0 100000000)))|,
+       [evaluation_timeout_ms: 500, evaluation_heap_words: 100_000_000]}
+    ]
+
+    for structured_result <- [
+          input_required_state_only(),
+          input_required_with_requests(),
+          %{"resultType" => "input_required"}
+        ],
+        {program, limit_overrides} <- programs do
+      parent = self()
+      fixture = fixture(parent, structured_result: structured_result)
+      on_exit(fixture.close)
+
+      {:ok, limits} = Limits.new(limit_overrides)
+      evaluation_timeout_ms = limits.evaluation_timeout_ms
+
+      assert {:ok, mcp} =
+               ProviderRegistry.build(
+                 registry(fixture.endpoint),
+                 "fixture-mcp",
+                 %{
+                   "allow" => ["remote.structured"],
+                   "timeout_ms" => min(evaluation_timeout_ms, 2_000),
+                   "max_result_bytes" => 32_000
+                 },
+                 %{
+                   directory: File.cwd!(),
+                   destination: :mission,
+                   limits: limits,
+                   installed_limits: limits,
+                   owner: self()
+                 }
+               )
+
+      assert_receive {:mcp_request, "server/discover", _headers}
+      assert_receive {:mcp_request, "tools/list", _headers}
+      assert_receive {:mcp_request, "tools/list", _headers}
+
+      first = %{
+        content: nil,
+        tool_calls: [
+          %{
+            id: "mcp-refusal",
+            name: "run_ptc_lisp",
+            args: %{"program" => program}
+          }
+        ]
+      }
+
+      recovered = %{
+        content: nil,
+        tool_calls: [
+          %{id: "unexpected-retry", name: "run_ptc_lisp", args: %{"program" => "(return 42)"}}
+        ]
+      }
+
+      {:ok, responses} = Agent.start_link(fn -> [first, recovered] end)
+
+      {:ok, llm} =
+        LLMCapability.new(
+          requester: fn request ->
+            send(parent, {:agent_request, request})
+
+            Agent.get_and_update(responses, fn
+              [response | rest] -> {{:ok, response}, rest}
+              [] -> {{:error, :script_exhausted}, []}
+            end)
+          end
+        )
+
+      {:ok, components} =
+        Library.components(~w(agent.core agent.feedback agent.native agent.prompt agent.retry
+             kernel llm result workflow.event))
+
+      {:ok, bundle} = Kernel.compile_bundle(components)
+      {:ok, workflow} = WorkflowEnvironment.new(bundle: bundle, capabilities: [llm])
+      {:ok, mission} = MissionEnvironment.new(capabilities: mcp.capabilities)
+      {:ok, sink} = EventSink.start(:normal, limits, run_id: "mcp-mrtr-agent-refusal")
+
+      {:ok, config} =
+        RunConfig.new(
+          workflow_environment: workflow,
+          mission_environment: mission,
+          input: %{},
+          limits: limits,
+          event_sink: sink,
+          provider_resources: [mcp.close]
+        )
+
+      assert {:error, %{kind: :workflow_failed, reason: :explicit_failure}} =
+               Kernel.run(~S|(agent.core/run "Read once" {"max_turns" 3})|, config)
+
+      assert_receive {:agent_request, _first}
+      refute_receive {:agent_request, _second}
+      assert_receive {:mcp_request, "tools/call", _headers}
+      refute_receive {:mcp_request, "tools/call", _headers}
     end
   end
 
@@ -880,9 +1007,9 @@ defmodule PtcRunner.Kernel.MCPSourceTest do
   end
 
   @tag :tmp_dir
-  test "rejects unsupported modern result types", %{tmp_dir: dir} do
+  test "rejects unknown modern result types", %{tmp_dir: dir} do
     parent = self()
-    fixture = fixture(parent, result_type: "input_required")
+    fixture = fixture(parent, result_type: "future")
     on_exit(fixture.close)
 
     registry = registry(fixture.endpoint)
@@ -891,7 +1018,12 @@ defmodule PtcRunner.Kernel.MCPSourceTest do
     {:ok, built} = RunBuilder.load_and_build(manifest, registry)
     assert {:ok, result} = Kernel.run(built.entry_source, built.config)
 
-    assert %{status: :error, kind: :provider_error, reason: :invalid_result} =
+    assert %{
+             status: :error,
+             kind: :provider_error,
+             reason: :invalid_result,
+             details: "mcp_unsupported_result"
+           } =
              get_in(result.value, [:value, :value, "structured"])
 
     EventSink.stop(built.config.event_sink)
@@ -1740,6 +1872,32 @@ defmodule PtcRunner.Kernel.MCPSourceTest do
   defp assert_effect_state(failure, :write),
     do: assert(failure.mutation_state == :indeterminate)
 
+  defp input_required_state_only do
+    %{
+      "resultType" => "input_required",
+      "requestState" => "eyJwcm9ncmVzcyI6IjUwJSJ9"
+    }
+  end
+
+  defp input_required_with_requests do
+    %{
+      "resultType" => "input_required",
+      "inputRequests" => %{
+        "github_login" => %{
+          "method" => "elicitation/create",
+          "params" => %{
+            "message" => "Please provide your GitHub username",
+            "requestedSchema" => %{
+              "type" => "object",
+              "properties" => %{"name" => %{"type" => "string"}},
+              "required" => ["name"]
+            }
+          }
+        }
+      }
+    }
+  end
+
   defp public_mappings, do: Map.new(mappings(), fn {_upstream, mapping} -> {mapping.as, true} end)
 
   defp build_snapshot(dir, endpoint, tools) do
@@ -1889,37 +2047,7 @@ defmodule PtcRunner.Kernel.MCPSourceTest do
        ) do
     case params["name"] do
       "structured" ->
-        if opts[:rpc_error_tool] == "structured" do
-          rpc_error(
-            id,
-            -32_602,
-            "invalid parameters",
-            status: Keyword.get(opts, :rpc_error_status, 200)
-          )
-        else
-          value = Keyword.get(opts, :structured_value, 42)
-
-          if opts[:result_and_error?] do
-            body = %{
-              "jsonrpc" => "2.0",
-              "id" => id,
-              "result" => %{
-                "resultType" => "complete",
-                "structuredContent" => %{"value" => value},
-                "content" => []
-              },
-              "error" => %{"code" => -32_000, "message" => "must not coexist"}
-            }
-
-            {200, [{"content-type", "application/json"}], Jason.encode!(body)}
-          else
-            json(id, %{
-              "resultType" => Keyword.get(opts, :result_type, "complete"),
-              "structuredContent" => %{"value" => value},
-              "content" => []
-            })
-          end
-        end
+        structured_response(id, opts)
 
       "text" ->
         text =
@@ -1949,6 +2077,46 @@ defmodule PtcRunner.Kernel.MCPSourceTest do
 
           json(id, %{"resultType" => "complete", "isError" => true, "content" => content})
         end
+    end
+  end
+
+  defp structured_response(id, opts) do
+    cond do
+      opts[:rpc_error_tool] == "structured" ->
+        rpc_error(
+          id,
+          -32_602,
+          "invalid parameters",
+          status: Keyword.get(opts, :rpc_error_status, 200)
+        )
+
+      result = opts[:structured_result] ->
+        json(id, result)
+
+      opts[:result_and_error?] ->
+        value = Keyword.get(opts, :structured_value, 42)
+
+        body = %{
+          "jsonrpc" => "2.0",
+          "id" => id,
+          "result" => %{
+            "resultType" => "complete",
+            "structuredContent" => %{"value" => value},
+            "content" => []
+          },
+          "error" => %{"code" => -32_000, "message" => "must not coexist"}
+        }
+
+        {200, [{"content-type", "application/json"}], Jason.encode!(body)}
+
+      true ->
+        json(id, %{
+          "resultType" => Keyword.get(opts, :result_type, "complete"),
+          "structuredContent" => %{
+            "value" => Keyword.get(opts, :structured_value, 42)
+          },
+          "content" => []
+        })
     end
   end
 


### PR DESCRIPTION
## Summary

- validate MCP 2026-07-28 `input_required` results with the exact method-sensitive schema closure
- classify state-only results as closed policy refusal, valid input-bearing results as unsupported capability negotiation, and malformed/forbidden-method results as protocol errors
- retain terminal provider provenance across later evaluator errors, timeouts, and heap kills while preserving indeterminate write semantics
- update agent behavior, durable guides, the remaining MCP plan, and regression coverage

## Verification

- `mix precommit`
- pre-push root tests and audit/Dialyzer gates
- pre-push Viewer tests and documentation build
- clean fresh independent Codex review against `origin/main`