### PR TITLE
refactor(kernel): consolidate construction attestations

### DIFF
--- a/.duplication-baseline.json
+++ b/.duplication-baseline.json
@@ -748,30 +748,6 @@
       ],
       "type": "type_ii"
     },
-    "72acfd4a21f912b242d3fe4523196f5980c42ebbc62f916475d0ce6f740fa18b": {
-      "describe": "type_i mass=37 lib/ptc_runner/kernel/analysis_assembly.ex:90 <-> lib/ptc_runner/kernel/attestation.ex:38 <-> lib/ptc_runner/kernel/frozen_bundle.ex:139",
-      "files": [
-        "lib/ptc_runner/kernel/analysis_assembly.ex",
-        "lib/ptc_runner/kernel/attestation.ex",
-        "lib/ptc_runner/kernel/frozen_bundle.ex"
-      ],
-      "mass": 37,
-      "occurrences": [
-        {
-          "file": "lib/ptc_runner/kernel/analysis_assembly.ex",
-          "snippet": "1b44748766f3d2678ac7869c1a0c28a7a26969e5d6d6d488904a38e7dfba0478"
-        },
-        {
-          "file": "lib/ptc_runner/kernel/attestation.ex",
-          "snippet": "1b44748766f3d2678ac7869c1a0c28a7a26969e5d6d6d488904a38e7dfba0478"
-        },
-        {
-          "file": "lib/ptc_runner/kernel/frozen_bundle.ex",
-          "snippet": "1b44748766f3d2678ac7869c1a0c28a7a26969e5d6d6d488904a38e7dfba0478"
-        }
-      ],
-      "type": "type_i"
-    },
     "763c8a9e4ef38af437133014657da3890afd363f089b1e1693f858ab67849dbe": {
       "describe": "type_i mass=57 lib/ptc_runner/kernel/inspection_snapshot.ex:129 <-> lib/ptc_runner/kernel/trace_snapshot.ex:94",
       "files": [
@@ -1157,49 +1133,6 @@
         {
           "file": "lib/ptc_runner/kernel/log_analysis_profile.ex",
           "snippet": "8904df8e784e787d66ba1bbe7c042dc40931e10333ae656dfdc4cc1515f53c6d"
-        }
-      ],
-      "type": "type_i"
-    },
-    "aa88592927623db563d245dc94d35db7d3af974f0d3d3d6f624cf4339f4a8524": {
-      "describe": "type_i mass=47 lib/ptc_runner/kernel/analysis_assembly.ex:87 <-> lib/ptc_runner/kernel/frozen_bundle.ex:136",
-      "files": [
-        "lib/ptc_runner/kernel/analysis_assembly.ex",
-        "lib/ptc_runner/kernel/frozen_bundle.ex"
-      ],
-      "mass": 47,
-      "occurrences": [
-        {
-          "file": "lib/ptc_runner/kernel/analysis_assembly.ex",
-          "snippet": "ddaea5da8f8bf301f92af18ce67c12430c86c3e3c360801366cd5dfbaa5260c5"
-        },
-        {
-          "file": "lib/ptc_runner/kernel/frozen_bundle.ex",
-          "snippet": "ddaea5da8f8bf301f92af18ce67c12430c86c3e3c360801366cd5dfbaa5260c5"
-        }
-      ],
-      "type": "type_i"
-    },
-    "aeffdb58d813f11b42cdbd9fdd3aec32f7aecaab0daeb54b087e981e5766ae30": {
-      "describe": "type_i mass=44 lib/ptc_runner/kernel/analysis_assembly.ex:75 <-> lib/ptc_runner/kernel/attestation.ex:23 <-> lib/ptc_runner/kernel/frozen_bundle.ex:113",
-      "files": [
-        "lib/ptc_runner/kernel/analysis_assembly.ex",
-        "lib/ptc_runner/kernel/attestation.ex",
-        "lib/ptc_runner/kernel/frozen_bundle.ex"
-      ],
-      "mass": 44,
-      "occurrences": [
-        {
-          "file": "lib/ptc_runner/kernel/analysis_assembly.ex",
-          "snippet": "26b2298314e5b828a1eb8c075d29b02de47815ba5be87ec7ee79067af7cbdd6d"
-        },
-        {
-          "file": "lib/ptc_runner/kernel/attestation.ex",
-          "snippet": "26b2298314e5b828a1eb8c075d29b02de47815ba5be87ec7ee79067af7cbdd6d"
-        },
-        {
-          "file": "lib/ptc_runner/kernel/frozen_bundle.ex",
-          "snippet": "26b2298314e5b828a1eb8c075d29b02de47815ba5be87ec7ee79067af7cbdd6d"
         }
       ],
       "type": "type_i"

--- a/lib/ptc_runner/kernel/analysis_assembly.ex
+++ b/lib/ptc_runner/kernel/analysis_assembly.ex
@@ -1,9 +1,8 @@
 defmodule PtcRunner.Kernel.AnalysisAssembly do
   @moduledoc false
 
-  import Bitwise, only: [bor: 2, bxor: 2]
-
   alias PtcRunner.Kernel.AnalysisProfileRegistry
+  alias PtcRunner.Kernel.Attestation
   alias PtcRunner.Kernel.SessionTrace
 
   @enforce_keys [:config, :profile, :resources, :session_trace, :run_state, :attestation]
@@ -20,12 +19,12 @@ defmodule PtcRunner.Kernel.AnalysisAssembly do
       attestation: nil
     }
 
