### PR TITLE
fix(scripts): stop install-hooks reporting hooks it failed to install

### DIFF
--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -23,24 +23,53 @@ echo "Installing git hooks..."
 # configured core.hooksPath use the same location Git itself will execute.
 HOOKS_DIR=$(git rev-parse --git-path hooks)
 
-# Create hooks directory if it doesn't exist
-mkdir -p "$HOOKS_DIR"
+# A clone that disables hooks by pointing core.hooksPath at a non-directory
+# resolves to a path no hook can occupy. Every copy below would fail one line
+# at a time while the script still reported success, so establish that the
+# destination is usable before claiming anything about it.
+if ! mkdir -p "$HOOKS_DIR" 2>/dev/null || [ ! -d "$HOOKS_DIR" ]; then
+  echo "❌ Cannot install hooks: $HOOKS_DIR is not a usable directory"
+
+  CONFIGURED_HOOKS_PATH=$(git config --get core.hooksPath)
+  if [ -n "$CONFIGURED_HOOKS_PATH" ]; then
+    echo "   core.hooksPath is set to: $CONFIGURED_HOOKS_PATH"
+    echo "   Clear it to restore hooks: git config --unset core.hooksPath"
+  fi
+
+  echo "   The merge driver above is registered regardless."
+  exit 1
+fi
 
 # Install a stable wrapper; the implementation remains tracked in .githooks/.
+# Failing to copy or mark a hook executable leaves the clone ungated, so treat
+# either as fatal rather than printing a checkmark over a failed command.
+install_hook() {
+  source_path=$1
+  hook_name=$2
+  destination="$HOOKS_DIR/$hook_name"
+
+  if ! cp "$source_path" "$destination"; then
+    echo "❌ Failed to copy $source_path to $destination"
+    exit 1
+  fi
+
+  if ! chmod +x "$destination"; then
+    echo "❌ Failed to make $destination executable"
+    exit 1
+  fi
+
+  echo "✅ ${hook_name} hook installed at $destination"
+}
+
 if [ -f scripts/pre-commit.template ]; then
-  cp scripts/pre-commit.template "$HOOKS_DIR/pre-commit"
-  chmod +x "$HOOKS_DIR/pre-commit"
-  echo "✅ Pre-commit hook installed at $HOOKS_DIR/pre-commit"
+  install_hook scripts/pre-commit.template pre-commit
 else
   echo "❌ Template not found: scripts/pre-commit.template"
   exit 1
 fi
 
-# Install a stable wrapper; the implementation remains tracked in .githooks/.
 if [ -f scripts/pre-push ]; then
-  cp scripts/pre-push "$HOOKS_DIR/pre-push"
-  chmod +x "$HOOKS_DIR/pre-push"
-  echo "✅ Pre-push hook installed at $HOOKS_DIR/pre-push"
+  install_hook scripts/pre-push pre-push
 else
   echo "⚠️  Pre-push hook not found: scripts/pre-push (skipping)"
 fi

