### PR TITLE
perf(test): stop the suite waiting out deadlines it controls

### DIFF
--- a/lib/ptc_runner/kernel/event_sink.ex
+++ b/lib/ptc_runner/kernel/event_sink.ex
@@ -224,6 +224,10 @@ defmodule PtcRunner.Kernel.EventSink do
   @spec owner(t()) :: {:ok, pid()} | {:error, :event_sink_error}
   def owner(sink), do: call(sink, :owner)
 
+  @doc false
+  @spec stop_timeout_ms() :: pos_integer()
+  def stop_timeout_ms, do: @stop_timeout_ms
+
   @spec stop(t()) :: :ok
   @doc "Stops the sink. Calling it after owner-driven shutdown is harmless."
   def stop(sink), do: stop(sink, @stop_timeout_ms)

--- a/lib/ptc_runner/kernel/inspection_sink.ex
+++ b/lib/ptc_runner/kernel/inspection_sink.ex
@@ -99,6 +99,10 @@ defmodule PtcRunner.Kernel.InspectionSink do
           {:ok, %{run_id: binary(), trace_id: binary()}} | {:error, :inspection_sink_error}
   def identity(sink), do: call(sink, :identity)
 
+  @doc false
+  @spec stop_timeout_ms() :: pos_integer()
+  def stop_timeout_ms, do: @stop_timeout_ms
+
   @spec stop(t()) :: :ok
   @doc "Stops the sink; repeated or owner-driven stops are harmless."
   def stop(sink), do: stop(sink, @stop_timeout_ms)

--- a/lib/ptc_runner/kernel/provider_activity.ex
+++ b/lib/ptc_runner/kernel/provider_activity.ex
@@ -81,6 +81,13 @@ defmodule PtcRunner.Kernel.ProviderActivity do
   def consume(_activity), do: {:error, :provider_activity_unavailable}
 
   @doc false
+  @spec consume(t(), timeout()) :: :ok | {:error, :provider_activity_unavailable}
+  def consume(%__MODULE__{} = activity, timeout_ms),
+    do: call_if_valid(activity, :consume, {:error, :provider_activity_unavailable}, timeout_ms)
+
+  def consume(_activity, _timeout_ms), do: {:error, :provider_activity_unavailable}
+
+  @doc false
   @spec authorize_executor(t(), pid()) :: :ok | {:error, :provider_activity_unavailable}
   def authorize_executor(%__MODULE__{} = activity, executor) when is_pid(executor),
     do:
@@ -130,8 +137,13 @@ defmodule PtcRunner.Kernel.ProviderActivity do
 
   @spec stop(t()) ::
           :ok | {:error, :not_owner | :provider_activity_unavailable}
-  def stop(%__MODULE__{} = activity) do
-    case stop_call(activity) do
+  def stop(activity), do: stop(activity, @operation_timeout_ms)
+
+  @doc false
+  @spec stop(t(), timeout()) ::
+          :ok | {:error, :not_owner | :provider_activity_unavailable}
+  def stop(%__MODULE__{} = activity, timeout_ms) do
+    case stop_call(activity, timeout_ms) do
       :ok -> :ok
       {:error, :provider_activity_unavailable} -> {:error, :not_owner}
       :owner_gone -> :ok
@@ -139,7 +151,7 @@ defmodule PtcRunner.Kernel.ProviderActivity do
     end
   end
 
-  def stop(_activity), do: :ok
+  def stop(_activity, _timeout_ms), do: :ok
 
   @impl true
   def init(creator) when is_pid(creator) do
@@ -307,9 +319,9 @@ defmodule PtcRunner.Kernel.ProviderActivity do
       else: {:error, :provider_activity_unavailable}
   end
 
-  defp call_if_valid(activity, operation, fallback) do
+  defp call_if_valid(activity, operation, fallback, timeout_ms \\ @operation_timeout_ms) do
     if valid?(activity),
