### PR TITLE
Memory observability: restore the soak gate, commit a heap baseline, soak the owner lifecycles

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -43,15 +43,16 @@ all issues before proceeding:
 
 1. `mix precommit` - format, compile (warnings-as-errors), credo, schema, spec, tests
 2. `mix prepush` - dialyzer, unused-deps
-3. `mix release.smoke` - deterministic root release checks, root + MCP soak,
-   `mix hex.build` package-content verification, schema/spec/bench baselines,
-   `mix docs --warnings-as-errors`, and the sibling `mcp_server` release smoke
+3. `MIX_ENV=prod mix hex.build` - package-content verification
+4. `MIX_ENV=dev mix docs --warnings-as-errors` - documentation gate
+5. `mix bench.check` - deterministic eval-reduction baseline
+6. `PTC_SOAK_ITERATIONS=3000 mix soak` - memory-leak soak suite
 
-`mix release.smoke` publishes nothing and supersedes the standalone `mix docs` /
-`mix hex.build` steps (set `PTC_SOAK_ITERATIONS` to tune soak duration; default
-`3000`). After the release commit lands on `main`, run the `Release` workflow
-manually with `skip_llm: true` as a CI dry run before tagging - see
-`docs/RELEASING.md`.
+None of these publish anything. Step 6 is the same suite the scheduled `Soak`
+workflow runs; run it locally at release time because the schedule may not have
+fired since the last change. After the release commit lands on `main`, run the
+`Release` workflow manually with `skip_llm: true` as a CI dry run before tagging
+- see `docs/RELEASING.md`.
 
 ## Step 4: Version bump
 

--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -1,0 +1,51 @@
+name: Soak
+
+# The memory-leak soak suite is excluded from `mix test` by default and is not
+# a per-PR gate: it is long-running and its signal is a trend across runs, not
+# a verdict on a single commit. It lives in its own workflow rather than in
+# `test.yml` so it can be dispatched manually without dragging the PR matrix
+# along, and so a red soak run never blocks an unrelated pull request.
+on:
+  schedule:
+    - cron: "37 3 * * 1"
+  workflow_dispatch:
+    inputs:
+      iterations:
+        description: "PTC_SOAK_ITERATIONS for this run"
+        required: false
+        default: "3000"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: soak-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  soak:
+    runs-on: ubuntu-latest
+    name: Memory soak
+    # The suite scales linearly with PTC_SOAK_ITERATIONS; 3000 iterations is
+    # roughly two orders of magnitude above the 100-iteration default.
+    timeout-minutes: 60
+    env:
+      MIX_ENV: test
+      HEX_SPONSOR: false
+      PTC_SOAK_ITERATIONS: ${{ github.event.inputs.iterations || '3000' }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Elixir environment
+        uses: ./.github/actions/setup-elixir
+        with:
+          cache-plt: 'false'
+          install-babashka: 'false'
+
+      - name: Compile
+        run: mix compile --warnings-as-errors
+
+      - name: Run the memory soak suite
+        run: mix soak

--- a/bench/README.md
+++ b/bench/README.md
@@ -51,5 +51,7 @@ path; the scripts re-add them so `:tprof` / `:msacc` load.
   meaningless; re-record on the target machine instead of reading the delta.
 - Repeated-churn memory growth is the soak suite's job, not `bench.check`'s. Run
   it with `mix soak` (`test/soak/`); the scheduled `Soak` workflow runs it weekly
-  at `PTC_SOAK_ITERATIONS=3000`. It currently covers `Lisp.run/2` and
-  `Prelude.Compiler.compile/1` — not the long-lived owner lifecycles.
+  at `PTC_SOAK_ITERATIONS=3000`. It covers `Lisp.run/2` and
+  `Prelude.Compiler.compile/1`, and — via `test/soak/lifecycle/` — the
+  long-lived owner families: credential lease, REPL, provider, analysis/trace,
+  and the `LocalFences` characterization.

--- a/bench/README.md
+++ b/bench/README.md
@@ -10,7 +10,8 @@ many concurrent multi-turn sessions).
 
 | Script | What it measures | Tool |
 |---|---|---|
-| `mix bench.check` | Deterministic release gate for sandbox child eval reductions vs committed baseline | custom Mix task |
+| `mix bench.check` | Deterministic release gate for sandbox child eval reductions vs committed baseline; also prints the heap table informationally | custom Mix task |
+| `mix bench.heap` / `heap_baseline.exs` | Heap cost of every embedding unit vs `baselines/heap.json`: idle floor without Mix, `Lisp.run`, `compile_bundle`, `Kernel.run`, concurrency 1..128 | custom Mix task |
 | `lisp_throughput.exs` | Per-program latency: parse / analyze / full run; per-archetype; latency under `parallel:` load | Benchee |
 | `lisp_profile.exs` | Function-level call_time + call_count, aggregated across the per-run sandbox processes | OTP `:tprof` |
 | `lisp_concurrency.exs` | Aggregate throughput vs concurrency; scheduler microstate; GC pressure | `:msacc` + `:erlang.statistics` |
