### PR TITLE
test(lisp): accept either describe refusal path

### DIFF
--- a/test/ptc_runner/lisp/runtime/json_test.exs
+++ b/test/ptc_runner/lisp/runtime/json_test.exs
@@ -379,8 +379,12 @@ defmodule PtcRunner.Lisp.Runtime.JsonTest do
       assert msg =~ "cannot encode a keyword as a JSON value"
       assert msg =~ ~s|at [:keys "status" :examples 0]|
 
-      assert eval_error("(json/generate-string (describe ##Inf))") =~
-               "cannot encode ##Inf as a JSON value at [:examples 0]"
+      special_float_error = eval_error("(json/generate-string (describe ##Inf))")
+
+      assert special_float_error =~ "cannot encode ##Inf as a JSON value"
+
+      assert special_float_error =~ "at [:examples 0]" or
+               special_float_error =~ "at [:sample]"
     end
 
     test "a keyword value fails loudly with a named type_error" do


### PR DESCRIPTION
## Summary

- stop coupling the JSON refusal regression to map traversal order
- accept either accurate path emitted when describe of a special float contains the same invalid value in sample and examples

## Verification

- focused JSON runtime suite
- independent Codex review: clean
- full precommit: 5,635 root tests, 72 Viewer tests, 36 launcher tests

This test-only prerequisite was discovered while gating the separate UTF-8 duplication cleanup.