### PR TITLE
fix(mcp-oauth): spend one budget closing an unresponsive store

### DIFF
--- a/lib/ptc_runner/kernel/mcp_oauth/store/memory.ex
+++ b/lib/ptc_runner/kernel/mcp_oauth/store/memory.ex
@@ -54,7 +54,11 @@ defmodule PtcRunner.Kernel.MCPOAuth.Store.Memory do
   # cannot run that cleanup.
   @doc false
   @spec close(t()) :: :ok
-  def close(%__MODULE__{pid: pid}) do
+  def close(%__MODULE__{} = memory), do: close(memory, @close_timeout_ms)
+
+  @doc false
+  @spec close(t(), pos_integer()) :: :ok
+  def close(%__MODULE__{pid: pid}, timeout_ms) when is_integer(timeout_ms) and timeout_ms > 0 do
     # Checked before anything is sent, not just before the process is
     # terminated: `:close` is a plausible message for an unrelated GenServer, so
     # a handle naming the wrong pid must not stop or mutate one.
@@ -68,25 +72,33 @@ defmodule PtcRunner.Kernel.MCPOAuth.Store.Memory do
     if store_process?(pid) do
       reference = Process.monitor(pid)
 
+      # One budget spans both phases. The cooperative call and the shutdown it
+      # asks for are two steps of a single close, so charging each the full
+      # timeout let a wedged store hold the abort path for twice the bound this
+      # module documents.
+      deadline = Deadline.new(timeout_ms)
+
       _replied =
         try do
-          GenServer.call(pid, :close, @close_timeout_ms)
+          GenServer.call(pid, :close, Deadline.remaining(deadline))
         catch
           :exit, _reason -> :ok
         end
 
-      await_close(pid, reference)
+      await_close(pid, reference, deadline)
     else
       :ok
     end
   end
 
-  defp await_close(pid, reference) do
+  defp await_close(pid, reference, deadline) do
     receive do
       {:DOWN, ^reference, :process, ^pid, _reason} ->
         :ok
     after
-      @close_timeout_ms ->
+      # `remaining/1` floors at zero, so an already-spent budget goes straight
+      # to termination rather than waiting again.
+      Deadline.remaining(deadline) ->
         terminate_store(pid, reference)
     end
   end

--- a/priv/semantic_build_projection.json
+++ b/priv/semantic_build_projection.json
@@ -129,7 +129,7 @@
     "req_llm",
     "telemetry"
   ],
