### PR TITLE
fix(test): remove two flake sources and close the pre-push gate that let them reach CI

### DIFF
--- a/.duplication-baseline.json
+++ b/.duplication-baseline.json
@@ -1,24 +1,5 @@
 {
   "clones": {
-    "00e8ab958fcd56a97883817c9e13266252b21a5eec60ab34f032eb975fccb1b2": {
-      "describe": "type_i mass=31 test/ptc_runner/kernel/mcp_oauth/store_memory_test.exs:842 <-> test/ptc_runner/kernel/run_coordinator_execution_test.exs:559",
-      "files": [
-        "test/ptc_runner/kernel/mcp_oauth/store_memory_test.exs",
-        "test/ptc_runner/kernel/run_coordinator_execution_test.exs"
-      ],
-      "mass": 31,
-      "occurrences": [
-        {
-          "file": "test/ptc_runner/kernel/mcp_oauth/store_memory_test.exs",
-          "snippet": "805883e88dabbb2190b125b74ef539fd7ade38127ed8bbf3b82a4c41cfa6285e"
-        },
-        {
-          "file": "test/ptc_runner/kernel/run_coordinator_execution_test.exs",
-          "snippet": "805883e88dabbb2190b125b74ef539fd7ade38127ed8bbf3b82a4c41cfa6285e"
-        }
-      ],
-      "type": "type_i"
-    },
     "07084d9632bf4b9c5b4ef57fdb68d4248c79a08526ef637bb7a4b9ff8eefa89f": {
       "describe": "type_i mass=30 lib/ptc_runner/kernel/inspection_analysis_profile.ex:43 <-> lib/ptc_runner/kernel/log_analysis_profile.ex:24",
       "files": [
@@ -134,7 +115,7 @@
       "type": "type_i"
     },
     "17b8263cf529a4e1bed34858ac77e3d0551097499427933412d4bf081b7c3a83": {
-      "describe": "type_i mass=68 test/mix/tasks/ptc_run_test.exs:1161 <-> test/ptc_runner/kernel/provider_active_session_test.exs:1274",
+      "describe": "type_i mass=68 test/mix/tasks/ptc_run_test.exs:1161 <-> test/ptc_runner/kernel/provider_active_session_test.exs:1301",
       "files": [
         "test/mix/tasks/ptc_run_test.exs",
         "test/ptc_runner/kernel/provider_active_session_test.exs"
@@ -153,7 +134,7 @@
       "type": "type_i"
     },
     "19c5d17e24d817a4f9620f48abcc943a418714840edb1eba9827e90b722ca169": {
-      "describe": "type_i mass=43 lib/ptc_runner/kernel/analysis_session.ex:260 <-> lib/ptc_runner/kernel/execution_session_owner.ex:264 <-> lib/ptc_runner/kernel/host_installation_owner.ex:352 <-> lib/ptc_runner/kernel/inspection_sink.ex:187 <-> lib/ptc_runner/kernel/inspection_snapshot.ex:244 <-> lib/ptc_runner/kernel/mcp_oauth/store/memory.ex:692 <-> lib/ptc_runner/kernel/mcp_oauth/token_manager.ex:421 <-> lib/ptc_runner/kernel/mcp_request_context.ex:356 <-> lib/ptc_runner/kernel/mcp_stdio_transport.ex:405 <-> lib/ptc_runner/kernel/provider_session.ex:1191 <-> lib/ptc_runner/kernel/provider_task_tracker.ex:111 <-> lib/ptc_runner/kernel/repl_session_owner.ex:92 <-> lib/ptc_runner/kernel/run_state.ex:752 <-> lib/ptc_runner/kernel/session_trace.ex:292 <-> lib/ptc_runner/kernel/trace_snapshot.ex:228 <-> lib/ptc_runner/kernel/viewer_repl_backend.ex:349",
+      "describe": "type_i mass=43 lib/ptc_runner/kernel/analysis_session.ex:260 <-> lib/ptc_runner/kernel/execution_session_owner.ex:264 <-> lib/ptc_runner/kernel/host_installation_owner.ex:352 <-> lib/ptc_runner/kernel/inspection_sink.ex:191 <-> lib/ptc_runner/kernel/inspection_snapshot.ex:244 <-> lib/ptc_runner/kernel/mcp_oauth/store/memory.ex:704 <-> lib/ptc_runner/kernel/mcp_oauth/token_manager.ex:421 <-> lib/ptc_runner/kernel/mcp_request_context.ex:356 <-> lib/ptc_runner/kernel/mcp_stdio_transport.ex:405 <-> lib/ptc_runner/kernel/provider_session.ex:1212 <-> lib/ptc_runner/kernel/provider_task_tracker.ex:111 <-> lib/ptc_runner/kernel/repl_session_owner.ex:92 <-> lib/ptc_runner/kernel/run_state.ex:752 <-> lib/ptc_runner/kernel/session_trace.ex:292 <-> lib/ptc_runner/kernel/trace_snapshot.ex:228 <-> lib/ptc_runner/kernel/viewer_repl_backend.ex:349",
       "files": [
         "lib/ptc_runner/kernel/analysis_session.ex",
         "lib/ptc_runner/kernel/execution_session_owner.ex",
@@ -260,7 +241,7 @@
       "type": "type_ii"
     },
     "22b906ebb444263576b0ba42aeab41de27e3cafc0472fde963e925b4653e9aa4": {
-      "describe": "type_i mass=30 test/ptc_runner/kernel/provider_execution_lifecycle_test.exs:267 <-> test/ptc_runner/kernel/provider_execution_lifecycle_test.exs:481",
+      "describe": "type_i mass=30 test/ptc_runner/kernel/provider_execution_lifecycle_test.exs:269 <-> test/ptc_runner/kernel/provider_execution_lifecycle_test.exs:483",
       "files": [
         "test/ptc_runner/kernel/provider_execution_lifecycle_test.exs"
       ],
@@ -451,7 +432,7 @@
       "type": "type_i"
     },
     "510ba2e7c084c86c1e0ccf6324eb24ee6b703c941a4277325b50776289c5034a": {
-      "describe": "type_ii mass=30 lib/ptc_runner/kernel/event_sink.ex:271 <-> lib/ptc_runner/kernel/inspection_sink.ex:182 <-> lib/ptc_runner/kernel/llm_replay_owner.ex:65 <-> lib/ptc_runner/kernel/repl_session_owner.ex:87 <-> lib/ptc_runner/kernel/trace_snapshot.ex:223",
+      "describe": "type_ii mass=30 lib/ptc_runner/kernel/event_sink.ex:275 <-> lib/ptc_runner/kernel/inspection_sink.ex:186 <-> lib/ptc_runner/kernel/llm_replay_owner.ex:65 <-> lib/ptc_runner/kernel/repl_session_owner.ex:87 <-> lib/ptc_runner/kernel/trace_snapshot.ex:223",
       "files": [
         "lib/ptc_runner/kernel/event_sink.ex",
         "lib/ptc_runner/kernel/inspection_sink.ex",
@@ -598,7 +579,7 @@
       "type": "type_i"
     },
     "5f450b809feb307b73c888b5faecbe7ef40c5b89bf3db34ac398e9b8d2623d15": {
-      "describe": "type_i mass=38 test/ptc_runner/kernel/command_engine_test.exs:4552 <-> test/ptc_runner/kernel/host_installation_test.exs:1539 <-> test/ptc_runner/kernel/provider_declaration_test.exs:1952",
+      "describe": "type_i mass=38 test/ptc_runner/kernel/command_engine_test.exs:4552 <-> test/ptc_runner/kernel/host_installation_test.exs:1526 <-> test/ptc_runner/kernel/provider_declaration_test.exs:1952",
       "files": [
         "test/ptc_runner/kernel/command_engine_test.exs",
         "test/ptc_runner/kernel/host_installation_test.exs",
@@ -749,7 +730,7 @@
       "type": "type_i"
     },
     "7b3aec65c10a62357920b31e331cfe801d1013ed9db584dd113a39a4627d7fe3": {
-      "describe": "type_ii mass=73 lib/ptc_runner/kernel/inspection_sink.ex:182 <-> lib/ptc_runner/kernel/repl_session_owner.ex:87 <-> lib/ptc_runner/kernel/trace_snapshot.ex:223",
+      "describe": "type_ii mass=73 lib/ptc_runner/kernel/inspection_sink.ex:186 <-> lib/ptc_runner/kernel/repl_session_owner.ex:87 <-> lib/ptc_runner/kernel/trace_snapshot.ex:223",
       "files": [
         "lib/ptc_runner/kernel/inspection_sink.ex",
         "lib/ptc_runner/kernel/repl_session_owner.ex",
@@ -955,7 +936,7 @@
       "type": "type_ii"
     },
     "a1a94dc98cd22bfc2b5de743e98b2490ac17fa6b048d296d276f0df77d50aea0": {
-      "describe": "type_ii mass=82 lib/ptc_runner/kernel/inspection_sink.ex:179 <-> lib/ptc_runner/kernel/trace_snapshot.ex:220",
+      "describe": "type_ii mass=82 lib/ptc_runner/kernel/inspection_sink.ex:183 <-> lib/ptc_runner/kernel/trace_snapshot.ex:220",
       "files": [
         "lib/ptc_runner/kernel/inspection_sink.ex",
         "lib/ptc_runner/kernel/trace_snapshot.ex"
@@ -1011,7 +992,7 @@
       "type": "type_i"
     },
     "a3d335b448953597156aeccd156f3b55248ab616228c103f0821597c6804d29e": {
-      "describe": "type_i mass=30 lib/ptc_runner/kernel/analysis_session.ex:721 <-> lib/ptc_runner/kernel/execution_session_owner.ex:567 <-> lib/ptc_runner/kernel/host_installation_owner.ex:362 <-> lib/ptc_runner/kernel/inspection_sink.ex:391 <-> lib/ptc_runner/kernel/inspection_snapshot.ex:572 <-> lib/ptc_runner/kernel/mcp_oauth/store/memory.ex:1516 <-> lib/ptc_runner/kernel/mcp_oauth/token_manager.ex:914 <-> lib/ptc_runner/kernel/mcp_request_context.ex:379 <-> lib/ptc_runner/kernel/mcp_stdio_transport.ex:1016 <-> lib/ptc_runner/kernel/provider_session.ex:1652 <-> lib/ptc_runner/kernel/provider_task_tracker.ex:148 <-> lib/ptc_runner/kernel/repl_session_owner.ex:134 <-> lib/ptc_runner/kernel/run_state.ex:800 <-> lib/ptc_runner/kernel/session_trace.ex:540 <-> lib/ptc_runner/kernel/trace_snapshot.ex:380 <-> lib/ptc_runner/kernel/viewer_repl_backend.ex:601",
+      "describe": "type_i mass=30 lib/ptc_runner/kernel/analysis_session.ex:721 <-> lib/ptc_runner/kernel/execution_session_owner.ex:567 <-> lib/ptc_runner/kernel/host_installation_owner.ex:362 <-> lib/ptc_runner/kernel/inspection_sink.ex:395 <-> lib/ptc_runner/kernel/inspection_snapshot.ex:572 <-> lib/ptc_runner/kernel/mcp_oauth/store/memory.ex:1528 <-> lib/ptc_runner/kernel/mcp_oauth/token_manager.ex:914 <-> lib/ptc_runner/kernel/mcp_request_context.ex:379 <-> lib/ptc_runner/kernel/mcp_stdio_transport.ex:1016 <-> lib/ptc_runner/kernel/provider_session.ex:1673 <-> lib/ptc_runner/kernel/provider_task_tracker.ex:148 <-> lib/ptc_runner/kernel/repl_session_owner.ex:134 <-> lib/ptc_runner/kernel/run_state.ex:800 <-> lib/ptc_runner/kernel/session_trace.ex:540 <-> lib/ptc_runner/kernel/trace_snapshot.ex:380 <-> lib/ptc_runner/kernel/viewer_repl_backend.ex:601",
       "files": [
         "lib/ptc_runner/kernel/analysis_session.ex",
         "lib/ptc_runner/kernel/execution_session_owner.ex",
@@ -1325,7 +1306,7 @@
       "type": "type_i"
     },
     "c679bcc9b0eed91b6c6ec07724a37ef8febdffb367bf827a78918d9cebab9522": {
-      "describe": "type_i mass=73 lib/ptc_runner/kernel/inspection_sink.ex:182 <-> lib/ptc_runner/kernel/repl_session_owner.ex:87",
+      "describe": "type_i mass=73 lib/ptc_runner/kernel/inspection_sink.ex:186 <-> lib/ptc_runner/kernel/repl_session_owner.ex:87",
       "files": [
         "lib/ptc_runner/kernel/inspection_sink.ex",
         "lib/ptc_runner/kernel/repl_session_owner.ex"
@@ -1344,7 +1325,7 @@
       "type": "type_i"
     },
     "c802296125eb0568ec7d29f9b5ec9a8283b049cec37af65a59da692f59574f49": {
-      "describe": "type_i mass=30 lib/ptc_runner/kernel/event_sink.ex:271 <-> lib/ptc_runner/kernel/inspection_sink.ex:182 <-> lib/ptc_runner/kernel/repl_session_owner.ex:87",
+      "describe": "type_i mass=30 lib/ptc_runner/kernel/event_sink.ex:275 <-> lib/ptc_runner/kernel/inspection_sink.ex:186 <-> lib/ptc_runner/kernel/repl_session_owner.ex:87",
       "files": [
         "lib/ptc_runner/kernel/event_sink.ex",
         "lib/ptc_runner/kernel/inspection_sink.ex",
@@ -1387,7 +1368,7 @@
       "type": "type_i"
     },
     "d311c7826ee7b7deb9d9434678db71429400eb129423c64e70f0c78c2059c5af": {
-      "describe": "type_i mass=36 test/mix/tasks/ptc_run_downstream_test.exs:62 <-> test/mix/tasks/ptc_run_test.exs:1012",
+      "describe": "type_i mass=36 test/mix/tasks/ptc_run_downstream_test.exs:76 <-> test/mix/tasks/ptc_run_test.exs:1012",
       "files": [
         "test/mix/tasks/ptc_run_downstream_test.exs",
         "test/mix/tasks/ptc_run_test.exs"
@@ -1521,7 +1502,7 @@
       "type": "type_i"
     },
     "eab38378a7cf3498853edd5074f7c6842ab0039953eed003abfd7f9f7d98e75a": {
-      "describe": "type_i mass=41 test/ptc_runner/kernel/execution_session_owner_privacy_test.exs:230 <-> test/ptc_runner/kernel/provider_execution_lifecycle_test.exs:765 <-> test/ptc_runner/kernel/run_coordinator_execution_test.exs:413",
+      "describe": "type_i mass=41 test/ptc_runner/kernel/execution_session_owner_privacy_test.exs:230 <-> test/ptc_runner/kernel/provider_execution_lifecycle_test.exs:754 <-> test/ptc_runner/kernel/run_coordinator_execution_test.exs:415",
       "files": [
         "test/ptc_runner/kernel/execution_session_owner_privacy_test.exs",
         "test/ptc_runner/kernel/provider_execution_lifecycle_test.exs",

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -6,8 +6,11 @@
 #      other documentation-only changes run the ExDoc warnings gate.
 #   2. Otherwise: classify the affected contracts, run documentation first,
 #      then run the relevant root, Viewer, and launcher gates. Root changes
-#      invoke the canonical `mix prepush` alias for the upstream audit,
-#      Dialyzer, and unused-dependency check.
+#      invoke the canonical `mix prepush` alias for generated-artifact
+#      staleness, the upstream audit, Dialyzer, and the unused-dependency
+#      check. The staleness checks are shared with `precommit`, which an
+#      ordinary push does not run, so this hook is where a stale generated
+#      artifact is caught before CI rather than by it.
 #
 # Override:
 #   FORCE_FULL_PRE_PUSH=1 git push  → always run the full gate, even if

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,12 +47,17 @@ how it was verified.
   run before every commit. This is intentionally much broader than the fast,
   staged-file Git pre-commit hook and can take a few minutes in a fresh worktree.
 - `MIX_ENV=dev mix docs --warnings-as-errors` — ExDoc reference and rendering
-  gate; run when changing user-facing documentation. Generated-doc consistency
-  is a separate check inside `mix precommit`.
+  gate; run when changing user-facing documentation. Generated-artifact
+  staleness is checked separately, by both `mix precommit` and `mix prepush`.
 - `git push` — the tracked pre-push hook classifies pushed and dirty paths and
   runs the relevant root, Viewer, launcher, or documentation gates. Root
-  changes run the root tests and `mix prepush` (upstream API audit, Dialyzer,
-  unused-deps). Do not run `mix prepush` immediately before an ordinary push;
+  changes run the root tests and `mix prepush` (generated-artifact staleness,
+  upstream API audit, Dialyzer, unused-deps). The staleness checks are also in
+  `precommit`, and are repeated here because an ordinary push does not run
+  `precommit` — without them a `lib/` edit can clear every local gate and still
+  fail CI on an artifact you were never prompted to regenerate. When one fires,
+  run `mix regen` and stage the result. Do not run `mix prepush` immediately
+  before an ordinary push;
   invoke it directly only for diagnosis or when hooks are unavailable. PR CI
   runs the same checks as individual steps. On a resource-constrained machine,
   `PTC_PRE_PUSH_MAX_CASES=2 git push` keeps every gate enabled while reducing

--- a/mix.exs
+++ b/mix.exs
@@ -173,7 +173,19 @@ defmodule PtcRunner.MixProject do
       # Slower checks kept out of the per-commit loop; run before pushing.
       # PR CI runs these as individual steps. The upstream audit attests all
       # exact Java descriptors when Java 11 or newer is available.
+      #
+      # The three staleness checks are also in `precommit`, and are repeated
+      # here on purpose. A generated artifact goes stale from an ordinary edit
+      # to the sources it projects, `AGENTS.md` tells you not to run `precommit`
+      # before an ordinary push because the hook already gates it, and the hook
+      # runs the suite and this alias rather than `precommit`. Without them a
+      # push that touches `lib/` clears every local gate and still fails CI on
+      # an artifact the author never had a chance to regenerate. They cost a few
+      # seconds inside a run that already spends minutes.
       prepush: [
+        "ptc.gen_semantic_revision --check",
+        "ptc.gen_docs --check",
+        "ptc.conformance_report --check-inventory",
         "ptc.audit_upstream",
         "dialyzer",
         "deps.unlock --check-unused"

--- a/priv/semantic_build_projection.json
+++ b/priv/semantic_build_projection.json
@@ -129,7 +129,7 @@
     "req_llm",
     "telemetry"
   ],
-  "source_closure_hash": "40ea0ff6e0f991aac3dee37557da299887924ee937d0e4e0167989cecea28dec",
+  "source_closure_hash": "4058632dee36c238c9ac85bb74ce802b26cf043d2aa95b4cdb611e3b8d61f39a",
   "sources": [
     {
       "bytes": 870,
@@ -1577,9 +1577,9 @@
       "sha256": "956cf2feb4d5f543e35892b47c9048fbca23181cbe2fe86e89c6e7c10603dd2b"
     },
     {
-      "bytes": 13205,
+      "bytes": 13955,
       "path": "mix.exs",
-      "sha256": "2387b675a22be6013386d2cd43079aacf7f0f417b3c0b5c3869131f1c85733ce"
+      "sha256": "31bbc2a658da09367a83b5b55ec5f348837c0236bea61f3d6c6db0c65210c086"
     },
     {
       "bytes": 117541,

--- a/test/ptc_runner/kernel/host_installation_test.exs
+++ b/test/ptc_runner/kernel/host_installation_test.exs
@@ -1,6 +1,8 @@
 defmodule PtcRunner.Kernel.HostInstallationTest do
   use ExUnit.Case, async: false
 
+  import PtcRunner.TestSupport.Eventually, only: [assert_eventually: 1]
+
   alias PtcRunner.Kernel.Attestation
   alias PtcRunner.Kernel.CommandDiagnostic
   alias PtcRunner.Kernel.Deadline
@@ -1494,21 +1496,6 @@ defmodule PtcRunner.Kernel.HostInstallationTest do
       wait_until_expired(deadline)
     end
   end
-
-  defp assert_eventually(predicate, attempts \\ 10_000)
-
-  defp assert_eventually(predicate, attempts) when attempts > 0 do
-    if predicate.() do
-      :ok
-    else
-      receive do
-      after
-        0 -> assert_eventually(predicate, attempts - 1)
-      end
-    end
-  end
-
-  defp assert_eventually(_predicate, 0), do: flunk("condition did not become true")
 
   defp assert_local_preflight_parity(host, name, destination, expected) do
     assert {:ok, catalog} = HostInstallation.catalog(host)

--- a/test/ptc_runner/kernel/local_preflight_test.exs
+++ b/test/ptc_runner/kernel/local_preflight_test.exs
@@ -430,7 +430,7 @@ defmodule PtcRunner.Kernel.LocalPreflightTest do
     # during setup must stop the callback starting, not merely change how its
     # result is reported afterwards.
     catalog = catalog(%{"custom" => [source: :custom, local_preflight: :unverified]})
-    prepared = prepared(catalog, ["custom"], [], %{"run_duration_ms" => 1})
+    prepared = prepared(catalog, ["custom"], [], %{"run_duration_ms" => 100})
     assert :ok = ProviderActivity.mark(prepared.provider_activity)
 
     assert {:error, %CommandDiagnostic{} = diagnostic} =
@@ -517,17 +517,56 @@ defmodule PtcRunner.Kernel.LocalPreflightTest do
 
   # A session whose operation clock is already spent. The step must refuse to
   # start a callback under it rather than report the timeout after the fact.
-  defp expired_session(prepared) do
+  #
+  # Setting up that state is itself racy, and no budget removes the race. The
+  # operation budget has to outlast `begin_operation/2`: it seals the deadline
+  # before the call and the session re-checks it on arrival, so a budget the
+  # round-trip outruns is already expired when the server reads it and the
+  # session is refused as `:provider_session_unavailable`. But the budget is
+  # also what the caller then waits out, so raising it only trades wall clock
+  # for a wider margin -- 1ms lost that race often enough to fail CI, and 100ms
+  # would still lose it under a long enough stall.
+  #
+  # So the margin is sized from measurement and the residue is retried rather
+  # than hoped away: the round-trip is 6us at the median and ~1ms at its worst
+  # under scheduler pressure, 100ms clears that by two orders of magnitude, and
+  # a setup that loses anyway starts over instead of failing the test. Only
+  # setup retries; the assertion runs once, against a session whose clock is
+  # genuinely spent.
+  @setup_attempts 5
+
+  defp expired_session(prepared, attempt \\ 1) do
     limits = prepared.request.package.limits
     {:ok, session} = ProviderSession.start_active(limits, prepared.attestation)
     on_exit(fn -> ProviderSession.close(session) end)
-    {:ok, session} = ProviderSession.begin_operation(session, :run)
-    burn_until(Deadline.expires_at(ProviderSession.run_deadline(session)) + 5)
-    session
+
+    case ProviderSession.begin_operation(session, :run) do
+      {:ok, begun} ->
+        wait_until(Deadline.expires_at(ProviderSession.run_deadline(begun)) + 5)
+        begun
+
+      {:error, :provider_session_unavailable} when attempt < @setup_attempts ->
+        expired_session(prepared, attempt + 1)
+
+      {:error, reason} ->
+        flunk("could not open an operation in #{@setup_attempts} attempts: #{inspect(reason)}")
+    end
   end
 
-  defp burn_until(target_ms) do
-    if System.monotonic_time(:millisecond) < target_ms, do: burn_until(target_ms), else: :ok
+  # Yields rather than spinning. `max_cases` is capped at the scheduler count
+  # precisely because sandbox children starve under load, so burning a core to
+  # watch a clock steals runtime from the tests running beside this one.
+  defp wait_until(target_ms) do
+    remaining_ms = target_ms - System.monotonic_time(:millisecond)
+
+    if remaining_ms > 0 do
+      receive do
+      after
+        remaining_ms -> wait_until(target_ms)
+      end
+    else
+      :ok
+    end
   end
 
   # A root registers itself from inside the callback's scope, which is the

--- a/test/ptc_runner/kernel/mcp_oauth/store_memory_test.exs
+++ b/test/ptc_runner/kernel/mcp_oauth/store_memory_test.exs
@@ -1,6 +1,8 @@
 defmodule PtcRunner.Kernel.MCPOAuth.StoreMemoryTest do
   use ExUnit.Case, async: true
 
+  import PtcRunner.TestSupport.Eventually, only: [assert_eventually: 1]
+
   alias PtcRunner.Kernel.Deadline
   alias PtcRunner.Kernel.MCPOAuth.Authority
   alias PtcRunner.Kernel.MCPOAuth.Context
@@ -864,14 +866,6 @@ defmodule PtcRunner.Kernel.MCPOAuth.StoreMemoryTest do
 
   defp replace_grant(store, key, access_token, scopes \\ MapSet.new(["read"])),
     do: seed_grant(store, key, access_token, scopes)
-
-  defp assert_eventually(callback, attempts \\ 100)
-
-  defp assert_eventually(callback, attempts) when attempts > 0 do
-    if callback.(), do: :ok, else: assert_eventually(callback, attempts - 1)
-  end
-
-  defp assert_eventually(_callback, 0), do: flunk("condition did not become true")
 
   defp manager_monitor_count(store_pid, manager) do
     {:monitors, monitors} = Process.info(store_pid, :monitors)

--- a/test/ptc_runner/kernel/mcp_stdio_transport_test.exs
+++ b/test/ptc_runner/kernel/mcp_stdio_transport_test.exs
@@ -1,6 +1,8 @@
 defmodule PtcRunner.Kernel.MCPStdioTransportTest do
   use ExUnit.Case, async: false
 
+  import PtcRunner.TestSupport.Eventually, only: [assert_eventually: 1]
+
   alias PtcRunner.Kernel.MCPStdioTransport
 
   @fixture Path.expand("../../support/mcp_stdio_fixture.exs", __DIR__)
@@ -727,24 +729,4 @@ defmodule PtcRunner.Kernel.MCPStdioTransportTest do
   catch
     :exit, _reason -> nil
   end
-
-  # 10 ms polls, so this is a ceiling on patience rather than a cost: a healthy
-  # machine satisfies these predicates in milliseconds and the budget is never
-  # spent. It has to cover the worst scheduling case instead of the median,
-  # because a saturated runner can starve a transport well past three seconds
-  # and the only symptom is an unreproducible failure.
-  defp assert_eventually(predicate, attempts \\ 1_500)
-
-  defp assert_eventually(predicate, attempts) when attempts > 0 do
-    if predicate.() do
-      :ok
-    else
-      receive do
-      after
-        10 -> assert_eventually(predicate, attempts - 1)
-      end
-    end
-  end
-
-  defp assert_eventually(_predicate, 0), do: flunk("condition did not become true")
 end

--- a/test/ptc_runner/kernel/provider_execution_lifecycle_test.exs
+++ b/test/ptc_runner/kernel/provider_execution_lifecycle_test.exs
@@ -1,6 +1,8 @@
 defmodule PtcRunner.Kernel.ProviderExecutionLifecycleTest do
   use ExUnit.Case, async: false
 
+  import PtcRunner.TestSupport.Eventually, only: [assert_eventually: 1]
+
   alias PtcRunner.Kernel.ApplicationPackage
   alias PtcRunner.Kernel.Capability
   alias PtcRunner.Kernel.CommandDiagnostic
@@ -537,19 +539,6 @@ defmodule PtcRunner.Kernel.ProviderExecutionLifecycleTest do
   end
 
   defp await_state(_owner_pid, _projection, 0), do: flunk("owner state never became ready")
-
-  defp assert_eventually(callback, attempts \\ 50_000)
-
-  defp assert_eventually(callback, attempts) when attempts > 0 do
-    if callback.() do
-      :ok
-    else
-      :erlang.yield()
-      assert_eventually(callback, attempts - 1)
-    end
-  end
-
-  defp assert_eventually(_callback, 0), do: flunk("condition did not become true")
 
   defp watch(processes) do
     Map.new(processes, fn {name, pid} -> {name, {pid, Process.monitor(pid)}} end)

--- a/test/ptc_runner/kernel/run_coordinator_execution_test.exs
+++ b/test/ptc_runner/kernel/run_coordinator_execution_test.exs
@@ -1,6 +1,8 @@
 defmodule PtcRunner.Kernel.RunCoordinatorExecutionTest do
   use ExUnit.Case, async: false
 
+  import PtcRunner.TestSupport.Eventually, only: [assert_eventually: 1]
+
   alias PtcRunner.Kernel.ApplicationPackage
   alias PtcRunner.Kernel.Capability
   alias PtcRunner.Kernel.CommandDiagnostic
@@ -553,14 +555,6 @@ defmodule PtcRunner.Kernel.RunCoordinatorExecutionTest do
   end
 
   defp run_started?(sink), do: Enum.any?(EventSink.events(sink), &(&1.type == "run-started"))
-
-  defp assert_eventually(callback, attempts \\ 1_000)
-
-  defp assert_eventually(callback, attempts) when attempts > 0 do
-    if callback.(), do: :ok, else: assert_eventually(callback, attempts - 1)
-  end
-
-  defp assert_eventually(_callback, 0), do: flunk("condition did not become true")
 
   defp stop_trace(pid) do
     :erlang.trace(pid, false, [:call])

--- a/test/support/eventually.ex
+++ b/test/support/eventually.ex
@@ -1,0 +1,94 @@
+defmodule PtcRunner.TestSupport.Eventually do
+  @moduledoc """
+  Polls a predicate until it holds, bounded by wall clock rather than attempts.
+
+  Five test files each carried their own `assert_eventually/2`, and the five
+  disagreed about what the bound meant: 100, 1_000, 1_500, 10_000, and 50_000
+  attempts, backed by no delay, `receive after 0`, `:erlang.yield/0`, or
+  `receive after 10`. An attempt count is not a budget — 100 undelayed attempts
+  expire in microseconds while 1_500 attempts at 10 ms cover fifteen seconds —
+  so the copies that spun without delay gave up almost immediately and reported
+  it as `condition did not become true`.
+
+  Two of them also spun a scheduler flat while waiting. `test/test_helper.exs`
+  caps `max_cases` at `System.schedulers_online()` precisely because sandbox
+  children starve under scheduler pressure, so a busy-wait here does not merely
+  burn its own core: it steals runtime from the tests running beside it and
+  makes *their* timing assertions flake.
+
+  The bound is therefore a duration, and the wait backs off in two phases. Note
+  that the timeout is spent only when the predicate never holds — a condition
+  that becomes true immediately returns immediately — so a generous default
+  costs a passing suite nothing and buys a wide margin against a loaded runner.
+
+  ## Why the first phase yields instead of sleeping
+
+  Some of these predicates are edge-triggered, not level-triggered. The
+  lifecycle tests watch for a committed closer on a session that then exits,
+  so the state they assert on exists for a moment and is gone; polling every
+  few milliseconds walks straight past it and then raises from `:sys.get_state`
+  against a dead pid. Their original loop caught it by polling as fast as the
+  scheduler allowed, which is why replacing that with a plain sleep broke them.
+
+  So the opening stretch polls continuously via `:erlang.yield/0`, which is
+  tight enough for an edge and still hands the scheduler to everything else,
+  and only after that does the wait become a real sleep. That bounds the busy
+  phase — the previous copies had no bound on theirs — while keeping the long
+  tail free.
+
+  This is a polling helper, not a substitute for synchronisation. Where a test
+  can observe the transition directly, a monitor or a message from the process
+  under test remains the better assertion; this exists for the cases that can
+  only be observed by looking again.
+  """
+
+  import ExUnit.Assertions, only: [flunk: 1]
+
+  # Covers the worst scheduling case rather than the median. The transport
+  # tests documented needing well past three seconds on a saturated runner,
+  # and being generous here is free unless the assertion is already failing.
+  @default_timeout_ms 15_000
+
+  # How long to poll continuously before backing off. Long enough to cover an
+  # edge-triggered predicate on a loaded machine, short enough that a genuinely
+  # absent condition stops burning runtime almost immediately.
+  @yield_phase_ms 100
+
+  # Long enough that polling costs nothing measurable, short enough that it
+  # does not add visible latency to a condition that resolves late.
+  @poll_interval_ms 5
+
+  @doc """
+  Asserts `predicate` returns a truthy value within the module's budget.
+
+  Returns `:ok` as soon as it holds. Fails the test if the deadline passes
+  first, naming the budget that was spent. The budget is deliberately not a
+  parameter: every call site wants "as long as a loaded runner might need",
+  and no caller has yet wanted anything else.
+  """
+  @spec assert_eventually((-> as_boolean(term()))) :: :ok
+  def assert_eventually(predicate) when is_function(predicate, 0) do
+    started_at_ms = System.monotonic_time(:millisecond)
+    poll(predicate, started_at_ms + @default_timeout_ms, started_at_ms + @yield_phase_ms)
+  end
+
+  defp poll(predicate, deadline_ms, yield_until_ms) do
+    cond do
+      predicate.() ->
+        :ok
+
+      System.monotonic_time(:millisecond) >= deadline_ms ->
+        flunk("condition did not become true within #{@default_timeout_ms}ms")
+
+      System.monotonic_time(:millisecond) < yield_until_ms ->
+        :erlang.yield()
+        poll(predicate, deadline_ms, yield_until_ms)
+
+      true ->
+        receive do
+        after
+          @poll_interval_ms -> poll(predicate, deadline_ms, yield_until_ms)
+        end
+    end
+  end
+end


### PR DESCRIPTION
Three fixes found while reducing suite wall-clock. Distinct mechanisms, one commit each, so any one can be reverted alone.

---

## 1. `fix(test)` — the preflight fixture raced its own operation budget

`local_preflight_test.exs:427` built a session with `run_duration_ms: 1`. `begin_operation/2` seals that deadline **before** its call and the session re-checks it **on arrival**, so a budget the round-trip outruns is already expired when the server reads it — the session comes back `:provider_session_unavailable` and the fixture raises `MatchError` instead of testing the timeout.

This is what failed CI on #1197 (job 93126815505) while passing locally.

**No budget removes the race**, because the budget is also what the fixture then waits out — raising it only trades wall clock for margin. So the margin is sized from measurement and the residue is retried:

| | |
|---|---|
| round-trip, median | 6 µs |
| round-trip, p99 | 121 µs |
| round-trip, max under load | **~957 µs** |

A 1 ms budget sits exactly at the observed maximum. 100 ms clears it by two orders of magnitude; a setup that loses anyway restarts.

```
refused, 1ms budget, under load:     7 / 400
refused, 100ms budget, under load:   0 / 400
needed a retry, 1ms, under load:     2 / 400  (0 / 400 never converged)
needed a retry, 100ms, under load:   0 / 400
```

Only setup retries — the assertion still runs once, and an operation that cannot open in five attempts fails loudly rather than looking like a timeout.

---

## 2. `test(support)` — `assert_eventually` had five different bounds

Five files each carried a private copy that disagreed about what the bound meant: **100, 1_000, 1_500, 10_000 and 50_000 attempts**, backed by no delay, `receive after 0`, `:erlang.yield/0`, or `receive after 10`.

An attempt count is not a budget. 100 undelayed attempts expire in *microseconds*; 1_500 at 10 ms cover *fifteen seconds*. The undelayed copies gave up almost immediately and reported `condition did not become true` — which reads like a product failure and is actually the helper timing out sub-millisecond.

Two also spun a scheduler flat. `test_helper.exs` halves `max_cases` precisely because sandbox children starve under scheduler pressure, so a busy-wait steals runtime from tests running beside it and makes *their* timing assertions flake. That is a wall-clock cost as much as a correctness one.

### Why the first phase yields rather than sleeps

Some predicates are **edge-triggered**. The lifecycle tests watch for a committed closer on a session that then exits — the state exists for a moment and is gone. A flat 5 ms poll walks past it and then raises from `:sys.get_state` against a dead pid; **both lifecycle tests failed exactly that way against a sleep-only first draft.** The opening stretch therefore polls via `:erlang.yield/0` — tight enough for an edge, still hands the scheduler to everything else — and is *bounded*, where the previous busy-waits were not.

The budget is not a parameter: no call site passed one, all 23 want "as long as a loaded runner might need", and 15 s preserves the ceiling the transport tests documented needing. It is spent only when the predicate never holds.

Duplication gate: **baseline 78 → 77**, one resolved clone (the two undelayed copies). Baseline blessed.

---

## 3. `build(prepush)` — generated artifacts were only checked by CI

A push touching `lib/` could clear **every** local gate and still fail CI on a stale generated artifact:

- the staleness checks live in `precommit`
- `AGENTS.md` tells you *not* to run `precommit` before an ordinary push, because the hook gates it
- the hook runs the suite and `mix prepush`, which had none of them

The one gate that would have caught it was the one the project tells you to skip. #1197 passed the pre-push hook **twice** and still failed CI on `semantic_build_projection.json`.

Adds the three staleness checks to `prepush`, ordered first so they fail in seconds rather than after Dialyzer. Duplicated from `precommit` on purpose — the point is that they run on the path an ordinary push actually takes.

Cost: **3 s of a 97 s `mix prepush`**, against pushes already spending 179–220 s in the hook.

It earned its place immediately — it caught this branch's own projection going stale from the `mix.exs` edit, regenerated in the same commit.

`AGENTS.md` and the hook header both described the old contract; both updated, and `AGENTS.md` now says to run `mix regen` when one fires.

---

## Verification

- 145 tests across the six touched files, `--warnings-as-errors`
- `mix credo --strict` clean, `mix format --check-formatted` clean
- `mix prepush` green end to end (97 s)
- pre-push hook green (220 s)
- `codex review --base main` — round 1 raised the residual 100 ms race and the stale docs, both fixed here; round 2 clean