### PR TITLE
fix(agent): correct invalid terminal results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The shipped `agent.main/run` entry now validates model-authored terminal
+  candidates against the manifest result contract while the bounded loop can
+  still request a correction. Rejected values remain withheld; other workflow
+  entries retain the final fail-closed publication check.
 - `PtcRunner.Lisp.run/2` now retains only statically referenced context keys
   when context filtering is enabled, including scalar grants. Set
   `filter_context: false` when a program requires dynamic or metadata

--- a/docs/guides/manifests-and-capabilities.md
+++ b/docs/guides/manifests-and-capabilities.md
@@ -156,9 +156,13 @@ The input contract covers inline input, an input file, and any `--mission` or
 `--private-mission` override. It is compiled and checked before provider
 preflight, credential resolution, process launch, or remote discovery. The
 result contract is checked after execution and evidence capture, but before
-stdout or `--output`/`--private-output` publication. A mismatch returns
-`input_contract_failed` or `result_contract_failed`; a rejected result value is
-not attached to the error.
+stdout or `--output`/`--private-output` publication. The shipped
+`agent.main/run` entry also checks each model-authored terminal candidate while
+the bounded agent loop is still live. When turns remain, it returns the same
+structural classification to the model for one ordinary correction turn; the
+rejected value itself is withheld. Other workflow entries retain only the
+final fail-closed check. A mismatch returns `input_contract_failed` or
+`result_contract_failed`.
 
 A rejection does carry a bounded classification, so a mismatch is diagnosable
 without repeating the run under private inspection. The command reports it as:

--- a/lib/ptc_runner/kernel/environment.ex
+++ b/lib/ptc_runner/kernel/environment.ex
@@ -11,7 +11,7 @@ defmodule PtcRunner.Kernel.Environment do
   alias PtcRunner.Kernel.FrozenBundle
   alias PtcRunner.Kernel.JSONValue
 
-  @reserved ~w(kernel-eval kernel-mission-inventory kernel-mission-model-context runtime-usage runtime-remaining cap-list cap-describe workflow-annotate)
+  @reserved ~w(kernel-eval kernel-mission-inventory kernel-mission-model-context kernel-result-contract runtime-usage runtime-remaining cap-list cap-describe workflow-annotate)
 
   @doc "Validates common environment fields and returns normalized attributes."
   def assemble(bundle, capabilities, data, kind)

--- a/lib/ptc_runner/kernel/library.ex
+++ b/lib/ptc_runner/kernel/library.ex
@@ -10,8 +10,9 @@ defmodule PtcRunner.Kernel.Library do
   and supplies `task` and `agent` through input, instead of every application
   repeating the same `agent.core` call. It is domain-blind by construction —
   it forwards two input keys and never learns what the task is about. It
-  selects `agent.core`'s raw-result mode so a manifest contract describes the
-  application value directly; callers of `agent.core/run` retain its explicit
+  validates each model-authored terminal candidate against the manifest result
+  contract while a bounded correction turn can still run, then returns the
+  raw application value; callers of `agent.core/run` retain its explicit
   `%{"ok" => true, "value" => value}` success envelope by default.
   `agent.core/run-value` is the composable variant: it returns the same
   model-authored value to its PTC-Lisp caller without terminating the outer

--- a/lib/ptc_runner/kernel/repl_session.ex
+++ b/lib/ptc_runner/kernel/repl_session.ex
@@ -549,6 +549,16 @@ defmodule PtcRunner.Kernel.ReplSession do
         )
       )
     )
+    |> Map.put(
+      "kernel-result-contract",
+      RuntimeTools.instrument(
+        session.state,
+        session.config.event_sink,
+        :workflow,
+        "kernel-result-contract",
+        RuntimeTools.result_contract(session.config.result_contract)
+      )
+    )
     |> Map.new(fn {name, callback} -> {name, %TrustedTool{function: callback}} end)
   end
 