--- a/test/githooks/install_hooks_test.exs
+++ b/test/githooks/install_hooks_test.exs
@@ -1,0 +1,74 @@
+defmodule PtcRunner.GitHooks.InstallHooksTest do
+  use ExUnit.Case, async: true
+
+  alias PtcRunner.TestSupport.GitEnv
+
+  @git_env GitEnv.clear()
+  @repo_root Path.expand("../..", __DIR__)
+
+  @tag :tmp_dir
+  test "installs both hooks and registers the merge driver", %{tmp_dir: dir} do
+    repo = init_repo(dir)
+
+    {output, status} = install(repo)
+
+    assert status == 0, output
+    assert output =~ "merge driver registered"
+
+    hooks = Path.join([repo, ".git", "hooks"])
+    assert File.exists?(Path.join(hooks, "pre-commit"))
+    assert File.exists?(Path.join(hooks, "pre-push"))
+
+    assert git(repo, ["config", "--get", "merge.ptc-generated.driver"]) == "true"
+  end
+
+  @tag :tmp_dir
+  test "fails loudly when core.hooksPath points somewhere unwritable", %{tmp_dir: dir} do
+    repo = init_repo(dir)
+    # What a clone that disables hooks looks like: Git resolves the hooks
+    # directory to this path, which cannot hold hook files.
+    {_, 0} = System.cmd("git", ["config", "core.hooksPath", "/dev/null"], cd: repo, env: @git_env)
+
+    {output, status} = install(repo)
+
+    refute status == 0, "expected a non-zero exit, got:\n#{output}"
+    refute output =~ "Pre-commit hook installed", "reported success it did not achieve"
+    refute output =~ "installed successfully"
+    assert output =~ "core.hooksPath"
+  end
+
+  @tag :tmp_dir
+  test "registers the merge driver even when hook installation fails", %{tmp_dir: dir} do
+    repo = init_repo(dir)
+    {_, 0} = System.cmd("git", ["config", "core.hooksPath", "/dev/null"], cd: repo, env: @git_env)
+
+    {_output, _status} = install(repo)
+
+    assert git(repo, ["config", "--get", "merge.ptc-generated.driver"]) == "true"
+  end
+
+  defp init_repo(dir) do
+    repo = Path.join(dir, "clone")
+    File.mkdir_p!(Path.join(repo, "scripts"))
+    {_, 0} = System.cmd("git", ["init", "-q", "."], cd: repo, env: @git_env)
+
+    for script <- ~w(install-hooks.sh pre-commit.template pre-push) do
+      File.cp!(Path.join([@repo_root, "scripts", script]), Path.join([repo, "scripts", script]))
+    end
+
+    repo
+  end
+
+  defp install(repo) do
+    System.cmd("bash", ["scripts/install-hooks.sh"],
+      cd: repo,
+      env: @git_env,
+      stderr_to_stdout: true
+    )
+  end
+
+  defp git(repo, args) do
+    {output, _status} = System.cmd("git", args, cd: repo, env: @git_env, stderr_to_stdout: true)
+    String.trim(output)
+  end
+end

--- a/test/githooks/pre_push_test.exs
+++ b/test/githooks/pre_push_test.exs
@@ -1,25 +1,10 @@
 defmodule PtcRunner.GitHooks.PrePushTest do
   use ExUnit.Case, async: true
 
+  alias PtcRunner.TestSupport.GitEnv
+
   @hook Path.expand("../../.githooks/pre-push", __DIR__)
-  @git_env ~w(
-    GIT_ALTERNATE_OBJECT_DIRECTORIES
-    GIT_CONFIG
-    GIT_CONFIG_PARAMETERS
-    GIT_CONFIG_COUNT
-    GIT_OBJECT_DIRECTORY
-    GIT_DIR
-    GIT_WORK_TREE
-    GIT_IMPLICIT_WORK_TREE
-    GIT_GRAFT_FILE
-    GIT_INDEX_FILE
-    GIT_NO_REPLACE_OBJECTS
-    GIT_REPLACE_REF_BASE
-    GIT_PREFIX
-    GIT_SHALLOW_FILE
-    GIT_COMMON_DIR
-  )
-           |> Enum.map(&{&1, nil})
+  @git_env GitEnv.clear()
 
   test "planning-only changes skip the full gate" do
     %{repo: repo, mix_marker: mix_marker, path: path} =