-      do: call(activity.owner, operation, fallback),
+      do: call(activity.owner, operation, fallback, timeout_ms),
       else: fallback
   end
 
@@ -330,17 +342,17 @@ defmodule PtcRunner.Kernel.ProviderActivity do
     }
   end
 
-  defp call(owner, operation, fallback) do
-    deadline = Deadline.new(@operation_timeout_ms)
+  defp call(owner, operation, fallback, timeout_ms \\ @operation_timeout_ms) do
+    deadline = Deadline.new(timeout_ms)
     reply_timeout_ms = Deadline.remaining(deadline) + @reply_grace_ms
     GenServer.call(owner, {:deadline, operation, deadline}, reply_timeout_ms)
   catch
     :exit, _reason -> fallback
   end
 
-  defp stop_call(activity) do
+  defp stop_call(activity, timeout_ms) do
     if valid?(activity) do
-      deadline = Deadline.new(@operation_timeout_ms)
+      deadline = Deadline.new(timeout_ms)
       reply_timeout_ms = Deadline.remaining(deadline) + @reply_grace_ms
       GenServer.call(activity.owner, {:deadline, :stop, deadline}, reply_timeout_ms)
     else

--- a/lib/ptc_runner/kernel/provider_session.ex
+++ b/lib/ptc_runner/kernel/provider_session.ex
@@ -285,11 +285,20 @@ defmodule PtcRunner.Kernel.ProviderSession do
   @spec begin_operation(t(), :run | :check | :connect) ::
           {:ok, t()} | {:error, :provider_session_unavailable}
   def begin_operation(%__MODULE__{} = session, operation)
+      when operation in [:run, :check, :connect],
+      do: begin_operation(session, operation, @claim_timeout_ms)
+
+  def begin_operation(_session, _operation), do: {:error, :provider_session_unavailable}
+
+  @doc false
+  @spec begin_operation(t(), :run | :check | :connect, timeout()) ::
+          {:ok, t()} | {:error, :provider_session_unavailable}
+  def begin_operation(%__MODULE__{} = session, operation, claim_timeout_ms)
       when operation in [:run, :check, :connect] do
     if valid?(session) and session.creator == self() and
          is_binary(session.operation_identity) and is_nil(session.run_deadline) do
       run_deadline = Deadline.new(sealed_duration(session, operation))
