### PR TITLE
feat(kernel): compose analysis preludes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,10 +55,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   grapheme-based. Oversized or unrepresentable String operations now return the
   documented bounded condition; locale-sensitive `.toLowerCase` and
   `.toUpperCase` and all legacy Java String aliases were removed.
-- Added the code-owned `log-analysis-v1` profile to `mix ptc.repl`, with
+- Added the code-owned `log-analysis-v2` profile to `mix ptc.repl`, with
   bounded multi-turn mission evaluation over an immutable trace capture,
-  deterministic JSONL output for coding agents, safe profile discovery, and
-  separate atomic analysis-trace persistence.
+  explicit whole-result cursor traversal, deterministic JSONL output for
+  coding agents, safe profile discovery, and separate atomic analysis-trace
+  persistence. Rejected log and inspection queries now fail instead of looking
+  like empty results, and both analysis profiles reuse the shipped `cap`
+  envelope and pagination helpers.
 - Added one typed MCP source with equivalent stateless Streamable HTTP and
   owned stdio transports. Stdio uses the optional precompiled
   `ptc_runner_launcher` companion, freezes launcher and server digests, and

--- a/docs/guides/building-agents.md
+++ b/docs/guides/building-agents.md
@@ -545,7 +545,7 @@ Inspect the run through the bounded log-analysis REPL:
 
 ```console
 mix ptc.repl \
-  --profile log-analysis-v1 \
+  --profile log-analysis-v2 \
   --resource traces=tmp/file-agent-traces \
   -e '(def run-id (get-in (log/runs {}) ["items" 0 "run_id"]))' \
   -e '(log/run run-id)' \

--- a/docs/guides/components-and-preludes.md
+++ b/docs/guides/components-and-preludes.md
@@ -23,6 +23,12 @@ Public `defn` and `def` forms become qualified exports. `defn-` remains
 private to its namespace. Cross-component calls require both a declared
 component dependency and a public export in the dependency.
 
+Dependencies are real composition boundaries, not authority grants. A
+component can call only the public namespaces of its direct dependencies. Once
+the whole bundle is installed, evaluated PTC-Lisp can call every public export
+in that bundle. `:visibility :discoverable` keeps an export out of model prompt
+inventory; it does not make the export inaccessible.
+
 ## Declare runtime contracts
 
 Public exports may declare contracts in their ordinary metadata map:
@@ -83,6 +89,29 @@ Their transitive dependencies are frozen into the same compiled bundle as local
 components. Unknown IDs, repeated selections, and local/library ID collisions
 are rejected. Workflow and mission bundles compile separately and attach to
 structurally distinct environments.
+
+Manifest library selections and `Library.resolve_components/1` expand shipped
+dependencies automatically. `Library.component/1` intentionally returns only
+the requested component; an embedder passing components directly to
+`PtcRunner.Kernel.compile_bundle/1` must first assemble a closed dependency set.
+
+Shipped components reuse lower-level components in the same way as application
+components. The analysis stack is a concrete example:
+
+| Component | Purpose |
+| --- | --- |
+| `cap` | Fail-safe capability-envelope handling and bounded cursor traversal |
+| `log.core` | One-page canonical trace queries |
+| `log.analysis` | Bounded whole-result trace traversal |
+| `inspection.core` | One-page private inspection queries |
+| `inspection.analysis` | Bounded whole-result private inspection traversal |
+
+`log.core` and `inspection.core` depend on `cap`; each analysis layer depends
+on its matching core component and on `cap`. This keeps each helper in one
+place without granting new host capabilities. Adding an installed dependency
+does widen the resolved bundle and its callable namespaces, so fixed profiles
+pin the complete resolved component list and version user-visible surface
+changes.
 
 [Building agents](building-agents.md) covers the `agent.core` loop and the
 `agent.prompt` policy seam these libraries provide.

--- a/docs/guides/embedding-in-elixir.md
+++ b/docs/guides/embedding-in-elixir.md
@@ -49,6 +49,20 @@ The host creates every authority-bearing value. `PtcRunner.Kernel.run/2` does no
 capabilities from application environment, the process dictionary, or other
 ambient state.
 
+The example component has no dependencies. For shipped libraries, resolve the
+installed closure before compiling it:
+
+```elixir
+{:ok, components} =
+  PtcRunner.Kernel.Library.resolve_components([{:library, "log.analysis"}])
+
+{:ok, bundle} = PtcRunner.Kernel.compile_bundle(components)
+```
+
+`Library.component/1` fetches exactly one component and does not expand its
+dependencies. This makes incomplete direct API usage fail at compilation
+instead of producing a partially functional bundle.
+
 ## Prefer manifests for deployable projects
 
 `PtcRunner.Kernel.RunBuilder` is the shared construction path for manifests and

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -104,13 +104,16 @@ limits. Query the captured directory through the fixed log-analysis profile:
 
 ```console
 mix ptc.repl \
-  --profile log-analysis-v1 \
+  --profile log-analysis-v2 \
   --resource traces=tmp/tutorial-traces \
-  -e '(log/runs {})'
+  -e '(log.analysis/all-runs {"limit" 50} 10)'
 ```
 
 The profile receives an immutable capture and has no filesystem, network,
-model, private-inspection, or nested-evaluation authority.
+model, private-inspection, or nested-evaluation authority. The final argument
+is a page bound. The result carries the immutable source's `snapshot_hash`.
+The returned `complete?` field is `false` if that bound stops the traversal
+before the captured source is exhausted.
 
 ## Try the language directly
 

--- a/docs/guides/kernel-maintainer.md
+++ b/docs/guides/kernel-maintainer.md
@@ -120,6 +120,24 @@ Exact component, schema, inventory, prompt-rendering, and projection rules live
 in `Component`, `FrozenBundle`, `Capability`, `MissionInventory`, and the Lisp
 runtime-contract module docs.
 
+Components may compose other components through declared acyclic dependencies.
+Edges should point toward lower-level reusable behavior: capability facades may
+reuse pure support components, while policy and ergonomics layers compose the
+facades. The bundle compiler admits only public exports from direct dependency
+namespaces and derives capability requirements through those calls. Evaluated
+source can call every public export in the resolved bundle, including
+`:discoverable` exports omitted from model prompts, so every new edge is also a
+callable-surface review.
+
+Installed-library selections expand transitively in manifests and through
+`Library.resolve_components/1`; raw `compile_bundle/1` callers still provide a
+closed set. Fixed analysis profiles go further: their component list must equal
+the resolved bundle order, their namespace list must equal all resolved
+namespaces, and their digest identifies the exact build. A source-only bug fix
+changes the digest. Change the profile ID when the declared callable surface,
+authority, limits, persistence policy, result policy, or other published
+behavioral contract changes.
+
 ## Subordinate evaluation and workflow policy
 
 The reserved `kernel-eval` capability delegates dynamic or compiled mission
@@ -337,7 +355,7 @@ so a write remains indeterminate.
 PtcRunner-owned canonical traces remain native rather than passing through
 MCP. A host-installed `ptc_trace_snapshot` uses `TraceSnapshot` to capture one
 directory and `TraceCapability` to expose the same four canonical `TraceLog`
-queries used by `log-analysis-v1`. A paired private
+queries used by `log-analysis-v2`. A paired private
 `ptc_inspection_snapshot` receives that already captured trace through the
 provider acquisition service, validates all artifacts and correlations before
 publication, and exposes the shared `InspectionQuery` layer through
@@ -347,8 +365,8 @@ Local analysis profiles are fixed, code-owned recipes selected through the
 closed `AnalysisProfileRegistry`. `AnalysisSessionBuilder` is the host entry;
 `AnalysisSession`, `SessionTrace`, and `AnalysisResources` share continuation,
 publication, and cleanup without letting a caller supply modules,
-capabilities, limits, or sink policy. `log-analysis-v1` remains the Viewer and
-ordinary terminal profile. `inspection-analysis-v1` adds correlated
+capabilities, limits, or sink policy. `log-analysis-v2` remains the Viewer and
+ordinary terminal profile. `inspection-analysis-v2` adds correlated
 `TraceSnapshot` and `InspectionSnapshot` captures behind a private
 interactive-terminal gate. Browser or Lisp input does not supply profile
 internals or paths.

--- a/docs/guides/kernel-maintainer.md
+++ b/docs/guides/kernel-maintainer.md
@@ -131,12 +131,15 @@ callable-surface review.
 
 Installed-library selections expand transitively in manifests and through
 `Library.resolve_components/1`; raw `compile_bundle/1` callers still provide a
-closed set. Fixed analysis profiles go further: their component list must equal
-the resolved bundle order, their namespace list must equal all resolved
-namespaces, and their digest identifies the exact build. A source-only bug fix
-changes the digest. Change the profile ID when the declared callable surface,
-authority, limits, persistence policy, result policy, or other published
-behavioral contract changes.
+closed set. Fixed analysis profiles go further: their declared component,
+namespace, and capability sets must equal the resolved environment exactly.
+Declaration order is not significant. Runtime identity records components in
+the bundle compiler's canonical dependency order and namespaces and
+capabilities in lexical order, so harmless recipe reordering does not change
+the digest. The bundle hash still identifies the exact compiled build, and a
+source-only bug fix changes the digest. Change the profile ID when the declared
+callable surface, authority, limits, persistence policy, result policy, or
+other published behavioral contract changes.
 
 ## Subordinate evaluation and workflow policy
 

--- a/docs/guides/kernel-repl.md
+++ b/docs/guides/kernel-repl.md
@@ -3,9 +3,9 @@
 `mix ptc.repl` provides deliberately different PTC-Lisp session modes:
 
 - direct and manifest-backed sessions are workflow scratchpads;
-- `log-analysis-v1` is a fixed mission session for querying an immutable
+- `log-analysis-v2` is a fixed mission session for querying an immutable
   capture of canonical traces; and
-- `inspection-analysis-v1` is a fixed private mission session for correlating
+- `inspection-analysis-v2` is a fixed private mission session for correlating
   canonical traces with exact private inspection evidence.
 
 All modes retain successful definitions and exact `*1`, `*2`, and `*3`
@@ -73,7 +73,7 @@ Select the code-owned profile and supply its required trace resource:
 
 ```bash
 mix ptc.repl \