-    %{assembly | attestation: attest(assembly)}
+    %{assembly | attestation: Attestation.attest(__MODULE__, payload(assembly))}
   end
 
   @doc false
   def valid?(%__MODULE__{attestation: attestation} = assembly) when is_binary(attestation) do
-    secure_compare(attestation, attest(assembly)) and
+    Attestation.valid?(__MODULE__, payload(assembly), attestation) and
       SessionTrace.valid_binding?(
         assembly.session_trace,
         assembly.run_state,
@@ -54,55 +53,13 @@ defmodule PtcRunner.Kernel.AnalysisAssembly do
 
   defp valid_profile_assembly?(_assembly), do: false
 
-  defp attest(assembly) do
-    :crypto.mac(
-      :hmac,
-      :sha256,
-      key(),
-      :erlang.term_to_binary(
-        {
-          assembly.config,
-          assembly.profile,
-          assembly.resources,
-          assembly.session_trace,
-          assembly.run_state
-        },
-        [:deterministic]
-      )
-    )
-  end
-
-  defp secure_compare(left, right) when byte_size(left) == byte_size(right) do
-    left
-    |> :binary.bin_to_list()
-    |> Enum.zip(:binary.bin_to_list(right))
-    |> Enum.reduce(0, fn {left_byte, right_byte}, difference ->
-      bor(difference, bxor(left_byte, right_byte))
-    end)
-    |> Kernel.==(0)
-  end
-
-  defp secure_compare(_left, _right), do: false
-
-  defp key do
-    storage_key = {__MODULE__, :attestation_key}
-
-    case :persistent_term.get(storage_key, :missing) do
-      :missing ->
-        :global.trans({storage_key, self()}, fn ->
-          case :persistent_term.get(storage_key, :missing) do
-            :missing ->
-              secret = :crypto.strong_rand_bytes(32)
-              :persistent_term.put(storage_key, secret)
-              secret
-
-            secret ->
-              secret
-          end
-        end)
-
-      secret ->
-        secret
-    end
+  defp payload(assembly) do
+    {
+      assembly.config,
+      assembly.profile,
+      assembly.resources,
+      assembly.session_trace,
+      assembly.run_state
+    }
   end
 end

--- a/lib/ptc_runner/kernel/attestation.ex
+++ b/lib/ptc_runner/kernel/attestation.ex
@@ -7,8 +7,6 @@ defmodule PtcRunner.Kernel.Attestation do
   running in the same VM.
   """
 
-  import Bitwise, only: [bor: 2, bxor: 2]
-
   @spec attest(module(), term()) :: binary()
   def attest(owner, payload) when is_atom(owner) do
     :crypto.mac(:hmac, :sha256, key(owner), :erlang.term_to_binary(payload, [:deterministic]))
@@ -20,15 +18,8 @@ defmodule PtcRunner.Kernel.Attestation do
 
   def valid?(_owner, _payload, _attestation), do: false
 
-  defp secure_compare(left, right) when byte_size(left) == byte_size(right) do
-    left
-    |> :binary.bin_to_list()
-    |> Enum.zip(:binary.bin_to_list(right))
-    |> Enum.reduce(0, fn {left_byte, right_byte}, difference ->
-      bor(difference, bxor(left_byte, right_byte))
-    end)
-    |> Kernel.==(0)
-  end
+  defp secure_compare(left, right) when byte_size(left) == byte_size(right),
+    do: :crypto.hash_equals(left, right)
 
   defp secure_compare(_left, _right), do: false
 

--- a/lib/ptc_runner/kernel/frozen_bundle.ex
+++ b/lib/ptc_runner/kernel/frozen_bundle.ex
@@ -32,7 +32,8 @@ defmodule PtcRunner.Kernel.FrozenBundle do
   Hosts obtain bundles through `PtcRunner.Kernel.compile_bundle/1`; `seal/1`
   and `valid?/1` support the Kernel's construction boundary.
   """
-  import Bitwise, only: [bor: 2, bxor: 2]
+  alias PtcRunner.Kernel.Attestation
+
   @enforce_keys [:components, :component_ids, :hash, :prelude]
   defstruct [:components, :component_ids, :hash, :prelude, :attestation]
   @field_keys Enum.sort([:__struct__, :components, :component_ids, :hash, :prelude, :attestation])
@@ -99,59 +100,18 @@ defmodule PtcRunner.Kernel.FrozenBundle do
 
   @spec seal(t()) :: t()
   @doc "Attests a newly compiled bundle for later environment validation."
-  def seal(%__MODULE__{} = bundle), do: %{bundle | attestation: attest(bundle)}
+  def seal(%__MODULE__{} = bundle),
+    do: %{bundle | attestation: Attestation.attest(__MODULE__, payload(bundle))}
 
   @spec valid?(t()) :: boolean()
   @doc "Checks that a bundle still matches its in-VM attestation."
   def valid?(%__MODULE__{attestation: attestation} = bundle) when is_binary(attestation),
     do:
       Enum.sort(Map.keys(bundle)) == @field_keys and
-        secure_compare(attestation, attest(bundle))
+        Attestation.valid?(__MODULE__, payload(bundle), attestation)
 
   def valid?(_bundle), do: false
 
-  defp secure_compare(left, right) when byte_size(left) == byte_size(right) do
-    left
-    |> :binary.bin_to_list()
-    |> Enum.zip(:binary.bin_to_list(right))
-    |> Enum.reduce(0, fn {left_byte, right_byte}, difference ->
-      bor(difference, bxor(left_byte, right_byte))
-    end)
-    |> Kernel.==(0)
-  end
-
-  defp secure_compare(_left, _right), do: false
-
-  defp attest(bundle) do
-    :crypto.mac(:hmac, :sha256, key(), canonical(bundle))
-  end
-
-  defp canonical(bundle) do
-    :erlang.term_to_binary(
-      {bundle.components, bundle.component_ids, bundle.hash, bundle.prelude},
-      [:deterministic]
-    )
-  end
-
-  defp key do
-    storage_key = {__MODULE__, :attestation_key}
-
-    case :persistent_term.get(storage_key, :missing) do
-      :missing ->
-        :global.trans({storage_key, self()}, fn ->
-          case :persistent_term.get(storage_key, :missing) do
-            :missing ->
-              secret = :crypto.strong_rand_bytes(32)
-              :persistent_term.put(storage_key, secret)
-              secret
-
-            secret ->
-              secret
-          end
-        end)
-
-      secret ->
-        secret
-    end
-  end
+  defp payload(bundle),
+    do: {bundle.components, bundle.component_ids, bundle.hash, bundle.prelude}
 end

--- a/priv/semantic_build_projection.json
+++ b/priv/semantic_build_projection.json
@@ -129,7 +129,7 @@
     "req_llm",
     "telemetry"
   ],