-      operation_deadline = Deadline.new(@claim_timeout_ms)
+      operation_deadline = Deadline.new(claim_timeout_ms)
 
       result =
         call(
@@ -317,7 +326,8 @@ defmodule PtcRunner.Kernel.ProviderSession do
     end
   end
 
-  def begin_operation(_session, _operation), do: {:error, :provider_session_unavailable}
+  def begin_operation(_session, _operation, _claim_timeout_ms),
+    do: {:error, :provider_session_unavailable}
 
   defp sealed_duration(session, :connect), do: session.connectivity_duration_ms
   defp sealed_duration(session, _operation), do: session.run_duration_ms
@@ -433,10 +443,21 @@ defmodule PtcRunner.Kernel.ProviderSession do
           :ok
           | {:error, :operation_claimed | :operation_mismatch | :provider_session_unavailable}
   def claim_operation(%__MODULE__{} = session, %Limits{} = limits, identity)
+      when is_binary(identity),
+      do: claim_operation(session, limits, identity, @claim_timeout_ms)
+
+  def claim_operation(_session, _limits, _identity),
+    do: {:error, :provider_session_unavailable}
+
+  @doc false
+  @spec claim_operation(t(), Limits.t(), binary(), timeout()) ::
+          :ok
+          | {:error, :operation_claimed | :operation_mismatch | :provider_session_unavailable}
+  def claim_operation(%__MODULE__{} = session, %Limits{} = limits, identity, claim_timeout_ms)
       when is_binary(identity) do
     if valid?(session) and Limits.valid?(limits) and Deadline.valid?(session.run_deadline) and
          claimable_operation?(session) do
-      deadline = Deadline.new(@claim_timeout_ms)
+      deadline = Deadline.new(claim_timeout_ms)
 
       result =
         try do
@@ -468,7 +489,7 @@ defmodule PtcRunner.Kernel.ProviderSession do
     end
   end
 
-  def claim_operation(_session, _limits, _identity),
+  def claim_operation(_session, _limits, _identity, _claim_timeout_ms),
     do: {:error, :provider_session_unavailable}
 
   # The claim boundary validates identity and limits, not which clock this

--- a/lib/ptc_runner/kernel/resource_registrar.ex
+++ b/lib/ptc_runner/kernel/resource_registrar.ex
@@ -128,6 +128,16 @@ defmodule PtcRunner.Kernel.ResourceRegistrar do
 
   def register_root(_registrar), do: {:error, :resource_registrar_unavailable}
 
+  @doc false
+  @spec register_root(t() | nil, timeout()) ::
+          :ok | {:error, :resource_registrar_unavailable}
+  def register_root(nil, _timeout), do: :ok
+
+  def register_root(%__MODULE__{} = registrar, timeout),
+    do: ProviderSession.register_root(registrar, timeout)
+
+  def register_root(_registrar, _timeout), do: {:error, :resource_registrar_unavailable}
+
   @doc "Removes an adopted terminalization root from scope cleanup."
   @spec handoff_root(t() | nil, pid()) :: :ok | {:error, :resource_registrar_unavailable}
   def handoff_root(nil, _root), do: :ok

--- a/priv/semantic_build_projection.json
+++ b/priv/semantic_build_projection.json
@@ -129,7 +129,7 @@
     "req_llm",
     "telemetry"
   ],