-  --profile log-analysis-v1 \
+  --profile log-analysis-v2 \
   --resource traces=tmp/tutorial-traces
 ```
 
@@ -82,13 +82,27 @@ files. The task captures it immutably when the session starts. The caller
 cannot select the profile's component, capabilities, limits, mission data,
 labels, persistence policy, or result projection.
 
-`log-analysis-v1` installs the shipped `log.core` component, whose exported
-namespace is `log`. It grants only:
+`log-analysis-v2` installs `cap`, `log.core`, and `log.analysis`. It grants
+only:
 
 - `trace-list-runs` through `log/runs`;
 - `trace-get-run` through `log/run`;
 - `trace-list-turns` through `log/turns`;
 - `trace-counters` through `log/counters`.
+
+The four `log/*` functions return one bounded page. Use the matching analysis
+functions when you need the complete selected result:
+
+```clojure
+(log.analysis/all-runs {"limit" 50} 10)
+(log.analysis/all-turns "run-id" {"limit" 100} 20)
+```
+
+The final argument is an explicit page bound. Results contain `items`, `pages`,
+`complete?`, and the source `snapshot_hash`. `complete?` is `true` only when
+the source was exhausted; a page-bound stop returns the collected prefix with
+`complete? false`. Invalid or rejected source queries fail the form instead of
+returning an error map that can be mistaken for an empty result.
 
 Ordinary bounded mission introspection such as `(tool/runtime-usage {})` and
 `(tool/cap-list {})` is also available. Filesystem, network, LLM, agent,
@@ -97,13 +111,13 @@ workflow, MCP, private-inspection, and nested evaluation authority is absent.
 One session can build up an investigation interactively:
 
 ```clojure
-(def runs (log/runs {}))
+(def runs (log.analysis/all-runs {"limit" 50} 10))
 (def items (get runs "items"))
 (def ok-runs (filter #(= "ok" (get % "status")) items))
 (map #(select-keys % ["run_id" "duration_ms" "mission_capability_calls"])
      ok-runs)
 (def slowest (first (sort-by #(get % "duration_ms") > items)))
-(log/turns (get slowest "run_id") {"limit" 100})
+(log.analysis/all-turns (get slowest "run_id") {"limit" 100} 20)
 ```
 
 Loaded files, repeated `--eval` forms, positional scripts, stdin, and
@@ -116,7 +130,7 @@ reading an unbounded source into the Mix task.
 
 ```bash
 mix ptc.repl \
-  --profile log-analysis-v1 \
+  --profile log-analysis-v2 \
   --resource traces=tmp/tutorial-traces \
   -e '(def runs (log/runs {}))' \
   -e '(count (get runs "items"))'
@@ -133,7 +147,7 @@ that terminal as the private result sink:
 
 ```bash
 mix ptc.repl \
-  --profile inspection-analysis-v1 \
+  --profile inspection-analysis-v2 \
   --resource traces=tmp/tutorial-traces \
   --resource inspection=tmp/tutorial-inspection \
   --session-trace-dir tmp/analysis-traces \
@@ -147,8 +161,9 @@ symlink aliases. Inspection capture validates every private artifact against
 the corresponding run in the immutable canonical trace capture; malformed,
 replaced, uncorrelated, or oversized input rejects the whole private source.
 
-`inspection-analysis-v1` installs only `log.core` and `inspection.core`.
-Alongside the ordinary `log/*` functions, it exports:
+`inspection-analysis-v2` installs both core query components, both analysis
+layers, and their shared `cap` dependency. Alongside the ordinary `log/*`
+functions, it exports one-page private queries:
 
 - `inspection/runs`;
 - `inspection/model-exchanges`;
@@ -157,15 +172,24 @@ Alongside the ordinary `log/*` functions, it exports:
 - `inspection/effective-preludes`; and
 - `inspection/provider-exchanges`.
 
-All collection functions are bounded and return an opaque `next_cursor` for a
-later page. For example:
+Each collection returns an opaque `next_cursor` for a later page. The
+`inspection.analysis/*` namespace provides bounded whole-result variants:
+
+- `inspection.analysis/all-runs`;
+- `inspection.analysis/all-model-exchanges`;
+- `inspection.analysis/all-capability-calls`;
+- `inspection.analysis/all-generated-sources`;
+- `inspection.analysis/all-effective-preludes`; and
+- `inspection.analysis/all-provider-exchanges`.
+
+For example:
 
 ```clojure
-(def runs (inspection/runs {"limit" 20}))
+(def runs (inspection.analysis/all-runs {"limit" 20} 10))
 (def run-id (get (first (get runs "items")) "run_id"))
-(inspection/model-exchanges run-id nil)
-(inspection/generated-sources run-id nil)
-(inspection/provider-exchanges run-id nil)
+(inspection.analysis/all-model-exchanges run-id 10)
+(inspection.analysis/all-generated-sources run-id 10)
+(inspection.analysis/all-provider-exchanges run-id 10)
 ```
 
 Exact model messages, generated source, capability arguments/results,
@@ -187,7 +211,7 @@ input tree. Supply an existing physically separate output directory:
 
 ```bash
 mix ptc.repl \
-  --profile log-analysis-v1 \
+  --profile log-analysis-v2 \
   --resource traces=tmp/tutorial-traces \
   --session-trace-dir tmp/analysis-traces \
   -e '(log/counters {})'
@@ -209,7 +233,7 @@ Coding agents can avoid PTY and prompt handling by repeating `-e` with
 
 ```bash
 mix ptc.repl \
-  --profile log-analysis-v1 \
+  --profile log-analysis-v2 \
   --resource traces=tmp/tutorial-traces \
   --session-trace-dir tmp/analysis-traces \
   --format jsonl \
@@ -242,7 +266,7 @@ form error, use `--continue-on-error` with at least two `-e` arguments:
 
 ```bash
 mix ptc.repl \
-  --profile log-analysis-v1 \
+  --profile log-analysis-v2 \
   --resource traces=tmp/tutorial-traces \
   --format jsonl \
   --continue-on-error \
@@ -259,12 +283,12 @@ Inspect the safe static contract without capturing traces or starting a
 session:
 
 ```bash
-mix ptc.repl --describe-profile log-analysis-v1
-mix ptc.repl --describe-profile log-analysis-v1 --format jsonl
+mix ptc.repl --describe-profile log-analysis-v2
+mix ptc.repl --describe-profile log-analysis-v2 --format jsonl
 ```
 
-The description lists the required resource, component, namespace,
-capabilities, fixed limits, and policies. It contains no path, snapshot,
+The description lists the required resources, complete component closure,
+callable namespaces, capabilities, fixed limits, and policies. It contains no path, snapshot,
 callback, process identifier, source, or credential.
 
 ## Next steps
@@ -276,8 +300,8 @@ callback, process identifier, source, or credential.
 - [Manifests and capabilities](manifests-and-capabilities.md) documents the
   manifest that `--manifest` sessions attach to, and the trace and inspection
   snapshot providers these profiles read.
-- [Components and preludes](components-and-preludes.md) explains the `log.core`
-  and `inspection.core` components these profiles install, and how to package
-  your own analysis functions the same way.
+- [Components and preludes](components-and-preludes.md) explains the core and
+  analysis components these profiles install, dependency closure, and how to
+  package your own analysis functions the same way.
 - Hosts driving `PtcRunner.Kernel.ReplSession` programmatically should read
   [Embedding in Elixir](embedding-in-elixir.md) for its ownership rules.

--- a/docs/guides/running-and-debugging.md
+++ b/docs/guides/running-and-debugging.md
@@ -194,7 +194,7 @@ immutable directory capture through the fixed log-analysis profile:
 
 ```console
 mix ptc.repl \
-  --profile log-analysis-v1 \
+  --profile log-analysis-v2 \
   --resource traces=traces \
   -e '(log/runs {})' \
   -e '(log/counters {})'

--- a/docs/trace-log-contract.md
+++ b/docs/trace-log-contract.md
@@ -163,15 +163,17 @@ directory changes later. The snapshot exits with its owning analysis session;
 cleanup is idempotent. This immutable boundary also prevents an analysis run's
 new canonical events from mutating the source it is paging.
 
-### Local log-analysis sessions
+### Local analysis sessions
 
-The server-owned `log-analysis-v1` profile is the sole local analysis profile
-and is shared by the Viewer and terminal REPL frontends. Its mission bundle
-contains the shipped `log.core` component,
-its explicit authority contains only `trace-list-runs`, `trace-get-run`,
-`trace-list-turns`, and `trace-counters`, and ordinary implicit mission
-introspection remains available. Filesystem, network, LLM, agent, workflow,
-MCP, private-inspection, and nested `kernel-eval` authority are absent.
+The server-owned `log-analysis-v2` profile is shared by the Viewer and ordinary
+terminal REPL frontends. Its mission bundle contains `cap`, `log.core`, and
+`log.analysis`; its explicit authority contains only `trace-list-runs`,
+`trace-get-run`, `trace-list-turns`, and `trace-counters`; and ordinary implicit
+mission introspection remains available. Filesystem, network, LLM, agent,
+workflow, MCP, private-inspection, and nested `kernel-eval` authority are
+absent. The separate `inspection-analysis-v2` profile adds the validated
+private-inspection source, both inspection components, and a private terminal
+gate.
 
 Each session queries one immutable snapshot and records its own canonical events
 in the same owner process that holds its continuation and quotas, under a
@@ -419,14 +421,22 @@ Host query capabilities follow the standard Kernel envelope and may be named:
 - `trace-list-turns`;
 - `trace-counters`.
 
-The default `log.core` prelude requires them and provides the regular Lisp API.
-Higher-level preludes may compose it:
+The default `log.core` prelude requires them and provides the regular one-page
+Lisp API. The shipped `log.analysis` layer composes it with the pure pagination
+helpers in `cap`:
 
 ```text
 log.analysis
-  depends: log.core
-  requires: trace-counters
+  depends: cap, log.core
+  traverses through log.core: trace-list-runs, trace-list-turns
 ```
+
+`log.analysis/all-runs` and `log.analysis/all-turns` take an explicit positive
+page bound and return `items`, `pages`, `complete?`, and `snapshot_hash`. A
+bound-limited prefix is always marked `complete? false`. The aggregate
+preserves the source's `snapshot_hash`, and a changed snapshot identity fails
+traversal. Capability error envelopes fail evaluation rather than flowing into
+projections as ordinary empty data.
 
 Preludes may change ergonomics, projections, defaults, or analysis policy. They
 cannot expand the source grant, bypass bounds/sanitization, or acquire private

--- a/lib/mix/tasks/ptc.repl.ex
+++ b/lib/mix/tasks/ptc.repl.ex
@@ -11,12 +11,12 @@ defmodule Mix.Tasks.Ptc.Repl do
       mix ptc.repl -
       mix ptc.repl --manifest ptc.json
       mix ptc.repl --manifest ptc.json --trace trace.jsonl
-      mix ptc.repl --profile log-analysis-v1 --resource traces=tmp/traces
-      mix ptc.repl --profile inspection-analysis-v1 \
+      mix ptc.repl --profile log-analysis-v2 --resource traces=tmp/traces
+      mix ptc.repl --profile inspection-analysis-v2 \
         --resource traces=tmp/traces \
         --resource inspection=tmp/inspection \
         --private-terminal
-      mix ptc.repl --describe-profile log-analysis-v1
+      mix ptc.repl --describe-profile log-analysis-v2
 
   Options:
 
@@ -31,7 +31,7 @@ defmodule Mix.Tasks.Ptc.Repl do
     * `--session-trace-dir` — existing output directory for a profile session's
       separate canonical trace;
     * `--private-terminal` — explicitly authorize an attached terminal as the
-      private output sink required by `inspection-analysis-v1`;
+      private output sink required by `inspection-analysis-v2`;
     * `--format clojure|jsonl` — choose human output or non-interactive
       profile-mode JSON Lines;
     * `--continue-on-error` — evaluate later repeated `--eval` forms after a
@@ -272,10 +272,10 @@ defmodule Mix.Tasks.Ptc.Repl do
     do: "selected profile does not allow --continue-on-error"
 
   defp profile_frontend_error(:private_terminal_required),
-    do: "inspection-analysis-v1 requires --private-terminal"
+    do: "inspection-analysis-v2 requires --private-terminal"
 
   defp profile_frontend_error(:interactive_terminal_required),
-    do: "inspection-analysis-v1 requires attached stdin and stdout terminals"
+    do: "inspection-analysis-v2 requires attached stdin and stdout terminals"
 
   defp profile_frontend_error(:private_terminal_unsupported),
     do: "--private-terminal is supported only by a private analysis profile"

--- a/lib/ptc_runner/kernel/analysis_profile.ex
+++ b/lib/ptc_runner/kernel/analysis_profile.ex
@@ -32,6 +32,7 @@ defmodule PtcRunner.Kernel.AnalysisProfile do
          true <- resources.profile_id == recipe.id(),
          {:ok, components} <- Library.resolve_components(recipe.component_selections()),
          {:ok, bundle} <- PtcRunner.Kernel.compile_bundle(components),
+         true <- bundle.component_ids == recipe.component_ids(),
          true <- namespaces(bundle) == recipe.namespaces(),
          {:ok, capabilities} <- recipe.capabilities(resources),
          true <- capability_names(capabilities) == recipe.explicit_capabilities(),
@@ -72,7 +73,8 @@ defmodule PtcRunner.Kernel.AnalysisProfile do
   @spec descriptor(recipe(), map(), map(), Limits.t()) ::
           {:ok, map()} | {:error, atom()}
   def descriptor(recipe, bundle, mission, %Limits{} = limits) when is_atom(recipe) do
-    with true <- namespaces(bundle) == recipe.namespaces(),
+    with true <- bundle.component_ids == recipe.component_ids(),
+         true <- namespaces(bundle) == recipe.namespaces(),
          {:ok, inventory} <- MissionInventory.build(mission, limits),
          identity = identity(recipe, bundle, inventory, limits),
          {:ok, encoded} <- DeterministicJSON.encode(identity) do

--- a/lib/ptc_runner/kernel/analysis_profile.ex
+++ b/lib/ptc_runner/kernel/analysis_profile.ex
@@ -32,10 +32,8 @@ defmodule PtcRunner.Kernel.AnalysisProfile do
          true <- resources.profile_id == recipe.id(),
          {:ok, components} <- Library.resolve_components(recipe.component_selections()),
          {:ok, bundle} <- PtcRunner.Kernel.compile_bundle(components),
-         true <- bundle.component_ids == recipe.component_ids(),
-         true <- namespaces(bundle) == recipe.namespaces(),
          {:ok, capabilities} <- recipe.capabilities(resources),
-         true <- capability_names(capabilities) == recipe.explicit_capabilities(),
+         :ok <- validate_contract(recipe, bundle, capabilities),
          {:ok, mission} <-
            MissionEnvironment.new(bundle: bundle, capabilities: capabilities, data: %{}),
          {:ok, workflow} <- WorkflowEnvironment.new([]),
@@ -73,10 +71,9 @@ defmodule PtcRunner.Kernel.AnalysisProfile do
   @spec descriptor(recipe(), map(), map(), Limits.t()) ::
           {:ok, map()} | {:error, atom()}
   def descriptor(recipe, bundle, mission, %Limits{} = limits) when is_atom(recipe) do
-    with true <- bundle.component_ids == recipe.component_ids(),
-         true <- namespaces(bundle) == recipe.namespaces(),
+    with :ok <- validate_contract(recipe, bundle, Map.values(mission.capabilities)),
          {:ok, inventory} <- MissionInventory.build(mission, limits),
-         identity = identity(recipe, bundle, inventory, limits),
+         identity = identity(recipe, bundle, mission, inventory, limits),
          {:ok, encoded} <- DeterministicJSON.encode(identity) do
       digest = "sha256:" <> sha256(encoded)
 
@@ -84,7 +81,7 @@ defmodule PtcRunner.Kernel.AnalysisProfile do
        %{
          id: recipe.id(),
          digest: digest,
-         namespaces: recipe.namespaces(),
+         namespaces: namespaces(bundle),
          identity: identity,
          mission_inventory: inventory
        }}
@@ -93,17 +90,55 @@ defmodule PtcRunner.Kernel.AnalysisProfile do
     end
   end
 
+  @doc false
+  @spec validate_contract(recipe(), map(), [map()]) ::
+          :ok
+          | {:error,
+             :profile_component_set_mismatch
+             | :profile_namespace_set_mismatch
+             | :profile_capability_set_mismatch
+             | :invalid_profile_contract}
+  def validate_contract(
+        recipe,
+        %{component_ids: component_ids, components: components} = bundle,
+        capabilities
+      )
+      when is_atom(recipe) and is_list(component_ids) and is_list(components) and
+             is_list(capabilities) do
+    with :ok <-
+           validate_members(
+             component_ids,
+             recipe.component_ids(),
+             :profile_component_set_mismatch
+           ),
+         :ok <-
+           validate_members(
+             namespaces(bundle),
+             recipe.namespaces(),
+             :profile_namespace_set_mismatch
+           ) do
+      validate_members(
+        capability_names(capabilities),
+        recipe.explicit_capabilities(),
+        :profile_capability_set_mismatch
+      )
+    end
+  end
+
+  def validate_contract(_recipe, _bundle, _capabilities),
+    do: {:error, :invalid_profile_contract}
+
   defp comparable_config(%RunConfig{} = config), do: %{config | claim_id: nil}
 
-  defp identity(recipe, bundle, inventory, limits) do
+  defp identity(recipe, bundle, mission, inventory, limits) do
     base = %{
       "profile_id" => recipe.id(),
       "bundle_hash" => bundle.hash,
       "mission_inventory_hash" => inventory.hash,
       "implicit_runtime" => RuntimeTools.mission_contract_descriptor(),
       "limits" => limits |> Map.from_struct() |> stringify_keys(),
-      "explicit_capabilities" => recipe.explicit_capabilities(),
-      "components" => recipe.component_ids(),
+      "explicit_capabilities" => mission.capabilities |> Map.keys() |> Enum.sort(),
+      "components" => bundle.component_ids,
       "mission_data" => %{},
       "persistence_policy" => recipe.persistence_policy(),
       "result_policy" => recipe.result_policy()
@@ -133,6 +168,13 @@ defmodule PtcRunner.Kernel.AnalysisProfile do
     |> Enum.uniq()
     |> Enum.sort()
   end
+
+  defp validate_members(actual, expected, mismatch)
+       when is_list(actual) and is_list(expected) do
+    if Enum.sort(actual) == Enum.sort(expected), do: :ok, else: {:error, mismatch}
+  end
+
+  defp validate_members(_actual, _expected, mismatch), do: {:error, mismatch}
 
   defp stringify_keys(map), do: Map.new(map, fn {key, value} -> {Atom.to_string(key), value} end)
   defp sha256(value), do: :crypto.hash(:sha256, value) |> Base.encode16(case: :lower)

--- a/lib/ptc_runner/kernel/analysis_profile_registry.ex
+++ b/lib/ptc_runner/kernel/analysis_profile_registry.ex
@@ -12,8 +12,8 @@ defmodule PtcRunner.Kernel.AnalysisProfileRegistry do
   alias PtcRunner.Kernel.LogAnalysisProfile
 
   @profiles %{
-    "inspection-analysis-v1" => InspectionAnalysisProfile,
-    "log-analysis-v1" => LogAnalysisProfile
+    "inspection-analysis-v2" => InspectionAnalysisProfile,
+    "log-analysis-v2" => LogAnalysisProfile
   }
 
   @type recipe :: module()
@@ -110,7 +110,7 @@ defmodule PtcRunner.Kernel.AnalysisProfileRegistry do
       "continue_on_error" => frontend_value(frontend.continue_on_error)
     }
 
-    if recipe.id() == "log-analysis-v1",
+    if frontend.private_terminal == :forbidden,
       do: description,
       else: Map.put(description, "private_terminal", frontend_value(frontend.private_terminal))
   end

--- a/lib/ptc_runner/kernel/analysis_resources.ex
+++ b/lib/ptc_runner/kernel/analysis_resources.ex
@@ -4,8 +4,8 @@ defmodule PtcRunner.Kernel.AnalysisResources do
   alias PtcRunner.Kernel.InspectionSnapshot
   alias PtcRunner.Kernel.TraceSnapshot
 
-  @log_profile "log-analysis-v1"
-  @inspection_profile "inspection-analysis-v1"
+  @log_profile "log-analysis-v2"
+  @inspection_profile "inspection-analysis-v2"
 
   @enforce_keys [:profile_id, :handles]
   defstruct [:profile_id, :handles]

--- a/lib/ptc_runner/kernel/analysis_session_builder.ex
+++ b/lib/ptc_runner/kernel/analysis_session_builder.ex
@@ -8,7 +8,7 @@ defmodule PtcRunner.Kernel.AnalysisSessionBuilder do
   profile module, component, capability set, mission data, label, limit, or
   sink policy.
 
-  `inspection-analysis-v1` is admitted only with `private_terminal: true` on
+  `inspection-analysis-v2` is admitted only with `private_terminal: true` on
   attached stdin and stdout. That check and physical separation of its trace,
   inspection, and analysis-trace directories happen before either source is
   captured.

--- a/lib/ptc_runner/kernel/inspection_analysis_profile.ex
+++ b/lib/ptc_runner/kernel/inspection_analysis_profile.ex
@@ -2,11 +2,11 @@ defmodule PtcRunner.Kernel.InspectionAnalysisProfile do
   @moduledoc """
   Fixed private authority recipe for correlated trace and inspection analysis.
 
-  `inspection-analysis-v1` captures one canonical trace directory and one
+  `inspection-analysis-v2` captures one canonical trace directory and one
   private inspection directory, validates the private records against the
-  captured canonical runs, and exposes only shipped `log/*` and
-  `inspection/*` read functions. It grants no model, filesystem, network, MCP,
-  write, or inspection-capture authority.
+  captured canonical runs, and exposes the shipped primitive and bounded
+  traversal functions for both sources. It grants no model, filesystem,
+  network, MCP, write, or inspection-capture authority.
   """
 
   alias PtcRunner.Kernel.AnalysisProfile
@@ -17,9 +17,15 @@ defmodule PtcRunner.Kernel.InspectionAnalysisProfile do
   alias PtcRunner.Kernel.TraceCapability
   alias PtcRunner.Kernel.TraceSnapshot
 
-  @id "inspection-analysis-v1"
-  @component_ids ["inspection.core", "log.core"]
-  @namespaces ["inspection", "log"]
+  @id "inspection-analysis-v2"
+  @component_ids [
+    "cap",
+    "inspection.core",
+    "inspection.analysis",
+    "log.core",
+    "log.analysis"
+  ]
+  @namespaces ["cap", "inspection", "inspection.analysis", "log", "log.analysis"]
   @trace_capabilities ~w(trace-counters trace-get-run trace-list-runs trace-list-turns)
   @inspection_capabilities ~w(
     inspection-capability-calls
@@ -108,7 +114,7 @@ defmodule PtcRunner.Kernel.InspectionAnalysisProfile do
     }
   end
 
-  @doc "Returns the safe, static discovery contract for `inspection-analysis-v1`."
+  @doc "Returns the safe, static discovery contract for `inspection-analysis-v2`."
   @spec description() :: map()
   def description do
     %{

--- a/lib/ptc_runner/kernel/library.ex
+++ b/lib/ptc_runner/kernel/library.ex
@@ -4,7 +4,8 @@ defmodule PtcRunner.Kernel.Library do
 
   Available component IDs are `kernel`, `runtime`, `cap`, `workflow.event`,
   `llm`, `agent.native`, `agent.core`, `agent.feedback`, `agent.retry`,
-  `agent.prompt`, `agent.main`, `result`, `log.core`, and `inspection.core`.
+  `agent.prompt`, `agent.main`, `result`, `log.core`, `log.analysis`,
+  `inspection.core`, and `inspection.analysis`.
 
   `agent.main` is a generic entry wrapper: a manifest names `agent.main/run`
   and supplies `task` and `agent` through input, instead of every application
@@ -18,17 +19,16 @@ defmodule PtcRunner.Kernel.Library do
   model-authored value to its PTC-Lisp caller without terminating the outer
   workflow, allowing an evaluator to judge the answer before returning.
 
-  `cap` is `:discoverable` rather than `:prompt`. Its `unwrap!` and
-  `with-cursor` helpers compose capability envelopes for other libraries and
-  are not something a generated program should be prompted to call, so they
-  stay out of the prompt inventory. `unwrap!` fails the program on an error
-  envelope rather than returning it, so a forgotten check cannot turn a
-  provider error into ordinary data; `with-cursor` adds one opaque cursor to
-  an argument map and leaves traversal to the caller.
+  `cap` is `:discoverable` rather than `:prompt`. Its envelope and pagination
+  helpers compose capabilities for other libraries and stay out of the prompt
+  inventory. `unwrap!` fails the program on an error envelope rather than
+  returning it, `with-cursor` adds one opaque cursor to an argument map, and
+  `collect-pages` follows cursors only up to its explicit page bound.
 
-  Fetching a component does not expand its dependencies. `PtcRunner.Kernel`
-  refuses to compile an incomplete set, so a manifest selecting `agent.main`
-  must also carry the `agent.core` closure.
+  Fetching one component with `component/1` does not expand its dependencies,
+  and `PtcRunner.Kernel` refuses to compile an incomplete set. Manifests and
+  `resolve_components/1` expand installed-library selections transitively;
+  direct callers of `compile_bundle/1` must supply the resulting closed set.
 
   Fetching a component grants no capability. The host still compiles the
   selected closed component set and supplies the capabilities required by its
@@ -51,6 +51,12 @@ defmodule PtcRunner.Kernel.Library do
   @result_path Path.expand("../../../priv/preludes/kernel/result.clj", __DIR__)
   @log_core_path Path.expand("../../../priv/preludes/kernel/log.core.clj", __DIR__)
   @inspection_core_path Path.expand("../../../priv/preludes/kernel/inspection.core.clj", __DIR__)
+  @log_analysis_path Path.expand("../../../priv/preludes/kernel/log.analysis.clj", __DIR__)
+
+  @inspection_analysis_path Path.expand(
+                              "../../../priv/preludes/kernel/inspection.analysis.clj",
+                              __DIR__
+                            )
   @external_resource @kernel_path
   @external_resource @runtime_path
   @external_resource @cap_path
@@ -65,6 +71,8 @@ defmodule PtcRunner.Kernel.Library do
   @external_resource @result_path
   @external_resource @log_core_path
   @external_resource @inspection_core_path
+  @external_resource @log_analysis_path
+  @external_resource @inspection_analysis_path
   @sources %{
     "kernel" => File.read!(@kernel_path),
     "runtime" => File.read!(@runtime_path),
@@ -79,9 +87,15 @@ defmodule PtcRunner.Kernel.Library do
     "agent.retry" => File.read!(@agent_retry_path),
     "result" => File.read!(@result_path),
     "log.core" => File.read!(@log_core_path),
-    "inspection.core" => File.read!(@inspection_core_path)
+    "inspection.core" => File.read!(@inspection_core_path),
+    "log.analysis" => File.read!(@log_analysis_path),
+    "inspection.analysis" => File.read!(@inspection_analysis_path)
   }
   @dependencies %{
+    "inspection.analysis" => ["cap", "inspection.core"],
+    "inspection.core" => ["cap"],
+    "log.analysis" => ["cap", "log.core"],
+    "log.core" => ["cap"],
     "agent.prompt" => ["kernel"],
     "agent.core" => [
       "agent.feedback",

--- a/lib/ptc_runner/kernel/log_analysis_profile.ex
+++ b/lib/ptc_runner/kernel/log_analysis_profile.ex
@@ -2,11 +2,9 @@ defmodule PtcRunner.Kernel.LogAnalysisProfile do
   @moduledoc """
   Fixed authority recipe for local log-analysis sessions.
 
-  `log-analysis-v1` installs only the shipped `log.core` mission component,
-  four read-only snapshot capabilities, empty mission data, and the ordinary
-  implicit mission introspection routes. Its descriptor and behavior remain
-  stable while the shared analysis-session engine also serves other closed
-  profiles.
+  `log-analysis-v2` installs the shipped `cap`, `log.core`, and `log.analysis`
+  mission components, four read-only snapshot capabilities, empty mission
+  data, and the ordinary implicit mission introspection routes.
   """
 
   alias PtcRunner.Kernel.AnalysisProfile
@@ -15,9 +13,9 @@ defmodule PtcRunner.Kernel.LogAnalysisProfile do
   alias PtcRunner.Kernel.TraceCapability
   alias PtcRunner.Kernel.TraceSnapshot
 
-  @id "log-analysis-v1"
-  @component_ids ["log.core"]
-  @namespaces ["log"]
+  @id "log-analysis-v2"
+  @component_ids ["cap", "log.core", "log.analysis"]
+  @namespaces ["cap", "log", "log.analysis"]
   @capabilities ~w(trace-counters trace-get-run trace-list-runs trace-list-turns)
   @persistence "canonical-trace-on-close"
   @result_policy "bounded-json-v1"
@@ -91,7 +89,7 @@ defmodule PtcRunner.Kernel.LogAnalysisProfile do
     }
   end
 
-  @doc "Returns the safe, static discovery contract for `log-analysis-v1`."
+  @doc "Returns the safe, static discovery contract for `log-analysis-v2`."
   @spec description() :: map()
   def description do
     %{

--- a/lib/ptc_runner/kernel/viewer_repl_adapter.ex
+++ b/lib/ptc_runner/kernel/viewer_repl_adapter.ex
@@ -10,9 +10,11 @@ defmodule PtcRunner.Kernel.ViewerReplAdapter do
 
   alias PtcRunner.Kernel.ViewerReplBackend
 
+  @profile_id "log-analysis-v2"
+
   # The standalone Viewer validates this callback contract dynamically. The
   # root library deliberately does not depend on the nested Viewer project.
-  def connect(%{trace_dir: trace_dir, profile_id: "log-analysis-v1"})
+  def connect(%{trace_dir: trace_dir, profile_id: @profile_id})
       when is_binary(trace_dir) do
     with expanded <- Path.expand(trace_dir),
          {:ok, %File.Stat{type: :directory}} <- File.stat(expanded),
@@ -20,8 +22,8 @@ defmodule PtcRunner.Kernel.ViewerReplAdapter do
       {:ok, backend,
        %{
          "enabled" => true,
-         "profile_id" => "log-analysis-v1",
-         "namespaces" => ["log"],
+         "profile_id" => @profile_id,
+         "namespaces" => ["cap", "log", "log.analysis"],
          "source_limit_bytes" => 65_536
        }}
     else

--- a/priv/preludes/kernel/cap.clj
+++ b/priv/preludes/kernel/cap.clj
@@ -19,10 +19,46 @@
 (defn with-cursor
   "Adds an opaque pagination cursor to a capability argument map.
 
-  A nil cursor denotes the first page and leaves the arguments unchanged.
+  A nil cursor denotes the first page and removes any existing cursor.
   Traversal stays explicit in the caller; this helper never follows or
   interprets a cursor."
   [arguments cursor]
-  (if cursor
-    (assoc arguments "cursor" cursor)
-    arguments))
+  (let [arguments (dissoc arguments "cursor" :cursor)]
+    (if (nil? cursor)
+      arguments
+      (assoc arguments "cursor" cursor))))
+
+(defn- pagination-result [items pages complete? snapshot-hash]
+  (let [result {"items" items "pages" pages "complete?" complete?}]
+    (if (= snapshot-hash :absent)
+      result
+      (assoc result "snapshot_hash" snapshot-hash))))
+
+(defn collect-pages
+  "Collects `items` from cursor-paginated responses up to `max-pages`.
+
+  `fetch` receives nil for the first page and each opaque `next_cursor`
+  afterward. The result reports how many pages were read and whether the
+  source was exhausted. Snapshot-bound pages preserve their `snapshot_hash`
+  and traversal fails if that identity changes. A page bound that stops
+  traversal returns the collected prefix with `complete?` false; it never
+  presents the prefix as complete."
+  [fetch max-pages]
+  (if (and (integer? max-pages) (pos? max-pages))
+    (loop [cursor nil
+           pages 0
+           items []
+           snapshot-hash :unset]
+      (if (>= pages max-pages)
+        (pagination-result items pages false snapshot-hash)
+        (let [page (fetch cursor)
+              items (into items (get page "items"))
+              next-cursor (get page "next_cursor")
+              page-hash (get page "snapshot_hash" :absent)]
+          (if (or (= snapshot-hash :unset) (= snapshot-hash page-hash))
+            (let [snapshot-hash (if (= snapshot-hash :unset) page-hash snapshot-hash)]
+              (if (nil? next-cursor)
+                (pagination-result items (inc pages) true snapshot-hash)
+                (recur next-cursor (inc pages) items snapshot-hash)))
+            (fail {:status :error :kind :invalid-response :reason :snapshot-changed})))))
+    (fail {:status :error :kind :invalid-request :reason :invalid-max-pages})))

--- a/priv/preludes/kernel/inspection.analysis.clj
+++ b/priv/preludes/kernel/inspection.analysis.clj
@@ -1,0 +1,46 @@
+(ns inspection.analysis
+  "Bounded whole-result traversal for private inspection queries."
+  {:visibility :discoverable})
+
+(defn all-runs
+  "Reads inspection-run pages until exhausted or `max-pages` is reached."
+  [options max-pages]
+  (cap/collect-pages
+    (fn [cursor]
+      (inspection/runs (cap/with-cursor options cursor)))
+    max-pages))
+
+(defn all-model-exchanges
+  "Reads one run's model exchanges until exhausted or `max-pages` is reached."
+  [run-id max-pages]
+  (cap/collect-pages
+    (fn [cursor] (inspection/model-exchanges run-id cursor))
+    max-pages))
+
+(defn all-capability-calls
+  "Reads one run's capability calls until exhausted or `max-pages` is reached."
+  [run-id max-pages]
+  (cap/collect-pages
+    (fn [cursor] (inspection/capability-calls run-id cursor))
+    max-pages))
+
+(defn all-generated-sources
+  "Reads one run's generated sources until exhausted or `max-pages` is reached."
+  [run-id max-pages]
+  (cap/collect-pages
+    (fn [cursor] (inspection/generated-sources run-id cursor))
+    max-pages))
+
+(defn all-effective-preludes
+  "Reads one run's effective preludes until exhausted or `max-pages` is reached."
+  [run-id max-pages]
+  (cap/collect-pages
+    (fn [cursor] (inspection/effective-preludes run-id cursor))
+    max-pages))
+
+(defn all-provider-exchanges
+  "Reads one run's provider exchanges until exhausted or `max-pages` is reached."
+  [run-id max-pages]
+  (cap/collect-pages
+    (fn [cursor] (inspection/provider-exchanges run-id cursor))
+    max-pages))

--- a/priv/preludes/kernel/inspection.core.clj
+++ b/priv/preludes/kernel/inspection.core.clj
@@ -1,39 +1,29 @@
 (ns inspection "Correlated private inspection queries." {:visibility :discoverable})
 
-(defn- unwrap [response]
-  (if (= :ok (get response :status))
-    (get response :value)
-    response))
-
-(defn- with-cursor [arguments cursor]
-  (if (nil? cursor)
-    arguments
-    (assoc arguments "cursor" cursor)))
-
 (defn runs [options]
-  (unwrap (tool/inspection-list-runs options)))
+  (cap/unwrap! (tool/inspection-list-runs options)))
 
 (defn model-exchanges [run-id cursor]
-  (unwrap
+  (cap/unwrap!
     (tool/inspection-model-exchanges
-      (with-cursor {"run_id" run-id "limit" 100} cursor))))
+      (cap/with-cursor {"run_id" run-id "limit" 100} cursor))))
 
 (defn capability-calls [run-id cursor]
-  (unwrap
+  (cap/unwrap!
     (tool/inspection-capability-calls
-      (with-cursor {"run_id" run-id "limit" 100} cursor))))
+      (cap/with-cursor {"run_id" run-id "limit" 100} cursor))))
 
 (defn generated-sources [run-id cursor]
-  (unwrap
+  (cap/unwrap!
     (tool/inspection-generated-sources
-      (with-cursor {"run_id" run-id "limit" 100} cursor))))
+      (cap/with-cursor {"run_id" run-id "limit" 100} cursor))))
 
 (defn effective-preludes [run-id cursor]
-  (unwrap
+  (cap/unwrap!
     (tool/inspection-effective-preludes
-      (with-cursor {"run_id" run-id "limit" 100} cursor))))
+      (cap/with-cursor {"run_id" run-id "limit" 100} cursor))))
 
 (defn provider-exchanges [run-id cursor]
-  (unwrap
+  (cap/unwrap!
     (tool/inspection-provider-exchanges
-      (with-cursor {"run_id" run-id "limit" 100} cursor))))
+      (cap/with-cursor {"run_id" run-id "limit" 100} cursor))))

--- a/priv/preludes/kernel/log.analysis.clj
+++ b/priv/preludes/kernel/log.analysis.clj
@@ -1,0 +1,18 @@
+(ns log.analysis
+  "Bounded whole-result traversal for canonical trace queries."
+  {:visibility :prompt})
+
+(defn all-runs
+  "Reads run pages until the source is exhausted or `max-pages` is reached."
+  [options max-pages]
+  (cap/collect-pages
+    (fn [cursor] (log/runs (cap/with-cursor options cursor)))
+    max-pages))
+
+(defn all-turns
+  "Reads one run's turn pages until exhausted or `max-pages` is reached."
+  [run-id options max-pages]
+  (cap/collect-pages
+    (fn [cursor]
+      (log/turns run-id (cap/with-cursor options cursor)))
+    max-pages))

--- a/priv/preludes/kernel/log.core.clj
+++ b/priv/preludes/kernel/log.core.clj
@@ -1,12 +1,7 @@
 (ns log "Source-scoped canonical trace queries." {:visibility :prompt})
 
-(defn- unwrap [response]
-  (if (= :ok (get response :status))
-    (get response :value)
-    response))
-
-(defn runs [options] (unwrap (tool/trace-list-runs options)))
-(defn run [run-id] (unwrap (tool/trace-get-run {"run_id" run-id})))
+(defn runs [options] (cap/unwrap! (tool/trace-list-runs options)))
+(defn run [run-id] (cap/unwrap! (tool/trace-get-run {"run_id" run-id})))
 (defn turns [run-id options]
-  (unwrap (tool/trace-list-turns (assoc options "run_id" run-id))))
-(defn counters [options] (unwrap (tool/trace-counters options)))
+  (cap/unwrap! (tool/trace-list-turns (assoc options "run_id" run-id))))
+(defn counters [options] (cap/unwrap! (tool/trace-counters options)))

--- a/ptc_viewer/README.md
+++ b/ptc_viewer/README.md
@@ -24,18 +24,19 @@ local server on port 4123, and opens the browser. Use `--port`, `--trace-dir`,
 always binds to loopback.
 
 The REPL evaluates PTC-Lisp against an immutable capture of the selected trace
-directory. The server fixes the `log-analysis-v1` profile: normal bounded
-PTC-Lisp built-ins, the shipped `log.core` component (`log/runs`, `log/run`,
-`log/turns`, and `log/counters`), four read-only trace capabilities, and the
-ordinary runtime/capability introspection routes. It does not grant filesystem,
-network, LLM, MCP, workflow-event, or arbitrary prelude authority.
+directory. The server fixes the `log-analysis-v2` profile: normal bounded
+PTC-Lisp built-ins, one-page `log/*` queries, bounded whole-result
+`log.analysis/all-runs` and `log.analysis/all-turns` queries, their shared
+`cap` helpers, four read-only trace capabilities, and the ordinary
+runtime/capability introspection routes. It does not grant filesystem, network,
+LLM, MCP, workflow-event, or arbitrary prelude authority.
 
 Forms such as `(log/runs {})`, `(log/run "run-id")`, and
-`(log/turns "run-id" {})` return bounded values, prints, errors, continuation
-effects, duration, and remaining usage. The server-owned transcript survives a
-page reload. Reset first closes and persists the analysis run, then captures a
-new snapshot and starts with fresh definitions; Close persists the analysis
-trace and ends further evaluation.
+`(log.analysis/all-turns "run-id" {"limit" 100} 20)` return bounded values,
+prints, errors, continuation effects, duration, and remaining usage. The
+server-owned transcript survives a page reload. Reset first closes and persists
+the analysis run, then captures a new snapshot and starts with fresh
+definitions; Close persists the analysis trace and ends further evaluation.
 
 Entered human-REPL source and returned inspection payloads are not copied into
 the canonical analysis trace. Model-generated PTC-Lisp and the feedback sent

--- a/ptc_viewer/lib/mix/tasks/ptc_viewer.ex
+++ b/ptc_viewer/lib/mix/tasks/ptc_viewer.ex
@@ -61,6 +61,6 @@ defmodule Mix.Tasks.Ptc.Viewer do
   end
 
   defp repl_config(trace_dir) do
-    %{trace_dir: Path.expand(trace_dir || "traces"), profile_id: "log-analysis-v1"}
+    %{trace_dir: Path.expand(trace_dir || "traces"), profile_id: "log-analysis-v2"}
   end
 end

--- a/ptc_viewer/lib/ptc_viewer/repl_adapter.ex
+++ b/ptc_viewer/lib/ptc_viewer/repl_adapter.ex
@@ -63,8 +63,8 @@ defmodule PtcViewer.ReplAdapter do
   def validate_features(
         %{
           "enabled" => true,
-          "profile_id" => "log-analysis-v1",
-          "namespaces" => ["log"],
+          "profile_id" => "log-analysis-v2",
+          "namespaces" => ["cap", "log", "log.analysis"],
           "source_limit_bytes" => 65_536
         } = features
       )

--- a/ptc_viewer/lib/ptc_viewer/repl_store.ex
+++ b/ptc_viewer/lib/ptc_viewer/repl_store.ex
@@ -779,8 +779,8 @@ defmodule PtcViewer.ReplStore do
 
     projected = info |> Map.take(allowed) |> Map.put(:session_id, public_session_id)
 
-    with "log-analysis-v1" <- Map.get(projected, :profile_id),
-         ["log"] <- Map.get(projected, :namespaces),
+    with "log-analysis-v2" <- Map.get(projected, :profile_id),
+         ["cap", "log", "log.analysis"] <- Map.get(projected, :namespaces),
          {:ok, encoded} <- Jason.encode(projected),
          true <- byte_size(encoded) <= 524_288 do
       {:ok, projected}

--- a/ptc_viewer/test/ptc_viewer/repl_router_test.exs
+++ b/ptc_viewer/test/ptc_viewer/repl_router_test.exs
@@ -188,7 +188,7 @@ defmodule PtcViewer.ReplRouterTest do
 
     assert html.status == 200
     assert html.resp_body =~ "ptc-viewer-config"
-    refute html.resp_body =~ "log-analysis-v1"
+    refute html.resp_body =~ "log-analysis-v2"
     refute html.resp_body =~ "source_limit_bytes"
     refute html.resp_body =~ "test_pid"
 

--- a/ptc_viewer/test/ptc_viewer/repl_store_test.exs
+++ b/ptc_viewer/test/ptc_viewer/repl_store_test.exs
@@ -15,7 +15,7 @@ defmodule PtcViewer.ReplStoreTest do
     assert byte_size(nonce) == 43
     assert first["generation_sequence"] == 1
     assert first["lifecycle"] == "open"
-    assert first["session"][:profile_id] == "log-analysis-v1"
+    assert first["session"][:profile_id] == "log-analysis-v2"
 
     assert {:ok, evaluated} = ReplStore.evaluate(store, first_session, "(+ 1 2)")
     assert evaluated["evaluation"].status == :ok

--- a/ptc_viewer/test/repl_ui.mjs
+++ b/ptc_viewer/test/repl_ui.mjs
@@ -78,9 +78,9 @@ const envelope = (instance, generation, revision, lifecycle = 'open') => ({
   transcript: [],
   transcript_omitted_count: 0,
   session: {
-    profile_id: 'log-analysis-v1',
+    profile_id: 'log-analysis-v2',
     profile_digest: 'digest',
-    namespaces: ['log'],
+    namespaces: ['cap', 'log', 'log.analysis'],
     snapshot: { capture_id: `capture-${generation}`, captured_at: '2026-07-19T12:00:00Z', run_count: 2 },
     usage: { evaluations: { remaining: 10 }, remaining_ms: 30_000, trace_calls: {} },
     trace: { persistence: 'pending', event_count: 0 }

--- a/ptc_viewer/test/support/repl_test_adapter.ex
+++ b/ptc_viewer/test/support/repl_test_adapter.ex
@@ -15,8 +15,8 @@ defmodule PtcViewer.TestReplAdapter do
     {:ok, backend,
      %{
        "enabled" => true,
-       "profile_id" => "log-analysis-v1",
-       "namespaces" => ["log"],
+       "profile_id" => "log-analysis-v2",
+       "namespaces" => ["cap", "log", "log.analysis"],
        "source_limit_bytes" => 65_536
      }}
   end
@@ -273,9 +273,9 @@ defmodule PtcViewer.TestReplAdapter do
     %{
       session_id: session_id,
       lifecycle: lifecycle,
-      profile_id: "log-analysis-v1",
+      profile_id: "log-analysis-v2",
       profile_digest: String.duplicate("a", 64),
-      namespaces: ["log"],
+      namespaces: ["cap", "log", "log.analysis"],
       snapshot: %{
         capture_id: "capture",
         captured_at: DateTime.utc_now(),

--- a/test/mix/tasks/ptc_repl_test.exs
+++ b/test/mix/tasks/ptc_repl_test.exs
@@ -188,14 +188,14 @@ defmodule Mix.Tasks.Ptc.ReplTest do
   test "describes the fixed log-analysis profile as safe JSONL" do
     output =
       capture_io(fn ->
-        Repl.run(["--describe-profile", "log-analysis-v1", "--format", "jsonl"])
+        Repl.run(["--describe-profile", "log-analysis-v2", "--format", "jsonl"])
       end)
 
     assert [description] = decode_jsonl(output)
     assert description["type"] == "profile"
-    assert description["id"] == "log-analysis-v1"
-    assert description["components"] == ["log.core"]
-    assert description["namespaces"] == ["log"]
+    assert description["id"] == "log-analysis-v2"
+    assert description["components"] == ["cap", "log.core", "log.analysis"]
+    assert description["namespaces"] == ["cap", "log", "log.analysis"]
     assert description["resources"]["traces"]["required"] == true
     assert description["frontend"]["output_formats"] == ["clojure", "jsonl"]
     refute output =~ "#Function<"
@@ -205,7 +205,7 @@ defmodule Mix.Tasks.Ptc.ReplTest do
   test "private profile frontend policy fails before opening declared sources" do
     missing_resources = [
       "--profile",
-      "inspection-analysis-v1",
+      "inspection-analysis-v2",
       "--resource",
       "traces=/definitely/missing/private-traces",
       "--resource",
@@ -241,7 +241,7 @@ defmodule Mix.Tasks.Ptc.ReplTest do
       capture_io(fn ->
         Repl.run([
           "--profile",
-          "log-analysis-v1",
+          "log-analysis-v2",
           "--resource",
           "traces=#{source}",
           "--session-trace-dir",
@@ -269,7 +269,7 @@ defmodule Mix.Tasks.Ptc.ReplTest do
              TraceLog.query(trace, :list_runs, %{})
 
     assert name == SafeMetadata.fingerprint("ptc.log-analysis.repl")
-    assert profile["id"] == "log-analysis-v1"
+    assert profile["id"] == "log-analysis-v2"
     assert profile["digest"] =~ ~r/\Asha256:[0-9a-f]{64}\z/
   end
 
@@ -300,7 +300,7 @@ defmodule Mix.Tasks.Ptc.ReplTest do
       command =
         [
           "--profile",
-          "log-analysis-v1",
+          "log-analysis-v2",
           "--resource",
           "traces=#{source}",
           "--session-trace-dir",
@@ -330,7 +330,7 @@ defmodule Mix.Tasks.Ptc.ReplTest do
         assert_raise Mix.Error, ~r/one or more profile evaluations failed/, fn ->
           Repl.run([
             "--profile",
-            "log-analysis-v1",
+            "log-analysis-v2",
             "--resource",
             "traces=#{source}",
             "--session-trace-dir",
@@ -454,7 +454,7 @@ defmodule Mix.Tasks.Ptc.ReplTest do
       capture_io(fn ->
         Repl.run([
           "--profile",
-          "log-analysis-v1",
+          "log-analysis-v2",
           "--resource",
           "traces=#{source}",
           "--format",
@@ -512,20 +512,20 @@ defmodule Mix.Tasks.Ptc.ReplTest do
           ["--resource", "traces=tmp"],
           ["--no-continue-on-error", "-e", "42"],
           ["--profile", "unknown", "--resource", "traces=tmp"],
-          ["--profile", "log-analysis-v1", "--manifest", "ptc.json", "--resource", "traces=tmp"],
+          ["--profile", "log-analysis-v2", "--manifest", "ptc.json", "--resource", "traces=tmp"],
           [
             "--profile",
-            "log-analysis-v1",
+            "log-analysis-v2",
             "--resource",
             "traces=tmp",
             "--resource",
             "traces=tmp"
           ],
-          ["--profile", "log-analysis-v1", "--resource", "other=tmp"],
-          ["--profile", "log-analysis-v1", "--resource", "traces=tmp", "--format", "jsonl"],
+          ["--profile", "log-analysis-v2", "--resource", "other=tmp"],
+          ["--profile", "log-analysis-v2", "--resource", "traces=tmp", "--format", "jsonl"],
           [
             "--profile",
-            "log-analysis-v1",
+            "log-analysis-v2",
             "--resource",
             "traces=tmp",
             "--continue-on-error",
@@ -583,7 +583,7 @@ defmodule Mix.Tasks.Ptc.ReplTest do
         [
           "ptc.repl",
           "--profile",
-          "log-analysis-v1",
+          "log-analysis-v2",
           "--resource",
           "traces=#{source}",
           "--session-trace-dir",
@@ -606,7 +606,7 @@ defmodule Mix.Tasks.Ptc.ReplTest do
   defp profile_args(source, output_directory) do
     [
       "--profile",
-      "log-analysis-v1",
+      "log-analysis-v2",
       "--resource",
       "traces=#{source}",
       "--session-trace-dir",

--- a/test/ptc_runner/kernel/analysis_profile_test.exs
+++ b/test/ptc_runner/kernel/analysis_profile_test.exs
@@ -1,0 +1,72 @@
+defmodule PtcRunner.Kernel.AnalysisProfileTest do
+  use ExUnit.Case, async: true
+
+  alias PtcRunner.Kernel.AnalysisProfile
+  alias PtcRunner.Kernel.Component
+  alias PtcRunner.Kernel.InspectionAnalysisProfile
+  alias PtcRunner.Kernel.Library
+  alias PtcRunner.Kernel.Limits
+  alias PtcRunner.Kernel.LogAnalysisProfile
+  alias PtcRunner.Kernel.MissionEnvironment
+  alias PtcRunner.TestSupport.ReorderedAnalysisProfileRecipe
+
+  test "fixed profile declarations match their resolved contracts" do
+    for recipe <- [LogAnalysisProfile, InspectionAnalysisProfile] do
+      {:ok, components} = Library.resolve_components(recipe.component_selections())
+      {:ok, bundle} = PtcRunner.Kernel.compile_bundle(components)
+      capabilities = Enum.map(recipe.explicit_capabilities(), &%{name: &1})
+
+      assert :ok = AnalysisProfile.validate_contract(recipe, bundle, capabilities)
+    end
+  end
+
+  test "recipe declaration order does not affect the compiled profile identity" do
+    {:ok, base} = Component.new(id: "base", source: "(ns base) (defn value [] 1)")
+
+    {:ok, consumer} =
+      Component.new(
+        id: "consumer",
+        source: "(ns consumer) (defn value [] (base/value))",
+        dependencies: ["base"]
+      )
+
+    {:ok, bundle} = PtcRunner.Kernel.compile_bundle([consumer, base])
+    {:ok, mission} = MissionEnvironment.new(bundle: bundle)
+    {:ok, limits} = Limits.new()
+
+    assert {:ok, profile} =
+             AnalysisProfile.descriptor(
+               ReorderedAnalysisProfileRecipe,
+               bundle,
+               mission,
+               limits
+             )
+
+    assert profile.identity["components"] == bundle.component_ids
+    assert profile.namespaces == ["base", "consumer"]
+
+    assert :ok =
+             AnalysisProfile.validate_contract(ReorderedAnalysisProfileRecipe, bundle, [])
+
+    assert {:error, :profile_component_set_mismatch} =
+             AnalysisProfile.validate_contract(
+               ReorderedAnalysisProfileRecipe,
+               %{bundle | component_ids: ["base"]},
+               []
+             )
+
+    assert {:error, :profile_namespace_set_mismatch} =
+             AnalysisProfile.validate_contract(
+               ReorderedAnalysisProfileRecipe,
+               %{bundle | components: []},
+               []
+             )
+
+    assert {:error, :profile_capability_set_mismatch} =
+             AnalysisProfile.validate_contract(
+               ReorderedAnalysisProfileRecipe,
+               bundle,
+               [%{name: "unexpected"}]
+             )
+  end
+end

--- a/test/ptc_runner/kernel/analysis_session_test.exs
+++ b/test/ptc_runner/kernel/analysis_session_test.exs
@@ -35,13 +35,13 @@ defmodule PtcRunner.Kernel.AnalysisSessionTest do
       AnalysisSession.stop(second)
     end)
 
-    assert first_info.profile_id == "log-analysis-v1"
+    assert first_info.profile_id == "log-analysis-v2"
     assert first_info.profile_digest == second_info.profile_digest
 
     assert first_info.profile_digest ==
-             "sha256:1574100cc8695016550e21c41c9ce68cfe2a6a0e2fcd280057efbeef71b2609e"
+             "sha256:845d54529806c34a7df353bb828d8453e215697d39afbcf659d5c2ceac78704f"
 
-    assert first_info.namespaces == ["log"]
+    assert first_info.namespaces == ["cap", "log", "log.analysis"]
     refute inspect(first_info) =~ directory
 
     forged = %{first | token: make_ref()}
@@ -54,8 +54,8 @@ defmodule PtcRunner.Kernel.AnalysisSessionTest do
     assert Process.read_timer(first_state.timer) <=
              remaining_before_timer_read + 10
 
-    assert identity["profile_id"] == "log-analysis-v1"
-    assert identity["components"] == ["log.core"]
+    assert identity["profile_id"] == "log-analysis-v2"
+    assert identity["components"] == ["cap", "log.core", "log.analysis"]
     assert identity["explicit_capabilities"] == LogAnalysisProfile.explicit_capabilities()
 
     assert identity["implicit_runtime"] == %{
@@ -605,6 +605,81 @@ defmodule PtcRunner.Kernel.AnalysisSessionTest do
              AnalysisSession.evaluate(session, "(log/runs {})")
 
     assert Enum.map(still_frozen, & &1["run_id"]) == ["seed"]
+  end
+
+  @tag :tmp_dir
+  test "log analysis fails rejected queries and traverses bounded pages", %{
+    tmp_dir: directory
+  } do
+    for run_id <- ~w(first second third), do: seed_trace(directory, run_id)
+
+    assert {:ok, session, _info} =
+             start_log_session({:directory, directory}, {:directory, directory})
+
+    on_exit(fn -> AnalysisSession.stop(session) end)
+
+    assert {:ok, %{status: :error, outcome: :failed}} =
+             AnalysisSession.evaluate(session, ~S|(log/runs {"limit" 101})|)
+
+    assert {:ok,
+            %{
+              status: :ok,
+              value: %{
+                "complete?" => true,
+                "items" => items,
+                "pages" => 3,
+                "snapshot_hash" => snapshot_hash
+              }
+            }} =
+             AnalysisSession.evaluate(
+               session,
+               ~S|(log.analysis/all-runs {"limit" 1} 4)|
+             )
+
+    assert items |> Enum.map(& &1["run_id"]) |> Enum.sort() == ~w(first second third)
+    assert snapshot_hash =~ ~r/\Asha256:[0-9a-f]{64}\z/
+
+    assert {:ok, %{value: %{"items" => from_first_page}}} =
+             AnalysisSession.evaluate(
+               session,
+               ~S"""
+               (let [cursor (get (log/runs {"limit" 1}) "next_cursor")]
+                 (log.analysis/all-runs {"limit" 1 "cursor" cursor} 4))
+               """
+             )
+
+    assert from_first_page |> Enum.map(& &1["run_id"]) |> Enum.sort() ==
+             ~w(first second third)
+
+    assert {:ok,
+            %{
+              value: %{
+                "complete?" => true,
+                "items" => turns,
+                "pages" => 2,
+                "snapshot_hash" => ^snapshot_hash
+              }
+            }} =
+             AnalysisSession.evaluate(
+               session,
+               ~S|(log.analysis/all-turns "first" {"limit" 1} 3)|
+             )
+
+    assert Enum.map(turns, & &1["type"]) == ["run-started", "run-stopped"]
+
+    assert {:ok,
+            %{
+              value: %{
+                "complete?" => false,
+                "items" => [_],
+                "pages" => 1,
+                "snapshot_hash" => ^snapshot_hash
+              }
+            }} =
+             AnalysisSession.evaluate(
+               session,
+               ~S|(log.analysis/all-runs {"limit" 1} 1)|
+             )
   end
 
   @tag :tmp_dir

--- a/test/ptc_runner/kernel/cap_agent_main_test.exs
+++ b/test/ptc_runner/kernel/cap_agent_main_test.exs
@@ -56,14 +56,119 @@ defmodule PtcRunner.Kernel.CapAgentMainTest do
                ~S|{"cursor" "abc" "limit" 100}|
     end
 
-    test "leaves first-page arguments unchanged for a nil cursor" do
+    test "a nil cursor selects the first page and removes a stale cursor" do
       assert run(~S|(cap/with-cursor {"path" "lib" "limit" 100} nil)|) ==
                ~S|{"limit" 100 "path" "lib"}|
+
+      assert run(~S|(cap/with-cursor {"cursor" "stale" "limit" 100} nil)|) ==
+               ~S|{"limit" 100}|
+
+      assert run(~S|(cap/with-cursor {:cursor "stale" :limit 100} nil)|) ==
+               ~S|{:limit 100}|
     end
 
     test "does not interpret or transform the cursor" do
       assert run(~S|(cap/with-cursor {} "opaque:page/2?x=1")|) ==
                ~S|{"cursor" "opaque:page/2?x=1"}|
+    end
+  end
+
+  describe "cap/collect-pages" do
+    test "follows opaque cursors and reports complete traversal" do
+      source = ~S"""
+      (cap/collect-pages
+        (fn [cursor]
+          (if cursor
+            {"items" [3] "next_cursor" nil}
+            {"items" [1 2] "next_cursor" "page-2"}))
+        2)
+      """
+
+      assert run(source) ==
+               ~S|{"complete?" true "items" [1 2 3] "pages" 2}|
+    end
+
+    test "preserves snapshot provenance and rejects a changed snapshot" do
+      source = ~S"""
+      (cap/collect-pages
+        (fn [cursor]
+          (if cursor
+            {"items" [2] "next_cursor" nil "snapshot_hash" "sha256:same"}
+            {"items" [1] "next_cursor" "page-2" "snapshot_hash" "sha256:same"}))
+        2)
+      """
+
+      assert run(source) ==
+               ~S|{"complete?" true "items" [1 2] "pages" 2 "snapshot_hash" "sha256:same"}|
+
+      changed = ~S"""
+      (cap/collect-pages
+        (fn [cursor]
+          (if cursor
+            {"items" [2] "next_cursor" nil "snapshot_hash" "sha256:changed"}
+            {"items" [1] "next_cursor" "page-2" "snapshot_hash" "sha256:first"}))
+        2)
+      """
+
+      assert run(changed) =~ ":snapshot-changed"
+    end
+
+    test "marks a bounded prefix incomplete and rejects an invalid bound" do
+      source = ~S"""
+      (cap/collect-pages
+        (fn [cursor]
+          {"items" [(if cursor 2 1)] "next_cursor" "more"})
+        1)
+      """
+
+      assert run(source) ==
+               ~S|{"complete?" false "items" [1] "pages" 1}|
+
+      assert run(~S|(cap/collect-pages (fn [_] {"items" []}) 0)|) =~
+               ":invalid-max-pages"
+    end
+  end
+
+  describe "analysis prelude composition" do
+    test "primitive and analysis components declare their direct shared dependencies" do
+      assert {:ok, log_core} = Library.component("log.core")
+      assert {:ok, inspection_core} = Library.component("inspection.core")
+      assert {:ok, log_analysis} = Library.component("log.analysis")
+      assert {:ok, inspection_analysis} = Library.component("inspection.analysis")
+
+      assert log_core.dependencies == ["cap"]
+      assert inspection_core.dependencies == ["cap"]
+      assert log_analysis.dependencies == ["cap", "log.core"]
+      assert inspection_analysis.dependencies == ["cap", "inspection.core"]
+
+      assert {:ok, components} =
+               Library.resolve_components([
+                 {:library, "log.analysis"},
+                 {:library, "inspection.analysis"}
+               ])
+
+      assert Enum.map(components, & &1.id) == [
+               "cap",
+               "inspection.core",
+               "inspection.analysis",
+               "log.core",
+               "log.analysis"
+             ]
+
+      assert {:ok, bundle} = Kernel.compile_bundle(components)
+
+      for ref <- [
+            "log.analysis/all-runs",
+            "log.analysis/all-turns",
+            "inspection.analysis/all-runs",
+            "inspection.analysis/all-model-exchanges",
+            "inspection.analysis/all-capability-calls",
+            "inspection.analysis/all-generated-sources",
+            "inspection.analysis/all-effective-preludes",
+            "inspection.analysis/all-provider-exchanges"
+          ] do
+        assert {:ok, _export} = Prelude.fetch_export(bundle.prelude, ref)
+      end
     end
   end
 

--- a/test/ptc_runner/kernel/inspection_analysis_profile_test.exs
+++ b/test/ptc_runner/kernel/inspection_analysis_profile_test.exs
@@ -16,17 +16,32 @@ defmodule PtcRunner.Kernel.InspectionAnalysisProfileTest do
   alias PtcRunner.Kernel.TraceLog
   alias PtcRunner.TestSupport.PrivateInspectionFixture
 
-  @profile_id "inspection-analysis-v1"
+  @profile_id "inspection-analysis-v2"
 
   test "the profile registry is closed and describes fixed private authority" do
-    assert AnalysisProfileRegistry.ids() == ["inspection-analysis-v1", "log-analysis-v1"]
+    assert AnalysisProfileRegistry.ids() == ["inspection-analysis-v2", "log-analysis-v2"]
     assert {:error, :unsupported_analysis_profile} = AnalysisProfileRegistry.fetch("custom")
     assert {:error, :unsupported_analysis_profile} = AnalysisProfileRegistry.fetch(nil)
 
     assert {:ok, description} = AnalysisProfileRegistry.description(@profile_id)
     assert description["resources"] |> Map.keys() |> Enum.sort() == ["inspection", "traces"]
-    assert description["components"] == ["inspection.core", "log.core"]
-    assert description["namespaces"] == ["inspection", "log"]
+
+    assert description["components"] == [
+             "cap",
+             "inspection.core",
+             "inspection.analysis",
+             "log.core",
+             "log.analysis"
+           ]
+
+    assert description["namespaces"] == [
+             "cap",
+             "inspection",
+             "inspection.analysis",
+             "log",
+             "log.analysis"
+           ]
+
     assert description["source_data_class"] == "private_inspection"
     assert description["result_data_class"] == "private_inspection"
 
@@ -168,10 +183,17 @@ defmodule PtcRunner.Kernel.InspectionAnalysisProfileTest do
     identity = state.profile.identity
     mission = state.config.mission_environment
 
-    assert identity["components"] == ["inspection.core", "log.core"]
+    assert identity["components"] == [
+             "cap",
+             "inspection.core",
+             "inspection.analysis",
+             "log.core",
+             "log.analysis"
+           ]
+
     assert identity["source_data_class"] == "private_inspection"
     assert identity["result_data_class"] == "private_inspection"
-    assert mission.bundle.component_ids == ["inspection.core", "log.core"]
+    assert mission.bundle.component_ids == identity["components"]
     assert mission.data == %{}
 
     assert mission.capabilities |> Map.keys() |> Enum.sort() ==
@@ -207,6 +229,26 @@ defmodule PtcRunner.Kernel.InspectionAnalysisProfileTest do
              )
 
     assert source["source"] == "(return 42)"
+
+    assert {:ok, %{status: :error, outcome: :failed}} =
+             AnalysisSession.evaluate(session, ~S|(inspection/runs {"limit" 1001})|)
+
+    assert {:ok,
+            %{
+              value: %{
+                "complete?" => true,
+                "items" => [collected_exchange],
+                "pages" => 1,
+                "snapshot_hash" => inspection_snapshot_hash
+              }
+            }} =
+             AnalysisSession.evaluate(
+               session,
+               ~s|(inspection.analysis/all-model-exchanges "#{fixture.run_id}" 2)|
+             )
+
+    assert collected_exchange == model_exchange
+    assert inspection_snapshot_hash =~ ~r/\Asha256:[0-9a-f]{64}\z/
 
     assert {:ok, %{value: %{"items" => [exchange]}}} =
              AnalysisSession.evaluate(

--- a/test/ptc_runner/kernel/trace_capability_test.exs
+++ b/test/ptc_runner/kernel/trace_capability_test.exs
@@ -14,7 +14,14 @@ defmodule PtcRunner.Kernel.TraceCapabilityTest do
 
   test "log.core requires source-scoped query capabilities" do
     assert {:ok, component} = Library.component("log.core")
-    assert {:ok, bundle} = Kernel.compile_bundle([component])
+    assert component.dependencies == ["cap"]
+
+    assert {:error, %{id: "log.core", reason: :missing_component_dependency}} =
+             Kernel.compile_bundle([component])
+
+    assert {:ok, components} = Library.resolve_components([{:library, "log.core"}])
+    assert Enum.map(components, & &1.id) == ["cap", "log.core"]
+    assert {:ok, bundle} = Kernel.compile_bundle(components)
 
     assert {:error,
             {:missing_capability_requirement,
@@ -119,9 +126,9 @@ defmodule PtcRunner.Kernel.TraceCapabilityTest do
 
     {:ok, trace_capabilities} = TraceCapability.new(source: source_sink)
     {:ok, kernel_component} = Library.component("kernel")
-    {:ok, log_component} = Library.component("log.core")
     {:ok, workflow_bundle} = Kernel.compile_bundle([kernel_component])
-    {:ok, mission_bundle} = Kernel.compile_bundle([log_component])
+    {:ok, log_components} = Library.resolve_components([{:library, "log.core"}])
+    {:ok, mission_bundle} = Kernel.compile_bundle(log_components)
     {:ok, workflow} = WorkflowEnvironment.new(bundle: workflow_bundle)
 
     {:ok, mission} =

--- a/test/ptc_runner/kernel/viewer_repl_adapter_test.exs
+++ b/test/ptc_runner/kernel/viewer_repl_adapter_test.exs
@@ -14,13 +14,13 @@ defmodule PtcRunner.Kernel.ViewerReplAdapterTest do
     assert {:ok, backend, features} =
              ViewerReplAdapter.connect(%{
                trace_dir: trace_dir,
-               profile_id: "log-analysis-v1"
+               profile_id: "log-analysis-v2"
              })
 
     assert features == %{
              "enabled" => true,
-             "namespaces" => ["log"],
-             "profile_id" => "log-analysis-v1",
+             "namespaces" => ["cap", "log", "log.analysis"],
+             "profile_id" => "log-analysis-v2",
              "source_limit_bytes" => 65_536
            }
 
@@ -32,7 +32,7 @@ defmodule PtcRunner.Kernel.ViewerReplAdapterTest do
              ViewerReplAdapter.start(backend, start_id, public_session_id)
 
     assert info.session_id == public_session_id
-    assert info.profile_id == "log-analysis-v1"
+    assert info.profile_id == "log-analysis-v2"
 
     assert Map.keys(info) |> Enum.sort() ==
              Enum.sort([
@@ -98,7 +98,7 @@ defmodule PtcRunner.Kernel.ViewerReplAdapterTest do
     assert {:ok, backend, _features} =
              ViewerReplAdapter.connect(%{
                trace_dir: trace_dir,
-               profile_id: "log-analysis-v1"
+               profile_id: "log-analysis-v2"
              })
 
     start_id = random_id()
@@ -127,7 +127,7 @@ defmodule PtcRunner.Kernel.ViewerReplAdapterTest do
         {:ok, backend, _features} =
           ViewerReplAdapter.connect(%{
             trace_dir: trace_dir,
-            profile_id: "log-analysis-v1"
+            profile_id: "log-analysis-v2"
           })
 
         start_id = random_id()
@@ -170,7 +170,7 @@ defmodule PtcRunner.Kernel.ViewerReplAdapterTest do
     assert {:ok, backend, _features} =
              ViewerReplAdapter.connect(%{
                trace_dir: trace_dir,
-               profile_id: "log-analysis-v1"
+               profile_id: "log-analysis-v2"
              })
 
     start_id = random_id()
@@ -208,7 +208,7 @@ defmodule PtcRunner.Kernel.ViewerReplAdapterTest do
     assert {:ok, backend, _features} =
              ViewerReplAdapter.connect(%{
                trace_dir: trace_dir,
-               profile_id: "log-analysis-v1"
+               profile_id: "log-analysis-v2"
              })
 
     start_id = random_id()
@@ -240,7 +240,7 @@ defmodule PtcRunner.Kernel.ViewerReplAdapterTest do
     assert {:ok, backend, _features} =
              ViewerReplAdapter.connect(%{
                trace_dir: trace_dir,
-               profile_id: "log-analysis-v1"
+               profile_id: "log-analysis-v2"
              })
 
     start_id = random_id()
@@ -271,7 +271,7 @@ defmodule PtcRunner.Kernel.ViewerReplAdapterTest do
     assert {:ok, backend, _features} =
              ViewerReplAdapter.connect(%{
                trace_dir: private_dir,
-               profile_id: "log-analysis-v1"
+               profile_id: "log-analysis-v2"
              })
 
     status = backend.pid |> :sys.get_status() |> inspect()
@@ -285,7 +285,7 @@ defmodule PtcRunner.Kernel.ViewerReplAdapterTest do
     assert {:ok, backend, _features} =
              ViewerReplAdapter.connect(%{
                trace_dir: trace_dir,
-               profile_id: "log-analysis-v1"
+               profile_id: "log-analysis-v2"
              })
 
     start_id = random_id()
@@ -310,7 +310,7 @@ defmodule PtcRunner.Kernel.ViewerReplAdapterTest do
     assert {:ok, backend, _features} =
              ViewerReplAdapter.connect(%{
                trace_dir: trace_dir,
-               profile_id: "log-analysis-v1"
+               profile_id: "log-analysis-v2"
              })
 
     start_id = random_id()

--- a/test/ptc_runner/kernel/viewer_repl_http_test.exs
+++ b/test/ptc_runner/kernel/viewer_repl_http_test.exs
@@ -29,7 +29,7 @@ defmodule PtcRunner.Kernel.ViewerReplHttpTest do
         port: 0,
         trace_dir: trace_dir,
         repl_adapter: ViewerReplAdapter,
-        repl_config: %{trace_dir: trace_dir, profile_id: "log-analysis-v1"},
+        repl_config: %{trace_dir: trace_dir, profile_id: "log-analysis-v2"},
         open: false
       )
 
@@ -60,8 +60,8 @@ defmodule PtcRunner.Kernel.ViewerReplHttpTest do
     assert bootstrap.status == 200
     session_id = bootstrap.body["session_id"]
     nonce = bootstrap.body["mutation_nonce"]
-    assert bootstrap.body["session"]["profile_id"] == "log-analysis-v1"
-    assert bootstrap.body["session"]["namespaces"] == ["log"]
+    assert bootstrap.body["session"]["profile_id"] == "log-analysis-v2"
+    assert bootstrap.body["session"]["namespaces"] == ["cap", "log", "log.analysis"]
     refute inspect(bootstrap.body) =~ trace_dir
 
     private_source = ~S|(do "PRIVATE_REPL_SOURCE" (log/runs {}))|

--- a/test/support/reordered_analysis_profile_recipe.ex
+++ b/test/support/reordered_analysis_profile_recipe.ex
@@ -1,0 +1,12 @@
+defmodule PtcRunner.TestSupport.ReorderedAnalysisProfileRecipe do
+  @moduledoc false
+
+  def id, do: "reordered-analysis-test-v1"
+  def component_ids, do: ["consumer", "base"]
+  def namespaces, do: ["consumer", "base"]
+  def explicit_capabilities, do: []
+  def persistence_policy, do: "none"
+  def result_policy, do: "test"
+  def identity_extension, do: %{}
+  def invalid_profile_error, do: :invalid_reordered_analysis_profile
+end


### PR DESCRIPTION
## Summary

- compose log and private-inspection query preludes through shared fail-safe envelope and cursor helpers
- add bounded, snapshot-bound whole-result traversal helpers while preserving one-page primitives
- register component dependency closure and enforce exact bundle composition in profile attestation
- update the CLI, Viewer, embedding, REPL, component, and trace docs with clear one-page versus aggregate examples

## Breaking change

- replace `log-analysis-v1` and `inspection-analysis-v1` with the corrected `log-analysis-v2` and `inspection-analysis-v2` profile IDs

## Verification

- `mix precommit` — 5,111 root tests, 70 Viewer tests, 35 launcher tests, plus static/spec/generated-doc/package checks
- pre-push gate — root suite, upstream API audit, Dialyzer, Viewer suite, and warnings-as-errors documentation
- focused pagination and profile regressions — 71 tests
- timing-sensitive unchanged MCP shutdown case — 11 repeated isolated passes after a transient loaded-suite miss
- independent Codex challenge and final review — no actionable findings