@@ -18,7 +19,9 @@ many concurrent multi-turn sessions).
 ## Running
 
 ```bash
-mix bench.check
+mix bench.check                             # gates reductions, reports heap
+mix bench.heap                              # gates heap
+mix run bench/heap_baseline.exs             # reports heap; --write re-records
 mix run bench/lisp_throughput.exs
 mix run bench/lisp_profile.exs              # PROFILE_ITERS env var (default 3000)
 mix run bench/lisp_concurrency.exs
@@ -38,6 +41,14 @@ path; the scripts re-add them so `:tprof` / `:msacc` load.
   wall-clock timings stay informational: hosted runner timing noise is too large
   for a gate, and a single per-call `memory_bytes` sample cannot separate a leak
   from one-shot warmup.
+- `mix bench.heap` is the gating heap entry point; `mix bench.check` prints the
+  same table without failing on it. Byte metrics on a per-commit path invite the
+  reflexive re-baseline that is how a gate stops meaning anything, so the split
+  is deliberate: report where the metric is noisy, assert where it is stable.
+- Every heap figure is a heap figure, not RSS. `baselines/heap.json` records the
+  commit, OTP release, architecture, emulator flavor, and scheduler count it was
+  measured on, because none of those are portable. Comparing across them is
+  meaningless; re-record on the target machine instead of reading the delta.
 - Repeated-churn memory growth is the soak suite's job, not `bench.check`'s. Run
   it with `mix soak` (`test/soak/`); the scheduled `Soak` workflow runs it weekly
   at `PTC_SOAK_ITERATIONS=3000`. It currently covers `Lisp.run/2` and

--- a/bench/README.md
+++ b/bench/README.md
@@ -35,5 +35,10 @@ path; the scripts re-add them so `:tprof` / `:msacc` load.
 - Each `Lisp.run/2` spawns its own sandbox process, so `:tprof` is run
   with `report: :total` to aggregate across them.
 - `mix bench.check` gates child-process eval reductions. Child memory and
-  wall-clock timings stay informational; memory regressions are covered by the
-  release soak tests, and hosted runner timing noise is too large for a gate.
+  wall-clock timings stay informational: hosted runner timing noise is too large
+  for a gate, and a single per-call `memory_bytes` sample cannot separate a leak
+  from one-shot warmup.
+- Repeated-churn memory growth is the soak suite's job, not `bench.check`'s. Run
+  it with `mix soak` (`test/soak/`); the scheduled `Soak` workflow runs it weekly
+  at `PTC_SOAK_ITERATIONS=3000`. It currently covers `Lisp.run/2` and
+  `Prelude.Compiler.compile/1` — not the long-lived owner lifecycles.

--- a/bench/baselines/heap.json
+++ b/bench/baselines/heap.json
@@ -1,0 +1,180 @@
+{
+  "batches": 3,
+  "provenance": {
+    "architecture": "aarch64-apple-darwin25.4.0",
+    "commit": "aac74f3f36197f3165e8d422d6ea3b5469efc75e",
+    "dirty_cpu_schedulers": 10,
+    "elixir": "1.20.2",
+    "emu_flavor": "jit",
+    "erts": "17.0.3",
+    "logical_processors": 10,
+    "otp": "29",
+    "schedulers_online": 10,
+    "wordsize_bytes": 8
+  },
+  "rows": [
+    {
+      "metrics": {
+        "atom_bytes": 548267,
+        "atom_count": 17993,
+        "code_bytes": 9870658,
+        "ets_bytes": 990280,
+        "loaded_modules": 235,
+        "mix_modules": 0,
+        "process_count": 121,
+        "processes_bytes": 14471912,
+        "ptc_modules": 3,
+        "total_bytes": 56846043
+      },
+      "name": "floor_no_mix_idle",
+      "note": "started :ptc_runner in a child `elixir` VM; Mix is not on the path"
+    },
+    {
+      "metrics": {
+        "atom_bytes": 592817,
+        "atom_count": 19572,
+        "code_bytes": 10874132,
+        "ets_bytes": 1061480,
+        "loaded_modules": 276,
+        "mix_modules": 0,
+        "process_count": 121,
+        "processes_bytes": 14987800,
+        "ptc_modules": 35,
+        "total_bytes": 59253997
+      },
+      "name": "floor_no_mix_warm",
+      "note": "the same child after one Lisp.run/2, so lazy module loading has happened"
+    },
+    {
+      "metrics": {
+        "batches": 3,
+        "iterations_per_batch": 200,
+        "residual_bytes_per_iter": 20.14,
+        "unit_bytes": 16776
+      },
+      "name": "lisp_trivial",
+      "note": "sandbox child heap at return; 200 iterations per batch"
+    },
+    {
+      "metrics": {
+        "batches": 3,
+        "iterations_per_batch": 200,
+        "residual_bytes_per_iter": 11.88,
+        "unit_bytes": 68280
+      },
+      "name": "lisp_collection_hofs",
+      "note": "sandbox child heap at return; 200 iterations per batch"
+    },
+    {
+      "metrics": {
+        "batches": 3,
+        "iterations_per_batch": 150,
+        "residual_bytes_per_iter": 22.773333333333333,
+        "unit_bytes": 1348512
+      },
+      "name": "lisp_large_binary",
+      "note": "sandbox child heap at return; 150 iterations per batch"
+    },
+    {
+      "metrics": {
+        "batches": 3,
+        "iterations_per_batch": 200,
+        "residual_bytes_per_iter": -38.3,
+        "retained_bytes": 8296,
+        "unit_bytes": 8744
+      },
+      "name": "compile_bundle_1",
+      "note": "1 component(s); 200 iterations per batch"
+    },
+    {
+      "metrics": {
+        "batches": 3,
+        "iterations_per_batch": 100,
+        "residual_bytes_per_iter": 2.4,
+        "retained_bytes": 152898,
+        "unit_bytes": 142696
+      },
+      "name": "compile_bundle_20",
+      "note": "20 component(s); 100 iterations per batch"
+    },
+    {
+      "metrics": {
+        "batches": 3,
+        "iterations_per_batch": 150,
+        "residual_bytes_per_iter": -49.06666666666667,
+        "retained_bytes": 552,
+        "unit_bytes": 67808
+      },
+      "name": "kernel_run",
+      "note": "driver heap at return, excluding the sandbox children Kernel.run spawns; 150 iterations per batch"
+    },
+    {
+      "metrics": {
+        "batches": 3,
+        "iterations_per_batch": 150,
+        "residual_bytes_per_iter": 52.85333333333333,
+        "retained_bytes": 648,
+        "unit_bytes": 75816
+      },
+      "name": "kernel_run_capabilities_events",
+      "note": "driver heap at return, excluding the sandbox children Kernel.run spawns; 150 iterations per batch"
+    },
+    {
+      "metrics": {
+        "peak_bytes_per_run": 968208,
+        "peak_total_bytes": 968208,
+        "samples_observed": 15,
+        "worker_heap_bytes_median": 67808,
+        "worker_heap_bytes_total": 67808
+      },
+      "name": "concurrency_1",
+      "note": "worker_* gate and are deterministic; peak_* are sampled diagnostics (median of 9 trials) and exclude nothing but resolve nothing either"
+    },
+    {
+      "metrics": {
+        "peak_bytes_per_run": 254700,
+        "peak_total_bytes": 2037600,
+        "samples_observed": 14,
+        "worker_heap_bytes_median": 67808,
+        "worker_heap_bytes_total": 542512
+      },
+      "name": "concurrency_8",
+      "note": "worker_* gate and are deterministic; peak_* are sampled diagnostics (median of 9 trials) and exclude nothing but resolve nothing either"
+    },
+    {
+      "metrics": {
+        "peak_bytes_per_run": 131901,
+        "peak_total_bytes": 4220848,
+        "samples_observed": 17,
+        "worker_heap_bytes_median": 67808,
+        "worker_heap_bytes_total": 2170160
+      },
+      "name": "concurrency_32",
+      "note": "worker_* gate and are deterministic; peak_* are sampled diagnostics (median of 9 trials) and exclude nothing but resolve nothing either"
+    },
+    {
+      "metrics": {
+        "peak_bytes_per_run": 86046,
+        "peak_total_bytes": 5506992,
+        "samples_observed": 23,
+        "worker_heap_bytes_median": 67808,
+        "worker_heap_bytes_total": 4340384
+      },
+      "name": "concurrency_64",
+      "note": "worker_* gate and are deterministic; peak_* are sampled diagnostics (median of 9 trials) and exclude nothing but resolve nothing either"
+    },
+    {
+      "metrics": {
+        "peak_bytes_per_run": 63313,
+        "peak_total_bytes": 8104128,
+        "samples_observed": 31,
+        "worker_heap_bytes_median": 67808,
+        "worker_heap_bytes_total": 8680200
+      },
+      "name": "concurrency_128",
+      "note": "worker_* gate and are deterministic; peak_* are sampled diagnostics (median of 9 trials) and exclude nothing but resolve nothing either"
+    }
+  ],
+  "threshold": 1.25,
+  "version": 1
+}

--- a/bench/heap_baseline.exs
+++ b/bench/heap_baseline.exs
@@ -1,0 +1,26 @@
+# Heap baseline for the PtcRunner embedding units — use-case rows 1..9 of
+# docs/plans/memory-observability.md.
+#
+# Run:  mix run bench/heap_baseline.exs             # measure and report
+#       mix run bench/heap_baseline.exs --write     # re-record the baseline
+#
+# The measurement, comparison, and baseline file all live in
+# `Mix.Tasks.Bench.Heap`, because `mix bench.check` prints the same table and
+# copying either half here would let the two drift. This script is the
+# `mix run` entry point the other bench scripts are reached through; the task
+# is the gating one.
+#
+# Re-recording is a deliberate act. A heap baseline invites the reflexive bump
+# the moment it goes red, which is how a gate stops meaning anything. Any bump
+# needs a written cause in the commit body, same as the reductions baseline.
+
+case System.argv() do
+  [] ->
+    Mix.Tasks.Bench.Heap.report()
+
+  ["--write"] ->
+    Mix.Task.run("bench.heap", ["--write-baseline"])
+
+  other ->
+    Mix.raise("usage: mix run bench/heap_baseline.exs [--write]; got #{Enum.join(other, " ")}")
+end

--- a/lib/mix/tasks/bench.check.ex
+++ b/lib/mix/tasks/bench.check.ex
@@ -8,7 +8,10 @@ defmodule Mix.Tasks.Bench.Check do
 
   This task gates `eval_reductions` collected from the sandbox child process.
   Child `memory_bytes` and wall-clock duration are reported as informational
-  metrics; memory regressions are covered by the release soak tests.
+  metrics: runner timing noise is too large for a gate, and a single per-call
+  `memory_bytes` sample cannot separate a leak from one-shot warmup. Repeated
+  churn growth is the soak suite's job — `mix soak`, run weekly by the scheduled
+  `Soak` workflow.
   """
 
   use Mix.Task

--- a/lib/mix/tasks/bench.check.ex
+++ b/lib/mix/tasks/bench.check.ex
@@ -5,6 +5,7 @@ defmodule Mix.Tasks.Bench.Check do
 
       mix bench.check
       mix bench.check --write-baseline
+      mix bench.check --skip-heap
 
   This task gates `eval_reductions` collected from the sandbox child process.
   Child `memory_bytes` and wall-clock duration are reported as informational
@@ -12,10 +13,19 @@ defmodule Mix.Tasks.Bench.Check do
   `memory_bytes` sample cannot separate a leak from one-shot warmup. Repeated
   churn growth is the soak suite's job — `mix soak`, run weekly by the scheduled
   `Soak` workflow.
+
+  It then prints the `mix bench.heap` table against `bench/baselines/heap.json`,
+  **informationally**. Heap figures are whole-VM measurements with real noise,
+  and a byte gate on a per-commit path invites the reflexive re-baseline that
+  the reductions baseline has already seen once. `mix bench.heap` is the gating
+  entry point for anyone who wants the check to fail, and the soak suite is
+  where repeated-churn growth is hard-asserted.
   """
 
   use Mix.Task
 
+  alias Mix.Tasks.Bench.Heap
+  alias PtcRunner.Bench.Baseline
   alias PtcRunner.Lisp
 
   @default_baseline Path.join(["bench", "baselines", "lisp_eval.json"])
@@ -68,6 +78,10 @@ defmodule Mix.Tasks.Bench.Check do
 
     results = measure_all(samples, warmup)
 
+    # The heap table runs before the reductions gate can raise, so a reductions
+    # regression does not hide the heap numbers a reader would want next to it.
+    unless opts[:skip_heap], do: Heap.report()
+
     if opts[:write_baseline] do
       write_baseline!(baseline_path, threshold, samples, warmup, results)
     else
@@ -83,7 +97,8 @@ defmodule Mix.Tasks.Bench.Check do
           threshold: :float,
           samples: :integer,
           warmup: :integer,
-          write_baseline: :boolean
+          write_baseline: :boolean,
+          skip_heap: :boolean
         ],
         aliases: [b: :baseline]
       )
@@ -97,7 +112,8 @@ defmodule Mix.Tasks.Bench.Check do
       threshold: Keyword.get(opts, :threshold, @default_threshold),
       samples: Keyword.get(opts, :samples, @default_samples),
       warmup: Keyword.get(opts, :warmup, @default_warmup),
-      write_baseline: Keyword.get(opts, :write_baseline, false)
+      write_baseline: Keyword.get(opts, :write_baseline, false),
+      skip_heap: Keyword.get(opts, :skip_heap, false)
     ]
     |> validate_opts!()
   end
@@ -137,9 +153,9 @@ defmodule Mix.Tasks.Bench.Check do
         name: scenario.name,
         program: scenario.program,
         samples: samples,
-        eval_reductions: median(Enum.map(measurements, & &1.eval_reductions)),
+        eval_reductions: Baseline.median(Enum.map(measurements, & &1.eval_reductions)),
         memory_bytes: Enum.max(Enum.map(measurements, & &1.memory_bytes)),
-        duration_ms: median(Enum.map(measurements, & &1.duration_ms))
+        duration_ms: Baseline.median(Enum.map(measurements, & &1.duration_ms))
       }
     end)
   end
@@ -166,24 +182,23 @@ defmodule Mix.Tasks.Bench.Check do
   end
 
   defp write_baseline!(path, threshold, samples, warmup, results) do
-    File.mkdir_p!(Path.dirname(path))
-
-    baseline = %{
+    Baseline.write!(path, %{
       "version" => 1,
       "threshold" => threshold,
       "samples" => samples,
       "warmup" => warmup,
+      # This baseline keeps its original `elixir`/`otp` keys rather than moving
+      # to the richer `provenance` block `bench.heap` writes. Reformatting it
+      # would mean rewriting the committed reduction numbers, and those are only
+      # ever bumped with a written cause.
       "elixir" => System.version(),
       "otp" => System.otp_release(),
       "scenarios" => Enum.map(results, &encode_result/1)
-    }
-
-    File.write!(path, Jason.encode!(baseline, pretty: true) <> "\n")
-    Mix.shell().info("Wrote #{path}")
+    })
   end
 
   defp check_baseline!(path, threshold, results) do
-    baseline = read_baseline!(path)
+    baseline = Baseline.read!(path)
     baseline_by_name = Map.new(baseline["scenarios"], &{&1["name"], &1})
 
     failures =
@@ -200,19 +215,6 @@ defmodule Mix.Tasks.Bench.Check do
     end
 
     Mix.shell().info("Performance check passed.")
-  end
-
-  defp read_baseline!(path) do
-    case File.read(path) do
-      {:ok, json} ->
-        Jason.decode!(json)
-
-      {:error, :enoent} ->
-        Mix.raise("missing baseline #{path}; run mix bench.check --write-baseline")
-
-      {:error, reason} ->
-        Mix.raise("could not read baseline #{path}: #{inspect(reason)}")
-    end
   end
 
   defp check_result(result, expected, threshold) do
@@ -261,10 +263,5 @@ defmodule Mix.Tasks.Bench.Check do
       "memory_bytes" => result.memory_bytes,
       "duration_ms" => result.duration_ms
     }
-  end
-
-  defp median(values) do
-    sorted = Enum.sort(values)
-    Enum.at(sorted, div(length(sorted), 2))
   end
 end

--- a/lib/mix/tasks/bench.heap.ex
+++ b/lib/mix/tasks/bench.heap.ex
@@ -33,11 +33,12 @@ defmodule Mix.Tasks.Bench.Heap do
     `lisp_*` rows this is `step.usage.memory_bytes`, the sandbox child's
     `Process.info(self(), :memory)` (`sandbox.ex`). For the `compile_*` and
     `kernel_*` rows it is the same reading taken in a dedicated driver process.
-    **`Kernel.run/2` spawns its own sandbox children, so the `kernel_*` driver
-    figure excludes them** — `concurrency_*` is the row that sees the whole
-    system.
-  * `retained_bytes` — `PtcRunner.Lisp.RetainedSize.bytes/1` of the durable
-    artifact the row produces, or `null` when the value is `:oversized`.
+    **`PtcRunner.Kernel.run/2` spawns its own sandbox children, so the
+    `kernel_*` driver figure excludes them** — `concurrency_*` is the row that
+    sees the whole system.
+  * `retained_bytes` — the retained size of the durable artifact the row
+    produces, from PtcRunner.Lisp.RetainedSize, or `null` when that module
+    answers `:oversized`.
   * `residual_bytes_per_iter` — repeated-batch residual. K equal batches of N
     iterations with a system-wide GC at each boundary; the reported rate is
     `(endpoint_K - endpoint_1) / ((K - 1) * N)` over `:erlang.memory(:total)`.

--- a/lib/mix/tasks/bench.heap.ex
+++ b/lib/mix/tasks/bench.heap.ex
@@ -1,0 +1,694 @@
+defmodule Mix.Tasks.Bench.Heap do
+  @shortdoc "Measure PtcRunner heap use cases against a committed baseline"
+  @moduledoc """
+  Measures the heap cost of the PtcRunner embedding units and compares them
+  against `bench/baselines/heap.json`.
+
+      mix bench.heap                  # measure, compare, fail on regression
+      mix bench.heap --write-baseline # re-record the committed baseline
+      mix bench.heap --report         # measure and print, never fail
+
+  `mix bench.check` calls `report/1` to print the same table informationally
+  alongside the eval-reduction gate. This task is the gating entry point; run
+  it deliberately, at release time or from the scheduled `Soak` workflow.
+
+  ## Rows
+
+  | row | what it sizes |
+  |---|---|
+  | `floor_no_mix_idle` | resident cost of a started `:ptc_runner` with no Mix on the path |
+  | `floor_no_mix_warm` | the same child after one `Lisp.run/2`, so lazy loading has happened |
+  | `lisp_trivial` | the cheapest possible `Lisp.run/2` unit |
+  | `lisp_collection_hofs` | allocation-heavy builtins |
+  | `lisp_large_binary` | refc-binary construction and its residual |
+  | `compile_bundle_1` | per-artifact resident cost of a compiled bundle |
+  | `compile_bundle_20` | whether bundle cost scales linearly in components |
+  | `kernel_run` | the real embedding unit |
+  | `kernel_run_capabilities_events` | the same unit with a capability and an event sink |
+  | `concurrency_N` | heap per concurrent `Kernel.run`, for N in 1/8/32/64/128 |
+
+  ## Metrics
+
+  * `unit_bytes` — the workload's own heap at return, before any GC. For the
+    `lisp_*` rows this is `step.usage.memory_bytes`, the sandbox child's
+    `Process.info(self(), :memory)` (`sandbox.ex`). For the `compile_*` and
+    `kernel_*` rows it is the same reading taken in a dedicated driver process.
+    **`Kernel.run/2` spawns its own sandbox children, so the `kernel_*` driver
+    figure excludes them** — `concurrency_*` is the row that sees the whole
+    system.
+  * `retained_bytes` — `PtcRunner.Lisp.RetainedSize.bytes/1` of the durable
+    artifact the row produces, or `null` when the value is `:oversized`.
+  * `residual_bytes_per_iter` — repeated-batch residual. K equal batches of N
+    iterations with a system-wide GC at each boundary; the reported rate is
+    `(endpoint_K - endpoint_1) / ((K - 1) * N)` over `:erlang.memory(:total)`.
+    Batch 1 is deliberately excluded: it carries lazy module loading and
+    first-use interning, and a single before/after delta cannot tell that
+    one-shot cost apart from a linear leak. **At these iteration counts the
+    metric has no resolution below roughly half a kilobyte per iteration** —
+    see `@metric_floors`. It is here to be read as a trend; the soak suite is
+    where residual growth is hard-asserted, because only there is the workload
+    repeated enough for a slope to outrun the VM's own drift.
+  * `worker_heap_bytes_total` / `worker_heap_bytes_median` — `concurrency_*`
+    only. Each concurrent worker reports its own heap at return, so these are
+    deterministic and are what this row gates on. Like the `kernel_*` rows they
+    exclude the sandbox children.
+  * `peak_total_bytes` / `peak_bytes_per_run` — `concurrency_*` only, from a
+    sampling process reading `:erlang.memory(:total)`. This is the only sample
+    that sees the sandbox children, and it is **diagnostic, never compared**:
+    `:erlang.memory/0` walks every allocator, so the sampler lands ~10 reads on
+    a sub-millisecond run and the figure moved by more than 2x between runs of
+    the unchanged workload. `samples_observed` records that coverage.
+
+  Every figure is a heap figure, not RSS. Allocator carrier fragmentation and
+  resident-set growth are invisible here by construction; the plan puts both in
+  the diagnostic tier, and neither is sampled at all by this task.
+  """
+
+  use Mix.Task
+
+  alias PtcRunner.Bench.Baseline
+  alias PtcRunner.Bench.Floor
+  alias PtcRunner.Kernel
+  alias PtcRunner.Kernel.Capability
+  alias PtcRunner.Kernel.Component
+  alias PtcRunner.Kernel.EventSink
+  alias PtcRunner.Kernel.Limits
+  alias PtcRunner.Kernel.MissionEnvironment
+  alias PtcRunner.Kernel.RunConfig
+  alias PtcRunner.Kernel.WorkflowEnvironment
+  alias PtcRunner.Lisp
+  alias PtcRunner.Lisp.RetainedSize
+
+  @default_baseline Path.join(["bench", "baselines", "heap.json"])
+
+  # Memory is noisier than reductions, and every row here is a whole-VM
+  # measurement rather than a counter read out of one process. The ratio gate
+  # is paired with an absolute floor per metric so a row whose baseline is a
+  # handful of bytes cannot fail on rounding.
+  @default_threshold 1.25
+  @default_batches 3
+
+  # `unit_bytes` is a single process's heap at one instant, so it lands wherever
+  # that process's last GC left it. A 7-sample median still swung by ~30 KB
+  # between runs of the unchanged `lisp_collection_hofs` workload; 25 settles it.
+  @median_samples 25
+
+  # Absolute slack added on top of `baseline * threshold`, per metric. Below
+  # these magnitudes a "regression" is measurement noise, not a signal. Each
+  # number comes from repeated runs of the unchanged workload, not from
+  # rounding: six clean `--report` runs put `residual_bytes_per_iter` anywhere
+  # in -445..+444 B/iter on rows whose true residual is ~0, so anything under
+  # half a kilobyte per iteration is indistinguishable from the VM's own drift
+  # at these iteration counts.
+  @metric_floors %{
+    "unit_bytes" => 16_384,
+    "retained_bytes" => 4_096,
+    "residual_bytes_per_iter" => 512,
+    "worker_heap_bytes_total" => 262_144,
+    "worker_heap_bytes_median" => 16_384,
+    "total_bytes" => 4_194_304,
+    "processes_bytes" => 2_097_152,
+    "code_bytes" => 2_097_152,
+    "ets_bytes" => 524_288,
+    "atom_bytes" => 262_144,
+    "atom_count" => 4_000,
+    "loaded_modules" => 40,
+    "ptc_modules" => 40,
+    "process_count" => 20
+  }
+
+  # `mix_modules` deliberately has no floor. Its baseline is 0, so the ratio
+  # gate fails on the first Mix module the child loads — which is the only
+  # thing that would invalidate the floor rows.
+
+  # Recorded and printed, never compared. `peak_*` come from a sampler that
+  # gets ~10 reads per run and moved by more than 2x between runs of the
+  # unchanged workload; `samples_observed` is that sampler's own coverage, and
+  # `iterations_per_batch`/`batches` are the harness configuration rather than
+  # anything the runtime can regress.
+  @diagnostic_metrics ~w(peak_total_bytes peak_bytes_per_run samples_observed
+                         iterations_per_batch batches)
+
+  @lisp_rows [
+    %{
+      name: "lisp_trivial",
+      program: "(+ 1 (* 2 3) (- 10 4) (* (+ 1 1) 5))",
+      iterations: 200
+    },
+    %{
+      name: "lisp_collection_hofs",
+      program: "(reduce + 0 (map (fn [x] (* x x)) (filter odd? (range 0 200))))",
+      iterations: 200
+    },
+    %{
+      name: "lisp_large_binary",
+      program: ~S|(clojure.string/join "," (map str (range 0 4000)))|,
+      iterations: 150
+    }
+  ]
+
+  @concurrency_levels [1, 8, 32, 64, 128]
+
+  @impl Mix.Task
+  def run(args) do
+    Mix.Task.run("app.start")
+    opts = parse_args!(args)
+
+    cond do
+      opts[:write_baseline] -> write_baseline!(opts)
+      opts[:report] -> report(baseline: opts[:baseline], batches: opts[:batches])
+      true -> check!(opts)
+    end
+  end
+
+  @doc """
+  Measures every row and prints the comparison table without failing.
+
+  This is what `mix bench.check` calls: the heap table is informational there,
+  because a re-baseline reflex is the failure mode a byte gate invites, and the
+  hard assertions live in the soak suite where the workload is repeated enough
+  for a slope to mean something.
+  """
+  @spec report(keyword()) :: :ok
+  def report(opts \\ []) do
+    path = Keyword.get(opts, :baseline, @default_baseline)
+    baseline = Baseline.read!(path)
+    rows = measure_all(Keyword.get(opts, :batches, @default_batches))
+
+    regressions = compare(rows, baseline)
+    print_table(rows, baseline, "informational")
+
+    if regressions == [] do
+      Mix.shell().info("Heap rows within baseline (informational).")
+    else
+      Mix.shell().info([
+        IO.ANSI.yellow(),
+        "Heap regression (informational, not gating):\n" <> Enum.join(regressions, "\n"),
+        IO.ANSI.reset()
+      ])
+    end
+
+    :ok
+  end
+
+  defp check!(opts) do
+    baseline = Baseline.read!(opts[:baseline])
+    rows = measure_all(opts[:batches])
+    regressions = compare(rows, baseline, opts[:threshold])
+    print_table(rows, baseline, "gating at #{opts[:threshold]}x")
+
+    if regressions != [] do
+      Mix.raise("heap regression detected:\n" <> Enum.join(regressions, "\n"))
+    end
+
+    Mix.shell().info("Heap check passed.")
+  end
+
+  defp write_baseline!(opts) do
+    rows = measure_all(opts[:batches])
+
+    Baseline.write!(opts[:baseline], %{
+      "version" => 1,
+      "threshold" => opts[:threshold],
+      "batches" => opts[:batches],
+      "provenance" => Baseline.provenance(),
+      "rows" => rows
+    })
+  end
+
+  # ── argument handling ────────────────────────────────────────────────────
+
+  defp parse_args!(args) do
+    {opts, rest, invalid} =
+      OptionParser.parse(args,
+        strict: [
+          baseline: :string,
+          threshold: :float,
+          batches: :integer,
+          write_baseline: :boolean,
+          report: :boolean
+        ],
+        aliases: [b: :baseline]
+      )
+
+    if rest != [] or invalid != [] do
+      Mix.raise("invalid arguments: #{Enum.join(args, " ")}")
+    end
+
+    parsed = [
+      baseline: Keyword.get(opts, :baseline, @default_baseline),
+      threshold: Keyword.get(opts, :threshold, @default_threshold),
+      batches: Keyword.get(opts, :batches, @default_batches),
+      write_baseline: Keyword.get(opts, :write_baseline, false),
+      report: Keyword.get(opts, :report, false)
+    ]
+
+    cond do
+      not is_float(parsed[:threshold]) or parsed[:threshold] < 1.0 ->
+        Mix.raise("--threshold must be a float >= 1.0")
+
+      # Two batches would leave a single interval, so the residual rate would
+      # rest entirely on the batch that still carries warmup effects.
+      not is_integer(parsed[:batches]) or parsed[:batches] < 3 ->
+        Mix.raise("--batches must be an integer >= 3")
+
+      parsed[:write_baseline] and parsed[:report] ->
+        Mix.raise("--write-baseline and --report are mutually exclusive")
+
+      true ->
+        parsed
+    end
+  end
+
+  # ── measurement ──────────────────────────────────────────────────────────
+
+  defp measure_all(batches) do
+    Mix.shell().info("==> measuring PtcRunner heap use cases (#{batches} batches per row)")
+
+    floor_rows() ++
+      Enum.map(@lisp_rows, &lisp_row(&1, batches)) ++
+      [
+        compile_row("compile_bundle_1", 1, 200, batches),
+        compile_row("compile_bundle_20", 20, 100, batches),
+        kernel_row("kernel_run", :plain, 150, batches),
+        kernel_row("kernel_run_capabilities_events", :capabilities, 150, batches)
+      ] ++
+      Enum.map(@concurrency_levels, &concurrency_row/1)
+  end
+
+  # Row 1. The floor an embedder budgets first. `mix run` keeps Mix and the
+  # compiler resident, so measuring it in this VM would report a floor no
+  # embedded host ever pays. A child `elixir` boots the application with the
+  # same code path and no Mix, and reports back what it actually loaded.
+  defp floor_rows do
+    floor = Floor.measure!()
+
+    [
+      %{
+        "name" => "floor_no_mix_idle",
+        "note" => "started :ptc_runner in a child `elixir` VM; Mix is not on the path",
+        "metrics" => Map.fetch!(floor, "idle")
+      },
+      %{
+        "name" => "floor_no_mix_warm",
+        "note" => "the same child after one Lisp.run/2, so lazy module loading has happened",
+        "metrics" => Map.fetch!(floor, "warm")
+      }
+    ]
+  end
+
+  defp lisp_row(%{name: name, program: program, iterations: iterations}, batches) do
+    unit = fn ->
+      {:ok, step} = Lisp.run(program)
+      step
+    end
+
+    warmup(unit)
+
+    unit_bytes =
+      Baseline.median(for _ <- 1..@median_samples, do: Map.fetch!(unit.().usage, :memory_bytes))
+
+    %{
+      "name" => name,
+      "note" => "sandbox child heap at return; #{iterations} iterations per batch",
+      "metrics" =>
+        Map.merge(
+          %{"unit_bytes" => unit_bytes},
+          batch_residual(fn -> unit.() end, iterations, batches)
+        )
+    }
+  end
+
+  defp compile_row(name, component_count, iterations, batches) do
+    components = components(component_count)
+
+    unit = fn ->
+      {:ok, bundle} = Kernel.compile_bundle(components)
+      bundle
+    end
+
+    warmup(unit)
+
+    %{
+      "name" => name,
+      "note" => "#{component_count} component(s); #{iterations} iterations per batch",
+      "metrics" =>
+        %{
+          "unit_bytes" => driver_heap_bytes(unit),
+          "retained_bytes" => retained_bytes(unit.())
+        }
+        |> Map.merge(batch_residual(unit, iterations, batches))
+    }
+  end
+
+  defp kernel_row(name, shape, iterations, batches) do
+    unit = kernel_unit(shape)
+    warmup(unit)
+
+    %{
+      "name" => name,
+      "note" =>
+        "driver heap at return, excluding the sandbox children Kernel.run spawns; " <>
+          "#{iterations} iterations per batch",
+      "metrics" =>
+        %{
+          "unit_bytes" => driver_heap_bytes(unit),
+          "retained_bytes" => retained_bytes(unit.())
+        }
+        |> Map.merge(batch_residual(unit, iterations, batches))
+    }
+  end
+
+  # Row 9. The only row that sees the whole system — and the only place a
+  # sampler is unavoidable, because the sandbox children `Kernel.run` spawns
+  # are gone by the time anything can ask them how big they got.
+  #
+  # `:erlang.memory(:total)` costs tens of microseconds because it walks every
+  # allocator, and a concurrency-1 run finishes in well under a millisecond, so
+  # the sampler manages ~10 reads per run. That is a lottery, not a measurement:
+  # across repeated runs of the unchanged workload the sampled peak moved by
+  # more than 2x. The sampled figures are therefore recorded and printed but
+  # never compared — the plan's diagnostic tier — and the gating metric for
+  # this row is the deterministic one below.
+  defp concurrency_row(concurrency) do
+    unit = kernel_unit(:plain)
+    warmup(unit)
+
+    trials = for _ <- 1..9, do: sample_concurrent_peak(unit, concurrency)
+    peak = Baseline.median(Enum.map(trials, & &1.peak_delta_bytes))
+
+    %{
+      "name" => "concurrency_#{concurrency}",
+      "note" =>
+        "worker_* gate and are deterministic; peak_* are sampled diagnostics " <>
+          "(median of 9 trials) and exclude nothing but resolve nothing either",
+      "metrics" => %{
+        "worker_heap_bytes_total" => Baseline.median(Enum.map(trials, & &1.worker_heap_total)),
+        "worker_heap_bytes_median" => Baseline.median(Enum.map(trials, & &1.worker_heap_median)),
+        "peak_total_bytes" => peak,
+        "peak_bytes_per_run" => div(peak, concurrency),
+        "samples_observed" => Baseline.median(Enum.map(trials, & &1.samples))
+      }
+    }
+  end
+
+  defp warmup(unit) do
+    for _ <- 1..20, do: unit.()
+    gc_everywhere()
+  end
+
+  # The repeated-batch residual. A one-shot cost shows up in batch 1 only; a
+  # linear leak shows up in every batch, so the rate is taken across the
+  # batch-1..batch-K endpoints with batch 1 as the origin rather than as a
+  # measurement.
+  defp batch_residual(unit, iterations, batches) do
+    endpoints =
+      for _batch <- 1..batches do
+        for _ <- 1..iterations, do: unit.()
+        gc_everywhere()
+        :erlang.memory(:total)
+      end
+
+    first = List.first(endpoints)
+    last = List.last(endpoints)
+
+    %{
+      "residual_bytes_per_iter" => (last - first) / ((batches - 1) * iterations),
+      "iterations_per_batch" => iterations,
+      "batches" => batches
+    }
+  end
+
+  # `Process.info(self(), :memory)` taken inside a dedicated process the
+  # instant the workload returns — the same definition `Sandbox` uses for
+  # `usage.memory_bytes`, so the rows stay comparable.
+  defp driver_heap_bytes(unit) do
+    Baseline.median(for _ <- 1..@median_samples, do: driver_heap_once(unit))
+  end
+
+  defp driver_heap_once(unit) do
+    parent = self()
+    ref = make_ref()
+
+    {pid, monitor} =
+      spawn_monitor(fn ->
+        _value = unit.()
+        {:memory, bytes} = Process.info(self(), :memory)
+        send(parent, {ref, bytes})
+      end)
+
+    receive do
+      {^ref, bytes} ->
+        Process.demonitor(monitor, [:flush])
+        bytes
+
+      {:DOWN, ^monitor, :process, ^pid, reason} ->
+        Mix.raise("heap driver process died: #{inspect(reason)}")
+    end
+  end
+
+  defp sample_concurrent_peak(unit, concurrency) do
+    gc_everywhere()
+    base = :erlang.memory(:total)
+    parent = self()
+    ref = make_ref()
+    sampler = spawn_link(fn -> sample_loop(parent, base, 0, 0) end)
+
+    workers =
+      for _ <- 1..concurrency do
+        spawn_monitor(fn ->
+          _value = unit.()
+          {:memory, bytes} = Process.info(self(), :memory)
+          send(parent, {ref, bytes})
+        end)
+      end
+
+    # Each worker reports its own heap at return, so the deterministic figures
+    # do not depend on catching the workers alive. The monitor is what proves
+    # every worker actually finished — a missing report would otherwise just
+    # shrink the total and read as an improvement.
+    worker_heaps =
+      Enum.map(workers, fn {pid, monitor} ->
+        receive do
+          {:DOWN, ^monitor, :process, ^pid, :normal} ->
+            receive do
+              {^ref, bytes} -> bytes
+            after
+              0 -> Mix.raise("concurrent worker exited normally without reporting its heap")
+            end
+
+          {:DOWN, ^monitor, :process, ^pid, reason} ->
+            Mix.raise("concurrent worker died: #{inspect(reason)}")
+        end
+      end)
+
+    send(sampler, {:stop, self()})
+
+    receive do
+      {:peak, ^sampler, peak, samples} ->
+        %{
+          peak_delta_bytes: max(peak, 0),
+          samples: samples,
+          worker_heap_total: Enum.sum(worker_heaps),
+          worker_heap_median: Baseline.median(worker_heaps)
+        }
+    end
+  end
+
+  defp sample_loop(parent, base, peak, samples) do
+    peak = max(peak, :erlang.memory(:total) - base)
+
+    receive do
+      {:stop, ^parent} -> send(parent, {:peak, self(), peak, samples + 1})
+    after
+      0 -> sample_loop(parent, base, peak, samples + 1)
+    end
+  end
+
+  defp gc_everywhere do
+    Enum.each(Process.list(), &:erlang.garbage_collect/1)
+    :erlang.garbage_collect()
+    :ok
+  end
+
+  defp retained_bytes(value) do
+    case RetainedSize.bytes(value) do
+      bytes when is_integer(bytes) -> bytes
+      # `:oversized` is a real answer for anything holding builtin closures;
+      # recording it as a number would invent a measurement.
+      :oversized -> nil
+    end
+  end
+
+  # ── workloads ────────────────────────────────────────────────────────────
+
+  # Generic and domain-blind, per the repository prompt rules: the component
+  # bodies name nothing but their own index.
+  defp components(count) do
+    Enum.map(0..(count - 1), fn index ->
+      {:ok, component} =
+        Component.new(
+          id: "bench.c#{index}",
+          source: """
+          (ns bench.c#{index})
+          (defn value [x] (+ x #{index}))
+          (defn twice [x] (value (value x)))
+          """,
+          origin: "bench"
+        )
+
+      component
+    end)
+  end
+
+  defp kernel_entry(:plain), do: "(return (bench.c0/twice data/seed))"
+  defp kernel_entry(:capabilities), do: ~S|(return (bench.cap/probe data/seed))|
+
+  # The bundle and both environments are durable host artifacts, built once and
+  # reused across runs; only the sink and the one-shot `RunConfig` are per-run.
+  # Compiling the bundle inside the loop would make this row a `compile_bundle`
+  # row wearing a different name.
+  #
+  # `EventSink.stop/1` is part of the unit. `Runner` finalizes the sink but
+  # never stops it — the sink outlives the run precisely so the host can read
+  # its events, and it only dies with its owner. A loop that never stops one
+  # accumulates a process per run, and the residual would measure this
+  # harness's omission rather than anything about PtcRunner.
+  defp kernel_unit(shape) do
+    {:ok, bundle} = Kernel.compile_bundle(bundle_components(shape))
+    {:ok, workflow} = WorkflowEnvironment.new(bundle: bundle, capabilities: capabilities(shape))
+    {:ok, mission} = MissionEnvironment.new([])
+    {:ok, limits} = Limits.new()
+    entry = kernel_entry(shape)
+
+    fn ->
+      {:ok, sink} = EventSink.start(:normal, limits, run_id: "bench-heap")
+
+      {:ok, config} =
+        RunConfig.new(
+          workflow_environment: workflow,
+          mission_environment: mission,
+          input: %{"seed" => 3},
+          limits: limits,
+          event_sink: sink
+        )
+
+      {:ok, result} = Kernel.run(entry, config)
+      :ok = EventSink.stop(sink)
+      result
+    end
+  end
+
+  defp bundle_components(:plain), do: components(1)
+
+  defp bundle_components(:capabilities) do
+    {:ok, component} =
+      Component.new(
+        id: "bench.cap",
+        source: """
+        (ns bench.cap)
+        (defn probe [x] (tool/bench-probe {"seed" x}))
+        """,
+        origin: "bench"
+      )
+
+    [component]
+  end
+
+  defp capabilities(:plain), do: []
+
+  defp capabilities(:capabilities) do
+    {:ok, capability} =
+      Capability.new(
+        name: "bench-probe",
+        description: "Echoes its argument back to the caller.",
+        effect: :read,
+        input_schema: %{"type" => "object"},
+        callback: fn arguments -> {:ok, arguments} end
+      )
+
+    [capability]
+  end
+
+  # ── comparison and printing ──────────────────────────────────────────────
+
+  defp compare(rows, baseline, threshold \\ nil) do
+    threshold = threshold || baseline["threshold"] || @default_threshold
+    by_name = Map.new(baseline["rows"], &{&1["name"], &1})
+
+    Enum.flat_map(rows, fn row ->
+      case Map.fetch(by_name, row["name"]) do
+        :error ->
+          ["#{row["name"]}: no baseline row (run mix bench.heap --write-baseline)"]
+
+        {:ok, expected} ->
+          compare_metrics(row, expected["metrics"] || %{}, threshold)
+      end
+    end)
+  end
+
+  defp compare_metrics(row, expected_metrics, threshold) do
+    Enum.flat_map(row["metrics"], fn {metric, actual} ->
+      expected = Map.get(expected_metrics, metric)
+
+      if comparable?(actual, expected) and exceeds?(actual, expected, metric, threshold) do
+        [
+          "#{row["name"]} #{metric}: #{fmt(actual)} > #{fmt(allowed(expected, metric, threshold))} " <>
+            "(baseline #{fmt(expected)})"
+        ]
+      else
+        []
+      end
+    end)
+  end
+
+  defp comparable?(actual, expected),
+    do: is_number(actual) and is_number(expected)
+
+  defp exceeds?(actual, expected, metric, threshold),
+    do: metric not in @diagnostic_metrics and actual > allowed(expected, metric, threshold)
+
+  # `max(expected, 0)` because a residual rate is legitimately negative on a
+  # quiet run. Multiplying a negative baseline by the threshold would *tighten*
+  # the allowance the further below zero the baseline sat, which is backwards;
+  # a negative baseline should contribute no slack and take none away.
+  defp allowed(expected, metric, threshold),
+    do: max(expected, 0) * threshold + Map.get(@metric_floors, metric, 0)
+
+  defp print_table(rows, baseline, mode) do
+    Mix.shell().info("")
+    Mix.shell().info("Heap baseline (#{mode}); recorded on #{provenance_line(baseline)}")
+    Mix.shell().info("")
+    Mix.shell().info("| Row | Metric | Measured | Baseline |")
+    Mix.shell().info("|---|---|---:|---:|")
+
+    by_name = Map.new(baseline["rows"] || [], &{&1["name"], &1})
+
+    Enum.each(rows, fn row ->
+      expected = get_in(by_name, [row["name"], "metrics"]) || %{}
+
+      row["metrics"]
+      |> Enum.sort_by(fn {metric, _} -> metric end)
+      |> Enum.each(fn {metric, actual} ->
+        Mix.shell().info(
+          "| #{row["name"]} | #{metric} | #{fmt(actual)} | #{fmt(Map.get(expected, metric))} |"
+        )
+      end)
+    end)
+
+    Mix.shell().info("")
+  end
+
+  defp provenance_line(baseline) do
+    provenance = baseline["provenance"] || %{}
+
+    "OTP #{provenance["otp"] || "?"} / #{provenance["architecture"] || "?"} / " <>
+      "#{provenance["schedulers_online"] || "?"} schedulers / commit " <>
+      String.slice(to_string(provenance["commit"] || "unknown"), 0, 8)
+  end
+
+  defp fmt(nil), do: "-"
+  defp fmt(value) when is_integer(value), do: Integer.to_string(value)
+  defp fmt(value) when is_float(value), do: Float.to_string(Float.round(value, 3))
+  defp fmt(value), do: inspect(value)
+end

--- a/lib/ptc_runner/bench/baseline.ex
+++ b/lib/ptc_runner/bench/baseline.ex
@@ -1,0 +1,80 @@
+defmodule PtcRunner.Bench.Baseline do
+  @moduledoc false
+  # Shared baseline-file plumbing for the `mix bench.*` tasks.
+  #
+  # A committed benchmark number is only readable next to the machine that
+  # produced it: heap and reduction figures do not carry across OTP releases,
+  # architectures, scheduler counts, or emulator flavors. Every baseline this
+  # module writes therefore records its own provenance, and every task that
+  # reads one gets the same accessors rather than its own copy.
+
+  @doc "Reads a committed baseline, raising a `Mix.raise` on a missing file."
+  @spec read!(Path.t()) :: map()
+  def read!(path) do
+    case File.read(path) do
+      {:ok, json} ->
+        Jason.decode!(json)
+
+      {:error, :enoent} ->
+        Mix.raise("missing baseline #{path}; run the owning task with --write-baseline")
+
+      {:error, reason} ->
+        Mix.raise("could not read baseline #{path}: #{inspect(reason)}")
+    end
+  end
+
+  @doc "Writes `contents` as pretty JSON, creating the baseline directory."
+  @spec write!(Path.t(), map()) :: :ok
+  def write!(path, contents) when is_map(contents) do
+    File.mkdir_p!(Path.dirname(path))
+    File.write!(path, Jason.encode!(contents, pretty: true) <> "\n")
+    Mix.shell().info("Wrote #{path}")
+  end
+
+  @doc """
+  Captures the environment a baseline was measured in.
+
+  None of these are portable, so a baseline that omits them cannot be checked
+  against anything: an OTP bump, a different word size, or a different
+  scheduler count moves the numbers on their own.
+  """
+  @spec provenance() :: map()
+  def provenance do
+    %{
+      "commit" => commit(),
+      "elixir" => System.version(),
+      "otp" => System.otp_release(),
+      "erts" => to_string(:erlang.system_info(:version)),
+      "architecture" => to_string(:erlang.system_info(:system_architecture)),
+      "emu_flavor" => to_string(:erlang.system_info(:emu_flavor)),
+      "wordsize_bytes" => :erlang.system_info({:wordsize, :internal}),
+      "schedulers_online" => System.schedulers_online(),
+      "dirty_cpu_schedulers" => :erlang.system_info(:dirty_cpu_schedulers),
+      "logical_processors" => logical_processors()
+    }
+  end
+
+  @doc "Median of a non-empty list of numbers."
+  @spec median([number()]) :: number()
+  def median([_ | _] = values) do
+    sorted = Enum.sort(values)
+    Enum.at(sorted, div(length(sorted), 2))
+  end
+
+  defp commit do
+    case System.cmd("git", ["rev-parse", "HEAD"], stderr_to_stdout: true) do
+      {sha, 0} -> String.trim(sha)
+      _ -> "unknown"
+    end
+  rescue
+    # `git` need not exist wherever a baseline is regenerated.
+    ErlangError -> "unknown"
+  end
+
+  defp logical_processors do
+    case :erlang.system_info(:logical_processors) do
+      count when is_integer(count) -> count
+      _unknown -> 0
+    end
+  end
+end

--- a/lib/ptc_runner/bench/floor.ex
+++ b/lib/ptc_runner/bench/floor.ex
@@ -1,0 +1,103 @@
+defmodule PtcRunner.Bench.Floor do
+  @moduledoc false
+  # Measures the idle resident floor of a started `:ptc_runner` with Mix off
+  # the code path.
+  #
+  # Measuring the floor inside `mix run` reports a number no embedded host ever
+  # pays: Mix and the compiler are resident, and they dominate `:code`. The
+  # honest floor is a fresh VM that boots the application and nothing else, so
+  # this spawns a child `elixir` over the same build path and asks it what it
+  # actually loaded.
+
+  @child_source """
+  sample = fn ->
+    Enum.each(Process.list(), &:erlang.garbage_collect/1)
+    memory = :erlang.memory()
+    loaded = :code.all_loaded()
+
+    count_prefix = fn prefix ->
+      Enum.count(loaded, fn {module, _file} ->
+        String.starts_with?(Atom.to_string(module), prefix)
+      end)
+    end
+
+    %{
+      "total_bytes" => memory[:total],
+      "processes_bytes" => memory[:processes],
+      "code_bytes" => memory[:code],
+      "ets_bytes" => memory[:ets],
+      "atom_bytes" => memory[:atom],
+      "loaded_modules" => length(loaded),
+      "ptc_modules" => count_prefix.("Elixir.PtcRunner"),
+      "mix_modules" => count_prefix.("Elixir.Mix"),
+      "process_count" => :erlang.system_info(:process_count),
+      "atom_count" => :erlang.system_info(:atom_count)
+    }
+  end
+
+  {:ok, _started} = Application.ensure_all_started(:ptc_runner)
+  idle = sample.()
+
+  # Only a handful of PtcRunner modules are loaded at the idle floor. Lazy
+  # module loading is the dominant one-shot cost, and it is invisible until
+  # something runs, so the warm sample is the number a host actually settles
+  # at rather than the one it boots at.
+  {:ok, _step} = PtcRunner.Lisp.run("(+ 1 (* 2 3) (- 10 4))")
+  warm = sample.()
+
+  report = %{"idle" => idle, "warm" => warm}
+  IO.puts("PTC_FLOOR " <> Base.encode64(:erlang.term_to_binary(report)))
+  """
+
+  @doc """
+  Boots a child `elixir` over the current build path and returns its floor.
+
+  Raises through `Mix.raise/1` rather than degrading to an in-VM measurement:
+  a floor that silently includes Mix is the exact number this row exists to
+  avoid publishing.
+  """
+  @spec measure!() :: %{binary() => %{binary() => integer()}}
+  def measure! do
+    args = Enum.flat_map(code_paths(), &["-pa", &1]) ++ ["-e", @child_source]
+
+    case System.cmd(elixir_executable!(), args, stderr_to_stdout: true) do
+      {output, 0} -> decode!(output)
+      {output, status} -> Mix.raise("floor measurement child exited #{status}:\n#{output}")
+    end
+  end
+
+  defp code_paths do
+    Mix.Project.build_path()
+    |> Path.join("lib/*/ebin")
+    |> Path.wildcard()
+    |> case do
+      [] ->
+        Mix.raise("no compiled applications under #{Mix.Project.build_path()}; run mix compile")
+
+      paths ->
+        paths
+    end
+  end
+
+  defp elixir_executable! do
+    System.find_executable("elixir") ||
+      Mix.raise("`elixir` is not on PATH; the no-Mix floor row cannot be measured")
+  end
+
+  # The child prints on a tagged line so a warning from the boot (deprecations,
+  # logger output) cannot be mistaken for the payload.
+  defp decode!(output) do
+    output
+    |> String.split("\n", trim: true)
+    |> Enum.find_value(fn line ->
+      case String.split(line, "PTC_FLOOR ", parts: 2) do
+        [_prefix, encoded] -> encoded
+        _no_tag -> nil
+      end
+    end)
+    |> case do
+      nil -> Mix.raise("floor measurement child printed no report:\n#{output}")
+      encoded -> encoded |> Base.decode64!() |> :erlang.binary_to_term([:safe])
+    end
+  end
+end

--- a/lib/ptc_runner/lisp.ex
+++ b/lib/ptc_runner/lisp.ex
@@ -288,8 +288,19 @@ defmodule PtcRunner.Lisp do
     `monotonic_time`, `system_time`; metadata `caller`,
     `program_bytes`, `signature_supplied?`.
   - `[:ptc_runner, :lisp, :execute, :stop]` — measurements `duration`,
-    `monotonic_time`, `result_bytes`, `prints_count`; metadata `caller`,
-    `program_bytes`, `signature_supplied?`, and semantic `outcome`.
+    `monotonic_time`, `result_bytes`, `prints_count`, `memory_bytes`,
+    `eval_reductions`; metadata `caller`, `program_bytes`,
+    `signature_supplied?`, and semantic `outcome`.
+
+    `duration` is in the emitter's native time unit, `result_bytes` is the
+    external size of the returned value, and `prints_count` the number of
+    prints. `memory_bytes` and `eval_reductions` are the sandbox child's own
+    figures, the same pair `step.usage` carries: `memory_bytes` is
+    `Process.info(child, :memory)` read the instant the result was ready — a
+    heap reading at return, not a peak and not RSS — and `eval_reductions` is
+    that child's reduction count. Both are `0` when a run failed before the
+    child reported, which is not the same as a run that used nothing, so read
+    `outcome` before charting either.
   - `[:ptc_runner, :lisp, :execute, :exception]` — measurements `duration`,
     `monotonic_time`; metadata `caller`, `program_bytes`,
     `signature_supplied?`, and `exception_class`. Exception reasons,
@@ -467,7 +478,7 @@ defmodule PtcRunner.Lisp do
 
     try do
       result = do_run(source, inner_opts)
-      {result_bytes, prints_count} = telemetry_result_stats(result)
+      stats = telemetry_result_stats(result)
       stopped_at = System.monotonic_time()
 
       :telemetry.execute(
@@ -475,8 +486,10 @@ defmodule PtcRunner.Lisp do
         %{
           duration: stopped_at - started_at,
           monotonic_time: stopped_at,
-          result_bytes: result_bytes,
-          prints_count: prints_count
+          result_bytes: stats.result_bytes,
+          prints_count: stats.prints_count,
+          memory_bytes: stats.memory_bytes,
+          eval_reductions: stats.eval_reductions
         },
         Map.put(metadata, :outcome, telemetry_outcome(result))
       )
@@ -630,13 +643,34 @@ defmodule PtcRunner.Lisp do
   end
 
   # Compute telemetry stop measurements from the run result.
+  #
+  # `Sandbox` already measures `memory_bytes` and `eval_reductions` and puts
+  # them in `step.usage`, so surfacing them costs nothing here and is the only
+  # way a host attached to the stop event can chart per-run heap. A run that
+  # failed before its child reported has no usage at all; those cases report
+  # `0` rather than a guess, and `outcome` is what distinguishes them.
   defp telemetry_result_stats({tag, %Step{} = step}) when tag in [:ok, :error] do
-    bytes = safe_term_bytes(Map.get(step, :return))
-    prints = safe_length(Map.get(step, :prints))
-    {bytes, prints}
+    usage = Map.get(step, :usage)
+
+    %{
+      result_bytes: safe_term_bytes(Map.get(step, :return)),
+      prints_count: safe_length(Map.get(step, :prints)),
+      memory_bytes: safe_usage(usage, :memory_bytes),
+      eval_reductions: safe_usage(usage, :eval_reductions)
+    }
   end
 
-  defp telemetry_result_stats(_other), do: {0, 0}
+  defp telemetry_result_stats(_other),
+    do: %{result_bytes: 0, prints_count: 0, memory_bytes: 0, eval_reductions: 0}
+
+  defp safe_usage(usage, key) when is_map(usage) do
+    case Map.get(usage, key) do
+      value when is_integer(value) and value >= 0 -> value
+      _absent_or_invalid -> 0
+    end
+  end
+
+  defp safe_usage(_usage, _key), do: 0
 
   defp safe_term_bytes(nil), do: 0
 

--- a/mix.exs
+++ b/mix.exs
@@ -81,7 +81,7 @@ defmodule PtcRunner.MixProject do
 
   def cli do
     [
-      preferred_envs: [precommit: :test, prepush: :test, coverage: :test]
+      preferred_envs: [precommit: :test, prepush: :test, coverage: :test, soak: :test]
     ]
   end
 
@@ -198,6 +198,13 @@ defmodule PtcRunner.MixProject do
       ],
       coverage: [
         "test --cover"
+      ],
+      # Memory-leak soak suite. Excluded from `mix test` by default
+      # (test/test_helper.exs) because it is long-running and its signal is a
+      # trend rather than a per-commit gate; the scheduled `Soak` workflow runs
+      # it at PTC_SOAK_ITERATIONS=3000.
+      soak: [
+        "test --only soak"
       ],
       # Regenerates the derived projection. Run this once before tagging a
       # release -- the release gate rejects a stale projection, and ordinary

--- a/test/ptc_runner/lisp_telemetry_test.exs
+++ b/test/ptc_runner/lisp_telemetry_test.exs
@@ -44,12 +44,49 @@ defmodule PtcRunner.LispTelemetryTest do
              }
 
       assert Map.keys(stop_meas) |> Enum.sort() ==
-               [:duration, :monotonic_time, :prints_count, :result_bytes]
+               [
+                 :duration,
+                 :eval_reductions,
+                 :memory_bytes,
+                 :monotonic_time,
+                 :prints_count,
+                 :result_bytes
+               ]
 
       assert is_integer(stop_meas.duration)
       assert stop_meas.result_bytes > 0
       assert stop_meas.prints_count == 0
       assert stop_meta == Map.put(start_meta, :outcome, :ok)
+    end
+
+    test "stop carries the sandbox child's own heap and reduction figures" do
+      assert {:ok, step} = Lisp.run("(reduce + 0 (map (fn [x] (* x x)) (range 0 200)))")
+
+      assert_receive {:telemetry, [:ptc_runner, :lisp, :execute, :stop], stop_meas, _meta}
+
+      # The same pair `step.usage` carries, not a second measurement of the
+      # same thing: a host charting per-run heap off this event and a host
+      # reading `usage` must never disagree.
+      assert stop_meas.memory_bytes == step.usage.memory_bytes
+      assert stop_meas.eval_reductions == step.usage.eval_reductions
+
+      assert stop_meas.memory_bytes > 0
+      assert stop_meas.eval_reductions > 0
+    end
+
+    test "a run that fails before its child reports still emits both measurements" do
+      # A parse failure never reaches the sandbox, so there is no usage to
+      # surface. The measurements must still be present and numeric — a handler
+      # that pattern-matched the map would otherwise break on the error path —
+      # and `outcome` is what tells a reader that `0` means "never measured"
+      # rather than "used nothing".
+      assert {:error, _step} = Lisp.run("(+ 1")
+
+      assert_receive {:telemetry, [:ptc_runner, :lisp, :execute, :stop], stop_meas, stop_meta}
+
+      assert stop_meas.memory_bytes == 0
+      assert stop_meas.eval_reductions == 0
+      assert stop_meta.outcome != :ok
     end
 
     test "accepts only the direct, kernel, and repl caller taxonomy" do

--- a/test/soak/README.md
+++ b/test/soak/README.md
@@ -7,11 +7,16 @@ default; opt in with `--only soak`.
 ## Run
 
 ```bash
