### PR TITLE
Checkpoint C stabilization: descriptor authority, --check parity, and bounded terminal cleanup

### DIFF
--- a/docs/guides/embedding-in-elixir.md
+++ b/docs/guides/embedding-in-elixir.md
@@ -87,11 +87,11 @@ to both package acquisition and `RunBuilder.build/3`.
 The core application deliberately starts no provider dependency on your behalf,
 so depending on `ptc_runner` never starts `req_llm` or `llm_db` inside your
 release. A run admits the application it needs through
-`PtcRunner.Kernel.ProviderApplicationGate`. A one-shot `mix ptc.run` reaches it
-through the execution-owned `ProviderActiveSession.open_consumed_setup/5`,
-where the execution-session owner already owns the prepared run and the
-session's lifecycle. `ProviderActiveSession.open/3` is the creator-owned
-variant that `--check` still uses; do not copy it as the normal path.
+`PtcRunner.Kernel.ProviderApplicationGate`. Both `mix ptc.run` and
+`mix ptc.run --check` reach it through the execution-owned
+`ProviderActiveSession.open_consumed_setup/5`, where the execution-session owner
+already owns the prepared run and the session's lifecycle. There is no
+creator-owned variant.
 
 An embedded frontend that drives `ProviderRegistry` and `RunBuilder` directly
 does not pass through that gate, so it owns the admission itself:

--- a/docs/guides/host-configuration.md
+++ b/docs/guides/host-configuration.md
@@ -114,8 +114,12 @@ selected provider application. A reused host-owned application keeps whatever
 its own start applied, because it was already running.
 
 For a selected shipped LLM whose declared credential uses `env`, the Mix
-frontend loads the nearest `.env` through `PtcRunner.Dotenv` after provider
-activity begins and before resolving that credential. One declared credential
+frontend loads the nearest `.env` through `PtcRunner.Dotenv` once, after
+preparation has established which providers are selected and before any
+execution owner, provider session, or run clock exists. Loading is command
+setup rather than bounded run work: it reads the filesystem and mutates the VM
+environment, so it can be neither deadline-cancelled nor rolled back, and it
+never consumes the run budget. One declared credential
 triggers the load, but the load is not scoped to it: the loader walks up from
 the invocation directory to the filesystem root and sets every variable in the
 first `.env` it finds. This happens once per VM and those variables persist for

--- a/docs/guides/kernel-maintainer.md
+++ b/docs/guides/kernel-maintainer.md
@@ -134,10 +134,10 @@ start the private owner and its credential lease — with no embedder-supplied
 callback, file, socket, or network reachable inside it. Its input is bounded by
 the confined read ceiling both `HostConfig` loaders share, so every host
 document a command or embedding acquires through them stays within it; an
-embedding that builds a `HostConfig` by other means owns that bound itself. The deadline is checked immediately before the step and
-rechecked after it, so an expired operation releases the authority instead of
-yielding a registry; a pathological activation delays the command rather than
-being cancelled.
+embedding that builds a `HostConfig` by other means owns that bound itself.
+The deadline is checked immediately before the step and rechecked after it, so
+an expired operation releases the authority instead of yielding a registry; a
+pathological activation delays the command rather than being cancelled.
 `PtcRunner.Kernel.RunCoordinator.prepare/2` compiles the captured workflow and
 mission component graphs, validates the public workflow entry, and performs
 provider-inert declaration checks without accepting a path, looking up an
@@ -823,6 +823,13 @@ cleanup budget. `RunBuilder` assembles the returned capabilities and transfers
 the session into the run lifecycle. Exact
 declarative selection grammar belongs in `SelectionRules`; active transport
 behavior belongs in each provider module and the later runtime dispatcher.
+
+Ambient `.env` acquisition belongs to the CLI frontend, not the Kernel. The
+Mix adapter decides once, before the `--check`/one-shot branch, whether a
+selected live-LLM installation declares an environment-backed credential, and
+loads the nearest `.env` there, containing a loader failure as a closed command
+diagnostic. No Kernel module loads it, so an embedding acquires ambient
+environment state only when it chooses to.
 
 Provider occurrence contexts are path-free. They carry safe display identity,
 application content and effective digests, final bundle hashes, input

--- a/docs/guides/kernel-maintainer.md
+++ b/docs/guides/kernel-maintainer.md
@@ -127,6 +127,17 @@ host document only as an authenticated, process-local encrypted payload; their
 inspectable callback environments expose neither paths nor credential values.
 Generic runtime-service construction cannot mint a host binding, and a
 host-bound catalog requires activation to return a valid host authority.
+That activation is a deliberate exception to the operation deadline rather than
+cancellable work. Because only host-sealed runtime services carry a binding,
+the branch runs one code-owned step — decrypt the sealed host payload, then
+start the private owner and its credential lease — with no embedder-supplied
+callback, file, socket, or network reachable inside it. Its input is bounded by
+the confined read ceiling both `HostConfig` loaders share, so every host
+document a command or embedding acquires through them stays within it; an
+embedding that builds a `HostConfig` by other means owns that bound itself. The deadline is checked immediately before the step and
+rechecked after it, so an expired operation releases the authority instead of
+yielding a registry; a pathological activation delays the command rather than
+being cancelled.
 `PtcRunner.Kernel.RunCoordinator.prepare/2` compiles the captured workflow and
 mission component graphs, validates the public workflow entry, and performs
 provider-inert declaration checks without accepting a path, looking up an

--- a/docs/guides/kernel-maintainer.md
+++ b/docs/guides/kernel-maintainer.md
@@ -515,9 +515,13 @@ owner-down window and seals the set when force-close begins. This
 avoids a start-then-register gap, keeps provisional roots isolated, and removes
 reconciliation races between cleanup paths.
 Before callbacks can start, execution transfers the session from its build
-creator to the Runner or REPL session owner and binds its run state. The
-provider session itself tracks, cancels, and observes in-flight Kernel provider
-work before it runs any closer, including after owner or run state death.
+creator to the Runner or REPL session owner and binds it to the run's one
+provider-task owner. That owner is a separate process outside both lifecycles;
+it monitors the session and the run state, so in-flight Kernel provider work is
+drained before any closer runs and killed outright when either lifecycle
+disappears — including a session terminated at its cleanup deadline, where
+`terminate/2` never runs. The drain also ends that owner, so an attachment
+racing it is refused rather than accepted behind the closers.
 Normal close and lifecycle-owner death share one bounded reverse-order resource
 drain. Provider-free assembly carries no session and starts no provider owner.
 

--- a/docs/guides/kernel-maintainer.md
+++ b/docs/guides/kernel-maintainer.md
@@ -797,7 +797,12 @@ store context.
 Provider implementations later return capabilities plus optional safe connector metadata
 and an idempotent closer. Staged builders may also exchange bounded code-owned
 acquisition services after the global preflight and credential barrier; these
-opaque values never enter environments or artifacts. `ProviderAcquisition`
+opaque values never enter environments or artifacts. A run-bound registry keeps
+every builder bound to its sealed descriptor, so preparation reporting a data
+class or accepted-class set other than the declared one fails with
+`provider_declaration_mismatch` before preflight, credential resolution, or
+acquisition; the declaration phase 5 and sink authorization used stays
+authoritative. `ProviderAcquisition`
 resolves those dependencies and immediately commits each successful resource
 to the provider session's cleanup stack. For active commands, its preparation,
 preflight, and acquisition callbacks—including work behind the private host

--- a/docs/guides/kernel-maintainer.md
+++ b/docs/guides/kernel-maintainer.md
@@ -41,11 +41,15 @@ Frontends own presentation and host choices. They must enter through
 `PtcRunner.Kernel.RunRequest`. The closed command pipeline uses
 `PtcRunner.Kernel.CommandEngine`; the existing Mix command still has its
 transitional argv and presentation adapter, but its runtime path now prepares
-through `RunCoordinator` and preflights destinations. One-shot runs then
-execute through a dedicated execution-session owner, whether or not they select
-providers. A provider-bearing one-shot opens `ProviderActiveSession` inside
-that owner's subordinate worker rather than in the adapter. `--check` and the
-REPL keep their existing adapter-owned sessions until their parity cutover.
+through `RunCoordinator` and preflights destinations. One-shot runs and
+`--check` both execute through a dedicated execution-session owner, whether or
+not they select providers, and a provider-bearing invocation opens
+`ProviderActiveSession` inside that owner's subordinate worker rather than in
+the adapter. A check differs from a run only in how the owner completes an
+assembled build: it reports the acquisition's safe connector snapshots instead
+of evaluating the entry, so both share one activity marker, session, registry,
+credential, OAuth, acquisition, and cleanup boundary. The REPL keeps its
+adapter-owned path until its parity cutover.
 Embedding frontends execute a sealed request through
 `PtcRunner.Kernel.RunBuilder.build/3`. For a provider-free request they may
 instead call the path-free `PtcRunner.Kernel.RunCoordinator` and pass its
@@ -193,14 +197,15 @@ effective projection/digest at construction and on every seal check, so
 provider-bearing preparation cannot bypass declaration processing by calling
 the constructor directly. Such provider-bearing values are presently
 continuation state for the staged command pipeline. `RunBuilder.build_prepared/3`
-rejects them; after `ProviderActiveSession` consumes and marks one, its runtime
-registry is opened and the active value and same session are passed to
-`RunBuilder`. A one-shot run does that inside the execution-session owner's
-subordinate worker, which calls `build_active_owned/5` with the owner-opened
-sinks. `--check` still opens the registry in the Mix adapter and calls
-`build_active/4`. The REPL is a third transitional path and opens no active
-session: it calls `load_and_build/3` with an empty registry. All three keep
-their current shape until the parity cutover. After application admission, that session
+rejects them; the execution-session owner consumes one when it opens its
+sinks, `ProviderActiveSession` then marks activity and opens the session, and
+the runtime registry, active value, and that same session are passed to
+`RunBuilder`. A run and a `--check` both do that inside the execution-session
+owner's subordinate worker, which calls `build_active_owned/5` with the
+owner-opened sinks and then completes through `execute_built/1` or
+`check_built/1`. The REPL remains transitional and opens no active session: it
+calls `load_and_build/3` with an empty registry, keeping its current shape
+until the parity cutover. After application admission, that session
 anchors one absolute run deadline shared by active selection, construction,
 and Kernel execution. The active build atomically claims the session sealed to
 the exact prepared run; swapping sessions or replaying the same prepared/session

--- a/docs/plans/lisp-kernel/stable-cli-contract.md
+++ b/docs/plans/lisp-kernel/stable-cli-contract.md
@@ -814,11 +814,7 @@ Checkpoint C starts with a small stabilization prefix before adding doctor:
   client that keeps trickling past the deadline, and a silent client that stops
   mid-request. The pre-receive expiry branch remains fail-closed defense in
   depth: its neighbouring branches report the same closed reason at the same
-  instant, so it is not independently observable through the socket. A
-  follow-up remains open: `Authorization.cancel_authorization/3` charges its
-  store mutation the residual budget of the interaction it is cleaning up, so
-  cancellation after expiry runs with a one-millisecond deadline whose failure
-  is discarded; and
+  instant, so it is not independently observable through the socket; and
 - (complete) move `--check` onto the shared execution-owner composition. A
   check now differs from a run only in the owner's completion step, so both
   share the activity marker, session, registry, credentials, OAuth,
@@ -827,13 +823,20 @@ Checkpoint C starts with a small stabilization prefix before adding doctor:
   Mix adapter's session, registry, OAuth context, deadline, and authorization
   helpers, `RunBuilder.build_active/4`, and `ProviderActiveSession`'s
   frontend-owned `open/3`, `open_setup/3`, and `begin_run/3` together with the
-  ownership branch they required. Two terminal-cleanup follow-ups remain open
-  and are deliberately not patched with fresh ad-hoc timeouts:
-  `Authorization.cancel_authorization/3` charges its store mutation the residual
-  budget of the interaction it cleans up, and `ProviderExecution`'s
-  `close_owned_session/3` closes an alive session with `ProviderSession.close/1`,
-  whose call is unbounded, so an unresponsive session turns a bounded failure
-  into a wait. Both need a cleanup deadline supplied by the lifecycle owner.
+  ownership branch they required; and
+- (complete) bound terminal cleanup with the budget the lifecycle owner
+  installs. `ProviderSession.close/1` and `close_with_unregistered/2` now wait
+  `provider_cleanup_timeout_ms` plus one reply grace and terminate a session
+  that misses it, returning the classified cleanup failure instead of waiting
+  indefinitely. `Authorization.cancel_authorization/3` requires a supplied
+  `:cleanup_deadline` rather than minting one from the residual budget of the
+  interaction it cleans up, and `LoopbackListener.await/4` reports an
+  uncommitted cancellation as `authorization_cleanup_failed` instead of
+  discarding it. One residual is scoped out of that repair: terminating a
+  wedged session skips the `terminate/2` that would kill its attached provider
+  tasks, because the session tracks them by monitor alone. Coupling those tasks
+  to session death is an ownership change of its own and must not be smuggled
+  into a terminal-deadline fix.
 
 Keep these as independently reviewable commits in the Checkpoint C PR. Do not
 start doctor implementation until the descriptor and ownership boundaries are

--- a/docs/plans/lisp-kernel/stable-cli-contract.md
+++ b/docs/plans/lisp-kernel/stable-cli-contract.md
@@ -852,12 +852,18 @@ Checkpoint C starts with a small stabilization prefix before adding doctor:
   scope root, and further attachment are all gone once the wedged session is
   terminated; a second proves a committed closer never observes a live task;
   and
-- bound every terminal action with one absolute deadline. The first terminal
-  action anchors the session's `cleanup_deadline`; OAuth cancellation and the
-  later `close/1` or `close_with_unregistered/2` cleanup consume what remains
-  of that same deadline instead of each minting `Deadline.new/1` from the
-  cleanup duration again. `provider_cleanup_failed` and
-  `authorization_cleanup_failed` stay exactly as classified.
+- (complete) bound every terminal action with one absolute deadline. The first
+  terminal action anchors the session's `cleanup_deadline` through
+  `ProviderSession.anchor_cleanup_deadline/1`; OAuth cancellation and the later
+  `close/1` or `close_with_unregistered/2` cleanup consume what remains of that
+  same deadline instead of each minting the installed cleanup duration again.
+  `LoopbackListener` no longer mints a deadline at all — it receives the
+  anchoring operation and spends what it returns — and the unregistered closer
+  that outlives a session that never answers takes the unspent half of the one
+  budget by duration rather than a second anchor. Aborting one acquisition
+  scope mid-run is deliberately outside that episode and keeps its own bounded
+  budget. `provider_cleanup_failed` and `authorization_cleanup_failed` stay
+  exactly as classified.
 
 Keep these as independently reviewable commits in the Checkpoint C PR. Do not
 start doctor implementation until the descriptor and ownership boundaries are

--- a/docs/plans/lisp-kernel/stable-cli-contract.md
+++ b/docs/plans/lisp-kernel/stable-cli-contract.md
@@ -807,8 +807,18 @@ Checkpoint C starts with a small stabilization prefix before adding doctor:
   branch, so both paths apply the same selected-provider rule and neither
   charges the load to the run clock. `ProviderExecution.maybe_load_dotenv/2`
   and the sealed `dotenv_required?` query chain it used are deleted;
-- return zero from `LoopbackListener.remaining/1` on expiry and prove a trickle
-  client cannot extend the receive loop; and
+- (complete) return zero from `LoopbackListener.remaining/1` on expiry, decide
+  expiry before `:gen_tcp.recv/3` rather than delegating it to a zero timeout,
+  and keep `:authorization_timeout` distinct from `:invalid_callback_request`.
+  Regressions cover a callback already buffered before an expired accept, a
+  client that keeps trickling past the deadline, and a silent client that stops
+  mid-request. The pre-receive expiry branch remains fail-closed defense in
+  depth: its neighbouring branches report the same closed reason at the same
+  instant, so it is not independently observable through the socket. A
+  follow-up remains open: `Authorization.cancel_authorization/3` charges its
+  store mutation the residual budget of the interaction it is cleaning up, so
+  cancellation after expiry runs with a one-millisecond deadline whose failure
+  is discarded; and
 - move `--check` onto the shared execution-owner composition and delete the
   frontend-owned active path it replaces before doctor becomes another caller.
 

--- a/docs/plans/lisp-kernel/stable-cli-contract.md
+++ b/docs/plans/lisp-kernel/stable-cli-contract.md
@@ -239,6 +239,21 @@ still revokes retained builders and credential access. Delete that owner only
 in the commit that replaces its lifecycle; an intermediate no-op close is not
 an acceptable simplification.
 
+Host-bound activation runs synchronously in the caller and is an explicit
+exception to the per-command deadline, on the same terms as application
+bootstrap. Only `from_host_payload/2` can seal a runtime binding, so that
+branch runs exactly one code-owned step: decrypt the sealed host payload, then
+start the private owner and its credential lease. It reaches no
+embedder-supplied callback, file, socket, or network, and its input is bounded
+by the confined read ceiling every command-loaded host document passes through.
+An embedding that constructs a `HostConfig` without that loader owns the bound
+itself.
+The operation deadline is checked immediately before that step and rechecked
+after it, so an expired operation releases the resulting authority instead of
+returning a usable registry. The residual non-guarantee is explicit: a
+pathological activation delays the command past its deadline rather than being
+cancelled.
+
 All selected OAuth aliases in one command use the session context. Authority
 identity still distinguishes aliases and grants. A future host needing several
 tenant partitions opens separate sessions; the stable CLI does not need
@@ -712,9 +727,9 @@ activation in deadline-cancelled workers, preserves
 authority, and rechecks expiry after host-bound activation. Host-bound
 activation itself still runs in the caller because its authority is owned by
 the process that created it and `transfer_to_registry/1` reparents to
-`self()`. Bounding that callback requires the explicit two-phase ownership
-handoff listed in Checkpoint C; it is not complete merely because the shipped
-activation returns promptly.
+`self()`. Checkpoint C keeps that step synchronous and records it as the
+bounded-input bootstrap exception described above, rather than wrapping
+repository-owned initialization in a second ownership protocol.
 
 One gate item stays structurally out of reach in process. `HostConfig` never
 enables `allow_insecure_loopback` for an OAuth authority and `HostInstallation`
@@ -768,12 +783,22 @@ evaluations and finalizes them exactly once at REPL close.
 
 Checkpoint C starts with a small stabilization prefix before adding doctor:
 
-- make the sealed provider descriptor authoritative during staged preparation;
-  reject `data_class` or `accepts_data` drift before preflight, credentials, or
-  acquisition, while retaining the owned-sink comparison as defense in depth;
-- bound host-bound runtime activation with an explicit two-phase ownership
-  handoff whose timeout and caller-death branches cannot strand or prematurely
-  destroy the returned authority;
+- (complete, `586f0de0`) make the sealed provider descriptor authoritative
+  during staged preparation; reject `data_class` or `accepts_data` drift before
+  preflight, credentials, or acquisition, while retaining the owned-sink
+  comparison as defense in depth;
+- record host-bound runtime activation as the code-owned bootstrap exception
+  above instead of bounding it. The expiry check before activation and the
+  release after it already exist, so this slice adds only the two missing
+  host-bound regressions — an expired deadline never activates the payload, and
+  an operation that expires during activation releases the owner and its lease
+  — plus the documented non-guarantee. Creator death is already covered by the
+  existing credential-drain regression. Both alternatives
+  are worse: decrypting in a worker would move the plaintext host document
+  through a process message for a partial bound, and a two-phase handoff would
+  add a second ownership protocol around initialization that performs no
+  external I/O and is already covered by the creator monitor, fence
+  arbitration, transfer reconciliation, and stale-authority protection;
 - decide whether `.env` loading is bounded run work or pre-run setup, and make
   both one-shot and `--check` use that decision;
 - return zero from `LoopbackListener.remaining/1` on expiry and prove a trickle
@@ -838,9 +863,9 @@ all and calls `load_and_build/3` with an empty registry. Behavioural drift
 between them has already produced one reachable privacy defect, so treat this
 slice as early simplification rather than work deferred behind later features.
 
-Checkpoint C pulls descriptor-authoritative acquisition, the remaining
-runtime-activation bound, `.env` ordering, listener expiry, and `--check`
-ownership parity forward from this slice. This section retains the broader
+Checkpoint C pulls descriptor-authoritative acquisition, the recorded
+runtime-activation bootstrap exception, `.env` ordering, listener expiry, and
+`--check` ownership parity forward from this slice. This section retains the broader
 command and REPL cutover after destination publication is complete:
 
 - finish shared `help`, `version`, `validate`, `models`, `doctor`, `run`, and
@@ -988,6 +1013,10 @@ them:
   service cancellation, or concurrency quotas;
 - a general object/transactional artifact store;
 - standalone durable OAuth authorization;
+- a two-phase ownership handoff that makes host-bound runtime activation
+  hard-cancellable; its trigger is a supported deployment that cannot accept
+  the bootstrap exception above, and decrypting in a worker is not an
+  acceptable substitute;
 - a new LLM adapter or removal of `req_llm`/`llm_db`;
 - a second general HTTP stack; a minimal native/port receive helper is allowed
   only when the shipped boundary cannot prove and enforce the slice-7 cap;

--- a/docs/plans/lisp-kernel/stable-cli-contract.md
+++ b/docs/plans/lisp-kernel/stable-cli-contract.md
@@ -799,8 +799,14 @@ Checkpoint C starts with a small stabilization prefix before adding doctor:
   add a second ownership protocol around initialization that performs no
   external I/O and is already covered by the creator monitor, fence
   arbitration, transfer reconciliation, and stale-authority protection;
-- decide whether `.env` loading is bounded run work or pre-run setup, and make
-  both one-shot and `--check` use that decision;
+- (complete) classify `.env` loading as command setup rather than bounded run
+  work, because dotenv discovery reads the filesystem and mutates the process
+  environment: it cannot be deadline-cancelled or rolled back, and an embedding
+  must not acquire ambient `.env` state implicitly inside the Kernel. The Mix
+  adapter decides once, after preparation and before the `--check`/one-shot
+  branch, so both paths apply the same selected-provider rule and neither
+  charges the load to the run clock. `ProviderExecution.maybe_load_dotenv/2`
+  and the sealed `dotenv_required?` query chain it used are deleted;
 - return zero from `LoopbackListener.remaining/1` on expiry and prove a trickle
   client cannot extend the receive loop; and
 - move `--check` onto the shared execution-owner composition and delete the

--- a/docs/plans/lisp-kernel/stable-cli-contract.md
+++ b/docs/plans/lisp-kernel/stable-cli-contract.md
@@ -858,12 +858,35 @@ Checkpoint C starts with a small stabilization prefix before adding doctor:
   `close/1` or `close_with_unregistered/2` cleanup consume what remains of that
   same deadline instead of each minting the installed cleanup duration again.
   `LoopbackListener` no longer mints a deadline at all — it receives the
-  anchoring operation and spends what it returns — and the unregistered closer
-  that outlives a session that never answers takes the unspent half of the one
-  budget by duration rather than a second anchor. Aborting one acquisition
-  scope mid-run is deliberately outside that episode and keeps its own bounded
-  budget. `provider_cleanup_failed` and `authorization_cleanup_failed` stay
-  exactly as classified.
+  anchoring operation and spends what it returns — the caller anchors where its
+  terminal action began so a busy session cannot restart the budget at dequeue,
+  and the session is told the share reserved for the closer that must outlive
+  it so both bounds agree. Aborting one acquisition scope mid-run is
+  deliberately outside that episode and keeps its own bounded budget.
+  `provider_cleanup_failed` and `authorization_cleanup_failed` stay exactly as
+  classified.
+
+  Three residuals are recorded rather than repaired here, each because closing
+  it is an ownership change rather than a deadline fix:
+
+  - The deadline bounds a session's own cleanup, not the last root's exit. A
+    scope reaper starts its own `provider_cleanup_timeout_ms` window when it
+    observes the session's death, so a terminated session's registered roots can
+    outlive the close that reported the failure, inside that separately bounded
+    tail. Folding the tail in means propagating the anchored deadline into the
+    scope reapers.
+  - A terminal stage that must ask the session for the anchored deadline can
+    only bound that request by the installed budget, because it cannot know the
+    remainder before the reply. A session that answers an OAuth cancellation and
+    then stops answering therefore costs one further budget on the close that
+    follows, before it is terminated. Removing it means returning the anchored
+    deadline out through the authorization subphase so the close inherits it
+    instead of asking.
+  - Caller death during a check aborts through the execution owner, which closes
+    the registry and the OAuth runtime before the session, while a close request
+    already delivered to that session continues concurrently. This is the
+    shipped abort ordering for runs as well, pinned by its own regression;
+    reversing it for the abort path is a separate ownership slice.
 
 Keep these as independently reviewable commits in the Checkpoint C PR. Do not
 start doctor implementation until the descriptor and ownership boundaries are

--- a/docs/plans/lisp-kernel/stable-cli-contract.md
+++ b/docs/plans/lisp-kernel/stable-cli-contract.md
@@ -824,19 +824,40 @@ Checkpoint C starts with a small stabilization prefix before adding doctor:
   helpers, `RunBuilder.build_active/4`, and `ProviderActiveSession`'s
   frontend-owned `open/3`, `open_setup/3`, and `begin_run/3` together with the
   ownership branch they required; and
-- (complete) bound terminal cleanup with the budget the lifecycle owner
-  installs. `ProviderSession.close/1` and `close_with_unregistered/2` now wait
-  `provider_cleanup_timeout_ms` plus one reply grace and terminate a session
-  that misses it, returning the classified cleanup failure instead of waiting
-  indefinitely. `Authorization.cancel_authorization/3` requires a supplied
+- (incomplete, superseded by the two entries below) bound terminal cleanup with
+  the budget the lifecycle owner installs. `ProviderSession.close/1` and
+  `close_with_unregistered/2` wait `provider_cleanup_timeout_ms` plus one reply
+  grace and terminate a session that misses it, returning the classified
+  cleanup failure instead of waiting indefinitely.
+  `Authorization.cancel_authorization/3` requires a supplied
   `:cleanup_deadline` rather than minting one from the residual budget of the
   interaction it cleans up, and `LoopbackListener.await/4` reports an
   uncommitted cancellation as `authorization_cleanup_failed` instead of
-  discarding it. One residual is scoped out of that repair: terminating a
-  wedged session skips the `terminate/2` that would kill its attached provider
-  tasks, because the session tracks them by monitor alone. Coupling those tasks
-  to session death is an ownership change of its own and must not be smuggled
-  into a terminal-deadline fix.
+  discarding it. That bounded the caller but left the cleanup it bounds
+  violating its own contract in two ways, so the entry does not stand alone:
+  terminating a wedged session skipped the `terminate/2` that would have killed
+  the provider tasks the session tracked by monitor alone, and every stage of
+  terminal cleanup still minted a fresh full budget, so sequential stages were
+  bounded individually and not together. Both are repaired below; the wait
+  bounds and the two classified failures above are retained unchanged;
+- (complete) make one external owner responsible for provider tasks.
+  `ProviderTaskTracker` is the sole owner of a run's live callbacks. It
+  monitors both `RunState` and the `ProviderSession`, so either lifecycle
+  disappearing kills and reaps every attached task — including a session
+  terminated at its cleanup deadline, where `terminate/2` cannot run. Session
+  attachment routes through that owner and the session's monitor-only provider
+  map is deleted, so a session drains through the one owner before any provider
+  closer runs rather than tracking tasks itself. A regression proves an
+  attached task is alive before the session is wedged and that the task, its
+  scope root, and further attachment are all gone once the wedged session is
+  terminated; a second proves a committed closer never observes a live task;
+  and
+- bound every terminal action with one absolute deadline. The first terminal
+  action anchors the session's `cleanup_deadline`; OAuth cancellation and the
+  later `close/1` or `close_with_unregistered/2` cleanup consume what remains
+  of that same deadline instead of each minting `Deadline.new/1` from the
+  cleanup duration again. `provider_cleanup_failed` and
+  `authorization_cleanup_failed` stay exactly as classified.
 
 Keep these as independently reviewable commits in the Checkpoint C PR. Do not
 start doctor implementation until the descriptor and ownership boundaries are

--- a/docs/plans/lisp-kernel/stable-cli-contract.md
+++ b/docs/plans/lisp-kernel/stable-cli-contract.md
@@ -819,8 +819,21 @@ Checkpoint C starts with a small stabilization prefix before adding doctor:
   store mutation the residual budget of the interaction it is cleaning up, so
   cancellation after expiry runs with a one-millisecond deadline whose failure
   is discarded; and
-- move `--check` onto the shared execution-owner composition and delete the
-  frontend-owned active path it replaces before doctor becomes another caller.
+- (complete) move `--check` onto the shared execution-owner composition. A
+  check now differs from a run only in the owner's completion step, so both
+  share the activity marker, session, registry, credentials, OAuth,
+  acquisition, and cleanup ownership, and `--check --authorize-mcp` reaches the
+  same authorization subphase. The replaced scaffolding is deleted with it: the
+  Mix adapter's session, registry, OAuth context, deadline, and authorization
+  helpers, `RunBuilder.build_active/4`, and `ProviderActiveSession`'s
+  frontend-owned `open/3`, `open_setup/3`, and `begin_run/3` together with the
+  ownership branch they required. Two terminal-cleanup follow-ups remain open
+  and are deliberately not patched with fresh ad-hoc timeouts:
+  `Authorization.cancel_authorization/3` charges its store mutation the residual
+  budget of the interaction it cleans up, and `ProviderExecution`'s
+  `close_owned_session/3` closes an alive session with `ProviderSession.close/1`,
+  whose call is unbounded, so an unresponsive session turns a bounded failure
+  into a wait. Both need a cleanup deadline supplied by the lifecycle owner.
 
 Keep these as independently reviewable commits in the Checkpoint C PR. Do not
 start doctor implementation until the descriptor and ownership boundaries are

--- a/lib/mix/tasks/ptc.run.ex
+++ b/lib/mix/tasks/ptc.run.ex
@@ -149,10 +149,12 @@ defmodule Mix.Tasks.Ptc.Run do
          opts,
          runtime
        ) do
-    if Keyword.get(opts, :check, false) do
-      execute_check_prepared(prepared, run_opts, opts, runtime)
-    else
-      execute_one_shot(prepared, run_opts, opts, runtime)
+    with :ok <- load_environment_credentials(prepared, runtime) do
+      if Keyword.get(opts, :check, false) do
+        execute_check_prepared(prepared, run_opts, opts, runtime)
+      else
+        execute_one_shot(prepared, run_opts, opts, runtime)
+      end
     end
   end
 
@@ -196,8 +198,7 @@ defmodule Mix.Tasks.Ptc.Run do
   defp execute_check_prepared(prepared, run_opts, opts, runtime) do
     case ProviderActiveSession.open(prepared, runtime.catalog, runtime.services) do
       {:ok, session} ->
-        case with :ok <- maybe_load_dotenv(prepared, runtime),
-                  do: active_registry(prepared, session, runtime) do
+        case active_registry(prepared, session, runtime) do
           {:ok, registry, cleanup} ->
             try do
               execute_with_registry(prepared, registry, session, run_opts, opts, runtime.host)
@@ -238,8 +239,7 @@ defmodule Mix.Tasks.Ptc.Run do
     authorities = oauth_authorities(runtime.host, selected_names)
 
     result =
-      with :ok <- maybe_load_dotenv(prepared, runtime),
-           deadline when not is_nil(deadline) <-
+      with deadline when not is_nil(deadline) <-
              oauth_setup_deadline(
                prepared.provider_declarations,
                authorities,
@@ -593,9 +593,15 @@ defmodule Mix.Tasks.Ptc.Run do
     if :req_llm in started_applications(), do: :host_owned, else: :command_vm
   end
 
-  defp maybe_load_dotenv(_prepared, %{host: nil}), do: :ok
+  # Dotenv discovery reads the filesystem and mutates the VM environment, so it
+  # is command setup rather than bounded run work: it cannot be cancelled by a
+  # deadline or rolled back, and an embedding must never acquire ambient `.env`
+  # state implicitly inside the Kernel. The CLI therefore decides once, after
+  # preparation has established which providers are selected and before any
+  # execution owner, provider session, or run clock exists.
+  defp load_environment_credentials(_prepared, %{host: nil}), do: :ok
 
-  defp maybe_load_dotenv(prepared, runtime) do
+  defp load_environment_credentials(prepared, runtime) do
     # Keyed on the declared credential, not on provider-application admission: a
     # direct `ollama:`/`openai-compat:` route needs no backing application but
     # can still resolve its credential from the nearest `.env`.
@@ -608,10 +614,22 @@ defmodule Mix.Tasks.Ptc.Run do
            _other -> false
          end
        end) do
-      Dotenv.load()
+      load_dotenv()
     else
       :ok
     end
+  end
+
+  # `PtcRunner.Dotenv` reads the file it finds with `File.read!/1`. Inside the
+  # execution owner that raise became a closed internal diagnostic; in the
+  # frontend it would otherwise put a raw exception and the `.env` path in the
+  # command's failure output.
+  defp load_dotenv do
+    Dotenv.load()
+  rescue
+    _exception -> {:error, :dotenv_unavailable}
+  catch
+    _kind, _reason -> {:error, :dotenv_unavailable}
   end
 
   defp started_applications,

--- a/lib/mix/tasks/ptc.run.ex
+++ b/lib/mix/tasks/ptc.run.ex
@@ -47,21 +47,12 @@ defmodule Mix.Tasks.Ptc.Run do
   alias PtcRunner.Dotenv
   alias PtcRunner.Kernel.CommandDiagnostic
   alias PtcRunner.Kernel.CommandEngine
-  alias PtcRunner.Kernel.CommandSubject
-  alias PtcRunner.Kernel.Deadline
   alias PtcRunner.Kernel.HostInstallation
   alias PtcRunner.Kernel.InstallationCatalog
   alias PtcRunner.Kernel.MCPOAuth.Authority
-  alias PtcRunner.Kernel.MCPOAuth.Authorization
-  alias PtcRunner.Kernel.MCPOAuth.Context, as: OAuthContext
-  alias PtcRunner.Kernel.MCPOAuth.LoopbackListener
-  alias PtcRunner.Kernel.MCPOAuth.Store.Memory
   alias PtcRunner.Kernel.PreparedRun
-  alias PtcRunner.Kernel.ProviderActiveSession
   alias PtcRunner.Kernel.ProviderExecution
-  alias PtcRunner.Kernel.ProviderRegistry
   alias PtcRunner.Kernel.ProviderRuntimeServices
-  alias PtcRunner.Kernel.ProviderSession
   alias PtcRunner.Kernel.PublicationAuthority
   alias PtcRunner.Kernel.RunBuilder
   alias PtcRunner.Kernel.RunCoordinator
@@ -151,69 +142,29 @@ defmodule Mix.Tasks.Ptc.Run do
        ) do
     with :ok <- load_environment_credentials(prepared, runtime) do
       if Keyword.get(opts, :check, false) do
-        execute_check_prepared(prepared, run_opts, opts, runtime)
+        execute_check(prepared, run_opts, runtime)
       else
         execute_one_shot(prepared, run_opts, opts, runtime)
       end
     end
   end
 
-  defp execute_check_prepared(
-         %PreparedRun{provider_declarations: []} = prepared,
-         run_opts,
-         opts,
-         runtime
-       ) do
-    with {:ok, registry} <-
-           ProviderRegistry.new(%{}, installed_limits: runtime.catalog.installed_limits) do
-      try do
-        execute_with_registry(prepared, registry, nil, run_opts, opts, runtime.host)
-      after
-        ProviderRegistry.close(registry)
-      end
+  # A check and a one-shot differ only in what the execution owner completes:
+  # both open the same session, registry, credentials, OAuth, acquisition, and
+  # cleanup ownership. `--check` rejects every artifact option, so its authority
+  # carries no destination and nothing is published.
+  defp execute_check(prepared, run_opts, runtime) do
+    with {:ok, authority} <- PublicationAuthority.new(run_opts),
+         {:ok, snapshots} <- check_owned(prepared, authority, runtime) do
+      report_check(resolved_view(snapshots, runtime.host))
     end
   end
 
-  defp execute_check_prepared(
-         prepared,
-         run_opts,
-         opts,
-         %{authorizations: [_first | _rest]} = runtime
-       ) do
-    case ProviderActiveSession.open_setup(prepared, runtime.catalog, runtime.services) do
-      {:ok, setup_session} ->
-        execute_after_authorization_setup(
-          prepared,
-          setup_session,
-          run_opts,
-          opts,
-          runtime
-        )
+  defp check_owned(%PreparedRun{provider_declarations: []} = prepared, authority, _runtime),
+    do: RunCoordinator.check(prepared, authority)
 