--- a/test/support/git_env.ex
+++ b/test/support/git_env.ex
@@ -1,0 +1,40 @@
+defmodule PtcRunner.TestSupport.GitEnv do
+  @moduledoc """
+  Environment scrubbing for tests that drive Git against a throwaway repository.
+
+  Git exports these to any process it spawns, so a test running under a hook —
+  or under a `mix test` that a hook invoked — inherits pointers to the *outer*
+  repository. A nested `git init` then looks correct while `git config` and
+  `git rev-parse` answer for the parent, which turns a hermetic fixture into a
+  reader of whatever the developer's clone happens to be configured with.
+  """
+
+  @inherited ~w(
+    GIT_ALTERNATE_OBJECT_DIRECTORIES
+    GIT_CONFIG
+    GIT_CONFIG_PARAMETERS
+    GIT_CONFIG_COUNT
+    GIT_OBJECT_DIRECTORY
+    GIT_DIR
+    GIT_WORK_TREE
+    GIT_IMPLICIT_WORK_TREE
+    GIT_GRAFT_FILE
+    GIT_INDEX_FILE
+    GIT_NO_REPLACE_OBJECTS
+    GIT_REPLACE_REF_BASE
+    GIT_PREFIX
+    GIT_SHALLOW_FILE
+    GIT_COMMON_DIR
+  )
+
+  @doc """
+  Returns a `System.cmd/3` `:env` list that clears every inherited Git variable.
+
+  Pass `extra` to set variables on top of the cleared ones.
+  """
+  @spec clear(keyword() | [{String.t(), String.t() | nil}]) :: [{String.t(), String.t() | nil}]
+  def clear(extra \\ []) do
+    Enum.map(@inherited, &{&1, nil}) ++
+      Enum.map(extra, fn {key, value} -> {to_string(key), value} end)
+  end
+end


### PR DESCRIPTION
`scripts/install-hooks.sh` resolved its destination through `git rev-parse --git-path hooks` but never checked the result was usable. A clone that disables hooks by pointing `core.hooksPath` at a non-directory resolves to exactly that path, so `mkdir`, `cp`, and `chmod` each failed in turn while the script printed a checkmark per hook and exited `0`:

```
mkdir: /dev/null: File exists
cp: /dev/null/pre-commit: Not a directory
chmod: /dev/null/pre-commit: Not a directory
✅ Pre-commit hook installed at /dev/null/pre-commit
...
Git hooks installed successfully!
---EXIT=0---
```

The clone was left completely ungated by a run that reported success. That is the failure mode worth caring about: a developer who runs the installer has no reason to check whether it worked.

## After

```
✅ Generated-file merge driver registered (merge.ptc-generated)

Installing git hooks...
❌ Cannot install hooks: /dev/null is not a usable directory
   core.hooksPath is set to: /dev/null
   Clear it to restore hooks: git config --unset core.hooksPath
   The merge driver above is registered regardless.
---EXIT=1---
```

The destination is validated before anything is claimed about it, `core.hooksPath` is named as the cause when set (it is the only setting that produces this), and a failed `cp`/`chmod` is fatal rather than printed over. The merge-driver registration still runs first, and the message says so, since a clone that cannot take hooks should still know what it did get.

## Tests

`test/githooks/install_hooks_test.exs` covers the happy path, the `core.hooksPath` failure, and that the merge driver lands even when hook installation fails. Against the previous script the second case fails exactly as reported above — exit `0` with `Pre-commit hook installed` for a hook never written.

## A hazard these tests hit, and now guard

Tests that drive Git against a throwaway repository must clear the variables Git exports to every process it spawns. Without that, a test running underneath a hook inherits `GIT_DIR`/`GIT_WORK_TREE` and operates on the *outer* clone rather than the fixture.

This is not theoretical: the first version of this test passed standalone and then, when the pre-commit hook invoked it, its `git init` reinitialised the developer's own repository and set `core.bare=true` on the shared config, breaking every linked worktree until it was reset.

`pre_push_test.exs` already carried a 16-variable scrub list for this reason. It moves to `PtcRunner.TestSupport.GitEnv` and both files share it rather than it being copied into a second module. Verified by rerunning with `GIT_DIR`/`GIT_WORK_TREE` deliberately pointed at the real repository: 14/14 pass and `core.bare` stays `false`.

## Verification

Pre-commit hook green on commit; pre-push gate green in 212s — root suite, `mix prepush` (upstream audit, Dialyzer 0 errors, unused-deps), Viewer, and launcher.

https://claude.ai/code/session_01S74ttew2hWarqFEBNveaXc