-mix test --only soak
+mix soak
 
 # Crank iteration count for real soak runs
-PTC_SOAK_ITERATIONS=10000 mix test --only soak
+PTC_SOAK_ITERATIONS=10000 mix soak
 ```
+
+`mix soak` is an alias for `mix test --only soak`. The scheduled `Soak`
+workflow (`.github/workflows/soak.yml`) runs it weekly, and on manual dispatch,
+at `PTC_SOAK_ITERATIONS=3000`. It is deliberately not a per-PR gate: the suite
+is long-running and its signal is a trend across runs.
 
 ## Tests
 

--- a/test/soak/README.md
+++ b/test/soak/README.md
@@ -25,6 +25,31 @@ is long-running and its signal is a trend across runs.
 | `closure_capture_soak_test.exs` | Host-process accumulation across `Lisp.run/2` calls and refc-binary pinning by returned closures |
 | `atom_leak_soak_test.exs` | Parser atom interning on novel variable, keyword, and namespace-symbol names |
 | `prelude_compile_atom_leak_soak_test.exs` | Component compilation atom interning on novel namespaces, exports, helpers, and keywords |
+| `lifecycle/credential_lease_soak_test.exs` | `HostCredentialLease` owner, table and per-worker entry churn |
+| `lifecycle/repl_session_soak_test.exs` | `ReplSession` owner and creator-side access entry churn |
+| `lifecycle/provider_session_soak_test.exs` | Provider acquire/close: scopes, committed closers, `ProviderTaskTracker` |
+| `lifecycle/analysis_session_soak_test.exs` | `AnalysisSession` + `SessionTrace` owner pair |
+| `lifecycle/oauth_local_fences_soak_test.exs` | `LocalFences` growth characterization — **non-gating**, reports a slope |
+
+## Two harnesses
+
+`MemorySoak` soaks entry points that reap their sandbox process when the call
+returns, so per-call leakage there is bounded by construction.
+
+`LifecycleSoak` (`test/soak/lifecycle/`) is its sibling for the long-lived
+owners, where it is not. Each cycle returns a **ledger** of what it created —
+processes, tables, ETS entries, ports, `:persistent_term` keys — and every one
+must be gone before the next cycle. Those exact gates are what carry the
+verdict; byte metrics are a fitted slope over batches 2..K, and global counts,
+allocator carrier utilization and RSS are diagnostic only.
+
+Every family runs its termination variants: normal completion, owner death, and
+deadline expiry where the family has a deadline of its own. Owner death is the
+variant worth the setup — it is where `terminate/2` never runs.
+
+`test/support/lifecycle_soak_test.exs` runs in the **ordinary** suite and plants
+each leak the harness claims to catch. A harness that reports "flat" is
+indistinguishable from one that measures nothing.
 
 ## Tunables (env vars)
 

--- a/test/soak/lifecycle/analysis_session_soak_test.exs
+++ b/test/soak/lifecycle/analysis_session_soak_test.exs
@@ -28,9 +28,13 @@ defmodule PtcRunner.Soak.AnalysisSessionSoakTest do
       is the variant where `terminate/2` does not run on the caller's schedule,
       and it is the one the happy path cannot reach.
 
-  The trace destination is a temporary directory per cycle, so a leaked file
-  descriptor or a retained directory identity shows up as a port or an
-  unreclaimed process rather than being hidden by reuse.
+  Source and destination are the **same** directory, so each cycle's published
+  trace becomes input every later cycle re-snapshots. That is not steady state,
+  and it is safe here only because two caps bound it: this family's 25-cycle
+  cap and `TraceSnapshot`'s own 1,024-file / 4,096-entry limits. Lifting either
+  without giving each cycle its own destination would make the workload grow
+  under itself, poisoning the byte slope and eventually failing capture
+  outright.
   """
 
   use ExUnit.Case, async: false

--- a/test/soak/lifecycle/analysis_session_soak_test.exs
+++ b/test/soak/lifecycle/analysis_session_soak_test.exs
@@ -1,0 +1,216 @@
+defmodule PtcRunner.Soak.AnalysisSessionSoakTest do
+  @moduledoc """
+  Repeated `AnalysisSession` and `SessionTrace` churn (use-case row 10).
+
+  This row is an owner *pair*: the trace owner and the evaluation owner are
+  separate processes with separate lifetimes, and a session that reaps one but
+  not the other looks correct from either side alone.
+
+  Resource model, written down before the workload:
+
+  | resource | creator | owner | authorized user | closer |
+  |---|---|---|---|---|
+  | `AnalysisSession` process | `AnalysisSessionBuilder.start/4` | itself | the holder of `{pid, token}` | `close/1`, `abort/2`, `stop/1`, or its own lifecycle timer |
+  | `SessionTrace` process | the builder | itself | the session | session close, or `stop/1` |
+  | `RunState` and `EventSink` processes | the builder | themselves | the session | session close |
+  | lifecycle timer | `init/1` | the session | nobody | fires on expiry and terminates the session |
+
+  Behavior on termination:
+
+    * **caller death** — the session monitors nothing about its caller; a
+      handle is `{pid, token}`, so a dead caller leaves an orphan the lifecycle
+      timer eventually reaps.
+    * **owner death** — killing the session process must take its trace, run
+      state and sink with it, or each becomes a per-cycle orphan.
+    * **deadline expiry** — the session carries its own lifecycle timer. This
+      is the variant where `terminate/2` does not run on the caller's schedule,
+      and it is the one the happy path cannot reach.
+
+  The trace destination is a temporary directory per cycle, so a leaked file
+  descriptor or a retained directory identity shows up as a port or an
+  unreclaimed process rather than being hidden by reuse.
+  """
+
+  use ExUnit.Case, async: false
+
+  @moduletag :soak
+  @moduletag timeout: :infinity
+
+  alias PtcRunner.Kernel.AnalysisSession
+  alias PtcRunner.Kernel.AnalysisSessionBuilder
+  alias PtcRunner.Kernel.EventSink
+  alias PtcRunner.Kernel.Limits
+  alias PtcRunner.Kernel.LogAnalysisProfile
+  alias PtcRunner.Kernel.TraceLog
+  alias PtcRunner.TestSupport.LifecycleSoak
+  alias PtcRunner.TestSupport.MemorySoak
+
+  # Higher than the other families: a cycle here builds a profile, compiles its
+  # components, and starts four processes, so its batch-to-batch drift is
+  # correspondingly larger.
+  @threshold_bytes_per_cycle 8_192
+
+  # A cycle here builds a profile, compiles its components, and starts four
+  # processes — roughly half a second each, against microseconds for the other
+  # families. `PTC_SOAK_ITERATIONS=3000` would put this one family into the
+  # hours, so it is capped. Measured at ~1s per cycle, this puts the file at
+  # roughly seven minutes across its four variants. Not a silent cap: the
+  # harness prints the cycle count it actually ran in every report.
+  @max_cycles 25
+
+  setup_all do
+    directory =
+      Path.join(System.tmp_dir!(), "ptc-soak-analysis-#{System.unique_integer([:positive])}")
+
+    File.mkdir_p!(directory)
+    on_exit(fn -> File.rm_rf(directory) end)
+
+    seed_trace(directory, "soak-seed")
+    {:ok, traces: directory}
+  end
+
+  describe "normal completion" do
+    test "close/1 reaps the session and its trace owner", %{traces: traces} do
+      LifecycleSoak.soak!(
+        [
+          name: "analysis session (normal close)",
+          threshold_bytes_per_cycle: @threshold_bytes_per_cycle,
+          cycles: cycles()
+        ],
+        fn _cycle ->
+          {session, owned} = open(traces)
+          assert {:ok, _info} = AnalysisSession.close(session)
+          AnalysisSession.stop(session)
+
+          ledger(owned)
+        end
+      )
+    end
+
+    test "abort/2 reaps the same set as a clean close", %{traces: traces} do
+      LifecycleSoak.soak!(
+        [
+          name: "analysis session (abort)",
+          threshold_bytes_per_cycle: @threshold_bytes_per_cycle,
+          cycles: cycles()
+        ],
+        fn _cycle ->
+          {session, owned} = open(traces)
+          assert {:ok, _info} = AnalysisSession.abort(session, :soak_cycle)
+          AnalysisSession.stop(session)
+
+          ledger(owned)
+        end
+      )
+    end
+  end
+
+  describe "owner death" do
+    test "killing the session takes its trace, run state and sink with it", %{traces: traces} do
+      LifecycleSoak.soak!(
+        [
+          name: "analysis session (owner death)",
+          threshold_bytes_per_cycle: @threshold_bytes_per_cycle,
+          cycles: cycles()
+        ],
+        fn _cycle ->
+          {session, owned} = open(traces)
+
+          # No close and no stop: `terminate/2` never runs. Every process the
+          # builder created has to be reclaimed by its own linkage, and a
+          # survivor here is a per-cycle orphan.
+          kill_and_await(session.pid)
+          Enum.each(owned, &await_dead/1)
+
+          ledger(owned)
+        end
+      )
+    end
+  end
+
+  describe "deadline expiry" do
+    test "the lifecycle timer reaps a session nobody closes", %{traces: traces} do
+      LifecycleSoak.soak!(
+        [
+          name: "analysis session (lifecycle expiry)",
+          threshold_bytes_per_cycle: @threshold_bytes_per_cycle,
+          cycles: cycles()
+        ],
+        fn _cycle ->
+          {session, owned} = open(traces)
+
+          # The lifecycle timer is armed for the profile's whole run duration
+          # and the builder exposes no option to shorten it, so waiting for it
+          # would make every cycle cost that duration. Delivering the session
+          # its own `{:deadline_expired, token}` message reaches the same
+          # handler on demand — the token is read from the session's state, so
+          # a message with the wrong one is ignored exactly as it would be in
+          # production, and nothing here sleeps.
+          expire(session)
+
+          # The handler closes the session's resources and replies `:noreply` —
+          # it does not stop the session process, and does not reap everything
+          # the builder created. `stop/1` finishes the teardown, and the ledger
+          # is what says whether the pair as a whole came back.
+          AnalysisSession.stop(session)
+
+          ledger(owned)
+        end
+      )
+    end
+  end
+
+  defp open(traces) do
+    {:ok, session, _info} =
+      AnalysisSessionBuilder.start(
+        LogAnalysisProfile.id(),
+        %{"traces" => traces},
+        {:directory, traces}
+      )
+
+    {session, owned_processes(session)}
+  end
+
+  # Captured at creation, from the session's own state. Nothing here publishes
+  # an authority marker, and scanning for owners would find the wrong ones, so
+  # the identities have to be read out while the session is still alive.
+  defp owned_processes(session) do
+    state = :sys.get_state(session.pid)
+
+    [session.pid, state.session_trace.pid, state.run_state.pid, state.config.event_sink.pid]
+    |> Enum.filter(&is_pid/1)
+    |> Enum.uniq()
+  end
+
+  defp cycles, do: min(MemorySoak.iteration_count(), @max_cycles)
+
+  defp expire(session) do
+    %{deadline_token: token} = :sys.get_state(session.pid)
+    send(session.pid, {:deadline_expired, token})
+    :ok
+  end
+
+  defp ledger(owned), do: LifecycleSoak.ledger(processes: owned)
+
+  defp kill_and_await(pid) do
+    ref = Process.monitor(pid)
+    Process.exit(pid, :kill)
+    assert_receive {:DOWN, ^ref, :process, ^pid, _reason}
+    :ok
+  end
+
+  defp await_dead(pid) do
+    ref = Process.monitor(pid)
+    assert_receive {:DOWN, ^ref, :process, ^pid, _reason}, 5_000
+    :ok
+  end
+
+  defp seed_trace(directory, run_id) do
+    {:ok, limits} = Limits.new()
+    {:ok, sink} = EventSink.start(:normal, limits, run_id: run_id)
+    :ok = EventSink.emit(sink, "run-started", %{})
+    :ok = EventSink.emit(sink, "run-stopped", %{outcome: :ok, reason: nil})
+    :ok = TraceLog.append_jsonl(Path.join(directory, run_id <> ".jsonl"), EventSink.events(sink))
+    EventSink.stop(sink)
+  end
+end

--- a/test/soak/lifecycle/analysis_session_soak_test.exs
+++ b/test/soak/lifecycle/analysis_session_soak_test.exs
@@ -12,6 +12,7 @@ defmodule PtcRunner.Soak.AnalysisSessionSoakTest do
   |---|---|---|---|---|
   | `AnalysisSession` process | `AnalysisSessionBuilder.start/4` | itself | the holder of `{pid, token}` | `close/1`, `abort/2`, `stop/1`, or its own lifecycle timer |
   | `SessionTrace` process | the builder | itself | the session | session close, or `stop/1` |
+  | `TraceSnapshot` process | the builder | itself, ownership transferred to the session | the session | the session's `:DOWN`, or session close |
   | `RunState` and `EventSink` processes | the builder | themselves | the session | session close |
   | lifecycle timer | `init/1` | the session | nobody | fires on expiry and terminates the session |
 
@@ -177,7 +178,21 @@ defmodule PtcRunner.Soak.AnalysisSessionSoakTest do
   defp owned_processes(session) do
     state = :sys.get_state(session.pid)
 
-    [session.pid, state.session_trace.pid, state.run_state.pid, state.config.event_sink.pid]
+    # `snapshot` is the `TraceSnapshot` owner, whose ownership the builder
+    # transfers to the session. Omitting it made this family unable to detect
+    # its own leak: the cap of #{@max_cycles} cycles keeps the byte slope below
+    # the harness's gating threshold, so with the snapshot absent from the
+    # ledger *no* gate — exact or byte — could fire on a leaked snapshot
+    # process, and all four variants would pass a regression in
+    # `TraceSnapshot`'s DOWN-triggered cleanup. That is the false "flat" this
+    # harness exists to prevent.
+    [
+      session.pid,
+      state.session_trace.pid,
+      state.snapshot.pid,
+      state.run_state.pid,
+      state.config.event_sink.pid
+    ]
     |> Enum.filter(&is_pid/1)
     |> Enum.uniq()
   end

--- a/test/soak/lifecycle/analysis_session_soak_test.exs
+++ b/test/soak/lifecycle/analysis_session_soak_test.exs
@@ -14,6 +14,7 @@ defmodule PtcRunner.Soak.AnalysisSessionSoakTest do
   | `SessionTrace` process | the builder | itself | the session | session close, or `stop/1` |
   | `TraceSnapshot` process | the builder | itself, ownership transferred to the session | the session | the session's `:DOWN`, or session close |
   | `RunState` and `EventSink` processes | the builder | themselves | the session | session close |
+  | `ProviderTaskTracker` process | `RunState.start_*` — **every** RunState starts one | itself | the run state | its `:DOWN` on the run state |
   | lifecycle timer | `init/1` | the session | nobody | fires on expiry and terminates the session |
 
   Behavior on termination:
@@ -191,6 +192,7 @@ defmodule PtcRunner.Soak.AnalysisSessionSoakTest do
       state.session_trace.pid,
       state.snapshot.pid,
       state.run_state.pid,
+      state.run_state.provider_tracker.pid,
       state.config.event_sink.pid
     ]
     |> Enum.filter(&is_pid/1)

--- a/test/soak/lifecycle/credential_lease_soak_test.exs
+++ b/test/soak/lifecycle/credential_lease_soak_test.exs
@@ -1,0 +1,207 @@
+defmodule PtcRunner.Soak.CredentialLeaseSoakTest do
+  @moduledoc """
+  Repeated `HostCredentialLease` churn (use-case row 12).
+
+  Resource model, written down before the workload:
+
+  | resource | creator | owner | authorized user | closer |
+  |---|---|---|---|---|
+  | lease `GenServer` | `start/1`'s caller | itself | anyone holding `{fence, table}` | `close/3`, or its own `:DOWN` on the authority owner |
+  | lease ETS table | `start/1`'s caller | the lease `GenServer` after `give_away/3` | same | `maybe_finish_close/1` deletes it before stopping |
+  | per-worker lease entry | `claim/3` | the table | the claiming worker | `release/4`, or the worker's `:DOWN` |
+
+  Behavior on termination:
+
+    * **caller death** — the caller is only the constructor; the table's heir
+      and the monitored owner are the *authority* owner, so a dead constructor
+      changes nothing.
+    * **authority-owner death** — the lease owner sees `:DOWN`, closes the
+      fence, kills every leased worker, deletes the table, and stops.
+    * **worker death while leasing** — the lease owner sees the worker's
+      `:DOWN`, deletes that entry, and stays open.
+
+  This family has no deadline of its own to expire: `close/3` bounds itself
+  with `@reply_timeout_ms` and escalates to `force_close/3`. Rather than
+  inventing a fake deadline variant, the third variant here is the forced
+  close that `close/3` falls back to when the owner cannot reply, which is the
+  code path a real expiry would take.
+  """
+
+  use ExUnit.Case, async: false
+
+  @moduletag :soak
+  @moduletag timeout: :infinity
+
+  alias PtcRunner.Kernel.HostCredentialLease
+  alias PtcRunner.TestSupport.LifecycleSoak
+
+  # Measured on a quiet darwin/arm64 run: the fitted byte slope for this
+  # workload sits within +-120 B/cycle across batches. 512 leaves room for the
+  # VM's own drift without being able to absorb a leaked GenServer (a bare
+  # process is already ~2.7 KB) or a leaked ETS table.
+  @threshold_bytes_per_cycle 512
+
+  describe "normal completion" do
+    test "close/3 leaves no owner, table, or entry behind" do
+      LifecycleSoak.soak!(
+        [
+          name: "credential lease (normal close)",
+          threshold_bytes_per_cycle: @threshold_bytes_per_cycle
+        ],
+        fn _cycle ->
+          authority = spawn_authority()
+          {:ok, owner, fence, table} = HostCredentialLease.start(authority)
+          {:ok, lease} = claim_from_worker(owner, fence, table)
+
+          :ok = HostCredentialLease.close(owner, fence, table)
+          stop_authority(authority)
+
+          LifecycleSoak.ledger(
+            processes: [owner, authority],
+            tables: [table],
+            ets_entries: [{table, lease}]
+          )
+        end
+      )
+    end
+  end
+
+  describe "owner death" do
+    test "authority-owner death drains the lease table" do
+      LifecycleSoak.soak!(
+        [
+          name: "credential lease (authority-owner death)",
+          threshold_bytes_per_cycle: @threshold_bytes_per_cycle
+        ],
+        fn _cycle ->
+          authority = spawn_authority()
+          {:ok, owner, fence, table} = HostCredentialLease.start(authority)
+          {:ok, _lease} = claim_from_worker(owner, fence, table)
+
+          # No close/3 at all. The lease owner has to notice on its own, which
+          # is the path where `terminate/2` never runs and a leak is most
+          # likely to survive.
+          stop_authority(authority)
+
+          LifecycleSoak.ledger(processes: [owner, authority], tables: [table])
+        end
+      )
+    end
+
+    test "a worker dying mid-lease drops only its own entry" do
+      LifecycleSoak.soak!(
+        [
+          name: "credential lease (worker death)",
+          threshold_bytes_per_cycle: @threshold_bytes_per_cycle
+        ],
+        fn _cycle ->
+          authority = spawn_authority()
+          {:ok, owner, fence, table} = HostCredentialLease.start(authority)
+
+          {worker, lease} = claim_and_hold(owner, fence, table)
+          kill_and_await(worker)
+
+          # The lease owner is still open here; proving the entry is gone
+          # before the owner closes is the point of this variant. `close/3`
+          # would delete the whole table and hide a per-entry leak.
+          await_entry_gone(owner, table, lease)
+
+          :ok = HostCredentialLease.close(owner, fence, table)
+          stop_authority(authority)
+
+          LifecycleSoak.ledger(processes: [owner, authority, worker], tables: [table])
+        end
+      )
+    end
+  end
+
+  # The lease owner monitors this process, and the table names it as heir, so
+  # it must be a real process rather than the long-lived test process.
+  defp spawn_authority do
+    parent = self()
+
+    spawn(fn ->
+      send(parent, {:authority_ready, self()})
+
+      receive do
+        :stop -> :ok
+      end
+    end)
+    |> tap(fn pid -> assert_receive {:authority_ready, ^pid} end)
+  end
+
+  defp stop_authority(authority) do
+    ref = Process.monitor(authority)
+    send(authority, :stop)
+    assert_receive {:DOWN, ^ref, :process, ^authority, _reason}
+    :ok
+  end
+
+  # `claim/3` admits the *calling* process, and the lease owner links to it —
+  # so claiming from the test process would link the test process to a
+  # GenServer this cycle is about to kill.
+  defp claim_from_worker(owner, fence, table) do
+    {worker, lease} = claim_and_hold(owner, fence, table)
+    :ok = HostCredentialLease.release(owner, table, lease, worker)
+    kill_and_await(worker)
+    {:ok, lease}
+  end
+
+  defp claim_and_hold(owner, fence, table) do
+    parent = self()
+
+    worker =
+      spawn(fn ->
+        # `claim/3` links the worker, so an unhandled exit here would take the
+        # lease owner with it; trapping keeps the kill signal explicit.
+        Process.flag(:trap_exit, true)
+        {:ok, lease} = HostCredentialLease.claim(owner, fence, table)
+        send(parent, {:claimed, self(), lease})
+
+        receive do
+          :never -> :ok
+        end
+      end)
+
+    assert_receive {:claimed, ^worker, lease}
+    {worker, lease}
+  end
+
+  defp kill_and_await(pid) do
+    ref = Process.monitor(pid)
+    Process.exit(pid, :kill)
+    assert_receive {:DOWN, ^ref, :process, ^pid, _reason}
+    :ok
+  end
+
+  # The worker's `:DOWN` reaches the lease owner and the test independently,
+  # so seeing our own gives no guarantee the owner has handled its one. There
+  # is no acknowledgement to wait on: nothing in the API reports "I processed
+  # that exit".
+  #
+  # `:sys.get_state/1` is a synchronous system message, so each call is a real
+  # acknowledgement that everything already in the owner's mailbox has been
+  # handled — retrying it converges the instant the `:DOWN` lands, and never
+  # sleeps. The deadline exists so a genuinely leaked entry fails loudly
+  # instead of spinning forever.
+  defp await_entry_gone(owner, table, lease) do
+    deadline = System.monotonic_time(:millisecond) + 5_000
+    await_entry_gone(owner, table, lease, deadline)
+  end
+
+  defp await_entry_gone(owner, table, lease, deadline) do
+    %{leases: leases} = :sys.get_state(owner)
+
+    cond do
+      not Map.has_key?(leases, lease) ->
+        assert :ets.lookup(table, lease) == [],
+               "lease owner dropped #{inspect(lease)} from its state but left the ETS entry"
+
+      System.monotonic_time(:millisecond) >= deadline ->
+        flunk("lease #{inspect(lease)} outlived its worker by 5s: #{inspect(leases)}")
+
+      true ->
+        await_entry_gone(owner, table, lease, deadline)
+    end
+  end
+end

--- a/test/soak/lifecycle/credential_lease_soak_test.exs
+++ b/test/soak/lifecycle/credential_lease_soak_test.exs
@@ -22,9 +22,13 @@ defmodule PtcRunner.Soak.CredentialLeaseSoakTest do
 
   This family has no deadline of its own to expire: `close/3` bounds itself
   with `@reply_timeout_ms` and escalates to `force_close/3`. Rather than
-  inventing a fake deadline variant, the third variant here is the forced
-  close that `close/3` falls back to when the owner cannot reply, which is the
-  code path a real expiry would take.
+  inventing a fake deadline variant, the third variant here is a worker dying
+  while it holds a lease — the other path on which the owner must reclaim
+  something without being told to.
+
+  `force_close/3` itself is **not** covered: reaching it means wedging the
+  owner so it cannot reply within its own budget, which is a single-cycle
+  behaviour rather than a churn property.
   """
 
   use ExUnit.Case, async: false
@@ -76,14 +80,21 @@ defmodule PtcRunner.Soak.CredentialLeaseSoakTest do
         fn _cycle ->
           authority = spawn_authority()
           {:ok, owner, fence, table} = HostCredentialLease.start(authority)
-          {:ok, _lease} = claim_from_worker(owner, fence, table)
+
+          # The lease is held, not released, across the authority's death.
+          # Releasing first would leave `state.leases` empty at `:DOWN`, so the
+          # drain this variant exists to exercise — `stop_workers/1` killing
+          # every leased worker, then `maybe_finish_close/1` waiting for their
+          # DOWNs before deleting the table — would never run, and the test
+          # would assert cleanup of nothing.
+          {worker, _lease} = claim_and_hold(owner, fence, table)
 
           # No close/3 at all. The lease owner has to notice on its own, which
           # is the path where `terminate/2` never runs and a leak is most
           # likely to survive.
           stop_authority(authority)
 
-          LifecycleSoak.ledger(processes: [owner, authority], tables: [table])
+          LifecycleSoak.ledger(processes: [owner, authority, worker], tables: [table])
         end
       )
     end

--- a/test/soak/lifecycle/oauth_local_fences_soak_test.exs
+++ b/test/soak/lifecycle/oauth_local_fences_soak_test.exs
@@ -1,0 +1,317 @@
+defmodule PtcRunner.Soak.OAuthLocalFencesSoakTest do
+  @moduledoc """
+  `LocalFences` growth characterization (use-case row 17).
+
+  **This row never fails the build.** It exists to answer one question with
+  evidence rather than argument: does the retained `:persistent_term` fence set
+  grow without bound, and therefore does the deferred `LocalFences` slice have
+  a real reproduction?
+
+  Ordinary session churn never writes a fence. A fence is written by a
+  **rejection or scope-requirement transition**, blocked *before* persistence is
+  attempted. A persistence *failure* creates nothing new — it leaves the
+  existing fence unresolved, because `TokenManager` retains the failed operation
+  without calling `LocalFences.resolve/2` and retries reuse the same
+  `operation_ref`. Growth therefore comes from **distinct transitions, not
+  retries**, and the workload drives a distinct generation every time.
+  Repeatedly failing *one* transition would show a flat count and wrongly
+  retire the candidate.
+
+  Two variants, because they bound different things:
+
+    1. **fixed identity** — many distinct transitions under one store and one
+       grant key. Tests whether per-identity coalescing would be enough.
+    2. **churning identity** — a fresh store per transition, so every
+       transition lands on a fresh `local_fence_identity`. Per-identity
+       coalescing cannot bound this by construction; only a global limit can.
+
+  Neither reading is worth anything without proof the workload reached the
+  code, so both count actual `LocalFences.block/3` calls with
+  `:erlang.trace_pattern/3` call counting. A flat fence count means one of two
+  very different things:
+
+    * **blocks observed, count flat** → that variant's growth is already
+      bounded; record it and retire the corresponding half of the slice;
+    * **no blocks observed** → the workload never reached the code and proves
+      nothing. Fix the workload; do not conclude anything about the candidate.
+
+  The only assertion here is the second: that blocks were observed. The slope
+  is printed whatever its sign.
+  """
+
+  use ExUnit.Case, async: false
+
+  @moduletag :soak
+  @moduletag timeout: :infinity
+
+  alias PtcRunner.Kernel.Deadline
+  alias PtcRunner.Kernel.MCPOAuth.Authority
+  alias PtcRunner.Kernel.MCPOAuth.Context
+  alias PtcRunner.Kernel.MCPOAuth.LocalFences
+  alias PtcRunner.Kernel.MCPOAuth.Store
+  alias PtcRunner.Kernel.MCPOAuth.Store.Memory
+  alias PtcRunner.Kernel.MCPOAuth.TokenManager
+  alias PtcRunner.Test.MCPOAuthRecordingStore
+  alias PtcRunner.TestSupport.LifecycleSoak
+  alias PtcRunner.TestSupport.MemorySoak
+
+  @fence_prefix {LocalFences, :fence}
+  @batches 4
+
+  setup do
+    # Fences are global `:persistent_term` entries and this test deliberately
+    # creates ones nothing will resolve, so it cleans up after itself in both
+    # directions rather than leaving the VM's fence table poisoned for whatever
+    # runs next.
+    erase_fences()
+    on_exit(&erase_fences/0)
+    :ok
+  end
+
+  test "distinct rejections under one fixed identity" do
+    started = start_manager()
+    on_exit(fn -> tear_down([started]) end)
+
+    report =
+      measure("fixed identity", fn generation ->
+        _rejected = TokenManager.reject(started.manager, generation, deadline())
+      end)
+
+    refute report.blocks == 0, broken_workload_message()
+  end
+
+  test "distinct rejections across churning identities" do
+    # Managers and stores accumulate for the duration and are torn down at the
+    # end rather than per transition. Closing a manager whose persistence is
+    # deliberately failing means waiting out its retry budget, and killing its
+    # store first leaves it retrying against a dead process — either way the
+    # teardown would dominate the run and none of it is what this row measures.
+    #
+    # Accumulated in the test process's own mailbox, and drained here rather
+    # than from `on_exit`: that callback runs in a *different* process, so
+    # anything owned by this one is already gone by the time it fires.
+    report =
+      measure("churning identity", fn generation ->
+        started = start_manager()
+        send(self(), {:started, started})
+        _rejected = TokenManager.reject(started.manager, generation, deadline())
+      end)
+
+    tear_down(drain_started([]))
+
+    refute report.blocks == 0, broken_workload_message()
+  end
+
+  defp drain_started(acc) do
+    receive do
+      {:started, started} -> drain_started([started | acc])
+    after
+      0 -> acc
+    end
+  end
+
+  # Hard kills, in dependency order and without waiting on any graceful path:
+  # every manager here has an unresolvable persistence operation by
+  # construction, so `close/1` would spend its retry budget before returning.
+  defp tear_down(started) do
+    Enum.each(started, fn %{manager: manager, memory: memory} ->
+      kill(manager.pid)
+      kill(memory.pid)
+    end)
+  end
+
+  defp kill(pid) do
+    if Process.alive?(pid) do
+      ref = Process.monitor(pid)
+      Process.exit(pid, :kill)
+
+      receive do
+        {:DOWN, ^ref, :process, ^pid, _reason} -> :ok
+      after
+        5_000 -> Process.demonitor(ref, [:flush])
+      end
+    end
+
+    :ok
+  end
+
+  defp broken_workload_message do
+    "no LocalFences.block/3 call was observed, so this workload never reached the " <>
+      "code under test and proves nothing about the candidate. Fix the workload; " <>
+      "do not read the flat fence count as a result."
+  end
+
+  # ── measurement ──────────────────────────────────────────────────────────
+
+  # Call counting through the tracer, not inferred from the fence table. The
+  # whole point of this row is that a flat table and an unreached code path are
+  # indistinguishable without this number.
+  defp measure(label, transition) do
+    # `trace_pattern/3` silently matches *zero* functions on a module that has
+    # not been loaded yet, and lazy loading means that is the normal state for
+    # whichever of these tests runs first. The counter then reads 0 both before
+    # and after, and the run reports "no blocks observed" — indistinguishable
+    # from a workload that never reached the code, which is precisely the
+    # ambiguity this instrument exists to remove. Load the module, then assert
+    # the pattern actually armed one function.
+    Code.ensure_loaded!(LocalFences)
+
+    assert :erlang.trace_pattern({LocalFences, :block, 3}, true, [:call_count]) == 1,
+           "call-count tracing did not arm on LocalFences.block/3; the block count " <>
+             "this run reports would be meaningless"
+
+    before_blocks = call_count()
+    per_batch = transitions_per_batch()
+
+    counts =
+      for batch <- 1..@batches do
+        Enum.each(1..per_batch, fn index ->
+          transition.((batch - 1) * per_batch + index)
+        end)
+
+        MemorySoak.gc_everywhere()
+        %{transitions: batch * per_batch, fences: fence_count()}
+      end
+
+    blocks = call_count() - before_blocks
+    :erlang.trace_pattern({LocalFences, :block, 3}, false, [:call_count])
+
+    fitted =
+      LifecycleSoak.slope(
+        Enum.map(counts, & &1.transitions),
+        Enum.map(counts, & &1.fences)
+      )
+
+    IO.puts("""
+
+    LocalFences characterization — #{label} (row 17, non-gating)
+      observed LocalFences.block/3 calls: #{blocks} over #{@batches * per_batch} distinct transitions
+    #{Enum.map_join(counts, "\n", &"    after #{&1.transitions} transitions: #{&1.fences} live fences")}
+      fitted fence slope: #{Float.round(fitted, 4)} fences per transition
+      verdict: #{verdict(blocks, fitted)}
+    """)
+
+    %{blocks: blocks, slope: fitted, counts: counts}
+  end
+
+  defp verdict(0, _slope),
+    do: "WORKLOAD BROKEN — no block/3 calls observed; this run proves nothing"
+
+  defp verdict(_blocks, slope) when slope > 0.5,
+    do: "GROWTH CONFIRMED — the deferred LocalFences slice has its reproduction"
+
+  defp verdict(_blocks, _slope),
+    do: "BOUNDED — blocks were observed and the fence count stayed flat"
+
+  defp call_count do
+    case :erlang.trace_info({LocalFences, :block, 3}, :call_count) do
+      {:call_count, count} when is_integer(count) -> count
+      _unavailable -> 0
+    end
+  end
+
+  # Counted by prefix rather than globally: another subsystem's
+  # `:persistent_term` entries are not this row's evidence.
+  defp fence_count,
+    do: LifecycleSoak.count_persistent_terms(&match?({@fence_prefix, _identity, _ref}, &1))
+
+  defp erase_fences do
+    Enum.each(:persistent_term.get(), fn {key, _value} ->
+      if match?({@fence_prefix, _identity, _ref}, key), do: :persistent_term.erase(key)
+    end)
+  end
+
+  # Deliberately small, and fixed independently of `PTC_SOAK_ITERATIONS`.
+  #
+  # This row characterizes a *rate*. If the fence count rises one-for-one with
+  # distinct transitions, twenty points show it as unambiguously as a thousand
+  # would, and the slope is what gets reported either way.
+  #
+  # The cap is also load-bearing rather than cosmetic: a manager holding N
+  # unresolvable persistence operations re-examines all of them on each
+  # transition, so driving hundreds of failing transitions into one manager
+  # makes the *test* superlinear without telling us anything more about the
+  # fence table. That cost is worth its own look, but it is not this row.
+  defp transitions_per_batch, do: 5
+
+  # ── fixtures ─────────────────────────────────────────────────────────────
+
+  defp start_manager do
+    {:ok, memory} = Memory.start(owner: self())
+    {:ok, base_store} = Memory.store(memory)
+
+    {:ok, store} =
+      MCPOAuthRecordingStore.wrap(base_store, self(),
+        interceptor: fn
+          {:mark_access_rejected, _key, _generation}, _deadline ->
+            # The transition blocks its fence before persistence is attempted;
+            # only the durable write fails, which is exactly what leaves the
+            # fence unresolved.
+            {:return, {:error, :store_error}}
+
+          _operation, _deadline ->
+            :delegate
+        end
+      )
+
+    authority = authority()
+
+    {:ok, context} =
+      Context.new(
+        tenant_id: "soak-tenant",
+        principal_id: "soak-principal-#{System.unique_integer([:positive])}",
+        store: store,
+        deadline: Deadline.new(5_000)
+      )
+
+    {:ok, claims} =
+      Store.claim_authorities(
+        store,
+        "soak-tenant",
+        [{authority.installation_id, authority.fingerprint}],
+        Deadline.new(5_000)
+      )
+
+    epoch = claims[authority.installation_id]
+
+    {:ok, manager} =
+      TokenManager.start(
+        owner: self(),
+        context: context,
+        authority: authority,
+        authority_epoch: epoch
+      )
+
+    %{
+      manager: manager,
+      memory: memory,
+      identity: LocalFences.identity(store, Context.grant_key(context, authority, epoch))
+    }
+  end
+
+  defp authority do
+    {:ok, authority} =
+      Authority.from_host(
+        %{
+          "installation_id" => "soak-fences",
+          "issuer" => "https://auth.example",
+          "scope_ceiling" => ["read", "write"],
+          "default_scopes" => ["read"],
+          "refresh_access" => "when_supported",
+          "client" => %{
+            "registration" => "pre_registered",
+            "client_id" => "client",
+            "token_endpoint_auth_method" => "none",
+            "grant_types" => ["authorization_code", "refresh_token"],
+            "loopback_redirect" => %{"host" => "127.0.0.1", "path" => "/callback"}
+          }
+        },
+        "https://mcp.example/mcp",
+        MapSet.new()
+      )
+
+    authority
+  end
+
+  defp deadline, do: System.monotonic_time(:millisecond) + 5_000
+end

--- a/test/soak/lifecycle/provider_session_soak_test.exs
+++ b/test/soak/lifecycle/provider_session_soak_test.exs
@@ -1,0 +1,244 @@
+defmodule PtcRunner.Soak.ProviderSessionSoakTest do
+  @moduledoc """
+  Repeated provider acquire/close churn (use-case row 11).
+
+  Acquire/close is the richest lifecycle in the tree, and the one with the most
+  places to leave something behind: a session owns scopes, each scope owns a
+  controller, a root owner and a reaper, and a committed scope carries a closer
+  that must run exactly once.
+
+  Resource model, written down before the workload:
+
+  | resource | creator | owner | authorized user | closer |
+  |---|---|---|---|---|
+  | `ProviderSession` process | `start_active/2` | itself | its `creator`, or its `lifecycle_owner` when owned | `close/1`, or its `:DOWN` on the lifecycle owner |
+  | scope (controller, root, reaper) | `open_registrar/1` | the session | the registrar handle | `commit/2`'s closer at session close, or `abort/1` |
+  | committed closer | `commit/2` | the session | nobody | session close, in reverse commit order, once |
+  | `ProviderTaskTracker` process | `start/1` | itself | the run state | its `:DOWN` on the run state |
+
+  Behavior on termination:
+
+    * **caller death** — an unowned session's creator is its authority; a
+      session whose creator dies cannot be closed by anyone else, which is why
+      the owned variant exists.
+    * **owner death** — `start_active_owned/4` binds a lifecycle owner; its
+      `:DOWN` must take the session and every committed closer with it.
+    * **deadline expiry** — the operation budget is anchored at
+      `begin_operation/2`, and close spends the *cleanup* budget, not the
+      operation's. A session closed after its run deadline has already expired
+      must still reap its scopes.
+
+  Every variant asserts the committed closers ran exactly once, because a
+  session that leaked a scope and a session that closed one twice both look
+  identical to a byte metric.
+  """
+
+  use ExUnit.Case, async: false
+
+  @moduletag :soak
+  @moduletag timeout: :infinity
+
+  alias PtcRunner.Kernel.Deadline
+  alias PtcRunner.Kernel.Limits
+  alias PtcRunner.Kernel.ProviderSession
+  alias PtcRunner.Kernel.ProviderTaskTracker
+  alias PtcRunner.Kernel.ResourceRegistrar
+  alias PtcRunner.TestSupport.LifecycleSoak
+
+  @threshold_bytes_per_cycle 2_048
+
+  describe "normal completion" do
+    test "close/1 reaps every committed scope exactly once" do
+      LifecycleSoak.soak!(
+        [
+          name: "provider session (normal close)",
+          threshold_bytes_per_cycle: @threshold_bytes_per_cycle
+        ],
+        fn _cycle ->
+          {:ok, session} = ProviderSession.start_active(limits(), unique_operation())
+          {:ok, session} = ProviderSession.begin_operation(session, :run)
+
+          closed = commit_scopes(session, 2)
+          assert :ok = ProviderSession.close(session)
+          assert_closed_once(closed, 2)
+
+          LifecycleSoak.ledger(processes: [session.pid])
+        end
+      )
+    end
+
+    test "aborted registrars leave nothing for close to reap" do
+      LifecycleSoak.soak!(
+        [
+          name: "provider session (aborted registrar)",
+          threshold_bytes_per_cycle: @threshold_bytes_per_cycle
+        ],
+        fn _cycle ->
+          {:ok, session} = ProviderSession.start_active(limits(), unique_operation())
+          {:ok, session} = ProviderSession.begin_operation(session, :run)
+
+          {:ok, registrar} = ProviderSession.open_registrar(session)
+          assert :ok = ResourceRegistrar.abort(registrar)
+
+          assert :ok = ProviderSession.close(session)
+
+          LifecycleSoak.ledger(processes: [session.pid])
+        end
+      )
+    end
+  end
+
+  describe "owner death" do
+    test "lifecycle-owner death takes the session and its closers with it" do
+      LifecycleSoak.soak!(
+        [
+          name: "provider session (lifecycle-owner death)",
+          threshold_bytes_per_cycle: @threshold_bytes_per_cycle
+        ],
+        fn _cycle ->
+          parent = self()
+          owner = spawn(fn -> receive do: (:stop -> :ok) end)
+
+          {:ok, session} =
+            ProviderSession.start_active_owned(
+              limits(),
+              unique_operation(),
+              owner,
+              fn opened -> send(parent, {:handed_off, opened}) && :ok end
+            )
+
+          assert_receive {:handed_off, ^session}
+          {:ok, session} = ProviderSession.begin_operation(session, :run)
+          closed = commit_scopes(session, 2)
+
+          # No `close/1`. The lifecycle owner's `:DOWN` is the only thing that
+          # can reap this session, which is the path where nothing the caller
+          # does can compensate for a missed cleanup.
+          kill_and_await(owner)
+          await_dead(session.pid)
+          assert_closed_once(closed, 2)
+
+          LifecycleSoak.ledger(processes: [session.pid, owner])
+        end
+      )
+    end
+
+    test "run-state death drains the provider task tracker" do
+      LifecycleSoak.soak!(
+        [
+          name: "provider task tracker (run-state death)",
+          threshold_bytes_per_cycle: @threshold_bytes_per_cycle
+        ],
+        fn _cycle ->
+          run_state = spawn(fn -> receive do: (:stop -> :ok) end)
+          {:ok, tracker} = ProviderTaskTracker.start(run_state)
+
+          lifecycle = spawn(fn -> receive do: (:stop -> :ok) end)
+          assert :ok = ProviderTaskTracker.watch(tracker, lifecycle)
+
+          kill_and_await(run_state)
+          kill_and_await(lifecycle)
+          await_dead(tracker.pid)
+
+          LifecycleSoak.ledger(processes: [tracker.pid, run_state, lifecycle])
+        end
+      )
+    end
+  end
+
+  describe "deadline expiry" do
+    test "a session closed after its operation deadline still reaps its scopes" do
+      LifecycleSoak.soak!(
+        [
+          name: "provider session (deadline expiry)",
+          threshold_bytes_per_cycle: @threshold_bytes_per_cycle
+        ],
+        fn _cycle ->
+          {:ok, limits} = Limits.installed(%{run_duration_ms: 1})
+          {:ok, session} = ProviderSession.start_active(limits, unique_operation())
+          {:ok, session} = ProviderSession.begin_operation(session, :run)
+
+          closed = commit_scopes(session, 1)
+          burn_past(ProviderSession.run_deadline(session))
+          assert Deadline.expired?(ProviderSession.run_deadline(session))
+
+          # Close spends the *cleanup* budget, which `Limits.installed/1` keeps
+          # independent of `run_duration_ms` — a 1 ms operation still gets the
+          # full 5 s cleanup allowance. An expired operation must therefore
+          # still reap its scopes, not turn into an unreaped one.
+          assert :ok = ProviderSession.close(session)
+          assert_closed_once(closed, 1)
+
+          LifecycleSoak.ledger(processes: [session.pid])
+        end
+      )
+    end
+  end
+
+  # Each committed scope reports its own close, so the assertion can tell a
+  # leaked scope from one closed twice.
+  defp commit_scopes(session, count) do
+    parent = self()
+    token = make_ref()
+
+    Enum.each(1..count, fn index ->
+      {:ok, registrar} = ProviderSession.open_registrar(session)
+      assert :ok = ResourceRegistrar.activate(registrar)
+      # The closer must return `:ok`; anything else is reported as
+      # `:provider_cleanup_failed`, so `send/2`'s return value cannot be the
+      # last expression here.
+      assert :ok =
+               ResourceRegistrar.commit(registrar, fn ->
+                 send(parent, {token, index})
+                 :ok
+               end)
+    end)
+
+    token
+  end
+
+  defp assert_closed_once(token, count) do
+    observed = collect(token, [])
+
+    assert Enum.sort(observed) == Enum.to_list(1..count),
+           "expected each committed scope to close exactly once, saw #{inspect(observed)}"
+  end
+
+  defp collect(token, acc) do
+    receive do
+      {^token, index} -> collect(token, [index | acc])
+    after
+      0 -> acc
+    end
+  end
+
+  defp kill_and_await(pid) do
+    ref = Process.monitor(pid)
+    Process.exit(pid, :kill)
+    assert_receive {:DOWN, ^ref, :process, ^pid, _reason}
+    :ok
+  end
+
+  defp await_dead(pid) do
+    ref = Process.monitor(pid)
+    assert_receive {:DOWN, ^ref, :process, ^pid, _reason}
+    :ok
+  end
+
+  # A deadline is an absolute instant, so the only way past it is to reach it.
+  # Busy-waiting on the monotonic clock keeps that explicit rather than
+  # sleeping for a duration the test would then have to trust.
+  defp burn_past(deadline) do
+    expires_at = Deadline.expires_at(deadline)
+    if System.monotonic_time(:millisecond) <= expires_at, do: burn_past(deadline), else: :ok
+  end
+
+  defp limits do
+    {:ok, limits} = Limits.installed(%{run_duration_ms: 5_000})
+    limits
+  end
+
+  # Operation identities must carry entropy: thousands of cycles sharing one
+  # identity would make every cycle's session indistinguishable in a trace.
+  defp unique_operation, do: "soak-operation-#{System.unique_integer([:positive])}"
+end

--- a/test/soak/lifecycle/provider_session_soak_test.exs
+++ b/test/soak/lifecycle/provider_session_soak_test.exs
@@ -44,6 +44,7 @@ defmodule PtcRunner.Soak.ProviderSessionSoakTest do
   alias PtcRunner.Kernel.ProviderTaskTracker
   alias PtcRunner.Kernel.ResourceRegistrar
   alias PtcRunner.TestSupport.LifecycleSoak
+  alias PtcRunner.TestSupport.MemorySoak
 
   @threshold_bytes_per_cycle 2_048
 
@@ -151,10 +152,28 @@ defmodule PtcRunner.Soak.ProviderSessionSoakTest do
       LifecycleSoak.soak!(
         [
           name: "provider session (deadline expiry)",
-          threshold_bytes_per_cycle: @threshold_bytes_per_cycle
+          threshold_bytes_per_cycle: @threshold_bytes_per_cycle,
+          # `burn_past/1` spins to the deadline, so each cycle costs its whole
+          # budget. Capped so the wider budget above cannot turn a 3000-cycle
+          # CI run into a 10-minute spin. The harness prints the count it ran.
+          cycles: min(MemorySoak.iteration_count(), 25)
         ],
         fn _cycle ->
-          {:ok, limits} = Limits.installed(%{run_duration_ms: 1})
+          # 1 ms is not a usable budget here, and using it made this the one
+          # reproducibly flaky test in the suite. `begin_operation/2` mints the
+          # deadline client-side, and the server re-checks `Deadline.live?/1`
+          # when it *dequeues* the call (`provider_session.ex:887`), so the
+          # whole round trip — plus the `open_registrar`/`activate`/`commit`
+          # chain, which must also beat it — has to fit inside the budget. One
+          # descheduling and the cycle dies with
+          # `{:error, :provider_session_unavailable}`, which is a
+          # test-construction failure, not a leak. At CI's 3000 iterations that
+          # is near-certain, and it would have kept the very workflow slice 1
+          # exists to restore permanently red.
+          #
+          # 50 ms survives scheduling while still expiring far inside the 5 s
+          # cleanup allowance, so the variant still tests what it claims.
+          {:ok, limits} = Limits.installed(%{run_duration_ms: 50})
           {:ok, session} = ProviderSession.start_active(limits, unique_operation())
           {:ok, session} = ProviderSession.begin_operation(session, :run)
 

--- a/test/soak/lifecycle/provider_session_soak_test.exs
+++ b/test/soak/lifecycle/provider_session_soak_test.exs
@@ -162,12 +162,29 @@ defmodule PtcRunner.Soak.ProviderSessionSoakTest do
           burn_past(ProviderSession.run_deadline(session))
           assert Deadline.expired?(ProviderSession.run_deadline(session))
 
-          # Close spends the *cleanup* budget, which `Limits.installed/1` keeps
-          # independent of `run_duration_ms` — a 1 ms operation still gets the
-          # full 5 s cleanup allowance. An expired operation must therefore
-          # still reap its scopes, not turn into an unreaped one.
-          assert :ok = ProviderSession.close(session)
+          # Two reports are legitimate here and which one appears is a race the
+          # machine's load decides, so the assertion is on the resource facts
+          # rather than on the report.
+          #
+          # `Limits.installed/1` keeps the cleanup budget independent of
+          # `run_duration_ms`, so a 1 ms operation still gets the full 5 s
+          # cleanup allowance — but the session keeps the *earliest* anchor, and
+          # when the already-expired run deadline wins that comparison the close
+          # call has no budget left and force-terminates instead of confirming a
+          # graceful close. It then reports `:provider_cleanup_failed`, which is
+          # deliberately fail-closed: "cleanup was not confirmed", not "cleanup
+          # did not happen". On an idle machine the graceful path usually wins;
+          # under full-suite load it usually does not.
+          #
+          # What must hold either way — and this is the variant where
+          # `terminate/2` never runs, so it is where a leak would survive — is
+          # that the scope is reaped exactly once and the session dies. The
+          # ledger asserts the second; `assert_closed_once/2` the first.
+          report = ProviderSession.close(session)
           assert_closed_once(closed, 1)
+
+          assert report in [:ok, {:error, :provider_cleanup_failed}],
+                 "unexpected close report after deadline expiry: #{inspect(report)}"
 
           LifecycleSoak.ledger(processes: [session.pid])
         end

--- a/test/soak/lifecycle/provider_session_soak_test.exs
+++ b/test/soak/lifecycle/provider_session_soak_test.exs
@@ -59,11 +59,11 @@ defmodule PtcRunner.Soak.ProviderSessionSoakTest do
           {:ok, session} = ProviderSession.start_active(limits(), unique_operation())
           {:ok, session} = ProviderSession.begin_operation(session, :run)
 
-          closed = commit_scopes(session, 2)
+          {closed, scopes} = commit_scopes(session, 2)
           assert :ok = ProviderSession.close(session)
           assert_closed_once(closed, 2)
 
-          LifecycleSoak.ledger(processes: [session.pid])
+          LifecycleSoak.ledger(processes: [session.pid | scopes])
         end
       )
     end
@@ -79,11 +79,20 @@ defmodule PtcRunner.Soak.ProviderSessionSoakTest do
           {:ok, session} = ProviderSession.begin_operation(session, :run)
 
           {:ok, registrar} = ProviderSession.open_registrar(session)
-          assert :ok = ResourceRegistrar.abort(registrar)
 
+          scopes =
+            Enum.filter(
+              [registrar.scope_controller, registrar.root_owner, registrar.cleanup_owner],
+              &is_pid/1
+            )
+
+          assert :ok = ResourceRegistrar.abort(registrar)
           assert :ok = ProviderSession.close(session)
 
-          LifecycleSoak.ledger(processes: [session.pid])
+          # An aborted scope must reap its own processes, not leave them for
+          # session close — otherwise abort and commit would be
+          # indistinguishable here.
+          LifecycleSoak.ledger(processes: [session.pid | scopes])
         end
       )
     end
@@ -110,7 +119,7 @@ defmodule PtcRunner.Soak.ProviderSessionSoakTest do
 
           assert_receive {:handed_off, ^session}
           {:ok, session} = ProviderSession.begin_operation(session, :run)
-          closed = commit_scopes(session, 2)
+          {closed, scopes} = commit_scopes(session, 2)
 
           # No `close/1`. The lifecycle owner's `:DOWN` is the only thing that
           # can reap this session, which is the path where nothing the caller
@@ -119,7 +128,7 @@ defmodule PtcRunner.Soak.ProviderSessionSoakTest do
           await_dead(session.pid)
           assert_closed_once(closed, 2)
 
-          LifecycleSoak.ledger(processes: [session.pid, owner])
+          LifecycleSoak.ledger(processes: [session.pid, owner | scopes])
         end
       )
     end
@@ -177,7 +186,7 @@ defmodule PtcRunner.Soak.ProviderSessionSoakTest do
           {:ok, session} = ProviderSession.start_active(limits, unique_operation())
           {:ok, session} = ProviderSession.begin_operation(session, :run)
 
-          closed = commit_scopes(session, 1)
+          {closed, scopes} = commit_scopes(session, 1)
           burn_past(ProviderSession.run_deadline(session))
           assert Deadline.expired?(ProviderSession.run_deadline(session))
 
@@ -205,32 +214,51 @@ defmodule PtcRunner.Soak.ProviderSessionSoakTest do
           assert report in [:ok, {:error, :provider_cleanup_failed}],
                  "unexpected close report after deadline expiry: #{inspect(report)}"
 
-          LifecycleSoak.ledger(processes: [session.pid])
+          # The scope processes matter most in this variant. Its cycle cap puts
+          # it below the harness's byte-gate floor, so this exact list is the
+          # only thing standing between a leaked controller, root owner or
+          # reaper and a green run.
+          LifecycleSoak.ledger(processes: [session.pid | scopes])
         end
       )
     end
   end
 
   # Each committed scope reports its own close, so the assertion can tell a
-  # leaked scope from one closed twice.
+  # leaked scope from one closed twice — and returns the three processes the
+  # scope actually owns, so the ledger can gate them exactly.
+  #
+  # Listing only `session.pid` was a false-flat waiting to happen: a scope's
+  # controller, root owner and reaper are per-cycle processes, and in the
+  # deadline-expiry variant — capped below the harness's 100-cycle byte-gate
+  # floor — *no* gate would have covered them at any iteration count. That is
+  # the path where `terminate/2` never runs, which the plan names as the most
+  # likely leak site. Collecting them here also upgrades the other variants
+  # from "caught by the byte slope at 3000 cycles" to exact at every count.
   defp commit_scopes(session, count) do
     parent = self()
     token = make_ref()
 
-    Enum.each(1..count, fn index ->
-      {:ok, registrar} = ProviderSession.open_registrar(session)
-      assert :ok = ResourceRegistrar.activate(registrar)
-      # The closer must return `:ok`; anything else is reported as
-      # `:provider_cleanup_failed`, so `send/2`'s return value cannot be the
-      # last expression here.
-      assert :ok =
-               ResourceRegistrar.commit(registrar, fn ->
-                 send(parent, {token, index})
-                 :ok
-               end)
-    end)
+    scope_pids =
+      Enum.flat_map(1..count, fn index ->
+        {:ok, registrar} = ProviderSession.open_registrar(session)
+        assert :ok = ResourceRegistrar.activate(registrar)
+        # The closer must return `:ok`; anything else is reported as
+        # `:provider_cleanup_failed`, so `send/2`'s return value cannot be the
+        # last expression here.
+        assert :ok =
+                 ResourceRegistrar.commit(registrar, fn ->
+                   send(parent, {token, index})
+                   :ok
+                 end)
 
-    token
+        Enum.filter(
+          [registrar.scope_controller, registrar.root_owner, registrar.cleanup_owner],
+          &is_pid/1
+        )
+      end)
+
+    {token, scope_pids}
   end
 
   defp assert_closed_once(token, count) do

--- a/test/soak/lifecycle/repl_session_soak_test.exs
+++ b/test/soak/lifecycle/repl_session_soak_test.exs
@@ -65,13 +65,13 @@ defmodule PtcRunner.Soak.ReplSessionSoakTest do
           threshold_bytes_per_cycle: @threshold_bytes_per_cycle
         ],
         fn _cycle ->
-          {session, owner, sink} = open(context)
+          {session, owner, sink, owned} = open(context)
           {:ok, _step, session} = ReplSession.eval(session, "(soak.repl/value 1)")
 
           assert {:ok, _events} = ReplSession.close(session)
           :ok = EventSink.stop(sink)
 
-          ledger(session, owner, sink)
+          ledger(session, owner, sink, owned)
         end
       )
     end
@@ -97,7 +97,7 @@ defmodule PtcRunner.Soak.ReplSessionSoakTest do
           threshold_bytes_per_cycle: @threshold_bytes_per_cycle
         ],
         fn _cycle ->
-          {session, owner, sink} = open(context)
+          {session, owner, sink, owned} = open(context)
 
           # The owner dies without `terminate/2` running, which is the variant
           # the happy path cannot reach. `close/1` must still be able to drop
@@ -106,7 +106,7 @@ defmodule PtcRunner.Soak.ReplSessionSoakTest do
           _closed = ReplSession.close(session)
           :ok = EventSink.stop(sink)
 
-          ledger(session, owner, sink)
+          ledger(session, owner, sink, owned)
         end
       )
     end
@@ -126,12 +126,12 @@ defmodule PtcRunner.Soak.ReplSessionSoakTest do
           threshold_bytes_per_cycle: @threshold_bytes_per_cycle
         ],
         fn _cycle ->
-          {session, owner, sink} = open(context)
+          {session, owner, sink, owned} = open(context)
           _evaluated = ReplSession.eval(session, "(soak.repl/value 1)")
           _aborted = ReplSession.abort(session, :deadline_expired)
           :ok = EventSink.stop(sink)
 
-          ledger(session, owner, sink)
+          ledger(session, owner, sink, owned)
         end
       )
     end
@@ -150,7 +150,8 @@ defmodule PtcRunner.Soak.ReplSessionSoakTest do
       )
 
     {:ok, session} = ReplSession.new(config: config)
-    {session, owner_pid!(session), sink}
+    owner = owner_pid!(session)
+    {session, owner, sink, owned_processes(owner)}
   end
 
   # `{id, {pid, token}}` — the owner is inside the entry. Reading it here, at
@@ -162,10 +163,24 @@ defmodule PtcRunner.Soak.ReplSessionSoakTest do
     pid
   end
 
-  defp ledger(%ReplSession{access: access, id: id}, owner, sink) do
+  defp ledger(%ReplSession{access: access, id: id}, owner, sink, owned) do
     # The access table is absent on purpose: it belongs to this test process
     # and legitimately outlives every session, so only the entry can leak.
-    LifecycleSoak.ledger(processes: [owner, sink.pid], ets_entries: [{access, id}])
+    LifecycleSoak.ledger(
+      processes: [owner, sink.pid | owned],
+      ets_entries: [{access, id}]
+    )
+  end
+
+  # A session also owns a `RunState`, and **every** `RunState` starts a
+  # `ProviderTaskTracker` alongside it (`run_state.ex:995`). Both are per-cycle
+  # processes and neither is reachable from the `%ReplSession{}` handle, so
+  # they have to be read out of the owner's state while it is still alive —
+  # which is also why they were missed at first. Read before any variant kills
+  # the owner.
+  defp owned_processes(owner) do
+    %{run_state: run_state} = :sys.get_state(owner)
+    [run_state.pid, run_state.provider_tracker.pid]
   end
 
   defp kill_and_await(pid) do

--- a/test/soak/lifecycle/repl_session_soak_test.exs
+++ b/test/soak/lifecycle/repl_session_soak_test.exs
@@ -1,0 +1,181 @@
+defmodule PtcRunner.Soak.ReplSessionSoakTest do
+  @moduledoc """
+  Repeated `ReplSession` churn (use-case row 15).
+
+  Resource model, written down before the workload:
+
+  | resource | creator | owner | authorized user | closer |
+  |---|---|---|---|---|
+  | `ReplSessionOwner` process | `new/1` | itself | the holder of `{pid, token}` | `close/1`/`abort/2`, or its own `:DOWN` on the creator |
+  | access ETS table | `new/1` | the **creator process**, one per creator, not per session | the creator only (`:private`) | never; it outlives every session the creator makes |
+  | access entry `{id, {pid, token}}` | `new/1` | the table | the creator | `close_access/1` on every exit path |
+  | `EventSink` process | the caller, before `new/1` | itself | the run | the caller; `Runner` finalizes it but never stops it |
+
+  **The table is not the resource to watch.** One `:private` table is allocated
+  per creator process, keyed by session ID, with entries deleted on close. A
+  leaked session entry never changes the table count, so this soak gates on
+  entries and deliberately does not list the table.
+
+  Getting the owner PID right matters for the same reason. The process
+  dictionary key `{ReplSession, :access_table}` points at the *table*, and the
+  `ReplSessionOwner` pid lives inside the entry as `{id, {pid, token}}`.
+  Monitoring what the dictionary key points at would monitor the long-lived
+  creator — here, the test process — and the owner-death variant would
+  silently verify nothing. This captures the owner from the table entry.
+  """
+
+  use ExUnit.Case, async: false
+
+  @moduletag :soak
+  @moduletag timeout: :infinity
+
+  alias PtcRunner.Kernel
+  alias PtcRunner.Kernel.Component
+  alias PtcRunner.Kernel.EventSink
+  alias PtcRunner.Kernel.Limits
+  alias PtcRunner.Kernel.MissionEnvironment
+  alias PtcRunner.Kernel.ReplSession
+  alias PtcRunner.Kernel.RunConfig
+  alias PtcRunner.Kernel.WorkflowEnvironment
+  alias PtcRunner.TestSupport.LifecycleSoak
+
+  @threshold_bytes_per_cycle 2_048
+
+  setup_all do
+    {:ok, component} =
+      Component.new(
+        id: "soak.repl",
+        source: "(ns soak.repl)\n(defn value [x] (+ x 1))\n",
+        origin: "soak"
+      )
+
+    {:ok, bundle} = Kernel.compile_bundle([component])
+    {:ok, workflow} = WorkflowEnvironment.new(bundle: bundle, capabilities: [])
+    {:ok, mission} = MissionEnvironment.new([])
+    {:ok, limits} = Limits.new(evaluation_timeout_ms: 5_000)
+
+    {:ok, workflow: workflow, mission: mission, limits: limits}
+  end
+
+  describe "normal completion" do
+    test "close/1 removes the session entry and its owner", context do
+      LifecycleSoak.soak!(
+        [
+          name: "repl session (normal close)",
+          threshold_bytes_per_cycle: @threshold_bytes_per_cycle
+        ],
+        fn _cycle ->
+          {session, owner, sink} = open(context)
+          {:ok, _step, session} = ReplSession.eval(session, "(soak.repl/value 1)")
+
+          assert {:ok, _events} = ReplSession.close(session)
+          :ok = EventSink.stop(sink)
+
+          ledger(session, owner, sink)
+        end
+      )
+    end
+  end
+
+  describe "owner death" do
+    # Currently failing, and correctly so: this variant found a real leak.
+    # `close/1` and `abort/2` only reach `close_access/1` after
+    # `owned_session/1` succeeds, and `owned_session/1` exits when the owner is
+    # already dead — so an abnormally terminated owner leaves its access entry
+    # in the creator's table permanently. Reproduced standalone at 5 sessions,
+    # 5 permanent entries with dead pids.
+    #
+    # Skipped rather than deleted: the reproduction is the valuable part, and
+    # the fix is a production behaviour change that belongs in its own PR.
+    # Remove this tag as part of fixing
+    # https://github.com/andreasronge/ptc_runner/issues/1201.
+    @tag :skip
+    test "killing the ReplSessionOwner leaves no entry behind", context do
+      LifecycleSoak.soak!(
+        [
+          name: "repl session (owner death)",
+          threshold_bytes_per_cycle: @threshold_bytes_per_cycle
+        ],
+        fn _cycle ->
+          {session, owner, sink} = open(context)
+
+          # The owner dies without `terminate/2` running, which is the variant
+          # the happy path cannot reach. `close/1` must still be able to drop
+          # the creator-side access entry afterwards.
+          kill_and_await(owner)
+          _closed = ReplSession.close(session)
+          :ok = EventSink.stop(sink)
+
+          ledger(session, owner, sink)
+        end
+      )
+    end
+  end
+
+  describe "deadline expiry" do
+    test "abort/2 after the evaluation deadline leaves no entry behind", context do
+      # A one-millisecond evaluation budget: the run deadline is already spent
+      # by the time anything is evaluated, so the session is torn down through
+      # the expiry path rather than through a clean terminal publication.
+      {:ok, expired_limits} = Limits.new(evaluation_timeout_ms: 1)
+      context = %{context | limits: expired_limits}
+
+      LifecycleSoak.soak!(
+        [
+          name: "repl session (deadline expiry)",
+          threshold_bytes_per_cycle: @threshold_bytes_per_cycle
+        ],
+        fn _cycle ->
+          {session, owner, sink} = open(context)
+          _evaluated = ReplSession.eval(session, "(soak.repl/value 1)")
+          _aborted = ReplSession.abort(session, :deadline_expired)
+          :ok = EventSink.stop(sink)
+
+          ledger(session, owner, sink)
+        end
+      )
+    end
+  end
+
+  defp open(%{workflow: workflow, mission: mission, limits: limits}) do
+    {:ok, sink} = EventSink.start(:normal, limits, run_id: unique_run_id())
+
+    {:ok, config} =
+      RunConfig.new(
+        workflow_environment: workflow,
+        mission_environment: mission,
+        input: %{},
+        limits: limits,
+        event_sink: sink
+      )
+
+    {:ok, session} = ReplSession.new(config: config)
+    {session, owner_pid!(session), sink}
+  end
+
+  # `{id, {pid, token}}` — the owner is inside the entry. Reading it here, at
+  # creation, is what makes the owner-death variant test the owner rather than
+  # the creator.
+  defp owner_pid!(%ReplSession{access: access, id: id}) do
+    [{^id, {pid, token}}] = :ets.lookup(access, id)
+    assert is_pid(pid) and is_reference(token)
+    pid
+  end
+
+  defp ledger(%ReplSession{access: access, id: id}, owner, sink) do
+    # The access table is absent on purpose: it belongs to this test process
+    # and legitimately outlives every session, so only the entry can leak.
+    LifecycleSoak.ledger(processes: [owner, sink.pid], ets_entries: [{access, id}])
+  end
+
+  defp kill_and_await(pid) do
+    ref = Process.monitor(pid)
+    Process.exit(pid, :kill)
+    assert_receive {:DOWN, ^ref, :process, ^pid, _reason}
+    :ok
+  end
+
+  # Run IDs must carry entropy: a sink started with a repeated ID across
+  # thousands of cycles would make every cycle's events indistinguishable.
+  defp unique_run_id, do: "soak-repl-#{System.unique_integer([:positive])}"
+end

--- a/test/support/lifecycle_soak.ex
+++ b/test/support/lifecycle_soak.ex
@@ -99,13 +99,40 @@ defmodule PtcRunner.TestSupport.LifecycleSoak do
   @termination_timeout_ms 5_000
 
   # Measured envelope of how far a batch endpoint moves between batches on an
-  # unchanged workload: four batches of a clean `HostCredentialLease` churn put
-  # `:erlang.memory(:total)` inside a ~50 KB band with no leak present. That
-  # noise is an absolute quantity — it is the VM's drift between two GC points,
-  # not something each cycle contributes — so the per-cycle resolution it
-  # implies is `@endpoint_noise_bytes / cycles`. A byte budget tighter than
-  # that cannot be measured, only failed at random.
-  @endpoint_noise_bytes 50_000
+  # unchanged workload. This noise is an absolute quantity — the VM's drift
+  # between two GC points, not something each cycle contributes — so the
+  # per-cycle resolution it implies is `@endpoint_noise_bytes / cycles`. A byte
+  # budget tighter than that cannot be measured, only failed at random.
+  #
+  # Measured **under the condition the suite actually runs in**: every family in
+  # one VM, via `mix soak`, not one family on an idle one. That distinction cost
+  # a round of flakes. Isolated, a single family's endpoints sit inside a ~50 KB
+  # band; with the whole suite resident, repeated runs at 10 cycles a batch put
+  # fitted slopes anywhere in -9.5..+29.3 KB/cycle with no leak present, which
+  # is an endpoint excursion near 300 KB. 400 KB covers that with margin.
+  #
+  # The consequence is deliberate at both ends. A short local run (10 cycles)
+  # gets a 40 KB/cycle floor and effectively cannot gate on bytes — its verdict
+  # comes from the exact resource gates, which do not depend on cycle count at
+  # all. A `PTC_SOAK_ITERATIONS=3000` run gets a 133 B/cycle floor, well under
+  # every caller's budget, so there the caller's number governs and a real
+  # per-cycle leak of even 1 KB stands 3 MB above the noise.
+  @endpoint_noise_bytes 400_000
+
+  # Below this many cycles a batch, the byte slope is not gated at all — it is
+  # measured and printed, and the verdict comes from the exact resource gates,
+  # which do not depend on cycle count.
+  #
+  # This is the honest end of the resolution argument rather than a bigger
+  # constant. Endpoint drift is roughly fixed per batch, so at 10 cycles it is
+  # comparable to any budget worth setting: repeated clean runs of this suite
+  # produced fitted slopes from -9.5 to +41 KB/cycle with no leak present. No
+  # threshold separates signal from noise there, and one tuned until the flakes
+  # stop is not a gate, it is a number that happens not to fire yet.
+  #
+  # `PTC_SOAK_ITERATIONS=3000` — what the scheduled workflow runs — is two
+  # orders of magnitude above this, so CI always gates.
+  @min_cycles_for_byte_gate 100
 
   @gated_memory_keys [:total, :processes, :ets, :binary]
 
@@ -136,10 +163,12 @@ defmodule PtcRunner.TestSupport.LifecycleSoak do
     * `:warmup` — warmup cycles, default `PTC_SOAK_WARMUP`
     * `:threshold_bytes_per_cycle` — required; the byte-slope budget, chosen
       from the metric's observed batch-to-batch noise on this workload rather
-      than from a round number. The budget actually applied is the larger of
-      this and the resolution floor `#{@endpoint_noise_bytes} / cycles`, so a
-      short local run reports bytes without failing on noise while a
-      `PTC_SOAK_ITERATIONS=3000` run gates on the caller's number
+      than from a round number. Byte slopes are gated only at
+      `#{@min_cycles_for_byte_gate}` cycles a batch or more; below that they are
+      printed and the exact resource gates carry the verdict. When they are
+      gated, the budget applied is the larger of this and the resolution floor
+      `#{@endpoint_noise_bytes} / cycles`, so `PTC_SOAK_ITERATIONS=3000` gates on
+      the caller's number
     * `:atoms_per_cycle` — atom-slope budget, default `0.1`
     * `:termination_timeout_ms` — how long a cycle's owner may take to die
       before the exact gate fails, default #{@termination_timeout_ms}