-      {:error, %CommandDiagnostic{}} = error ->
-        error
-    end
-  end
-
-  defp execute_check_prepared(prepared, run_opts, opts, runtime) do
-    case ProviderActiveSession.open(prepared, runtime.catalog, runtime.services) do
-      {:ok, session} ->
-        case active_registry(prepared, session, runtime) do
-          {:ok, registry, cleanup} ->
-            try do
-              execute_with_registry(prepared, registry, session, run_opts, opts, runtime.host)
-            after
-              cleanup.()
-            end
-
-          {:error, _reason} = error ->
-            _ = ProviderSession.close(session)
-            error
-        end
-
-      {:error, %CommandDiagnostic{}} = error ->
-        error
-    end
+  defp check_owned(prepared, authority, runtime) do
+    RunCoordinator.check(prepared, authority, runtime.execution, &notify_authorization_url/1)
   end
 
   defp execute_one_shot(prepared, run_opts, opts, runtime) do
@@ -228,60 +179,12 @@ defmodule Mix.Tasks.Ptc.Run do
     do: RunCoordinator.execute(prepared, authority)
 
   defp execute_owned(prepared, authority, runtime) do
-    RunCoordinator.execute(prepared, authority, runtime.execution, fn url ->
-      Mix.shell().info("Open this one-time authorization URL:\n#{url}")
-      :ok
-    end)
+    RunCoordinator.execute(prepared, authority, runtime.execution, &notify_authorization_url/1)
   end
 
-  defp execute_after_authorization_setup(prepared, setup_session, run_opts, opts, runtime) do
-    selected_names = selected_provider_names(prepared)
-    authorities = oauth_authorities(runtime.host, selected_names)
-
-    result =
-      with deadline when not is_nil(deadline) <-
-             oauth_setup_deadline(
-               prepared.provider_declarations,
-               authorities,
-               selected_names,
-               System.monotonic_time(:millisecond)
-             ),
-           {:ok, registry, context, cleanup} <-
-             open_oauth_registry(runtime, selected_names, deadline) do
-        try do
-          with :ok <-
-                 authorize_installations(
-                   runtime.host,
-                   context,
-                   registry,
-                   prepared.provider_declarations,
-                   authorities,
-                   runtime.authorizations
-                 )
-                 |> authorization_result(selected_names, runtime.catalog),
-               {:ok, session} <-
-                 ProviderActiveSession.begin_run(setup_session, prepared, runtime.catalog) do
-            execute_with_registry(prepared, registry, session, run_opts, opts, runtime.host)
-          end
-        after
-          cleanup.()
-        end
-      else
-        nil -> {:error, :invalid_mcp_authorization}
-        {:error, _reason} = error -> error
-      end
-
-    close_unstarted_session(setup_session, result)
-  end
-
-  defp execute_with_registry(prepared, registry, session, run_opts, opts, host) do
-    with true <- Keyword.get(opts, :check, false),
-         {:ok, view} <- check(prepared, registry, session, host, run_opts) do
-      report_check(view)
-    else
-      false -> {:error, :invalid_check}
-      {:error, _reason} = error -> error
-    end
+  defp notify_authorization_url(url) do
+    Mix.shell().info("Open this one-time authorization URL:\n#{url}")
+    :ok
   end
 
   defp exclusive_destinations(opts) do
@@ -355,240 +258,6 @@ defmodule Mix.Tasks.Ptc.Run do
     end
   end
 
-  defp active_registry(
-         prepared,
-         session,
-         %{host: nil, catalog: catalog, services: services}
-       ) do
-    catalog
-    |> InstallationCatalog.runtime_registry(
-      services,
-      selected_provider_names(prepared),
-      ProviderSession.run_deadline(session)
-    )
-    |> registry_result(:run)
-  end
-
-  defp active_registry(prepared, session, runtime) do
-    selected_names = selected_provider_names(prepared)
-    authorities = oauth_authorities(runtime.host, selected_names)
-
-    if Enum.any?(authorities, fn {_name, authority} -> not is_nil(authority) end) do
-      run_deadline = ProviderSession.run_deadline(session)
-
-      oauth_deadline =
-        oauth_operation_deadline(
-          run_deadline,
-          prepared.provider_declarations,
-          authorities,
-          System.monotonic_time(:millisecond)
-        )
-
-      with {:ok, registry, _context, cleanup} <-
-             open_oauth_registry(runtime, selected_names, oauth_deadline) do
-        {:ok, registry, cleanup}
-      end
-    else
-      runtime.catalog
-      |> InstallationCatalog.runtime_registry(
-        runtime.services,
-        selected_names,
-        ProviderSession.run_deadline(session)
-      )
-      |> registry_result(:run)
-    end
-  end
-
-  defp open_oauth_registry(runtime, selected_names, deadline) do
-    with {:ok, memory} <- Memory.start_link(owner: self()) do
-      result =
-        with {:ok, store} <- Memory.store(memory),
-             {:ok, context} <-
-               OAuthContext.new(
-                 tenant_id: "local-cli",
-                 principal_id: "local-user",
-                 store: store,
-                 deadline: deadline
-               ),
-             {:ok, services} <-
-               HostInstallation.runtime_services(runtime.host,
-                 provider_application_mode: runtime.services.provider_application_mode,
-                 oauth_mode:
-                   {:context_factory,
-                    fn
-                      ^deadline -> {:ok, context}
-                      _other -> {:error, :authorization_context_required}
-                    end}
-               ),
-             {:ok, registry} <-
-               InstallationCatalog.runtime_registry(
-                 runtime.catalog,
-                 services,
-                 selected_names,
-                 deadline
-               )
-               |> registry_result({:oauth, selected_names, runtime.catalog}) do
-          {:ok, registry, context,
-           fn ->
-             ProviderRegistry.close(registry)
-             Memory.close(memory)
-           end}
-        end
-
-      case result do
-        {:ok, _registry, _context, _cleanup} = success ->
-          success
-
-        {:error, _reason} = error ->
-          error
-          |> registry_result({:oauth, selected_names, runtime.catalog})
-          |> then(&close_memory(memory, &1))
-      end
-    end
-  end
-
-  defp selected_provider_names(prepared),
-    do: prepared.provider_declarations |> Enum.map(& &1.name) |> Enum.uniq()
-
-  @doc false
-  @spec oauth_authorities(map(), [binary()]) :: %{binary() => Authority.t() | nil}
-  def oauth_authorities(%{install: install}, selected_names)
-      when is_map(install) and is_list(selected_names) do
-    Map.new(selected_names, fn name ->
-      authority =
-        case Map.get(install, name) do
-          %{source: :mcp, transport: %{oauth: %Authority{} = authority}} -> authority
-          _not_oauth -> nil
-        end
-
-      {name, authority}
-    end)
-  end
-
-  def oauth_authorities(_host, _selected_names), do: %{}
-
-  @doc false
-  @spec authorization_result(:ok | {:error, term()}, [binary()], InstallationCatalog.t()) ::
-          :ok | {:error, term()}
-  def authorization_result(:ok, _selected_names, _catalog), do: :ok
-
-  def authorization_result({:error, _reason} = result, selected_names, catalog),
-    do: registry_result(result, {:oauth, selected_names, catalog})
-
-  @doc false
-  @spec oauth_operation_deadline(Deadline.t(), [map()], map(), integer()) :: Deadline.t()
-  def oauth_operation_deadline(run_deadline, declarations, authorities, anchor_ms) do
-    Enum.reduce(declarations, run_deadline, fn declaration, deadline ->
-      case declaration do
-        %{name: name, config: %{"timeout_ms" => timeout_ms}}
-        when is_integer(timeout_ms) and timeout_ms > 0 ->
-          if Map.get(authorities, name) do
-            Deadline.earliest(deadline, Deadline.new(timeout_ms, anchor_ms))
-          else
-            deadline
-          end
-
-        _declaration ->
-          deadline
-      end
-    end)
-  end
-
-  @doc false
-  @spec oauth_setup_deadline([map()], map(), [binary()], integer()) :: Deadline.t() | nil
-  def oauth_setup_deadline(declarations, authorities, selected_names, anchor_ms) do
-    Enum.reduce(selected_names, nil, fn name, deadline ->
-      case oauth_target_deadline(name, declarations, authorities, anchor_ms) do
-        nil -> deadline
-        target when is_nil(deadline) -> target
-        target -> Deadline.earliest(deadline, target)
-      end
-    end)
-  end
-
-  @doc false
-  @spec oauth_target_deadline(binary(), [map()], map(), integer()) :: Deadline.t() | nil
-  def oauth_target_deadline(name, declarations, authorities, anchor_ms) do
-    case Map.get(authorities, name) do
-      %{authorization_timeout_ms: timeout_ms}
-      when is_integer(timeout_ms) and timeout_ms > 0 ->
-        Enum.reduce(declarations, Deadline.new(timeout_ms, anchor_ms), fn declaration, deadline ->
-          case declaration do
-            %{name: ^name, config: %{"timeout_ms" => occurrence_timeout_ms}}
-            when is_integer(occurrence_timeout_ms) and occurrence_timeout_ms > 0 ->
-              Deadline.earliest(deadline, Deadline.new(occurrence_timeout_ms, anchor_ms))
-
-            _other ->
-              deadline
-          end
-        end)
-
-      _not_oauth ->
-        nil
-    end
-  end
-
-  defp registry_result({:ok, registry}, :run),
-    do: {:ok, registry, fn -> ProviderRegistry.close(registry) end}
-
-  defp registry_result({:ok, registry}, {:oauth, _selected_names, _catalog}),
-    do: {:ok, registry}
-
-  defp registry_result({:error, :operation_deadline_expired}, :run),
-    do: {:error, CommandDiagnostic.new!(:execution, :run_timeout, provider_activity: true)}
-
-  defp registry_result(
-         {:error, {:authorization_timeout, name}},
-         {:oauth, _selected_names, _catalog}
-       ),
-       do: {:error, authorization_diagnostic(name)}
-
-  defp registry_result(
-         {:error, {:authorization_unavailable, name}},
-         {:oauth, _selected_names, _catalog}
-       ),
-       do: {:error, authorization_diagnostic(name)}
-
-  defp registry_result(
-         {:error, reason},
-         {:oauth, selected_names, catalog}
-       )
-       when reason in [:operation_deadline_expired, :timeout] do
-    name =
-      selected_names
-      |> Enum.filter(&(catalog.authorities[&1] != nil))
-      |> Enum.min()
-
-    {:error, authorization_diagnostic(name)}
-  end
-
-  defp registry_result({:error, _reason} = error, _operation), do: error
-
-  defp close_memory(%Memory{pid: pid}) do
-    if Process.alive?(pid), do: Memory.close(%Memory{pid: pid}), else: :ok
-  end
-
-  defp close_memory(memory, error) do
-    close_memory(memory)
-    error
-  end
-
-  defp close_unstarted_session(session, {:error, _reason} = error) do
-    if is_nil(ProviderSession.run_deadline(session)), do: ProviderSession.close(session)
-    error
-  end
-
-  defp close_unstarted_session(_session, result), do: result
-
-  defp authorization_diagnostic(name) do
-    {:ok, subject} = CommandSubject.provider(name, :authorization)
-
-    CommandDiagnostic.new!(:active_preflight, :authorization_unavailable,
-      provider_activity: true,
-      subject: subject
-    )
-  end
-
   defp provider_application_mode do
     if :req_llm in started_applications(), do: :host_owned, else: :command_vm
   end
@@ -653,80 +322,6 @@ defmodule Mix.Tasks.Ptc.Run do
     end
   end
 
