### PR TITLE
perf(dev): share the Dialyzer core PLT and scope launcher precompile to host arch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,9 +69,11 @@ mix compile
 ```
 
 Run `./scripts/install-hooks.sh` once per clone. Linked worktrees share the
-clone's installed hook wrappers, so they do not need to reinstall them. The
-first Dialyzer run in a worktree builds its local `priv/plts` cache and is
-expected to be slower.
+clone's installed hook wrappers, so they do not need to reinstall them.
+Outside CI, the Dialyzer core PLT lives under `~/.cache/ptc_runner/` and is
+shared across every worktree, so only the very first Dialyzer run on a
+machine builds it from scratch; each worktree still keeps its own
+project-specific `priv/plts/project.plt`.
 
 If a timing-sensitive test fails only in the full suite, rerun the exact file
 and line reported by ExUnit. Do not bypass the hook; use

--- a/mix.exs
+++ b/mix.exs
@@ -36,13 +36,35 @@ defmodule PtcRunner.MixProject do
         ]
       ],
       dialyzer: [
-        plt_core_path: "priv/plts",
+        plt_core_path: dialyzer_plt_core_path(),
         plt_file: {:no_warn, "priv/plts/project.plt"},
         plt_add_apps: [:ex_unit, :mix, :req, :req_llm, :llm_db, :recon],
         ignore_warnings: ".dialyzer_ignore.exs",
         list_unused_filters: true
       ]
     ]
+  end
+
+  # The core PLT (Erlang/Elixir/OTP plus `plt_add_apps`) is identical across
+  # every worktree of this repo: mise.toml pins the same Elixir/OTP build,
+  # and worktree branches share one mix.lock unless a branch deliberately
+  # changes deps. Keeping it worktree-local means the first Dialyzer run in
+  # every fresh worktree rebuilds it from scratch. Outside CI, share one
+  # copy under the user's cache directory instead. `plt_file` (this
+  # project's own module signatures) stays worktree-local: unlike the core
+  # PLT, it legitimately differs between branches with diverging code, and
+  # concurrent worktree sessions writing the same project PLT would race.
+  #
+  # CI keeps the repo-local "priv/plts" path because `setup-elixir`
+  # restores/saves it via `actions/cache`, keyed by OS/arch/OTP/Elixir/
+  # mix.lock — an external-cache scheme that expects a path inside the
+  # checkout, not the user cache directory of an ephemeral runner.
+  defp dialyzer_plt_core_path do
+    if System.get_env("CI") do
+      "priv/plts"
+    else
+      Path.expand("~/.cache/ptc_runner/dialyzer_plts")
+    end
   end
 
   # Run "mix help compile.app" to learn about applications.

--- a/priv/semantic_build_projection.json
+++ b/priv/semantic_build_projection.json
@@ -69,7 +69,7 @@
       "version": "1.1.0"
     },
     {
-      "content_identity": "5a42b1f793d0c7fa456a45bdcf69c6008b961497a70f94ad8a5bb2f01ea063bf",
+      "content_identity": "df32ad11758b92f09f4c252dc19f4de727bef342aa474520febeb3814ca5562e",
       "name": "ptc_runner_launcher",
       "version": "0.1.0"
     },
@@ -129,7 +129,7 @@
     "req_llm",
     "telemetry"
   ],
-  "source_closure_hash": "6b35d984e117668d06144656f8d120a0e148c7c7f8907275d531faee7bb90643",
+  "source_closure_hash": "08d93bec5cfa2bd10b9d1f2d15247f3db1c1bc783ecc9d545ccde3fcc3eddfbc",
   "sources": [
     {
       "bytes": 870,
@@ -1532,9 +1532,9 @@
       "sha256": "845e3cd3cc8240c96d758e14da41c41b5ffc7e5b79e6345db49b16954e89b329"
     },
     {
-      "bytes": 11007,
+      "bytes": 12132,
       "path": "mix.exs",
-      "sha256": "0ad4b3262edc6e0463e8f9d210b2a6e592f64d790cb378336286dd04aff40200"
+      "sha256": "1a3f4ce3f8f249f098d06eb78aaa8db46abd0dacddde72e41f823ee95e8bc43d"
     },
     {
       "bytes": 117541,

--- a/ptc_runner_launcher/scripts/verify_package.sh
+++ b/ptc_runner_launcher/scripts/verify_package.sh
@@ -21,8 +21,26 @@ if [ -f "$checksum_path" ]; then
   cp "$checksum_path" "$checksum_backup"
 fi
 
-CC_PRECOMPILER_PRECOMPILE_ONLY_LOCAL=true \
-  ELIXIR_MAKE_CACHE_DIR="$package_tmp_dir/cache" \
+# CI's mcp-stdio-launcher matrix already builds every listed target natively,
+# one per runner (ubuntu-22.04, ubuntu-24.04-arm, macos-15, macos-15-intel).
+# Locally, precompiling every target on every run just doubles native-compile
+# time for coverage CI already has; restrict to the host target outside CI.
+# An unrecognized host falls through to the full multi-target build.
+precompile_target=""
+if [ -z "${CI:-}" ]; then
+  case "$(uname -s):$(uname -m)" in
+    Darwin:arm64) precompile_target="aarch64-apple-darwin" ;;
+    Darwin:x86_64) precompile_target="x86_64-apple-darwin" ;;
+    Linux:aarch64 | Linux:arm64) precompile_target="aarch64-linux-gnu" ;;
+    Linux:x86_64) precompile_target="x86_64-linux-gnu" ;;
+  esac
+fi
+
+if [ -n "$precompile_target" ]; then
+  export PTC_RUNNER_LAUNCHER_PRECOMPILE_TARGET="$precompile_target"
+fi
+
+ELIXIR_MAKE_CACHE_DIR="$package_tmp_dir/cache" \
   MIX_ENV=prod \
   mix elixir_make.precompile
 


### PR DESCRIPTION
## Problem

`mix precommit`/hooks were slow enough that it prompted a diagnostic pass.
Two structural causes found there have real headroom with no correctness
tradeoff:

1. Dialyzer's core PLT (Erlang/Elixir/OTP + `plt_add_apps`) lived at the
   worktree-local `priv/plts`, so every fresh worktree paid a full cold
   build on its first Dialyzer run — even though the core PLT's contents
   are identical across worktrees (`mise.toml` pins one Elixir/OTP build,
   and worktree branches share one `mix.lock` unless a branch deliberately
   changes deps).
2. `ptc_runner_launcher/scripts/verify_package.sh` precompiled native
   archives for **both** `aarch64-apple-darwin` and `x86_64-apple-darwin`
   on every local `mix precommit` run, doubling native C compile time for
   coverage CI already provides independently.

## What changed

- `mix.exs`: outside CI, `plt_core_path` now points at
  `~/.cache/ptc_runner/dialyzer_plts`, shared across every worktree on the
  machine — only the very first Dialyzer run ever pays the cold-build
  cost. `plt_file` (this project's own module signatures) stays
  worktree-local, since it legitimately diverges per-branch and
  concurrent worktree writes to a shared copy would race. CI is
  unaffected: it keeps the repo-local `priv/plts` path that
  `setup-elixir`'s `actions/cache` step depends on.
- `ptc_runner_launcher/scripts/verify_package.sh`: outside CI, restricts
  `mix elixir_make.precompile` to the host's own architecture via
  `PTC_RUNNER_LAUNCHER_PRECOMPILE_TARGET` (already supported by
  `mix.exs`, just previously unused here). Verified CI's
  `mcp-stdio-launcher` matrix job already runs `mix precommit` natively
  on `macos-15` (arm64) *and* `macos-15-intel` (x86_64), so both target
  architectures stay independently covered in CI regardless of what a
  local machine builds. An unrecognized host still falls through to the
  full multi-target build. Also removed
  `CC_PRECOMPILER_PRECOMPILE_ONLY_LOCAL=true`, which didn't correspond to
  anything in the current `cc_precompiler`/`elixir_make` versions and had
  no effect — confirmed by grepping both deps for the name.
- `AGENTS.md` (source of the `CLAUDE.md` symlink) updated to describe the
  new shared-PLT behavior instead of the stale "first run per worktree is
  slower" note.
- `priv/semantic_build_projection.json` regenerated via
  `mix ptc.gen_semantic_revision`, since `mix.exs` is part of the
  semantic source closure.

## Verification

- `mix precommit`: green end to end.
- `bash ptc_runner_launcher/scripts/verify_package.sh` run directly:
  confirmed it now builds only `aarch64-apple-darwin` (this machine's
  arch) instead of both.
- `mix dialyzer`: clean run (0 errors), confirmed
  `~/.cache/ptc_runner/dialyzer_plts` is created and populated on first
  use.
- `mix compile --warnings-as-errors`: clean.

https://claude.ai/code/session_01AFbUwnHbP9q7XKZQfVe2Tw