--- a/lib/ptc_runner/kernel/run_builder.ex
+++ b/lib/ptc_runner/kernel/run_builder.ex
@@ -11,7 +11,6 @@ defmodule PtcRunner.Kernel.RunBuilder do
 
   alias PtcRunner.Kernel
   alias PtcRunner.Kernel.ComponentOverride
-  alias PtcRunner.Kernel.DeterministicJSON
   alias PtcRunner.Kernel.EventSink
   alias PtcRunner.Kernel.InspectionArtifact
   alias PtcRunner.Kernel.InspectionSink
@@ -101,6 +100,7 @@ defmodule PtcRunner.Kernel.RunBuilder do
            input: %{"input" => manifest.input},
            limits: manifest.limits,
            event_sink: sink,
+           result_contract: manifest.contracts.result,
            inspection_sink: inspection_sink,
            inspection_path: inspection_path,
            provider_resources: providers.resources,
@@ -752,8 +752,7 @@ defmodule PtcRunner.Kernel.RunBuilder do
   # contracts see ordinary JSON values without a second, potentially lossy
   # map-key conversion.
   defp json_contract_value(value) do
-    with {:ok, encoded} <- DeterministicJSON.encode(value),
-         do: Jason.decode(encoded)
+    ValueContract.json_value(value)
   end
 
   defp persist_trace(nil, _sink, _events), do: :ok

--- a/lib/ptc_runner/kernel/run_config.ex
+++ b/lib/ptc_runner/kernel/run_config.ex
@@ -31,6 +31,10 @@ defmodule PtcRunner.Kernel.RunConfig do
   `connector_snapshots` are bounded safe metadata copied into `run-started`;
   neither field is visible to Lisp.
 
+  `result_contract` is an optional compiled application contract exposed only
+  through the reserved workflow validator used by `agent.main`. Final
+  publication enforcement remains the responsibility of `RunBuilder`.
+
   `labels` is an optional closed safe-metadata map. Caller-defined identifier
   fields become SHA-256 fingerprints and tags use finite enumerated values
   before the map enters `run-started`.
@@ -52,6 +56,7 @@ defmodule PtcRunner.Kernel.RunConfig do
   alias PtcRunner.Kernel.ProviderRegistry
   alias PtcRunner.Kernel.ProviderResources
   alias PtcRunner.Kernel.SafeMetadata
+  alias PtcRunner.Kernel.ValueContract
   alias PtcRunner.Kernel.WorkflowEnvironment
   alias PtcRunner.Lisp.RetainedSize
 
@@ -76,6 +81,7 @@ defmodule PtcRunner.Kernel.RunConfig do
     :event_sink_owner,
     :mission_inventory,
     :claim_id,
+    result_contract: nil,
     inspection_sink: nil,
     inspection_sink_owner: nil,
     inspection_path: nil,
@@ -95,6 +101,7 @@ defmodule PtcRunner.Kernel.RunConfig do
           event_sink_owner: pid(),
           mission_inventory: MissionInventory.t(),
           claim_id: reference(),
+          result_contract: ValueContract.t() | nil,
           inspection_sink: InspectionSink.t() | nil,
           inspection_sink_owner: pid() | nil,
           inspection_path: binary() | nil,
@@ -121,6 +128,7 @@ defmodule PtcRunner.Kernel.RunConfig do
                :input,
                :limits,
                :event_sink,
+               :result_contract,
                :inspection_sink,
                :inspection_path,
                :provider_resources,
@@ -136,6 +144,7 @@ defmodule PtcRunner.Kernel.RunConfig do
          %Limits{} = limits <- Keyword.get(opts, :limits),
          %EventSink{} = sink <- Keyword.get(opts, :event_sink),
          true <- valid_event_sink_contract?(sink, limits),
+         true <- result_contract?(Keyword.get(opts, :result_contract)),
          {:ok, event_sink_owner} <- EventSink.owner(sink),
          true <-
            inspection?(Keyword.get(opts, :inspection_sink), Keyword.get(opts, :inspection_path)),