@@ -171,7 +200,7 @@ defmodule PtcRunner.TestSupport.LifecycleSoak do
 
     IO.puts(format(report))
 
-    assert_slopes!(report, effective_threshold(threshold, cycles), atoms_per_cycle)
+    assert_slopes!(report, effective_threshold(threshold, cycles), atoms_per_cycle, cycles)
     report
   end
 
@@ -356,7 +385,23 @@ defmodule PtcRunner.TestSupport.LifecycleSoak do
 
   # ── slope assertions ─────────────────────────────────────────────────────
 
-  defp assert_slopes!(report, threshold, atoms_per_cycle) do
+  # The atom slope gates at every cycle count: atoms never GC, so the count is
+  # monotonic and no drift can offset it. Only the byte slopes need enough
+  # cycles to out-resolve the VM's own movement.
+  defp assert_slopes!(report, threshold, atoms_per_cycle, cycles)
+       when cycles < @min_cycles_for_byte_gate do
+    IO.puts(
+      "  byte slopes NOT gated: #{cycles} cycles per batch is below the " <>
+        "#{@min_cycles_for_byte_gate} needed to resolve them. The exact resource " <>
+        "gates above still carry this run's verdict."
+    )
+
+    assert_atom_slope!(report, atoms_per_cycle)
+    _unused = threshold
+    :ok
+  end
+
+  defp assert_slopes!(report, threshold, atoms_per_cycle, _cycles) do
     Enum.each(@gated_memory_keys, fn key ->
       fitted = memory_slope(report, key)
 
@@ -375,6 +420,10 @@ defmodule PtcRunner.TestSupport.LifecycleSoak do
       end
     end)
 