-  defp authorize_installations(
-         host,
-         context,
-         registry,
-         declarations,
-         authorities,
-         requested
-       ) do
-    Enum.reduce_while(requested, :ok, fn name, :ok ->
-      case Map.get(host.install, name) do
-        %{source: :mcp, transport: %{oauth: authority}} when not is_nil(authority) ->
-          deadline =
-            oauth_target_deadline(
-              name,
-              declarations,
-              authorities,
-              System.monotonic_time(:millisecond)
-            )
-
-          with true <- Deadline.valid?(deadline),
-               {:ok, authority_epoch} <-
-                 ProviderRegistry.oauth_authority_epoch(registry, name, deadline),
-               :ok <- authorize_installation(context, authority, authority_epoch, deadline) do
-            {:cont, :ok}
-          else
-            false ->
-              {:halt, {:error, :invalid_mcp_authorization}}
-
-            {:error, reason} when reason in [:timeout, :authorization_timeout] ->
-              {:halt, {:error, {:authorization_timeout, name}}}
-
-            {:error, :authorization_context_required} ->
-              {:halt, {:error, {:authorization_unavailable, name}}}
-
-            {:error, _reason} = error ->
-              {:halt, error}
-          end
-
-        _missing_or_not_oauth ->
-          {:halt, {:error, :invalid_mcp_authorization}}
-      end
-    end)
-  end
-
-  defp authorize_installation(context, authority, authority_epoch, deadline) do
-    with true <- Authority.cli_compatible?(authority),
-         {:ok, listener} <- LoopbackListener.start(authority) do
-      authorize_with_listener(context, authority, authority_epoch, deadline, listener)
-    else
-      false -> {:error, :mcp_authorization_not_cli_compatible}
-      {:error, _reason} = error -> error
-    end
-  end
-
-  defp authorize_with_listener(context, authority, authority_epoch, deadline, listener) do
-    case Authorization.begin_authorization(context, authority,
-           authority_epoch: authority_epoch,
-           deadline_ms: Deadline.expires_at(deadline),
-           redirect_uri: listener.redirect_uri
-         ) do
-      {:ok, pending} ->
-        Mix.shell().info("Open this one-time authorization URL:\n#{pending.url}")
-
-        case LoopbackListener.await(listener, context, pending, []) do
-          {:ok, _grant} -> :ok
-          {:error, _reason} = error -> error
-        end
-
-      {:error, _reason} = error ->
-        LoopbackListener.close(listener)
-        error
-    end
-  end
-
   defp run_options(opts) do
     opts
     |> Keyword.drop([
@@ -760,24 +355,8 @@ defmodule Mix.Tasks.Ptc.Run do
   defp maybe_request_option(opts, _key, nil), do: opts
   defp maybe_request_option(opts, key, value), do: Keyword.put(opts, key, value)
 
-  defp check(prepared, registry, session, host, opts) do
-    result =
-      if session,
-        do: RunBuilder.build_active(prepared, registry, session, opts),
-        else: RunBuilder.build_prepared(prepared, registry, opts)
-
-    with {:ok, built} <- result do
-      view = resolved_view(built, host)
-
-      case RunBuilder.close(built.config) do
-        :ok -> {:ok, view}
-        {:error, _reason} = error -> error
-      end
-    end
-  end
-
-  defp resolved_view(built, host) do
-    built.config.connector_snapshots
+  defp resolved_view(snapshots, host) do
+    snapshots
     |> Enum.map(fn snapshot ->
       installation = if host, do: host.install[snapshot["provider"]]
       resolved_provider(snapshot, installation)

--- a/lib/ptc_runner/kernel/execution_session_owner.ex
+++ b/lib/ptc_runner/kernel/execution_session_owner.ex
@@ -27,7 +27,8 @@ defmodule PtcRunner.Kernel.ExecutionSessionOwner do
              :invalid_prepared_run
              | :invalid_publication_authority
              | :provider_session_required}
-  def start(prepared, authority, caller), do: start(prepared, authority, caller, nil, nil)
+  def start(prepared, authority, caller),
+    do: start(prepared, authority, caller, nil, nil, :run)
 
   @doc false
   @spec start(
@@ -35,7 +36,8 @@ defmodule PtcRunner.Kernel.ExecutionSessionOwner do
           PublicationAuthority.t(),
           pid(),
           ProviderExecution.t() | nil,
-          (binary() -> term()) | nil
+          (binary() -> term()) | nil,
+          :run | :check
         ) ::
           {:ok, t()}
           | {:error,
@@ -43,7 +45,10 @@ defmodule PtcRunner.Kernel.ExecutionSessionOwner do
              | :invalid_publication_authority
              | :provider_session_required
              | :invalid_provider_execution}
-  def start(prepared, authority, caller, provider_execution, notifier) when is_pid(caller) do
+  def start(prepared, authority, caller, provider_execution, notifier, operation \\ :run)
+
+  def start(prepared, authority, caller, provider_execution, notifier, operation)
+      when is_pid(caller) and operation in [:run, :check] do
     cond do
       not PreparedRun.valid?(prepared) ->
         {:error, :invalid_prepared_run}
@@ -69,7 +74,7 @@ defmodule PtcRunner.Kernel.ExecutionSessionOwner do
 
         case GenServer.start(
                __MODULE__,
-               {prepared, authority, caller, token, provider_execution, notifier}
+               {prepared, authority, caller, token, provider_execution, notifier, operation}
              ) do
           {:ok, pid} -> {:ok, %__MODULE__{pid: pid, token: token}}
           {:error, _reason} -> {:error, :invalid_prepared_run}
@@ -77,11 +82,14 @@ defmodule PtcRunner.Kernel.ExecutionSessionOwner do
     end
   end
 
-  def start(_prepared, _authority, _caller, _provider_execution, _notifier),
+  def start(_prepared, _authority, _caller, _provider_execution, _notifier, _operation),
     do: {:error, :invalid_prepared_run}
 
+  # A check completes with the acquisition's safe connector snapshots where a
+  # run completes with a sealed execution outcome.
   @doc false
-  @spec await(t()) :: {:ok, PtcRunner.Kernel.ExecutionOutcome.t()} | {:error, term()}
+  @spec await(t()) ::
+          {:ok, PtcRunner.Kernel.ExecutionOutcome.t() | [map()]} | {:error, term()}
   def await(%__MODULE__{pid: pid, token: token}) do
     GenServer.call(pid, {token, :await}, :infinity)
   catch
@@ -93,7 +101,7 @@ defmodule PtcRunner.Kernel.ExecutionSessionOwner do
   def pid(%__MODULE__{pid: pid}), do: pid
 
   @impl GenServer
-  def init({prepared, authority, caller, token, provider_execution, notifier}) do
+  def init({prepared, authority, caller, token, provider_execution, notifier, operation}) do
     caller_ref = Process.monitor(caller)
 
     initial = %{
@@ -117,14 +125,15 @@ defmodule PtcRunner.Kernel.ExecutionSessionOwner do
     case RunBuilder.open_prepared_sinks(prepared, authority, self()) do
       {:ok, opened_sinks} ->
         if prepared.provider_declarations == [] do
-          open_provider_free(initial, authority, opened_sinks)
+          open_provider_free(initial, authority, opened_sinks, operation)
         else
           open_provider_execution(
             initial,
             authority,
             opened_sinks,
             provider_execution,
-            notifier
+            notifier,
+            operation
           )
         end
 
@@ -238,7 +247,7 @@ defmodule PtcRunner.Kernel.ExecutionSessionOwner do
     :ok
   end
 
-  defp open_provider_free(initial, authority, opened_sinks) do
+  defp open_provider_free(initial, authority, opened_sinks, operation) do
     prepared = initial.prepared
 
     result =
@@ -259,7 +268,7 @@ defmodule PtcRunner.Kernel.ExecutionSessionOwner do
 
         {worker_pid, worker_ref} =
           spawn_monitor(fn ->
-            execution_result = RunBuilder.execute_built(built)
+            execution_result = complete_operation(built, operation)
             send(owner, {token, :execution_result, self(), execution_result})
           end)
 
@@ -301,7 +310,8 @@ defmodule PtcRunner.Kernel.ExecutionSessionOwner do
          authority,
          opened_sinks,
          provider_execution,
-         notifier
+         notifier,
+         operation
        ) do
     owner = self()
     token = initial.token
@@ -326,7 +336,8 @@ defmodule PtcRunner.Kernel.ExecutionSessionOwner do
                 provider_execution,
                 notifier,
                 tracker,
-                owner
+                owner,
+                operation
               )
 
             send(owner, {token, :execution_result, self(), execution_result})
@@ -362,6 +373,9 @@ defmodule PtcRunner.Kernel.ExecutionSessionOwner do
         {:ok, next}
     end
   end
+
+  defp complete_operation(built, :run), do: RunBuilder.execute_built(built)
+  defp complete_operation(built, :check), do: RunBuilder.check_built(built)
 
   defp finish_or_wait(%{waiter: nil} = state), do: {:noreply, state}
 

--- a/lib/ptc_runner/kernel/host_installation.ex
+++ b/lib/ptc_runner/kernel/host_installation.ex
@@ -329,26 +329,6 @@ defmodule PtcRunner.Kernel.HostInstallation do
     end
   end
 
-  def owner_call(%HostConfig{} = host, {:dotenv_required, selected_names})
-      when is_list(selected_names) and length(selected_names) <= 128 do
-    if selected_names == Enum.uniq(selected_names) and
-         Enum.all?(selected_names, &Map.has_key?(host.install, &1)) do
-      required? =
-        Enum.any?(selected_names, fn name ->
-          with %{source: :llm, credential: credential} <- Map.fetch!(host.install, name),
-               %{source: :env} <- Map.get(host.credentials, credential) do
-            true
-          else
-            _not_dotenv_backed -> false
-          end
-        end)
-
-      {:ok, required?}
-    else
-      {:error, :invalid_host_installation}
-    end
-  end
-
   def owner_call(_host, _request), do: {:error, :invalid_host_installation}
 
   defp descriptor(installation, rules, authority) do

--- a/lib/ptc_runner/kernel/host_runtime_payload.ex
+++ b/lib/ptc_runner/kernel/host_runtime_payload.ex
@@ -99,14 +99,6 @@ defmodule PtcRunner.Kernel.HostRuntimePayload do
   def oauth_authorities(_payload, _selected_names),
     do: {:error, :invalid_host_runtime_payload}
 
-  @doc false
-  @spec dotenv_required?(t(), [binary()]) :: {:ok, boolean()} | {:error, term()}
-  def dotenv_required?(%__MODULE__{} = payload, selected_names) when is_list(selected_names),
-    do: with_host(payload, &HostInstallation.owner_call(&1, {:dotenv_required, selected_names}))
-
-  def dotenv_required?(_payload, _selected_names),
-    do: {:error, :invalid_host_runtime_payload}
-
   @spec invoke(t(), term()) :: term()
   def invoke(
         %__MODULE__{} = payload,

--- a/lib/ptc_runner/kernel/installation_catalog.ex
+++ b/lib/ptc_runner/kernel/installation_catalog.ex
@@ -14,6 +14,9 @@ defmodule PtcRunner.Kernel.InstallationCatalog do
   activation deadline because it has no run selection.
   Catalog construction checks that active validators, connectivity probes, and
   local checks agree with their descriptors without invoking any callback.
+  Every builder placed in a run-bound registry carries the data policy its
+  validated sealed descriptor declares, so a staged preparation cannot
+  contradict the policy phase 5 and sink authorization already used.
   """
 
   alias PtcRunner.Kernel.Attestation
@@ -537,7 +540,11 @@ defmodule PtcRunner.Kernel.InstallationCatalog do
     catalog.implementations
     |> Map.take(selected_names)
     |> Map.new(fn {name, _implementation} ->
-      {name, ProviderRegistry.staged(HostInstallation.runtime_builder(owner, name))}
+      {name,
+       ProviderRegistry.staged(
+         HostInstallation.runtime_builder(owner, name),
+         declared_policy(catalog, name)
+       )}
     end)
   end
 
@@ -556,9 +563,12 @@ defmodule PtcRunner.Kernel.InstallationCatalog do
             implementation.builder
         end
 
-      {name, ProviderRegistry.staged(builder)}
+      {name, ProviderRegistry.staged(builder, declared_policy(catalog, name))}
     end)
   end
+
+  defp declared_policy(catalog, name),
+    do: catalog.descriptors |> Map.fetch!(name) |> ProviderDescriptor.data_policy()
 
   defp valid_runtime_selection?(catalog, selected_names)
        when is_list(selected_names) and length(selected_names) <= 128 do

--- a/lib/ptc_runner/kernel/mcp_oauth/authorization.ex
+++ b/lib/ptc_runner/kernel/mcp_oauth/authorization.ex
@@ -136,23 +136,46 @@ defmodule PtcRunner.Kernel.MCPOAuth.Authorization do
   def complete_authorization(_context, _pending, _parameters, _opts),
     do: {:error, :invalid_authorization}
 
+  @doc """
+  Cancels one pending authorization under a supplied terminal deadline.
+
+  The `:cleanup_deadline` option is required and belongs to the lifecycle owner
+  that installed the provider cleanup budget. Cancellation is terminal cleanup,
+  so it is never charged whatever remained of the interaction it cleans up, and
+  a caller must not treat an uncommitted cancellation as success.
+  """
   @spec cancel_authorization(Context.t(), PendingAuthorization.t(), keyword()) ::
           :ok | {:error, atom()}
-  def cancel_authorization(%Context{} = context, %PendingAuthorization{} = pending, _opts) do
-    if pending_context?(context, pending) do
-      Store.cancel_flow(
-        context.store,
-        pending.key,
-        pending.flow_id,
-        Deadline.new(max(remaining(pending.deadline_ms), 1))
-      )
+  def cancel_authorization(%Context{} = context, %PendingAuthorization{} = pending, opts) do
+    # Cancellation is terminal cleanup, so its budget belongs to the lifecycle
+    # owner that installed it and is anchored by the caller entering cleanup.
+    # Charging it whatever remained of the interaction it is cleaning up gave an
+    # expired interaction one millisecond and then discarded the outcome.
+    with {:ok, deadline} <- terminal_deadline(opts),
+         true <- pending_context?(context, pending) do
+      Store.cancel_flow(context.store, pending.key, pending.flow_id, deadline)
     else
-      {:error, :invalid_authorization_context}
+      {:error, _reason} = error -> error
+      false -> {:error, :invalid_authorization_context}
     end
   end
 
   def cancel_authorization(_context, _pending, _opts),
     do: {:error, :invalid_authorization}
+
+  defp terminal_deadline(opts) when is_list(opts) do
+    case Keyword.fetch(opts, :cleanup_deadline) do
+      {:ok, deadline} ->
+        if Deadline.valid?(deadline),
+          do: {:ok, deadline},
+          else: {:error, :invalid_authorization}
+
+      :error ->
+        {:error, :invalid_authorization}
+    end
+  end
+
+  defp terminal_deadline(_opts), do: {:error, :invalid_authorization}
 
   defp complete_callback(
          context,

--- a/lib/ptc_runner/kernel/mcp_oauth/loopback_listener.ex
+++ b/lib/ptc_runner/kernel/mcp_oauth/loopback_listener.ex
@@ -16,7 +16,6 @@ defmodule PtcRunner.Kernel.MCPOAuth.LoopbackListener do
   `:invalid_callback_request`.
   """
 
-  alias PtcRunner.Kernel.Deadline
   alias PtcRunner.Kernel.MCPOAuth.Authority
   alias PtcRunner.Kernel.MCPOAuth.Authorization
   alias PtcRunner.Kernel.MCPOAuth.Context
@@ -102,23 +101,23 @@ defmodule PtcRunner.Kernel.MCPOAuth.LoopbackListener do
 
   # A failed interaction must not leave a live pending authorization behind, so
   # an unsettled cancellation outranks the reason that triggered it rather than
-  # being discarded. Its budget is the lifecycle owner's installed provider
-  # cleanup timeout, anchored here because this is where cleanup begins.
+  # being discarded. Cancellation is the first terminal action here, so it
+  # anchors the lifecycle owner's one cleanup deadline through the supplied
+  # operation and spends that deadline; the session close that follows consumes
+  # what is left of the same one rather than minting the budget again.
   defp cancel_pending(context, pending, opts, error) do
-    with {:ok, timeout_ms} <- cleanup_timeout(opts),
+    with {:ok, deadline} <- anchor_cleanup_deadline(opts),
          :ok <-
-           Authorization.cancel_authorization(context, pending,
-             cleanup_deadline: Deadline.new(timeout_ms)
-           ) do
+           Authorization.cancel_authorization(context, pending, cleanup_deadline: deadline) do
       error
     else
       _unsettled -> {:error, :authorization_cleanup_failed}
     end
   end
 
-  defp cleanup_timeout(opts) do
-    case Keyword.get(opts, :cleanup_timeout_ms) do
-      timeout_ms when is_integer(timeout_ms) and timeout_ms > 0 -> {:ok, timeout_ms}
+  defp anchor_cleanup_deadline(opts) do
+    case Keyword.get(opts, :anchor_cleanup_deadline) do
+      anchor when is_function(anchor, 0) -> anchor.()
       _missing -> :error
     end
   end

--- a/lib/ptc_runner/kernel/mcp_oauth/loopback_listener.ex
+++ b/lib/ptc_runner/kernel/mcp_oauth/loopback_listener.ex
@@ -158,8 +158,9 @@ defmodule PtcRunner.Kernel.MCPOAuth.LoopbackListener do
 
   # `:gen_tcp.recv/3` returns bytes the socket has already buffered even with a
   # zero timeout, so a client that keeps trickling would extend an expired
-  # interaction indefinitely. Expiry is therefore decided before the call
-  # rather than delegated to its timeout.
+  # interaction past its deadline, potentially until the request cap stops it.
+  # Expiry is therefore decided before the call rather than delegated to its
+  # timeout.
   defp receive_chunk(_socket, _accumulator, _deadline_ms, 0),
     do: {:error, :authorization_timeout}
 

--- a/lib/ptc_runner/kernel/mcp_oauth/loopback_listener.ex
+++ b/lib/ptc_runner/kernel/mcp_oauth/loopback_listener.ex
@@ -16,6 +16,7 @@ defmodule PtcRunner.Kernel.MCPOAuth.LoopbackListener do
   `:invalid_callback_request`.
   """
 
+  alias PtcRunner.Kernel.Deadline
   alias PtcRunner.Kernel.MCPOAuth.Authority
   alias PtcRunner.Kernel.MCPOAuth.Authorization
   alias PtcRunner.Kernel.MCPOAuth.Context
@@ -92,13 +93,35 @@ defmodule PtcRunner.Kernel.MCPOAuth.LoopbackListener do
         success
 
       {:error, _reason} = error ->
-        _ = Authorization.cancel_authorization(context, pending, [])
-        error
+        cancel_pending(context, pending, opts, error)
     end
   end
 
   def await(_listener, _context, _pending, _opts),
     do: {:error, :authorization_callback_failed}
+
+  # A failed interaction must not leave a live pending authorization behind, so
+  # an unsettled cancellation outranks the reason that triggered it rather than
+  # being discarded. Its budget is the lifecycle owner's installed provider
+  # cleanup timeout, anchored here because this is where cleanup begins.
+  defp cancel_pending(context, pending, opts, error) do
+    with {:ok, timeout_ms} <- cleanup_timeout(opts),
+         :ok <-
+           Authorization.cancel_authorization(context, pending,
+             cleanup_deadline: Deadline.new(timeout_ms)
+           ) do
+      error
+    else
+      _unsettled -> {:error, :authorization_cleanup_failed}
+    end
+  end
+
+  defp cleanup_timeout(opts) do
+    case Keyword.get(opts, :cleanup_timeout_ms) do
+      timeout_ms when is_integer(timeout_ms) and timeout_ms > 0 -> {:ok, timeout_ms}
+      _missing -> :error
+    end
+  end
 
   defp await_callback(listener, context, pending, opts) do
     case remaining(pending.deadline_ms) do

--- a/lib/ptc_runner/kernel/mcp_oauth/loopback_listener.ex
+++ b/lib/ptc_runner/kernel/mcp_oauth/loopback_listener.ex
@@ -7,6 +7,13 @@ defmodule PtcRunner.Kernel.MCPOAuth.LoopbackListener do
   with one exact `Host` header and no request body. The socket is passive and
   owned by the foreground caller; callback parameters never enter another
   process, Logger, Telemetry, or command-line arguments.
+
+  The pending authorization's deadline is absolute. An interaction that has
+  already expired accepts no connection and reads no bytes, including bytes the
+  socket has already buffered, so a client cannot complete or extend an
+  authorization after its deadline. Expiry at any point reports
+  `:authorization_timeout`; only malformed input or a socket failure reports
+  `:invalid_callback_request`.
   """
 
   alias PtcRunner.Kernel.MCPOAuth.Authority
@@ -145,10 +152,22 @@ defmodule PtcRunner.Kernel.MCPOAuth.LoopbackListener do
         {:ok, accumulator}
 
       true ->
-        case :gen_tcp.recv(socket, 0, remaining(deadline_ms)) do
-          {:ok, chunk} -> receive_request(socket, accumulator <> chunk, deadline_ms)
-          _failure -> {:error, :invalid_callback_request}
-        end
+        receive_chunk(socket, accumulator, deadline_ms, remaining(deadline_ms))
+    end
+  end
+
+  # `:gen_tcp.recv/3` returns bytes the socket has already buffered even with a
+  # zero timeout, so a client that keeps trickling would extend an expired
+  # interaction indefinitely. Expiry is therefore decided before the call
+  # rather than delegated to its timeout.
+  defp receive_chunk(_socket, _accumulator, _deadline_ms, 0),
+    do: {:error, :authorization_timeout}
+
+  defp receive_chunk(socket, accumulator, deadline_ms, timeout_ms) do
+    case :gen_tcp.recv(socket, 0, timeout_ms) do
+      {:ok, chunk} -> receive_request(socket, accumulator <> chunk, deadline_ms)
+      {:error, :timeout} -> {:error, :authorization_timeout}
+      _failure -> {:error, :invalid_callback_request}
     end
   end
 
@@ -271,8 +290,10 @@ defmodule PtcRunner.Kernel.MCPOAuth.LoopbackListener do
     end
   end
 
+  # Zero, not one: an expired interaction must reach the explicit timeout
+  # branches above instead of buying another millisecond of accept or receive.
   defp remaining(deadline_ms),
-    do: max(deadline_ms - System.monotonic_time(:millisecond), 1)
+    do: max(deadline_ms - System.monotonic_time(:millisecond), 0)
 
   defp response(status, reason, body) do
     "HTTP/1.1 #{status} #{reason}\r\n" <>

--- a/lib/ptc_runner/kernel/provider_active_session.ex
+++ b/lib/ptc_runner/kernel/provider_active_session.ex
@@ -3,13 +3,15 @@ defmodule PtcRunner.Kernel.ProviderActiveSession do
   Opens the active provider boundary through selection validation.
 
   The opener first verifies the exact sealed `PreparedRun` and
-  `InstallationCatalog` pair, consumes the prepared run, and monotonically
-  marks provider activity. It then opens the command's `ProviderSession` and
+  `InstallationCatalog` pair — already consumed by the execution-session owner
+  that opens the sinks — and monotonically marks provider activity. It then opens the command's `ProviderSession` and
   admits selected optional provider applications according to the sealed
   runtime services before invoking active selection validators in declaration
-  order. `open_setup/3` and `begin_run/3` expose that boundary in two steps for
-  the Mix-only explicit OAuth interaction: setup admission occurs first, while
-  the ordinary run clock and active validators begin only after interaction.
+  order. `open_consumed_setup/5` and `begin_owned_run/3` expose that boundary in
+  two steps for the Mix-only explicit OAuth interaction: setup admission occurs
+  first, while the ordinary run clock and active validators begin only after
+  interaction. Both halves belong to the execution-session owner, which owns the
+  prepared run; a failure here closes only the session it opened.
 
   Each validator runs in a heap- and time-bounded worker with its own
   provisional `ResourceRegistrar`. The callback receives only the normalized
@@ -18,14 +20,10 @@ defmodule PtcRunner.Kernel.ProviderActiveSession do
   so a validator cannot retain a process or port root. Caller death kills the
   linked worker while the session owner drains its provisional scope.
 
-  Cleanup responsibility differs by entry point. A frontend-owned caller of
-  `open/3` or `open_setup/3` owns both the returned session and the consumed
-  prepared run: it must close the session and then release the prepared run's
-  activity marker, and a failed open performs both operations before returning.
-  An execution-owned caller of `open_consumed_setup/5` supplies a preparation
-  the execution owner already consumed and a lifecycle owner that receives the
-  session, so a failed open closes neither; the execution owner remains
-  responsible for both.
+  Cleanup responsibility is fixed: `open_consumed_setup/5` receives a
+  preparation the execution owner already consumed and a lifecycle owner that
+  receives the session, so a failed open closes only the session it opened. The
+  execution owner remains responsible for the prepared run's activity marker.
   """
 
   alias PtcRunner.Kernel.BoundedWorker
@@ -39,42 +37,6 @@ defmodule PtcRunner.Kernel.ProviderActiveSession do
   alias PtcRunner.Kernel.ProviderRuntimeServices
   alias PtcRunner.Kernel.ProviderSession
   alias PtcRunner.Kernel.ResourceRegistrar
-
-  @spec open(PreparedRun.t(), InstallationCatalog.t(), ProviderRuntimeServices.t()) ::
-          {:ok, ProviderSession.t()} | {:error, CommandDiagnostic.t()}
-  def open(
-        %PreparedRun{} = prepared,
-        %InstallationCatalog{} = catalog,
-        %ProviderRuntimeServices{} = services
-      ) do
-    with {:ok, session} <- open_setup(prepared, catalog, services) do
-      begin_run(session, prepared, catalog)
-    end
-  end
-
-  def open(_prepared, _catalog, _services), do: {:error, internal_diagnostic(false)}
-
-  @doc false
-  @spec open_setup(PreparedRun.t(), InstallationCatalog.t(), ProviderRuntimeServices.t()) ::
-          {:ok, ProviderSession.t()} | {:error, CommandDiagnostic.t()}
-  def open_setup(
-        %PreparedRun{} = prepared,
-        %InstallationCatalog{} = catalog,
-        %ProviderRuntimeServices{} = services
-      ) do
-    with true <- PreparedRun.valid?(prepared),
-         true <- InstallationCatalog.valid?(catalog),
-         true <- prepared.catalog_attestation == catalog.attestation,
-         true <- ProviderRuntimeServices.bound_to?(services, catalog.runtime_binding),
-         true <- prepared.provider_declarations != [],
-         :ok <- PreparedRun.consume(prepared) do
-      open_consumed(prepared, catalog, services)
-    else
-      _invalid -> {:error, internal_diagnostic(false)}
-    end
-  end
-
-  def open_setup(_prepared, _catalog, _services), do: {:error, internal_diagnostic(false)}
 
   @doc false
   @spec open_consumed_setup(
@@ -113,59 +75,33 @@ defmodule PtcRunner.Kernel.ProviderActiveSession do
       do: {:error, internal_diagnostic(false)}
 
   @doc false
-  @spec begin_run(ProviderSession.t(), PreparedRun.t(), InstallationCatalog.t()) ::
-          {:ok, ProviderSession.t()} | {:error, CommandDiagnostic.t()}
-  def begin_run(
-        session,
-        %PreparedRun{} = prepared,
-        %InstallationCatalog{} = catalog
-      ) do
-    if PreparedRun.active_valid?(prepared) and InstallationCatalog.valid?(catalog) and
-         prepared.catalog_attestation == catalog.attestation and
-         ProviderSession.bound_to_operation?(session, prepared.attestation) do
-      do_begin_run(session, prepared, catalog, :frontend_owned)
-    else
-      reject_begin_run(session, prepared, :frontend_owned)
-    end
-  end
-
-  def begin_run(_session, _prepared, _catalog), do: {:error, internal_diagnostic(false)}
-
-  @doc false
   @spec begin_owned_run(ProviderSession.t(), PreparedRun.t(), InstallationCatalog.t()) ::
           {:ok, ProviderSession.t()} | {:error, CommandDiagnostic.t()}
   def begin_owned_run(session, %PreparedRun{} = prepared, %InstallationCatalog{} = catalog) do
     if PreparedRun.active_valid?(prepared) and InstallationCatalog.valid?(catalog) and
          prepared.catalog_attestation == catalog.attestation and
          ProviderSession.bound_to_operation?(session, prepared.attestation) do
-      do_begin_run(session, prepared, catalog, :execution_owned)
+      do_begin_run(session, prepared, catalog)
     else
-      reject_begin_run(session, prepared, :execution_owned)
+      reject_begin_run(session, prepared)
     end
   end
 
   def begin_owned_run(_session, _prepared, _catalog), do: {:error, internal_diagnostic(false)}
 
-  defp open_consumed(prepared, catalog, services) do
-    open_consumed(prepared, catalog, services, :frontend_owned)
-  end
-
   defp open_consumed(prepared, catalog, services, ownership) do
     case ProviderActivity.mark(prepared.provider_activity) do
       :ok -> open_marked(prepared, catalog, services, ownership)
-      {:error, _reason} -> fail_without_session(prepared, internal_diagnostic(false), ownership)
+      {:error, _reason} -> {:error, internal_diagnostic(false)}
     end
   end
 
   defp open_marked(prepared, catalog, services, ownership) do
     case start_session(prepared, ownership) do
-      {:ok, session} -> admit_open_session(session, prepared, catalog, services, ownership)
-      {:error, _reason} -> fail_without_session(prepared, internal_diagnostic(true), ownership)
+      {:ok, session} -> admit_open_session(session, prepared, catalog, services)
+      {:error, _reason} -> {:error, internal_diagnostic(true)}
     end
   end
-
-  defp start_session(prepared, :frontend_owned),
-    do: ProviderSession.start_active(prepared.request.package.limits, prepared.attestation)
 
   defp start_session(prepared, {:owned, lifecycle_owner, handoff}),
     do:
@@ -176,38 +112,41 @@ defmodule PtcRunner.Kernel.ProviderActiveSession do
         handoff
       )
 
-  defp admit_open_session(session, prepared, catalog, services, ownership) do
+  defp admit_open_session(session, prepared, catalog, services) do
     case ProviderApplicationGate.admit(prepared, catalog, services) do
       :ok ->
         {:ok, session}
 
       {:error, %CommandDiagnostic{} = diagnostic} ->
-        fail_with_session(session, prepared, diagnostic, ownership)
+        fail_with_session(session, diagnostic)
     end
   end
 
-  defp do_begin_run(session, prepared, catalog, ownership) do
+  defp do_begin_run(session, prepared, catalog) do
     case ProviderSession.begin_run(session) do
       {:ok, session} ->
-        validate_open_session(session, prepared, catalog, ownership)
+        validate_open_session(session, prepared, catalog)
 
+      # `ProviderSession.begin_run/1` queues token-authenticated cleanup when its
+      # bounded call becomes unavailable. Do not follow that timeout with an
+      # unbounded synchronous close against the same unavailable process.
       {:error, _reason} ->
-        fail_after_unavailable_session(prepared, internal_diagnostic(true), ownership)
+        {:error, internal_diagnostic(true)}
     end
   end
 
-  defp validate_open_session(session, prepared, catalog, ownership) do
+  defp validate_open_session(session, prepared, catalog) do
     case validate_active_selections(session, prepared, catalog) do
       :ok ->
         {:ok, session}
 
       {:error, %CommandDiagnostic{} = diagnostic} ->
-        fail_with_session(session, prepared, diagnostic, ownership)
+        fail_with_session(session, diagnostic)
     end
   rescue
-    _exception -> fail_with_session(session, prepared, internal_diagnostic(true), ownership)
+    _exception -> fail_with_session(session, internal_diagnostic(true))
   catch
-    _kind, _reason -> fail_with_session(session, prepared, internal_diagnostic(true), ownership)
+    _kind, _reason -> fail_with_session(session, internal_diagnostic(true))
   end
 
   defp validate_active_selections(session, prepared, catalog) do
@@ -311,40 +250,26 @@ defmodule PtcRunner.Kernel.ProviderActiveSession do
     end
   end
 
-  defp fail_with_session(session, prepared, diagnostic, ownership) do
+  # The prepared run belongs to the execution owner, so a failure here closes
+  # only the session it opened and leaves that run for its owner to release.
+  defp fail_with_session(session, diagnostic) do
     cleanup = ProviderSession.close(session)
-    maybe_close_prepared(prepared, ownership)
 
     if cleanup == :ok,
       do: {:error, diagnostic},
       else: {:error, cleanup_diagnostic()}
   end
 
-  defp fail_without_session(prepared, diagnostic, ownership) do
-    maybe_close_prepared(prepared, ownership)
-    {:error, diagnostic}
-  end
-
-  defp reject_begin_run(session, prepared, ownership) do
+  defp reject_begin_run(session, prepared) do
     diagnostic = internal_diagnostic(ProviderSession.alive?(session))
 
     if PreparedRun.active_valid?(prepared) and
          ProviderSession.bound_to_operation?(session, prepared.attestation) do
-      fail_with_session(session, prepared, diagnostic, ownership)
+      fail_with_session(session, diagnostic)
     else
       {:error, diagnostic}
     end
   end
-
-  # `ProviderSession.begin_run/1` queues token-authenticated cleanup when its
-  # bounded call becomes unavailable. Do not follow that timeout with an
-  # unbounded synchronous close against the same unavailable process.
-  defp fail_after_unavailable_session(prepared, diagnostic, ownership),
-    do: fail_without_session(prepared, diagnostic, ownership)
-
-  defp maybe_close_prepared(prepared, :frontend_owned), do: PreparedRun.close(prepared)
-  defp maybe_close_prepared(_prepared, {:owned, _lifecycle_owner, _handoff}), do: :ok
-  defp maybe_close_prepared(_prepared, :execution_owned), do: :ok
 
   defp selection_diagnostic(declaration, code) do
     occurrence = %{destination: declaration.destination, index: declaration.index}

--- a/lib/ptc_runner/kernel/provider_descriptor.ex
+++ b/lib/ptc_runner/kernel/provider_descriptor.ex
@@ -45,6 +45,10 @@ defmodule PtcRunner.Kernel.ProviderDescriptor do
           | :ptc_trace_snapshot
           | :ptc_inspection_snapshot
           | :custom
+  @type data_policy :: %{
+          data_class: :normal | :private_inspection,
+          accepts_data: [:normal | :private_inspection]
+        }
   @type t :: %__MODULE__{
           source: source(),
           installation_revision: binary(),
@@ -106,6 +110,17 @@ defmodule PtcRunner.Kernel.ProviderDescriptor do
         Attestation.valid?(__MODULE__, payload(descriptor), attestation)
 
   def valid?(_descriptor), do: false
+
+  @spec data_policy(t()) :: data_policy()
+  @doc """
+  Projects the declared data policy a run-bound builder must honor.
+
+  Run-bound registries carry only this projection. A complete descriptor also
+  holds selection rules, which are bounded but large enough that copying them
+  into every provider worker would compete with the provider heap limit.
+  """
+  def data_policy(%__MODULE__{} = descriptor),
+    do: %{data_class: descriptor.data_class, accepts_data: descriptor.accepts_data}
 
   @spec public_projection(t(), binary(), map()) :: map()
   @doc "Projects only selector-safe declaration identity for one occurrence."

--- a/lib/ptc_runner/kernel/provider_execution.ex
+++ b/lib/ptc_runner/kernel/provider_execution.ex
@@ -265,7 +265,8 @@ defmodule PtcRunner.Kernel.ProviderExecution do
                    authorities,
                    execution.authorizations,
                    notifier,
-                   tracker
+                   tracker,
+                   session
                  )
                  |> authorization_result(selected_names, execution.catalog),
                {:ok, session} <-
@@ -548,7 +549,8 @@ defmodule PtcRunner.Kernel.ProviderExecution do
          authorities,
          requested,
          notifier,
-         tracker
+         tracker,
+         session
        ) do
     Enum.reduce_while(requested, :ok, fn name, :ok ->
       authority = Map.get(authorities, name)
@@ -573,7 +575,8 @@ defmodule PtcRunner.Kernel.ProviderExecution do
                  authority_epoch,
                  deadline,
                  notifier,
-                 tracker
+                 tracker,
+                 session
                ) do
           :ok
         else
@@ -601,7 +604,15 @@ defmodule PtcRunner.Kernel.ProviderExecution do
     end)
   end
 
-  defp authorize_installation(context, authority, authority_epoch, deadline, notifier, tracker) do
+  defp authorize_installation(
+         context,
+         authority,
+         authority_epoch,
+         deadline,
+         notifier,
+         tracker,
+         session
+       ) do
     with true <- Authority.cli_compatible?(authority),
          {:ok, listener} <- LoopbackListener.start(authority),
          :ok <- tracker.(:put, :listener, listener) do
@@ -612,7 +623,8 @@ defmodule PtcRunner.Kernel.ProviderExecution do
           authority_epoch,
           deadline,
           listener,
-          notifier
+          notifier,
+          session
         )
       after
         LoopbackListener.close(listener)
@@ -630,7 +642,8 @@ defmodule PtcRunner.Kernel.ProviderExecution do
          authority_epoch,
          deadline,
          listener,
-         notifier
+         notifier,
+         session
        ) do
     case Authorization.begin_authorization(context, authority,
            authority_epoch: authority_epoch,
@@ -640,18 +653,33 @@ defmodule PtcRunner.Kernel.ProviderExecution do
       {:ok, pending} ->
         case notify(notifier, pending.url, deadline) do
           :ok ->
-            case LoopbackListener.await(listener, context, pending, []) do
+            case LoopbackListener.await(listener, context, pending, cleanup_opts(session)) do
               {:ok, _grant} -> :ok
               {:error, _reason} = error -> error
             end
 
           {:error, _reason} = error ->
-            _ = Authorization.cancel_authorization(context, pending, [])
-            error
+            cancel_pending(context, pending, session, error)
         end
 
       {:error, _reason} = error ->
         error
+    end
+  end
+
+  # Terminal cleanup spends the lifecycle owner's installed provider cleanup
+  # budget, not whatever remained of the interaction being cleaned up.
+  defp cleanup_opts(session),
+    do: [cleanup_timeout_ms: ProviderSession.cleanup_timeout(session)]
+
+  defp cancel_pending(context, pending, session, error) do
+    case Authorization.cancel_authorization(
+           context,
+           pending,
+           cleanup_deadline: Deadline.new(ProviderSession.cleanup_timeout(session))
+         ) do
+      :ok -> error
+      {:error, _reason} -> {:error, :authorization_cleanup_failed}
     end
   end
 

--- a/lib/ptc_runner/kernel/provider_execution.ex
+++ b/lib/ptc_runner/kernel/provider_execution.ex
@@ -667,19 +667,21 @@ defmodule PtcRunner.Kernel.ProviderExecution do
     end
   end
 
-  # Terminal cleanup spends the lifecycle owner's installed provider cleanup
-  # budget, not whatever remained of the interaction being cleaned up.
+  # Terminal cleanup spends the one budget the lifecycle owner installed, and
+  # the session anchors it when cleanup actually begins. Anchoring lazily is the
+  # point: the interaction this accompanies may run for its whole authorization
+  # timeout before anything fails, and an eagerly anchored deadline would
+  # already be spent by then.
   defp cleanup_opts(session),
-    do: [cleanup_timeout_ms: ProviderSession.cleanup_timeout(session)]
+    do: [anchor_cleanup_deadline: fn -> ProviderSession.anchor_cleanup_deadline(session) end]
 
   defp cancel_pending(context, pending, session, error) do
-    case Authorization.cancel_authorization(
-           context,
-           pending,
-           cleanup_deadline: Deadline.new(ProviderSession.cleanup_timeout(session))
-         ) do
-      :ok -> error
-      {:error, _reason} -> {:error, :authorization_cleanup_failed}
+    with {:ok, deadline} <- ProviderSession.anchor_cleanup_deadline(session),
+         :ok <-
+           Authorization.cancel_authorization(context, pending, cleanup_deadline: deadline) do
+      error
+    else
+      _unsettled -> {:error, :authorization_cleanup_failed}
     end
   end
 

--- a/lib/ptc_runner/kernel/provider_execution.ex
+++ b/lib/ptc_runner/kernel/provider_execution.ex
@@ -91,8 +91,10 @@ defmodule PtcRunner.Kernel.ProviderExecution do
           t(),
           (binary() -> term()),
           tracker(),
-          pid()
-        ) :: {:ok, PtcRunner.Kernel.ExecutionOutcome.t()} | {:error, term()}
+          pid(),
+          :run | :check
+        ) ::
+          {:ok, PtcRunner.Kernel.ExecutionOutcome.t() | [map()]} | {:error, term()}
   def execute(
         %PreparedRun{} = prepared,
         authority,
@@ -100,9 +102,11 @@ defmodule PtcRunner.Kernel.ProviderExecution do
         %__MODULE__{} = execution,
         notifier,
         tracker,
-        lifecycle_owner
+        lifecycle_owner,
+        operation
       )
-      when is_function(notifier, 1) and is_function(tracker, 3) and is_pid(lifecycle_owner) do
+      when is_function(notifier, 1) and is_function(tracker, 3) and is_pid(lifecycle_owner) and
+             operation in [:run, :check] do
     with true <- valid?(execution),
          true <- PreparedRun.consumed_valid?(prepared),
          true <- PublicationAuthority.valid?(authority),
@@ -122,7 +126,8 @@ defmodule PtcRunner.Kernel.ProviderExecution do
         execution,
         notifier,
         tracker,
-        session
+        session,
+        operation
       )
     else
       false -> {:error, :invalid_provider_execution}
@@ -141,7 +146,8 @@ defmodule PtcRunner.Kernel.ProviderExecution do
         _execution,
         _notifier,
         _tracker,
-        _lifecycle_owner
+        _lifecycle_owner,
+        _operation
       ),
       do: {:error, :invalid_provider_execution}
 
@@ -152,7 +158,8 @@ defmodule PtcRunner.Kernel.ProviderExecution do
          execution,
          notifier,
          tracker,
-         session
+         session,
+         operation
        ) do
     result =
       if execution.authorizations == [] do
@@ -162,7 +169,8 @@ defmodule PtcRunner.Kernel.ProviderExecution do
           opened_sinks,
           execution,
           tracker,
-          session
+          session,
+          operation
         )
       else
         execute_after_authorization(
@@ -172,7 +180,8 @@ defmodule PtcRunner.Kernel.ProviderExecution do
           execution,
           notifier,
           tracker,
-          session
+          session,
+          operation
         )
       end
 
@@ -193,7 +202,7 @@ defmodule PtcRunner.Kernel.ProviderExecution do
     end
   end
 
-  defp execute_ordinary(prepared, authority, opened_sinks, execution, tracker, session) do
+  defp execute_ordinary(prepared, authority, opened_sinks, execution, tracker, session, operation) do
     selected_names = selected_provider_names(prepared)
 
     with {:ok, session} <-
@@ -214,7 +223,7 @@ defmodule PtcRunner.Kernel.ProviderExecution do
         tracker,
         :run,
         fn registry ->
-          build_and_execute(prepared, authority, opened_sinks, registry, session)
+          build_and_complete(prepared, authority, opened_sinks, registry, session, operation)
         end
       )
     end
@@ -227,7 +236,8 @@ defmodule PtcRunner.Kernel.ProviderExecution do
          execution,
          notifier,
          tracker,
-         session
+         session,
+         operation
        ) do
     selected_names = selected_provider_names(prepared)
 
@@ -260,7 +270,7 @@ defmodule PtcRunner.Kernel.ProviderExecution do
                  |> authorization_result(selected_names, execution.catalog),
                {:ok, session} <-
                  ProviderActiveSession.begin_owned_run(session, prepared, execution.catalog) do
-            build_and_execute(prepared, authority, opened_sinks, registry, session)
+            build_and_complete(prepared, authority, opened_sinks, registry, session, operation)
           end
         end
       )
@@ -270,7 +280,11 @@ defmodule PtcRunner.Kernel.ProviderExecution do
     end
   end
 
-  defp build_and_execute(prepared, authority, opened_sinks, registry, session) do
+  # Every step above this one is shared by a run and a check: the same activity
+  # marker, session, registry, credentials, OAuth, acquisition, and cleanup
+  # ownership. Only the completion differs, so a check cannot drift into its own
+  # provider lifecycle.
+  defp build_and_complete(prepared, authority, opened_sinks, registry, session, operation) do
     with {:ok, built} <-
            RunBuilder.build_active_owned(
              prepared,
@@ -279,9 +293,12 @@ defmodule PtcRunner.Kernel.ProviderExecution do
              authority,
              opened_sinks
            ) do
-      RunBuilder.execute_built(built)
+      complete_operation(built, operation)
     end
   end
+
+  defp complete_operation(built, :run), do: RunBuilder.execute_built(built)
+  defp complete_operation(built, :check), do: RunBuilder.check_built(built)
 
   defp with_runtime_registry(
          execution,

--- a/lib/ptc_runner/kernel/provider_execution.ex
+++ b/lib/ptc_runner/kernel/provider_execution.ex
@@ -299,7 +299,16 @@ defmodule PtcRunner.Kernel.ProviderExecution do
   end
 
   defp complete_operation(built, :run), do: RunBuilder.execute_built(built)
-  defp complete_operation(built, :check), do: RunBuilder.check_built(built)
+
+  # A check closes its own provider session inside this runtime, exactly where a
+  # run closes its own, so its cleanup failure is classified here rather than
+  # reaching the owner as a bare reason after the session is already gone.
+  defp complete_operation(built, :check) do
+    case RunBuilder.check_built(built) do
+      {:error, :provider_cleanup_failed} -> {:error, cleanup_diagnostic()}
+      result -> result
+    end
+  end
 
   defp with_runtime_registry(
          execution,

--- a/lib/ptc_runner/kernel/provider_execution.ex
+++ b/lib/ptc_runner/kernel/provider_execution.ex
@@ -1,7 +1,6 @@
 defmodule PtcRunner.Kernel.ProviderExecution do
   @moduledoc false
 
-  alias PtcRunner.Dotenv
   alias PtcRunner.Kernel.Attestation
   alias PtcRunner.Kernel.BoundedWorker
   alias PtcRunner.Kernel.CommandDiagnostic
@@ -199,7 +198,6 @@ defmodule PtcRunner.Kernel.ProviderExecution do
 
     with {:ok, session} <-
            ProviderActiveSession.begin_owned_run(session, prepared, execution.catalog),
-         :ok <- maybe_load_dotenv(execution.services, selected_names),
          {:ok, authorities} <- oauth_authorities(execution, selected_names),
          deadline <-
            oauth_operation_deadline(
@@ -233,8 +231,7 @@ defmodule PtcRunner.Kernel.ProviderExecution do
        ) do
     selected_names = selected_provider_names(prepared)
 
-    with :ok <- maybe_load_dotenv(execution.services, selected_names),
-         {:ok, authorities} <- oauth_authorities(execution, selected_names),
+    with {:ok, authorities} <- oauth_authorities(execution, selected_names),
          deadline when not is_nil(deadline) <-
            oauth_setup_deadline(
              prepared.provider_declarations,
@@ -418,14 +415,6 @@ defmodule PtcRunner.Kernel.ProviderExecution do
 
   defp registry_result({:error, _reason} = error, _operation, _selected_names, _catalog),
     do: error
-
-  defp maybe_load_dotenv(services, selected_names) do
-    case ProviderRuntimeServices.dotenv_required?(services, selected_names) do
-      {:ok, true} -> Dotenv.load()
-      {:ok, false} -> :ok
-      {:error, _reason} -> {:error, :invalid_provider_execution}
-    end
-  end
 
   defp oauth_authorities(execution, selected_names) do
     with {:ok, authorities} <-

--- a/lib/ptc_runner/kernel/provider_registry.ex
+++ b/lib/ptc_runner/kernel/provider_registry.ex
@@ -23,6 +23,14 @@ defmodule PtcRunner.Kernel.ProviderRegistry do
   Preparation also freezes
   the provider's `data_class` and `accepts_data` policy so run assembly can
   reject an incompatible information flow before preflight or credentials.
+  A builder bound to the data policy declared by its sealed
+  `PtcRunner.Kernel.ProviderDescriptor` cannot contradict it: preparation
+  returning a different `data_class` or set of accepted classes than phase 5
+  admitted, and than sink authorization used, fails with
+  `:provider_declaration_mismatch` before preflight, credentials, or
+  acquisition. Explicit embedding builders registered without a declared policy
+  have no such declaration, so their preparation remains authoritative for
+  them.
   A staged provider may additionally require or provide a bounded, code-owned
   acquisition service. Services pass opaque values only between selected
   trusted providers after the barrier; they never enter Lisp environments,
@@ -74,6 +82,7 @@ defmodule PtcRunner.Kernel.ProviderRegistry do
   alias PtcRunner.Kernel.HostInstallationAuthority
   alias PtcRunner.Kernel.JSONValue
   alias PtcRunner.Kernel.Limits
+  alias PtcRunner.Kernel.ProviderDescriptor
   alias PtcRunner.Kernel.ResourceRegistrar
 
   @application_content_digest ~r/\A[0-9a-f]{64}\z/
@@ -158,7 +167,7 @@ defmodule PtcRunner.Kernel.ProviderRegistry do
   @type staged_builder ::
           {:staged,
            (map(), context() ->
-              {:ok, prepared()} | {:error, term()})}
+              {:ok, prepared()} | {:error, term()}), ProviderDescriptor.data_policy() | nil}
   @type registry_builder :: builder() | staged_builder()
   @type credential_resolver ::
           ([binary()] -> {:ok, credential_values()} | {:error, term()})
@@ -254,18 +263,28 @@ defmodule PtcRunner.Kernel.ProviderRegistry do
   def oauth_authority_epoch(_registry, _name, _deadline),
     do: {:error, :authorization_context_required}
 
-  @spec staged((map(), context() -> {:ok, prepared()} | {:error, term()})) ::
-          staged_builder()
+  @spec staged(
+          (map(), context() -> {:ok, prepared()} | {:error, term()}),
+          ProviderDescriptor.data_policy() | nil
+        ) :: staged_builder()
   @doc """
-  Marks a trusted builder as staged.
+  Marks a trusted builder as staged, optionally bound to its declared policy.
 
   The preparation callback must be side-effect free. Its returned preflight
   callback may perform only non-secret local checks; the acquire callback is
   the first phase allowed to use resolved credentials or open a provider.
   Optional `:data_class` and `:accepts_data` fields default to normal-only and
-  must exactly match the acquired build.
+  must exactly match the acquired build. A builder bound to a declared policy
+  must also prepare exactly that policy; an installed catalog projects one from
+  the sealed descriptor of every builder it selects.
   """
-  def staged(prepare) when is_function(prepare, 2), do: {:staged, prepare}
+  def staged(prepare, declared_policy \\ nil)
+
+  def staged(prepare, nil) when is_function(prepare, 2), do: {:staged, prepare, nil}
+
+  def staged(prepare, %{data_class: _class, accepts_data: _accepts} = declared_policy)
+      when is_function(prepare, 2),
+      do: {:staged, prepare, declared_policy}
 
   @spec build(t(), binary(), map(), build_context()) ::
           {:ok, built_provider()} | {:error, term()}
@@ -307,12 +326,13 @@ defmodule PtcRunner.Kernel.ProviderRegistry do
 
   defp prepare_builder(builders, name, config, context) do
     case Map.fetch(builders, name) do
-      {:ok, {:staged, prepare}} ->
+      {:ok, {:staged, prepare, declared_policy}} ->
         invoke(
           fn -> prepare.(config, Map.put(context, :provider, name)) end,
           :provider_prepare_failed
         )
         |> normalize_prepared()
+        |> declared_policy_honored(declared_policy)
 
       {:ok, builder} when is_function(builder, 2) ->
         full_context = Map.put(context, :provider, name)
@@ -501,6 +521,28 @@ defmodule PtcRunner.Kernel.ProviderRegistry do
   defp normalize_prepared({:error, _reason} = error), do: error
   defp normalize_prepared(_result), do: {:error, :invalid_provider_preparation}
 
+  # Checked after normalization so an omitted field is compared as the
+  # normal-only default it becomes, not as an absent value. `accepts_data` is a
+  # set of admitted classes; the declaration keeps it in canonical order and a
+  # preparation need not.
+  defp declared_policy_honored(result, nil), do: result
+
+  defp declared_policy_honored({:ok, prepared}, %{data_class: class, accepts_data: accepts})
+       when is_list(accepts) do
+    if prepared.data_class == class and
+         MapSet.new(prepared.accepts_data) == MapSet.new(accepts),
+       do: {:ok, prepared},
+       else: {:error, :provider_declaration_mismatch}
+  end
+
+  defp declared_policy_honored({:error, _reason} = error, _declared_policy), do: error
+
+  # A bound builder whose declared policy is not that projection cannot be
+  # honored at all, so its preparation is refused rather than admitted
+  # unchecked.
+  defp declared_policy_honored(_result, _declared_policy),
+    do: {:error, :provider_declaration_mismatch}
+
   defp normalize_preflight({:ok, acquire}, data_class, accepts_data, requires, provides)
        when is_function(acquire, 1) and requires == [] do
     {:ok,
@@ -665,11 +707,16 @@ defmodule PtcRunner.Kernel.ProviderRegistry do
   defp default_credential_resolver(_names), do: {:error, :credential_resolver_missing}
 
   defp valid_builder?(builder) when is_function(builder, 2), do: true
-  defp valid_builder?({:staged, prepare}) when is_function(prepare, 2), do: true
+  defp valid_builder?({:staged, prepare, nil}) when is_function(prepare, 2), do: true
+
+  defp valid_builder?({:staged, prepare, %{data_class: class, accepts_data: accepts} = policy})
+       when is_function(prepare, 2) and map_size(policy) == 2,
+       do: valid_data_policy?(class, accepts)
+
   defp valid_builder?(_builder), do: false
 
   defp valid_data_policy?(data_class, accepts_data) do
-    data_class in [:normal, :private_inspection] and
+    data_class in [:normal, :private_inspection] and is_list(accepts_data) and
       accepts_data != [] and accepts_data == Enum.uniq(accepts_data) and
       Enum.all?(accepts_data, &(&1 in [:normal, :private_inspection]))
   end

--- a/lib/ptc_runner/kernel/provider_runtime_services.ex
+++ b/lib/ptc_runner/kernel/provider_runtime_services.ex
@@ -308,24 +308,6 @@ defmodule PtcRunner.Kernel.ProviderRuntimeServices do
   def oauth_authorities(_services, _selected_names),
     do: {:error, :invalid_provider_runtime_services}
 
-  @doc false
-  @spec dotenv_required?(t(), [binary()]) :: {:ok, boolean()} | {:error, term()}
-  def dotenv_required?(%__MODULE__{host_payload: nil} = services, selected_names)
-      when is_list(selected_names) do
-    if valid?(services), do: {:ok, false}, else: {:error, :invalid_provider_runtime_services}
-  end
-
-  def dotenv_required?(%__MODULE__{} = services, selected_names) when is_list(selected_names) do
-    if valid?(services) do
-      HostRuntimePayload.dotenv_required?(services.host_payload, selected_names)
-    else
-      {:error, :invalid_provider_runtime_services}
-    end
-  end
-
-  def dotenv_required?(_services, _selected_names),
-    do: {:error, :invalid_provider_runtime_services}
-
   defp unique_allowed_options?(opts) do
     keys = Keyword.keys(opts)
 

--- a/lib/ptc_runner/kernel/provider_session.ex
+++ b/lib/ptc_runner/kernel/provider_session.ex
@@ -9,8 +9,11 @@ defmodule PtcRunner.Kernel.ProviderSession do
   claims the operation before provider acquisition, so neither another prepared
   run nor a replay can share its cleanup boundary. Before provider
   callbacks can start, execution binds the session exactly once to its lifecycle
-  owner and run state. The session then tracks every provider task itself, so
-  owner or run-state death drains live tasks before any provider closer runs.
+  owner and to the run's one provider-task owner. That task owner is an
+  internal process outside both lifecycles and monitors the session in return,
+  so live tasks are drained before any provider closer runs and are killed
+  outright when the session or the run state disappears, including when the
+  session is terminated at its cleanup deadline and `terminate/2` never runs.
   Each scope starts provisional, activates immediately before acquisition, and
   is either committed with one provider close operation or aborted. Normal
   close and lifecycle-owner death drain committed scopes in reverse commit
@@ -44,6 +47,7 @@ defmodule PtcRunner.Kernel.ProviderSession do
   alias PtcRunner.Kernel.Deadline
   alias PtcRunner.Kernel.Limits
   alias PtcRunner.Kernel.ProviderScopeOwner
+  alias PtcRunner.Kernel.ProviderTaskTracker
   alias PtcRunner.Kernel.ResourceRegistrar
 
   @enforce_keys [
@@ -412,15 +416,15 @@ defmodule PtcRunner.Kernel.ProviderSession do
   def close_with_unregistered(_session, _close), do: {:error, :provider_cleanup_failed}
 
   @doc false
-  @spec bind_lifecycle(t(), pid(), pid()) ::
+  @spec bind_lifecycle(t(), pid(), pid(), ProviderTaskTracker.t()) ::
           :ok | {:error, :provider_session_unavailable}
-  def bind_lifecycle(%__MODULE__{} = session, owner, run_state)
+  def bind_lifecycle(%__MODULE__{} = session, owner, run_state, %ProviderTaskTracker{} = tracker)
       when is_pid(owner) and is_pid(run_state) do
     if valid?(session) and
          (not session.fixed_lifecycle? or owner == session.creator) do
       call(
         session.pid,
-        {session.token, {:bind_lifecycle, owner, run_state}},
+        {session.token, {:bind_lifecycle, owner, run_state, tracker}},
         5_000,
         {:error, :provider_session_unavailable}
       )
@@ -429,37 +433,8 @@ defmodule PtcRunner.Kernel.ProviderSession do
     end
   end
 
-  def bind_lifecycle(_session, _owner, _run_state),
+  def bind_lifecycle(_session, _owner, _run_state, _tracker),
     do: {:error, :provider_session_unavailable}
-
-  @doc false
-  @spec attach_provider(t(), pid()) :: :ok | {:error, :closed | :provider_down}
-  def attach_provider(%__MODULE__{} = session, provider) when is_pid(provider) do
-    if valid?(session) do
-      call(
-        session.pid,
-        {session.token, {:attach_provider, provider}},
-        :infinity,
-        {:error, :closed}
-      )
-    else
-      {:error, :closed}
-    end
-  end
-
-  @doc false
-  @spec drain_provider_tasks(t()) :: :ok
-  def drain_provider_tasks(%__MODULE__{} = session) do
-    if valid?(session) do
-      # A pre-close courtesy, not cleanup: it answers from session state or the
-      # session is wedged, and `close/1` owns the terminal budget either way.
-      call(session.pid, {session.token, :drain_provider_tasks}, @claim_reply_grace_ms, :ok)
-    else
-      :ok
-    end
-  end
-
-  def drain_provider_tasks(_session), do: :ok
 
   @doc false
   def activate_registrar(%ResourceRegistrar{} = registrar),
@@ -541,9 +516,7 @@ defmodule PtcRunner.Kernel.ProviderSession do
        cleanup_deadline: nil,
        max_heap_words: limits.provider_heap_words,
        lifecycle_bound?: false,
-       run_state: nil,
-       run_state_monitor: nil,
-       providers: %{},
+       provider_tasks: nil,
        pending_registrations: %{},
        scopes: %{},
        scope_order: [],
@@ -767,8 +740,10 @@ defmodule PtcRunner.Kernel.ProviderSession do
     end
   end
 
+  # The task owner monitors the session in return, so it can kill this run's
+  # callbacks even when the session ends without running `terminate/2`.
   def handle_call(
-        {token, {:bind_lifecycle, owner, run_state}},
+        {token, {:bind_lifecycle, owner, run_state, tracker}},
         {executor, _tag},
         %{
           token: token,
@@ -778,26 +753,23 @@ defmodule PtcRunner.Kernel.ProviderSession do
         } = state
       )
       when is_pid(owner) and is_pid(run_state) do
-    if owner == executor and Process.alive?(state.owner) and Process.alive?(run_state) do
-      {:reply, :ok,
-       %{
-         state
-         | lifecycle_bound?: true,
-           run_state: run_state,
-           run_state_monitor: Process.monitor(run_state)
-       }}
+    with true <-
+           owner == executor and Process.alive?(state.owner) and Process.alive?(run_state),
+         :ok <- ProviderTaskTracker.watch(tracker, self()) do
+      {:reply, :ok, %{state | lifecycle_bound?: true, provider_tasks: tracker}}
     else
-      {:reply, {:error, :provider_session_unavailable}, state}
+      _unavailable -> {:reply, {:error, :provider_session_unavailable}, state}
     end
   end
 
   def handle_call(
-        {token, {:bind_lifecycle, owner, run_state}},
+        {token, {:bind_lifecycle, owner, run_state, tracker}},
         _from,
         %{token: token, lifecycle_fixed?: false, lifecycle_bound?: false} = state
       )
       when is_pid(owner) and is_pid(run_state) do
-    if Process.alive?(owner) and Process.alive?(run_state) do
+    with true <- Process.alive?(owner) and Process.alive?(run_state),
+         :ok <- ProviderTaskTracker.watch(tracker, self()) do
       Process.demonitor(state.owner_monitor, [:flush])
 
       {:reply, :ok,
@@ -806,30 +778,11 @@ defmodule PtcRunner.Kernel.ProviderSession do
          | owner: owner,
            owner_monitor: Process.monitor(owner),
            lifecycle_bound?: true,
-           run_state: run_state,
-           run_state_monitor: Process.monitor(run_state)
+           provider_tasks: tracker
        }}
     else
-      {:reply, {:error, :provider_session_unavailable}, state}
+      _unavailable -> {:reply, {:error, :provider_session_unavailable}, state}
     end
-  end
-
-  def handle_call(
-        {token, {:attach_provider, provider}},
-        _from,
-        %{token: token, lifecycle_bound?: true} = state
-      )
-      when is_pid(provider) do
-    if Process.alive?(provider) do
-      monitor = Process.monitor(provider)
-      {:reply, :ok, %{state | providers: Map.put(state.providers, monitor, provider)}}
-    else
-      {:reply, {:error, :provider_down}, state}
-    end
-  end
-
-  def handle_call({token, :drain_provider_tasks}, _from, state) when token == state.token do
-    {:reply, :ok, drain_provider_tasks_state(state)}
   end
 
   def handle_call({token, {:close_with_unregistered, close}}, _from, state)
@@ -837,7 +790,7 @@ defmodule PtcRunner.Kernel.ProviderSession do
     state =
       state
       |> reject_pending_registrations()
-      |> drain_provider_tasks_state()
+      |> drain_provider_tasks()
       |> add_committed_close(close)
 
     {result, state} = drain(state)
@@ -845,7 +798,7 @@ defmodule PtcRunner.Kernel.ProviderSession do
   end
 
   def handle_call({token, :close}, _from, state) when token == state.token do
-    state = state |> reject_pending_registrations() |> drain_provider_tasks_state()
+    state = state |> reject_pending_registrations() |> drain_provider_tasks()
     {result, state} = drain(state)
     {:stop, :normal, result, state}
   end
@@ -871,21 +824,9 @@ defmodule PtcRunner.Kernel.ProviderSession do
         {:DOWN, monitor, :process, owner, _reason},
         %{owner_monitor: monitor, owner: owner} = state
       ) do
-    state = state |> reject_pending_registrations() |> drain_provider_tasks_state()
+    state = state |> reject_pending_registrations() |> drain_provider_tasks()
     {_result, state} = drain(state)
     {:stop, :normal, state}
-  end
-
-  def handle_info(
-        {:DOWN, monitor, :process, run_state, _reason},
-        %{run_state_monitor: monitor, run_state: run_state} = state
-      ) do
-    state = drain_provider_tasks_state(state)
-    {:noreply, %{state | run_state: nil, run_state_monitor: nil}}
-  end
-
-  def handle_info({:DOWN, monitor, :process, _provider, _reason}, state) do
-    {:noreply, %{state | providers: Map.delete(state.providers, monitor)}}
   end
 
   def handle_info(
@@ -938,24 +879,19 @@ defmodule PtcRunner.Kernel.ProviderSession do
 
   @impl GenServer
   def terminate(_reason, state) do
-    state = state |> reject_pending_registrations() |> drain_provider_tasks_state()
+    state = state |> reject_pending_registrations() |> drain_provider_tasks()
     {_result, _state} = drain(state)
     :ok
   end
 
-  defp drain_provider_tasks_state(%{providers: providers} = state) do
-    Enum.each(providers, fn {_monitor, provider} -> Process.exit(provider, :kill) end)
-    drain_provider_monitors(providers)
-    %{state | providers: %{}}
-  end
-
-  defp drain_provider_monitors(providers) when map_size(providers) == 0, do: :ok
-
-  defp drain_provider_monitors(providers) do
-    receive do
-      {:DOWN, monitor, :process, _provider, _reason} when is_map_key(providers, monitor) ->
-        drain_provider_monitors(Map.delete(providers, monitor))
-    end
+  # No provider callback from this run may still be live when a connector
+  # closes. The task owner is a separate process that runs no provider code and
+  # reaps each kill it issues, so this call settles; a session that is wedged
+  # long enough to be terminated instead has that owner kill the same tasks
+  # when it observes the session's death.
+  defp drain_provider_tasks(state) do
+    :ok = ProviderTaskTracker.drain_provider_tasks(state.provider_tasks)
+    state
   end
 
   defp abort_scope(scope, state) do

--- a/lib/ptc_runner/kernel/provider_session.ex
+++ b/lib/ptc_runner/kernel/provider_session.ex
@@ -36,13 +36,17 @@ defmodule PtcRunner.Kernel.ProviderSession do
   absolute cleanup deadline; an OAuth cancellation and the reverse-order
   cleanup that follows it each consume what remains of that one deadline, and
   every close operation runs in a heap-bounded worker inside it. That budget
-  also bounds the caller: `close/1` waits one reply grace beyond it and then
-  terminates a session that has not answered, so a wedged session becomes a
-  classified cleanup failure rather than an unbounded wait. Aborting one
-  acquisition scope mid-run is not part of that episode and keeps its own
-  bounded budget. Failures never stop later cleanup attempts. This is a
-  process-local ownership boundary, not a durable resource journal or a
-  security boundary against trusted code in the same VM.
+  also bounds the caller: `close/1` waits one reply grace beyond what remains of
+  that deadline and then terminates a session that has not answered, so a wedged
+  session becomes a classified cleanup failure rather than an unbounded wait and
+  never a second budget. That deadline bounds this session's own cleanup, not
+  the last root's exit: terminating a wedged session ends the caller's wait, and
+  its scope reapers then observe that death and force their registered roots
+  within their own separately bounded tail. Aborting one acquisition scope
+  mid-run is likewise not part of the episode and keeps its own bounded budget.
+  Failures never stop later cleanup attempts. This is a process-local ownership
+  boundary, not a durable resource journal or a security boundary against
+  trusted code in the same VM.
   """
 
   use GenServer
@@ -318,18 +322,38 @@ defmodule PtcRunner.Kernel.ProviderSession do
           {:ok, Deadline.t()} | {:error, :provider_cleanup_failed}
   def anchor_cleanup_deadline(%__MODULE__{} = session) do
     if valid?(session) do
-      call(
-        session.pid,
-        {session.token, :anchor_cleanup_deadline},
-        @claim_timeout_ms,
-        {:error, :provider_cleanup_failed}
-      )
+      anchor_cleanup_deadline(session, session.cleanup_timeout_ms + @claim_reply_grace_ms)
     else
       {:error, :provider_cleanup_failed}
     end
   end
 
   def anchor_cleanup_deadline(_session), do: {:error, :provider_cleanup_failed}
+
+  # Anchoring is itself terminal work, so it is charged to the budget it
+  # anchors: a session that cannot answer within the share its caller can spare
+  # is wedged, and waiting a fixed interval unrelated to the installed limit
+  # would overrun that limit before cleanup had even started. Such a session is
+  # ended here rather than left for the next terminal action — an OAuth
+  # cancellation is followed by a close — to spend a second full budget
+  # discovering the same thing.
+  defp anchor_cleanup_deadline(session, timeout_ms) do
+    # Anchored where this terminal action began rather than where the session
+    # happens to dequeue it. A busy session would otherwise hand back a cutoff
+    # measured from its own dequeue, granting the time already spent waiting
+    # for it a second time. The session keeps the earliest anchor either way.
+    proposed = Deadline.new(session.cleanup_timeout_ms)
+
+    case call(
+           session.pid,
+           {session.token, {:anchor_cleanup_deadline, proposed}},
+           timeout_ms,
+           :cleanup_unsettled
+         ) do
+      {:ok, _deadline} = anchored -> anchored
+      _unsettled -> settle_terminal_close(:cleanup_unsettled, session)
+    end
+  end
 
   @doc false
   @spec claim_operation(t(), Limits.t(), binary()) ::
@@ -402,9 +426,7 @@ defmodule PtcRunner.Kernel.ProviderSession do
   @spec close(t()) :: :ok | {:error, :provider_cleanup_failed}
   def close(%__MODULE__{} = session) do
     if valid?(session) do
-      session.pid
-      |> call({session.token, :close}, terminal_timeout(session), :cleanup_unsettled)
-      |> settle_terminal_close(session)
+      close_within_anchored_budget(session)
     else
       {:error, :provider_cleanup_failed}
     end
@@ -412,36 +434,55 @@ defmodule PtcRunner.Kernel.ProviderSession do
 
   def close(_session), do: {:error, :provider_cleanup_failed}
 
+  # The caller waits what is left of the one anchored deadline, not the whole
+  # installed duration again: an OAuth cancellation may already have spent part
+  # of it, and waiting a fresh budget on top would make terminal cleanup last
+  # nearly two. Anchoring itself gets the installed budget, because a caller
+  # that has to ask cannot yet know the remainder, and a session that cannot
+  # answer within it is wedged: it is ended rather than waited on a second time.
+  defp close_within_anchored_budget(session) do
+    case anchor_cleanup_deadline(session, session.cleanup_timeout_ms + @claim_reply_grace_ms) do
+      {:ok, deadline} ->
+        session.pid
+        |> call(
+          {session.token, :close},
+          Deadline.remaining(deadline) + @claim_reply_grace_ms,
+          :cleanup_unsettled
+        )
+        |> settle_terminal_close(session)
+
+      # Anchoring already ended a session that could not answer within its own
+      # budget, so there is nothing left to wait for.
+      {:error, :provider_cleanup_failed} = error ->
+        error
+    end
+  end
+
   @doc false
   @spec close_with_unregistered(t(), (-> term()) | nil) ::
           :ok | {:error, :provider_cleanup_failed}
   def close_with_unregistered(%__MODULE__{} = session, close)
       when is_function(close, 0) or is_nil(close) do
     if valid?(session) do
-      # Two cleanup owners split the one installed budget by duration rather
-      # than anchoring a second deadline: the session gets a fair half, bounded
-      # inside by the one deadline it anchored, and the closer that outlives a
-      # session that never answers keeps the rest. Reply grace extends only the
-      # call, never the budget.
-      session_share_ms = div(session.cleanup_timeout_ms, 2)
+      # Two cleanup owners split the one budget: the session gets a fair share
+      # of what remains of the anchored deadline and bounds its own stack by
+      # that same share, so a stack it could not finish inside it is not killed
+      # at a bound only the caller knew about. The closer that must outlive a
+      # session which never answers keeps the rest. Anchoring is charged to the
+      # session's share, so a wedged session cannot spend the closer's.
+      started_at_ms = System.monotonic_time(:millisecond)
 
-      case call(
-             session.pid,
-             {session.token, {:close_with_unregistered, close}},
-             session_share_ms + @claim_reply_grace_ms,
-             :cleanup_unsettled
-           ) do
-        :cleanup_unsettled ->
-          _terminated = settle_terminal_close(:cleanup_unsettled, session)
+      {_share_ms, anchor_wait_ms} = cleanup_split(session.cleanup_timeout_ms)
 
-          close_after_session_loss(
-            session,
-            close,
-            session.cleanup_timeout_ms - session_share_ms
-          )
+      case anchor_cleanup_deadline(session, anchor_wait_ms) do
+        {:ok, deadline} ->
+          close_within_anchored_budget(session, close, deadline)
 
-        result ->
-          result
+        {:error, :provider_cleanup_failed} ->
+          # Anchoring already ended the wedged session. There is no anchored
+          # deadline to measure against, so the closer keeps what this call has
+          # not already spent of the installed budget.
+          close_after_session_loss(session, close, unspent_ms(session, started_at_ms))
       end
     else
       {:error, :provider_cleanup_failed}
@@ -449,6 +490,39 @@ defmodule PtcRunner.Kernel.ProviderSession do
   end
 
   def close_with_unregistered(_session, _close), do: {:error, :provider_cleanup_failed}
+
+  defp close_within_anchored_budget(session, close, deadline) do
+    {session_share_ms, wait_ms} = cleanup_split(Deadline.remaining(deadline))
+
+    case call(
+           session.pid,
+           {session.token, {:close_with_unregistered, close, session_share_ms}},
+           wait_ms,
+           :cleanup_unsettled
+         ) do
+      :cleanup_unsettled ->
+        _terminated = settle_terminal_close(:cleanup_unsettled, session)
+        # Measured against the absolute deadline, so the reply grace and any
+        # other elapsed time are already spent rather than granted again.
+        close_after_session_loss(session, close, Deadline.remaining(deadline))
+
+      result ->
+        result
+    end
+  end
+
+  # The two cleanup owners split what remains in half, and the reply grace that
+  # extends the call comes out of the caller's own half rather than off the top,
+  # so both keep a real share even at the smallest supported cleanup limit —
+  # where subtracting a full grace first would leave the session no budget at
+  # all and silently skip the closer it was handed.
+  defp cleanup_split(remaining_ms) do
+    share_ms = div(remaining_ms, 2)
+    {share_ms, share_ms + min(@claim_reply_grace_ms, div(remaining_ms, 4))}
+  end
+
+  defp unspent_ms(session, started_at_ms),
+    do: max(session.cleanup_timeout_ms - (System.monotonic_time(:millisecond) - started_at_ms), 0)
 
   @doc false
   @spec bind_lifecycle(t(), pid(), pid(), ProviderTaskTracker.t()) ::
@@ -820,14 +894,21 @@ defmodule PtcRunner.Kernel.ProviderSession do
     end
   end
 
-  def handle_call({token, :anchor_cleanup_deadline}, _from, state) when token == state.token do
-    state = ensure_cleanup_deadline(state)
+  def handle_call({token, {:anchor_cleanup_deadline, proposed}}, _from, state)
+      when token == state.token do
+    state = ensure_cleanup_deadline(state, proposed)
     {:reply, {:ok, state.cleanup_deadline}, state}
   end
 
-  def handle_call({token, {:close_with_unregistered, close}}, _from, state)
-      when token == state.token and (is_function(close, 0) or is_nil(close)) do
-    state = state |> begin_terminal_cleanup() |> add_committed_close(close)
+  def handle_call({token, {:close_with_unregistered, close, share_ms}}, _from, state)
+      when token == state.token and (is_function(close, 0) or is_nil(close)) and
+             is_integer(share_ms) and share_ms >= 0 do
+    state =
+      state
+      |> begin_terminal_cleanup()
+      |> narrow_cleanup_deadline(share_ms)
+      |> add_committed_close(close)
+
     {result, state} = drain(state)
     {:stop, :normal, result, state}
   end
@@ -916,6 +997,15 @@ defmodule PtcRunner.Kernel.ProviderSession do
     :ok
   end
 
+  # The caller keeps the rest of the one budget for a closer that must outlive
+  # this session, so the stack below is bounded by the share it was given
+  # instead of the whole remainder it would otherwise spend. Narrowing only ever
+  # shortens the anchored deadline.
+  defp narrow_cleanup_deadline(state, share_ms) do
+    share = Deadline.from_expires_at(System.monotonic_time(:millisecond) + share_ms)
+    %{state | cleanup_deadline: Deadline.earliest(state.cleanup_deadline, share)}
+  end
+
   # The first terminal action anchors the one cleanup deadline, before the task
   # drain rather than after it, so every later stage measures against the
   # instant cleanup actually began.
@@ -974,13 +1064,6 @@ defmodule PtcRunner.Kernel.ProviderSession do
         committed: [scope | state.committed]
     }
   end
-
-  # The lifecycle owner installs `provider_cleanup_timeout_ms` as this session's
-  # whole terminal budget, and the session bounds its own LIFO cleanup by it, so
-  # a reply that misses that budget plus one reply grace means the session is
-  # wedged rather than slow. Waiting past it would turn a bounded failure into a
-  # permanent one.
-  defp terminal_timeout(session), do: session.cleanup_timeout_ms + @claim_reply_grace_ms
 
   # Cleanup has already begun and cannot be re-entered, so the caller ends the
   # session rather than leaving it holding scope owners no one is waiting on.
@@ -1103,6 +1186,18 @@ defmodule PtcRunner.Kernel.ProviderSession do
     do: %{state | cleanup_deadline: Deadline.new(state.cleanup_timeout_ms)}
 
   defp ensure_cleanup_deadline(state), do: state
+
+  # A caller that entered terminal cleanup before this session dequeued its
+  # request supplies the earlier cutoff, and the earliest anchor always wins, so
+  # a queued request can only shorten the one budget, never restart it.
+  defp ensure_cleanup_deadline(state, proposed) do
+    if Deadline.valid?(proposed) do
+      anchored = state.cleanup_deadline || proposed
+      %{state | cleanup_deadline: Deadline.earliest(anchored, proposed)}
+    else
+      ensure_cleanup_deadline(state)
+    end
+  end
 
   defp close_roots(entry, deadline) do
     root_slots = if entry.roots_registered?, do: 1, else: 0

--- a/lib/ptc_runner/kernel/provider_session.ex
+++ b/lib/ptc_runner/kernel/provider_session.ex
@@ -29,7 +29,10 @@ defmodule PtcRunner.Kernel.ProviderSession do
   cooperative owner-down window.
 
   Cleanup shares the sealed `provider_cleanup_timeout_ms` deadline and runs
-  each close operation in a heap-bounded worker. Failures never stop later
+  each close operation in a heap-bounded worker. That budget also bounds the
+  caller: `close/1` waits one reply grace beyond it and then terminates a
+  session that has not answered, so a wedged session becomes a classified
+  cleanup failure rather than an unbounded wait. Failures never stop later
   cleanup attempts. This is a process-local ownership boundary, not a durable
   resource journal or a security boundary against trusted code in the same VM.
   """
@@ -366,12 +369,9 @@ defmodule PtcRunner.Kernel.ProviderSession do
   @spec close(t()) :: :ok | {:error, :provider_cleanup_failed}
   def close(%__MODULE__{} = session) do
     if valid?(session) do
-      call(
-        session.pid,
-        {session.token, :close},
-        :infinity,
-        {:error, :provider_cleanup_failed}
-      )
+      session.pid
+      |> call({session.token, :close}, terminal_timeout(session), :cleanup_unsettled)
+      |> settle_terminal_close(session)
     else
       {:error, :provider_cleanup_failed}
     end
@@ -385,14 +385,24 @@ defmodule PtcRunner.Kernel.ProviderSession do
   def close_with_unregistered(%__MODULE__{} = session, close)
       when is_function(close, 0) or is_nil(close) do
     if valid?(session) do
+      # Two cleanup owners share one terminal budget, so the session gets a fair
+      # half and the unregistered closer keeps the rest for the case where the
+      # session never answers. Reply grace extends only the call.
+      deadline = Deadline.new(session.cleanup_timeout_ms)
+      session_share = div(session.cleanup_timeout_ms, 2) + @claim_reply_grace_ms
+
       case call(
              session.pid,
              {session.token, {:close_with_unregistered, close}},
-             :infinity,
-             :session_unavailable
+             session_share,
+             :cleanup_unsettled
            ) do
-        :session_unavailable -> close_after_session_loss(session, close)
-        result -> result
+        :cleanup_unsettled ->
+          _terminated = settle_terminal_close(:cleanup_unsettled, session)
+          close_after_session_loss(session, close, Deadline.remaining(deadline))
+
+        result ->
+          result
       end
     else
       {:error, :provider_cleanup_failed}
@@ -441,7 +451,9 @@ defmodule PtcRunner.Kernel.ProviderSession do
   @spec drain_provider_tasks(t()) :: :ok
   def drain_provider_tasks(%__MODULE__{} = session) do
     if valid?(session) do
-      call(session.pid, {session.token, :drain_provider_tasks}, :infinity, :ok)
+      # A pre-close courtesy, not cleanup: it answers from session state or the
+      # session is wedged, and `close/1` owns the terminal budget either way.
+      call(session.pid, {session.token, :drain_provider_tasks}, @claim_reply_grace_ms, :ok)
     else
       :ok
     end
@@ -982,12 +994,39 @@ defmodule PtcRunner.Kernel.ProviderSession do
     }
   end
 
-  defp close_after_session_loss(_session, nil), do: {:error, :provider_cleanup_failed}
+  # The lifecycle owner installs `provider_cleanup_timeout_ms` as this session's
+  # whole terminal budget, and the session bounds its own LIFO cleanup by it, so
+  # a reply that misses that budget plus one reply grace means the session is
+  # wedged rather than slow. Waiting past it would turn a bounded failure into a
+  # permanent one.
+  defp terminal_timeout(session), do: session.cleanup_timeout_ms + @claim_reply_grace_ms
 
-  defp close_after_session_loss(session, close) do
+  # Cleanup has already begun and cannot be re-entered, so the caller ends the
+  # session rather than leaving it holding scope owners no one is waiting on.
+  # Its roots monitor those owners and terminate with them; an OAuth
+  # terminalization root has already been handed out of the force-close set and
+  # is unaffected. The classified cleanup failure is what the caller reports.
+  defp settle_terminal_close(:cleanup_unsettled, session) do
+    monitor = Process.monitor(session.pid)
+    Process.exit(session.pid, :kill)
+
+    receive do
+      {:DOWN, ^monitor, :process, _pid, _reason} -> :ok
+    end
+
+    {:error, :provider_cleanup_failed}
+  end
+
+  defp settle_terminal_close(result, _session), do: result
+
+  defp close_after_session_loss(_session, nil, _remaining_ms),
+    do: {:error, :provider_cleanup_failed}
+
+  # Whatever is left of the one anchored budget, never a second full one.
+  defp close_after_session_loss(session, close, remaining_ms) do
     _ =
       BoundedWorker.run(close,
-        timeout_ms: session.cleanup_timeout_ms,
+        timeout_ms: max(remaining_ms, 1),
         max_heap_words: session.max_heap_words,
         cancel_with_caller: true
       )

--- a/lib/ptc_runner/kernel/provider_session.ex
+++ b/lib/ptc_runner/kernel/provider_session.ex
@@ -31,13 +31,18 @@ defmodule PtcRunner.Kernel.ProviderSession do
   force-close phase; abnormal session death permits that handoff during the
   cooperative owner-down window.
 
-  Cleanup shares the sealed `provider_cleanup_timeout_ms` deadline and runs
-  each close operation in a heap-bounded worker. That budget also bounds the
-  caller: `close/1` waits one reply grace beyond it and then terminates a
-  session that has not answered, so a wedged session becomes a classified
-  cleanup failure rather than an unbounded wait. Failures never stop later
-  cleanup attempts. This is a process-local ownership boundary, not a durable
-  resource journal or a security boundary against trusted code in the same VM.
+  The sealed `provider_cleanup_timeout_ms` is one budget for the whole terminal
+  episode, not one per stage. The first terminal action anchors this session's
+  absolute cleanup deadline; an OAuth cancellation and the reverse-order
+  cleanup that follows it each consume what remains of that one deadline, and
+  every close operation runs in a heap-bounded worker inside it. That budget
+  also bounds the caller: `close/1` waits one reply grace beyond it and then
+  terminates a session that has not answered, so a wedged session becomes a
+  classified cleanup failure rather than an unbounded wait. Aborting one
+  acquisition scope mid-run is not part of that episode and keeps its own
+  bounded budget. Failures never stop later cleanup attempts. This is a
+  process-local ownership boundary, not a durable resource journal or a
+  security boundary against trusted code in the same VM.
   """
 
   use GenServer
@@ -302,6 +307,30 @@ defmodule PtcRunner.Kernel.ProviderSession do
 
   def cleanup_timeout(_session), do: nil
 
+  # Terminal cleanup spends one budget, not one per stage. The first terminal
+  # action anchors this session's absolute cleanup deadline, and every later
+  # action — an OAuth cancellation, then the session's own reverse-order
+  # cleanup — consumes what remains of that same deadline instead of minting
+  # the installed duration again. Anchoring belongs to the session because it
+  # is the only holder both stages share.
+  @doc false
+  @spec anchor_cleanup_deadline(term()) ::
+          {:ok, Deadline.t()} | {:error, :provider_cleanup_failed}
+  def anchor_cleanup_deadline(%__MODULE__{} = session) do
+    if valid?(session) do
+      call(
+        session.pid,
+        {session.token, :anchor_cleanup_deadline},
+        @claim_timeout_ms,
+        {:error, :provider_cleanup_failed}
+      )
+    else
+      {:error, :provider_cleanup_failed}
+    end
+  end
+
+  def anchor_cleanup_deadline(_session), do: {:error, :provider_cleanup_failed}
+
   @doc false
   @spec claim_operation(t(), Limits.t(), binary()) ::
           :ok
@@ -389,21 +418,27 @@ defmodule PtcRunner.Kernel.ProviderSession do
   def close_with_unregistered(%__MODULE__{} = session, close)
       when is_function(close, 0) or is_nil(close) do
     if valid?(session) do
-      # Two cleanup owners share one terminal budget, so the session gets a fair
-      # half and the unregistered closer keeps the rest for the case where the
-      # session never answers. Reply grace extends only the call.
-      deadline = Deadline.new(session.cleanup_timeout_ms)
-      session_share = div(session.cleanup_timeout_ms, 2) + @claim_reply_grace_ms
+      # Two cleanup owners split the one installed budget by duration rather
+      # than anchoring a second deadline: the session gets a fair half, bounded
+      # inside by the one deadline it anchored, and the closer that outlives a
+      # session that never answers keeps the rest. Reply grace extends only the
+      # call, never the budget.
+      session_share_ms = div(session.cleanup_timeout_ms, 2)
 
       case call(
              session.pid,
              {session.token, {:close_with_unregistered, close}},
-             session_share,
+             session_share_ms + @claim_reply_grace_ms,
              :cleanup_unsettled
            ) do
         :cleanup_unsettled ->
           _terminated = settle_terminal_close(:cleanup_unsettled, session)
-          close_after_session_loss(session, close, Deadline.remaining(deadline))
+
+          close_after_session_loss(
+            session,
+            close,
+            session.cleanup_timeout_ms - session_share_ms
+          )
 
         result ->
           result
@@ -785,21 +820,20 @@ defmodule PtcRunner.Kernel.ProviderSession do
     end
   end
 
+  def handle_call({token, :anchor_cleanup_deadline}, _from, state) when token == state.token do
+    state = ensure_cleanup_deadline(state)
+    {:reply, {:ok, state.cleanup_deadline}, state}
+  end
+
   def handle_call({token, {:close_with_unregistered, close}}, _from, state)
       when token == state.token and (is_function(close, 0) or is_nil(close)) do
-    state =
-      state
-      |> reject_pending_registrations()
-      |> drain_provider_tasks()
-      |> add_committed_close(close)
-
+    state = state |> begin_terminal_cleanup() |> add_committed_close(close)
     {result, state} = drain(state)
     {:stop, :normal, result, state}
   end
 
   def handle_call({token, :close}, _from, state) when token == state.token do
-    state = state |> reject_pending_registrations() |> drain_provider_tasks()
-    {result, state} = drain(state)
+    {result, state} = state |> begin_terminal_cleanup() |> drain()
     {:stop, :normal, result, state}
   end
 
@@ -824,8 +858,7 @@ defmodule PtcRunner.Kernel.ProviderSession do
         {:DOWN, monitor, :process, owner, _reason},
         %{owner_monitor: monitor, owner: owner} = state
       ) do