@@ -176,6 +185,7 @@ defmodule PtcRunner.Kernel.RunConfig do
          event_sink_owner: event_sink_owner,
          mission_inventory: mission_inventory,
          claim_id: make_ref(),
+         result_contract: Keyword.get(opts, :result_contract),
          inspection_sink: Keyword.get(opts, :inspection_sink),
          inspection_sink_owner: inspection_sink_owner,
          inspection_path: Keyword.get(opts, :inspection_path),
@@ -191,6 +201,10 @@ defmodule PtcRunner.Kernel.RunConfig do
       _ -> {:error, :invalid_run_config}
     end
   end
+
+  defp result_contract?(nil), do: true
+  defp result_contract?(%ValueContract{}), do: true
+  defp result_contract?(_contract), do: false
 
   defp valid_event_sink_contract?(%EventSink{policy: :normal} = sink, limits) do
     reserve = EventSink.terminal_reserve(:normal, limits)

--- a/lib/ptc_runner/kernel/runner.ex
+++ b/lib/ptc_runner/kernel/runner.ex
@@ -283,6 +283,16 @@ defmodule PtcRunner.Kernel.Runner do
         RuntimeTools.mission_model_context(state, config.mission_inventory.model_rendered)
       )
     )
+    |> Map.put(
+      "kernel-result-contract",
+      RuntimeTools.instrument(
+        state,
+        config.event_sink,
+        :workflow,
+        "kernel-result-contract",
+        RuntimeTools.result_contract(config.result_contract)
+      )
+    )
     |> Map.new(fn {name, callback} -> {name, %TrustedTool{function: callback}} end)
   end
 

--- a/lib/ptc_runner/kernel/runtime_tools.ex
+++ b/lib/ptc_runner/kernel/runtime_tools.ex
@@ -15,6 +15,7 @@ defmodule PtcRunner.Kernel.RuntimeTools do
   alias PtcRunner.Kernel.Program
   alias PtcRunner.Kernel.RunState
   alias PtcRunner.Kernel.SafeMetadata
+  alias PtcRunner.Kernel.ValueContract
   alias PtcRunner.Lisp.Keyword, as: LispKeyword
   alias PtcRunner.Lisp.RetainedSize
 
@@ -109,6 +110,58 @@ defmodule PtcRunner.Kernel.RuntimeTools do
       _arguments ->
         invalid_kernel_eval_request(state)
     end
+  end
+
+  @doc "Builds the workflow-only application-result contract callback."
+  def result_contract(nil) do
+    fn
+      %{"value" => _value, "json_value" => json_value?} when is_boolean(json_value?) ->
+        %{status: :ok, value: %{enforced?: false, valid?: true}}
+
+      _arguments ->
+        %{status: :error, kind: :protocol_error, reason: :invalid_result_contract_request}
+    end
+  end
+
+  def result_contract(%ValueContract{} = contract) do
+    fn
+      %{"value" => value, "json_value" => json_value?} when is_boolean(json_value?) ->
+        validate_result_contract(contract, value, json_value?)
+
+      _arguments ->
+        %{status: :error, kind: :protocol_error, reason: :invalid_result_contract_request}
+    end
+  end
+
+  defp validate_result_contract(contract, value, true) do
+    case ValueContract.json_value(value) do
+      {:ok, json_value} ->
+        if ValueContract.valid?(contract, json_value) do
+          %{status: :ok, value: %{enforced?: true, valid?: true}}
+        else
+          invalid_result_contract(ValueContract.classify(contract, json_value))
+        end
+
+      {:error, _reason} ->
+        invalid_json_result_contract(contract, value)
+    end
+  end
+
+  defp validate_result_contract(contract, value, false),
+    do: invalid_json_result_contract(contract, value)
+
+  defp invalid_json_result_contract(contract, value) do
+    details =
+      contract
+      |> ValueContract.classify(value)
+      |> Map.put(:json_value, false)
+      |> Map.put(:violations, [])
+
+    invalid_result_contract(details)
+  end
+
+  defp invalid_result_contract(details) do
+    %{status: :ok, value: %{enforced?: true, valid?: false, details: details}}
   end
 
   @doc "Wraps an internal runtime callback with canonical capability events."

