### PR TITLE
refactor(kernel): extract the shared JSON Schema path walker

### DIFF
--- a/.duplication-baseline.json
+++ b/.duplication-baseline.json
@@ -1,7 +1,7 @@
 {
   "clones": {
     "00e8ab958fcd56a97883817c9e13266252b21a5eec60ab34f032eb975fccb1b2": {
-      "describe": "type_i mass=31 test/ptc_runner/kernel/mcp_oauth/store_memory_test.exs:791 <-> test/ptc_runner/kernel/run_coordinator_execution_test.exs:446",
+      "describe": "type_i mass=31 test/ptc_runner/kernel/mcp_oauth/store_memory_test.exs:842 <-> test/ptc_runner/kernel/run_coordinator_execution_test.exs:559",
       "files": [
         "test/ptc_runner/kernel/mcp_oauth/store_memory_test.exs",
         "test/ptc_runner/kernel/run_coordinator_execution_test.exs"
@@ -134,7 +134,7 @@
       "type": "type_i"
     },
     "17b8263cf529a4e1bed34858ac77e3d0551097499427933412d4bf081b7c3a83": {
-      "describe": "type_i mass=68 test/mix/tasks/ptc_run_test.exs:1161 <-> test/ptc_runner/kernel/provider_active_session_test.exs:1198",
+      "describe": "type_i mass=68 test/mix/tasks/ptc_run_test.exs:1161 <-> test/ptc_runner/kernel/provider_active_session_test.exs:1274",
       "files": [
         "test/mix/tasks/ptc_run_test.exs",
         "test/ptc_runner/kernel/provider_active_session_test.exs"
@@ -153,7 +153,7 @@
       "type": "type_i"
     },
     "19c5d17e24d817a4f9620f48abcc943a418714840edb1eba9827e90b722ca169": {
-      "describe": "type_i mass=43 lib/ptc_runner/kernel/analysis_session.ex:260 <-> lib/ptc_runner/kernel/execution_session_owner.ex:234 <-> lib/ptc_runner/kernel/host_installation_owner.ex:352 <-> lib/ptc_runner/kernel/inspection_sink.ex:187 <-> lib/ptc_runner/kernel/inspection_snapshot.ex:244 <-> lib/ptc_runner/kernel/mcp_oauth/store/memory.ex:621 <-> lib/ptc_runner/kernel/mcp_oauth/token_manager.ex:421 <-> lib/ptc_runner/kernel/mcp_request_context.ex:356 <-> lib/ptc_runner/kernel/mcp_stdio_transport.ex:405 <-> lib/ptc_runner/kernel/provider_session.ex:984 <-> lib/ptc_runner/kernel/provider_task_tracker.ex:111 <-> lib/ptc_runner/kernel/repl_session_owner.ex:92 <-> lib/ptc_runner/kernel/run_state.ex:752 <-> lib/ptc_runner/kernel/session_trace.ex:292 <-> lib/ptc_runner/kernel/trace_snapshot.ex:228 <-> lib/ptc_runner/kernel/viewer_repl_backend.ex:349",
+      "describe": "type_i mass=43 lib/ptc_runner/kernel/analysis_session.ex:260 <-> lib/ptc_runner/kernel/execution_session_owner.ex:264 <-> lib/ptc_runner/kernel/host_installation_owner.ex:352 <-> lib/ptc_runner/kernel/inspection_sink.ex:187 <-> lib/ptc_runner/kernel/inspection_snapshot.ex:244 <-> lib/ptc_runner/kernel/mcp_oauth/store/memory.ex:692 <-> lib/ptc_runner/kernel/mcp_oauth/token_manager.ex:421 <-> lib/ptc_runner/kernel/mcp_request_context.ex:356 <-> lib/ptc_runner/kernel/mcp_stdio_transport.ex:405 <-> lib/ptc_runner/kernel/provider_session.ex:1191 <-> lib/ptc_runner/kernel/provider_task_tracker.ex:111 <-> lib/ptc_runner/kernel/repl_session_owner.ex:92 <-> lib/ptc_runner/kernel/run_state.ex:752 <-> lib/ptc_runner/kernel/session_trace.ex:292 <-> lib/ptc_runner/kernel/trace_snapshot.ex:228 <-> lib/ptc_runner/kernel/viewer_repl_backend.ex:349",
       "files": [
         "lib/ptc_runner/kernel/analysis_session.ex",
         "lib/ptc_runner/kernel/execution_session_owner.ex",
@@ -260,7 +260,7 @@
       "type": "type_ii"
     },
     "22b906ebb444263576b0ba42aeab41de27e3cafc0472fde963e925b4653e9aa4": {
-      "describe": "type_i mass=30 test/ptc_runner/kernel/provider_execution_lifecycle_test.exs:213 <-> test/ptc_runner/kernel/provider_execution_lifecycle_test.exs:403",
+      "describe": "type_i mass=30 test/ptc_runner/kernel/provider_execution_lifecycle_test.exs:267 <-> test/ptc_runner/kernel/provider_execution_lifecycle_test.exs:481",
       "files": [
         "test/ptc_runner/kernel/provider_execution_lifecycle_test.exs"
       ],
@@ -321,7 +321,7 @@
       "type": "type_ii"
     },
     "41f30d7e6e40f905a3655972436df6881f923d32d8f26b6807042adcb0105d9a": {
-      "describe": "type_i mass=41 test/ptc_runner/kernel/provider_execution_oauth_test.exs:210 <-> test/ptc_runner/kernel/provider_execution_oauth_test.exs:355",
+      "describe": "type_i mass=41 test/ptc_runner/kernel/provider_execution_oauth_test.exs:258 <-> test/ptc_runner/kernel/provider_execution_oauth_test.exs:465",
       "files": [
         "test/ptc_runner/kernel/provider_execution_oauth_test.exs"
       ],
@@ -395,7 +395,7 @@
       "type": "type_i"
     },
     "4fb8929e2db79521808dac424116c41338c86ecc4e7ab9725165845d8846ccdd": {
-      "describe": "type_i mass=36 test/ptc_runner/kernel/mcp_request_context_test.exs:600 <-> test/ptc_runner/kernel/mcp_source_test.exs:2280",
+      "describe": "type_i mass=36 test/ptc_runner/kernel/mcp_request_context_test.exs:608 <-> test/ptc_runner/kernel/mcp_source_test.exs:2280",
       "files": [
         "test/ptc_runner/kernel/mcp_request_context_test.exs",
         "test/ptc_runner/kernel/mcp_source_test.exs"
@@ -432,7 +432,7 @@
       "type": "type_i"
     },
     "50b2f61d557838ea3705f858fbe03a8c5543318148b5475a922e0872bde86c0a": {
-      "describe": "type_i mass=32 test/ptc_runner/kernel/command_engine_test.exs:3973 <-> test/ptc_runner/kernel/provider_declaration_test.exs:1618",
+      "describe": "type_i mass=32 test/ptc_runner/kernel/command_engine_test.exs:4414 <-> test/ptc_runner/kernel/provider_declaration_test.exs:1706",
       "files": [
         "test/ptc_runner/kernel/command_engine_test.exs",
         "test/ptc_runner/kernel/provider_declaration_test.exs"
@@ -578,25 +578,6 @@
       ],
       "type": "type_i"
     },
-    "5d70cf1520fcf4b46a76231230ed7534e11249f04ed9c2512f3ed972ab800a80": {
-      "describe": "type_i mass=141 lib/ptc_runner/kernel/host_config.ex:449 <-> lib/ptc_runner/kernel/manifest.ex:1007",
-      "files": [
-        "lib/ptc_runner/kernel/host_config.ex",
-        "lib/ptc_runner/kernel/manifest.ex"
-      ],
-      "mass": 141,
-      "occurrences": [
-        {
-          "file": "lib/ptc_runner/kernel/host_config.ex",
-          "snippet": "2c462b4e741d7495a0daf64c4cc5888ca9a77fcd49a72d3bdb13572dde995a0d"
-        },
-        {
-          "file": "lib/ptc_runner/kernel/manifest.ex",
-          "snippet": "2c462b4e741d7495a0daf64c4cc5888ca9a77fcd49a72d3bdb13572dde995a0d"
-        }
-      ],
-      "type": "type_i"
-    },
     "5ef621c02ed0857b4ef273d1e724ca264db4525e6d0c07e8f9558bf4c0a7e377": {
       "describe": "type_i mass=30 lib/ptc_runner/kernel/llm_replay_owner.ex:65 <-> lib/ptc_runner/kernel/trace_snapshot.ex:223",
       "files": [
@@ -617,7 +598,7 @@
       "type": "type_i"
     },
     "5f450b809feb307b73c888b5faecbe7ef40c5b89bf3db34ac398e9b8d2623d15": {
-      "describe": "type_i mass=38 test/ptc_runner/kernel/command_engine_test.exs:4029 <-> test/ptc_runner/kernel/host_installation_test.exs:1464 <-> test/ptc_runner/kernel/provider_declaration_test.exs:1864",
+      "describe": "type_i mass=38 test/ptc_runner/kernel/command_engine_test.exs:4552 <-> test/ptc_runner/kernel/host_installation_test.exs:1539 <-> test/ptc_runner/kernel/provider_declaration_test.exs:1952",
       "files": [
         "test/ptc_runner/kernel/command_engine_test.exs",
         "test/ptc_runner/kernel/host_installation_test.exs",
@@ -725,7 +706,7 @@
       "type": "type_i"
     },
     "71ac557332e8abad794dafc0046fd067e9c840fae278265805469cf0cf41050f": {
-      "describe": "type_ii mass=34 lib/ptc_runner/kernel/execution_policy.ex:61 <-> lib/ptc_runner/kernel/installation_catalog.ex:111 <-> lib/ptc_runner/kernel/selection_rules.ex:76",
+      "describe": "type_ii mass=34 lib/ptc_runner/kernel/execution_policy.ex:61 <-> lib/ptc_runner/kernel/installation_catalog.ex:116 <-> lib/ptc_runner/kernel/selection_rules.ex:76",
       "files": [
         "lib/ptc_runner/kernel/execution_policy.ex",
         "lib/ptc_runner/kernel/installation_catalog.ex",
@@ -1012,7 +993,7 @@
       "type": "type_ii"
     },
     "a37cf972b79c1c0917de2e14c4dd036e1626814b5e9eebab8c3b27caaa76733f": {
-      "describe": "type_i mass=54 test/ptc_runner/kernel/provider_declaration_test.exs:1433 <-> test/ptc_runner/kernel/provider_declaration_test.exs:1790",
+      "describe": "type_i mass=54 test/ptc_runner/kernel/provider_declaration_test.exs:1521 <-> test/ptc_runner/kernel/provider_declaration_test.exs:1878",
       "files": [
         "test/ptc_runner/kernel/provider_declaration_test.exs"
       ],
@@ -1030,7 +1011,7 @@
       "type": "type_i"
     },
     "a3d335b448953597156aeccd156f3b55248ab616228c103f0821597c6804d29e": {
-      "describe": "type_i mass=30 lib/ptc_runner/kernel/analysis_session.ex:721 <-> lib/ptc_runner/kernel/execution_session_owner.ex:536 <-> lib/ptc_runner/kernel/host_installation_owner.ex:362 <-> lib/ptc_runner/kernel/inspection_sink.ex:391 <-> lib/ptc_runner/kernel/inspection_snapshot.ex:572 <-> lib/ptc_runner/kernel/mcp_oauth/store/memory.ex:1445 <-> lib/ptc_runner/kernel/mcp_oauth/token_manager.ex:914 <-> lib/ptc_runner/kernel/mcp_request_context.ex:379 <-> lib/ptc_runner/kernel/mcp_stdio_transport.ex:1016 <-> lib/ptc_runner/kernel/provider_session.ex:1342 <-> lib/ptc_runner/kernel/provider_task_tracker.ex:148 <-> lib/ptc_runner/kernel/repl_session_owner.ex:134 <-> lib/ptc_runner/kernel/run_state.ex:800 <-> lib/ptc_runner/kernel/session_trace.ex:540 <-> lib/ptc_runner/kernel/trace_snapshot.ex:380 <-> lib/ptc_runner/kernel/viewer_repl_backend.ex:601",
+      "describe": "type_i mass=30 lib/ptc_runner/kernel/analysis_session.ex:721 <-> lib/ptc_runner/kernel/execution_session_owner.ex:567 <-> lib/ptc_runner/kernel/host_installation_owner.ex:362 <-> lib/ptc_runner/kernel/inspection_sink.ex:391 <-> lib/ptc_runner/kernel/inspection_snapshot.ex:572 <-> lib/ptc_runner/kernel/mcp_oauth/store/memory.ex:1516 <-> lib/ptc_runner/kernel/mcp_oauth/token_manager.ex:914 <-> lib/ptc_runner/kernel/mcp_request_context.ex:379 <-> lib/ptc_runner/kernel/mcp_stdio_transport.ex:1016 <-> lib/ptc_runner/kernel/provider_session.ex:1652 <-> lib/ptc_runner/kernel/provider_task_tracker.ex:148 <-> lib/ptc_runner/kernel/repl_session_owner.ex:134 <-> lib/ptc_runner/kernel/run_state.ex:800 <-> lib/ptc_runner/kernel/session_trace.ex:540 <-> lib/ptc_runner/kernel/trace_snapshot.ex:380 <-> lib/ptc_runner/kernel/viewer_repl_backend.ex:601",
       "files": [
         "lib/ptc_runner/kernel/analysis_session.ex",
         "lib/ptc_runner/kernel/execution_session_owner.ex",
@@ -1269,7 +1250,7 @@
       "type": "type_i"
     },
     "bca305e02f05f3a6715625ce59bfd6e1c3b19676c0269898f6277cba60341b82": {
-      "describe": "type_i mass=31 lib/ptc_runner/kernel/command_contract.ex:650 <-> lib/ptc_runner/kernel/command_contract.ex:862",
+      "describe": "type_i mass=31 lib/ptc_runner/kernel/command_contract.ex:655 <-> lib/ptc_runner/kernel/command_contract.ex:867",
       "files": [
         "lib/ptc_runner/kernel/command_contract.ex"
       ],
@@ -1447,7 +1428,7 @@
       "type": "type_i"
     },
     "da241194085c15f4be57bc5d899f9ed222f81e69ad6570a67ae780247351e332": {
-      "describe": "type_i mass=43 lib/ptc_runner/kernel/host_config.ex:1688 <-> lib/ptc_runner/kernel/manifest.ex:1178",
+      "describe": "type_i mass=43 lib/ptc_runner/kernel/host_config.ex:1656 <-> lib/ptc_runner/kernel/manifest.ex:1146",
       "files": [
         "lib/ptc_runner/kernel/host_config.ex",
         "lib/ptc_runner/kernel/manifest.ex"
@@ -1540,7 +1521,7 @@
       "type": "type_i"
     },
     "eab38378a7cf3498853edd5074f7c6842ab0039953eed003abfd7f9f7d98e75a": {
-      "describe": "type_i mass=41 test/ptc_runner/kernel/execution_session_owner_privacy_test.exs:220 <-> test/ptc_runner/kernel/provider_execution_lifecycle_test.exs:604 <-> test/ptc_runner/kernel/run_coordinator_execution_test.exs:389",
+      "describe": "type_i mass=41 test/ptc_runner/kernel/execution_session_owner_privacy_test.exs:230 <-> test/ptc_runner/kernel/provider_execution_lifecycle_test.exs:765 <-> test/ptc_runner/kernel/run_coordinator_execution_test.exs:413",
       "files": [
         "test/ptc_runner/kernel/execution_session_owner_privacy_test.exs",
         "test/ptc_runner/kernel/provider_execution_lifecycle_test.exs",
@@ -1667,7 +1648,7 @@
       "type": "type_i"
     },
     "fa2b4ff4d3ffafa7f5a7e1aa9c3fb9411f98f071a820f850dc82f4ca83768f89": {
-      "describe": "type_ii mass=33 lib/ptc_runner/kernel/component_override.ex:128 <-> lib/ptc_runner/kernel/component_override.ex:304",
+      "describe": "type_ii mass=33 lib/ptc_runner/kernel/component_override.ex:129 <-> lib/ptc_runner/kernel/component_override.ex:305",
       "files": [
         "lib/ptc_runner/kernel/component_override.ex"
       ],

--- a/lib/ptc_runner/kernel/component_override.ex
+++ b/lib/ptc_runner/kernel/component_override.ex
@@ -35,6 +35,7 @@ defmodule PtcRunner.Kernel.ComponentOverride do
   alias PtcRunner.Kernel.ApplicationSource
   alias PtcRunner.Kernel.Component
   alias PtcRunner.Kernel.ConfinedFile
+  alias PtcRunner.Kernel.SchemaPath
   alias PtcRunner.Kernel.StrictJSON
 
   @max_descriptor_bytes 65_536
@@ -363,19 +364,8 @@ defmodule PtcRunner.Kernel.ComponentOverride do
   defp descriptor_violation(path),
     do: {:error, {:component_override_path, path, :invalid_override_descriptor}}
 
-  defp safe_descriptor_path(path), do: safe_schema_path(path, @descriptor_schema, [])
-
-  defp safe_schema_path([], _schema, retained), do: Enum.reverse(retained)
-
-  defp safe_schema_path([segment | rest], %{"properties" => properties}, retained)
-       when is_binary(segment) and is_map(properties) do
-    case Map.fetch(properties, segment) do
-      {:ok, child} -> safe_schema_path(rest, child, [{:property, segment} | retained])
-      :error -> Enum.reverse(retained)
-    end
-  end
-
-  defp safe_schema_path(_path, _schema, retained), do: Enum.reverse(retained)
+  defp safe_descriptor_path(path),
+    do: SchemaPath.explained_prefix(path, @descriptor_schema)
 
   # ConfinedFile rejects absolute paths, traversal segments, and symlinks that
   # leave the root, so a descriptor cannot point at source outside its own

--- a/lib/ptc_runner/kernel/host_config.ex
+++ b/lib/ptc_runner/kernel/host_config.ex
@@ -42,6 +42,7 @@ defmodule PtcRunner.Kernel.HostConfig do
   alias PtcRunner.Kernel.LimitCatalog
   alias PtcRunner.Kernel.Limits
   alias PtcRunner.Kernel.MCPOAuth.Authority
+  alias PtcRunner.Kernel.SchemaPath
   alias PtcRunner.Kernel.StrictJSON
 
   @max_config_bytes 1_000_000
@@ -444,40 +445,7 @@ defmodule PtcRunner.Kernel.HostConfig do
     end
   end
 
-  defp safe_host_path(path), do: safe_schema_path(path, schema(), [])
-
-  defp safe_schema_path([], _schema, retained), do: Enum.reverse(retained)
-
-  defp safe_schema_path([segment | rest], schema, retained) do
-    case next_schema(schema, segment) do
-      {:ok, child} when is_binary(segment) ->
-        safe_schema_path(rest, child, [{:property, segment} | retained])
-
-      {:ok, child} when is_integer(segment) and segment >= 0 ->
-        safe_schema_path(rest, child, [{:index, segment} | retained])
-
-      :error ->
-        Enum.reverse(retained)
-    end
-  end
-
-  defp next_schema(%{"properties" => properties}, segment)
-       when is_map(properties) and is_binary(segment),
-       do: Map.fetch(properties, segment)
-
-  defp next_schema(%{"items" => items}, segment) when is_integer(segment) and segment >= 0,
-    do: {:ok, items}
-
-  defp next_schema(%{"oneOf" => branches}, segment) when is_list(branches) do
-    Enum.find_value(branches, :error, fn branch ->
-      case next_schema(branch, segment) do
-        {:ok, _child} = found -> found
-        :error -> false
-      end
-    end)
-  end
-
-  defp next_schema(_schema, _segment), do: :error
+  defp safe_host_path(path), do: SchemaPath.explained_prefix(path, schema())
 
   defp command_limits(value) when is_map(value) do
     if Map.keys(value) -- Limits.names() == [] do

--- a/lib/ptc_runner/kernel/manifest.ex
+++ b/lib/ptc_runner/kernel/manifest.ex
@@ -71,6 +71,7 @@ defmodule PtcRunner.Kernel.Manifest do
   alias PtcRunner.Kernel.LimitCatalog
   alias PtcRunner.Kernel.Limits
   alias PtcRunner.Kernel.SafeMetadata
+  alias PtcRunner.Kernel.SchemaPath
   alias PtcRunner.Kernel.StrictJSON
   alias PtcRunner.Kernel.ValueContract
 
@@ -1002,40 +1003,7 @@ defmodule PtcRunner.Kernel.Manifest do
     end
   end
 
-  defp safe_manifest_path(path), do: safe_schema_path(path, schema(), [])
-
-  defp safe_schema_path([], _schema, retained), do: Enum.reverse(retained)
-
-  defp safe_schema_path([segment | rest], schema, retained) do
-    case next_schema(schema, segment) do
-      {:ok, child} when is_binary(segment) ->
-        safe_schema_path(rest, child, [{:property, segment} | retained])
-
-      {:ok, child} when is_integer(segment) and segment >= 0 ->
-        safe_schema_path(rest, child, [{:index, segment} | retained])
-
-      :error ->
-        Enum.reverse(retained)
-    end
-  end
-
-  defp next_schema(%{"properties" => properties}, segment)
-       when is_map(properties) and is_binary(segment),
-       do: Map.fetch(properties, segment)
-
-  defp next_schema(%{"items" => items}, segment) when is_integer(segment) and segment >= 0,
-    do: {:ok, items}
-
-  defp next_schema(%{"oneOf" => branches}, segment) when is_list(branches) do
-    Enum.find_value(branches, :error, fn branch ->
-      case next_schema(branch, segment) do
-        {:ok, _child} = found -> found
-        :error -> false
-      end
-    end)
-  end
-
-  defp next_schema(_schema, _segment), do: :error
+  defp safe_manifest_path(path), do: SchemaPath.explained_prefix(path, schema())
 
   @doc "Returns the generated JSON Schema 2020-12 structural manifest contract."
   @spec schema() :: map()

--- a/lib/ptc_runner/kernel/schema_path.ex
+++ b/lib/ptc_runner/kernel/schema_path.ex
@@ -1,0 +1,69 @@
+defmodule PtcRunner.Kernel.SchemaPath do
+  @moduledoc """
+  Schema-explained prefix of an untrusted document path.
+
+  Strict JSON decoding and schema validation report a fault as a raw path into
+  the document: object keys as binaries, array indices as non-negative
+  integers. Those segments are caller-authored, so a diagnostic must not echo
+  them back unchecked.
+
+  `explained_prefix/2` walks such a path through the schema that rejected the
+  document and keeps only the leading segments the schema accounts for, tagged
+  as `t:PtcRunner.Kernel.CommandPath.segment/0`. Traversal covers `properties`,
+  `items`, and `oneOf`, and stops at the first segment the schema cannot
+  explain, so every returned segment is one the schema authorizes.
+
+  Keywords that admit caller-chosen names — `additionalProperties` above all —
+  are deliberately not traversed, so a path into an open map keeps the segments
+  down to that map and drops the caller's own key. A host diagnostic under
+  `install` therefore stops at `install` rather than naming the installation.
+
+  A `oneOf` descends into the first branch that explains the current segment.
+  A branch selected with knowledge of the whole remaining path could sometimes
+  explain more, so the result is the shortest safe prefix rather than the
+  longest possible one — truncating early loses diagnostic precision, never
+  authority. `PtcRunner.Kernel.CommandPath` authorizes an already-tagged path
+  and resolves `oneOf` against the whole remainder instead.
+  """
+
+  alias PtcRunner.Kernel.CommandPath
+
+  @doc """
+  Returns the leading segments of `path` that `schema` structurally explains.
+  """
+  @spec explained_prefix([binary() | non_neg_integer()], map()) :: [CommandPath.segment()]
+  def explained_prefix(path, schema) when is_list(path), do: walk(path, schema, [])
+
+  defp walk([], _schema, retained), do: Enum.reverse(retained)
+
+  defp walk([segment | rest], schema, retained) do
+    case child(schema, segment) do
+      {:ok, child} when is_binary(segment) ->
+        walk(rest, child, [{:property, segment} | retained])
+
+      {:ok, child} when is_integer(segment) and segment >= 0 ->
+        walk(rest, child, [{:index, segment} | retained])
+
+      :error ->
+        Enum.reverse(retained)
+    end
+  end
+
+  defp child(%{"properties" => properties}, segment)
+       when is_map(properties) and is_binary(segment),
+       do: Map.fetch(properties, segment)
+
+  defp child(%{"items" => items}, segment) when is_integer(segment) and segment >= 0,
+    do: {:ok, items}
+
+  defp child(%{"oneOf" => branches}, segment) when is_list(branches) do
+    Enum.find_value(branches, :error, fn branch ->
+      case child(branch, segment) do
+        {:ok, _child} = found -> found
+        :error -> false
+      end
+    end)
+  end
+
+  defp child(_schema, _segment), do: :error
+end

--- a/priv/semantic_build_projection.json
+++ b/priv/semantic_build_projection.json
@@ -129,7 +129,7 @@
     "req_llm",
     "telemetry"
   ],
-  "source_closure_hash": "e50babe0c93a6ca61476a0c49cde6a5683dd693e3f4dbd53458a6b4329c2eabb",
+  "source_closure_hash": "11280cd93b5f8f95a66c4a1e1bbd0d94a801cbf72a7e8b63b6a4f3fb1b965896",
   "sources": [
     {
       "bytes": 870,
@@ -242,9 +242,9 @@
       "sha256": "0f15e7a4bee948b42ca1b7b02974463600448515a165edd9e30551ff7094b45f"
     },
     {
-      "bytes": 16466,
+      "bytes": 16034,
       "path": "lib/ptc_runner/kernel/component_override.ex",
-      "sha256": "9d8d8f377362053cf3614afd46abaa13db9a57c64bdba5f28fa0eda94ed1199e"
+      "sha256": "46eefcbb1a2edc0955e7f136b481de3cb3898b11a4281d54d4cbbace16108ef5"
     },
     {
       "bytes": 11213,
@@ -347,9 +347,9 @@
       "sha256": "7c9d4f310404497b8cff9b17b3c9ee8091ed3314f2c34809c95c0f375a486e0d"
     },
     {
-      "bytes": 58648,
+      "bytes": 57611,
       "path": "lib/ptc_runner/kernel/host_config.ex",
-      "sha256": "91f8cec1f19ebcde427b25d481e36753a5eb3a46043070d57be9ebc846d2dd1c"
+      "sha256": "cb319af454f7ec5f4f875877a7d225e99948b8fa6cad977203da00e46bdade00"
     },
     {
       "bytes": 9838,
@@ -467,9 +467,9 @@
       "sha256": "2ebb42469958e9903652796d4f82445c93ef0873b87786bccd54b1347c841d6a"
     },
     {
-      "bytes": 39002,
+      "bytes": 37965,
       "path": "lib/ptc_runner/kernel/manifest.ex",
-      "sha256": "490b189720289e510499c8ee6590788486015adc1e5ed5116d40d3363ad577ce"
+      "sha256": "7cb4d6faf5146cb1771b14a8162c6f64ccfbc8663919e425efa64bf1d4fa22f2"
     },
     {
       "bytes": 544,
@@ -835,6 +835,11 @@
       "bytes": 6163,
       "path": "lib/ptc_runner/kernel/safe_metadata.ex",
       "sha256": "b231f1ade890c087a7622b82372cb7b49dc6792891b29f78240fcf0c8ebfd164"
+    },
+    {
+      "bytes": 2825,
+      "path": "lib/ptc_runner/kernel/schema_path.ex",
+      "sha256": "b129d8c236f093b1bffd5a1c48bab2602022548c8a250756af287717b8516fbf"
     },
     {
       "bytes": 16884,

--- a/test/ptc_runner/kernel/schema_path_test.exs
+++ b/test/ptc_runner/kernel/schema_path_test.exs
@@ -1,0 +1,95 @@
+defmodule PtcRunner.Kernel.SchemaPathTest do
+  use ExUnit.Case, async: true
+
+  alias PtcRunner.Kernel.CommandPath
+  alias PtcRunner.Kernel.ComponentOverride
+  alias PtcRunner.Kernel.HostConfig
+  alias PtcRunner.Kernel.Manifest
+  alias PtcRunner.Kernel.SchemaPath
+
+  @adversarial ["__proto__", "constructor", "", "properties", "items", "oneOf", "../escape"]
+
+  test "a segment the schema does not define is dropped along with everything after it" do
+    assert SchemaPath.explained_prefix(["install", "__proto__", "workspace"], HostConfig.schema()) ==
+             [{:property, "install"}]
+
+    assert SchemaPath.explained_prefix(["__proto__"], HostConfig.schema()) == []
+    assert SchemaPath.explained_prefix([], HostConfig.schema()) == []
+  end
+
+  test "an index is retained only where the schema declares an array" do
+    schema = %{"properties" => %{"tags" => %{"items" => %{"type" => "string"}}}}
+
+    assert SchemaPath.explained_prefix(["tags", 2], schema) ==
+             [{:property, "tags"}, {:index, 2}]
+
+    assert SchemaPath.explained_prefix(["tags", "2"], schema) == [{:property, "tags"}]
+  end
+
+  test "a oneOf is resolved through the branch that defines the segment" do
+    schema = %{
+      "properties" => %{
+        "transport" => %{
+          "oneOf" => [
+            %{"properties" => %{"command" => %{"type" => "string"}}},
+            %{"properties" => %{"url" => %{"type" => "string"}}}
+          ]
+        }
+      }
+    }
+
+    assert SchemaPath.explained_prefix(["transport", "url"], schema) ==
+             [{:property, "transport"}, {:property, "url"}]
+
+    assert SchemaPath.explained_prefix(["transport", "nope"], schema) ==
+             [{:property, "transport"}]
+  end
+
+  # The contract the three call sites depend on: whatever prefix survives the
+  # walk is a path CommandPath will authorize against the same schema. If the
+  # two walkers ever disagree about the schema grammar, this fails.
+  test "every explained prefix is a path CommandPath authorizes for that schema" do
+    for {label, schema, mint} <- [
+          {"host", HostConfig.schema(), &CommandPath.host/1},
+          {"manifest", Manifest.schema(), &CommandPath.manifest/1},
+          {"component_override", ComponentOverride.schema(), &CommandPath.component_override/1}
+        ] do
+      explained = document_paths(schema, 4)
+      truncating = for path <- explained, junk <- @adversarial, do: path ++ [junk]
+
+      for path <- explained ++ truncating do
+        prefix = SchemaPath.explained_prefix(path, schema)
+
+        assert {:ok, %CommandPath{segments: ^prefix}} = mint.(prefix),
+               "#{label}: #{inspect(prefix)} from #{inspect(path)} is not schema-authorized"
+      end
+
+      # Guard the generator: a schema shape it stopped following would make the
+      # assertions above pass vacuously. Depths differ by schema — the host
+      # tops out at two segments because installations hang off
+      # `additionalProperties`, which is deliberately not traversed.
+      deep = Enum.count(explained, &(length(&1) >= 2))
+
+      assert deep >= div(length(explained), 2),
+             "#{label}: only #{deep} of #{length(explained)} generated paths are multi-segment"
+    end
+  end
+
+  # Raw document paths the schema explains: property names as binaries, array
+  # indices as integers, every oneOf branch followed.
+  defp document_paths(_schema, 0), do: []
+
+  defp document_paths(%{"properties" => properties}, depth) when is_map(properties) do
+    Enum.flat_map(properties, fn {name, child} ->
+      [[name] | Enum.map(document_paths(child, depth - 1), &[name | &1])]
+    end)
+  end
+
+  defp document_paths(%{"items" => items}, depth),
+    do: [[0] | Enum.map(document_paths(items, depth - 1), &[0 | &1])]
+
+  defp document_paths(%{"oneOf" => branches}, depth) when is_list(branches),
+    do: Enum.flat_map(branches, &document_paths(&1, depth))
+
+  defp document_paths(_schema, _depth), do: []
+end


### PR DESCRIPTION
Closes the `safe_schema_path/3` half of #1183 item **0b**.

## What was duplicated

Confirmed by reading the source, not just the tool output:

| Copy | Shape |
| --- | --- |
| `lib/ptc_runner/kernel/host_config.ex:449-480` | `safe_schema_path/3` + `next_schema/2` |
| `lib/ptc_runner/kernel/manifest.ex:1007-1038` | **byte-identical** to the above |
| `lib/ptc_runner/kernel/component_override.ex:366-378` | a third, `properties`-only variant of the same walk |

The first pair is the `type_i mass=141` clone recorded in `.duplication-baseline.json`. The third copy is not listed in the issue.

All three sanitize a path that `StrictJSON.decode_with_locations/1` (or JSV validation) reports for an **untrusted** document, keeping only the prefix the schema structurally explains so a caller-authored key never reaches a diagnostic.

## What changed

All three now call `PtcRunner.Kernel.SchemaPath.explained_prefix/2`.

The walk is unchanged: `properties` / `items` / `oneOf` traversal, first-branch `oneOf` resolution, truncation at the first segment the schema cannot explain, and the same `{:property, name}` / `{:index, index}` tagging.

**Why a new leaf module.** `JSONSchema` was not a candidate — its contract is explicitly that it does not evaluate schemas. `CommandPath` owns `segment()` and is thematically closest, but it already calls back into all three schema owners, and `mix precommit` runs `xref graph --label compile-connected --fail-above 0`. A leaf with no dependencies of its own cannot introduce a cycle.

**Why folding in `component_override` is safe.** Its properties-only walker differs from the general one only where a schema declares `items` or `oneOf`; its descriptor schema declares neither (verified, and covered by the differential run below).

## Verification

- **Differential harness** comparing both pre-extraction walkers against the new module over **120,003 paths** across the three real schemas — **0 mismatches**. 14,231 produced a non-empty prefix, so the walk is genuinely exercised rather than trivially returning `[]`.
- `mix precommit` end to end: 5800 root, 72 Viewer, 36 launcher tests; Credo `--strict` clean.
- `MIX_ENV=test mix dialyzer`: `Total errors: 0`.
- `MIX_ENV=dev mix docs --warnings-as-errors`: clean.
- Duplication ratchet: `resolved=1 new=0`, baseline **79 → 78**, blessed.
- Independent Codex review (`xhigh`): no actionable findings.

## New test

`schema_path_test.exs` pins the contract the three call sites depend on: every prefix `explained_prefix/2` returns is a path `CommandPath` authorizes for the same schema — so if the two walkers ever disagree about the schema grammar, it fails. It carries a guard against the generator going vacuous, which caught a real defect in my first version (0 paths of depth ≥2 for host and manifest).

## Behaviour deliberately preserved, not fixed

- **`oneOf` picks the first branch that explains the current segment.** A branch chosen with knowledge of the whole remaining path could sometimes explain more, so a prefix can be shorter than the longest authorized one. This loses diagnostic precision, never authority. Pre-existing; now documented in one place instead of three.
- **`additionalProperties` is not traversed**, so a host diagnostic under `install` stops at `install` rather than naming the installation. This is what keeps caller-chosen keys out of diagnostics, and is now stated in the moduledoc.

Items 0a, 0c and 1-5 of #1183 are untouched.

https://claude.ai/code/session_01S74ttew2hWarqFEBNveaXc