### PR TITLE
fix(kernel): fail closed on the rest of the dispatch path

### DIFF
--- a/lib/ptc_runner/kernel/run_state.ex
+++ b/lib/ptc_runner/kernel/run_state.ex
@@ -24,13 +24,20 @@ defmodule PtcRunner.Kernel.RunState do
   its `:DOWN` observed. Thus connector cleanup cannot begin while a callback
   from that run remains live. Shutdown — owner death or explicit stop —
   likewise kills and drains every still-attached provider before state
-  terminates. A dispatching process routinely races that shutdown, so
-  `attach_provider/2`, `finish_provider/1`, and `release_provider_slot/1` report
-  closure rather than propagating the owner's exit; every other call still fails
-  loudly. Closure is what they report for any exit, including a call timeout. A process holds at most one reservation at a time: dispatch is
+  terminates. A process holds at most one reservation at a time: dispatch is
   sequential per process, so a second reserve while one is active is a protocol
   violation and is rejected rather than silently replacing the tracked
-  reservation. A provider process atomically records terminal policy
+  reservation.
+
+  A dispatching process routinely races that shutdown, so the calls it makes
+  here report closure rather than propagating the owner's exit, each answering
+  with the value that fails closed for its own caller. `usage/1` and `limits/1`
+  are the deliberate exceptions: invented limits would widen the ceilings a
+  caller is about to enforce and an invented usage snapshot would misreport the
+  budget, so exiting with the owner is the safe outcome and they stay unguarded.
+  What is reported is the same for any exit, including a call timeout; a reply
+  the owner actually sent is always passed through, so a mismatched token still
+  reaches the caller unchanged. A provider process atomically records terminal policy
   classification against the active evaluation before publishing its result;
   that evaluation-scoped bit therefore survives a later sandbox timeout or heap
   kill and is cleared with the lease.
@@ -109,7 +116,7 @@ defmodule PtcRunner.Kernel.RunState do
   @spec reserve_capability(t(), environment(), binary()) :: :ok | {:error, atom()}
   @doc "Atomically reserves environment, per-name, and live-provider budgets."
   def reserve_capability(state, environment, name),
-    do: call(state, {:reserve_capability, environment, name})
+    do: safe_call(state, {:reserve_capability, environment, name}, {:error, :run_closed})
 
   @spec attach_provider(t(), pid()) :: :ok | {:error, :closed | :provider_down}
   @doc "Attaches the caller's live provider process to its capability reservation."
@@ -158,9 +165,9 @@ defmodule PtcRunner.Kernel.RunState do
   def finish_provider(state), do: safe_call(state, :finish_provider, {:error, :run_closed})
 
   @doc false
-  @spec mark_evaluation_terminal_provider_failure(t()) :: :ok
+  @spec mark_evaluation_terminal_provider_failure(t()) :: :ok | {:error, :closed}
   def mark_evaluation_terminal_provider_failure(state),
-    do: call(state, :mark_evaluation_terminal_provider_failure)
+    do: safe_call(state, :mark_evaluation_terminal_provider_failure, :ok)
 
   @spec reserve_evaluation(t()) :: {:ok, map(), [term()], reference()} | {:error, atom()}
   @doc "Atomically reserves and returns native subordinate memory and turn history."
@@ -184,11 +191,13 @@ defmodule PtcRunner.Kernel.RunState do
 
   @spec protocol_error(t()) :: :ok | {:error, :protocol_error_limit}
   @doc "Records one protocol error and closes the run when its ceiling is exceeded."
-  def protocol_error(state), do: call(state, :protocol_error)
+  def protocol_error(state), do: safe_call(state, :protocol_error, :ok)
 
-  @spec fail(t(), atom(), atom()) :: :ok
+  # There is no failure left to record once the owner is gone. As above, the
+  # declared :ok never covered the mismatched-token reply.
+  @spec fail(t(), atom(), atom()) :: :ok | {:error, :closed}
   @doc "Records the first terminal failure and closes the run."
-  def fail(state, kind, reason), do: call(state, {:fail, kind, reason})
+  def fail(state, kind, reason), do: safe_call(state, {:fail, kind, reason}, :ok)
 
   @spec terminal_failure(t()) :: nil | %{kind: atom(), reason: atom()}
   @doc "Returns the first terminal failure, if any."
@@ -214,6 +223,10 @@ defmodule PtcRunner.Kernel.RunState do
     ProviderTaskTracker.close(state.provider_tracker)
   end
 
+  # These two answer with the owner's data, and there is no substitute that
+  # fails closed: invented limits would widen the byte ceilings a caller is
+  # about to enforce, and an invented usage snapshot would misreport the budget.
+  # Exiting with the dead owner is the safe outcome, so they stay unguarded.
   @spec usage(t()) :: map()
   @doc "Returns a read-only bounded usage snapshot."
   def usage(state), do: call(state, :usage)