--- a/lib/ptc_runner/kernel/value_contract.ex
+++ b/lib/ptc_runner/kernel/value_contract.ex
@@ -53,6 +53,18 @@ defmodule PtcRunner.Kernel.ValueContract do
 
   def valid?(_contract, _value), do: false
 
+  @doc false
+  @spec json_value(term()) :: {:ok, term()} | {:error, :duplicate_key | :invalid_json}
+  def json_value(value) do
+    with {:ok, encoded} <- DeterministicJSON.encode(value),
+         {:ok, decoded} <- Jason.decode(encoded) do
+      {:ok, decoded}
+    else
+      {:error, :duplicate_key} = error -> error
+      {:error, _reason} -> {:error, :invalid_json}
+    end
+  end
+
   @spec classify(t(), term()) :: map()
   @doc """
   Explains a contract rejection without disclosing the rejected value.

--- a/priv/preludes/kernel/agent.core.clj
+++ b/priv/preludes/kernel/agent.core.clj
@@ -67,7 +67,7 @@
          (or (true? (get error :retryable?))
              (false? (get error :retryable?))))))
 
-(defn run-outcome
+(defn- run-outcome*
   "Runs the agent loop and distinguishes model-authored completion from a
   bounded subject-attributable failure.
 
@@ -76,7 +76,7 @@
   score a model program failure, exhausted correction loop, or non-retryable
   generated-program error without misclassifying provider failure as subject
   behavior."
-  [task cfg]
+  [task cfg validate-result?]
   (let [max-turns (positive-int-or (get cfg "max_turns") 4 128)
         max-program-chars (positive-int-or (get cfg "max_program_chars") 64000 1000000)
         max-observation-chars (positive-int-or (get cfg "max_observation_chars") 2048 65536)
@@ -116,7 +116,22 @@
                       :terminal-provider-failure))
                   (case (get evaluation :outcome)
                     :returned
-                    (returned-outcome (get evaluation :value))
+                    (if validate-result?
+                      (let [validation (kernel/validate-result (get evaluation :value))]
+                        (if (true? (get validation :valid?))
+                          (returned-outcome (get evaluation :value))
+                          (if (agent.retry/retry? turn max-turns)
+                            (let [event (completed-event :result-contract-error turn max-turns)
+                                  next-prompt-state (transition-prompt prompt-state event)]
+                              (recur (inc turn)
+                                     (append-correlated
+                                       messages
+                                       action
+                                       (agent.feedback/result-contract validation))
+                                     next-prompt-state
+                                     closing?))
+                            (subject-failure :result-contract :invalid-result))))
+                      (returned-outcome (get evaluation :value)))
                     :failed
                     (if (and (correctable-capability-failure? evaluation)
                              (agent.retry/retry? turn max-turns))
@@ -192,6 +207,12 @@
 
               (fail (result/error :unknown-action (get action :kind))))))))))
 
+(defn run-outcome
+  "Runs the agent loop and distinguishes model-authored completion from a
+  bounded subject-attributable failure."
+  [task cfg]
+  (run-outcome* task cfg false))
+
 (defn run-value
   "Runs the agent loop and returns its model-authored value to the calling
   PTC-Lisp function. Unlike `run`, this does not terminate the outer program,
@@ -201,6 +222,15 @@
   to record those attempts use `run-outcome`."
   [task cfg]
   (let [outcome (run-outcome task cfg)]
+    (if (= :returned (get outcome :status))
+      (get outcome :value)
+      (fail (get outcome :error)))))
+
+(defn run-result-value
+  "Runs the agent loop and validates model-authored completion against the
+  manifest result contract before returning it to the calling workflow."
+  [task cfg]
+  (let [outcome (run-outcome* task cfg true)]
     (if (= :returned (get outcome :status))
       (get outcome :value)
       (fail (get outcome :error)))))

--- a/priv/preludes/kernel/agent.feedback.clj
+++ b/priv/preludes/kernel/agent.feedback.clj
@@ -53,3 +53,8 @@
        "error_code=" (or (get evaluation :kind) (get evaluation :outcome))
        ". Do not repeat that program. Return your best decision from the evidence "
        "you have already gathered, using return or fail on this turn."))
+
+(defn result-contract [validation]
+  (str "The returned value did not satisfy the application result contract. "
+       "Structural diagnostics: " (pr-str (get validation :details))
+       ". Send one corrected run_ptc_lisp call that returns a contract-valid value."))

--- a/priv/preludes/kernel/agent.main.clj
+++ b/priv/preludes/kernel/agent.main.clj
@@ -10,6 +10,7 @@
   entry returns the model-authored value directly so a manifest result contract
   describes that value rather than agent.core's default success envelope."
   [input]
-  (agent.core/run
-    (get input "task")
-    (assoc (get input "agent") "result_envelope" false)))
+  (return
+    (agent.core/run-result-value
+      (get input "task")
+      (get input "agent"))))

--- a/priv/preludes/kernel/kernel.clj
+++ b/priv/preludes/kernel/kernel.clj
@@ -1,5 +1,30 @@
 (ns kernel "Explicit subordinate evaluation helpers." {:visibility :prompt})
 
+(defn- json-contract-value? [value]
+  ;; Quoted symbol references intentionally report :unknown (DIV-19), but the
+  ;; host serializes them as their inert display strings. The host still
+  ;; performs the exact canonical JSON projection after this shape check.
+  (cond
+    (or (nil? value)
+        (true? value)
+        (false? value)
+        (string? value)
+        (= :unknown (type value))
+        (integer? value)
+        (float? value))
+    true
+
+    (map? value)
+    (every? (fn [[key nested]]
+              (and (or (string? key) (= :unknown (type key)))
+                   (json-contract-value? nested)))
+            value)
+
+    (sequential? value)
+    (every? json-contract-value? value)
+
+    :else false))
+
 (defn eval
   "Evaluate an opaque static Program in the mission environment."
   [program-value]
@@ -31,3 +56,13 @@
     (if (= :ok (get response :status))
       (get response :value)
       response)))
+
+(defn validate-result
+  "Validate one candidate against the manifest's application result contract."
+  [value]
+  (let [response (tool/kernel-result-contract
+                   {"value" value
+                    "json_value" (json-contract-value? value)})]
+    (if (= :ok (get response :status))
+      (get response :value)
+      (fail response))))

--- a/test/ptc_runner/kernel/agent_library_test.exs
+++ b/test/ptc_runner/kernel/agent_library_test.exs
@@ -12,8 +12,10 @@ defmodule PtcRunner.Kernel.AgentLibraryTest do
   alias PtcRunner.Kernel.MissionEnvironment
   alias PtcRunner.Kernel.ProviderError
   alias PtcRunner.Kernel.RunConfig
+  alias PtcRunner.Kernel.ValueContract
   alias PtcRunner.Kernel.WorkflowEnvironment
   alias PtcRunner.Lisp
+  alias PtcRunner.Lisp.Format
   alias PtcRunner.Lisp.TrustedTool
 
   test "llm/request is an ordinary bounded workflow capability" do
@@ -155,6 +157,188 @@ defmodule PtcRunner.Kernel.AgentLibraryTest do
 
     assert {:ok, %{value: %{"answer" => 42}}} =
              Kernel.run("(agent.main/run data/input)", config)
+  end
+
+  test "agent.main gives a rejected terminal result one bounded correction turn" do
+    invalid = %{
+      content: nil,
+      tool_calls: [
+        %{
+          id: "invalid-result",
+          name: "run_ptc_lisp",
+          args: %{
+            "program" => ~S|(return {"decision" "propose-change" "evidence" [{"resource" ""}]})|
+          }
+        }
+      ]
+    }
+
+    corrected = %{
+      content: nil,
+      tool_calls: [
+        %{
+          id: "corrected-result",
+          name: "run_ptc_lisp",
+          args: %{
+            "program" =>
+              ~S|(return {"decision" "propose-change" "evidence" [{"resource" "run-1"}]})|
+          }
+        }
+      ]
+    }
+
+    schema = %{
+      "type" => "object",
+      "additionalProperties" => false,
+      "required" => ["decision", "evidence"],
+      "properties" => %{
+        "decision" => %{"type" => "string", "const" => "propose-change"},
+        "evidence" => %{
+          "type" => "array",
+          "items" => %{
+            "type" => "object",
+            "additionalProperties" => false,
+            "required" => ["resource"],
+            "properties" => %{"resource" => %{"type" => "string", "minLength" => 1}}
+          }
+        }
+      }
+    }
+
+    assert {:ok, result_contract} = ValueContract.compile(schema)
+
+    input = %{
+      "input" => %{
+        "task" => "Return one application value",
+        "agent" => %{"max_turns" => 2}
+      }
+    }
+
+    {:ok, config} =
+      agent_config([invalid, corrected], [],
+        agent_main: true,
+        input: input,
+        result_contract: result_contract
+      )
+
+    assert {:ok,
+            %{
+              value: %{
+                "decision" => "propose-change",
+                "evidence" => [%{"resource" => "run-1"}]
+              }
+            }} = Kernel.run("(agent.main/run data/input)", config)
+
+    assert_receive {:agent_request, _first_request}
+    assert_receive {:agent_request, second_request}
+
+    assert List.last(second_request["messages"])["content"] =~
+             "did not satisfy the application result contract"
+
+    assert List.last(second_request["messages"])["content"] =~ "minLength"
+  end
+
+  test "agent.main rejects keyword-keyed candidates instead of normalizing them past a contract" do
+    keyword_keyed = %{
+      content: nil,
+      tool_calls: [
+        %{
+          id: "keyword-result",
+          name: "run_ptc_lisp",
+          args: %{"program" => ~S|(return {:when 42})|}
+        }
+      ]
+    }
+
+    corrected = %{
+      content: nil,
+      tool_calls: [
+        %{
+          id: "string-result",
+          name: "run_ptc_lisp",
+          args: %{"program" => ~S|(return {"when" 42})|}
+        }
+      ]
+    }
+
+    assert {:ok, result_contract} =
+             ValueContract.compile(%{
+               "type" => "object",
+               "additionalProperties" => false,
+               "required" => ["when"],
+               "properties" => %{"when" => %{"type" => "integer"}}
+             })
+
+    input = %{
+      "input" => %{
+        "task" => "Return one application value",
+        "agent" => %{"max_turns" => 2}
+      }
+    }
+
+    {:ok, config} =
+      agent_config([keyword_keyed, corrected], [],
+        agent_main: true,
+        input: input,
+        result_contract: result_contract
+      )
+
+    assert {:ok, %{value: %{"when" => 42}}} =
+             Kernel.run("(agent.main/run data/input)", config)
+
+    assert_receive {:agent_request, _first_request}
+    assert_receive {:agent_request, second_request}
+    assert List.last(second_request["messages"])["content"] =~ ":json_value false"
+  end
+
+  test "agent.main accepts quoted symbols through the result contract JSON projection" do
+    quoted_symbol = %{
+      content: nil,
+      tool_calls: [
+        %{
+          id: "quoted-symbol-result",
+          name: "run_ptc_lisp",
+          args: %{"program" => ~S|(return {"ref" 'foo 'kind "quoted"})|}
+        }
+      ]
+    }
+
+    assert {:ok, result_contract} =
+             ValueContract.compile(%{
+               "type" => "object",
+               "additionalProperties" => false,
+               "required" => ["ref", "'kind"],
+               "properties" => %{
+                 "ref" => %{"type" => "string", "const" => "'foo"},
+                 "'kind" => %{"type" => "string", "const" => "quoted"}
+               }
+             })
+
+    input = %{
+      "input" => %{
+        "task" => "Return one application value",
+        "agent" => %{"max_turns" => 1}
+      }
+    }
+
+    {:ok, config} =
+      agent_config([quoted_symbol], [],
+        agent_main: true,
+        input: input,
+        result_contract: result_contract
+      )
+
+    assert {:ok,
+            %{
+              value: %{
+                "ref" => %Format.SymbolRef{name: "foo"},
+                %Format.SymbolRef{name: "kind"} => "quoted"
+              }
+            }} =
+             Kernel.run("(agent.main/run data/input)", config)
+
+    assert_receive {:agent_request, _request}
+    refute_receive {:agent_request, _request}
   end
 
   test "agent.core persists a defn across a correlated intermediate turn" do
@@ -1671,7 +1855,7 @@ defmodule PtcRunner.Kernel.AgentLibraryTest do
     {:ok, limits} = Limits.new(limit_overrides)
     {:ok, sink} = EventSink.start(:normal, limits, run_id: "agent-library")
 
-    RunConfig.new(
+    config_opts = [
       workflow_environment: workflow,
       mission_environment: mission,
       input: Keyword.get(opts, :input, %{}),
@@ -1680,7 +1864,15 @@ defmodule PtcRunner.Kernel.AgentLibraryTest do
       provider_resources: Keyword.get(opts, :provider_resources, []),
       inspection_sink: Keyword.get(opts, :inspection_sink),
       inspection_path: Keyword.get(opts, :inspection_path)
-    )
+    ]
+
+    config_opts =
+      case Keyword.fetch(opts, :result_contract) do
+        {:ok, result_contract} -> Keyword.put(config_opts, :result_contract, result_contract)
+        :error -> config_opts
+      end
+
+    RunConfig.new(config_opts)
   end
 
   defp agent_config_with_requester(requester) do
@@ -1793,7 +1985,8 @@ defmodule PtcRunner.Kernel.AgentLibraryTest do
 
   defp required_agent_tools do
     Map.new(
-      ~w(kernel-eval kernel-mission-inventory kernel-mission-model-context llm-request workflow-annotate),
+      ~w(kernel-eval kernel-mission-inventory kernel-mission-model-context kernel-result-contract
+         llm-request workflow-annotate),
       &{&1, %TrustedTool{function: fn _arguments -> %{status: :error} end}}
     )
   end

--- a/test/ptc_runner/kernel/trace_capability_test.exs
+++ b/test/ptc_runner/kernel/trace_capability_test.exs
@@ -367,7 +367,7 @@ defmodule PtcRunner.Kernel.TraceCapabilityTest do
         )
       end)
 
-    assert_receive {:temporary_synced, temporary_publisher}
+    assert_receive {:temporary_synced, temporary_publisher}, 1_000
 
     [temporary] =
       directory


### PR DESCRIPTION
## Summary
- validate `agent.main` terminal candidates against the manifest result contract while the bounded loop can still request a correction
- return bounded structural feedback without disclosing the rejected value; every workflow retains the final fail-closed publication check
- share canonical JSON projection between early validation and final publication, including quoted-symbol values and keys, while preserving the model-authored result representation
- document the behavior and embedding boundary in the user guide, changelog, and `RunConfig`
- stabilize the existing trace-publication synchronization test that repeatedly failed under the full concurrent gate

## Review findings addressed
- rebasing onto current `main` exposed a mismatch with the newly merged quoted-symbol contract: early validation rejected values that final publication accepts
- successful validation previously returned the tool-projected copy, which changed quoted-symbol map keys into strings; it now returns the original authored value
- keyword-keyed maps remain rejected before they can be normalized past the contract

## Verification
- `mix precommit` — 4,904 root tests, 70 Viewer tests, 35 launcher tests, specification/schema/generated-doc checks, and package/archive verification passed
- repository pre-push hook — root, Viewer, and launcher suites; upstream API audit; Dialyzer; unused dependencies; packaging; and ExDoc warnings passed
- focused contract, manifest, Kernel, REPL, and agent suites — 166 tests passed

E2E tests were not run because they require external service credentials.