-    state = state |> reject_pending_registrations() |> drain_provider_tasks()
-    {_result, state} = drain(state)
+    {_result, state} = state |> begin_terminal_cleanup() |> drain()
     {:stop, :normal, state}
   end
 
@@ -879,9 +912,18 @@ defmodule PtcRunner.Kernel.ProviderSession do
 
   @impl GenServer
   def terminate(_reason, state) do
-    state = state |> reject_pending_registrations() |> drain_provider_tasks()
-    {_result, _state} = drain(state)
+    {_result, _state} = state |> begin_terminal_cleanup() |> drain()
     :ok
+  end
+
+  # The first terminal action anchors the one cleanup deadline, before the task
+  # drain rather than after it, so every later stage measures against the
+  # instant cleanup actually began.
+  defp begin_terminal_cleanup(state) do
+    state
+    |> ensure_cleanup_deadline()
+    |> reject_pending_registrations()
+    |> drain_provider_tasks()
   end
 
   # No provider callback from this run may still be live when a connector
@@ -894,6 +936,9 @@ defmodule PtcRunner.Kernel.ProviderSession do
     state
   end
 
+  # Aborting one scope is ordinary mid-run failure handling, not the terminal
+  # episode, so it bounds itself rather than spending the terminal deadline the
+  # session has not anchored yet.
   defp abort_scope(scope, state) do
     case Map.fetch(state.scopes, scope) do
       {:ok, %{phase: phase} = entry} when phase in [:inactive, :active] ->
@@ -958,7 +1003,7 @@ defmodule PtcRunner.Kernel.ProviderSession do
   defp close_after_session_loss(_session, nil, _remaining_ms),
     do: {:error, :provider_cleanup_failed}
 