-  "source_closure_hash": "bc6537185b47854ebfd2115cf1651cf78365a72cf0b1172f752ea89e2b713785",
+  "source_closure_hash": "7c407df001b15a60f3f889812ca061bc5e1338a04d47d75107ccba8efa9f1c50",
   "sources": [
     {
       "bytes": 870,
@@ -152,9 +152,9 @@
       "sha256": "f079a92f763aa40b191b38f00f015e91ac49672f7f1ae8af96b097b90eee5146"
     },
     {
-      "bytes": 2760,
+      "bytes": 1765,
       "path": "lib/ptc_runner/kernel/analysis_assembly.ex",
-      "sha256": "be910bec046bc9ca915594a45c80a65aef2d5cf909e0d14254e5b665d527521c"
+      "sha256": "5bd440248c707db9c76ba0676efebf29637080f5b21c682b9a04ffbba8b38a78"
     },
     {
       "bytes": 3658,
@@ -202,9 +202,9 @@
       "sha256": "fde1b236cb1a2fa5f0ffd4ca0cb3140a295ec44b7bb03d50c40c0610657f2523"
     },
     {
-      "bytes": 1702,
+      "bytes": 1466,
       "path": "lib/ptc_runner/kernel/attestation.ex",
-      "sha256": "c1e64d9b5780de398035349df0024bddccf4b96355f11c6f14e161d24b40b8e5"
+      "sha256": "f39cc0a3d34b82d5731792b5b05de7d05f4ae3405baf46e9c2ce5ebcbbeeb11f"
     },
     {
       "bytes": 5564,
@@ -317,9 +317,9 @@
       "sha256": "9c103b9a7ee924ee7001564591dc7f21998bc915865a8d68c6b6ee62e64d1a2b"
     },
     {
-      "bytes": 5427,
+      "bytes": 4437,
       "path": "lib/ptc_runner/kernel/frozen_bundle.ex",
-      "sha256": "f44681de228e6cb71b3532995511692ca1037edaf5aa297911a8524a100e04fb"
+      "sha256": "7c9d4f310404497b8cff9b17b3c9ee8091ed3314f2c34809c95c0f375a486e0d"
     },
     {
       "bytes": 58648,

--- a/test/ptc_runner/kernel/attestation_test.exs
+++ b/test/ptc_runner/kernel/attestation_test.exs
@@ -1,0 +1,23 @@
+defmodule PtcRunner.Kernel.AttestationTest do
+  use ExUnit.Case, async: true
+
+  alias PtcRunner.Kernel.Attestation
+
+  test "attestations are bound to their owner and exact payload" do
+    payload = {:sealed, %{value: 1}}
+    attestation = Attestation.attest(__MODULE__, payload)
+
+    assert Attestation.valid?(__MODULE__, payload, attestation)
+    refute Attestation.valid?(__MODULE__.Other, payload, attestation)
+    refute Attestation.valid?(__MODULE__, {:sealed, %{value: 2}}, attestation)
+  end
+
+  test "invalid and unequal-length attestations fail closed" do
+    payload = {:sealed, 1}
+    attestation = Attestation.attest(__MODULE__, payload)
+
+    refute Attestation.valid?(__MODULE__, payload, nil)
+    refute Attestation.valid?(__MODULE__, payload, <<0>>)
+    refute Attestation.valid?(__MODULE__, payload, :binary.copy(<<0>>, byte_size(attestation)))
+  end
+end

--- a/test/ptc_runner/kernel/frozen_bundle_test.exs
+++ b/test/ptc_runner/kernel/frozen_bundle_test.exs
@@ -2,6 +2,7 @@ defmodule PtcRunner.Kernel.FrozenBundleTest do
   use ExUnit.Case, async: false
 
   alias PtcRunner.Kernel
+  alias PtcRunner.Kernel.Attestation
   alias PtcRunner.Kernel.Component
   alias PtcRunner.Kernel.FrozenBundle
   alias PtcRunner.Kernel.Library
@@ -70,7 +71,7 @@ defmodule PtcRunner.Kernel.FrozenBundleTest do
   end
 
   test "concurrent first seals share one attestation key" do
-    storage_key = {FrozenBundle, :attestation_key}
+    storage_key = {Attestation, FrozenBundle}
     :persistent_term.erase(storage_key)
     parent = self()
     component = Library.component("kernel") |> elem(1)


### PR DESCRIPTION
## What changed

- route `FrozenBundle` and `AnalysisAssembly` through the shared owner-keyed `PtcRunner.Kernel.Attestation` implementation;
- replace three hand-maintained byte-fold comparisons with OTP `:crypto.hash_equals/2`, retaining the unequal-length guard;
- remove the duplicated key initialization and HMAC code;
- shrink the duplication baseline from 82 to 79 accepted clones;
- add focused coverage for owner isolation, payload mutation, malformed attestations, and concurrent first sealing.

## Why

The same security-sensitive comparison, key initialization, and HMAC construction lived in three modules. Centralizing it prevents fixes or hardening from drifting between sealed Kernel values.

This is an internal 0.x construction boundary. Hot-loading the refactor into a VM invalidates `FrozenBundle` and `AnalysisAssembly` values sealed under their old key locations; normal VM restarts are unaffected.

Closes the attestation portion of #1183.

## Verification

- focused attestation, frozen-bundle, and analysis-session tests;
- duplication gate: 79 current, 79 baselined, no new clones;
- `mix precommit`: 5,635 root tests, 72 Viewer tests, 36 launcher tests;
- independent Codex review: no actionable findings.

One known `RunCoordinatorExecutionTest:250` owner-tracing race occurred once during the first full run, passed at the exact location, and passed in the final full gate. It also predates and does not execute this change.