### PR TITLE
test(mix): tag the downstream consumer build as slow

### DIFF
--- a/test/mix/tasks/ptc_run_downstream_test.exs
+++ b/test/mix/tasks/ptc_run_downstream_test.exs
@@ -11,7 +11,13 @@ defmodule Mix.Tasks.Ptc.RunDownstreamTest do
   # recompile it whenever the library sources change.
   @build_path Path.join(@root, "_build/downstream_consumer")
 
+  # `:slow` because the assertion is only observable through a real `mix ptc.run`
+  # in a separate OS process against a real prod build. The cached build above
+  # holds a warm run to ~5.5 s, but the cache is per-worktree and PtcRunner is a
+  # path dependency, so a fresh clone or any library change pays the full
+  # compile: 36.4 s measured on a cold `_build/downstream_consumer`.
   @tag :tmp_dir
+  @tag :slow
   test "starts only the PtcRunner core when a downstream project depends on req_llm", %{
     tmp_dir: dir
   } do


### PR DESCRIPTION
## What

Tags `test/mix/tasks/ptc_run_downstream_test.exs:15` with `:slow`.

The assertion is only observable through a real `mix ptc.run` in a separate OS process against a real prod build, so its cost is a compile rather than anything the suite can shorten. That places it squarely in the same category as the tests already carrying the tag (`ptc_repl_test`, `pre_push_test`, `trace_capability_test`, `inspection_lab_test`).

## Why it still matters after #1193

#1193 moved the consumer build to a cached `_build/downstream_consumer`, taking a warm run from 38.9 s to ~5.5 s. But that cache is **per-worktree**, and PtcRunner enters it as a path dependency — so a fresh clone, a fresh worktree, or any library change pays the full compile again:

| condition | measured |
|---|---|
| cold `_build/downstream_consumer`, fresh worktree | **36.4 s** |
| warm cache | 4.6 – 5.5 s |

## What this does and does not change

`:slow` is currently honoured in exactly one place — `.githooks/pre-commit:115`, and only for test files you staged. It is not in `test_helper.exs` exclusions, not in pre-push, not in `mix precommit`, not in CI.

So **this changes no gate**. It makes the classification correct at the point where it is obvious. Whether the suite excludes `:slow` by default is a separate decision with its own tradeoffs, deliberately not bundled here.

Verified:

```
mix test test/mix/tasks/ptc_run_downstream_test.exs                  # 1 passed
mix test test/mix/tasks/ptc_run_downstream_test.exs --exclude slow   # 0 tests, 1 excluded
```

## Candidates measured and rejected

The other files considered for the tag do not warrant it:

| file | measured | verdict |
|---|---|---|
| `test/scripts/duplication_gate_test.exs` | 0.7 s | too fast |
| `test/scripts/classify_changes_test.exs` | 0.4 s | too fast |
| `test/ptc_runner/kernel/inspection_preflight_test.exs` | 3.7 s across many tests; its one real subprocess test is 569 ms | no single dominant test |

Adding tags that do not move wall clock only widens the surface that would silently lose coverage if `:slow` ever becomes a default exclusion.

Pre-push hook: all gates green in 179 s.