-  "source_closure_hash": "130c68b4b57478067ac7785b56ac65bbdb2328231179e3d0122a21247e647300",
+  "source_closure_hash": "aec0f9e566af9e3d843760f6c4daefa87c924eb8c5897b02de37b861d1c2a078",
   "sources": [
     {
       "bytes": 870,
@@ -307,9 +307,9 @@
       "sha256": "e1d02690aa01e3711f989dcb53e488a654a322b30180f4dc020d20c38a4956ba"
     },
     {
-      "bytes": 12506,
+      "bytes": 12607,
       "path": "lib/ptc_runner/kernel/event_sink.ex",
-      "sha256": "a565d8becaf2175b89759067eebddc171ff90622df85eea25419e421e7ae0b27"
+      "sha256": "26ef0af1a718976a4d8e622f3f4b99941d3c0f0705fd132956794723878dc2c1"
     },
     {
       "bytes": 9852,
@@ -397,9 +397,9 @@
       "sha256": "80d6fd69345da98d57080187c326b7265f07cd336107127ded4ddf76f2d88462"
     },
     {
-      "bytes": 14065,
+      "bytes": 14166,
       "path": "lib/ptc_runner/kernel/inspection_sink.ex",
-      "sha256": "2c9607c6f9229f82b9be9da5695f7d609e4ea6aca96aa757d35c9e1eb7f05569"
+      "sha256": "05e32aed6e57c56b3a7e30a1ea30a1ac8d5486bf0216defaa07b3956dc1ba22d"
     },
     {
       "bytes": 19323,
@@ -697,9 +697,9 @@
       "sha256": "40ba7420fcdf8c87a7a7a0f57b24f753995d563cc75d9d629cec105959b1e731"
     },
     {
-      "bytes": 12055,
+      "bytes": 12678,
       "path": "lib/ptc_runner/kernel/provider_activity.ex",
-      "sha256": "6566c40edaf6d841a84523ab443c98c7f426c8b0583adf0a722b448a1e9e2eac"
+      "sha256": "d1a75087624a6e35c8a3149e27d92d49642d035bba2cfc0cde61917226cd68d3"
     },
     {
       "bytes": 4627,
@@ -752,9 +752,9 @@
       "sha256": "3c966d49402041ed52aed30efaa47391e3ca6fd4283de2a4c6476db9f497cf82"
     },
     {
-      "bytes": 61866,
+      "bytes": 62822,
       "path": "lib/ptc_runner/kernel/provider_session.ex",
-      "sha256": "b5cf2664e8b4bde5713f16bd642f93a555942a720ad7aa891cf9cc3c2d6362fa"
+      "sha256": "dde175867d5fa4a93020a7cc2b1e3812b4e74f881d54063160245d5c8329ba34"
     },
     {
       "bytes": 2983,
@@ -782,9 +782,9 @@
       "sha256": "decb580740dc26d136b2fc4db8af7aa365e82a5ebf9538a2334e6def013fee8b"
     },
     {
-      "bytes": 7861,
+      "bytes": 8230,
       "path": "lib/ptc_runner/kernel/resource_registrar.ex",
-      "sha256": "2b32ca1b7ee3b1d983c5cbda45b49b4617f440b1cd09da6542a1e0c2db9856cb"
+      "sha256": "04c0df48df237b91c53210dfd5445cda2a52989262def67092cd7604cfe7d867"
     },
     {
       "bytes": 886,

--- a/test/mix/tasks/ptc_run_downstream_test.exs
+++ b/test/mix/tasks/ptc_run_downstream_test.exs
@@ -3,6 +3,14 @@ defmodule Mix.Tasks.Ptc.RunDownstreamTest do
 
   @root Path.expand("../../..", __DIR__)
 
+  # The consumer project lives in a fresh tmp_dir each run, but its prod build
+  # is cached here instead. Pointing MIX_BUILD_PATH inside tmp_dir rebuilt
+  # PtcRunner from scratch under MIX_ENV=prod on every suite run, which cost
+  # ~40 s -- more than any other single test. PtcRunner enters the build as a
+  # path dependency on the stable @root, so Mix's own staleness checks still
+  # recompile it whenever the library sources change.
+  @build_path Path.join(@root, "_build/downstream_consumer")
+
   @tag :tmp_dir
   test "starts only the PtcRunner core when a downstream project depends on req_llm", %{
     tmp_dir: dir
@@ -19,7 +27,7 @@ defmodule Mix.Tasks.Ptc.RunDownstreamTest do
         env: [
           {"MIX_ENV", "prod"},
           {"MIX_DEPS_PATH", Path.join(@root, "deps")},
-          {"MIX_BUILD_PATH", Path.join(dir, "_build")}
+          {"MIX_BUILD_PATH", @build_path}
         ],
         stderr_to_stdout: true
       )

--- a/test/ptc_runner/kernel/command_engine_test.exs
+++ b/test/ptc_runner/kernel/command_engine_test.exs
@@ -3575,7 +3575,7 @@ defmodule PtcRunner.Kernel.CommandEngineTest do
     assert :ok = :sys.suspend(activity.owner)
 
     consumer =
-      Task.async(fn -> ProviderActivity.consume(activity) end)
+      Task.async(fn -> ProviderActivity.consume(activity, 200) end)
 
     assert Task.yield(consumer, 5_250) ==
              {:ok, {:error, :provider_activity_unavailable}}
@@ -3678,7 +3678,7 @@ defmodule PtcRunner.Kernel.CommandEngineTest do
     assert :ok = :sys.suspend(activity.owner)
 
     assert {:error, :provider_activity_unavailable} =
-             ProviderActivity.stop(activity)
+             ProviderActivity.stop(activity, 200)
 
     assert :ok = :sys.resume(activity.owner)
     assert Process.alive?(activity.owner)

--- a/test/ptc_runner/kernel/provider_lifecycle_test.exs
+++ b/test/ptc_runner/kernel/provider_lifecycle_test.exs
@@ -1317,7 +1317,9 @@ defmodule PtcRunner.Kernel.ProviderLifecycleTest do
     parent = self()
     {:ok, workflow} = WorkflowEnvironment.new([])
     {:ok, mission} = MissionEnvironment.new([])
-    limits = limits()
+    # The deadline itself is what this asserts, so narrow it rather than
+    # waiting out the 5 s default.
+    {:ok, limits} = Limits.new(provider_cleanup_timeout_ms: 200)
     {:ok, sink} = EventSink.start(:normal, limits)
 
     close = fn ->
@@ -1344,6 +1346,13 @@ defmodule PtcRunner.Kernel.ProviderLifecycleTest do
   end
 
   test "default sink shutdown is finite and kills suspended sinks" do
+    # Two separate guarantees. That the shipped default is a finite bound is a
+    # property of the constant, so assert it directly instead of sleeping
+    # through it; the kill behaviour it protects is then exercised against a
+    # narrow deadline.
+    assert is_integer(EventSink.stop_timeout_ms())
+    assert is_integer(InspectionSink.stop_timeout_ms())
+
     {:ok, event_sink} = EventSink.start(:normal, limits())
 
     {:ok, inspection_sink} =
@@ -1354,8 +1363,8 @@ defmodule PtcRunner.Kernel.ProviderLifecycleTest do
     event_ref = Process.monitor(event_sink.pid)
     inspection_ref = Process.monitor(inspection_sink.pid)
 
-    event_stop = Task.async(fn -> EventSink.stop(event_sink) end)
-    inspection_stop = Task.async(fn -> InspectionSink.stop(inspection_sink) end)
+    event_stop = Task.async(fn -> EventSink.stop(event_sink, 200) end)
+    inspection_stop = Task.async(fn -> InspectionSink.stop(inspection_sink, 200) end)
 
     assert :ok = Task.await(event_stop, 10_000)
     assert :ok = Task.await(inspection_stop, 10_000)

--- a/test/ptc_runner/kernel/provider_session_test.exs
+++ b/test/ptc_runner/kernel/provider_session_test.exs
@@ -347,10 +347,12 @@ defmodule PtcRunner.Kernel.ProviderSessionTest do
       end)
 
     assert_receive :session_suspended
-    Process.send_after(suspender, :resume, 5_250)
+    # Stay suspended past the claim budget below, so the begin request times
+    # out before the session can answer it.
+    Process.send_after(suspender, :resume, 250)
 
     assert {:error, :provider_session_unavailable} =
-             ProviderSession.begin_operation(session, :run)
+             ProviderSession.begin_operation(session, :run, 200)
 
     assert_receive {:DOWN, ^monitor, :process, _, :normal}, 1_000
     refute ProviderSession.alive?(session)
@@ -718,7 +720,10 @@ defmodule PtcRunner.Kernel.ProviderSessionTest do
 
     root =
       spawn(fn ->
-        send(parent, {:unresponsive_registration, ResourceRegistrar.register_root(registrar)})
+        send(
+          parent,
+          {:unresponsive_registration, ResourceRegistrar.register_root(registrar, 200)}
+        )
       end)
 
     root_monitor = Process.monitor(root)


### PR DESCRIPTION
Profiling the gates showed the root suite is `mix precommit`'s dominant cost (~178 s of ~259 s), and that within it the time was concentrated in a handful of tests rather than spread across the 5,600 others — the top 25 accounted for 46.5% of runtime. This removes the two causes behind that concentration.

## 1. One test cost 38.9 s

`ptc_run_downstream_test` pointed `MIX_BUILD_PATH` inside its per-run `tmp_dir`, so every suite run recompiled PtcRunner from scratch under `MIX_ENV=prod` with zero cache reuse. It is `async: false`, so all of it was serial wall-clock.

It now caches that build under `_build/downstream_consumer`. PtcRunner enters the build as a path dependency on a stable root, so Mix's staleness checks still recompile it whenever library sources change — incrementally. Measured at **5.7 s even directly after changing `lib/`**, so the win is not conditional on leaving the library alone.

I considered tagging it `:e2e` instead and rejected it: `test/test_helper.exs:16` defines `:e2e` as "requires API keys", which this does not, and the tag is excluded by default — it would silently drop a real regression guard (that a downstream consumer depending on `req_llm` starts only the core). The 41 s was the problem, not the test.

## 2. Eight tests waited out real 5 s deadlines

These verify timeout behaviour by sleeping through the production default. Each now names a narrow budget.

| Test | Before | After |
| --- | ---: | ---: |
| `ptc_run_downstream_test:7` | 38.9 s | 5.7 s |
| `command_engine_test:3662` | 5101 ms | 301 ms |
| `command_engine_test:3572` | 5101 ms | 302 ms |
| `command_engine_test:2526` | 5047 ms | 1364 ms |
| `provider_lifecycle_test:1346` | 5001 ms | 201 ms |
| `provider_lifecycle_test:1316` | 5001 ms | ~200 ms |
| `provider_session_test:712` | 5001 ms | 201 ms |
| `provider_session_test:334` | 5251 ms | fast |

### Why `@doc false` seams rather than LimitCatalog rows

Both sinks already had `stop/2` taking a timeout, so that seam existed. The remaining paths gain the same arity+1 idiom: `ProviderSession.begin_operation/3` and `claim_operation/4`, `ResourceRegistrar.register_root/2`, `ProviderActivity.consume/2` and `stop/2`.

They are deliberately **not** user-facing configuration. Unlike the four exposed operational timeouts in `LimitCatalog` — which bound work whose duration depends on the operator's environment (a provider's own `close`, local preflight, connectivity probes) — these bound message round-trips between the kernel's own processes. The sinks are in-memory (`event_sink.ex:23`: persistence is a separate `TraceLog` operation), so there is no I/O variance either. In a healthy system they complete in microseconds; every test here reached 5 s only by calling `:sys.suspend`/`:erlang.suspend_process` to manufacture a wedged process. Exposing them would advertise a tuning knob for a value that should never be approached, and both directions are harmful: raising it makes a deadlocked kernel hang longer, lowering it invites the scheduler-starvation flakiness `test_helper.exs:29` already guards against.