-  # Whatever is left of the one anchored budget, never a second full one.
+  # The unspent half of the one installed budget, never a second full one.
   defp close_after_session_loss(session, close, remaining_ms) do
     _ =
       BoundedWorker.run(close,

--- a/lib/ptc_runner/kernel/provider_task_tracker.ex
+++ b/lib/ptc_runner/kernel/provider_task_tracker.ex
@@ -7,8 +7,9 @@ defmodule PtcRunner.Kernel.ProviderTaskTracker do
   # every attached task. Because the tracker is a separate process, that
   # guarantee survives an abnormal end of either owner — including a session
   # terminated at its cleanup deadline, where `terminate/2` never runs. A
-  # session drains through this owner before its own provider closers run, so
-  # no callback from the run is still live when a connector closes.
+  # session drains through this owner before its own provider closers run, and
+  # that drain also ends the owner, so no callback from the run is live when a
+  # connector closes and none can be attached behind it.
 
   use GenServer
 
@@ -40,26 +41,18 @@ defmodule PtcRunner.Kernel.ProviderTaskTracker do
 
   def attach(_tracker, _provider), do: {:error, :closed}
 
-  # Kills and reaps every attached task without ending the tracker, so a
-  # session can prove its callbacks are gone before running provider closers
-  # and still own tasks attached by a later evaluation. A tracker that has
-  # already stopped drained on its way out, so a failed call means there is
-  # nothing left to drain rather than an unsettled one.
+  # Kills and reaps every attached task and then ends the tracker, so terminal
+  # cleanup can prove the run's callbacks are gone. Sealing is the point:
+  # draining without it would let a dispatch that raced the drain attach a live
+  # callback behind it while connector closers already run, so an attachment
+  # after this finds the owner closed and fails instead. Either lifecycle may
+  # call it, and calling it again once it has settled is a no-op.
   @spec drain_provider_tasks(t()) :: :ok
-  def drain_provider_tasks(%__MODULE__{} = tracker) do
-    _ = safe_call(tracker, :drain)
-    :ok
-  end
-
-  # A session that was never bound to a tracker never owned a task.
-  def drain_provider_tasks(_tracker), do: :ok
-
-  @spec close(t()) :: :ok
-  def close(%__MODULE__{pid: pid} = tracker) do
+  def drain_provider_tasks(%__MODULE__{pid: pid} = tracker) do
     ref = Process.monitor(pid)
 
     try do
-      _ = safe_call(tracker, :close)
+      _ = safe_call(tracker, :drain)
 
       receive do
         {:DOWN, ^ref, :process, ^pid, _reason} -> :ok
@@ -68,6 +61,9 @@ defmodule PtcRunner.Kernel.ProviderTaskTracker do
       Process.demonitor(ref, [:flush])
     end
   end
+
+  # A session that was never bound to a tracker never owned a task.
+  def drain_provider_tasks(_tracker), do: :ok
 
   @impl GenServer
   def init({token, run_state}) do
@@ -97,9 +93,6 @@ defmodule PtcRunner.Kernel.ProviderTaskTracker do
   end
 
   def handle_call({token, :drain}, _from, %{token: token} = state),
-    do: {:reply, :ok, drain(state)}
-
-  def handle_call({token, :close}, _from, %{token: token} = state),
     do: {:stop, :normal, :ok, drain(state)}
 
   def handle_call(_request, _from, state), do: {:reply, {:error, :closed}, state}

--- a/lib/ptc_runner/kernel/provider_task_tracker.ex
+++ b/lib/ptc_runner/kernel/provider_task_tracker.ex
@@ -1,6 +1,15 @@
 defmodule PtcRunner.Kernel.ProviderTaskTracker do
   @moduledoc false
 
+  # The one owner of a run's live provider tasks, deliberately external to both
+  # lifecycles it serves. It monitors the run state and, once execution binds
+  # one, the provider session; either lifecycle disappearing kills and reaps
+  # every attached task. Because the tracker is a separate process, that
+  # guarantee survives an abnormal end of either owner — including a session
+  # terminated at its cleanup deadline, where `terminate/2` never runs. A
+  # session drains through this owner before its own provider closers run, so
+  # no callback from the run is still live when a connector closes.
+
   use GenServer
 
   @enforce_keys [:pid, :token]
@@ -18,9 +27,32 @@ defmodule PtcRunner.Kernel.ProviderTaskTracker do
     end
   end
 
+  @doc "Monitors a second lifecycle whose death must drain every attached task."
+  @spec watch(t(), pid()) :: :ok | {:error, :closed | :lifecycle_down}
+  def watch(%__MODULE__{} = tracker, lifecycle) when is_pid(lifecycle),
+    do: safe_call(tracker, {:watch, lifecycle})
+
+  def watch(_tracker, _lifecycle), do: {:error, :closed}
+
   @spec attach(t(), pid()) :: :ok | {:error, :closed | :provider_down}
-  def attach(tracker, provider) when is_pid(provider),
+  def attach(%__MODULE__{} = tracker, provider) when is_pid(provider),
     do: safe_call(tracker, {:attach, provider})
+
+  def attach(_tracker, _provider), do: {:error, :closed}
+
+  # Kills and reaps every attached task without ending the tracker, so a
+  # session can prove its callbacks are gone before running provider closers
+  # and still own tasks attached by a later evaluation. A tracker that has
+  # already stopped drained on its way out, so a failed call means there is
+  # nothing left to drain rather than an unsettled one.
+  @spec drain_provider_tasks(t()) :: :ok
+  def drain_provider_tasks(%__MODULE__{} = tracker) do
+    _ = safe_call(tracker, :drain)
+    :ok
+  end
+
+  # A session that was never bound to a tracker never owned a task.
+  def drain_provider_tasks(_tracker), do: :ok
 
   @spec close(t()) :: :ok
   def close(%__MODULE__{pid: pid} = tracker) do
@@ -42,32 +74,40 @@ defmodule PtcRunner.Kernel.ProviderTaskTracker do
     {:ok,
      %{
        token: token,
-       run_state_ref: Process.monitor(run_state),
+       lifecycles: %{Process.monitor(run_state) => run_state},
        providers: %{}
      }}
   end
 
   @impl GenServer
+  def handle_call({token, {:watch, lifecycle}}, _from, %{token: token} = state) do
+    if Process.alive?(lifecycle) do
+      {:reply, :ok, put_in(state.lifecycles[Process.monitor(lifecycle)], lifecycle)}
+    else
+      {:reply, {:error, :lifecycle_down}, state}
+    end
+  end
+
   def handle_call({token, {:attach, provider}}, _from, %{token: token} = state) do
     if Process.alive?(provider) do
-      ref = Process.monitor(provider)
-      {:reply, :ok, put_in(state.providers[ref], provider)}
+      {:reply, :ok, put_in(state.providers[Process.monitor(provider)], provider)}
     else
       {:reply, {:error, :provider_down}, state}
     end
   end
 
-  def handle_call({token, :close}, _from, %{token: token} = state) do
-    state = drain(state)
-    {:stop, :normal, :ok, state}
-  end
+  def handle_call({token, :drain}, _from, %{token: token} = state),
+    do: {:reply, :ok, drain(state)}
+
+  def handle_call({token, :close}, _from, %{token: token} = state),
+    do: {:stop, :normal, :ok, drain(state)}
 
   def handle_call(_request, _from, state), do: {:reply, {:error, :closed}, state}
 
   @impl GenServer
-  def handle_info({:DOWN, ref, :process, _pid, _reason}, %{run_state_ref: ref} = state) do
-    state = drain(state)
-    {:stop, :normal, state}
+  def handle_info({:DOWN, ref, :process, _pid, _reason}, %{lifecycles: lifecycles} = state)
+      when is_map_key(lifecycles, ref) do
+    {:stop, :normal, drain(state)}
   end
 
   def handle_info({:DOWN, ref, :process, _pid, _reason}, state),
@@ -85,6 +125,9 @@ defmodule PtcRunner.Kernel.ProviderTaskTracker do
   @impl GenServer
   def format_status(_reason, _status), do: [data: [{~c"State", :redacted}]]
 
+  # A killed task always yields the `:DOWN` this reaps, so the loop terminates
+  # without its own timer. Only provider monitors are consumed; a lifecycle
+  # notification that arrives mid-drain stays queued for the clause above.
   defp drain(state) do
     Enum.each(state.providers, fn {_ref, provider} -> Process.exit(provider, :kill) end)
     drain_monitors(state.providers)
@@ -95,7 +138,7 @@ defmodule PtcRunner.Kernel.ProviderTaskTracker do
 
   defp drain_monitors(providers) do
     receive do
-      {:DOWN, ref, :process, _pid, _reason} ->
+      {:DOWN, ref, :process, _pid, _reason} when is_map_key(providers, ref) ->
         drain_monitors(Map.delete(providers, ref))
     end
   end

--- a/lib/ptc_runner/kernel/repl_session.ex
+++ b/lib/ptc_runner/kernel/repl_session.ex
@@ -420,7 +420,7 @@ defmodule PtcRunner.Kernel.ReplSession do
   defp bind_and_start_session(config, state) do
     case ReplSessionOwner.start(config, state, self()) do
       {:ok, pid, token} ->
-        case RunConfig.bind_provider_session(config, pid, state.pid) do
+        case RunConfig.bind_provider_session(config, pid, state.pid, state.provider_tracker) do
           :ok ->
             register_access(pid, token)
 

--- a/lib/ptc_runner/kernel/run_builder.ex
+++ b/lib/ptc_runner/kernel/run_builder.ex
@@ -1030,17 +1030,28 @@ defmodule PtcRunner.Kernel.RunBuilder do
   def execute_built(_built), do: {:error, :invalid_execution_outcome}
 
   # Completes an assembled build as a check rather than an execution: it reports
-  # the safe connector snapshots the acquisition produced and stops the sinks.
-  # It never evaluates the entry, finalizes a terminal event batch, or
-  # publishes an artifact, so nothing belonging only to execution can reach a
-  # destination through this path.
+  # the safe connector snapshots the acquisition produced, closes the provider
+  # session, and stops the sinks. It never evaluates the entry, finalizes a
+  # terminal event batch, or publishes an artifact, so nothing belonging only to
+  # execution can reach a destination through this path.
+  #
+  # Closing the session here is what keeps a check on the run's cleanup
+  # ordering: a run closes its session inside `PtcRunner.Kernel` while the
+  # registry and the OAuth runtime that produced its resources are still alive.
+  # Leaving it to the execution owner would unwind that runtime first and run
+  # connector closers against a store and managers that are already gone.
   @doc false
   @spec check_built(map()) :: {:ok, [map()]} | {:error, term()}
   def check_built(%{config: %RunConfig{} = config, publication_authority: authority}) do
     if PublicationAuthority.valid?(authority) do
       snapshots = config.connector_snapshots
+      cleanup = RunConfig.close_provider_session(config)
       stop_execution_sinks(config)
-      {:ok, snapshots}
+
+      case cleanup do
+        :ok -> {:ok, snapshots}
+        {:error, :provider_cleanup_failed} = error -> error
+      end
     else
       reject_execution(config)
     end

--- a/lib/ptc_runner/kernel/run_builder.ex
+++ b/lib/ptc_runner/kernel/run_builder.ex
@@ -773,9 +773,11 @@ defmodule PtcRunner.Kernel.RunBuilder do
   end
 
   # Owner-opened sinks are fixed before any provider runs, from the sealed
-  # declaration's effective data class. A provider that acquires as a stricter
-  # class than it declared would otherwise emit through a sink opened for the
-  # weaker one, so the drift is refused rather than silently downgraded.
+  # declaration's effective data class. Descriptor-bound preparation and the
+  # acquired-build comparison already refuse a provider whose data policy
+  # contradicts its declaration, so this is defense in depth: it re-derives the
+  # required policy from what was actually acquired and refuses drift rather
+  # than emitting a stricter class through a sink opened for the weaker one.
   defp execution_sinks(
          request,
          providers,

--- a/lib/ptc_runner/kernel/run_builder.ex
+++ b/lib/ptc_runner/kernel/run_builder.ex
@@ -18,12 +18,12 @@ defmodule PtcRunner.Kernel.RunBuilder do
   execution-session owner so the prepared run and both sinks share one
   caller-death boundary.
   A provider-bearing prepared run is preflighted the same way, and its active
-  session is passed here for runtime assembly. The one-shot path opens that
-  session inside the execution-session owner and calls `build_active_owned/5`
-  with the owner's sinks; `--check` still opens it in the Mix adapter and calls
-  `build_active/4`. The REPL is a third transitional path: it calls
-  `load_and_build/3` with an empty registry and opens no active session at all.
-  All three converge here until their parity cutover.
+  session is passed here for runtime assembly. One-shot runs and `--check` both
+  open that session inside the execution-session owner and call
+  `build_active_owned/5` with the owner's sinks, then complete through
+  `execute_built/1` or `check_built/1`. The REPL remains transitional: it calls
+  `load_and_build/3` with an empty registry and opens no active session at
+  all.
   `PtcRunner.Kernel.ProviderAcquisition` then runs the selected providers'
   shared preparation, credentials, and dependency-ordered acquisition barrier.
   Active preparation, preflight, acquisition, and credential resolution are
@@ -317,58 +317,6 @@ defmodule PtcRunner.Kernel.RunBuilder do
   def preflight_prepared(_prepared, _opts), do: {:error, :invalid_prepared_run}
 
   @doc false
-  @spec build_active(
-          PreparedRun.t(),
-          ProviderRegistry.t(),
-          ProviderSession.t(),
-          keyword()
-        ) :: {:ok, map()} | {:error, term()}
-  def build_active(
-        %PreparedRun{} = prepared,
-        %ProviderRegistry{} = registry,
-        session,
-        opts
-      )
-      when is_list(opts) do
-    with true <- PreparedRun.active_valid?(prepared),
-         :ok <-
-           ProviderSession.claim_operation(
-             session,
-             prepared.request.package.limits,
-             prepared.attestation
-           ),
-         :ok <- validate_registry(registry),
-         :ok <- validate_build_options(opts),
-         :ok <- validate_installed_limits(prepared.request.package, registry, opts),
-         :ok <- validate_inspection_selection(prepared.request, opts) do
-      # Downstream provider/build failures close the session at the point that
-      # owns it. Only failures before that handoff are cleaned up here.
-      build_active_preflighted(prepared, registry, session, opts)
-    else
-      {:error, :operation_claimed} ->
-        {:error, :invalid_active_run}
-
-      {:error, :operation_mismatch} ->
-        prefer_cleanup_error({:error, :invalid_active_run}, close_live_session(session))
-
-      {:error, :provider_session_unavailable} ->
-        # Claim timeouts are ambiguous: the claim may have committed before
-        # its reply was lost. ProviderSession queues conditional cleanup that
-        # preserves a claimed session and closes only an abandoned one.
-        {:error, :invalid_active_run}
-
-      false ->
-        prefer_cleanup_error({:error, :invalid_active_run}, close_live_session(session))
-
-      {:error, _reason} = error ->
-        prefer_cleanup_error(error, close_live_session(session))
-    end
-  end
-
-  def build_active(_prepared, _registry, _session, _opts),
-    do: {:error, :invalid_active_run}
-
-  @doc false
   @spec build_active_owned(
           PreparedRun.t(),
           ProviderRegistry.t(),
@@ -587,26 +535,6 @@ defmodule PtcRunner.Kernel.RunBuilder do
         providers,
         authority,
         opened_sinks
-      )
-    end
-  end
-
-  defp build_active_preflighted(prepared, registry, session, opts) do
-    with {:ok, providers} <-
-           providers(
-             prepared.request.package,
-             registry,
-             provider_input_class(prepared.request.input.authority),
-             opts,
-             session
-           ) do
-      build_with_providers(
-        prepared.request,
-        {prepared.workflow_bundle, prepared.mission_bundle},
-        prepared.entry_source,
-        providers,
-        opts,
-        :close_opened_sinks
       )
     end
   end
@@ -1100,6 +1028,25 @@ defmodule PtcRunner.Kernel.RunBuilder do
 
   def execute_built(%{config: %RunConfig{} = config}), do: reject_execution(config)
   def execute_built(_built), do: {:error, :invalid_execution_outcome}
+
+  # Completes an assembled build as a check rather than an execution: it reports
+  # the safe connector snapshots the acquisition produced and stops the sinks.
+  # It never evaluates the entry, finalizes a terminal event batch, or
+  # publishes an artifact, so nothing belonging only to execution can reach a
+  # destination through this path.
+  @doc false
+  @spec check_built(map()) :: {:ok, [map()]} | {:error, term()}
+  def check_built(%{config: %RunConfig{} = config, publication_authority: authority}) do
+    if PublicationAuthority.valid?(authority) do
+      snapshots = config.connector_snapshots
+      stop_execution_sinks(config)
+      {:ok, snapshots}
+    else
+      reject_execution(config)
+    end
+  end
+
+  def check_built(_built), do: {:error, :invalid_execution_outcome}
 
   @doc false
   @spec publish_execution(ExecutionOutcome.t(), PublicationAuthority.t()) ::

--- a/lib/ptc_runner/kernel/run_config.ex
+++ b/lib/ptc_runner/kernel/run_config.ex
@@ -60,6 +60,7 @@ defmodule PtcRunner.Kernel.RunConfig do
   alias PtcRunner.Kernel.MissionEnvironment
   alias PtcRunner.Kernel.MissionInventory
   alias PtcRunner.Kernel.ProviderSession
+  alias PtcRunner.Kernel.ProviderTaskTracker
   alias PtcRunner.Kernel.SafeMetadata
   alias PtcRunner.Kernel.ValueContract
   alias PtcRunner.Kernel.WorkflowEnvironment
@@ -316,15 +317,15 @@ defmodule PtcRunner.Kernel.RunConfig do
     do: ProviderSession.close(session)
 
   @doc false
-  @spec bind_provider_session(t(), pid(), pid()) ::
+  @spec bind_provider_session(t(), pid(), pid(), ProviderTaskTracker.t()) ::
           :ok | {:error, :provider_session_unavailable}
-  def bind_provider_session(%__MODULE__{provider_session: nil}, owner, run_state)
+  def bind_provider_session(%__MODULE__{provider_session: nil}, owner, run_state, _tracker)
       when is_pid(owner) and is_pid(run_state),
       do: :ok
 
-  def bind_provider_session(%__MODULE__{provider_session: session}, owner, run_state)
+  def bind_provider_session(%__MODULE__{provider_session: session}, owner, run_state, tracker)
       when is_pid(owner) and is_pid(run_state),
-      do: ProviderSession.bind_lifecycle(session, owner, run_state)
+      do: ProviderSession.bind_lifecycle(session, owner, run_state, tracker)
 
   # A trial artifact has to name the base a candidate replaced, not only the
   # candidate itself. The effective bundle hash already changes when source

--- a/lib/ptc_runner/kernel/run_coordinator.ex
+++ b/lib/ptc_runner/kernel/run_coordinator.ex
@@ -82,7 +82,23 @@ defmodule PtcRunner.Kernel.RunCoordinator do
              | :invalid_publication_authority
              | :provider_session_required
              | term()}
-  def execute(%PreparedRun{} = prepared, authority) do
+  def execute(%PreparedRun{} = prepared, authority), do: open_free(prepared, authority, :run)
+
+  def execute(_prepared, _authority), do: {:error, :invalid_prepared_run}
+
+  @doc false
+  @spec check(PreparedRun.t(), PublicationAuthority.t()) ::
+          {:ok, [map()]}
+          | {:error,
+             :invalid_prepared_run
+             | :invalid_publication_authority
+             | :provider_session_required
+             | term()}
+  def check(%PreparedRun{} = prepared, authority), do: open_free(prepared, authority, :check)
+
+  def check(_prepared, _authority), do: {:error, :invalid_prepared_run}
+
+  defp open_free(prepared, authority, operation) do
     cond do
       not PreparedRun.valid?(prepared) ->
         {:error, :invalid_prepared_run}
@@ -94,12 +110,11 @@ defmodule PtcRunner.Kernel.RunCoordinator do
         {:error, :provider_session_required}
 
       true ->
-        with {:ok, owner} <- ExecutionSessionOwner.start(prepared, authority, self()),
+        with {:ok, owner} <-
+               ExecutionSessionOwner.start(prepared, authority, self(), nil, nil, operation),
              do: ExecutionSessionOwner.await(owner)
     end
   end
-
-  def execute(_prepared, _authority), do: {:error, :invalid_prepared_run}
 
   @doc false
   @spec execute(
@@ -115,7 +130,33 @@ defmodule PtcRunner.Kernel.RunCoordinator do
              | :invalid_provider_execution
              | term()}
   def execute(%PreparedRun{} = prepared, authority, provider_execution, notifier)
-      when is_function(notifier, 1) do
+      when is_function(notifier, 1),
+      do: open_active(prepared, authority, provider_execution, notifier, :run)
+
+  def execute(_prepared, _authority, _provider_execution, _notifier),
+    do: {:error, :invalid_prepared_run}
+
+  @doc false
+  @spec check(
+          PreparedRun.t(),
+          PublicationAuthority.t(),
+          ProviderExecution.t(),
+          (binary() -> term())
+        ) ::
+          {:ok, [map()]}
+          | {:error,
+             :invalid_prepared_run
+             | :invalid_publication_authority
+             | :invalid_provider_execution
+             | term()}
+  def check(%PreparedRun{} = prepared, authority, provider_execution, notifier)
+      when is_function(notifier, 1),
+      do: open_active(prepared, authority, provider_execution, notifier, :check)
+
+  def check(_prepared, _authority, _provider_execution, _notifier),
+    do: {:error, :invalid_prepared_run}
+
+  defp open_active(prepared, authority, provider_execution, notifier, operation) do
     cond do
       not PreparedRun.valid?(prepared) ->
         {:error, :invalid_prepared_run}
@@ -136,14 +177,12 @@ defmodule PtcRunner.Kernel.RunCoordinator do
                  authority,
                  self(),
                  provider_execution,
-                 notifier
+                 notifier,
+                 operation
                ),
              do: ExecutionSessionOwner.await(owner)
     end
   end
-
-  def execute(_prepared, _authority, _provider_execution, _notifier),
-    do: {:error, :invalid_prepared_run}
 
   defp compile_required(components) do
     case Kernel.compile_bundle(components) do

--- a/lib/ptc_runner/kernel/run_state.ex
+++ b/lib/ptc_runner/kernel/run_state.ex
@@ -17,9 +17,11 @@ defmodule PtcRunner.Kernel.RunState do
   co-hosted session construction receives a one-shot transfer.
 
   Each capability reservation monitors the dispatching process. Every attached
-  provider is also registered with a small monitor-only tracker that
-  untrappably kills the callback if RunState dies, even when `terminate/2`
-  cannot run. If the
+  provider is also registered with the run's one provider-task owner, an
+  internal process external to both this process and the provider session. It
+  monitors both, so it untrappably kills every attached callback when either
+  lifecycle disappears — including a session terminated at its cleanup
+  deadline, where `terminate/2` cannot run. If the
   dispatching process dies mid-call (heap kill, timeout kill), the reservation
   is reclaimed only after the attached provider process has been killed and
   its `:DOWN` observed. Thus connector cleanup cannot begin while a callback
@@ -63,7 +65,7 @@ defmodule PtcRunner.Kernel.RunState do
   @type environment :: :workflow | :mission
 
   @typedoc """
-  Opaque handle to the process tracking this run's provider tasks.
+  Opaque handle to the one process that owns this run's provider tasks.
 
   Its shape is an implementation detail: callers receive it inside `t:t/0` and
   hand it back to the Kernel rather than inspecting it. Declaring it here keeps
@@ -71,7 +73,7 @@ defmodule PtcRunner.Kernel.RunState do
   `pid()` would be inaccurate because the handle also carries an ownership
   token.
   """
-  @type provider_tracker :: {atom(), term()}
+  @type provider_tracker :: %{:__struct__ => module(), :pid => pid(), :token => reference()}
 
   @type t :: %__MODULE__{
           pid: pid(),
@@ -89,7 +91,7 @@ defmodule PtcRunner.Kernel.RunState do
 
     if Keyword.keys(opts) -- [:owner, :provider_session, :run_deadline] == [] and
          valid_provider_session?(provider_session) and valid_run_deadline?(run_deadline) do
-      start_state({limits, token, owner, nil, false, nil, provider_session, run_deadline})
+      start_state({limits, token, owner, nil, false, nil, run_deadline})
     else
       {:error, :invalid_run_state}
     end
@@ -107,7 +109,7 @@ defmodule PtcRunner.Kernel.RunState do
          owner = self(),
          {:ok, state} <-
            start_state(
-             {limits, token, owner, nil, false, {event_sink, inspection_sink}, nil, run_deadline}
+             {limits, token, owner, nil, false, {event_sink, inspection_sink}, run_deadline}
            ) do
       {:ok, state}
     else
@@ -123,7 +125,7 @@ defmodule PtcRunner.Kernel.RunState do
     with true <- Keyword.keys(opts) -- [:owner] == [],
          {:ok, event_sink, handle} <- EventSink.prepare(:normal, limits, sink_opts),
          {:ok, state} <-
-           start_state({limits, token, owner, event_sink, true, nil, nil, nil}) do
+           start_state({limits, token, owner, event_sink, true, nil, nil}) do
       {:ok, state, struct!(EventSink, Map.put(handle, :pid, state.pid))}
     else
       _ -> {:error, :invalid_run_state}
@@ -138,7 +140,7 @@ defmodule PtcRunner.Kernel.RunState do
   @spec attach_provider(t(), pid()) :: :ok | {:error, :closed | :provider_down}
   @doc "Attaches the caller's live provider process to its capability reservation."
   def attach_provider(%__MODULE__{} = state, provider) when is_pid(provider) do
-    case attach_provider_task(state.provider_tracker, provider) do
+    case ProviderTaskTracker.attach(state.provider_tracker, provider) do
       :ok ->
         # The external task owner can still accept an attachment while its
         # run-state death notification is queued. This call closes that window
@@ -238,7 +240,7 @@ defmodule PtcRunner.Kernel.RunState do
   def close_and_drain(%__MODULE__{} = state) do
     call(state, :close_and_drain)
   after
-    drain_provider_tasks(state.provider_tracker)
+    ProviderTaskTracker.close(state.provider_tracker)
   end
 
   @spec stop(t()) :: :ok
@@ -246,7 +248,7 @@ defmodule PtcRunner.Kernel.RunState do
   def stop(%__MODULE__{} = state) do
     GenServer.stop(state.pid, :normal)
   after
-    drain_provider_tasks(state.provider_tracker)
+    ProviderTaskTracker.close(state.provider_tracker)
   end
 
   # These two answer with the owner's data, and there is no substitute that
@@ -296,30 +298,24 @@ defmodule PtcRunner.Kernel.RunState do
   @doc false
   def transfer_owner(state, owner) when is_pid(owner), do: call(state, {:transfer_owner, owner})
 
+  # Task ownership does not move with the session: the one tracker keeps it and
+  # starts monitoring the session when execution binds its lifecycle. This only
+  # refuses a session that could never be bound.
   @doc false
   @spec use_provider_session(t(), ProviderSession.t() | nil) ::
           {:ok, t()} | {:error, :invalid_run_state}
   def use_provider_session(%__MODULE__{} = state, nil), do: {:ok, state}
 
-  def use_provider_session(
-        %__MODULE__{provider_tracker: {:task_tracker, tracker}} = state,
-        session
-      ) do
-    if ProviderSession.valid?(session) do
-      :ok = ProviderTaskTracker.close(tracker)
-      {:ok, %{state | provider_tracker: {:provider_session, session}}}
-    else
-      {:error, :invalid_run_state}
-    end
+  def use_provider_session(%__MODULE__{} = state, session) do
+    if ProviderSession.valid?(session),
+      do: {:ok, state},
+      else: {:error, :invalid_run_state}
   end
 
   def use_provider_session(_state, _session), do: {:error, :invalid_run_state}
 
   @impl GenServer
-  def init(
-        {limits, token, owner, event_sink, owner_transferable?, repl_resources, _session,
-         run_deadline}
-      ) do
+  def init({limits, token, owner, event_sink, owner_transferable?, repl_resources, run_deadline}) do
     deadline_ms =
       if Deadline.valid?(run_deadline),
         do: Deadline.expires_at(run_deadline),
@@ -998,7 +994,7 @@ defmodule PtcRunner.Kernel.RunState do
   defp start_state(args) do
     case GenServer.start(__MODULE__, args) do
       {:ok, pid} ->
-        case start_provider_tracker(elem(args, 6), pid) do
+        case ProviderTaskTracker.start(pid) do
           {:ok, provider_tracker} ->
             token = elem(args, 1)
             {:ok, %__MODULE__{pid: pid, token: token, provider_tracker: provider_tracker}}
@@ -1012,27 +1008,6 @@ defmodule PtcRunner.Kernel.RunState do
         {:error, reason}
     end
   end
-
-  defp start_provider_tracker(nil, run_state) do
-    case ProviderTaskTracker.start(run_state) do
-      {:ok, tracker} -> {:ok, {:task_tracker, tracker}}
-      {:error, _reason} = error -> error
-    end
-  end
-
-  defp start_provider_tracker(session, _run_state),
-    do: {:ok, {:provider_session, session}}
-
-  defp attach_provider_task({:task_tracker, tracker}, provider),
-    do: ProviderTaskTracker.attach(tracker, provider)
-
-  defp attach_provider_task({:provider_session, session}, provider),
-    do: ProviderSession.attach_provider(session, provider)
-
-  defp drain_provider_tasks({:task_tracker, tracker}), do: ProviderTaskTracker.close(tracker)
-
-  defp drain_provider_tasks({:provider_session, session}),
-    do: ProviderSession.drain_provider_tasks(session)
 
   defp valid_provider_session?(nil), do: true
   defp valid_provider_session?(session), do: ProviderSession.valid?(session)

--- a/lib/ptc_runner/kernel/run_state.ex
+++ b/lib/ptc_runner/kernel/run_state.ex
@@ -240,7 +240,7 @@ defmodule PtcRunner.Kernel.RunState do
   def close_and_drain(%__MODULE__{} = state) do
     call(state, :close_and_drain)
   after
-    ProviderTaskTracker.close(state.provider_tracker)
+    ProviderTaskTracker.drain_provider_tasks(state.provider_tracker)
   end
 
   @spec stop(t()) :: :ok
@@ -248,7 +248,7 @@ defmodule PtcRunner.Kernel.RunState do
   def stop(%__MODULE__{} = state) do
     GenServer.stop(state.pid, :normal)
   after
-    ProviderTaskTracker.close(state.provider_tracker)
+    ProviderTaskTracker.drain_provider_tasks(state.provider_tracker)
   end
 
   # These two answer with the owner's data, and there is no substitute that

--- a/lib/ptc_runner/kernel/runner.ex
+++ b/lib/ptc_runner/kernel/runner.ex
@@ -93,7 +93,7 @@ defmodule PtcRunner.Kernel.Runner do
   end
 
   defp transfer_provider_cleanup(config, state) do
-    RunConfig.bind_provider_session(config, self(), state.pid)
+    RunConfig.bind_provider_session(config, self(), state.pid, state.provider_tracker)
   end
 
   defp run_claimed(entry_source, config, state) do

--- a/priv/semantic_build_projection.json
+++ b/priv/semantic_build_projection.json
@@ -129,7 +129,7 @@
     "req_llm",
     "telemetry"
   ],
