### PR TITLE
ci(ex-dna): test candidate cache

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -302,6 +302,44 @@ jobs:
       - name: Check unused dependencies
         run: mix deps.unlock --check-unused
 
+  ex-dna-candidate:
+    needs: changes
+    if: needs.changes.outputs.core == 'true'
+    runs-on: ubuntu-latest
+    name: ExDNA candidate compatibility
+    env:
+      MIX_ENV: test
+      HEX_SPONSOR: false
+
+    steps:
+      - name: Checkout PtcRunner
+        uses: actions/checkout@v6
+
+      - name: Checkout pinned ExDNA candidate
+        uses: actions/checkout@v6
+        with:
+          repository: andreasronge/ex_dna
+          ref: 8fe513647329bff792a3a3d2d20c3810f9e30269
+          path: .candidate/ex_dna
+
+      - name: Setup Elixir environment
+        uses: ./.github/actions/setup-elixir
+        with:
+          cache-plt: 'false'
+          install-babashka: 'false'
+
+      - name: Verify cold and warm duplication gates
+        env:
+          PTC_EX_DNA_PATH: ${{ github.workspace }}/.candidate/ex_dna
+        run: |
+          test "$(git -C "$PTC_EX_DNA_PATH" rev-parse HEAD)" = \
+            "8fe513647329bff792a3a3d2d20c3810f9e30269"
+          mix deps.compile ex_dna --force
+          scripts/duplication_gate.sh check
+          sha256sum .ex_dna_cache .ex_dna_cache.fingerprints > "$RUNNER_TEMP/ex-dna-cache.before"
+          scripts/duplication_gate.sh check
+          sha256sum --check "$RUNNER_TEMP/ex-dna-cache.before"
+
   java-interop-conformance:
     needs: changes
     if: needs.changes.outputs.java == 'true'

--- a/.gitignore
+++ b/.gitignore
@@ -67,4 +67,4 @@ repo-analyst/private/
 .claude/settings.local.json
 
 # ExDNA clone-detection parse cache (large, machine-local)
-.ex_dna_cache
+.ex_dna_cache*

--- a/docs/guides/duplication-gate.md
+++ b/docs/guides/duplication-gate.md
@@ -94,3 +94,32 @@ mix ex_dna.explain 3 lib/ test/      # extraction breakdown for one clone
 Detection takes roughly fifteen seconds over `lib/` and `test/`. Configuration
 lives in `.ex_dna.exs`; `.ex_dna_cache` is a machine-local artefact and is
 ignored.
+
+## Testing an unreleased ExDNA checkout
+
+Normal development and package builds resolve ExDNA from Hex. To test an
+unreleased checkout without changing `mix.lock`, point the complete build at
+that checkout:
+
+```bash
+mix deps.get
+export PTC_EX_DNA_PATH=/absolute/path/to/ex_dna
+mix deps.compile ex_dna --force
+scripts/duplication_gate.sh check
+```
+
+The override also enables ExDNA's opt-in result cache for the duplication gate.
+Fetch the locked dependency graph before setting the variable; running
+`mix deps.get` with the override active may legitimately re-resolve the
+candidate's transitive development dependencies. Keep the variable set for
+every subsequent Mix command in that build. Unset it and recompile to return to
+the locked Hex dependency:
+
+```bash
+unset PTC_EX_DNA_PATH
+mix deps.compile ex_dna --force
+```
+
+CI has a separate compatibility job pinned to the candidate commit. It runs the
+gate once cold and once warm and verifies that the warm run does not rewrite
+either cache artifact. Ordinary validation and release jobs remain on Hex.

--- a/mix.exs
+++ b/mix.exs
@@ -112,7 +112,7 @@ defmodule PtcRunner.MixProject do
       {:telemetry, "~> 1.0"},
       {:stream_data, "~> 1.1", only: [:test, :dev]},
       {:credo, "~> 1.7", only: [:dev, :test], runtime: false},
-      {:ex_dna, "~> 1.5", only: [:dev, :test], runtime: false},
+      ex_dna_dep(),
       {:dialyxir, "~> 1.4", only: [:dev, :test], runtime: false},
       {:ex_doc, "~> 0.31", only: :dev, runtime: false},
       {:req_llm, "~> 1.19", optional: true, runtime: false},
