### PR TITLE
chore(git): stop generated-projection conflicts blocking every rebase

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,21 @@
+# Generated whole-tree fingerprints.
+#
+# `priv/semantic_build_projection.json` embeds a `source_closure_hash` over the
+# entire semantic source and dependency closure, so every branch that touches
+# any input rewrites the same lines. Two branches changing unrelated files still
+# collide there, every time.
+#
+# The file is derived entirely from other tracked inputs, so a textual merge of
+# those hashes is meaningless -- regenerating is the only correct resolution.
+# The `ptc-generated` driver therefore keeps one side verbatim so the merge or
+# rebase does not stop, and `mix precommit` catches the staleness through
+# `ptc.gen_semantic_revision --check`. Regenerate once at the end with
+# `mix ptc.regen`.
+#
+# Deliberately NOT applied to `.duplication-baseline.json`: regenerating that
+# file blesses whatever duplication the merged tree contains, which is a review
+# decision rather than a derivation. Resolve it by hand.
+#
+# Registered per clone by `scripts/install-hooks.sh`, since Git merge drivers
+# live in local config and cannot be committed.
+priv/semantic_build_projection.json merge=ptc-generated

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,10 @@ mix compile
 ```
 
 Run `./scripts/install-hooks.sh` once per clone. Linked worktrees share the
-clone's installed hook wrappers, so they do not need to reinstall them.
+clone's installed hook wrappers, so they do not need to reinstall them. It also
+registers the merge driver that keeps `priv/semantic_build_projection.json`
+from conflicting on every rebase; after one, run `mix regen` to regenerate and
+stage it. Never hand-merge its hashes — `.gitattributes` explains why.
 Outside CI, the Dialyzer core PLT lives under `~/.cache/ptc_runner/` and is
 shared across every worktree, so only the very first Dialyzer run on a
 machine builds it from scratch; each worktree still keeps its own

--- a/mix.exs
+++ b/mix.exs
@@ -164,6 +164,12 @@ defmodule PtcRunner.MixProject do
       ],
       coverage: [
         "test --cover"
+      ],
+      # Regenerates the derived projection after a merge or rebase kept one
+      # side of it. See `.gitattributes` for why the hashes cannot be merged.
+      regen: [
+        "ptc.gen_semantic_revision",
+        "cmd git add priv/semantic_build_projection.json"
       ]
     ]
   end

--- a/priv/semantic_build_projection.json
+++ b/priv/semantic_build_projection.json
@@ -129,7 +129,7 @@
     "req_llm",
     "telemetry"
   ],
-  "source_closure_hash": "aec0f9e566af9e3d843760f6c4daefa87c924eb8c5897b02de37b861d1c2a078",
+  "source_closure_hash": "a351ad793ca7d1fcd28fd2be01f062978a9055e81b934b4f56e59f33570caaf5",
   "sources": [
     {
       "bytes": 870,
@@ -1577,9 +1577,9 @@
       "sha256": "956cf2feb4d5f543e35892b47c9048fbca23181cbe2fe86e89c6e7c10603dd2b"
     },
     {
-      "bytes": 12323,
+      "bytes": 12596,
       "path": "mix.exs",
-      "sha256": "ea65b9a6801cfa5d549c8152c3274b940e8f582ff40060505d70693dece4c8d3"
+      "sha256": "a6eca527638a156dbf2389812dc6149268ff38da3df7cb19832d006af9818e54"
     },
     {
       "bytes": 117541,

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,5 +1,22 @@
 #!/bin/bash
 
+# Register the merge driver named by `.gitattributes` first, and independently
+# of hook installation. Merge drivers live in local config and cannot be
+# committed, and this must still land when hook installation is skipped or
+# fails -- a clone that sets `core.hooksPath` elsewhere resolves the hooks
+# directory to a path this script cannot write.
+#
+# `true` leaves Git's staged side in place rather than writing conflict markers
+# into a generated file whose hashes cannot be merged textually. Regenerating
+# here instead would recompile the project once per conflicting commit during a
+# rebase; `mix precommit` already runs `ptc.gen_semantic_revision --check`, so
+# staleness is caught regardless. Finish with `mix regen`.
+git config merge.ptc-generated.name \
+  "keep one side of a generated projection; regenerate with mix regen"
+git config merge.ptc-generated.driver true
+echo "✅ Generated-file merge driver registered (merge.ptc-generated)"
+echo ""
+
 echo "Installing git hooks..."
 
 # Resolve the effective hooks directory through Git so linked worktrees and a


### PR DESCRIPTION
`priv/semantic_build_projection.json` embeds a `source_closure_hash` over the whole semantic source and dependency closure, so **every** branch that changes any input rewrites the same lines. Two branches touching entirely unrelated files still collide there — it is a structural guarantee, not bad luck. `mix.exs` is itself a semantic source (`semantic_build_inventory.exs:25`), so this PR triggers the very regeneration it automates.

## Why not something simpler

Not committing the file is unavailable: it ships in the hex package (`mix.exs:326`) and is compiled in via `@external_resource` at `semantic_revision.ex:17-19`, with `@build_identity` hashing the whole file's bytes.

Trimming it does not help either. The `sources` array feeds nothing but the revision hash, so it could in principle be dropped — but `source_closure_hash` is the line that collides, so that shrinks conflicts without making them rarer, and loses the diagnostic that shows *which* files moved.

So the conflict cannot be designed away. Only the resolution can be automated.

## What this does

- `.gitattributes` names a `ptc-generated` driver for the projection
- `scripts/install-hooks.sh` registers it, since merge drivers live in local config and cannot be committed
- `mix regen` regenerates and stages the file

The driver is `true` — it keeps one side rather than writing conflict markers. Regenerating *inside* the driver was rejected: during a rebase it would recompile the project once per conflicting commit, and could run against a tree whose other paths are not yet resolved. `mix precommit` already runs `ptc.gen_semantic_revision --check`, so a forgotten regeneration cannot reach a commit regardless.

## Verified against a control

| | code file | generated file |
| --- | --- | --- |
| without driver | conflict | **conflict** |
| with driver | conflict | **auto-resolved** |

The left column is the important one: a genuine code conflict still stops the rebase. Only the spurious conflict is removed.

## Known limitation: it does not bootstrap itself

Git resolves `.gitattributes` from the tree being merged *into*, so the driver only takes effect once this commit is on the base branch. Rebasing **this** commit still conflicts on the projection.

That was confirmed live: #1193 merged mid-review, this branch went behind, and the rebase conflicted exactly as before. Resolved by regenerating — a one-time cost.

The steady state was then verified explicitly: branching from a base that *does* carry `.gitattributes` and rebasing two conflicting projection changes produces **zero conflicts**.

## Two deliberate choices

**Registration runs first, and independently of hook installation.** A clone that points `core.hooksPath` elsewhere resolves the hooks directory to a path the script cannot write — this repo currently does, so `git rev-parse --git-path hooks` returns `/dev/null`. The driver must still land. (That hook installation is silently broken under that setting is a separate pre-existing issue, untouched here.)

**`.duplication-baseline.json` is excluded.** Regenerating it blesses whatever duplication the merged tree contains, which AGENTS.md treats as a review decision rather than a derivation. It stays a manual resolution, and `.gitattributes` records why.

## Scope

This does not stop GitHub showing a PR as `CONFLICTING` — its server-side merge does not run custom drivers. What changes is that the local rebase resolves silently instead of by hand, which is where the actual cost and the risk of a plausible-but-wrong resolution sat.

## Verification

`mix precommit` green on the rebased tree: 5800 root, 72 Viewer, 36 launcher.

https://claude.ai/code/session_01S74ttew2hWarqFEBNveaXc