-  "source_closure_hash": "5f657fdb251fde1d79ed32db735cdde3627dad57fb1e58b582bee674ec122cc1",
+  "source_closure_hash": "c806d1a7acc4a9d31e5257416873eddad5c0892850ab3c3c3d6606c9203741fe",
   "sources": [
     {
       "bytes": 870,
@@ -717,9 +717,9 @@
       "sha256": "3c966d49402041ed52aed30efaa47391e3ca6fd4283de2a4c6476db9f497cf82"
     },
     {
-      "bytes": 41918,
+      "bytes": 40432,
       "path": "lib/ptc_runner/kernel/provider_session.ex",
-      "sha256": "eed2d62891b609563a8fe04bca374e98f3400569d61b5d33ee1ccdcfc09fa833"
+      "sha256": "1d4d8180593e9c987c30f4708679ea868e98e460fdc20d1ec0d651a966e747f9"
     },
     {
       "bytes": 2983,
@@ -727,9 +727,9 @@
       "sha256": "189adbdddf7987a79dfc40aad97cf16d631c86fa92af90ddf954c013094958ed"
     },
     {
-      "bytes": 3235,
+      "bytes": 5510,
       "path": "lib/ptc_runner/kernel/provider_task_tracker.ex",
-      "sha256": "e3f62ef2227f505348268fba97b33e3797dc836f3a35b5797b0ccead6c60977f"
+      "sha256": "23e6390fb83ff8fe126556c22b3d2b09ddf1934b52e6f2f2a4d4a671d8778047"
     },
     {
       "bytes": 3586,
@@ -737,9 +737,9 @@
       "sha256": "aba7665926b7e413a51bea56c33ad67fd12dd7d7454fce8a64a97ec9459c4b3b"
     },
     {
-      "bytes": 30088,
+      "bytes": 30112,
       "path": "lib/ptc_runner/kernel/repl_session.ex",
-      "sha256": "8b474e9ff2e76c2fee60da2d3e0eb2cc3223ad3358f391dabe006017f457edd6"
+      "sha256": "4d635b927d3cdee2c96d6cbf1edf6ce3fbcf602fd294fa9e5c53b4dfd123e18c"
     },
     {
       "bytes": 4231,
@@ -767,9 +767,9 @@
       "sha256": "d1c71eb6c49db705cfed815e30d0c1fc27a445c9f5d225063f1a29022c188a6a"
     },
     {
-      "bytes": 16621,
+      "bytes": 16719,
       "path": "lib/ptc_runner/kernel/run_config.ex",
-      "sha256": "6138de12146c1d6d58bfb2332725fa177983fcc3a42b7f58b046a4e6b2708344"
+      "sha256": "abccceabb73cec6b5b71804049984daba65fad089391b86cd49188eb82c6b27c"
     },
     {
       "bytes": 16295,
@@ -782,14 +782,14 @@
       "sha256": "47f1b568056e09e9f7286544bfeba405e6a0ab1957c73358397c26e14778b63e"
     },
     {
-      "bytes": 36759,
+      "bytes": 36252,
       "path": "lib/ptc_runner/kernel/run_state.ex",
-      "sha256": "11c5489f07a22895ed863d5d6d481d20cb6326a1d814036129916f2f13156084"
+      "sha256": "85394bbc0c2dba9dd0696e4823d6ba04dce2179e35dfd0301145ed68d15923bb"
     },
     {
-      "bytes": 16106,
+      "bytes": 16130,
       "path": "lib/ptc_runner/kernel/runner.ex",
-      "sha256": "926051260dfc2365ab3ff34c86cc29ff1e267455424d86bba3c6b940a5fbc5d2"
+      "sha256": "96714054e678cd00422e1b3be985d694cf53c916eb3a1e95e25f92d218edcfc5"
     },
     {
       "bytes": 16501,

--- a/priv/semantic_build_projection.json
+++ b/priv/semantic_build_projection.json
@@ -129,7 +129,7 @@
     "req_llm",
     "telemetry"
   ],
-  "source_closure_hash": "e35ad257ce42d03742b459c44c22feed750ecb832beb6fdb5bca239558e1f2d2",
+  "source_closure_hash": "dafdfa7d6785d17eec465ad63a6bf2f688f9105c394e9b5eaec02571c345867e",
   "sources": [
     {
       "bytes": 870,
@@ -717,9 +717,9 @@
       "sha256": "3c966d49402041ed52aed30efaa47391e3ca6fd4283de2a4c6476db9f497cf82"
     },
     {
-      "bytes": 42445,
+      "bytes": 47179,
       "path": "lib/ptc_runner/kernel/provider_session.ex",
-      "sha256": "a1d9e7c75f98f60da3f8b07e2761bd3d87dfb5a7c86a6427f22f6c9af4efa3af"
+      "sha256": "8c4150f3c6a964512d8d88429f7253cd2eea18264986c5aa1a26e55f7eadbc47"
     },
     {
       "bytes": 2983,
@@ -727,9 +727,9 @@
       "sha256": "189adbdddf7987a79dfc40aad97cf16d631c86fa92af90ddf954c013094958ed"
     },
     {
-      "bytes": 5510,
+      "bytes": 5455,
       "path": "lib/ptc_runner/kernel/provider_task_tracker.ex",
-      "sha256": "23e6390fb83ff8fe126556c22b3d2b09ddf1934b52e6f2f2a4d4a671d8778047"
+      "sha256": "089e178d7668cea521c7f2034baebe3007ac4e1b9a2ece0aaba1a95069c76b20"
     },
     {
       "bytes": 3586,
@@ -782,9 +782,9 @@
       "sha256": "47f1b568056e09e9f7286544bfeba405e6a0ab1957c73358397c26e14778b63e"
     },
     {
-      "bytes": 36211,
+      "bytes": 36241,
       "path": "lib/ptc_runner/kernel/run_state.ex",
-      "sha256": "efa8c604572af7f749fa997af52eb5284892bb76f5390c55660cad5390b4740e"
+      "sha256": "fa980a957695abf981dd4aa9a532dc09db594e5ba5b26ab9f10b459bf0e2278f"
     },
     {
       "bytes": 16130,

--- a/priv/semantic_build_projection.json
+++ b/priv/semantic_build_projection.json
@@ -129,7 +129,7 @@
     "req_llm",
     "telemetry"
   ],
-  "source_closure_hash": "1f620d6f20ffaec6d533894d989c102348eb4c1f512180a53c65e0d12e1a2233",
+  "source_closure_hash": "e35ad257ce42d03742b459c44c22feed750ecb832beb6fdb5bca239558e1f2d2",
   "sources": [
     {
       "bytes": 870,
@@ -692,9 +692,9 @@
       "sha256": "798cc0516ef8c18f54aff21bbb1cbd914c89fab948316640608d9103ccc31646"
     },
     {
-      "bytes": 22941,
+      "bytes": 23298,
       "path": "lib/ptc_runner/kernel/provider_execution.ex",
-      "sha256": "cac6d76cb8aa3943ff4bc16032fef2da89c620e0147ec2fb69a450ed261999f9"
+      "sha256": "a155dce0d123bdbfbb946f6433b7bf671f332aaf481960fe06ecb3b32dfc1dec"
     },
     {
       "bytes": 6850,
@@ -762,9 +762,9 @@
       "sha256": "db45d9d38563d9e1828bc40007aca20fa764e0d7aea4ae87761d3526b2302124"
     },
     {
-      "bytes": 52500,
+      "bytes": 53072,
       "path": "lib/ptc_runner/kernel/run_builder.ex",
-      "sha256": "d1c71eb6c49db705cfed815e30d0c1fc27a445c9f5d225063f1a29022c188a6a"
+      "sha256": "4dda43ffadb1c9dc643ae8466af4ffb42cefb3004742ccaabab5f5b22577f989"
     },
     {
       "bytes": 16719,

--- a/priv/semantic_build_projection.json
+++ b/priv/semantic_build_projection.json
@@ -129,7 +129,7 @@
     "req_llm",
     "telemetry"
   ],
-  "source_closure_hash": "5d2e613a506cf3926b16c01be50bc055b1a1995a40702bac462286fd27cc55be",
+  "source_closure_hash": "5f657fdb251fde1d79ed32db735cdde3627dad57fb1e58b582bee674ec122cc1",
   "sources": [
     {
       "bytes": 870,
@@ -462,9 +462,9 @@
       "sha256": "af3d6f49540c4561648e52a90eb99199ff43789bbf1f9e14998aacb77a397109"
     },
     {
-      "bytes": 18077,
+      "bytes": 19204,
       "path": "lib/ptc_runner/kernel/mcp_oauth/authorization.ex",
-      "sha256": "bbad7da96ef09a0af416247d6b3dfc293b653ec1be012880a612aee8979371b3"
+      "sha256": "b457afcdda90043857b58623b2456775f4e1722dc3e1af537cb20c16cfc75357"
     },
     {
       "bytes": 7758,
@@ -512,9 +512,9 @@
       "sha256": "bc511779ebd0e1f6e6339044147ab62fd7e8eda3dcb472ec5037a397115a1b14"
     },
     {
-      "bytes": 9881,
+      "bytes": 10760,
       "path": "lib/ptc_runner/kernel/mcp_oauth/loopback_listener.ex",
-      "sha256": "2ffb7a70a90c0638f77f4b2f8945c70750dbf4f6c91d54c1d75da2b26aff9c22"
+      "sha256": "3cdfcb3f710b4a535df61abfd07ed97d6362834b5479a39327ffc96a8fea21f2"
     },
     {
       "bytes": 162,
@@ -692,9 +692,9 @@
       "sha256": "798cc0516ef8c18f54aff21bbb1cbd914c89fab948316640608d9103ccc31646"
     },
     {
-      "bytes": 21950,
+      "bytes": 22722,
       "path": "lib/ptc_runner/kernel/provider_execution.ex",
-      "sha256": "15e0543ba25efc310bcc0e8fcc087c2e8a4a8178f16a88a6213b2d1bd6f9d1e2"
+      "sha256": "1edb677e32029a4a3bc6dea95328bc5aa3d0f189b1fa0a6756b0eb84d372eec9"
     },
     {
       "bytes": 6850,
@@ -717,9 +717,9 @@
       "sha256": "3c966d49402041ed52aed30efaa47391e3ca6fd4283de2a4c6476db9f497cf82"
     },
     {
-      "bytes": 39780,
+      "bytes": 41918,
       "path": "lib/ptc_runner/kernel/provider_session.ex",
-      "sha256": "18992fce8880672059edee9559cdf72fb1c4383972585c7ed4ca1143d922dd76"
+      "sha256": "eed2d62891b609563a8fe04bca374e98f3400569d61b5d33ee1ccdcfc09fa833"
     },
     {
       "bytes": 2983,

--- a/priv/semantic_build_projection.json
+++ b/priv/semantic_build_projection.json
@@ -129,7 +129,7 @@
     "req_llm",
     "telemetry"
   ],
-  "source_closure_hash": "64b4d5263976fac71e4397edc401e628a4f9d63cdbf647382bb31893f26fd02a",
+  "source_closure_hash": "f34e9e4fd4cc618cb4c9e2554f56a32e7b02df1e02262d99f760956ce4922e78",
   "sources": [
     {
       "bytes": 870,
@@ -512,9 +512,9 @@
       "sha256": "bc511779ebd0e1f6e6339044147ab62fd7e8eda3dcb472ec5037a397115a1b14"
     },
     {
-      "bytes": 8709,
+      "bytes": 9828,
       "path": "lib/ptc_runner/kernel/mcp_oauth/loopback_listener.ex",
-      "sha256": "a0f46094138914c307d6d7c864ee20b68dee9a411482609ce394cfcd7f64534c"
+      "sha256": "fbe578a3d05d73fdfe28e411e54889c3b89d1e516fd6b08873f90ebe7360a506"
     },
     {
       "bytes": 162,

--- a/priv/semantic_build_projection.json
+++ b/priv/semantic_build_projection.json
@@ -129,7 +129,7 @@
     "req_llm",
     "telemetry"
   ],
-  "source_closure_hash": "c806d1a7acc4a9d31e5257416873eddad5c0892850ab3c3c3d6606c9203741fe",
+  "source_closure_hash": "1f620d6f20ffaec6d533894d989c102348eb4c1f512180a53c65e0d12e1a2233",
   "sources": [
     {
       "bytes": 870,
@@ -512,9 +512,9 @@
       "sha256": "bc511779ebd0e1f6e6339044147ab62fd7e8eda3dcb472ec5037a397115a1b14"
     },
     {
-      "bytes": 10760,
+      "bytes": 10826,
       "path": "lib/ptc_runner/kernel/mcp_oauth/loopback_listener.ex",
-      "sha256": "3cdfcb3f710b4a535df61abfd07ed97d6362834b5479a39327ffc96a8fea21f2"
+      "sha256": "a2981d1d14f4758c94f1784cb8ccbafd594f240afa3b491c25b36aedcb8c4a94"
     },
     {
       "bytes": 162,
@@ -692,9 +692,9 @@
       "sha256": "798cc0516ef8c18f54aff21bbb1cbd914c89fab948316640608d9103ccc31646"
     },
     {
-      "bytes": 22722,
+      "bytes": 22941,
       "path": "lib/ptc_runner/kernel/provider_execution.ex",
-      "sha256": "1edb677e32029a4a3bc6dea95328bc5aa3d0f189b1fa0a6756b0eb84d372eec9"
+      "sha256": "cac6d76cb8aa3943ff4bc16032fef2da89c620e0147ec2fb69a450ed261999f9"
     },
     {
       "bytes": 6850,
@@ -717,9 +717,9 @@
       "sha256": "3c966d49402041ed52aed30efaa47391e3ca6fd4283de2a4c6476db9f497cf82"
     },
     {
-      "bytes": 40432,
+      "bytes": 42445,
       "path": "lib/ptc_runner/kernel/provider_session.ex",
-      "sha256": "1d4d8180593e9c987c30f4708679ea868e98e460fdc20d1ec0d651a966e747f9"
+      "sha256": "a1d9e7c75f98f60da3f8b07e2761bd3d87dfb5a7c86a6427f22f6c9af4efa3af"
     },
     {
       "bytes": 2983,
@@ -782,9 +782,9 @@
       "sha256": "47f1b568056e09e9f7286544bfeba405e6a0ab1957c73358397c26e14778b63e"
     },
     {
-      "bytes": 36252,
+      "bytes": 36211,
       "path": "lib/ptc_runner/kernel/run_state.ex",
-      "sha256": "85394bbc0c2dba9dd0696e4823d6ba04dce2179e35dfd0301145ed68d15923bb"
+      "sha256": "efa8c604572af7f749fa997af52eb5284892bb76f5390c55660cad5390b4740e"
     },
     {
       "bytes": 16130,

--- a/priv/semantic_build_projection.json
+++ b/priv/semantic_build_projection.json
@@ -129,7 +129,7 @@
     "req_llm",
     "telemetry"
   ],
-  "source_closure_hash": "c0f0318146c539add7d2330251700c6899f44f29f44cb7a8b0b4edd1c29b31b6",
+  "source_closure_hash": "0232175f96034f9c4ea814adb793c5e6cf0b4d343e1bb891fa52252b33f01147",
   "sources": [
     {
       "bytes": 870,
@@ -382,9 +382,9 @@
       "sha256": "102e7c52d89d15c23660358e88a78c23acdf89a1f58e665ee595640bc068f39f"
     },
     {
-      "bytes": 21936,
+      "bytes": 22373,
       "path": "lib/ptc_runner/kernel/installation_catalog.ex",
-      "sha256": "4669b64930a9028a6f2cfaf7834094212d2cbd9cbce9f941f4c50a73e6214e31"
+      "sha256": "aca55551b5b86a1eff39ff08e7ff4ba0dc3b3ce4f1461274d8d01b5a31cef09d"
     },
     {
       "bytes": 11019,
@@ -682,9 +682,9 @@
       "sha256": "b0022b75ddec3890dd30bb54f95faaed5ed87312b3f0b3a8c3459ed642c01723"
     },
     {
-      "bytes": 9943,
+      "bytes": 10577,
       "path": "lib/ptc_runner/kernel/provider_descriptor.ex",
-      "sha256": "156874847f443787a8def77068062a976f082e0a3b6cc769fe38e1cbc4bb662b"
+      "sha256": "e0bf64330fcb0508b880222f0323cd7a6c6bf5f7d899124c74a176ba8d56d500"
     },
     {
       "bytes": 4309,
@@ -702,9 +702,9 @@
       "sha256": "fb2f499428f1a1f40adfab16edae03d5469668aab3aef8cc61175ccce3778ee5"
     },
     {
-      "bytes": 27239,
+      "bytes": 29620,
       "path": "lib/ptc_runner/kernel/provider_registry.ex",
-      "sha256": "599f2fff9309b998ace95173768cb78956893230e39a866650f7c0f6de52ba45"
+      "sha256": "c78f22317de270847d01b549445e9b5a0536773c5ea41e356692e71d1030d1d2"
     },
     {
       "bytes": 14468,
@@ -762,9 +762,9 @@
       "sha256": "db45d9d38563d9e1828bc40007aca20fa764e0d7aea4ae87761d3526b2302124"
     },
     {
-      "bytes": 54050,
+      "bytes": 54205,
       "path": "lib/ptc_runner/kernel/run_builder.ex",
-      "sha256": "6cbade6deea0d3901dd848fffcba03ef7e72e6420490e91a6bd7fdf3bd106f35"
+      "sha256": "466a092c8e0ec9d7026382aa52e1527cc97ec23f4061bc334c52280f3089deed"
     },
     {
       "bytes": 16621,

--- a/priv/semantic_build_projection.json
+++ b/priv/semantic_build_projection.json
@@ -129,7 +129,7 @@
     "req_llm",
     "telemetry"
   ],
-  "source_closure_hash": "0232175f96034f9c4ea814adb793c5e6cf0b4d343e1bb891fa52252b33f01147",
+  "source_closure_hash": "64b4d5263976fac71e4397edc401e628a4f9d63cdbf647382bb31893f26fd02a",
   "sources": [
     {
       "bytes": 870,
@@ -332,9 +332,9 @@
       "sha256": "6a600b4f98f392bef91974018fb5fb6a4c07feda43369064d839ae65c746841a"
     },
     {
-      "bytes": 56755,
+      "bytes": 56064,
       "path": "lib/ptc_runner/kernel/host_installation.ex",
-      "sha256": "91692e9278464aa464279399f2624f732adb110d1c8c5d02d9d7b718828b080f"
+      "sha256": "e35512725e370766e3c626a2ac6b0ec9bb384f75c420fe8084caeec368935c39"
     },
     {
       "bytes": 7423,
@@ -347,9 +347,9 @@
       "sha256": "2df2775eaa69764934cef52c195c79692343fa6970fd8b8c8f56d1a0d0358592"
     },
     {
-      "bytes": 6087,
+      "bytes": 5701,
       "path": "lib/ptc_runner/kernel/host_runtime_payload.ex",
-      "sha256": "e94fb2a8aa12fd4711caa5dc40b6ef2b9024f82df7c5fddde80eed146938911b"
+      "sha256": "089de6fd326aa8b61959a073c2ff73c321c23ea5233affcfa889cc9049d9454c"
     },
     {
       "bytes": 7483,
@@ -692,9 +692,9 @@
       "sha256": "798cc0516ef8c18f54aff21bbb1cbd914c89fab948316640608d9103ccc31646"
     },
     {
-      "bytes": 21695,
+      "bytes": 21254,
       "path": "lib/ptc_runner/kernel/provider_execution.ex",
-      "sha256": "4fdc6f28d64c6614a9dee4e14fb9c51d23320588462ea308e8beaf240215c0d2"
+      "sha256": "b7b979ab5007e6c69178ebb98d9571bed1081ae4f035094a540524bec0c7df1b"
     },
     {
       "bytes": 6850,
@@ -707,9 +707,9 @@
       "sha256": "c78f22317de270847d01b549445e9b5a0536773c5ea41e356692e71d1030d1d2"
     },
     {
-      "bytes": 14468,
+      "bytes": 13767,
       "path": "lib/ptc_runner/kernel/provider_runtime_services.ex",
-      "sha256": "578225a4b383456179a49e44938ffcc10d500907f1465e5e746f7d5471c42e3c"
+      "sha256": "1b1968026e215f60a650226e18d5add96aac296ad0009a8cca4c88d6c7825977"
     },
     {
       "bytes": 15111,

--- a/priv/semantic_build_projection.json
+++ b/priv/semantic_build_projection.json
@@ -129,7 +129,7 @@
     "req_llm",
     "telemetry"
   ],
-  "source_closure_hash": "f34e9e4fd4cc618cb4c9e2554f56a32e7b02df1e02262d99f760956ce4922e78",
+  "source_closure_hash": "5d2e613a506cf3926b16c01be50bc055b1a1995a40702bac462286fd27cc55be",
   "sources": [
     {
       "bytes": 870,
@@ -312,9 +312,9 @@
       "sha256": "045af7e3f517de1320be1daf25a9f18a020502dd9ad0c9d3a9fc62aa2296f5f7"
     },
     {
-      "bytes": 15659,
+      "bytes": 16267,
       "path": "lib/ptc_runner/kernel/execution_session_owner.ex",
-      "sha256": "07b1989254d0f266f57870ccd5b14becad8c9dbd64878cf4d2a518c1e64a0ec2"
+      "sha256": "9c103b9a7ee924ee7001564591dc7f21998bc915865a8d68c6b6ee62e64d1a2b"
     },
     {
       "bytes": 5427,
@@ -512,9 +512,9 @@
       "sha256": "bc511779ebd0e1f6e6339044147ab62fd7e8eda3dcb472ec5037a397115a1b14"
     },
     {
-      "bytes": 9828,
+      "bytes": 9881,
       "path": "lib/ptc_runner/kernel/mcp_oauth/loopback_listener.ex",
-      "sha256": "fbe578a3d05d73fdfe28e411e54889c3b89d1e516fd6b08873f90ebe7360a506"
+      "sha256": "2ffb7a70a90c0638f77f4b2f8945c70750dbf4f6c91d54c1d75da2b26aff9c22"
     },
     {
       "bytes": 162,
@@ -662,9 +662,9 @@
       "sha256": "a9a4a86d2d0d9d81f79575b0f83de33558ab6d6a518a35a7eba26983b5d908c2"
     },
     {
-      "bytes": 13795,
+      "bytes": 10548,
       "path": "lib/ptc_runner/kernel/provider_active_session.ex",
-      "sha256": "75fe92d011c517a267be44faba5a07d12e0881d9933188f0ddaa2b9f0bd385a4"
+      "sha256": "e32f83bb1d139a645ad86b577d2fd1638c04c2b8d2d71423237ee1bae0959541"
     },
     {
       "bytes": 12055,
@@ -692,9 +692,9 @@
       "sha256": "798cc0516ef8c18f54aff21bbb1cbd914c89fab948316640608d9103ccc31646"
     },
     {
-      "bytes": 21254,
+      "bytes": 21950,
       "path": "lib/ptc_runner/kernel/provider_execution.ex",
-      "sha256": "b7b979ab5007e6c69178ebb98d9571bed1081ae4f035094a540524bec0c7df1b"
+      "sha256": "15e0543ba25efc310bcc0e8fcc087c2e8a4a8178f16a88a6213b2d1bd6f9d1e2"
     },
     {
       "bytes": 6850,
@@ -762,9 +762,9 @@
       "sha256": "db45d9d38563d9e1828bc40007aca20fa764e0d7aea4ae87761d3526b2302124"
     },
     {
-      "bytes": 54205,
+      "bytes": 52500,
       "path": "lib/ptc_runner/kernel/run_builder.ex",
-      "sha256": "466a092c8e0ec9d7026382aa52e1527cc97ec23f4061bc334c52280f3089deed"
+      "sha256": "d1c71eb6c49db705cfed815e30d0c1fc27a445c9f5d225063f1a29022c188a6a"
     },
     {
       "bytes": 16621,
@@ -772,9 +772,9 @@
       "sha256": "6138de12146c1d6d58bfb2332725fa177983fcc3a42b7f58b046a4e6b2708344"
     },
     {
-      "bytes": 14875,
+      "bytes": 16295,
       "path": "lib/ptc_runner/kernel/run_coordinator.ex",
-      "sha256": "9a6d473243bd9971bba5cf3c64f9f6d92dc0c926025d202f990c12c091932ada"
+      "sha256": "d5a464c3d94965ec38fc4c80fccbc1ba7d8da55058186fe5d754740b0795e023"
     },
     {
       "bytes": 3105,

--- a/test/mix/tasks/ptc_run_test.exs
+++ b/test/mix/tasks/ptc_run_test.exs
@@ -4,7 +4,9 @@ defmodule Mix.Tasks.Ptc.RunTest do
   import ExUnit.CaptureIO
 
   alias Mix.Tasks.Ptc.Run
+  alias PtcRunner.Dotenv
   alias PtcRunner.Kernel.Deadline
+  alias PtcRunner.Kernel.ProviderSession
   alias PtcRunner.Kernel.SafeMetadata
   alias PtcRunner.Kernel.TraceLog
 
@@ -246,24 +248,7 @@ defmodule Mix.Tasks.Ptc.RunTest do
     stop_provider_applications()
 
     credential_env = "PTC_RUN_DOTENV_CREDENTIAL"
-    previous_credential = System.get_env(credential_env)
-    dotenv_key = {PtcRunner.Dotenv, :dotenv_loaded}
-    previous_dotenv_state = :persistent_term.get(dotenv_key, :missing)
-
-    System.delete_env(credential_env)
-    :persistent_term.erase(dotenv_key)
-
-    on_exit(fn ->
-      if previous_credential,
-        do: System.put_env(credential_env, previous_credential),
-        else: System.delete_env(credential_env)
-
-      case previous_dotenv_state do
-        :missing -> :persistent_term.erase(dotenv_key)
-        state -> :persistent_term.put(dotenv_key, state)
-      end
-    end)
-
+    reset_dotenv_state(credential_env)
     File.write!(Path.join(dir, ".env"), "#{credential_env}=dotenv-secret\n")
 
     {manifest_path, host_path} =
@@ -279,6 +264,129 @@ defmodule Mix.Tasks.Ptc.RunTest do
 
     assert output =~ "workflow  deepseek  llm  revision check-llm-v1"
     refute output =~ "dotenv-secret"
+  end
+
+  @tag :tmp_dir
+  test "one-shot and --check apply the same env-credential rule", %{tmp_dir: dir} do
+    restore_provider_applications_on_exit()
+    stop_provider_applications()
+
+    credential_env = "PTC_RUN_DOTENV_SHARED_CREDENTIAL"
+    reset_dotenv_state(credential_env)
+    File.write!(Path.join(dir, ".env"), "#{credential_env}=dotenv-secret\n")
+    {manifest_path, host_path} = write_llm_check_fixture(dir, %{"env" => credential_env})
+
+    one_shot = run_in(dir, [manifest_path, "--host-config", host_path])
+
+    assert System.get_env(credential_env) == "dotenv-secret"
+    refute one_shot =~ "dotenv-secret"
+
+    # Loading is latched per VM, so the check invocation must reload it rather
+    # than inherit the one-shot's environment.
+    clear_dotenv_state(credential_env)
+
+    check = run_in(dir, [manifest_path, "--host-config", host_path, "--check"])
+
+    assert System.get_env(credential_env) == "dotenv-secret"
+    refute check =~ "dotenv-secret"
+  end
+
+  @tag :tmp_dir
+  test "provider-free and literal-credential runs never read the nearest .env", %{tmp_dir: dir} do
+    restore_provider_applications_on_exit()
+    stop_provider_applications()
+
+    credential_env = "PTC_RUN_DOTENV_UNUSED_CREDENTIAL"
+    reset_dotenv_state(credential_env)
+    File.write!(Path.join(dir, ".env"), "#{credential_env}=dotenv-secret\n")
+
+    {literal_manifest, literal_host} = write_llm_check_fixture(dir)
+    _literal = run_in(dir, [literal_manifest, "--host-config", literal_host])
+    assert System.get_env(credential_env) == nil
+
+    free_dir = Path.join(dir, "provider-free")
+    File.mkdir_p!(free_dir)
+    File.write!(Path.join(free_dir, "main.clj"), ~S|(ns main) (defn run [input] (return input))|)
+
+    free_manifest = Path.join(free_dir, "ptc.json")
+
+    File.write!(
+      free_manifest,
+      Jason.encode!(%{
+        "version" => 1,
+        "workflow" => %{
+          "components" => [%{"id" => "main", "path" => "main.clj"}],
+          "entry" => "main/run"
+        },
+        "input" => %{"value" => %{}}
+      })
+    )
+
+    _free = run_in(dir, [free_manifest])
+    assert System.get_env(credential_env) == nil
+  end
+
+  @tag :tmp_dir
+  test "a one-shot loads .env before the run clock starts", %{tmp_dir: dir} do
+    restore_provider_applications_on_exit()
+    stop_provider_applications()
+
+    credential_env = "PTC_RUN_DOTENV_ORDER_CREDENTIAL"
+    reset_dotenv_state(credential_env)
+    File.write!(Path.join(dir, ".env"), "#{credential_env}=dotenv-secret\n")
+    {manifest_path, host_path} = write_llm_check_fixture(dir, %{"env" => credential_env})
+
+    trace_calls(
+      [
+        {{Dotenv, :load, 0}, [{:_, [], [{:return_trace}]}]},
+        {{ProviderSession, :begin_run, 1}, true}
+      ],
+      fn -> run_in(dir, [manifest_path, "--host-config", host_path]) end
+    )
+
+    # Mailbox order across processes is not a happens-before proof, so the
+    # assertion compares the VM's own monotonic trace timestamps, and it uses
+    # the load's return rather than its call so a blocked loader cannot pass.
+    assert_receive {:trace_ts, loader, :return_from, {Dotenv, :load, 0}, :ok, loaded_at}, 5_000
+
+    assert_receive {:trace_ts, _worker, :call, {ProviderSession, :begin_run, [_session]},
+                    run_clock_started_at},
+                   5_000
+
+    assert loader == self()
+    assert loaded_at < run_clock_started_at
+  end
+
+  @tag :tmp_dir
+  test "an unreadable .env fails the command without exposing its path", %{tmp_dir: dir} do
+    restore_provider_applications_on_exit()
+    stop_provider_applications()
+
+    credential_env = "PTC_RUN_DOTENV_UNREADABLE_CREDENTIAL"
+    reset_dotenv_state(credential_env)
+    env_path = Path.join(dir, ".env")
+    File.write!(env_path, "#{credential_env}=dotenv-secret\n")
+    File.chmod!(env_path, 0o000)
+    on_exit(fn -> File.chmod(env_path, 0o600) end)
+
+    {manifest_path, host_path} = write_llm_check_fixture(dir, %{"env" => credential_env})
+
+    # A privileged user can read the file anyway, which would make the failure
+    # unreachable rather than the assertion wrong.
+    if match?({:error, _reason}, File.read(env_path)) do
+      for argv <- [
+            [manifest_path, "--host-config", host_path],
+            [manifest_path, "--host-config", host_path, "--check"]
+          ] do
+        error =
+          assert_raise Mix.Error, fn ->
+            run_in(dir, argv)
+          end
+
+        assert error.message == "ptc.run failed: dotenv_unavailable"
+        refute error.message =~ dir
+      end
+    end
   end
 
   @tag :tmp_dir
@@ -981,6 +1089,78 @@ defmodule Mix.Tasks.Ptc.RunTest do
 
   defp started_applications,
     do: Application.started_applications() |> Enum.map(&elem(&1, 0))
+
+  defp run_in(dir, argv) do
+    File.cd!(dir, fn ->
+      capture_io(fn ->
+        Mix.Task.reenable("ptc.run")
+        Run.run(argv)
+      end)
+    end)
+  end
+
+  defp reset_dotenv_state(credential_env) do
+    previous_credential = System.get_env(credential_env)
+    previous_state = :persistent_term.get(dotenv_key(), :missing)
+    clear_dotenv_state(credential_env)
+
+    on_exit(fn ->
+      if previous_credential,
+        do: System.put_env(credential_env, previous_credential),
+        else: System.delete_env(credential_env)
+
+      case previous_state do
+        :missing -> :persistent_term.erase(dotenv_key())
+        state -> :persistent_term.put(dotenv_key(), state)
+      end
+    end)
+  end
+
+  defp clear_dotenv_state(credential_env) do
+    System.delete_env(credential_env)
+    :persistent_term.erase(dotenv_key())
+  end
+
+  defp dotenv_key, do: {Dotenv, :dotenv_loaded}
+
+  # Traces the named calls in this process and in every process the run spawns,
+  # so an ordering assertion can span the frontend and the execution owner
+  # without tracing unrelated work. A process receives no trace messages for
+  # its own calls while it is its own tracer, so a forwarding tracer collects
+  # them on the test process's behalf.
+  defp trace_calls(functions, operation) do
+    test = self()
+    tracer = spawn_link(fn -> forward_traces(test) end)
+
+    # `:set_on_spawn` keeps the trace inside this invocation's process tree, so
+    # an unrelated process cannot satisfy an ordering assertion.
+    flags = [:call, :monotonic_timestamp, :set_on_spawn, {:tracer, tracer}]
+
+    Enum.each(functions, fn {{module, function, arity}, match_spec} ->
+      Code.ensure_loaded!(module)
+      assert :erlang.trace_pattern({module, function, arity}, match_spec, [:local]) == 1
+    end)
+
+    :erlang.trace(self(), true, flags)
+
+    try do
+      operation.()
+    after
+      :erlang.trace(self(), false, [:call, :set_on_spawn])
+
+      Enum.each(functions, fn {{module, function, arity}, _match_spec} ->
+        :erlang.trace_pattern({module, function, arity}, false, [:local])
+      end)
+    end
+  end
+
+  defp forward_traces(test) do
+    receive do
+      message ->
+        send(test, message)
+        forward_traces(test)
+    end
+  end
 
   defp stop_provider_applications do
     running = started_applications()

--- a/test/mix/tasks/ptc_run_test.exs
+++ b/test/mix/tasks/ptc_run_test.exs
@@ -1131,6 +1131,7 @@ defmodule Mix.Tasks.Ptc.RunTest do
   defp trace_calls(functions, operation) do
     test = self()
     tracer = spawn_link(fn -> forward_traces(test) end)
+    tracer_down = Process.monitor(tracer)
 
     # `:set_on_spawn` keeps the trace inside this invocation's process tree, so
     # an unrelated process cannot satisfy an ordering assertion.
@@ -1151,11 +1152,30 @@ defmodule Mix.Tasks.Ptc.RunTest do
       Enum.each(functions, fn {{module, function, arity}, _match_spec} ->
         :erlang.trace_pattern({module, function, arity}, false, [:local])
       end)
+
+      # Trace signals from the spawned execution owner can still be in flight
+      # when `operation.()` returns, so delivery is settled before the
+      # forwarder is stopped. A test process exits normally, which a linked
+      # process ignores, so it is stopped explicitly rather than left for the
+      # suite to accumulate.
+      delivered = :erlang.trace_delivered(:all)
+
+      receive do
+        {:trace_delivered, :all, ^delivered} -> :ok
+      after
+        5_000 -> flunk("trace delivery did not settle")
+      end
+
+      send(tracer, :stop)
+      assert_receive {:DOWN, ^tracer_down, :process, ^tracer, :normal}, 5_000
     end
   end
 
   defp forward_traces(test) do
     receive do
+      :stop ->
+        :ok
+
       message ->
         send(test, message)
         forward_traces(test)

--- a/test/mix/tasks/ptc_run_test.exs
+++ b/test/mix/tasks/ptc_run_test.exs
@@ -5,36 +5,12 @@ defmodule Mix.Tasks.Ptc.RunTest do
 
   alias Mix.Tasks.Ptc.Run
   alias PtcRunner.Dotenv
-  alias PtcRunner.Kernel.Deadline
   alias PtcRunner.Kernel.ProviderSession
   alias PtcRunner.Kernel.SafeMetadata
   alias PtcRunner.Kernel.TraceLog
 
   @root Path.expand("../../..", __DIR__)
   @stdio_fixture Path.expand("../../support/mcp_stdio_source_fixture.sh", __DIR__)
-
-  test "OAuth setup and each requested target use their exact independent deadlines" do
-    declarations = [
-      %{name: "first", config: %{"timeout_ms" => 5_000}},
-      %{name: "plain", config: %{"timeout_ms" => 1}},
-      %{name: "first", config: %{"timeout_ms" => 2_000}},
-      %{name: "second", config: %{"timeout_ms" => 3_000}}
-    ]
-
-    authorities = %{
-      "first" => %{authorization_timeout_ms: 7_000},
-      "plain" => nil,
-      "second" => %{authorization_timeout_ms: 4_000}
-    }
-
-    setup = Run.oauth_setup_deadline(declarations, authorities, ["second", "first"], 1_000)
-    first = Run.oauth_target_deadline("first", declarations, authorities, 10_000)
-    second = Run.oauth_target_deadline("second", declarations, authorities, 20_000)
-
-    assert Deadline.expires_at(setup) == 3_000
-    assert Deadline.expires_at(first) == 12_000
-    assert Deadline.expires_at(second) == 23_000
-  end
 
   @tag :tmp_dir
   test "runs the shared manifest path and accepts a confined mission override", %{tmp_dir: dir} do

--- a/test/ptc_runner/kernel/command_engine_test.exs
+++ b/test/ptc_runner/kernel/command_engine_test.exs
@@ -2634,6 +2634,22 @@ defmodule PtcRunner.Kernel.CommandEngineTest do
     refute ProviderRegistry.valid?(Map.put(registry, :unexpected, :retained))
   end
 
+  test "provider registries reject a builder bound to a malformed declared policy" do
+    prepare = fn _selection, _context ->
+      {:ok, %{credential_names: [], preflight: fn -> :ok end}}
+    end
+
+    for policy <- [
+          %{data_class: :normal, accepts_data: :normal},
+          %{data_class: :normal, accepts_data: []},
+          %{data_class: :unknown, accepts_data: [:normal]},
+          %{data_class: :normal, accepts_data: [:normal, :unknown]}
+        ] do
+      assert {:error, :invalid_provider_registry} =
+               ProviderRegistry.new(%{"bound" => ProviderRegistry.staged(prepare, policy)})
+    end
+  end
+
   @tag :tmp_dir
   test "preparation and assembly reject invalid registries before consuming work", %{
     tmp_dir: directory

--- a/test/ptc_runner/kernel/host_config_oauth_test.exs
+++ b/test/ptc_runner/kernel/host_config_oauth_test.exs
@@ -1,7 +1,6 @@
 defmodule PtcRunner.Kernel.HostConfigOAuthTest do
   use ExUnit.Case, async: true
 
-  alias Mix.Tasks.Ptc.Run
   alias PtcRunner.Kernel.CommandDiagnostic
   alias PtcRunner.Kernel.Deadline
   alias PtcRunner.Kernel.HostConfig
@@ -11,6 +10,7 @@ defmodule PtcRunner.Kernel.HostConfigOAuthTest do
   alias PtcRunner.Kernel.MCPOAuth.Context
   alias PtcRunner.Kernel.MCPOAuth.Store
   alias PtcRunner.Kernel.MCPOAuth.Store.Memory
+  alias PtcRunner.Kernel.ProviderExecution
   alias PtcRunner.Kernel.ProviderRegistry
 
   test "decodes OAuth only when normalized static authentication is empty" do
@@ -241,12 +241,11 @@ defmodule PtcRunner.Kernel.HostConfigOAuthTest do
     assert {:ok, catalog} = HostInstallation.catalog(host)
     assert catalog.authorities["github"] == :host_runtime
 
-    assert %{"github" => authority} = Run.oauth_authorities(host, ["github"])
+    authority = host.install["github"].transport.oauth
     assert Authority.valid?(authority)
-    assert authority == host.install["github"].transport.oauth
 
     assert {:error, %CommandDiagnostic{} = diagnostic} =
-             Run.authorization_result(
+             ProviderExecution.authorization_result(
                {:error, {:authorization_timeout, "github"}},
                ["github"],
                catalog

--- a/test/ptc_runner/kernel/host_installation_test.exs
+++ b/test/ptc_runner/kernel/host_installation_test.exs
@@ -104,6 +104,63 @@ defmodule PtcRunner.Kernel.HostInstallationTest do
   end
 
   @tag :tmp_dir
+  test "an expired operation deadline never activates the host payload", %{tmp_dir: dir} do
+    host = load_host(dir, http_config())
+    assert {:ok, catalog} = HostInstallation.catalog(host)
+    assert {:ok, services} = HostInstallation.runtime_services(host)
+    parent = self()
+    activation = services.activation
+
+    # Comparing owners after the call cannot separate "never started" from
+    # "started and then released"; only the first is correct once the deadline
+    # has already expired, so the activation itself reports whether it ran.
+    observed = fn ->
+      send(parent, :activated)
+      activation.()
+    end
+
+    services = replace_activation(services, observed)
+    owners_before = host_installation_owners()
+    expired = Deadline.from_expires_at(System.monotonic_time(:millisecond) - 1)
+
+    assert {:error, :operation_deadline_expired} =
+             InstallationCatalog.runtime_registry(catalog, services, ["remote"], expired)
+
+    refute_received :activated
+    assert host_installation_owners() == owners_before
+  end
+
+  @tag :tmp_dir
+  test "an operation expiring during activation releases the started authority", %{tmp_dir: dir} do
+    host = load_host(dir, http_config())
+    assert {:ok, catalog} = HostInstallation.catalog(host)
+    assert {:ok, services} = HostInstallation.runtime_services(host)
+    parent = self()
+    deadline = Deadline.new(50)
+    activation = services.activation
+
+    # Host-bound activation is a synchronous bootstrap exception, so the bound
+    # on a slow one is that its authority is released rather than handed to a
+    # registry. Publishing the real authority first lets the test name the
+    # exact owner and lease that must not survive the expired operation.
+    delayed = fn ->
+      result = activation.()
+      send(parent, {:activated, result})
+      wait_until_expired(deadline)
+      result
+    end
+
+    services = replace_activation(services, delayed)
+
+    assert {:error, :operation_deadline_expired} =
+             InstallationCatalog.runtime_registry(catalog, services, ["remote"], deadline)
+
+    assert_received {:activated, {:ok, authority}}
+    refute Process.alive?(authority.pid)
+    refute Process.alive?(authority.lease_owner)
+  end
+
+  @tag :tmp_dir
   test "host-backed credential resolution runs outside the authority owner", %{tmp_dir: dir} do
     parent = self()
     host = load_host(dir, http_config())
@@ -1344,14 +1401,27 @@ defmodule PtcRunner.Kernel.HostInstallationTest do
     host
   end
 
-  defp replace_credential_resolver(services, resolver) do
-    services = %{services | credential_resolver: resolver}
+  defp replace_credential_resolver(services, resolver),
+    do: reseal_services(%{services | credential_resolver: resolver})
 
+  defp replace_activation(services, activation),
+    do: reseal_services(%{services | activation: activation})
+
+  defp reseal_services(services) do
     payload =
       {services.activation, services.credential_resolver, services.provider_application_mode,
        services.oauth_mode, services.runtime_binding, services.host_payload}
 
     %{services | attestation: Attestation.attest(ProviderRuntimeServices, payload)}
+  end
+
+  defp wait_until_expired(deadline) do
+    if Deadline.expired?(deadline) do
+      :ok
+    else
+      :erlang.yield()
+      wait_until_expired(deadline)
+    end
   end
 
   defp assert_eventually(predicate, attempts \\ 10_000)

--- a/test/ptc_runner/kernel/mcp_oauth/authorization_test.exs
+++ b/test/ptc_runner/kernel/mcp_oauth/authorization_test.exs
@@ -2,6 +2,7 @@ defmodule PtcRunner.Kernel.MCPOAuth.AuthorizationTest do
   use ExUnit.Case, async: true
 
   alias PtcRunner.Kernel.Deadline
+  alias PtcRunner.Kernel.Limits
   alias PtcRunner.Kernel.MCPOAuth.Authority
   alias PtcRunner.Kernel.MCPOAuth.Authorization
   alias PtcRunner.Kernel.MCPOAuth.Context
@@ -9,6 +10,7 @@ defmodule PtcRunner.Kernel.MCPOAuth.AuthorizationTest do
   alias PtcRunner.Kernel.MCPOAuth.Metadata
   alias PtcRunner.Kernel.MCPOAuth.Store
   alias PtcRunner.Kernel.MCPOAuth.Store.Memory
+  alias PtcRunner.Kernel.ProviderSession
   alias PtcRunner.Test.MCPOAuthRecordingStore
 
   setup do
@@ -482,6 +484,58 @@ defmodule PtcRunner.Kernel.MCPOAuth.AuthorizationTest do
     assert remaining > 4_000 and remaining <= 5_000
   end
 
+  @tag timeout: 15_000
+  test "cancellation consumes the one anchored cleanup deadline", context do
+    parent = self()
+    request = request_fixture(context.authority, self())
+    {:ok, limits} = Limits.new(provider_cleanup_timeout_ms: 1_000)
+    assert {:ok, session} = ProviderSession.start(limits)
+
+    {:ok, recording_store} =
+      MCPOAuthRecordingStore.wrap(context.store, self(),
+        interceptor: fn operation, deadline ->
+          if elem(operation, 0) == :cancel_flow, do: send(parent, {:cancel_deadline, deadline})
+          :delegate
+        end
+      )
+
+    {:ok, recording_context} =
+      Context.new(
+        tenant_id: "tenant",
+        principal_id: "alice",
+        store: recording_store,
+        deadline: Deadline.new(10_000)
+      )
+
+    assert {:ok, listener} = LoopbackListener.start(context.authority)
+
+    assert {:ok, pending} =
+             Authorization.begin_authorization(recording_context, context.authority,
+               authority_epoch: context.epoch,
+               redirect_uri: listener.redirect_uri,
+               request: request
+             )
+
+    # An earlier terminal action has already anchored this session's one budget.
+    assert {:ok, anchored} = ProviderSession.anchor_cleanup_deadline(session)
+
+    # No client connects, so the interaction spends its own timeout before
+    # failing. Cleanup then gets what is left of the anchored budget.
+    interaction = %{pending | deadline_ms: System.monotonic_time(:millisecond) + 300}
+
+    assert {:error, :authorization_timeout} =
+             LoopbackListener.await(listener, recording_context, interaction,
+               request: request,
+               anchor_cleanup_deadline: fn -> ProviderSession.anchor_cleanup_deadline(session) end
+             )
+
+    assert_received {:cancel_deadline, cancel_deadline}
+    assert cancel_deadline == anchored
+    assert Deadline.remaining(cancel_deadline) <= 700
+
+    assert :ok = ProviderSession.close(session)
+  end
+
   test "a silent client that never completes its request reports a timeout", context do
     request = request_fixture(context.authority, self())
     assert {:ok, listener} = LoopbackListener.start(context.authority)
@@ -621,9 +675,11 @@ defmodule PtcRunner.Kernel.MCPOAuth.AuthorizationTest do
     end
   end
 
-  # Production supplies the lifecycle owner's installed cleanup budget; without
-  # it a failed interaction cannot cancel its pending authorization.
-  defp await_opts(request), do: [request: request, cleanup_timeout_ms: 5_000]
+  # Production supplies the operation that anchors the lifecycle owner's one
+  # cleanup deadline; without it a failed interaction cannot cancel its pending
+  # authorization.
+  defp await_opts(request),
+    do: [request: request, anchor_cleanup_deadline: fn -> {:ok, Deadline.new(5_000)} end]
 
   defp request_fixture(
          authority,

--- a/test/ptc_runner/kernel/mcp_oauth/authorization_test.exs
+++ b/test/ptc_runner/kernel/mcp_oauth/authorization_test.exs
@@ -386,6 +386,161 @@ defmodule PtcRunner.Kernel.MCPOAuth.AuthorizationTest do
     assert {:error, :invalid_callback_request} = Task.await(task, 1_000)
   end
 
+  test "an expired interaction refuses a callback that is already buffered", context do
+    request = request_fixture(context.authority, self())
+    assert {:ok, listener} = LoopbackListener.start(context.authority)
+
+    assert {:ok, pending} =
+             Authorization.begin_authorization(context.context, context.authority,
+               authority_epoch: context.epoch,
+               redirect_uri: listener.redirect_uri,
+               request: request
+             )
+
+    state =
+      pending.url
+      |> URI.parse()
+      |> Map.fetch!(:query)
+      |> URI.decode_query()
+      |> Map.fetch!("state")
+
+    {:ok, socket} =
+      :gen_tcp.connect({127, 0, 0, 1}, listener.port, [:binary, active: false], 1_000)
+
+    target =
+      "/callback?" <>
+        URI.encode_query(%{
+          "code" => "late-code",
+          "state" => state,
+          "iss" => context.authority.issuer
+        })
+
+    # A complete, otherwise valid callback sitting in the socket before the
+    # listener ever accepts it. Accepting a connection or reading buffered
+    # bytes after expiry would complete an interaction whose deadline passed.
+    assert :ok =
+             :gen_tcp.send(
+               socket,
+               "GET #{target} HTTP/1.1\r\nHost: 127.0.0.1:#{listener.port}\r\n\r\n"
+             )
+
+    expired = %{pending | deadline_ms: System.monotonic_time(:millisecond) - 1}
+
+    assert {:error, :authorization_timeout} =
+             LoopbackListener.await(listener, context.context, expired, request: request)
+
+    assert {:error, :closed} = :gen_tcp.recv(socket, 0, 1_000)
+  end
+
+  test "a silent client that never completes its request reports a timeout", context do
+    request = request_fixture(context.authority, self())
+    assert {:ok, listener} = LoopbackListener.start(context.authority)
+
+    assert {:ok, pending} =
+             Authorization.begin_authorization(context.context, context.authority,
+               authority_epoch: context.epoch,
+               redirect_uri: listener.redirect_uri,
+               request: request
+             )
+
+    pending = %{pending | deadline_ms: System.monotonic_time(:millisecond) + 200}
+
+    task =
+      Task.async(fn ->
+        receive do: (:go -> :ok)
+        LoopbackListener.await(listener, context.context, pending, request: request)
+      end)
+
+    assert :ok = :gen_tcp.controlling_process(listener.socket, task.pid)
+    send(task.pid, :go)
+
+    {:ok, socket} =
+      :gen_tcp.connect({127, 0, 0, 1}, listener.port, [:binary, active: false], 1_000)
+
+    # A connection that stops mid-request is an expired interaction, not a
+    # malformed one; the distinction is what the caller reports to the user.
+    assert :ok =
+             :gen_tcp.send(
+               socket,
+               "GET /callback HTTP/1.1\r\nHost: 127.0.0.1:#{listener.port}\r\n"
+             )
+
+    assert {:error, :authorization_timeout} = Task.await(task, 5_000)
+
+    # Proves the interaction reached the receive loop; an accept that timed out
+    # first would satisfy the reason without ever handling a connection.
+    assert {:ok, response} = :gen_tcp.recv(socket, 0, 5_000)
+    assert response =~ "400 Bad Request"
+  end
+
+  test "a trickling client cannot extend an expired loopback interaction", context do
+    parent = self()
+    request = request_fixture(context.authority, self())
+
+    {:ok, observed_store} =
+      MCPOAuthRecordingStore.wrap(context.store, self(),
+        interceptor: fn operation, _deadline ->
+          if elem(operation, 0) == :cancel_flow, do: send(parent, :cancel_flow_issued)
+          :delegate
+        end
+      )
+
+    {:ok, observed_context} =
+      Context.new(
+        tenant_id: "tenant",
+        principal_id: "alice",
+        store: observed_store,
+        deadline: Deadline.new(10_000)
+      )
+
+    assert {:ok, listener} = LoopbackListener.start(context.authority)
+
+    assert {:ok, pending} =
+             Authorization.begin_authorization(observed_context, context.authority,
+               authority_epoch: context.epoch,
+               redirect_uri: listener.redirect_uri,
+               request: request
+             )
+
+    pending = %{pending | deadline_ms: System.monotonic_time(:millisecond) + 300}
+
+    task =
+      Task.async(fn ->
+        receive do: (:go -> :ok)
+        LoopbackListener.await(listener, observed_context, pending, request: request)
+      end)
+
+    assert :ok = :gen_tcp.controlling_process(listener.socket, task.pid)
+    send(task.pid, :go)
+
+    {:ok, socket} =
+      :gen_tcp.connect({127, 0, 0, 1}, listener.port, [:binary, active: false], 1_000)
+
+    # A request head that never terminates, followed by bytes that keep
+    # arriving after the absolute deadline.
+    assert :ok =
+             :gen_tcp.send(
+               socket,
+               "GET /callback HTTP/1.1\r\nHost: 127.0.0.1:#{listener.port}\r\n"
+             )
+
+    client = spawn(fn -> trickle(socket, parent) end)
+    on_exit(fn -> if Process.alive?(client), do: Process.exit(client, :kill) end)
+
+    assert {:error, :authorization_timeout} = Task.await(task, 5_000)
+
+    # The 400 proves the connection was accepted and the receive loop ran, so
+    # the timeout cannot have come from an accept that expired first.
+    assert {:ok, response} = :gen_tcp.recv(socket, 0, 5_000)
+    assert response =~ "400 Bad Request"
+
+    # The listener's own responsibility is to issue the cancellation; whether
+    # the store commits it is bounded by the residual budget of the expired
+    # interaction, which is a separate concern from this boundary.
+    assert_receive :cancel_flow_issued, 1_000
+    assert_receive {:trickle_stopped, _reason}, 5_000
+  end
+
   test "loopback callback reports an expired interaction as an authorization timeout", context do
     request = request_fixture(context.authority, self())
     assert {:ok, listener} = LoopbackListener.start(context.authority)
@@ -401,6 +556,19 @@ defmodule PtcRunner.Kernel.MCPOAuth.AuthorizationTest do
 
     assert {:error, :authorization_timeout} =
              LoopbackListener.await(listener, context.context, expired, request: request)
+  end
+
+  # Paces a deliberately slow client so the 16 KB request cap is not what ends
+  # the listener's loop. No assertion depends on the exact rate.
+  defp trickle(socket, parent) do
+    case :gen_tcp.send(socket, "X") do
+      :ok ->
+        Process.send_after(self(), :tick, 10)
+        receive do: (:tick -> trickle(socket, parent))
+
+      {:error, reason} ->
+        send(parent, {:trickle_stopped, reason})
+    end
   end
 
   defp request_fixture(

--- a/test/ptc_runner/kernel/mcp_oauth/authorization_test.exs
+++ b/test/ptc_runner/kernel/mcp_oauth/authorization_test.exs
@@ -277,7 +277,9 @@ defmodule PtcRunner.Kernel.MCPOAuth.AuthorizationTest do
              Authorization.complete_authorization(bob, pending, callback, request: request)
 
     assert {:error, :invalid_authorization_context} =
-             Authorization.cancel_authorization(bob, pending, [])
+             Authorization.cancel_authorization(bob, pending,
+               cleanup_deadline: Deadline.new(1_000)
+             )
 
     assert {:ok, _grant} =
              Authorization.complete_authorization(
@@ -319,7 +321,7 @@ defmodule PtcRunner.Kernel.MCPOAuth.AuthorizationTest do
         end
 
         result =
-          LoopbackListener.await(listener, context.context, pending, request: request)
+          LoopbackListener.await(listener, context.context, pending, await_opts(request))
 
         send(parent, {:awaited, result})
       end)
@@ -365,7 +367,7 @@ defmodule PtcRunner.Kernel.MCPOAuth.AuthorizationTest do
           :go -> :ok
         end
 
-        LoopbackListener.await(listener, context.context, pending, request: request)
+        LoopbackListener.await(listener, context.context, pending, await_opts(request))
       end)
 
     assert :ok = :gen_tcp.controlling_process(listener.socket, task.pid)
@@ -427,9 +429,57 @@ defmodule PtcRunner.Kernel.MCPOAuth.AuthorizationTest do
     expired = %{pending | deadline_ms: System.monotonic_time(:millisecond) - 1}
 
     assert {:error, :authorization_timeout} =
-             LoopbackListener.await(listener, context.context, expired, request: request)
+             LoopbackListener.await(listener, context.context, expired, await_opts(request))
 
     assert {:error, :closed} = :gen_tcp.recv(socket, 0, 1_000)
+  end
+
+  test "a blocked cancellation is reported, not silently accepted", context do
+    parent = self()
+    request = request_fixture(context.authority, self())
+
+    {:ok, blocked_store} =
+      MCPOAuthRecordingStore.wrap(context.store, self(),
+        interceptor: fn operation, deadline ->
+          if elem(operation, 0) == :cancel_flow do
+            send(parent, {:cancel_deadline, deadline})
+            {:return, {:error, :timeout}}
+          else
+            :delegate
+          end
+        end
+      )
+
+    {:ok, blocked_context} =
+      Context.new(
+        tenant_id: "tenant",
+        principal_id: "alice",
+        store: blocked_store,
+        deadline: Deadline.new(10_000)
+      )
+
+    assert {:ok, listener} = LoopbackListener.start(context.authority)
+
+    assert {:ok, pending} =
+             Authorization.begin_authorization(blocked_context, context.authority,
+               authority_epoch: context.epoch,
+               redirect_uri: listener.redirect_uri,
+               request: request
+             )
+
+    expired = %{pending | deadline_ms: System.monotonic_time(:millisecond) - 1}
+
+    # The interaction expired, but a cancellation that never commits leaves the
+    # pending authorization live, so the caller learns about the cleanup failure
+    # instead of a plain timeout.
+    assert {:error, :authorization_cleanup_failed} =
+             LoopbackListener.await(listener, blocked_context, expired, await_opts(request))
+
+    # Cleanup spends the supplied terminal budget, not whatever remained of the
+    # expired interaction it is cleaning up.
+    assert_received {:cancel_deadline, cancel_deadline}
+    remaining = Deadline.remaining(cancel_deadline)
+    assert remaining > 4_000 and remaining <= 5_000
   end
 
   test "a silent client that never completes its request reports a timeout", context do
@@ -448,7 +498,7 @@ defmodule PtcRunner.Kernel.MCPOAuth.AuthorizationTest do
     task =
       Task.async(fn ->
         receive do: (:go -> :ok)
-        LoopbackListener.await(listener, context.context, pending, request: request)
+        LoopbackListener.await(listener, context.context, pending, await_opts(request))
       end)
 
     assert :ok = :gen_tcp.controlling_process(listener.socket, task.pid)
@@ -507,7 +557,7 @@ defmodule PtcRunner.Kernel.MCPOAuth.AuthorizationTest do
     task =
       Task.async(fn ->
         receive do: (:go -> :ok)
-        LoopbackListener.await(listener, observed_context, pending, request: request)
+        LoopbackListener.await(listener, observed_context, pending, await_opts(request))
       end)
 
     assert :ok = :gen_tcp.controlling_process(listener.socket, task.pid)
@@ -555,7 +605,7 @@ defmodule PtcRunner.Kernel.MCPOAuth.AuthorizationTest do
     expired = %{pending | deadline_ms: System.monotonic_time(:millisecond) - 1}
 
     assert {:error, :authorization_timeout} =
-             LoopbackListener.await(listener, context.context, expired, request: request)
+             LoopbackListener.await(listener, context.context, expired, await_opts(request))
   end
 
   # Paces a deliberately slow client so the 16 KB request cap is not what ends
@@ -570,6 +620,10 @@ defmodule PtcRunner.Kernel.MCPOAuth.AuthorizationTest do
         send(parent, {:trickle_stopped, reason})
     end
   end
+
+  # Production supplies the lifecycle owner's installed cleanup budget; without
+  # it a failed interaction cannot cancel its pending authorization.
+  defp await_opts(request), do: [request: request, cleanup_timeout_ms: 5_000]
 
   defp request_fixture(
          authority,

--- a/test/ptc_runner/kernel/mcp_oauth/authorization_test.exs
+++ b/test/ptc_runner/kernel/mcp_oauth/authorization_test.exs
@@ -536,6 +536,42 @@ defmodule PtcRunner.Kernel.MCPOAuth.AuthorizationTest do
     assert :ok = ProviderSession.close(session)
   end
 
+  @tag timeout: 15_000
+  test "a session that cannot anchor its budget is ended by the cancellation", context do
+    request = request_fixture(context.authority, self())
+    {:ok, limits} = Limits.new(provider_cleanup_timeout_ms: 200)
+    assert {:ok, session} = ProviderSession.start(limits)
+    assert {:ok, listener} = LoopbackListener.start(context.authority)
+
+    assert {:ok, pending} =
+             Authorization.begin_authorization(context.context, context.authority,
+               authority_epoch: context.epoch,
+               redirect_uri: listener.redirect_uri,
+               request: request
+             )
+
+    expired = %{pending | deadline_ms: System.monotonic_time(:millisecond) - 1}
+    monitor = Process.monitor(session.pid)
+    assert :ok = :sys.suspend(session.pid)
+    started_at = System.monotonic_time(:millisecond)
+
+    assert {:error, :authorization_cleanup_failed} =
+             LoopbackListener.await(listener, context.context, expired,
+               request: request,
+               anchor_cleanup_deadline: fn -> ProviderSession.anchor_cleanup_deadline(session) end
+             )
+
+    elapsed = System.monotonic_time(:millisecond) - started_at
+
+    # Ending the wedged session here is what keeps the episode inside one
+    # budget: the close that follows a failed cancellation would otherwise
+    # start the same full wait again before killing it.
+    assert_received {:DOWN, ^monitor, :process, _pid, :killed}
+    assert {:error, :provider_cleanup_failed} = ProviderSession.close(session)
+    assert System.monotonic_time(:millisecond) - started_at < 1_000
+    assert elapsed < 1_000
+  end
+
   test "a silent client that never completes its request reports a timeout", context do
     request = request_fixture(context.authority, self())
     assert {:ok, listener} = LoopbackListener.start(context.authority)

--- a/test/ptc_runner/kernel/provider_active_session_test.exs
+++ b/test/ptc_runner/kernel/provider_active_session_test.exs
@@ -32,7 +32,7 @@ defmodule PtcRunner.Kernel.ProviderActiveSessionTest do
 
     {:ok, prepared, catalog} = fixture(validator, ["first", "second"])
 
-    assert {:ok, session} = ProviderActiveSession.open(prepared, catalog, services())
+    assert {:ok, session} = open_owned(prepared, catalog, services())
     assert_receive {:validated, "first", first_deadline}
     assert_receive {:validated, "second", second_deadline}
     assert is_integer(first_deadline)
@@ -57,7 +57,7 @@ defmodule PtcRunner.Kernel.ProviderActiveSessionTest do
     end
 
     {:ok, prepared, catalog} = fixture(validator, ["first"], limits)
-    assert {:ok, session} = ProviderActiveSession.open(prepared, catalog, services())
+    assert {:ok, session} = open_owned(prepared, catalog, services())
     run_deadline = ProviderSession.run_deadline(session)
 
     assert_receive {:selection_deadline, selection_deadline}
@@ -77,13 +77,13 @@ defmodule PtcRunner.Kernel.ProviderActiveSessionTest do
     {:ok, prepared, catalog} = fixture(validator, ["first"])
 
     assert {:ok, session} =
-             ProviderActiveSession.open_setup(prepared, catalog, services())
+             open_owned_setup(prepared, catalog, services())
 
     assert ProviderSession.run_deadline(session) == nil
     refute_received {:validated_after_run_began, _deadline_ms}
 
     assert {:ok, session} =
-             ProviderActiveSession.begin_run(session, prepared, catalog)
+             ProviderActiveSession.begin_owned_run(session, prepared, catalog)
 
     assert Deadline.valid?(ProviderSession.run_deadline(session))
     assert_receive {:validated_after_run_began, deadline_ms}
@@ -177,7 +177,7 @@ defmodule PtcRunner.Kernel.ProviderActiveSessionTest do
       fixture(fn _selection, _context -> {:error, :selection_rejected} end)
 
     assert {:error, %CommandDiagnostic{} = diagnostic} =
-             ProviderActiveSession.open(prepared, catalog, services())
+             open_owned(prepared, catalog, services())
 
     assert diagnostic.phase == :active_preflight
     assert diagnostic.code == :selection_rejected
@@ -185,12 +185,16 @@ defmodule PtcRunner.Kernel.ProviderActiveSessionTest do
     assert diagnostic.subject.name == "selected"
     assert diagnostic.subject.operation == :selection
     assert diagnostic.subject.occurrence == %{destination: :workflow, index: 0}
-    assert ProviderActivity.value(prepared.provider_activity) == :unknown
+
+    # The execution owner owns the prepared run, so a failed opening leaves the
+    # marked activity for that owner to release rather than closing it here.
+    assert ProviderActivity.value(prepared.provider_activity) == true
+    assert :ok = PreparedRun.close(prepared)
   end
 
   test "active build preserves provider dependency failures during session cleanup" do
     {:ok, prepared, catalog} = fixture(fn _selection, _context -> :ok end)
-    assert {:ok, session} = ProviderActiveSession.open(prepared, catalog, services())
+    assert {:ok, session} = open_owned(prepared, catalog, services())
 
     staged = fn _selection, _context ->
       {:ok,
@@ -205,7 +209,7 @@ defmodule PtcRunner.Kernel.ProviderActiveSessionTest do
              ProviderRegistry.new(%{"selected" => ProviderRegistry.staged(staged)})
 
     assert {:error, :provider_dependency_unavailable} =
-             RunBuilder.build_active(prepared, registry, session, [])
+             build_owned(prepared, registry, session, [])
 
     refute ProviderSession.alive?(session)
     assert :ok = PreparedRun.close(prepared)
@@ -214,7 +218,7 @@ defmodule PtcRunner.Kernel.ProviderActiveSessionTest do
   test "active build resolves credentials after every preflight and before acquisition" do
     parent = self()
     {:ok, prepared, catalog} = fixture(fn _selection, _context -> :ok end)
-    assert {:ok, session} = ProviderActiveSession.open(prepared, catalog, services())
+    assert {:ok, session} = open_owned(prepared, catalog, services())
 
     staged = fn _selection, context ->
       send(parent, {:provider_context_deadline, context.deadline, context.deadline_ms})
@@ -245,7 +249,7 @@ defmodule PtcRunner.Kernel.ProviderActiveSessionTest do
                credential_resolver: resolver
              )
 
-    assert {:ok, built} = RunBuilder.build_active(prepared, registry, session, [])
+    assert {:ok, built} = build_owned(prepared, registry, session, [])
     run_deadline = ProviderSession.run_deadline(session)
 
     assert_receive {:provider_context_deadline, ^run_deadline, deadline_ms}
@@ -262,7 +266,7 @@ defmodule PtcRunner.Kernel.ProviderActiveSessionTest do
     parent = self()
     limits = %{Limits.installed_defaults() | run_duration_ms: 1_000}
     {:ok, prepared, catalog} = fixture(fn _selection, _context -> :ok end, ["first"], limits)
-    assert {:ok, session} = ProviderActiveSession.open(prepared, catalog, services())
+    assert {:ok, session} = open_owned(prepared, catalog, services())
 
     resolver = fn ["secret"] ->
       send(parent, {:credential_resolver_started, self()})
@@ -277,7 +281,7 @@ defmodule PtcRunner.Kernel.ProviderActiveSessionTest do
               code: :credential_unavailable,
               provider_activity: true,
               subject: %{name: "selected", operation: :credentials, occurrence: nil}
-            }} = RunBuilder.build_active(prepared, registry, session, [])
+            }} = build_owned(prepared, registry, session, [])
 
     assert_receive {:credential_resolver_started, worker}
     refute Process.alive?(worker)
@@ -288,7 +292,7 @@ defmodule PtcRunner.Kernel.ProviderActiveSessionTest do
   test "credentialless active providers do not invoke the resolver" do
     parent = self()
     {:ok, prepared, catalog} = fixture(fn _selection, _context -> :ok end)
-    assert {:ok, session} = ProviderActiveSession.open(prepared, catalog, services())
+    assert {:ok, session} = open_owned(prepared, catalog, services())
 
     resolver = fn [] ->
       send(parent, :unexpected_credential_resolution)
@@ -296,7 +300,7 @@ defmodule PtcRunner.Kernel.ProviderActiveSessionTest do
     end
 
     {:ok, registry} = active_registry(credential_resolver: resolver)
-    assert {:ok, built} = RunBuilder.build_active(prepared, registry, session, [])
+    assert {:ok, built} = build_owned(prepared, registry, session, [])
     refute_receive :unexpected_credential_resolution
 
     assert :ok = RunBuilder.close(built)
@@ -309,7 +313,7 @@ defmodule PtcRunner.Kernel.ProviderActiveSessionTest do
 
     for blocked_phase <- [:prepare, :preflight, :acquisition] do
       {:ok, prepared, catalog} = fixture(fn _selection, _context -> :ok end, ["first"], limits)
-      assert {:ok, session} = ProviderActiveSession.open(prepared, catalog, services())
+      assert {:ok, session} = open_owned(prepared, catalog, services())
 
       block = fn phase ->
         if phase == blocked_phase do
@@ -352,7 +356,7 @@ defmodule PtcRunner.Kernel.ProviderActiveSessionTest do
                   operation: :acquisition,
                   occurrence: %{destination: :workflow, index: 0}
                 }
-              }} = RunBuilder.build_active(prepared, registry, session, [])
+              }} = build_owned(prepared, registry, session, [])
 
       assert_receive {:provider_callback_started, ^blocked_phase, worker}
       refute Process.alive?(worker)
@@ -371,7 +375,7 @@ defmodule PtcRunner.Kernel.ProviderActiveSessionTest do
     }
 
     {:ok, prepared, catalog} = fixture(fn _selection, _context -> :ok end, ["first"], limits)
-    assert {:ok, session} = ProviderActiveSession.open(prepared, catalog, services())
+    assert {:ok, session} = open_owned(prepared, catalog, services())
 
     staged = fn _selection, _context ->
       {:ok,
@@ -396,7 +400,7 @@ defmodule PtcRunner.Kernel.ProviderActiveSessionTest do
              )
 
     assert {:error, %CommandDiagnostic{code: :provider_unavailable}} =
-             RunBuilder.build_active(prepared, registry, session, [])
+             build_owned(prepared, registry, session, [])
 
     assert_receive {:blocking_preflight_release, release_worker}
     refute Process.alive?(release_worker)
@@ -421,7 +425,7 @@ defmodule PtcRunner.Kernel.ProviderActiveSessionTest do
         {:ok, prepared, catalog} =
           fixture(fn _selection, _context -> :ok end, ["first"], limits)
 
-        {:ok, session} = ProviderActiveSession.open(prepared, catalog, services())
+        {:ok, session} = open_owned(prepared, catalog, services())
         send(parent, {:boundary_session, session})
 
         staged = fn _selection, _context ->
@@ -453,7 +457,7 @@ defmodule PtcRunner.Kernel.ProviderActiveSessionTest do
             installed_limits: limits
           )
 
-        result = RunBuilder.build_active(prepared, registry, session, [])
+        result = build_owned(prepared, registry, session, [])
         send(parent, {:boundary_result, result})
         :ok = PreparedRun.close(prepared)
       end)
@@ -500,10 +504,10 @@ defmodule PtcRunner.Kernel.ProviderActiveSessionTest do
 
     owner =
       spawn(fn ->
-        {:ok, session} = ProviderActiveSession.open(prepared, catalog, services())
+        {:ok, session} = open_owned(prepared, catalog, services())
         send(parent, {:session_close_credential_session, session})
         {:ok, registry} = credential_registry(resolver)
-        result = RunBuilder.build_active(prepared, registry, session, [])
+        result = build_owned(prepared, registry, session, [])
         assert :ok = PreparedRun.close(prepared)
         send(parent, {:session_close_build_result, result})
         receive do: (:stop -> :ok)
@@ -526,7 +530,7 @@ defmodule PtcRunner.Kernel.ProviderActiveSessionTest do
     owner =
       spawn(fn ->
         {:ok, prepared, catalog} = fixture(fn _selection, _context -> :ok end)
-        {:ok, session} = ProviderActiveSession.open(prepared, catalog, services())
+        {:ok, session} = open_owned(prepared, catalog, services())
         send(parent, {:release_after_close_session, session})
 
         staged = fn _selection, _context ->
@@ -550,7 +554,7 @@ defmodule PtcRunner.Kernel.ProviderActiveSessionTest do
         {:ok, registry} =
           ProviderRegistry.new(%{"selected" => ProviderRegistry.staged(staged)})
 
-        result = RunBuilder.build_active(prepared, registry, session, [])
+        result = build_owned(prepared, registry, session, [])
         send(parent, {:release_after_close_result, result})
         :ok = PreparedRun.close(prepared)
       end)
@@ -580,10 +584,10 @@ defmodule PtcRunner.Kernel.ProviderActiveSessionTest do
 
     owner =
       spawn(fn ->
-        {:ok, session} = ProviderActiveSession.open(prepared, catalog, services())
+        {:ok, session} = open_owned(prepared, catalog, services())
         send(parent, {:caller_death_credential_session, session})
         {:ok, registry} = credential_registry(resolver)
-        RunBuilder.build_active(prepared, registry, session, [])
+        build_owned(prepared, registry, session, [])
       end)
 
     assert_receive {:caller_death_credential_session, session}
@@ -600,12 +604,12 @@ defmodule PtcRunner.Kernel.ProviderActiveSessionTest do
   test "active build rejects a session opened for another prepared run" do
     {:ok, first, first_catalog} = fixture(fn _selection, _context -> :ok end)
     {:ok, second, second_catalog} = fixture(fn _selection, _context -> :ok end)
-    assert {:ok, first_session} = ProviderActiveSession.open(first, first_catalog, services())
-    assert {:ok, second_session} = ProviderActiveSession.open(second, second_catalog, services())
+    assert {:ok, first_session} = open_owned(first, first_catalog, services())
+    assert {:ok, second_session} = open_owned(second, second_catalog, services())
     assert {:ok, registry} = ProviderRegistry.new(%{})
 
     assert {:error, :invalid_active_run} =
-             RunBuilder.build_active(second, registry, first_session, [])
+             build_owned(second, registry, first_session, [])
 
     refute ProviderSession.alive?(first_session)
     assert :ok = ProviderSession.close(second_session)
@@ -616,7 +620,7 @@ defmodule PtcRunner.Kernel.ProviderActiveSessionTest do
   test "active build rejects cloned identity with a different run duration before preparation" do
     parent = self()
     {:ok, prepared, catalog} = fixture(fn _selection, _context -> :ok end)
-    assert {:ok, opened_session} = ProviderActiveSession.open(prepared, catalog, services())
+    assert {:ok, opened_session} = open_owned(prepared, catalog, services())
     assert :ok = ProviderSession.close(opened_session)
 
     limits = prepared.request.package.limits
@@ -636,7 +640,7 @@ defmodule PtcRunner.Kernel.ProviderActiveSessionTest do
              ProviderRegistry.new(%{"selected" => ProviderRegistry.staged(staged)})
 
     assert {:error, :invalid_active_run} =
-             RunBuilder.build_active(prepared, registry, wrong_session, [])
+             build_owned(prepared, registry, wrong_session, [])
 
     refute_receive :unexpected_provider_preparation
     refute ProviderSession.alive?(wrong_session)
@@ -645,23 +649,23 @@ defmodule PtcRunner.Kernel.ProviderActiveSessionTest do
 
   test "active build claims its session once without closing it on replay" do
     {:ok, prepared, catalog} = fixture(fn _selection, _context -> :ok end)
-    assert {:ok, session} = ProviderActiveSession.open(prepared, catalog, services())
+    assert {:ok, session} = open_owned(prepared, catalog, services())
     assert {:ok, registry} = active_registry()
 
-    assert {:ok, built} = RunBuilder.build_active(prepared, registry, session, [])
+    assert {:ok, built} = build_owned(prepared, registry, session, [])
     assert built.config.run_deadline == ProviderSession.run_deadline(session)
 
     assert {:error, :invalid_active_run} =
-             RunBuilder.build_active(prepared, registry, session, [])
+             build_owned(prepared, registry, session, [])
 
     assert {:error, :invalid_active_run} =
-             RunBuilder.build_active(prepared, registry, session, unknown: true)
+             build_owned(prepared, registry, session, unknown: true)
 
     {:ok, other, other_catalog} = fixture(fn _selection, _context -> :ok end)
-    assert {:ok, other_session} = ProviderActiveSession.open(other, other_catalog, services())
+    assert {:ok, other_session} = open_owned(other, other_catalog, services())
 
     assert {:error, :invalid_active_run} =
-             RunBuilder.build_active(other, registry, session, [])
+             build_owned(other, registry, session, [])
 
     assert ProviderSession.alive?(session)
 
@@ -674,15 +678,15 @@ defmodule PtcRunner.Kernel.ProviderActiveSessionTest do
   @tag timeout: 10_000
   test "a timed-out replay cannot close a claimed active session" do
     {:ok, prepared, catalog} = fixture(fn _selection, _context -> :ok end)
-    assert {:ok, session} = ProviderActiveSession.open(prepared, catalog, services())
+    assert {:ok, session} = open_owned(prepared, catalog, services())
     assert {:ok, registry} = active_registry()
-    assert {:ok, built} = RunBuilder.build_active(prepared, registry, session, [])
+    assert {:ok, built} = build_owned(prepared, registry, session, [])
 
     assert true = :erlang.suspend_process(session.pid)
 
     try do
       assert {:error, :invalid_active_run} =
-               RunBuilder.build_active(prepared, registry, session, [])
+               build_owned(prepared, registry, session, [])
     after
       if Process.alive?(session.pid), do: :erlang.resume_process(session.pid)
     end
@@ -707,7 +711,7 @@ defmodule PtcRunner.Kernel.ProviderActiveSessionTest do
       {:ok, prepared, catalog} = fixture(callback)
 
       assert {:error, %CommandDiagnostic{code: :selection_validation_failed}} =
-               ProviderActiveSession.open(prepared, catalog, services())
+               open_owned(prepared, catalog, services())
     end
   end
 
@@ -723,7 +727,7 @@ defmodule PtcRunner.Kernel.ProviderActiveSessionTest do
     {:ok, prepared, catalog} = fixture(validator, ["first"], limits)
 
     assert {:error, %CommandDiagnostic{code: :selection_validation_timeout}} =
-             ProviderActiveSession.open(prepared, catalog, services())
+             open_owned(prepared, catalog, services())
 
     assert_receive {:validator_started, worker}
     refute Process.alive?(worker)
@@ -741,10 +745,14 @@ defmodule PtcRunner.Kernel.ProviderActiveSessionTest do
 
         {:ok, limits} = Limits.new(selection_validation_timeout_ms: 100)
         {:ok, prepared, catalog} = fixture(validator, ["first"], limits)
-        send(parent, {:late_result, ProviderActiveSession.open(prepared, catalog, services())})
+
+        send(parent, {:late_result, open_owned(prepared, catalog, services())})
       end)
 
-    assert_receive {:late_result_worker, worker}
+    # The owner compiles its fixture and opens the execution owner's sinks
+    # before the validator runs, which is slower than the default window on a
+    # cold start.
+    assert_receive {:late_result_worker, worker}, 5_000
     assert true = :erlang.suspend_process(owner)
     worker_ref = Process.monitor(worker)
     send(worker, :finish)
@@ -782,7 +790,7 @@ defmodule PtcRunner.Kernel.ProviderActiveSessionTest do
     end
 
     {:ok, prepared, catalog} = fixture(validator)
-    assert {:ok, session} = ProviderActiveSession.open(prepared, catalog, services())
+    assert {:ok, session} = open_owned(prepared, catalog, services())
     assert_receive {:validator_root, root}
     root_ref = Process.monitor(root)
     assert_receive {:DOWN, ^root_ref, :process, ^root, reason}, 2_000
@@ -817,7 +825,7 @@ defmodule PtcRunner.Kernel.ProviderActiveSessionTest do
         end
 
         {:ok, prepared, catalog} = fixture(validator)
-        ProviderActiveSession.open(prepared, catalog, services())
+        open_owned(prepared, catalog, services())
       end)
 
     assert_receive {:caller_death_worker, worker}
@@ -836,7 +844,7 @@ defmodule PtcRunner.Kernel.ProviderActiveSessionTest do
     {:ok, other_prepared, other_catalog} = fixture(callback, ["first"], nil, "other-v1")
 
     assert {:error, %CommandDiagnostic{phase: :internal, provider_activity: false}} =
-             ProviderActiveSession.open(prepared, other_catalog, services())
+             open_owned(prepared, other_catalog, services())
 
     assert ProviderActivity.value(prepared.provider_activity) == false
     PreparedRun.close(prepared)
@@ -855,7 +863,7 @@ defmodule PtcRunner.Kernel.ProviderActiveSessionTest do
     end
 
     {:ok, prepared, catalog} = fixture(validator)
-    assert {:ok, session} = ProviderActiveSession.open(prepared, catalog, services())
+    assert {:ok, session} = open_owned(prepared, catalog, services())
     close(session, prepared)
   end
 
@@ -872,12 +880,13 @@ defmodule PtcRunner.Kernel.ProviderActiveSessionTest do
               code: :provider_application_unavailable,
               provider_activity: true
             } = diagnostic} =