-  "source_closure_hash": "cfb14b91cc53017ad2a9b4890c58228a7133a4b9c442b176bb65b84bc5fa59fd",
+  "source_closure_hash": "40ea0ff6e0f991aac3dee37557da299887924ee937d0e4e0167989cecea28dec",
   "sources": [
     {
       "bytes": 870,
@@ -597,9 +597,9 @@
       "sha256": "da025436e6c2910b4ef91adb1f3e2aafaff3d6d524c6e24ee396b9eff28f87ac"
     },
     {
-      "bytes": 48255,
+      "bytes": 48918,
       "path": "lib/ptc_runner/kernel/mcp_oauth/store/memory.ex",
-      "sha256": "81c52a6ce3d73cfcf3b0e6a700994b8ce18d8a1fc1d1f8fa06941a152311ca05"
+      "sha256": "71c9bbb7744623a204cbe28049b84e5c15f76374dbaa07a6b7f6ad7d54eace0d"
     },
     {
       "bytes": 11642,

--- a/test/ptc_runner/kernel/mcp_oauth/store_memory_test.exs
+++ b/test/ptc_runner/kernel/mcp_oauth/store_memory_test.exs
@@ -58,15 +58,43 @@ defmodule PtcRunner.Kernel.MCPOAuth.StoreMemoryTest do
     # The store is detached from the worker that used it, so closing it is a
     # terminal action on the abort path. A wedged store must not hold that abort
     # open, and it must be gone when the close returns.
+    #
+    # The budget is named rather than waited out: what this proves is that a
+    # store which never answers is terminated at the bound, and the size of the
+    # bound is not part of that.
     {:ok, memory} = Memory.start(owner: self())
     reference = Process.monitor(memory.pid)
     assert :ok = :sys.suspend(memory.pid)
 
-    closer = Task.async(fn -> Memory.close(memory) end)
+    closer = Task.async(fn -> Memory.close(memory, 200) end)
 
     assert :ok = Task.await(closer, 10_000)
     assert_receive {:DOWN, ^reference, :process, _pid, _reason}, 5_000
     refute Process.alive?(memory.pid)
+  end
+
+  test "an unresponsive close spends one budget across both of its phases" do
+    # The cooperative call and the shutdown it asks for are two steps of a
+    # single close. Charging each the full timeout made the documented bound a
+    # floor of half the real one, so a wedged store held the abort path for
+    # twice as long as this module says it can.
+    {:ok, memory} = Memory.start(owner: self())
+    assert :ok = :sys.suspend(memory.pid)
+
+    # The clock starts before the closer is spawned. Timing from after the
+    # spawn would exclude whatever the task had already spent, which biases the
+    # measurement towards passing precisely when the two-budget behaviour is
+    # what is running. The task itself only exists so a close that never
+    # returns fails at `Task.await` rather than hanging to the case timeout.
+    budget_ms = 400
+    started_at_ms = System.monotonic_time(:millisecond)
+    closer = Task.async(fn -> Memory.close(memory, budget_ms) end)
+    assert :ok = Task.await(closer, 10_000)
+    elapsed_ms = System.monotonic_time(:millisecond) - started_at_ms
+
+    # Halfway between one budget and two, so neither a slow scheduler nor an
+    # early spawn moves either behaviour across it.
+    assert elapsed_ms < 600
   end
 
   test "a store destroyed by its owner's death takes its registered managers with it" do

--- a/test/ptc_runner/kernel/provider_session_test.exs
+++ b/test/ptc_runner/kernel/provider_session_test.exs
@@ -111,7 +111,9 @@ defmodule PtcRunner.Kernel.ProviderSessionTest do
     # sealed into the registrar came from the caller's copy it would be `nil` —
     # a legitimately attested handle whose activate and commit wait forever.
     # The sealed budget therefore comes back from the session too.
-    {:ok, limits} = Limits.installed(%{run_duration_ms: 2_000})
+    # The budget only has to be finite and observable; the test spends it in
+    # full, so its size is pure wall clock.
+    {:ok, limits} = Limits.installed(%{run_duration_ms: 300})
     {:ok, stale} = ProviderSession.start_active(limits, "stale-budget")
     on_exit(fn -> Process.exit(stale.pid, :kill) end)
     {:ok, begun} = ProviderSession.begin_operation(stale, :run)
@@ -127,9 +129,9 @@ defmodule PtcRunner.Kernel.ProviderSessionTest do
     assert :ok = :sys.suspend(stale.pid)
     started_at_ms = System.monotonic_time(:millisecond)
     assert {:error, :resource_registrar_unavailable} = ResourceRegistrar.activate(registrar)
-    # Wide on purpose. The bound only has to separate "spends the 2s budget"
-    # from "waits forever", and the unsealed-budget mutation never returns at
-    # all, so a tight margin buys nothing and flakes under load.
+    # Wide on purpose. The bound only has to separate "spends the sealed
+    # budget" from "waits forever", and the unsealed-budget mutation never
+    # returns at all, so a tight margin buys nothing and flakes under load.
     assert System.monotonic_time(:millisecond) - started_at_ms < 10_000
   end
 


### PR DESCRIPTION
## What

`Memory.close/1` charged `@close_timeout_ms` twice — once to the cooperative `GenServer.call(:close, ...)`, and again to the `await_close` receive waiting for the shutdown that call asked for. Those are two steps of a single close, so a wedged store held the abort path for **2 s against a bound the module documents as 1 s**.

This anchors one `Deadline` and spends it across both phases. `Deadline.remaining/1` floors at zero, so an already-spent budget goes straight to termination instead of waiting a second time. Same anchoring the terminal-cleanup path already uses.

## Why the cooperative path is unaffected

`handle_call(:close, ...)` returns `{:stop, :normal, :ok, state}`, so a store that answers is already stopping when the reply lands, and `terminate/2` only sends kills. The second phase costs a store that answers nothing worth budgeting separately — only a store that never answers can consume phase one, and that is exactly the case whose bound was wrong.

## Test-speed side

The close gains the `@doc false` arity+1 timeout seam the sinks already establish (the idiom from #1193), so the tests that prove the bound name a narrow budget instead of waiting out the shipped one.

| test | before | after |
|---|---|---|
| `store_memory_test:57` | 2002 ms | 201 ms |
| `provider_session_test:108` | 2102 ms | 401 ms |

The second is test-side only: its sealed `run_duration_ms` is spent in full by design, so 2 s of it was pure wall clock. 300 ms separates "spends the sealed budget" from "waits forever" just as well, which is all that test distinguishes.

## Regression test

Adds a test for the anchoring itself. It clocks from **before** the closer is spawned — timing from after would exclude what the task had already spent, biasing the measurement towards passing precisely when the two-budget behaviour is what is running. Threshold sits halfway between one budget and two:

- anchored: **401 ms** (passes)
- unanchored: **802 ms** (fails, 3/3 runs)
- threshold 600 ms — ~200 ms margin either way

## Verification

- `mix credo --strict` — clean
- `MIX_ENV=test mix dialyzer` — 0 errors
- pre-push hook — all gates green in 212 s
- `codex review --base main` — found the spawn-ordering flaw in the new test; fixed in this version

Measured on a 10-core machine against a 203.5 s suite baseline (93.7 s async / 109.8 s sync, 5805 tests).