--- a/test/ptc_runner/kernel/core_contract_test.exs
+++ b/test/ptc_runner/kernel/core_contract_test.exs
@@ -399,6 +399,28 @@ defmodule PtcRunner.Kernel.CoreContractTest do
   # The tracker hears about owner death only through its monitor, so it can still
   # accept an attachment after the owner is gone. Pinning the owner pid to an
   # already-dead process reproduces that window without racing the monitor.
+  # Everything a dispatch calls on a dead owner answers with the value that fails
+  # closed for its own caller, so the dispatching process unwinds into a terminal
+  # result instead of exiting. usage/1 and limits/1 are deliberately excluded:
+  # there is no safe answer to invent, so they still exit.
+  test "dispatch-path calls on a dead owner report instead of exiting" do
+    {:ok, state} = RunState.start(Limits.defaults())
+
+    owner_ref = Process.monitor(state.pid)
+    assert :ok = RunState.stop(state)
+    assert_receive {:DOWN, ^owner_ref, :process, _pid, _reason}
+
+    assert {:error, :run_closed} = RunState.reserve_capability(state, :workflow, "gone")
+    assert {:error, :run_closed} = RunState.finish_provider(state)
+    assert {:error, :closed} = RunState.release_provider_slot(state)
+    assert :ok = RunState.protocol_error(state)
+    assert :ok = RunState.fail(state, :event_sink_error, :event_sink_error)
+    assert :ok = RunState.mark_evaluation_terminal_provider_failure(state)
+
+    assert catch_exit(RunState.usage(state))
+    assert catch_exit(RunState.limits(state))
+  end
+
   test "provider attachment reports closure when the owner died before the tracker noticed" do
     {:ok, state} = RunState.start(Limits.defaults())
     assert :ok = RunState.reserve_capability(state, :workflow, "orphaned")


### PR DESCRIPTION
Follow-up to #1158, which left this as a known limitation.

A dispatch makes several calls against `RunState`, and the owner can die under any of them. #1158 made three of them exit-safe; the rest still propagated the owner's exit and took the dispatching process down instead of unwinding into a terminal result.

## What changed

Each remaining call now answers with the value that fails closed **for its own caller** — chosen per call site, not wrapped blindly:

| Call | On owner death | Why |
| --- | --- | --- |
| `reserve_capability/3` | `{:error, :run_closed}` | Refuses the capability. The dispatcher already has that clause. |
| `protocol_error/1` | `:ok` | The caller reports the protocol error it was going to report. `{:error, :protocol_error_limit}` would claim a ceiling was hit that wasn't. |
| `fail/3` | `:ok` | No failure left to record on a dead owner, and this is what `Events.emit/4` hard-matches after a sink failure. |
| `mark_evaluation_terminal_provider_failure/1` | `:ok` | Runs in the provider process — the one most likely to outlive the owner — and the bit only means anything to a live evaluation. |

`Events.emit/4` is the notable one: a sink failure returns `{:error, :event_sink_error}` and funnels straight into `:ok = RunState.fail(...)`, so an exit-safe path was feeding an exit-unsafe one.

## What deliberately still exits

`usage/1` and `limits/1` answer with the owner's data and have **no substitute that fails closed**:

- invented limits would *widen* the byte ceilings a caller is about to enforce — a fail-open on argument and result size;
- an invented usage snapshot would misreport the remaining budget.

Exiting with the dead owner is the safe outcome there, so blanket exit-safety would have been wrong. The moduledoc now states both the contract and the exception, and the test asserts those two exits are still present.

## Spec corrections

`fail/3` and `mark_evaluation_terminal_provider_failure/1` both declared `:: :ok` while a mismatched token has always replied `{:error, :closed}` through `RunState`'s catch-all `handle_call` clause. Both specs are corrected.

Only *exits* are translated. A reply the owner actually sent still reaches the caller unchanged, so a bad token stays as loud as it has always been.

## Verification

`mix format --check-formatted`, `compile --warnings-as-errors`, `credo --strict`, `xref` cycles, `ptc.validate_spec`, `ptc.gen_docs --check`, conformance inventory, **Dialyzer 0 errors** (including the widened specs against the `:ok =` hard matches), Viewer tests (70), root suite 4972/4974.

The new test was confirmed to fail with `(exit) no process` when the change is reverted.

Both suite failures are environmental and were checked individually rather than assumed:

- `test/mix/tasks/ptc_repl_test.exs:477` chmods a directory `0500` and expects the write to fail — impossible as root. Fails identically on an unmodified `main`.
- the bundle-compile limit test is load-sensitive in this container (passes on isolated re-run, and consistently once precompiled).

Neither reproduces in CI, which does not run as root.

## Remaining follow-ups from #1158

Not addressed here:

- the "unavailable" reasons are still inconsistent across artifact kinds (`:invalid_result_destination` / `:inspection_destination_unavailable` / `:trace_destination_unavailable` / `:source_unavailable` for one physical condition);
- `PrivateDirectory.create/1` can return unsafe at publication time, and inspection and trace publication both collapse it — only result publication names it, because `persist/5` preflights first;
- the ancestry check walks to `/` and fails closed, which is a deployability cliff on hosts where `/` is not root-owned.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MeqN1dmsT6huVLnhgJdmxd)_