-             ProviderActiveSession.open(prepared, catalog, services(:host_owned))
+             open_owned(prepared, catalog, services(:host_owned))
 
     assert diagnostic.subject.name == "selected"
     assert diagnostic.subject.operation == :application
     assert diagnostic.subject.occurrence == nil
-    assert ProviderActivity.value(prepared.provider_activity) == :unknown
+    assert ProviderActivity.value(prepared.provider_activity) == true
+    assert :ok = PreparedRun.close(prepared)
   end
 
   @tag :tmp_dir
@@ -915,7 +924,7 @@ defmodule PtcRunner.Kernel.ProviderActiveSessionTest do
 
     File.cd!(directory, fn ->
       assert {:ok, session} =
-               ProviderActiveSession.open(prepared, catalog, services(:command_vm))
+               open_owned(prepared, catalog, services(:command_vm))
 
       assert Application.get_env(:req_llm, :load_dotenv) == false
       assert Application.get_env(:llm_db, :load_dotenv) == false
@@ -941,7 +950,7 @@ defmodule PtcRunner.Kernel.ProviderActiveSessionTest do
 
     assert {:error,
             %CommandDiagnostic{code: :provider_application_unavailable, provider_activity: true}} =
-             ProviderActiveSession.open(
+             open_owned(
                command_prepared,
                command_catalog,
                services(:command_vm)
@@ -951,7 +960,7 @@ defmodule PtcRunner.Kernel.ProviderActiveSessionTest do
       fixture(fn _selection, _context -> :ok end, ["first"], nil, "host-v1", :req_llm)
 
     assert {:ok, session} =
-             ProviderActiveSession.open(host_prepared, host_catalog, services(:host_owned))
+             open_owned(host_prepared, host_catalog, services(:host_owned))
 
     close(session, host_prepared)
   end
@@ -1122,6 +1131,60 @@ defmodule PtcRunner.Kernel.ProviderActiveSessionTest do
     if Process.alive?(pid), do: :erlang.resume_process(pid)
   catch
     :error, :badarg -> true
+  end
+
+  # The execution owner is the only session opener left, so tests take the same
+  # route it does: open the owner's sinks (which consumes the prepared run),
+  # hand the session to a fixed lifecycle owner, and begin the run there.
+  defp open_owned(prepared, catalog, services) do
+    with {:ok, _inputs} <- owned_inputs(prepared),
+         {:ok, session} <- open_owned_setup(prepared, catalog, services) do
+      ProviderActiveSession.begin_owned_run(session, prepared, catalog)
+    end
+  end
+
+  defp open_owned_setup(prepared, catalog, services) do
+    with {:ok, _inputs} <- owned_inputs(prepared) do
+      ProviderActiveSession.open_consumed_setup(
+        prepared,
+        catalog,
+        services,
+        self(),
+        fn _session -> :ok end
+      )
+    end
+  end
+
+  # Opened once per prepared run and remembered, because opening the sinks is
+  # what consumes it. A spawned build passes the captured value explicitly,
+  # since it does not inherit this process's dictionary. The sinks monitor the
+  # process that opened them and exit with it, so no test teardown is needed —
+  # and registering one here would raise in a spawned caller.
+  defp owned_inputs(prepared) do
+    case Process.get({:owned_inputs, prepared.attestation}) do
+      nil ->
+        with {:ok, authority} <- PublicationAuthority.new([]),
+             {:ok, sinks} <- RunBuilder.open_prepared_sinks(prepared, authority, self()) do
+          Process.put({:owned_inputs, prepared.attestation}, {authority, sinks})
+          {:ok, {authority, sinks}}
+        end
+
+      inputs ->
+        {:ok, inputs}
+    end
+  end
+
+  defp owned_inputs!(prepared) do
+    {:ok, inputs} = owned_inputs(prepared)
+    inputs
+  end
+
+  defp build_owned(prepared, registry, session, opts) do
+    build_owned(owned_inputs!(prepared), prepared, registry, session, opts)
+  end
+
+  defp build_owned({authority, sinks}, prepared, registry, session, _opts) do
+    RunBuilder.build_active_owned(prepared, registry, session, authority, sinks)
   end
 
   defp services(mode \\ :host_owned) do

--- a/test/ptc_runner/kernel/provider_execution_lifecycle_test.exs
+++ b/test/ptc_runner/kernel/provider_execution_lifecycle_test.exs
@@ -292,6 +292,25 @@ defmodule PtcRunner.Kernel.ProviderExecutionLifecycleTest do
     assert_declaration_refused(fixture)
   end
 
+  test "a check assembles its providers without ever executing the workflow" do
+    # The entry never terminates, so a check that returns at all proves the
+    # Kernel was not run; only the acquisition's safe snapshots come back.
+    fixture = provider_fixture(body: "(loop [] (recur))")
+
+    assert {:ok, owner} =
+             ExecutionSessionOwner.start(
+               fixture.prepared,
+               fixture.authority,
+               self(),
+               fixture.execution,
+               &never_notify/1,
+               :check
+             )
+
+    assert {:ok, []} = ExecutionSessionOwner.await(owner)
+    assert_receive {:provider_phase, :acquire}, 5_000
+  end
+
   test "an execution from another catalog leaves the prepared run reusable" do
     fixture = provider_fixture()
     other = provider_fixture(installation_revision: "other-v1")

--- a/test/ptc_runner/kernel/provider_execution_lifecycle_test.exs
+++ b/test/ptc_runner/kernel/provider_execution_lifecycle_test.exs
@@ -311,6 +311,63 @@ defmodule PtcRunner.Kernel.ProviderExecutionLifecycleTest do
     assert_receive {:provider_phase, :acquire}, 5_000
   end
 
+  test "a check closes its provider session inside the runtime that acquired it" do
+    # A run closes its session while the registry and the OAuth runtime that
+    # produced its resources are still alive. A check that left the close to the
+    # execution owner would unwind that runtime first and run connector closers
+    # against a store and managers that are already gone.
+    parent = self()
+
+    fixture =
+      provider_fixture(
+        acquire: fn context ->
+          scoped_root(parent, context)
+          {:ok, capability} = fixture_capability()
+
+          {:ok,
+           %{
+             capabilities: [capability],
+             snapshot: nil,
+             close: fn ->
+               send(parent, :provider_closed)
+               :ok
+             end
+           }}
+        end
+      )
+
+    caller =
+      spawn(fn ->
+        receive do: (:go -> :ok)
+
+        {:ok, owner} =
+          ExecutionSessionOwner.start(
+            fixture.prepared,
+            fixture.authority,
+            self(),
+            fixture.execution,
+            &never_notify/1,
+            :check
+          )
+
+        send(parent, {:execution_result, ExecutionSessionOwner.await(owner)})
+      end)
+
+    # Tracing the caller before it starts anything makes the owner and its
+    # worker inherit the flag, so the order below is the order the run actually
+    # closed in rather than a snapshot taken after the fact.
+    trace_closes(caller, [:call, :set_on_spawn])
+
+    try do
+      send(caller, :go)
+      assert_receive {:execution_result, {:ok, _snapshots}}, 5_000
+      assert [ProviderSession, ProviderRegistry] == [next_close(), next_close()]
+      assert_received :provider_closed
+    after
+      stop_trace_closes(caller)
+    end
+  end
+
   test "an execution from another catalog leaves the prepared run reusable" do
     fixture = provider_fixture()
     other = provider_fixture(installation_revision: "other-v1")
@@ -428,11 +485,11 @@ defmodule PtcRunner.Kernel.ProviderExecutionLifecycleTest do
     end)
   end
 
-  defp trace_closes(owner_pid) do
+  defp trace_closes(owner_pid, flags \\ [:call]) do
     Enum.each([ProviderRegistry, ProviderSession], &Code.ensure_loaded!/1)
     assert :erlang.trace_pattern({ProviderRegistry, :close, 1}, true, [:local]) == 1
     assert :erlang.trace_pattern({ProviderSession, :close, 1}, true, [:local]) == 1
-    assert :erlang.trace(owner_pid, true, [:call]) == 1
+    assert :erlang.trace(owner_pid, true, flags) == 1
   end
 
   defp next_close do

--- a/test/ptc_runner/kernel/provider_execution_lifecycle_test.exs
+++ b/test/ptc_runner/kernel/provider_execution_lifecycle_test.exs
@@ -234,84 +234,62 @@ defmodule PtcRunner.Kernel.ProviderExecutionLifecycleTest do
     assert diagnostic.code == :provider_cleanup_failed
   end
 
-  test "a provider acquiring stricter than it declared is refused, not downgraded" do
-    # The owner opens sinks from the sealed declaration before any provider
-    # runs. A staged builder that acquires as :private_inspection while its
-    # descriptor declares :normal would otherwise emit through the normal sink
-    # the owner already opened.
+  test "a staged preparation stricter than its sealed declaration is refused" do
+    # Preparation, phase-5 identity, and the sinks the owner opened before any
+    # provider ran all come from the sealed descriptor. A builder preparing as
+    # :private_inspection while its descriptor declares :normal contradicts
+    # that declaration, so the run stops while every provider is still inert.
     fixture =
       provider_fixture(
+        credential_names: ["fixture-key"],
         descriptor_accepts_data: [:normal, :private_inspection],
         staged_data_class: :private_inspection,
-        acquire: fn _context ->
-          {:ok, capability} = fixture_capability()
-
-          {:ok,
-           %{
-             capabilities: [capability],
-             data_class: :private_inspection,
-             accepts_data: [:private_inspection]
-           }}
-        end
+        staged_accepts_data: [:normal, :private_inspection]
       )
 
     assert fixture.prepared.effective_data_class == :normal
-    parent = self()
-
-    caller =
-      spawn(fn ->
-        {:ok, owner} =
-          ExecutionSessionOwner.start(
-            fixture.prepared,
-            fixture.authority,
-            self(),
-            fixture.execution,
-            &never_notify/1
-          )
-
-        send(parent, {:execution_owner, owner})
-        send(parent, {:execution_result, ExecutionSessionOwner.await(owner)})
-      end)
-
-    assert_receive {:execution_owner, owner}, 5_000
-    on_exit(fn -> release(caller, ExecutionSessionOwner.pid(owner)) end)
-
-    assert_receive {:execution_result, {:error, :provider_data_class_drift}}, 5_000
+    assert_declaration_refused(fixture)
   end
 
-  test "a provider acquiring weaker than it declared is refused just as firmly" do
-    # The safe direction still contradicts the sealed declaration the owner
-    # already opened a private sink for, so it is refused rather than accepted
-    # because it happens to be stricter than needed.
+  test "a staged preparation weaker than its sealed declaration is refused just as firmly" do
+    # The safe direction still contradicts the declaration the effective data
+    # class, event policy, and opened sinks were derived from, so it is refused
+    # rather than accepted because it happens to be stricter than needed.
     fixture =
       provider_fixture(
+        credential_names: ["fixture-key"],
         descriptor_data_class: :private_inspection,
         descriptor_accepts_data: [:normal, :private_inspection],
-        acquire: fn _context -> fixture_capability() end
+        staged_accepts_data: [:normal, :private_inspection]
       )
 
     assert fixture.prepared.effective_data_class == :private_inspection
-    parent = self()
+    assert_declaration_refused(fixture)
+  end
 
-    caller =
-      spawn(fn ->
-        {:ok, owner} =
-          ExecutionSessionOwner.start(
-            fixture.prepared,
-            fixture.authority,
-            self(),
-            fixture.execution,
-            &never_notify/1
-          )
+  test "a staged preparation accepting more classes than it declared is refused" do
+    # Phase 5 admitted this occurrence against the declared accepted classes.
+    # A builder that widens them at run time answers a different information
+    # flow question than the one the sealed plan approved.
+    fixture =
+      provider_fixture(
+        credential_names: ["fixture-key"],
+        descriptor_accepts_data: [:normal],
+        staged_accepts_data: [:normal, :private_inspection]
+      )
 
-        send(parent, {:execution_owner, owner})
-        send(parent, {:execution_result, ExecutionSessionOwner.await(owner)})
-      end)
+    assert_declaration_refused(fixture)
+  end
 
-    assert_receive {:execution_owner, owner}, 5_000
-    on_exit(fn -> release(caller, ExecutionSessionOwner.pid(owner)) end)
+  test "a staged preparation accepting fewer classes than it declared is refused" do
+    fixture =
+      provider_fixture(
+        credential_names: ["fixture-key"],
+        descriptor_accepts_data: [:normal, :private_inspection],
+        staged_accepts_data: [:normal]
+      )
 
-    assert_receive {:execution_result, {:error, :provider_data_class_drift}}, 5_000
+    assert_declaration_refused(fixture)
   end
 
   test "an execution from another catalog leaves the prepared run reusable" do
@@ -451,11 +429,40 @@ defmodule PtcRunner.Kernel.ProviderExecutionLifecycleTest do
     :error, :badarg -> false
   end
 
+  # Every refused declaration must be refused for the same reason and while the
+  # provider is still inert: no credential resolution, no preflight, no
+  # acquisition, and no registered resource root.
+  defp assert_declaration_refused(fixture) do
+    _started = start_owned_execution(fixture)
+
+    assert_receive {:execution_result, {:error, :provider_declaration_mismatch}}, 5_000
+    refute_received {:resolved_credentials, _names}
+    refute_received {:provider_phase, :preflight}
+    refute_received {:provider_phase, :acquire}
+    refute_received {:provider_root, _root, _registration}
+  end
+
   defp provider_fixture(opts \\ []) do
+    parent = self()
     selection_validation = Keyword.get(opts, :selection_validation, :declarative)
     body = Keyword.get(opts, :body, "(return {\"answer\" 42})")
-    acquire = Keyword.get(opts, :acquire, fn _context -> fixture_capability() end)
-    staged_class = Keyword.get(opts, :staged_data_class)
+    credential_names = Keyword.get(opts, :credential_names, [])
+
+    # The default acquisition registers a resource root, so a refusal test can
+    # prove nothing was created rather than that nothing could have been.
+    acquire =
+      Keyword.get(opts, :acquire, fn context ->
+        scoped_root(parent, context)
+        fixture_capability()
+      end)
+
+    staged_policy =
+      %{
+        data_class: Keyword.get(opts, :staged_data_class),
+        accepts_data: Keyword.get(opts, :staged_accepts_data)
+      }
+      |> Enum.reject(fn {_key, value} -> is_nil(value) end)
+      |> Map.new()
 
     {:ok, rules} = SelectionRules.new(fields: %{}, cross_rules: [], named_sets: %{})
 
@@ -463,7 +470,7 @@ defmodule PtcRunner.Kernel.ProviderExecutionLifecycleTest do
       ProviderDescriptor.new(
         source: :custom,
         installation_revision: Keyword.get(opts, :installation_revision, "lifecycle-v1"),
-        credential_names: [],
+        credential_names: credential_names,
         authorization_mode: :none,
         data_class: Keyword.get(opts, :descriptor_data_class, :normal),
         accepts_data: Keyword.get(opts, :descriptor_accepts_data, [:normal]),
@@ -481,15 +488,19 @@ defmodule PtcRunner.Kernel.ProviderExecutionLifecycleTest do
 
     builder = fn _selection, context ->
       staged = %{
-        credential_names: [],
-        preflight: fn -> {:ok, fn %{} -> acquire.(context) end} end
+        credential_names: credential_names,
+        preflight: fn ->
+          send(parent, {:provider_phase, :preflight})
+
+          {:ok,
+           fn %{} ->
+             send(parent, {:provider_phase, :acquire})
+             acquire.(context)
+           end}
+        end
       }
 
-      if staged_class do
-        {:ok, Map.merge(staged, %{data_class: staged_class, accepts_data: [staged_class]})}
-      else
-        {:ok, staged}
-      end
+      {:ok, Map.merge(staged, staged_policy)}
     end
 
     implementation =
@@ -503,7 +514,14 @@ defmodule PtcRunner.Kernel.ProviderExecutionLifecycleTest do
     {:ok, catalog} =
       InstallationCatalog.new(%{"selected" => registration})
 
-    {:ok, services} = ProviderRuntimeServices.new()
+    {:ok, services} =
+      ProviderRuntimeServices.new(
+        credential_resolver: fn names ->
+          send(parent, {:resolved_credentials, names})
+          {:ok, Map.new(names, &{&1, "fixture-credential"})}
+        end
+      )
+
     {:ok, execution} = ProviderExecution.new(catalog, services, [])
     {:ok, authority} = PublicationAuthority.new([])
 

--- a/test/ptc_runner/kernel/provider_execution_oauth_test.exs
+++ b/test/ptc_runner/kernel/provider_execution_oauth_test.exs
@@ -99,7 +99,10 @@ defmodule PtcRunner.Kernel.ProviderExecutionOAuthTest do
              )
 
     visit_authorization_url(self(), pending.url)
-    assert {:ok, grant} = LoopbackListener.await(listener, context, pending, [])
+
+    assert {:ok, grant} =
+             LoopbackListener.await(listener, context, pending, cleanup_timeout_ms: 5_000)
+
     assert grant.status == :active
     assert grant.granted_scopes == MapSet.new(["read"])
     assert grant.access_token == "fixture-access-token"

--- a/test/ptc_runner/kernel/provider_execution_oauth_test.exs
+++ b/test/ptc_runner/kernel/provider_execution_oauth_test.exs
@@ -25,6 +25,36 @@ defmodule PtcRunner.Kernel.ProviderExecutionOAuthTest do
   alias PtcRunner.Kernel.RunCoordinator
   alias PtcRunner.TestSupport.MCPHTTPFixture
 
+  test "OAuth setup and each requested target use their exact independent deadlines" do
+    declarations = [
+      %{name: "first", config: %{"timeout_ms" => 5_000}},
+      %{name: "plain", config: %{"timeout_ms" => 1}},
+      %{name: "first", config: %{"timeout_ms" => 2_000}},
+      %{name: "second", config: %{"timeout_ms" => 3_000}}
+    ]
+
+    authorities = %{
+      "first" => %{authorization_timeout_ms: 7_000},
+      "plain" => nil,
+      "second" => %{authorization_timeout_ms: 4_000}
+    }
+
+    setup =
+      ProviderExecution.oauth_setup_deadline(
+        declarations,
+        authorities,
+        ["second", "first"],
+        1_000
+      )
+
+    first = ProviderExecution.oauth_target_deadline("first", declarations, authorities, 10_000)
+    second = ProviderExecution.oauth_target_deadline("second", declarations, authorities, 20_000)
+
+    assert Deadline.expires_at(setup) == 3_000
+    assert Deadline.expires_at(first) == 12_000
+    assert Deadline.expires_at(second) == 23_000
+  end
+
   test "loopback discovery fixture satisfies the shipped discovery boundary" do
     server = start_server()
     authority = authority(server.base)
@@ -112,6 +142,33 @@ defmodule PtcRunner.Kernel.ProviderExecutionOAuthTest do
     refute_received {:oauth_request, "POST", "/token"}
     assert_received {:authorization_notice, _url}
     refute_received {:authorization_notice, _other}
+  end
+
+  test "a check authorizes exactly as the run it shares its session with" do
+    # `--check --authorize-mcp` was deferred to the execution-owner cutover.
+    # A check runs the same marker, session, registry, credentials, OAuth, and
+    # acquisition prefix, so it stops at the same transport rule as the run
+    # above and never reaches a second authorization.
+    parent = self()
+    server = start_server()
+    fixture = provider_fixture(server)
+    trace_run_start()
+
+    {:ok, owner} =
+      ExecutionSessionOwner.start(
+        fixture.prepared,
+        fixture.authority,
+        self(),
+        fixture.execution,
+        &visit_authorization_url(parent, &1),
+        :check
+      )
+
+    assert {:error, :invalid_mcp_transport} = ExecutionSessionOwner.await(owner)
+    assert [:token_exchange, :run_started] == [next_event(), next_event()]
+    assert_received {:authorization_notice, _url}
+    refute_received {:authorization_notice, _other}
+    refute_received {:oauth_request, "POST", "/token"}
   end
 
   test "selected authorities share one execution-scoped OAuth context" do

--- a/test/ptc_runner/kernel/provider_execution_oauth_test.exs
+++ b/test/ptc_runner/kernel/provider_execution_oauth_test.exs
@@ -101,7 +101,9 @@ defmodule PtcRunner.Kernel.ProviderExecutionOAuthTest do
     visit_authorization_url(self(), pending.url)
 
     assert {:ok, grant} =
-             LoopbackListener.await(listener, context, pending, cleanup_timeout_ms: 5_000)
+             LoopbackListener.await(listener, context, pending,
+               anchor_cleanup_deadline: fn -> {:ok, Deadline.new(5_000)} end
+             )
 
     assert grant.status == :active
     assert grant.granted_scopes == MapSet.new(["read"])

--- a/test/ptc_runner/kernel/provider_lifecycle_test.exs
+++ b/test/ptc_runner/kernel/provider_lifecycle_test.exs
@@ -877,15 +877,19 @@ defmodule PtcRunner.Kernel.ProviderLifecycleTest do
 
     assert :ok =
              ResourceRegistrar.commit(registrar, fn ->
-               send(parent, {:closed, Process.alive?(provider)})
+               # The closer observes the exact window a racing dispatch would
+               # use: the session is still alive and the run is still open.
+               send(parent, {:closed, Process.alive?(provider), late_attach(state)})
                :ok
              end)
 
     assert Process.alive?(provider)
     assert :ok = ProviderSession.close(session)
 
-    # No callback from this run may still be live when a connector closes.
-    assert_receive {:closed, false}
+    # No callback from this run may still be live when a connector closes, and
+    # the drain that proved it also seals the owner, so one that raced it is
+    # refused rather than attached behind the closers.
+    assert_receive {:closed, false, {{:error, :closed}, :killed}}
     refute Process.alive?(provider)
 
     RunState.close(state)
@@ -1396,6 +1400,24 @@ defmodule PtcRunner.Kernel.ProviderLifecycleTest do
 
     assert_receive {:scope_root_ready, ^root}
     root
+  end
+
+  # Attaches from a separate process, since one process holds one reservation.
+  # A task the sealed owner accepted is killed here so the assertion reports the
+  # accepted attachment instead of timing out on a live one.
+  defp late_attach(state) do
+    Task.async(fn ->
+      task = spawn(fn -> receive do: (:stop -> :ok) end)
+      monitor = Process.monitor(task)
+      :ok = RunState.reserve_capability(state, :workflow, "late")
+      attached = RunState.attach_provider(state, task)
+      if attached == :ok, do: Process.exit(task, :kill)
+
+      receive do
+        {:DOWN, ^monitor, :process, ^task, reason} -> {attached, reason}
+      end
+    end)
+    |> Task.await()
   end
 
   defp start_provider_task(state, name) do

--- a/test/ptc_runner/kernel/provider_lifecycle_test.exs
+++ b/test/ptc_runner/kernel/provider_lifecycle_test.exs
@@ -826,6 +826,72 @@ defmodule PtcRunner.Kernel.ProviderLifecycleTest do
     end
   end
 
+  test "a session terminated at its cleanup budget still loses its provider tasks" do
+    # Terminating a wedged session skips `terminate/2`, so the session itself
+    # can kill nothing. The external task owner it registered with observes the
+    # death and kills the run's callbacks anyway.
+    parent = self()
+    {:ok, limits} = Limits.new(provider_cleanup_timeout_ms: 200)
+    {:ok, session} = ProviderSession.start(limits)
+    {:ok, registrar} = ProviderSession.open_registrar(session)
+    assert :ok = ResourceRegistrar.activate(registrar)
+    root = start_scope_root(registrar, parent)
+    assert :ok = ResourceRegistrar.commit(registrar, fn -> :ok end)
+
+    {:ok, state} = RunState.start(limits, provider_session: session)
+
+    assert :ok =
+             ProviderSession.bind_lifecycle(session, self(), state.pid, state.provider_tracker)
+
+    provider = start_provider_task(state, "wedged")
+    provider_monitor = Process.monitor(provider)
+    root_monitor = Process.monitor(root)
+    session_monitor = Process.monitor(session.pid)
+    assert Process.alive?(provider)
+
+    assert :ok = :sys.suspend(session.pid)
+    assert {:error, :provider_cleanup_failed} = ProviderSession.close(session)
+
+    assert_receive {:DOWN, ^session_monitor, :process, _, :killed}
+    assert_receive {:DOWN, ^provider_monitor, :process, ^provider, :killed}
+    assert_receive {:DOWN, ^root_monitor, :process, ^root, _reason}
+    assert {:error, :closed} = RunState.attach_provider(state, spawn(fn -> :ok end))
+
+    RunState.close(state)
+    RunState.stop(state)
+  end
+
+  test "provider tasks are drained before the session runs a provider closer" do
+    parent = self()
+    limits = limits()
+    {:ok, session} = ProviderSession.start(limits)
+    {:ok, registrar} = ProviderSession.open_registrar(session)
+    assert :ok = ResourceRegistrar.activate(registrar)
+
+    {:ok, state} = RunState.start(limits, provider_session: session)
+
+    assert :ok =
+             ProviderSession.bind_lifecycle(session, self(), state.pid, state.provider_tracker)
+
+    provider = start_provider_task(state, "drained")
+
+    assert :ok =
+             ResourceRegistrar.commit(registrar, fn ->
+               send(parent, {:closed, Process.alive?(provider)})
+               :ok
+             end)
+
+    assert Process.alive?(provider)
+    assert :ok = ProviderSession.close(session)
+
+    # No callback from this run may still be live when a connector closes.
+    assert_receive {:closed, false}
+    refute Process.alive?(provider)
+
+    RunState.close(state)
+    RunState.stop(state)
+  end
+
   test "successful Kernel cleanup terminates its provider session" do
     {:ok, workflow} = WorkflowEnvironment.new([])
     {:ok, mission} = MissionEnvironment.new([])
@@ -1313,6 +1379,30 @@ defmodule PtcRunner.Kernel.ProviderLifecycleTest do
 
   defp capability(name) do
     Capability.new(name: name, input_schema: @schema, callback: fn _arguments -> {:ok, %{}} end)
+  end
+
+  defp start_scope_root(registrar, parent) do
+    root =
+      spawn(fn ->
+        owner = ResourceRegistrar.owner(registrar)
+        owner_monitor = Process.monitor(owner)
+        :ok = ResourceRegistrar.register_root(registrar)
+        send(parent, {:scope_root_ready, self()})
+
+        receive do
+          {:DOWN, ^owner_monitor, :process, ^owner, _reason} -> :ok
+        end
+      end)
+
+    assert_receive {:scope_root_ready, ^root}
+    root
+  end
+
+  defp start_provider_task(state, name) do
+    provider = spawn(fn -> receive do: (:stop -> :ok) end)
+    assert :ok = RunState.reserve_capability(state, :workflow, name)
+    assert :ok = RunState.attach_provider(state, provider)
+    provider
   end
 
   defp limits do

--- a/test/ptc_runner/kernel/provider_session_test.exs
+++ b/test/ptc_runner/kernel/provider_session_test.exs
@@ -873,6 +873,86 @@ defmodule PtcRunner.Kernel.ProviderSessionTest do
     assert {:error, :provider_cleanup_failed} = ProviderSession.close(session)
   end
 
+  test "an unregistered close bounds the session's stack by the share it was given" do
+    # The caller reserves part of the one budget for the closer that must
+    # outlive a session which never answers. The session therefore bounds its
+    # own stack by that same share; otherwise a stack it could have worked
+    # through is killed at a bound only the caller knew about, and its oldest
+    # closer is never invoked at all.
+    parent = self()
+    {:ok, limits} = Limits.new(provider_cleanup_timeout_ms: 600)
+    {:ok, session} = ProviderSession.start(limits)
+
+    for label <- [:first, :second] do
+      {:ok, registrar} = ProviderSession.open_registrar(session)
+      assert :ok = ResourceRegistrar.activate(registrar)
+
+      assert :ok =
+               ResourceRegistrar.commit(registrar, fn ->
+                 send(parent, {:closed, label})
+                 receive do: (:never -> :ok)
+               end)
+    end
+
+    assert {:error, :provider_cleanup_failed} =
+             ProviderSession.close_with_unregistered(session, fn ->
+               send(parent, {:closed, :unregistered})
+               receive do: (:never -> :ok)
+             end)
+
+    # Every closer on the stack is attempted. A session spending the whole
+    # anchored remainder instead of its share is killed part-way through and
+    # strands the oldest one.
+    assert_receive {:closed, :unregistered}
+    assert_receive {:closed, :second}
+    assert_receive {:closed, :first}
+  end
+
+  @tag timeout: 15_000
+  test "the cleanup deadline starts where the terminal action began" do
+    # Anchoring inside the session would measure from the instant it dequeued
+    # the request, so time already spent waiting for a busy session would be
+    # granted a second time.
+    {:ok, limits} = Limits.new(provider_cleanup_timeout_ms: 1_000)
+    {:ok, session} = ProviderSession.start(limits)
+    parent = self()
+
+    suspender =
+      spawn(fn ->
+        true = :erlang.suspend_process(session.pid)
+        send(parent, :session_suspended)
+
+        receive do
+          :resume -> true = :erlang.resume_process(session.pid)
+        end
+      end)
+
+    assert_receive :session_suspended
+    Process.send_after(suspender, :resume, 300)
+
+    assert {:ok, deadline} = ProviderSession.anchor_cleanup_deadline(session)
+    assert Deadline.remaining(deadline) <= 700
+    assert :ok = ProviderSession.close(session)
+  end
+
+  test "an unregistered closer still runs at the smallest supported cleanup limit" do
+    # 100 ms is the smallest installable provider cleanup timeout, and it equals
+    # the reply grace. A split that took the grace off the top before halving
+    # would leave the session no budget at all and skip the closer it was just
+    # handed, leaving that resource open on the acquisition-failure path.
+    parent = self()
+    {:ok, limits} = Limits.new(provider_cleanup_timeout_ms: 100)
+    {:ok, session} = ProviderSession.start(limits)
+
+    assert :ok =
+             ProviderSession.close_with_unregistered(session, fn ->
+               send(parent, :minimum_budget_closed)
+               :ok
+             end)
+
+    assert_received :minimum_budget_closed
+  end
+
   test "cleanup continues in reverse order after a close failure" do
     {:ok, order} = Agent.start_link(fn -> [] end)
     {:ok, session} = ProviderSession.start(limits())
@@ -901,7 +981,8 @@ defmodule PtcRunner.Kernel.ProviderSessionTest do
 
     assert_received {:DOWN, ^monitor, :process, _pid, :killed}
     refute Process.alive?(session.pid)
-    assert elapsed < 5_000
+    # Bounded by the installed budget, not by a fixed interval unrelated to it.
+    assert elapsed < 1_000
   end
 
   test "an unresponsive session is terminated when closing an unregistered resource" do

--- a/test/ptc_runner/kernel/provider_session_test.exs
+++ b/test/ptc_runner/kernel/provider_session_test.exs
@@ -1,6 +1,7 @@
 defmodule PtcRunner.Kernel.ProviderSessionTest do
   use ExUnit.Case, async: true
 
+  alias PtcRunner.Kernel.Deadline
   alias PtcRunner.Kernel.Limits
   alias PtcRunner.Kernel.ProviderScopeOwner
   alias PtcRunner.Kernel.ProviderSession
@@ -835,6 +836,20 @@ defmodule PtcRunner.Kernel.ProviderSessionTest do
     assert_receive {:DOWN, ^session_monitor, :process, _, :normal}
   end
 
+  test "the cleanup deadline is anchored once for the whole terminal episode" do
+    {:ok, session} = ProviderSession.start(limits())
+
+    assert {:ok, anchored} = ProviderSession.anchor_cleanup_deadline(session)
+    assert Deadline.valid?(anchored)
+
+    # A later terminal stage consumes the same absolute deadline rather than
+    # minting the installed cleanup duration again.
+    assert {:ok, ^anchored} = ProviderSession.anchor_cleanup_deadline(session)
+
+    assert :ok = ProviderSession.close(session)
+    assert {:error, :provider_cleanup_failed} = ProviderSession.anchor_cleanup_deadline(session)
+  end
+
   test "cleanup has one shared bound" do
     {:ok, order} = Agent.start_link(fn -> [] end)
     {:ok, limits} = Limits.new(provider_cleanup_timeout_ms: 100)
@@ -908,10 +923,11 @@ defmodule PtcRunner.Kernel.ProviderSessionTest do
 
     assert_received {:DOWN, ^monitor, :process, _pid, :killed}
     # The unregistered closer keeps its share of the one terminal budget even
-    # when the session itself never answers.
+    # when the session itself never answers, and both shares together stay
+    # inside that one budget rather than each taking a fresh one.
     assert_received :unregistered_closed
     refute Process.alive?(session.pid)
-    assert elapsed < 5_000
+    assert elapsed < 1_000
   end
 
   test "tampered session and registrar handles are rejected" do

--- a/test/ptc_runner/kernel/provider_session_test.exs
+++ b/test/ptc_runner/kernel/provider_session_test.exs
@@ -860,6 +860,48 @@ defmodule PtcRunner.Kernel.ProviderSessionTest do
     assert [:first] = Agent.get(order, &Enum.reverse/1)
   end
 
+  test "an unresponsive session is terminated at its installed cleanup budget" do
+    # The lifecycle owner installs the whole terminal budget, so a session that
+    # cannot answer within it is ended rather than waited on forever.
+    {:ok, limits} = Limits.new(provider_cleanup_timeout_ms: 200)
+    assert {:ok, session} = ProviderSession.start(limits)
+    assert :ok = :sys.suspend(session.pid)
+    monitor = Process.monitor(session.pid)
+
+    started_at = System.monotonic_time(:millisecond)
+    assert {:error, :provider_cleanup_failed} = ProviderSession.close(session)
+    elapsed = System.monotonic_time(:millisecond) - started_at
+
+    assert_received {:DOWN, ^monitor, :process, _pid, :killed}
+    refute Process.alive?(session.pid)
+    assert elapsed < 5_000
+  end
+
+  test "an unresponsive session is terminated when closing an unregistered resource" do
+    {:ok, limits} = Limits.new(provider_cleanup_timeout_ms: 200)
+    assert {:ok, session} = ProviderSession.start(limits)
+    parent = self()
+    assert :ok = :sys.suspend(session.pid)
+    monitor = Process.monitor(session.pid)
+
+    started_at = System.monotonic_time(:millisecond)
+
+    assert {:error, :provider_cleanup_failed} =
+             ProviderSession.close_with_unregistered(session, fn ->
+               send(parent, :unregistered_closed)
+               :ok
+             end)
+
+    elapsed = System.monotonic_time(:millisecond) - started_at
+
+    assert_received {:DOWN, ^monitor, :process, _pid, :killed}
+    # The unregistered closer keeps its share of the one terminal budget even
+    # when the session itself never answers.
+    assert_received :unregistered_closed
+    refute Process.alive?(session.pid)
+    assert elapsed < 5_000
+  end
+
   test "tampered session and registrar handles are rejected" do
     {:ok, session} = ProviderSession.start(limits())
     {:ok, registrar} = ProviderSession.open_registrar(session)

--- a/test/ptc_runner/kernel/provider_session_test.exs
+++ b/test/ptc_runner/kernel/provider_session_test.exs
@@ -4,6 +4,7 @@ defmodule PtcRunner.Kernel.ProviderSessionTest do
   alias PtcRunner.Kernel.Limits
   alias PtcRunner.Kernel.ProviderScopeOwner
   alias PtcRunner.Kernel.ProviderSession
+  alias PtcRunner.Kernel.ProviderTaskTracker
   alias PtcRunner.Kernel.ResourceRegistrar
 
   test "committed scopes close once in reverse commit order" do
@@ -57,7 +58,10 @@ defmodule PtcRunner.Kernel.ProviderSessionTest do
     assert :ok = ResourceRegistrar.abort(registrar)
 
     run_state = spawn(fn -> receive do: (:stop -> :ok) end)
-    assert :ok = ProviderSession.bind_lifecycle(session, self(), run_state)
+
+    assert :ok =
+             ProviderSession.bind_lifecycle(session, self(), run_state, task_tracker(run_state))
+
     assert ProviderSession.lifecycle_owner(session) == lifecycle_owner
 
     session_ref = Process.monitor(session.pid)
@@ -121,7 +125,14 @@ defmodule PtcRunner.Kernel.ProviderSessionTest do
 
     lifecycle_owner = spawn(fn -> receive do: (:stop -> :ok) end)
     run_state = spawn(fn -> receive do: (:stop -> :ok) end)
-    assert :ok = ProviderSession.bind_lifecycle(session, lifecycle_owner, run_state)
+
+    assert :ok =
+             ProviderSession.bind_lifecycle(
+               session,
+               lifecycle_owner,
+               run_state,
+               task_tracker(run_state)
+             )
 
     assert {:error, :operation_claimed} =
              ProviderSession.claim_operation(session, limits, identity)
@@ -793,20 +804,21 @@ defmodule PtcRunner.Kernel.ProviderSessionTest do
 
         lifecycle_owner = spawn(fn -> receive do: (:stop -> :ok) end)
         run_state = spawn(fn -> receive do: (:stop -> :ok) end)
-        :ok = ProviderSession.bind_lifecycle(session, lifecycle_owner, run_state)
-        send(parent, {:session_ready, session, lifecycle_owner, run_state})
+        {:ok, tracker} = ProviderTaskTracker.start(run_state)
+        :ok = ProviderSession.bind_lifecycle(session, lifecycle_owner, run_state, tracker)
+        send(parent, {:session_ready, session, lifecycle_owner, run_state, tracker})
         receive do: (:stop -> :ok)
       end)
 
-    assert_receive {:session_ready, session, lifecycle_owner, run_state}
+    assert_receive {:session_ready, session, lifecycle_owner, run_state, tracker}
     session_monitor = Process.monitor(session.pid)
 
     assert {:error, :provider_session_unavailable} =
-             ProviderSession.bind_lifecycle(session, self(), run_state)
+             ProviderSession.bind_lifecycle(session, self(), run_state, tracker)
 
     provider = spawn(fn -> receive do: (:stop -> :ok) end)
     provider_monitor = Process.monitor(provider)
-    assert :ok = ProviderSession.attach_provider(session, provider)
+    assert :ok = ProviderTaskTracker.attach(tracker, provider)
 
     Process.exit(creator, :kill)
     refute_receive :committed_closed
@@ -919,6 +931,11 @@ defmodule PtcRunner.Kernel.ProviderSessionTest do
   end
 
   defp limits, do: Limits.defaults()
+
+  defp task_tracker(run_state) do
+    {:ok, tracker} = ProviderTaskTracker.start(run_state)
+    tracker
+  end
 
   defp record_close(agent, value) do
     fn ->


### PR DESCRIPTION
Stabilization prefix for Checkpoint C, ahead of doctor implementation. Ten
commits, each independently reviewable.

## Descriptor, ordering, and parity

- `586f0de0` makes the sealed provider descriptor authoritative during staged
  preparation, rejecting `data_class`/`accepts_data` drift before preflight.
- `0667b74c` records host-bound runtime activation as the code-owned bootstrap
  exception and adds its two missing regressions.
- `94396d45` classifies `.env` loading as command setup rather than bounded run
  work, so it is never charged to the run clock.
- `1dd7fb9a` refuses an expired loopback interaction before reading buffered
  bytes, keeping `:authorization_timeout` distinct from a malformed request.
- `c1bb1f62` runs `--check` through the execution-session owner, so a check and
  a run differ only in how the owner completes an assembled build.

## Terminal cleanup

- `71d6fcb2` bounds terminal cleanup by the budget the lifecycle owner installs
  and stops discarding an uncommitted OAuth cancellation.
- `2febac1a` makes `ProviderTaskTracker` the one owner of a run's live provider
  callbacks, external to both lifecycles it serves. It monitors `RunState` and
  the `ProviderSession`, so either lifecycle disappearing kills and reaps every
  attached task — including a session terminated at its cleanup deadline, where
  `terminate/2` cannot run. The session's monitor-only provider map is deleted.
- `44664e81` gives terminal cleanup one absolute deadline. The first terminal
  action anchors it; the OAuth cancellation and the close that follows consume
  what remains of that same deadline instead of each minting the installed
  duration again. `LoopbackListener` no longer constructs a deadline at all.
- `b3128961` closes a check's provider session inside the runtime that acquired
  it, where a run closes its own, instead of leaving connector closers to run
  against a registry and OAuth store already torn down.
- `bb4d3d25` seals the task owner on drain, so an attachment racing it cannot
  slip a live callback in behind the closers, and stops the anchored budget
  being spent twice across stages.

`provider_cleanup_failed` and `authorization_cleanup_failed` keep their exact
classifications throughout.

## Residuals

Recorded in `docs/plans/lisp-kernel/stable-cli-contract.md` rather than
repaired, because each is an ownership change rather than a deadline fix: the
deadline bounds a session's own cleanup and not its scope reapers' tail; a
terminal stage that must ask for the anchored deadline can only bound that
request by the installed budget; and caller death during a check aborts through
the execution owner's registry-before-session ordering, which is the shipped
abort ordering for runs and is pinned by its own regression.

## Verification

`mix precommit`, `MIX_ENV=test mix dialyzer`, `MIX_ENV=dev mix docs
--warnings-as-errors`, and five rounds of independent `codex review` against
`origin/main`, the last reporting no critical findings. Every regression added
here was checked against the mutation it is meant to catch.

https://claude.ai/code/session_01W5CtsgWothwaWcUvqGmtpd