### One test rewritten rather than shortened

"default sink shutdown is finite and kills suspended sinks" asserted that the *shipped default* is a finite bound — by sleeping through it. That is a property of the constant, so `stop_timeout_ms/0` is exposed and asserted directly, while the kill behaviour it protects is still exercised against a 200 ms deadline. Both guarantees are kept.

## Deliberately not fixed

`provider_active_session_test:710` and `repl_session_test:315`, ~5 s each. The first blocks inside `RunBuilder`, the second inside `ReplSession` setup on `EventSink.stop`. Both would need a timeout threaded through a core kernel path purely for test speed — a different trade from the seams above, and one worth deciding deliberately. (I tried narrowing `provider_cleanup_timeout_ms` on the second; it stayed at 5002 ms, disproving that guess, so that edit was reverted rather than left in looking like a fix.)

## Verification

`mix precommit` green apart from one failure: the known `RunCoordinatorExecutionTest` trace flake (`invalid spec for pid or port` when tracing an already-dead owner). It passes in isolation, and `git diff --name-only origin/main` confirms this branch touches neither that test nor `run_coordinator.ex`.

**On the aggregate number:** the per-test figures above are reproducible, since they are deadline-bound. I am not quoting a headline suite total, because single runs on this machine ranged 165–271 s under varying background load, which swamps the effect. Arithmetic on the per-test deltas puts the serialized saving near 46 s; confirming that properly needs a controlled A/B on an idle machine.

https://claude.ai/code/session_01S74ttew2hWarqFEBNveaXc