### PR TITLE
refactor(core): consolidate UTF-8 truncation

### DIFF
--- a/lib/ptc_runner/kernel/mcp_protocol.ex
+++ b/lib/ptc_runner/kernel/mcp_protocol.ex
@@ -46,6 +46,7 @@ defmodule PtcRunner.Kernel.MCPProtocol do
   alias PtcRunner.Kernel.JSONValue
   alias PtcRunner.Kernel.MCPBase64Format
   alias PtcRunner.Kernel.StrictJSON
+  alias PtcRunner.Utf8
 
   @input_request_schema_path Path.expand(
                                "../../../priv/schemas/mcp-input-request-2026-07-28.schema.json",
@@ -658,20 +659,12 @@ defmodule PtcRunner.Kernel.MCPProtocol do
       {:ok, texts} ->
         case texts |> Enum.reverse() |> Enum.join("\n") do
           "" -> {:ok, nil}
-          feedback -> {:ok, feedback |> sanitize_feedback() |> truncate_utf8(1_024)}
+          feedback -> {:ok, feedback |> sanitize_feedback() |> Utf8.truncate(1_024)}
         end
 
       error ->
         error
     end
-  end
-
-  defp truncate_utf8(value, max_bytes) when byte_size(value) <= max_bytes, do: value
-
-  defp truncate_utf8(value, max_bytes) do
-    value
-    |> binary_part(0, max_bytes)
-    |> valid_utf8_prefix()
   end
 
   defp valid_content_block?(block, allowed) do
@@ -727,14 +720,6 @@ defmodule PtcRunner.Kernel.MCPProtocol do
 
   defp sanitize_feedback(feedback) do
     String.replace(feedback, ~r/[\x00-\x1F\x7F-\x{9F}]/u, "�")
-  end
-
-  defp valid_utf8_prefix(value) do
-    if String.valid?(value) do
-      value
-    else
-      valid_utf8_prefix(binary_part(value, 0, byte_size(value) - 1))
-    end
   end
 
   defp classify_result(%{"resultType" => "complete"} = result, method) do

--- a/lib/ptc_runner/kernel/source_check.ex
+++ b/lib/ptc_runner/kernel/source_check.ex
@@ -6,6 +6,7 @@ defmodule PtcRunner.Kernel.SourceCheck do
   alias PtcRunner.Kernel.JSONValue
   alias PtcRunner.Kernel.RunState
   alias PtcRunner.Lisp
+  alias PtcRunner.Utf8
 
   @diagnostic_bytes 4_096
 
@@ -119,26 +120,10 @@ defmodule PtcRunner.Kernel.SourceCheck do
     end
   end
 
-  defp truncate_utf8(message, max_bytes)
-       when is_binary(message) and byte_size(message) <= max_bytes,
-       do: message
-
-  defp truncate_utf8(message, max_bytes) when is_binary(message) do
-    message
-    |> binary_part(0, max_bytes)
-    |> valid_utf8_prefix()
-    |> :binary.copy()
-  end
+  defp truncate_utf8(message, max_bytes) when is_binary(message),
+    do: Utf8.truncate(message, max_bytes)
 
   defp truncate_utf8(_message, _max_bytes), do: "Compilation failed"
-
-  defp valid_utf8_prefix(message) do
-    if String.valid?(message) do
-      message
-    else
-      valid_utf8_prefix(binary_part(message, 0, byte_size(message) - 1))
-    end
-  end
 
   defp fingerprint(source) do
     "sha256:" <> Base.encode16(:crypto.hash(:sha256, source), case: :lower)

--- a/lib/ptc_runner/lisp/metadata.ex
+++ b/lib/ptc_runner/lisp/metadata.ex
@@ -1,6 +1,8 @@
 defmodule PtcRunner.Lisp.Metadata do
   @moduledoc false
 
+  alias PtcRunner.Utf8
+
   @default_bytes 8 * 1024
   @public_keys ~w(reason parent_version parent_checksum source_session_id created_by
                   requires_preludes prelude_deps)
@@ -78,14 +80,5 @@ defmodule PtcRunner.Lisp.Metadata do
   defp normalize_key(key) when is_atom(key), do: Atom.to_string(key)
   defp normalize_key(key), do: inspect(key)
 
-  defp truncate(value, max_bytes) do
-    prefix = binary_part(value, 0, min(byte_size(value), max_bytes))
-    valid_prefix(prefix)
-  end
-
-  defp valid_prefix(value) do
-    if String.valid?(value),
-      do: value,
-      else: valid_prefix(binary_part(value, 0, byte_size(value) - 1))
-  end
+  defp truncate(value, max_bytes), do: Utf8.truncate_valid(value, max_bytes)
 end

--- a/lib/ptc_runner/lisp/prelude/compiler.ex
+++ b/lib/ptc_runner/lisp/prelude/compiler.ex
@@ -42,6 +42,7 @@ defmodule PtcRunner.Lisp.Prelude.Compiler do
   alias PtcRunner.Lisp.ProtectedNamespaces
   alias PtcRunner.Lisp.Signature
   alias PtcRunner.Sandbox
+  alias PtcRunner.Utf8
 
   @default_visibility :prompt
   @valid_effects [:read, :write, :unknown]
@@ -937,7 +938,7 @@ defmodule PtcRunner.Lisp.Prelude.Compiler do
 
         message =
           "constant `#{export.ref}` violates declared type #{export.type}: #{details}"
-          |> truncate_contract_diagnostic()
+          |> Utf8.truncate(@max_contract_diagnostic_bytes)
 
         {:error,
          ValidationError.new(
@@ -952,22 +953,6 @@ defmodule PtcRunner.Lisp.Prelude.Compiler do
   defp format_contract_error(%{path: path, message: message}) do
     prefix = if path == [], do: "", else: Enum.join(path, ".") <> ": "
     prefix <> message
-  end
-
-  defp truncate_contract_diagnostic(message)
-       when byte_size(message) <= @max_contract_diagnostic_bytes,
-       do: message
-
-  defp truncate_contract_diagnostic(message) do
-    message
-    |> binary_part(0, @max_contract_diagnostic_bytes)
-    |> valid_utf8_prefix()
-  end
-
-  defp valid_utf8_prefix(message) do
-    if String.valid?(message),
-      do: message,
-      else: valid_utf8_prefix(binary_part(message, 0, byte_size(message) - 1))
   end
 
   # Constants have no params vector. Function params preserve source names for

--- a/lib/ptc_runner/lisp/prelude/contract.ex
+++ b/lib/ptc_runner/lisp/prelude/contract.ex
@@ -4,6 +4,7 @@ defmodule PtcRunner.Lisp.Prelude.Contract do
   alias PtcRunner.Lisp.Eval.Abort
   alias PtcRunner.Lisp.Eval.Context, as: EvalContext
   alias PtcRunner.Lisp.Signature.Validator
+  alias PtcRunner.Utf8
 
   @max_errors 16
   @max_message_bytes 4_096
@@ -92,19 +93,5 @@ defmodule PtcRunner.Lisp.Prelude.Contract do
   defp public_path_segment(segment) when is_integer(segment), do: segment
   defp public_path_segment(segment), do: segment |> inspect(limit: 3) |> truncate(256)
 
-  defp truncate(value, max_bytes) when byte_size(value) <= max_bytes, do: value
-
-  defp truncate(value, max_bytes) do
-    value
-    |> binary_part(0, max_bytes)
-    |> valid_utf8_prefix()
-  end
-
-  defp valid_utf8_prefix(value) do
-    if String.valid?(value) do
-      value
-    else
-      valid_utf8_prefix(binary_part(value, 0, byte_size(value) - 1))
-    end
-  end
+  defp truncate(value, max_bytes), do: Utf8.truncate(value, max_bytes)
 end

--- a/lib/ptc_runner/utf8.ex
+++ b/lib/ptc_runner/utf8.ex
@@ -1,0 +1,51 @@
+defmodule PtcRunner.Utf8 do
+  @moduledoc """
+  Byte-bounded UTF-8 helpers shared by diagnostics and public metadata.
+
+  `truncate/2` leaves values within the byte limit unchanged. When truncation
+  is required, it backs up to a valid UTF-8 boundary and copies the result so
+  retaining a short diagnostic cannot retain its complete source binary.
+
+  This is a truncation helper, not a validator: an invalid binary already
+  within the limit is returned unchanged.
+  """
+
+  @spec truncate(binary(), non_neg_integer()) :: binary()
+  def truncate(value, max_bytes)
+      when is_binary(value) and is_integer(max_bytes) and max_bytes >= 0 and
+             byte_size(value) <= max_bytes,
+      do: value
+
+  def truncate(value, max_bytes)
+      when is_binary(value) and is_integer(max_bytes) and max_bytes >= 0 do
+    value |> binary_part(0, max_bytes) |> copy_valid_prefix()
+  end
+
+  @doc """
+  Returns the longest valid UTF-8 prefix within `max_bytes`.
+
+  Unlike `truncate/2`, this also sanitizes an invalid value that is already
+  within the byte limit. A changed result is copied out of its parent binary.
+  """
+  @spec truncate_valid(binary(), non_neg_integer()) :: binary()
+  def truncate_valid(value, max_bytes)
+      when is_binary(value) and is_integer(max_bytes) and max_bytes >= 0 do
+    prefix = binary_part(value, 0, min(byte_size(value), max_bytes))
+
+    if prefix == value and String.valid?(prefix) do
+      value
+    else
+      copy_valid_prefix(prefix)
+    end
+  end
+
+  defp copy_valid_prefix(value), do: value |> valid_prefix() |> :binary.copy()
+
+  defp valid_prefix(value) do
+    if String.valid?(value) do
+      value
+    else
+      valid_prefix(binary_part(value, 0, byte_size(value) - 1))
+    end
+  end
+end

--- a/priv/semantic_build_projection.json
+++ b/priv/semantic_build_projection.json
@@ -129,7 +129,7 @@
     "req_llm",
     "telemetry"
   ],
-  "source_closure_hash": "7c407df001b15a60f3f889812ca061bc5e1338a04d47d75107ccba8efa9f1c50",
+  "source_closure_hash": "1b1acec11e3ab22beea955dd152e0d1ff2ad837d46b8eab42eced61c61a7b1a3",
   "sources": [
     {
       "bytes": 870,
@@ -592,9 +592,9 @@
       "sha256": "7d27fd1c10131b8537c6cdbfae9c90c5a7149eb4268659d947ec1837f729542f"
     },
     {
-      "bytes": 36845,
+      "bytes": 36492,
       "path": "lib/ptc_runner/kernel/mcp_protocol.ex",
-      "sha256": "700072ca0b827558ba299bf603aa145402b74434d057e6f6ffaaa58995775e6c"
+      "sha256": "d3f591bbe2555dc73b93a4947733ba108890d632cc3fc45706abe0b97fa3341d"
     },
     {
       "bytes": 18170,
@@ -817,9 +817,9 @@
       "sha256": "3b2b6e0a4ed008519bcd9db4bc3b6f47d3e1176084b8ab3232dab0eeab0dd8db"
     },
     {
-      "bytes": 4693,
+      "bytes": 4346,
       "path": "lib/ptc_runner/kernel/source_check.ex",
-      "sha256": "99bd3a6c8b652770d041d6cd4bee713851db744c747b366da4136556b0804ee8"
+      "sha256": "5d9da0504c24abda8e1afdf6116f9bd375bda25c3be2e63e292990029e22fa79"
     },
     {
       "bytes": 7496,
@@ -1237,9 +1237,9 @@
       "sha256": "14a55d5942eb7dc080d49e0a5324eaaf1b3e6560a997d6ff352cf8394360e812"
     },
     {
-      "bytes": 2913,
+      "bytes": 2724,
       "path": "lib/ptc_runner/lisp/metadata.ex",
-      "sha256": "c0afd7bc0007673ddc31abc3410aaf3b69b1d52d0e02cdb3f156d45429d032b1"
+      "sha256": "7f6ca51f1546245b5c4d3182e4a9d42eaa48576ff223ca224158f6020f527e5f"
     },
     {
       "bytes": 3709,
@@ -1267,14 +1267,14 @@
       "sha256": "f0f99fec41466a6e7580e3ba2a8b8c4dd9dc5dcad2e2c60912415a361408483e"
     },
     {
-      "bytes": 64169,
+      "bytes": 63755,
       "path": "lib/ptc_runner/lisp/prelude/compiler.ex",
-      "sha256": "daac3491aa88d5b6a772d52e63835457190052e7308b367890b958b6db508175"
+      "sha256": "35bf94324ba03c94da080fa91de1a805bbfe4c4a035930bd1612104fcafc5b41"
     },
     {
-      "bytes": 3506,
+      "bytes": 3235,
       "path": "lib/ptc_runner/lisp/prelude/contract.ex",
-      "sha256": "ca7be4ad40102ecad2d1afe560b1570ab147bd7537fc1559af762061b3d1d629"
+      "sha256": "4fa549cd3734ee50dfe31755070dc5a2665cf63692550abe9762cb1c67114940"
     },
     {
       "bytes": 6272,
@@ -1530,6 +1530,11 @@
       "bytes": 22496,
       "path": "lib/ptc_runner/sandbox.ex",
       "sha256": "845e3cd3cc8240c96d758e14da41c41b5ffc7e5b79e6345db49b16954e89b329"
+    },
+    {
+      "bytes": 1724,
+      "path": "lib/ptc_runner/utf8.ex",
+      "sha256": "956cf2feb4d5f543e35892b47c9048fbca23181cbe2fe86e89c6e7c10603dd2b"
     },
     {
       "bytes": 12322,

--- a/test/ptc_runner/lisp/metadata_test.exs
+++ b/test/ptc_runner/lisp/metadata_test.exs
@@ -1,0 +1,9 @@
+defmodule PtcRunner.Lisp.MetadataTest do
+  use ExUnit.Case, async: true
+
+  alias PtcRunner.Lisp.Metadata
+
+  test "sanitizes invalid UTF-8 even when the value is within the byte bound" do
+    assert Metadata.public(%{reason: <<255>>}) == %{"reason" => ""}
+  end
+end

--- a/test/ptc_runner/utf8_test.exs
+++ b/test/ptc_runner/utf8_test.exs
@@ -1,0 +1,30 @@
+defmodule PtcRunner.Utf8Test do
+  use ExUnit.Case, async: true
+
+  alias PtcRunner.Utf8
+
+  test "truncates only at a valid UTF-8 boundary" do
+    assert Utf8.truncate("aéz", 4) == "aéz"
+    assert Utf8.truncate("aéz", 3) == "aé"
+    assert Utf8.truncate("aéz", 2) == "a"
+    assert Utf8.truncate("aéz", 0) == ""
+  end
+
+  test "copies truncated prefixes out of their parent binary" do
+    source = String.duplicate("a", 128 * 1_024)
+    truncated = Utf8.truncate(source, 32)
+
+    assert truncated == String.duplicate("a", 32)
+    assert :binary.referenced_byte_size(truncated) == byte_size(truncated)
+  end
+
+  test "does not reinterpret an untruncated binary as validation" do
+    invalid = <<255>>
+
+    assert Utf8.truncate(invalid, 1) == invalid
+  end
+
+  test "can sanitize an invalid binary when the caller requires valid UTF-8" do
+    assert Utf8.truncate_valid(<<"valid", 255, "suffix">>, 64) == "valid"
+  end
+end


### PR DESCRIPTION
## Summary

- replace five private UTF-8 truncation implementations with one shared helper
- copy truncated prefixes so bounded diagnostics do not retain their full parent binaries
- retain the stricter Metadata behavior that sanitizes short invalid binaries

## Verification

- failing-first helper and Metadata boundary regressions
- 208 focused tests
- fresh independent Codex review against current main: clean
- full precommit: 5,640 root tests, 72 Viewer tests, 36 launcher tests
- duplication ratchet remains green at 79 baseline / 79 current

This addresses the UTF-8 truncation portion of #1183.