@@ -122,6 +122,22 @@ defmodule PtcRunner.MixProject do
       {:recon, "~> 2.5", only: [:dev, :test], runtime: false},
       {:benchee, "~> 1.3", only: [:dev, :test], runtime: false}
     ]
+  end
+
+  # Keep published and ordinary development builds on Hex while allowing an
+  # unreleased ExDNA checkout to be exercised by an isolated compatibility
+  # build. The caller must keep this environment variable set for every Mix
+  # command in that build so dependency resolution stays consistent.
+  defp ex_dna_dep do
+    options = [only: [:dev, :test], runtime: false]
+
+    case {Mix.env(), System.get_env("PTC_EX_DNA_PATH")} do
+      {env, path} when env in [:dev, :test] and is_binary(path) and path != "" ->
+        {:ex_dna, Keyword.put(options, :path, Path.expand(path))}
+
+      {_env, _path} ->
+        {:ex_dna, "~> 1.5", options}
+    end
   end
 
   # Local development exercises the companion from this checkout. Published

--- a/priv/semantic_build_projection.json
+++ b/priv/semantic_build_projection.json
@@ -129,7 +129,7 @@
     "req_llm",
     "telemetry"
   ],
-  "source_closure_hash": "aec0f9e566af9e3d843760f6c4daefa87c924eb8c5897b02de37b861d1c2a078",
+  "source_closure_hash": "14594c17608f020619de00d7f666f2dfc1a8d8d26e90af8ee796d5bec30520fc",
   "sources": [
     {
       "bytes": 870,
@@ -1577,9 +1577,9 @@
       "sha256": "956cf2feb4d5f543e35892b47c9048fbca23181cbe2fe86e89c6e7c10603dd2b"
     },
     {
-      "bytes": 12323,
+      "bytes": 12932,
       "path": "mix.exs",
-      "sha256": "ea65b9a6801cfa5d549c8152c3274b940e8f582ff40060505d70693dece4c8d3"
+      "sha256": "24ae77188959195f496352d015e78e152dfc0aa691899b3169f815beb9f37954"
     },
     {
       "bytes": 117541,

--- a/scripts/duplication_gate.sh
+++ b/scripts/duplication_gate.sh
@@ -25,7 +25,15 @@ mix compile >&2
 
 # Give ExDNA a deliberately unreachable budget so clones still produce JSON and
 # an actual detector failure cannot be mistaken for a successful partial report.
-mix ex_dna lib/ test/ --format json --max-clones 1000000 >"$RAW"
+EX_DNA_ARGS=(lib/ test/ --format json --max-clones 1000000)
+
+# The opt-in checkout carries ExDNA's unreleased complete-result cache. Keep
+# ordinary Hex builds compatible with 1.5.4 until that option is released.
+if [ -n "${PTC_EX_DNA_PATH:-}" ]; then
+  EX_DNA_ARGS+=(--cache)
+fi
+
+mix ex_dna "${EX_DNA_ARGS[@]}" >"$RAW"
 
 # Anything Mix still emits (stale-dep recompiles, deprecation notices) precedes
 # the report on stdout, so keep only from the opening brace onwards.


### PR DESCRIPTION
## What changed

- add an opt-in `PTC_EX_DNA_PATH` dependency override for local development
- keep ordinary and production builds on the locked Hex release
- add a CI compatibility job pinned to ExDNA commit `8fe513647329bff792a3a3d2d20c3810f9e30269`
- run the real duplication ratchet cold and warm, then verify neither cache artifact was rewritten
- document the local checkout workflow and ignore the fingerprint sidecar

## Why

This lets PtcRunner exercise the unreleased ExDNA caching work before a Hex release without changing its production dependency or committed lockfile.

## Validation

- candidate duplication gate passed cold and warm; cache artifacts remained byte-identical
- measured 45.56s cold including full root recompilation and 4.36s warm locally
- root suite passed at reduced concurrency: 5,796 tests
- three timing-sensitive full-suite failures reproduced only under load and passed at their exact file/line
- Credo, compile/cycle checks, specification validation, package verification, workflow/shell syntax, semantic projection, and ExDoc warnings gate passed