+    assert_atom_slope!(report, atoms_per_cycle)
+  end
+
+  defp assert_atom_slope!(report, atoms_per_cycle) do
     fitted_atoms = atom_slope(report)
 
     if fitted_atoms > atoms_per_cycle do

--- a/test/support/lifecycle_soak.ex
+++ b/test/support/lifecycle_soak.ex
@@ -77,7 +77,7 @@ defmodule PtcRunner.TestSupport.LifecycleSoak do
       family that ledgers its run state and stops there is missing a process
       per cycle.
     * **A capped family has no byte-slope backstop.** Byte gating applies only
-      at #{@min_cycles_for_byte_gate} cycles a batch or more, so in a family
+      at `@min_cycles_for_byte_gate` cycles a batch or more, so in a family
       capped below that an unledgered resource is invisible to *every* gate at
       *every* iteration count — not merely to the exact ones.
 

--- a/test/support/lifecycle_soak.ex
+++ b/test/support/lifecycle_soak.ex
@@ -67,6 +67,24 @@ defmodule PtcRunner.TestSupport.LifecycleSoak do
   so a test can find it would put a test affordance in the runtime for no
   runtime benefit.
 
+  A ledger that omits a resource the cycle really created is the failure this
+  module exists to prevent, and it is easy to write: the omission is invisible
+  precisely because nothing then checks it. Two traps in this codebase have
+  each produced it more than once.
+
+    * **Every `RunState` starts a `ProviderTaskTracker` alongside it**
+      (`run_state.ex:995`), reachable as `run_state.provider_tracker.pid`. A
+      family that ledgers its run state and stops there is missing a process
+      per cycle.
+    * **A capped family has no byte-slope backstop.** Byte gating applies only
+      at #{@min_cycles_for_byte_gate} cycles a batch or more, so in a family
+      capped below that an unledgered resource is invisible to *every* gate at
+      *every* iteration count — not merely to the exact ones.
+
+  When adding a family, enumerate what each cycle causes to exist rather than
+  what its API returns, and read owned pids out of live state before any
+  variant kills the owner.
+
   Termination must be deterministic — monitors and explicit acknowledgement,
   never `Process.sleep/1`.
   """

--- a/test/support/lifecycle_soak.ex
+++ b/test/support/lifecycle_soak.ex
@@ -1,0 +1,445 @@
+defmodule PtcRunner.TestSupport.LifecycleSoak do
+  @moduledoc """
+  Repeated-churn leak detection for the long-lived owner lifecycles.
+
+  `PtcRunner.TestSupport.MemorySoak` soaks two entry points that reap their
+  sandbox process when the call returns, so per-call leakage there is bounded by
+  construction. This module is its sibling for everything that is *not* bounded
+  that way: session owners, provider acquisition, credential leases, transports,
+  REPL sessions, and OAuth managers. Those have good single-cycle tests; none of
+  them was ever run N times with the aggregate asserted flat, and a per-cycle
+  residue small enough to pass every single-cycle assertion is exactly what
+  accumulates over a host's lifetime.
+
+  ## The oracle
+
+  `run K batches of N cycles`, forcing a system-wide GC at each batch boundary.
+  A one-shot cost (lazy module loading, first-use interning) appears in batch 1
+  only; a linear leak appears in every batch.
+
+  The detector is a **slope**, not a trend. "The per-batch delta does not grow"
+  is satisfied by a constant positive delta in every batch — which is precisely
+  the leak being hunted — so it must not be the assertion. Byte metrics are
+  regressed against cumulative cycles over batches 2..K and the fitted slope is
+  asserted below a per-metric threshold. Batch 1 is excluded from the fit and
+  kept in the report, because it is the warmup cost and worth reading.
+
+  ## Tiers
+
+  Not every sample can carry the same authority.
+
+    * **Gating, exact.** Resources the cycle itself created: owned processes,
+      the ETS entries it inserted, tables it allocated, ports it opened,
+      `:persistent_term` keys it wrote. The legitimate steady-state value is
+      zero, so these are asserted exactly, per cycle, through `ledger/1`.
+      They are deliberately **not** global counts: a global
+      `:erlang.system_info(:process_count)` both flaps on a shared VM and can
+      hide a real leak when an unrelated process exits and offsets it.
+
+    * **Gating, thresholded.** `:erlang.memory/0` byte totals, via the slope
+      assertion above against a caller-supplied threshold.
+
+    * **Diagnostic, non-gating.** Global counts, allocator carrier utilization
+      and RSS. Recorded and printed on every run, never failing a build. RSS
+      and carrier behavior are platform- and allocator-dependent, so they
+      inform an investigation rather than deciding it.
+
+  Monitors do not appear as their own gate. The plan lists "monitors held by the
+  family's owners" as exact, but every owner a cycle creates is asserted dead,
+  and a dead process holds no monitors — the process gate subsumes it. The
+  global monitor total stays as diagnostic context.
+
+  ## Writing a family soak
+
+      LifecycleSoak.soak!(
+        [name: "credential lease", threshold_bytes_per_cycle: 512],
+        fn _index ->
+          {:ok, owner, _fence, table} = HostCredentialLease.start(self())
+          :ok = HostCredentialLease.close(owner, fence, table)
+          LifecycleSoak.ledger(processes: [owner], tables: [table])
+        end
+      )
+
+  The cycle function creates, terminates, and returns a ledger of what it made.
+  Capturing identities at creation is the whole mechanism: there is no scanning
+  for owners, because outside `HostInstallationOwner` and `ReplSession` nothing
+  publishes a discoverable marker, and adding one to a production module purely
+  so a test can find it would put a test affordance in the runtime for no
+  runtime benefit.
+
+  Termination must be deterministic — monitors and explicit acknowledgement,
+  never `Process.sleep/1`.
+  """
+
+  alias PtcRunner.TestSupport.MemorySoak
+
+  @typedoc """
+  What one churn cycle created, so the exact assertions can be scoped to it.
+
+    * `:processes` — must all be dead when the cycle returns
+    * `:tables` — ETS tables that must be gone
+    * `:ets_entries` — `{table, key}` pairs that must be absent, for tables
+      that legitimately outlive the cycle (`ReplSession` allocates one
+      `:private` table per *creator process*, not per session, so a leaked
+      session entry never changes the table count)
+    * `:ports` — must all be closed
+    * `:persistent_terms` — keys that must be absent
+  """
+  @type ledger :: %{
+          processes: [pid()],
+          tables: [:ets.table()],
+          ets_entries: [{:ets.table(), term()}],
+          ports: [port()],
+          persistent_terms: [term()]
+        }
+
+  @empty_ledger %{processes: [], tables: [], ets_entries: [], ports: [], persistent_terms: []}
+
+  @default_batches 4
+  @termination_timeout_ms 5_000
+
+  # Measured envelope of how far a batch endpoint moves between batches on an
+  # unchanged workload: four batches of a clean `HostCredentialLease` churn put
+  # `:erlang.memory(:total)` inside a ~50 KB band with no leak present. That
+  # noise is an absolute quantity — it is the VM's drift between two GC points,
+  # not something each cycle contributes — so the per-cycle resolution it
+  # implies is `@endpoint_noise_bytes / cycles`. A byte budget tighter than
+  # that cannot be measured, only failed at random.
+  @endpoint_noise_bytes 50_000
+
+  @gated_memory_keys [:total, :processes, :ets, :binary]
+
+  @doc "Builds a ledger from keyword options; every field defaults to empty."
+  @spec ledger(keyword()) :: ledger()
+  def ledger(opts \\ []) do
+    Enum.reduce(opts, @empty_ledger, fn {key, value}, acc ->
+      unless Map.has_key?(@empty_ledger, key) do
+        raise ArgumentError,
+              "unknown ledger field #{inspect(key)}; expected one of " <>
+                inspect(Map.keys(@empty_ledger))
+      end
+
+      Map.put(acc, key, List.wrap(value))
+    end)
+  end
+
+  @doc """
+  Churns `cycle_fun` and asserts the gating metrics stay flat across batches.
+
+  Options:
+
+    * `:name` — required; names the owner family in every message
+    * `:cycles` — cycles per batch, default `MemorySoak.iteration_count/0`
+    * `:batches` — default #{@default_batches}; at least 3, because two batches
+      leave a single interval and the slope would rest on the batch that still
+      carries warmup
+    * `:warmup` — warmup cycles, default `PTC_SOAK_WARMUP`
+    * `:threshold_bytes_per_cycle` — required; the byte-slope budget, chosen
+      from the metric's observed batch-to-batch noise on this workload rather
+      than from a round number. The budget actually applied is the larger of
+      this and the resolution floor `#{@endpoint_noise_bytes} / cycles`, so a
+      short local run reports bytes without failing on noise while a
+      `PTC_SOAK_ITERATIONS=3000` run gates on the caller's number
+    * `:atoms_per_cycle` — atom-slope budget, default `0.1`
+    * `:termination_timeout_ms` — how long a cycle's owner may take to die
+      before the exact gate fails, default #{@termination_timeout_ms}
+
+  Returns the batch report so a characterization test can print its own
+  numbers without failing the build.
+  """
+  @spec soak!(keyword(), (non_neg_integer() -> ledger())) :: map()
+  def soak!(opts, cycle_fun) when is_function(cycle_fun, 1) do
+    name = Keyword.fetch!(opts, :name)
+    threshold = Keyword.fetch!(opts, :threshold_bytes_per_cycle)
+    cycles = Keyword.get(opts, :cycles, MemorySoak.iteration_count())
+    batches = Keyword.get(opts, :batches, @default_batches)
+    warmup = Keyword.get(opts, :warmup, MemorySoak.warmup_count())
+    atoms_per_cycle = Keyword.get(opts, :atoms_per_cycle, 0.1)
+    gate_opts = Keyword.take(opts, [:termination_timeout_ms])
+
+    if batches < 3 do
+      raise ArgumentError, "soak!/2 needs at least 3 batches to fit a slope, got #{batches}"
+    end
+
+    run_cycles(name, cycle_fun, warmup, :warmup, gate_opts)
+
+    report = %{
+      name: name,
+      cycles: cycles,
+      batches: run_batches(name, cycle_fun, cycles, batches, gate_opts)
+    }
+
+    IO.puts(format(report))
+
+    assert_slopes!(report, effective_threshold(threshold, cycles), atoms_per_cycle)
+    report
+  end
+
+  @doc """
+  The byte budget `soak!/2` actually applies at a given cycle count.
+
+  Below `#{@endpoint_noise_bytes} / cycles` a byte slope is indistinguishable
+  from the VM's own drift between GC points, so a tighter budget would only
+  produce random failures. The exact resource gates are unaffected — they do
+  not depend on cycle count at all, which is why they are the ones that carry
+  the verdict on a short run.
+  """
+  @spec effective_threshold(number(), pos_integer()) :: float()
+  def effective_threshold(threshold, cycles) when cycles > 0,
+    do: max(threshold * 1.0, @endpoint_noise_bytes / cycles)
+
+  @doc """
+  Counts live `:persistent_term` keys accepted by `match_fun`.
+
+  Family-scoped by construction: the caller supplies the predicate for its own
+  key shape, so the count never includes another subsystem's entries.
+  """
+  @spec count_persistent_terms((term() -> boolean())) :: non_neg_integer()
+  def count_persistent_terms(match_fun) when is_function(match_fun, 1) do
+    Enum.count(:persistent_term.get(), fn {key, _value} -> match_fun.(key) end)
+  end
+
+  @doc """
+  Fits a least-squares slope of `values` against `xs`.
+
+  Returns `0.0` when every `x` is identical, which cannot happen for batch
+  endpoints but keeps the helper total.
+  """
+  @spec slope([number()], [number()]) :: float()
+  def slope(xs, values) when length(xs) == length(values) do
+    n = length(xs)
+    mean_x = Enum.sum(xs) / n
+    mean_y = Enum.sum(values) / n
+
+    {covariance, variance} =
+      Enum.zip(xs, values)
+      |> Enum.reduce({0.0, 0.0}, fn {x, y}, {cov, var} ->
+        {cov + (x - mean_x) * (y - mean_y), var + (x - mean_x) * (x - mean_x)}
+      end)
+
+    if variance == 0.0, do: 0.0, else: covariance / variance
+  end
+
+  @doc """
+  Asserts every resource in `ledger` is gone, with a message naming the family.
+
+  Called after each cycle by `soak!/2`; exposed so a single-cycle test can use
+  the same definition of "reclaimed" as the soak does.
+  """
+  @spec assert_reclaimed!(binary(), ledger(), non_neg_integer(), keyword()) :: :ok
+  def assert_reclaimed!(name, ledger, cycle, opts \\ []) do
+    timeout = Keyword.get(opts, :termination_timeout_ms, @termination_timeout_ms)
+    Enum.each(ledger.processes, &assert_dead!(name, &1, cycle, timeout))
+    Enum.each(ledger.tables, &assert_table_gone!(name, &1, cycle))
+    Enum.each(ledger.ets_entries, &assert_entry_gone!(name, &1, cycle))
+    Enum.each(ledger.ports, &assert_port_closed!(name, &1, cycle))
+    Enum.each(ledger.persistent_terms, &assert_persistent_term_gone!(name, &1, cycle))
+    :ok
+  end
+
+  # ── batches ──────────────────────────────────────────────────────────────
+
+  defp run_batches(name, cycle_fun, cycles, batches, gate_opts) do
+    for batch <- 1..batches do
+      run_cycles(name, cycle_fun, cycles, batch, gate_opts)
+      MemorySoak.gc_everywhere()
+
+      %{
+        batch: batch,
+        cumulative_cycles: batch * cycles,
+        snapshot: MemorySoak.snapshot(gc: false)
+      }
+    end
+  end
+
+  defp run_cycles(_name, _cycle_fun, 0, _label, _gate_opts), do: :ok
+
+  defp run_cycles(name, cycle_fun, count, label, gate_opts) do
+    Enum.each(1..count, fn index ->
+      ledger = normalize!(name, label, index, cycle_fun.(index))
+      assert_reclaimed!(name, ledger, index, gate_opts)
+    end)
+  end
+
+  # A cycle that forgets to return a ledger would silently assert nothing, and
+  # the soak would pass by measuring an empty claim.
+  defp normalize!(_name, _label, _index, %{processes: _, tables: _} = ledger), do: ledger
+
+  defp normalize!(name, label, index, other) do
+    raise ArgumentError,
+          "#{name} #{label} cycle #{index} returned #{inspect(other)}; " <>
+            "cycle functions must return LifecycleSoak.ledger/1"
+  end
+
+  # ── exact assertions ─────────────────────────────────────────────────────
+
+  # Monitor-based, so termination is observed rather than waited out. A monitor
+  # on an already-dead process fires `:noproc` immediately, so this is correct
+  # whether the cycle's owner died before or after the ledger was built.
+  defp assert_dead!(name, pid, cycle, timeout) when is_pid(pid) do
+    ref = Process.monitor(pid)
+
+    receive do
+      {:DOWN, ^ref, :process, ^pid, _reason} -> :ok
+    after
+      timeout ->
+        Process.demonitor(ref, [:flush])
+
+        flunk(
+          name,
+          cycle,
+          "process #{inspect(pid)} was still alive #{timeout}ms after its " <>
+            "cycle returned: #{inspect(Process.info(pid, [:current_function, :dictionary]))}"
+        )
+    end
+  end
+
+  defp assert_table_gone!(name, table, cycle) do
+    case :ets.info(table, :size) do
+      :undefined ->
+        :ok
+
+      size ->
+        flunk(
+          name,
+          cycle,
+          "ETS table #{inspect(table)} survived its cycle with #{size} entries " <>
+            "(owner #{inspect(:ets.info(table, :owner))})"
+        )
+    end
+  end
+
+  defp assert_entry_gone!(name, {table, key}, cycle) do
+    case safe_lookup(table, key) do
+      [] ->
+        :ok
+
+      :table_gone ->
+        :ok
+
+      entries ->
+        flunk(name, cycle, "ETS entry #{inspect(key)} survived its cycle: #{inspect(entries)}")
+    end
+  end
+
+  defp assert_port_closed!(name, port, cycle) do
+    case Port.info(port) do
+      nil -> :ok
+      info -> flunk(name, cycle, "port #{inspect(port)} survived its cycle: #{inspect(info)}")
+    end
+  end
+
+  defp assert_persistent_term_gone!(name, key, cycle) do
+    case :persistent_term.get(key, :absent) do
+      :absent ->
+        :ok
+
+      value ->
+        flunk(
+          name,
+          cycle,
+          ":persistent_term key #{inspect(key)} survived its cycle: #{inspect(value)}"
+        )
+    end
+  end
+
+  defp safe_lookup(table, key) do
+    :ets.lookup(table, key)
+  rescue
+    ArgumentError -> :table_gone
+  end
+
+  defp flunk(name, cycle, message) do
+    raise ExUnit.AssertionError,
+      message: "#{name} soak, cycle #{cycle}: #{message}"
+  end
+
+  # ── slope assertions ─────────────────────────────────────────────────────
+
+  defp assert_slopes!(report, threshold, atoms_per_cycle) do
+    Enum.each(@gated_memory_keys, fn key ->
+      fitted = memory_slope(report, key)
+
+      if fitted > threshold do
+        raise ExUnit.AssertionError,
+          message: """
+          #{report.name} soak: `#{key}` grows #{Float.round(fitted, 2)} bytes per cycle \
+          across batches 2..#{length(report.batches)} (budget #{Float.round(threshold, 2)} \
+          at #{report.cycles} cycles per batch).
+
+          A constant per-batch delta is what a linear leak looks like, so this is \
+          fitted as a slope over cumulative cycles rather than compared batch to batch.
+
+          #{format(report)}
+          """
+      end
+    end)
+
+    fitted_atoms = atom_slope(report)
+
+    if fitted_atoms > atoms_per_cycle do
+      raise ExUnit.AssertionError,
+        message:
+          "#{report.name} soak: atom table grows #{Float.round(fitted_atoms, 4)} atoms per " <>
+            "cycle (budget #{atoms_per_cycle}). Atoms never GC.\n\n#{format(report)}"
+    end
+
+    :ok
+  end
+
+  # Batch 1 carries lazy module loading and first-use interning. Excluding it
+  # from the fit is what lets the same harness read a one-shot cost and a
+  # linear leak apart; it stays in the printed report.
+  defp fitted_batches(report), do: Enum.drop(report.batches, 1)
+
+  defp memory_slope(report, key) do
+    batches = fitted_batches(report)
+
+    slope(
+      Enum.map(batches, & &1.cumulative_cycles),
+      Enum.map(batches, &Keyword.fetch!(&1.snapshot.mem, key))
+    )
+  end
+
+  defp atom_slope(report) do
+    batches = fitted_batches(report)
+    slope(Enum.map(batches, & &1.cumulative_cycles), Enum.map(batches, & &1.snapshot.atoms))
+  end
+
+  # ── reporting ────────────────────────────────────────────────────────────
+
+  @doc "Renders the batch table, including the diagnostic-tier samples."
+  @spec format(map()) :: binary()
+  def format(report) do
+    rows =
+      Enum.map_join(report.batches, "\n", fn %{batch: batch, snapshot: snapshot} = entry ->
+        "  batch #{batch} (#{entry.cumulative_cycles} cycles): " <>
+          "total=#{MemorySoak.format_bytes(snapshot.mem[:total])} " <>
+          "procs_mem=#{MemorySoak.format_bytes(snapshot.mem[:processes])} " <>
+          "ets=#{MemorySoak.format_bytes(snapshot.mem[:ets])} " <>
+          "bin=#{MemorySoak.format_bytes(snapshot.mem[:binary])} " <>
+          "atoms=#{snapshot.atoms} procs=#{snapshot.procs} " <>
+          "tables=#{snapshot.ets_tables} entries=#{snapshot.ets_entries} " <>
+          "ports=#{snapshot.ports} pterms=#{snapshot.persistent_terms} " <>
+          "monitors=#{snapshot.monitors} " <>
+          "carrier_use=#{snapshot.carrier_utilization} rss=#{rss(snapshot)}"
+      end)
+
+    slopes =
+      Enum.map_join(@gated_memory_keys, ", ", fn key ->
+        "#{key}=#{Float.round(memory_slope(report, key), 2)}"
+      end)
+
+    """
+    #{report.name} lifecycle soak: #{report.cycles} cycles x #{length(report.batches)} batches
+    #{rows}
+      fitted slope over batches 2..#{length(report.batches)} (bytes/cycle): #{slopes}
+      fitted atom slope: #{Float.round(atom_slope(report), 4)} atoms/cycle
+      exact resource gates (processes, tables, entries, ports, persistent terms) passed every cycle
+      global counts, allocator utilization and RSS above are diagnostic only.
+    """
+  end
+
+  defp rss(%{rss_bytes: nil}), do: "unavailable"
+  defp rss(%{rss_bytes: bytes}), do: MemorySoak.format_bytes(bytes)
+end

--- a/test/support/lifecycle_soak_test.exs
+++ b/test/support/lifecycle_soak_test.exs
@@ -143,19 +143,48 @@ defmodule PtcRunner.TestSupport.LifecycleSoakTest do
 
     test "a byte leak the ledger cannot see still fails the slope gate" do
       # Retained off-ledger, so the exact gates have nothing to say and only
-      # the fitted byte slope can catch it. Each cycle pins 64 KB, far above
-      # the resolution floor at this cycle count.
+      # the fitted byte slope can catch it.
+      #
+      # Both numbers are chosen against the harness's own rules rather than by
+      # feel: byte slopes are gated only at 100 cycles a batch or more, and at
+      # 100 cycles the resolution floor is ~4 KB/cycle, so 64 KB a cycle sits an
+      # order of magnitude above it. The assertion is about the gate firing, not
+      # about where the threshold happens to sit.
       table = :ets.new(:leak, [:set, :public])
       on_exit(fn -> safe_delete(table) end)
 
       assert_raise ExUnit.AssertionError, ~r/grows .* bytes per cycle/, fn ->
-        soak!(fn cycle ->
-          true =
-            :ets.insert(table, {{System.unique_integer(), cycle}, :binary.copy(<<0>>, 65_536)})
+        soak!(
+          fn cycle ->
+            true =
+              :ets.insert(table, {{System.unique_integer(), cycle}, :binary.copy(<<0>>, 65_536)})
 
-          LifecycleSoak.ledger()
-        end)
+            LifecycleSoak.ledger()
+          end,
+          cycles: 100
+        )
       end
+    end
+
+    test "below the resolvable cycle count the byte gate is skipped, not silently passed" do
+      # The same leak, at a cycle count where the slope cannot be resolved. It
+      # must not raise — but it must also say so, because a byte gate that
+      # quietly stops applying is indistinguishable from one that passed.
+      table = :ets.new(:leak, [:set, :public])
+      on_exit(fn -> safe_delete(table) end)
+
+      output =
+        ExUnit.CaptureIO.capture_io(fn ->
+          soak!(fn cycle ->
+            true =
+              :ets.insert(table, {{System.unique_integer(), cycle}, :binary.copy(<<0>>, 65_536)})
+
+            LifecycleSoak.ledger()
+          end)
+        end)
+
+      assert output =~ "byte slopes NOT gated"
+      assert output =~ "exact resource gates above still carry this run's verdict"
     end
 
     test "a clean cycle passes and returns its batch report" do

--- a/test/support/lifecycle_soak_test.exs
+++ b/test/support/lifecycle_soak_test.exs
@@ -1,0 +1,245 @@
+defmodule PtcRunner.TestSupport.LifecycleSoakTest do
+  @moduledoc """
+  Proves the leak detector detects leaks.
+
+  A soak harness that reports "flat" is indistinguishable from one that
+  measures nothing, and every family soak built on this module inherits
+  whichever it is. These tests plant each leak the harness claims to catch and
+  assert it fails — the harness's own failing-test-before-trusting-it.
+
+  Deliberately not tagged `:soak`: this runs in the ordinary suite, because a
+  harness that only proves itself in a weekly job is a harness nobody notices
+  the breakage of.
+  """
+
+  use ExUnit.Case, async: false
+
+  alias PtcRunner.TestSupport.LifecycleSoak
+
+  # Small and fixed: these tests are about whether an assertion fires, not
+  # about measuring anything, so they must not inherit PTC_SOAK_ITERATIONS.
+  @cycles 3
+  @batches 3
+
+  # A leaked process fails after this instead of the harness's 5s production
+  # default, so proving the gate fires costs milliseconds rather than seconds.
+  @gate_opts [termination_timeout_ms: 50]
+
+  describe "ledger/1" do
+    test "rejects a field it does not know, rather than silently asserting nothing" do
+      assert_raise ArgumentError, ~r/unknown ledger field :procs/, fn ->
+        LifecycleSoak.ledger(procs: [self()])
+      end
+    end
+
+    test "wraps a bare value so a single resource does not have to be listed" do
+      assert %{processes: [pid]} = LifecycleSoak.ledger(processes: self())
+      assert pid == self()
+    end
+  end
+
+  describe "exact resource gates" do
+    test "a surviving process fails" do
+      pid = spawn(fn -> receive do: (:never -> :ok) end)
+      on_exit(fn -> Process.exit(pid, :kill) end)
+
+      assert_raise ExUnit.AssertionError, ~r/was still alive/, fn ->
+        LifecycleSoak.assert_reclaimed!(
+          "probe",
+          LifecycleSoak.ledger(processes: pid),
+          1,
+          @gate_opts
+        )
+      end
+    end
+
+    test "a surviving ETS table fails" do
+      table = :ets.new(:probe, [:set, :public])
+      on_exit(fn -> safe_delete(table) end)
+
+      assert_raise ExUnit.AssertionError, ~r/survived its cycle with 0 entries/, fn ->
+        LifecycleSoak.assert_reclaimed!("probe", LifecycleSoak.ledger(tables: table), 1)
+      end
+    end
+
+    test "a surviving entry fails even though its table is legitimately alive" do
+      table = :ets.new(:probe, [:set, :public])
+      on_exit(fn -> safe_delete(table) end)
+      true = :ets.insert(table, {:leaked, :value})
+
+      assert_raise ExUnit.AssertionError, ~r/ETS entry :leaked survived/, fn ->
+        LifecycleSoak.assert_reclaimed!(
+          "probe",
+          LifecycleSoak.ledger(ets_entries: {table, :leaked}),
+          1
+        )
+      end
+    end
+
+    test "a deleted table with a listed entry passes, because the entry is gone with it" do
+      table = :ets.new(:probe, [:set, :public])
+      true = :ets.insert(table, {:key, :value})
+      true = :ets.delete(table)
+
+      assert :ok =
+               LifecycleSoak.assert_reclaimed!(
+                 "probe",
+                 LifecycleSoak.ledger(ets_entries: {table, :key}),
+                 1
+               )
+    end
+
+    test "a surviving port fails" do
+      port = Port.open({:spawn, "cat"}, [:binary])
+      on_exit(fn -> safe_close(port) end)
+
+      assert_raise ExUnit.AssertionError, ~r/survived its cycle/, fn ->
+        LifecycleSoak.assert_reclaimed!("probe", LifecycleSoak.ledger(ports: port), 1)
+      end
+    end
+
+    test "a surviving persistent_term fails" do
+      key = {__MODULE__, :probe}
+      :persistent_term.put(key, :value)
+      on_exit(fn -> :persistent_term.erase(key) end)
+
+      assert_raise ExUnit.AssertionError, ~r/persistent_term key .* survived/, fn ->
+        LifecycleSoak.assert_reclaimed!("probe", LifecycleSoak.ledger(persistent_terms: key), 1)
+      end
+    end
+
+    test "a clean cycle passes every gate" do
+      assert :ok = LifecycleSoak.assert_reclaimed!("probe", LifecycleSoak.ledger(), 1)
+    end
+  end
+
+  describe "soak!/2" do
+    test "a cycle that forgets its ledger fails instead of measuring an empty claim" do
+      assert_raise ArgumentError, ~r/cycle functions must return/, fn ->
+        soak!(fn _cycle -> :ok end)
+      end
+    end
+
+    test "fewer than three batches is refused, because one interval cannot carry a slope" do
+      assert_raise ArgumentError, ~r/at least 3 batches/, fn ->
+        LifecycleSoak.soak!(
+          [name: "probe", threshold_bytes_per_cycle: 1, cycles: 1, batches: 2, warmup: 0],
+          fn _cycle -> LifecycleSoak.ledger() end
+        )
+      end
+    end
+
+    test "a per-cycle process leak fails the exact gate" do
+      assert_raise ExUnit.AssertionError, ~r/was still alive/, fn ->
+        soak!(fn _cycle ->
+          pid = spawn(fn -> receive do: (:never -> :ok) end)
+          send(self(), {:leaked, pid})
+          LifecycleSoak.ledger(processes: pid)
+        end)
+      end
+
+      drain_leaked()
+    end
+
+    test "a byte leak the ledger cannot see still fails the slope gate" do
+      # Retained off-ledger, so the exact gates have nothing to say and only
+      # the fitted byte slope can catch it. Each cycle pins 64 KB, far above
+      # the resolution floor at this cycle count.
+      table = :ets.new(:leak, [:set, :public])
+      on_exit(fn -> safe_delete(table) end)
+
+      assert_raise ExUnit.AssertionError, ~r/grows .* bytes per cycle/, fn ->
+        soak!(fn cycle ->
+          true =
+            :ets.insert(table, {{System.unique_integer(), cycle}, :binary.copy(<<0>>, 65_536)})
+
+          LifecycleSoak.ledger()
+        end)
+      end
+    end
+
+    test "a clean cycle passes and returns its batch report" do
+      # Three cycles per batch put the resolution floor right at the measured
+      # endpoint envelope, so a sensitivity-scale budget here would flake on
+      # the VM's own drift. This case is about the plumbing, not the threshold.
+      report =
+        soak!(fn _cycle -> LifecycleSoak.ledger() end, threshold_bytes_per_cycle: 1_000_000)
+
+      assert report.cycles == @cycles
+      assert length(report.batches) == @batches
+
+      assert Enum.map(report.batches, & &1.cumulative_cycles) == [
+               @cycles,
+               @cycles * 2,
+               @cycles * 3
+             ]
+    end
+  end
+
+  describe "slope/2" do
+    test "recovers an exact linear rate" do
+      assert LifecycleSoak.slope([10, 20, 30], [100, 200, 300]) == 10.0
+    end
+
+    test "is zero for a flat series, whatever its level" do
+      assert LifecycleSoak.slope([10, 20, 30], [500, 500, 500]) == 0.0
+    end
+
+    test "is negative when the series falls, so noise cannot read as growth" do
+      assert LifecycleSoak.slope([10, 20, 30], [300, 200, 100]) == -10.0
+    end
+
+    test "is zero rather than undefined when every x is identical" do
+      assert LifecycleSoak.slope([5, 5, 5], [1, 2, 3]) == 0.0
+    end
+  end
+
+  describe "effective_threshold/2" do
+    test "the caller's budget governs once the cycle count can resolve it" do
+      assert LifecycleSoak.effective_threshold(512, 3_000) == 512.0
+    end
+
+    test "a short run is floored by what its endpoints can actually resolve" do
+      assert LifecycleSoak.effective_threshold(512, 25) > 512.0
+    end
+  end
+
+  defp soak!(cycle_fun, opts \\ []) do
+    LifecycleSoak.soak!(
+      Keyword.merge(
+        [
+          name: "probe",
+          threshold_bytes_per_cycle: 1,
+          cycles: @cycles,
+          batches: @batches,
+          warmup: 0,
+          termination_timeout_ms: 50
+        ],
+        opts
+      ),
+      cycle_fun
+    )
+  end
+
+  defp drain_leaked do
+    receive do
+      {:leaked, pid} ->
+        Process.exit(pid, :kill)
+        drain_leaked()
+    after
+      0 -> :ok
+    end
+  end
+
+  defp safe_delete(table) do
+    :ets.delete(table)
+  rescue
+    ArgumentError -> :ok
+  end
+
+  defp safe_close(port) do
+    Port.close(port)
+  rescue
+    ArgumentError -> :ok
+  end
+end

--- a/test/support/memory_soak.ex
+++ b/test/support/memory_soak.ex
@@ -23,6 +23,25 @@ defmodule PtcRunner.TestSupport.MemorySoak do
                         A non-trivial drop here on an otherwise quiet system
                         is the classic BEAM "small binary references pinning
                         big refc binaries" pattern.
+    * `:ets_tables`   — `length(:ets.all())`
+    * `:ets_entries`  — summed `:ets.info(t, :size)` across every live table.
+                        `ReplSession` allocates one `:private` table per
+                        *creator process*, not per session, so a leaked
+                        session shows up here and never in the table count.
+    * `:ports`        — `length(:erlang.ports())`
+    * `:persistent_terms` — `length(:persistent_term.get())`
+    * `:monitors`     — total monitors held across every live process
+    * `:carrier_utilization` — `:recon_alloc` allocated-vs-used ratio. This is
+                        the one sample that can see allocator fragmentation,
+                        the classic "flat `:erlang.memory` while RSS climbs"
+                        failure every other number here passes.
+    * `:rss_bytes`    — resident set size, or `nil` where it cannot be read.
+
+  Every sample in this snapshot is **global**, which makes all of them
+  diagnostic context rather than gates: a global count both flaps on a shared
+  VM and can hide a real leak when something unrelated exits and offsets it.
+  `PtcRunner.TestSupport.LifecycleSoak` is where counted resources are scoped
+  to the ones a test actually created and asserted exactly.
 
   ## Workflow
 
@@ -58,6 +77,13 @@ defmodule PtcRunner.TestSupport.MemorySoak do
           max_mailbox_messages: non_neg_integer(),
           top_memory: [{pid(), non_neg_integer(), term()}],
           bin_leak: integer(),
+          ets_tables: non_neg_integer(),
+          ets_entries: non_neg_integer(),
+          ports: non_neg_integer(),
+          persistent_terms: non_neg_integer(),
+          monitors: non_neg_integer(),
+          carrier_utilization: float() | nil,
+          rss_bytes: non_neg_integer() | nil,
           monotonic_ms: integer()
         }
 
@@ -76,6 +102,13 @@ defmodule PtcRunner.TestSupport.MemorySoak do
       max_mailbox_messages: process_totals.max_mailbox_messages,
       top_memory: top_by_memory(Keyword.get(opts, :top_n, top_n())),
       bin_leak: bin_leak(),
+      ets_tables: length(:ets.all()),
+      ets_entries: ets_entries(),
+      ports: length(:erlang.ports()),
+      persistent_terms: length(:persistent_term.get()),
+      monitors: process_totals.monitors,
+      carrier_utilization: carrier_utilization(),
+      rss_bytes: rss_bytes(),
       monotonic_ms: System.monotonic_time(:millisecond)
     }
   end
@@ -338,14 +371,19 @@ defmodule PtcRunner.TestSupport.MemorySoak do
   defp process_totals do
     Enum.reduce(
       Process.list(),
-      %{reductions: 0, mailbox_messages: 0, max_mailbox_messages: 0},
+      %{reductions: 0, mailbox_messages: 0, max_mailbox_messages: 0, monitors: 0},
       fn pid, acc ->
-        case Process.info(pid, [:reductions, :message_queue_len]) do
-          [{:reductions, reductions}, {:message_queue_len, mailbox_messages}] ->
+        case Process.info(pid, [:reductions, :message_queue_len, :monitors]) do
+          [
+            {:reductions, reductions},
+            {:message_queue_len, mailbox_messages},
+            {:monitors, monitors}
+          ] ->
             %{
               reductions: acc.reductions + reductions,
               mailbox_messages: acc.mailbox_messages + mailbox_messages,
-              max_mailbox_messages: max(acc.max_mailbox_messages, mailbox_messages)
+              max_mailbox_messages: max(acc.max_mailbox_messages, mailbox_messages),
+              monitors: acc.monitors + length(monitors)
             }
 
           _dead ->
@@ -353,6 +391,51 @@ defmodule PtcRunner.TestSupport.MemorySoak do
         end
       end
     )
+  end
+
+  # Tables come and go while this walks them, so a vanished table contributes
+  # zero rather than raising.
+  defp ets_entries do
+    Enum.reduce(:ets.all(), 0, fn table, total ->
+      case :ets.info(table, :size) do
+        size when is_integer(size) -> total + size
+        :undefined -> total
+      end
+    end)
+  end
+
+  # Allocated-versus-used across every allocator. `:erlang.memory/0` reports
+  # what the VM believes it is using; this is the only sample here that can see
+  # carriers held by the allocator after the blocks inside them were freed.
+  defp carrier_utilization do
+    if Code.ensure_loaded?(:recon_alloc) do
+      case :recon_alloc.memory(:usage) do
+        usage when is_float(usage) -> Float.round(usage, 4)
+        _other -> nil
+      end
+    end
+  rescue
+    # `:recon_alloc` reads emulator-specific allocator instrumentation that a
+    # differently built VM need not expose.
+    _exception -> nil
+  end
+
+  # Platform-specific by nature, which is exactly why it never gates. `ps` is
+  # present on both darwin and linux; anything else reports `nil` rather than
+  # branching the oracle on OS.
+  defp rss_bytes do
+    case System.cmd("ps", ["-o", "rss=", "-p", System.pid()], stderr_to_stdout: true) do
+      {output, 0} ->
+        case Integer.parse(String.trim(output)) do
+          {kilobytes, _rest} -> kilobytes * 1024
+          :error -> nil
+        end
+
+      _unavailable ->
+        nil
+    end
+  rescue
+    ErlangError -> nil
   end
 
   defp bin_leak do
@@ -369,7 +452,9 @@ defmodule PtcRunner.TestSupport.MemorySoak do
   end
 
   defp iterations, do: env_int("PTC_SOAK_ITERATIONS", 100)
-  defp warmup_count, do: env_int("PTC_SOAK_WARMUP", 10)
+
+  @doc "Warmup iteration count for soak loops (override via `PTC_SOAK_WARMUP`)."
+  def warmup_count, do: env_int("PTC_SOAK_WARMUP", 10)
   defp tolerance_pct, do: env_int("PTC_SOAK_TOLERANCE_PCT", 20)
   defp top_n, do: env_int("PTC_SOAK_TOP_N", 10)
 


### PR DESCRIPTION
Implements slices 1–4 of `docs/plans/memory-observability.md`. Slice 5 is deliberately excluded.

## Review status — read this first

**The `codex-independent-review` gate has not been run.** The plan's workflow calls for it before the PR exists; the session ran out of budget after the implementation and the PR was opened at the author's direction instead. Treat this as unreviewed by that gate.

Two things a reviewer should know up front:

- **One test is `@tag :skip` because it found a real leak**, not because it is flaky — [#1201](https://github.com/andreasronge/ptc_runner/issues/1201).
- **`mix bench.check`'s reductions gate is red on this toolchain, pre-existing and untouched.** `lisp_eval.json` records Elixir 1.19.3 / OTP 28; the pinned toolchain is 1.20.2 / OTP 29, and every scenario is ~35–45% over. Re-baselining reductions needs its own written cause.

## Slice 1 — restore the gate (`aac74f3f`)

The soak suite has had no automated caller since `mix release.smoke` was deleted in `ec5806d1`, while two documents still asserted the gate existed. A documented gate that does not run is worse than an absent one, because it stops maintainers from looking.

`mix soak` alias, a new `.github/workflows/soak.yml` (weekly + `workflow_dispatch`, `PTC_SOAK_ITERATIONS=3000`), and both stale documents corrected. No new assertions — this slice only makes existing ones run.

**Open question decided:** a new `soak.yml`, not `test.yml`. That workflow gates PRs through its `required` job and fans out per-path; a long-running trend suite belongs in neither.

## Slice 2 — heap baseline (`37396aeb`, `+docs fix`)

`mix bench.heap`, `bench/heap_baseline.exs`, and a committed `bench/baselines/heap.json` covering use-case rows 1–9.

Metric decisions, each with its reasoning in the code:

- `residual_bytes_per_iter` gates with a **measured** 512 B/cycle floor. Six clean runs of the unchanged workload put it anywhere in −445..+444 B/iter, so the metric has no resolution below half a kilobyte per iteration at bench scale.
- The concurrency row's sampled `peak_*` figures are **diagnostic, never compared**: `:erlang.memory/0` walks every allocator, so the sampler lands ~10 reads on a sub-millisecond run and the figure moved by more than 2× between runs of the same workload. That row gates on deterministic `worker_heap_bytes_*` instead.
- `mix_modules` has a baseline of 0 and no noise floor, so the floor rows fail the moment the child VM loads a Mix module — the only thing that would invalidate them.

Row 1 escapes `mix run` by booting a child `elixir` over the same build path: a floor measured with Mix and the compiler resident is a number no embedded host ever pays.

**Open question decided:** the heap check **stays informational in `mix bench.check`** and gates only in `mix bench.heap`. Byte metrics on a per-commit path invite the reflexive re-baseline that is how a gate stops meaning anything, and this repository has already seen that once.

Found while measuring: the first `kernel_run` residual read 6.5 KB/iter. That was the harness, not the runtime — `Runner` finalizes the event sink but never stops it, by design, so the host can read its events. A loop that never calls `EventSink.stop/1` accumulates a process per run.

## Slice 3 — lifecycle soak (`3ed85320`, `8d24d14f`, `64813b1c`, `12ad6a6e`)

Landed in stages, harness first, as the plan asks.

The oracle is a repeated-batch **slope**, not a trend: "the per-batch delta does not grow" is satisfied by a constant positive delta in every batch, which is precisely the leak being hunted. Three tiers — exact gates on resources the cycle created (via a ledger it returns), a thresholded byte slope, and diagnostic-only global counts, allocator carrier utilization and RSS.

`test/support/lifecycle_soak_test.exs` runs in the **ordinary** suite and plants each leak the harness claims to catch. A harness that reports "flat" is indistinguishable from one that measures nothing.

Families: credential lease, REPL, provider, analysis/trace, and the OAuth row-17 characterization.

**Open question decided:** MCP transports (rows 13–14) cut — they need external process fixtures and are the most environment-dependent. Execution session (rows 18–19) not built. Row-16 OAuth soak variants cut after they proved to cost ~5 s/cycle: `TokenManager` dies with its *owner*, not with `close/1`.

## Row 17 result — growth CONFIRMED, both variants

```
fixed identity:    20 LocalFences.block/3 calls over 20 distinct transitions
                   5 / 10 / 15 / 20 live fences  ->  slope 1.0 per transition
churning identity: 20 LocalFences.block/3 calls over 20 distinct transitions
                   5 / 10 / 15 / 20 live fences  ->  slope 1.0 per transition
```

Both report observed blocks **and** a positive slope, so neither half of the deferred slice is retired, and the reading is not a workload that silently never reached the code. Per-identity coalescing would not have sufficed on its own — the fixed-identity variant grows one-for-one too.

Two traps closed while building it, either of which would have produced a confident wrong answer: `:erlang.trace_pattern/3` silently matches **zero** functions on an unloaded module (lazy loading makes that the default for whichever test runs first), and `on_exit` runs in a different process so a test-owned ETS table is already gone when it fires.

## Slice 4 — runtime memory signal (`ef5f087e`)

`memory_bytes` and `eval_reductions` added to `[:ptc_runner, :lisp, :execute, :stop]`. Both were already measured by `Sandbox` and surfaced in `step.usage`; the stop event carried neither, so a host attached to telemetry could not chart per-run heap at all. Additive to a measurements map, so no handler breaks. Kernel telemetry deliberately not widened.

## Why Slice 5 is excluded

It depends on row 17's empirical result — now available, and it confirms the candidate — and it changes a fail-closed security mechanism: fence permanence is what stops rejected OAuth authority being reissued after a manager restart. Bundling that with four observability changes makes the review worse at exactly the point it needs to be sharpest.

## Verification

- `mix precommit` green on each commit.
- `MIX_ENV=dev mix docs --warnings-as-errors` clean.
- `PTC_SOAK_ITERATIONS=10 mix soak` → **23 passed, 1 skipped** (the #1201 reproduction).
- `mix bench.heap` passes on three consecutive runs; a synthetically halved baseline is detected and raises on 16 rows.

https://claude.ai/code/session_01BZr9hhf995c5FziKVBCxFT