### PR TITLE
fix(test): remove timing races from six full-suite-load flakes

### DIFF
--- a/test/ptc_runner/kernel/dispatcher_effect_test.exs
+++ b/test/ptc_runner/kernel/dispatcher_effect_test.exs
@@ -118,17 +118,19 @@ defmodule PtcRunner.Kernel.DispatcherEffectTest do
             # `await_provider/6` in the dispatcher uses this single value both
             # as the deadline it reports as `:provider_timeout` AND as the
             # window the provider process has to be scheduled at all -- past
-            # it, the dispatcher kills the provider outright, so a value too
-            # close to the default assert_receive timeout below risks the
-            # provider being killed before it ever ran, meaning
-            # `:callback_started` would never arrive no matter how long this
-            # test waited for it. 500ms gives the provider a comfortable
-            # scheduling window under full-suite contention.
+            # it, the dispatcher kills the provider outright, so 500ms gives
+            # it a comfortable scheduling window under full-suite contention.
             timeout_ms: 500
           )
         end)
 
-      assert_receive {:callback_started, ^effect}, 400
+      # Must be >= the dispatch timeout above, not below it: the callback
+      # can legitimately start scheduling at any point up to that deadline
+      # and still succeed, so an assert_receive timeout shorter than it
+      # would time out on a slow-but-successful start instead of only on a
+      # genuine failure to ever run. The margin covers message-delivery
+      # latency for the signal itself.
+      assert_receive {:callback_started, ^effect}, 700
 
       assert_effect_failure(
         Task.await(task),
@@ -161,10 +163,11 @@ defmodule PtcRunner.Kernel.DispatcherEffectTest do
           Dispatcher.dispatch(state, :mission, environment, capability.name, %{}, 1_000)
         end)
 
-      # Kept below the dispatch call's own 1_000ms deadline above -- an equal
-      # value would race the provider's scheduling delay against dispatch's
-      # own timeout instead of leaving it room to win.
-      assert_receive {:callback_started, ^effect, provider}, 500
+      # Must be >= the dispatch call's own 1_000ms deadline above, for the
+      # same reason as the other `assert_receive {:callback_started, ...}`
+      # in this file: a shorter wait can time out on a legitimately slow
+      # (but still successful) provider start.
+      assert_receive {:callback_started, ^effect, provider}, 1_200
       assert :ok = RunState.close(state)
       send(provider, :finish)
 

--- a/test/ptc_runner/kernel/dispatcher_effect_test.exs
+++ b/test/ptc_runner/kernel/dispatcher_effect_test.exs
@@ -119,7 +119,10 @@ defmodule PtcRunner.Kernel.DispatcherEffectTest do
           )
         end)
 
-      assert_receive {:callback_started, ^effect}
+      # Default assert_receive timeout is 100ms; under full-suite scheduler
+      # contention the Task.async'd callback can take longer than that just
+      # to get scheduled, unrelated to the timeout behaviour under test.
+      assert_receive {:callback_started, ^effect}, 1_000
 
       assert_effect_failure(
         Task.await(task),
@@ -152,7 +155,9 @@ defmodule PtcRunner.Kernel.DispatcherEffectTest do
           Dispatcher.dispatch(state, :mission, environment, capability.name, %{}, 1_000)
         end)
 
-      assert_receive {:callback_started, ^effect, provider}
+      # See the timeout note on the other `assert_receive {:callback_started, ...}`
+      # above -- same race against scheduler contention in the full suite.
+      assert_receive {:callback_started, ^effect, provider}, 1_000
       assert :ok = RunState.close(state)
       send(provider, :finish)
 

--- a/test/ptc_runner/kernel/dispatcher_effect_test.exs
+++ b/test/ptc_runner/kernel/dispatcher_effect_test.exs
@@ -115,14 +115,20 @@ defmodule PtcRunner.Kernel.DispatcherEffectTest do
                 :never -> {:ok, nil}
               end
             end,
-            timeout_ms: 50
+            # `await_provider/6` in the dispatcher uses this single value both
+            # as the deadline it reports as `:provider_timeout` AND as the
+            # window the provider process has to be scheduled at all -- past
+            # it, the dispatcher kills the provider outright, so a value too
+            # close to the default assert_receive timeout below risks the
+            # provider being killed before it ever ran, meaning
+            # `:callback_started` would never arrive no matter how long this
+            # test waited for it. 500ms gives the provider a comfortable
+            # scheduling window under full-suite contention.
+            timeout_ms: 500
           )
         end)
 
-      # Default assert_receive timeout is 100ms; under full-suite scheduler
-      # contention the Task.async'd callback can take longer than that just
-      # to get scheduled, unrelated to the timeout behaviour under test.
-      assert_receive {:callback_started, ^effect}, 1_000
+      assert_receive {:callback_started, ^effect}, 400
 
       assert_effect_failure(
         Task.await(task),
@@ -155,9 +161,10 @@ defmodule PtcRunner.Kernel.DispatcherEffectTest do
           Dispatcher.dispatch(state, :mission, environment, capability.name, %{}, 1_000)
         end)
 
-      # See the timeout note on the other `assert_receive {:callback_started, ...}`
-      # above -- same race against scheduler contention in the full suite.
-      assert_receive {:callback_started, ^effect, provider}, 1_000
+      # Kept below the dispatch call's own 1_000ms deadline above -- an equal
+      # value would race the provider's scheduling delay against dispatch's
+      # own timeout instead of leaving it room to win.
+      assert_receive {:callback_started, ^effect, provider}, 500
       assert :ok = RunState.close(state)
       send(provider, :finish)
 

--- a/test/ptc_runner/kernel/dispatcher_effect_test.exs
+++ b/test/ptc_runner/kernel/dispatcher_effect_test.exs
@@ -124,16 +124,19 @@ defmodule PtcRunner.Kernel.DispatcherEffectTest do
           )
         end)
 
-      # Must be >= the dispatch timeout above, not below it: the callback
-      # can legitimately start scheduling at any point up to that deadline
-      # and still succeed, so an assert_receive timeout shorter than it
-      # would time out on a slow-but-successful start instead of only on a
-      # genuine failure to ever run. The margin covers message-delivery
-      # latency for the signal itself.
-      assert_receive {:callback_started, ^effect}, 700
+      # No timing race: `dispatch_mission` above only returns once its own
+      # `timeout_ms` has elapsed (the callback blocks forever on :never, so
+      # nothing else makes it return), so by the time `Task.await` unblocks,
+      # `:callback_started` has already been sent if it was ever going to
+      # be -- `assert_received` just checks the mailbox, no wait needed. A
+      # racing `assert_receive` before this point (as a prior version of
+      # this test had) could time out on a legitimately slow-but-successful
+      # callback start that simply hadn't happened yet.
+      result = Task.await(task, 5_000)
+      assert_received {:callback_started, ^effect}
 
       assert_effect_failure(
-        Task.await(task),
+        result,
         effect,
         %{kind: :timeout, reason: :provider_timeout},
         true
@@ -160,14 +163,19 @@ defmodule PtcRunner.Kernel.DispatcherEffectTest do
 
       task =
         Task.async(fn ->
-          Dispatcher.dispatch(state, :mission, environment, capability.name, %{}, 1_000)
+          Dispatcher.dispatch(state, :mission, environment, capability.name, %{}, 3_000)
         end)
 
-      # Must be >= the dispatch call's own 1_000ms deadline above, for the
-      # same reason as the other `assert_receive {:callback_started, ...}`
-      # in this file: a shorter wait can time out on a legitimately slow
-      # (but still successful) provider start.
-      assert_receive {:callback_started, ^effect, provider}, 1_200
+      # Unlike the timeout test above, this callback doesn't block forever
+      # -- it waits for `:finish`, sent below -- so `Task.await` can't be
+      # moved after this wait the same way (we need `provider`'s pid from
+      # the message before we can send it anything). The wait here has to
+      # cover not just the dispatch call's own deadline, but everything
+      # before that deadline even starts ticking: Task scheduling plus
+      # `Dispatcher.dispatch/6`'s own setup (capability validation, budget
+      # reservation) ahead of `await_provider/6`. Both timeouts are
+      # generous specifically to swallow that prefix too.
+      assert_receive {:callback_started, ^effect, provider}, 5_000
       assert :ok = RunState.close(state)
       send(provider, :finish)
 

--- a/test/ptc_runner/kernel/owner_status_privacy_test.exs
+++ b/test/ptc_runner/kernel/owner_status_privacy_test.exs
@@ -1,6 +1,8 @@
 defmodule PtcRunner.Kernel.OwnerStatusPrivacyTest do
   use ExUnit.Case, async: false
 
+  import PtcRunner.TestSupport.TestHelpers, only: [long_running_body: 0]
+
   alias PtcRunner.Kernel.ApplicationPackage
   alias PtcRunner.Kernel.ExecutionSessionOwner
   alias PtcRunner.Kernel.InspectionSink
@@ -166,7 +168,9 @@ defmodule PtcRunner.Kernel.OwnerStatusPrivacyTest do
 
     documents = %{
       "ptc.json" => Jason.encode!(manifest),
-      "main.clj" => "(ns app) (defn run [_input] (loop [] (recur)))"
+      # The owner must still be running when the tests below call it and read
+      # its OTP status; `long_running_body/1` keeps it there for real.
+      "main.clj" => "(ns app) (defn run [_input] #{long_running_body()})"
     }
 
     {:ok, request} =

--- a/test/ptc_runner/kernel/provider_execution_lifecycle_test.exs
+++ b/test/ptc_runner/kernel/provider_execution_lifecycle_test.exs
@@ -2,6 +2,7 @@ defmodule PtcRunner.Kernel.ProviderExecutionLifecycleTest do
   use ExUnit.Case, async: false
 
   import PtcRunner.TestSupport.Eventually, only: [assert_eventually: 1]
+  import PtcRunner.TestSupport.TestHelpers, only: [long_running_body: 0]
 
   alias PtcRunner.Kernel.ApplicationPackage
   alias PtcRunner.Kernel.Capability
@@ -63,7 +64,7 @@ defmodule PtcRunner.Kernel.ProviderExecutionLifecycleTest do
 
     fixture =
       provider_fixture(
-        body: "(loop [] (recur))",
+        body: long_running_body(),
         acquire: fn context ->
           scoped_root(parent, context)
           {:ok, capability} = fixture_capability()
@@ -157,7 +158,7 @@ defmodule PtcRunner.Kernel.ProviderExecutionLifecycleTest do
 
     fixture =
       provider_fixture(
-        body: "(loop [] (recur))",
+        body: long_running_body(),
         acquire: fn _context ->
           send(parent, {:acquired, self()})
           fixture_capability()
@@ -222,7 +223,7 @@ defmodule PtcRunner.Kernel.ProviderExecutionLifecycleTest do
     # dies before it can reach normal Runner teardown.
     fixture =
       provider_fixture(
-        body: "(loop [] (recur))",
+        body: long_running_body(),
         acquire: fn _context ->
           {:ok, capability} = fixture_capability()
           {:ok, %{capabilities: [capability], close: fn -> :failed end}}
@@ -412,9 +413,12 @@ defmodule PtcRunner.Kernel.ProviderExecutionLifecycleTest do
   end
 
   test "a check assembles its providers without ever executing the workflow" do
-    # The entry never terminates, so a check that returns at all proves the
-    # Kernel was not run; only the acquisition's safe snapshots come back.
-    fixture = provider_fixture(body: "(loop [] (recur))")
+    # The entry occupies its worker for seconds, so a check that returns
+    # promptly proves the Kernel was not run; only the acquisition's safe
+    # snapshots come back. (The old body here was `(loop [] (recur))`, which
+    # only looks non-terminating -- see `long_running_body/1` for why that is
+    # not the same thing.)
+    fixture = provider_fixture(body: long_running_body())
 
     assert {:ok, owner} =
              ExecutionSessionOwner.start(

--- a/test/ptc_runner/kernel/repl_session_test.exs
+++ b/test/ptc_runner/kernel/repl_session_test.exs
@@ -527,7 +527,6 @@ defmodule PtcRunner.Kernel.ReplSessionTest do
     assert_receive {:trace, ^creator, :spawn, evaluation_worker, _mfa}, 2_000
     evaluation_ref = Process.monitor(evaluation_worker)
     assert Process.alive?(evaluation_worker)
-    assert {:trap_exit, false} = Process.info(creator, :trap_exit)
 
     on_exit(fn ->
       if Process.alive?(evaluation_worker), do: Process.exit(evaluation_worker, :kill)

--- a/test/ptc_runner/kernel/repl_session_test.exs
+++ b/test/ptc_runner/kernel/repl_session_test.exs
@@ -520,7 +520,11 @@ defmodule PtcRunner.Kernel.ReplSessionTest do
             # real work (5 chained 20k-element reduces, measured ~30s to reach
             # the cap on its own) so this test's setup has a large margin;
             # this still finishes fast since it interrupts the evaluation
-            # long before that natural completion.
+            # long before that natural completion. Unlike the equivalent fix
+            # in RunCoordinatorExecutionTest, a long duration here is safe:
+            # `Evaluation.evaluate_with_lease/6` passes `link: true`, so the
+            # underlying sandbox process is genuinely torn down when this
+            # evaluation's caller dies -- no orphaned-process risk to bound.
             ReplSession.eval(
               session,
               "(loop [i 0 acc 0] (if (< i 1000) (recur (inc i) (+ acc (reduce + 0 (range 20000)) (reduce + 0 (range 20000)) (reduce + 0 (range 20000)) (reduce + 0 (range 20000)) (reduce + 0 (range 20000)))) acc))"

--- a/test/ptc_runner/kernel/repl_session_test.exs
+++ b/test/ptc_runner/kernel/repl_session_test.exs
@@ -528,6 +528,14 @@ defmodule PtcRunner.Kernel.ReplSessionTest do
         end
       end)
 
+    # Registered immediately, before any assertion below can fail: killing
+    # `creator` is exactly this test's own mechanism for cancelling the
+    # evaluation, so this is a safe no-op on the pass path (creator is
+    # already dead by then) and, on any earlier failure, stops the ~30s
+    # CPU-heavy loop instead of leaving it running unlinked until its own
+    # deadline.
+    on_exit(fn -> if Process.alive?(creator), do: Process.exit(creator, :kill) end)
+
     assert_receive {:owner_exit_evaluation_ready, ^creator}, 2_000
     assert {:trap_exit, false} = Process.info(creator, :trap_exit)
     assert 1 = :erlang.trace(creator, true, [:procs])

--- a/test/ptc_runner/kernel/repl_session_test.exs
+++ b/test/ptc_runner/kernel/repl_session_test.exs
@@ -1,6 +1,8 @@
 defmodule PtcRunner.Kernel.ReplSessionTest do
   use ExUnit.Case, async: true
 
+  import PtcRunner.TestSupport.TestHelpers, only: [long_running_body: 1]
+
   alias PtcRunner.Kernel
   alias PtcRunner.Kernel.Capability
   alias PtcRunner.Kernel.EventSink
@@ -512,23 +514,17 @@ defmodule PtcRunner.Kernel.ReplSessionTest do
 
         receive do
           :evaluate ->
-            # `(loop [x 0] (recur (inc x)))` is NOT actually infinite: PTC-Lisp
-            # hard-caps loop/recur at exactly 1_000 jumps (see
-            # `eval_loop_test.exs`'s "custom loop limit" test), and this trivial
-            # body blows through that cap in well under a second -- racing this
-            # test's own setup below regardless of load. Give each iteration
-            # real work (5 chained 20k-element reduces, measured ~30s to reach
-            # the cap on its own) so this test's setup has a large margin;
-            # this still finishes fast since it interrupts the evaluation
-            # long before that natural completion. Unlike the equivalent fix
-            # in RunCoordinatorExecutionTest, a long duration here is safe:
+            # A trivial `(loop [x 0] (recur (inc x)))` would race this test's
+            # own setup regardless of load -- see `long_running_body/1` for
+            # why it is not the infinite loop it looks like. The heavier
+            # `repeats: 5` (~30s to reach the cap on its own) is safe here,
+            # unlike in RunCoordinatorExecutionTest:
             # `Evaluation.evaluate_with_lease/6` passes `link: true`, so the
             # underlying sandbox process is genuinely torn down when this
             # evaluation's caller dies -- no orphaned-process risk to bound.
-            ReplSession.eval(
-              session,
-              "(loop [i 0 acc 0] (if (< i 1000) (recur (inc i) (+ acc (reduce + 0 (range 20000)) (reduce + 0 (range 20000)) (reduce + 0 (range 20000)) (reduce + 0 (range 20000)) (reduce + 0 (range 20000)))) acc))"
-            )
+            # This still finishes fast, since the test interrupts the
+            # evaluation long before that natural completion.
+            ReplSession.eval(session, long_running_body(5))
         end
       end)
 

--- a/test/ptc_runner/kernel/repl_session_test.exs
+++ b/test/ptc_runner/kernel/repl_session_test.exs
@@ -511,7 +511,20 @@ defmodule PtcRunner.Kernel.ReplSessionTest do
         send(parent, {:owner_exit_evaluation_ready, self()})
 
         receive do
-          :evaluate -> ReplSession.eval(session, "(loop [x 0] (recur (inc x)))")
+          :evaluate ->
+            # `(loop [x 0] (recur (inc x)))` is NOT actually infinite: PTC-Lisp
+            # hard-caps loop/recur at exactly 1_000 jumps (see
+            # `eval_loop_test.exs`'s "custom loop limit" test), and this trivial
+            # body blows through that cap in well under a second -- racing this
+            # test's own setup below regardless of load. Give each iteration
+            # real work (5 chained 20k-element reduces, measured ~30s to reach
+            # the cap on its own) so this test's setup has a large margin;
+            # this still finishes fast since it interrupts the evaluation
+            # long before that natural completion.
+            ReplSession.eval(
+              session,
+              "(loop [i 0 acc 0] (if (< i 1000) (recur (inc i) (+ acc (reduce + 0 (range 20000)) (reduce + 0 (range 20000)) (reduce + 0 (range 20000)) (reduce + 0 (range 20000)) (reduce + 0 (range 20000)))) acc))"
+            )
         end
       end)
 

--- a/test/ptc_runner/kernel/run_coordinator_execution_test.exs
+++ b/test/ptc_runner/kernel/run_coordinator_execution_test.exs
@@ -413,15 +413,23 @@ defmodule PtcRunner.Kernel.RunCoordinatorExecutionTest do
     # premise -- that the run is still in flight when `Process.exit(caller,
     # :kill)` fires below -- was racing that natural completion, and could
     # lose even outside full-suite load (reproduced failing >50% of runs
-    # combined with just 3 other test files). Give each of the 1_000
-    # iterations real work so reaching the cap on its own takes several
-    # seconds; the test still finishes fast because it interrupts the run
-    # long before that. `evaluation_timeout_ms` doesn't apply here (that
-    # governs subordinate mission evaluations, not this top-level workflow
-    # call, which uses `workflow_timeout_ms` -- already a 30s default).
+    # combined with just 3 other test files).
+    #
+    # Give each of the 1_000 iterations real work so reaching the cap on its
+    # own takes roughly 30s on this machine (measured: 5 chained 20k-element
+    # reduces per iteration); the test still finishes fast because it
+    # interrupts the run long before that. This is still a calibrated
+    # duration, not a deterministic guarantee -- a sufficiently slower or
+    # more loaded machine could still lose the race -- but 30s is a large
+    # multiple of any plausible harness-setup delay between here and the
+    # `Process.alive?` check below, so a real regression is far more likely
+    # to explain a failure than hardware variance. `evaluation_timeout_ms`
+    # doesn't apply here (that governs subordinate mission evaluations, not
+    # this top-level workflow call, which uses `workflow_timeout_ms` --
+    # already a 30s default, unrelated to this loop's own budget).
     {prepared, catalog} =
       prepared_run(
-        "(loop [i 0 acc 0] (if (< i 1000) (recur (inc i) (+ acc (reduce + 0 (range 20000)))) acc))",
+        "(loop [i 0 acc 0] (if (< i 1000) (recur (inc i) (+ acc (reduce + 0 (range 20000)) (reduce + 0 (range 20000)) (reduce + 0 (range 20000)) (reduce + 0 (range 20000)) (reduce + 0 (range 20000)))) acc))",
         inspection_capture: true
       )
 
@@ -465,19 +473,18 @@ defmodule PtcRunner.Kernel.RunCoordinatorExecutionTest do
     activity_ref = Process.monitor(prepared.provider_activity.owner)
 
     try do
-      # `owner_pid` is running a loop built to take several seconds to reach
-      # its 1_000-iteration cap (see the comment above this test's
-      # `prepared_run/2` call), so it must still be alive here. If it is not,
-      # something ended the run
-      # far earlier than that -- fail with that distinction instead of the
-      # opaque ArgumentError `:erlang.trace/3` raises on a dead pid. Both
-      # checks stay inside this `try` so a failure here still runs the
-      # `after` cleanup below -- otherwise the global
-      # `:erlang.trace_pattern/3` enabled above would leak into every later
-      # test in the suite.
+      # `owner_pid` is running a loop built to take ~30s to reach its
+      # 1_000-iteration cap (see the comment above this test's
+      # `prepared_run/2` call), so it must still be alive here. If it is
+      # not, something ended the run far earlier than that -- fail with
+      # that distinction instead of the opaque ArgumentError
+      # `:erlang.trace/3` raises on a dead pid. Both checks stay inside this
+      # `try` so a failure here still runs the `after` cleanup below --
+      # otherwise the global `:erlang.trace_pattern/3` enabled above would
+      # leak into every later test in the suite.
       assert Process.alive?(owner_pid),
              "owner #{inspect(owner_pid)} exited before tracing could start; " <>
-               "the run ended far earlier than its ~6s natural completion"
+               "the run ended far earlier than its ~30s natural completion"
 
       assert :erlang.trace(owner_pid, true, [:call]) == 1
 

--- a/test/ptc_runner/kernel/run_coordinator_execution_test.exs
+++ b/test/ptc_runner/kernel/run_coordinator_execution_test.exs
@@ -416,20 +416,32 @@ defmodule PtcRunner.Kernel.RunCoordinatorExecutionTest do
     # combined with just 3 other test files).
     #
     # Give each of the 1_000 iterations real work so reaching the cap on its
-    # own takes roughly 30s on this machine (measured: 5 chained 20k-element
-    # reduces per iteration); the test still finishes fast because it
-    # interrupts the run long before that. This is still a calibrated
-    # duration, not a deterministic guarantee -- a sufficiently slower or
-    # more loaded machine could still lose the race -- but 30s is a large
-    # multiple of any plausible harness-setup delay between here and the
-    # `Process.alive?` check below, so a real regression is far more likely
-    # to explain a failure than hardware variance. `evaluation_timeout_ms`
-    # doesn't apply here (that governs subordinate mission evaluations, not
-    # this top-level workflow call, which uses `workflow_timeout_ms` --
-    # already a 30s default, unrelated to this loop's own budget).
+    # own takes roughly 6s on this machine (measured); the test still
+    # finishes fast because it interrupts the run long before that. This is
+    # still a calibrated duration, not a deterministic guarantee -- a
+    # sufficiently slower or more loaded machine could still lose the race
+    # -- but 6s is a large multiple of any plausible harness-setup delay
+    # between here and the `Process.alive?` check below, so a real
+    # regression is far more likely to explain a failure than hardware
+    # variance. `evaluation_timeout_ms` doesn't apply here (that governs
+    # subordinate mission evaluations, not this top-level workflow call,
+    # which uses `workflow_timeout_ms` -- already a 30s default, unrelated
+    # to this loop's own budget).
+    #
+    # Kept deliberately short rather than pushed higher for more margin:
+    # `Runner.execute_workflow/3` calls `Lisp.run_native/2` without
+    # `link: true`, so `Process.exit(worker_pid, :kill)` below (via the
+    # ExecutionSessionOwner abort path) does not itself terminate the
+    # underlying sandbox process -- only monitors it. On any test failure
+    # before that point, this loop's sandbox process keeps running,
+    # unlinked, until its own `workflow_timeout_ms` deadline. That's a real
+    # gap (arguably the workflow path should link like
+    # `ReplSession`/`repl_session.ex` does), but fixing it is a production
+    # change beyond what a flaky-test fix warrants -- keeping this loop's
+    # duration short bounds the cost of that gap instead.
     {prepared, catalog} =
       prepared_run(
-        "(loop [i 0 acc 0] (if (< i 1000) (recur (inc i) (+ acc (reduce + 0 (range 20000)) (reduce + 0 (range 20000)) (reduce + 0 (range 20000)) (reduce + 0 (range 20000)) (reduce + 0 (range 20000)))) acc))",
+        "(loop [i 0 acc 0] (if (< i 1000) (recur (inc i) (+ acc (reduce + 0 (range 20000)))) acc))",
         inspection_capture: true
       )
 
@@ -455,7 +467,7 @@ defmodule PtcRunner.Kernel.RunCoordinatorExecutionTest do
     # Registered immediately, before any assertion below can fail: caller
     # death is exactly this test's own mechanism for aborting the run, so
     # this is a safe no-op on the pass path (caller is already dead by
-    # then) and, on any earlier failure, stops the ~30s CPU-heavy loop
+    # then) and, on any earlier failure, stops the ~6s CPU-heavy loop
     # instead of leaving it running unlinked until its own deadline.
     on_exit(fn -> if Process.alive?(caller), do: Process.exit(caller, :kill) end)
 
@@ -489,7 +501,7 @@ defmodule PtcRunner.Kernel.RunCoordinatorExecutionTest do
     activity_ref = Process.monitor(prepared.provider_activity.owner)
 
     try do
-      # `owner_pid` is running a loop built to take ~30s to reach its
+      # `owner_pid` is running a loop built to take ~6s to reach its
       # 1_000-iteration cap (see the comment above this test's
       # `prepared_run/2` call), so it must still be alive here. If it is
       # not, something ended the run far earlier than that -- fail with
@@ -500,7 +512,7 @@ defmodule PtcRunner.Kernel.RunCoordinatorExecutionTest do
       # leak into every later test in the suite.
       assert Process.alive?(owner_pid),
              "owner #{inspect(owner_pid)} exited before tracing could start; " <>
-               "the run ended far earlier than its ~30s natural completion"
+               "the run ended far earlier than its ~6s natural completion"
 
       assert :erlang.trace(owner_pid, true, [:call]) == 1
 

--- a/test/ptc_runner/kernel/run_coordinator_execution_test.exs
+++ b/test/ptc_runner/kernel/run_coordinator_execution_test.exs
@@ -441,6 +441,16 @@ defmodule PtcRunner.Kernel.RunCoordinatorExecutionTest do
 
     Code.ensure_loaded!(EventSink)
     assert :erlang.trace_pattern({EventSink, :finalize_and_events, 2}, true, [:local]) == 1
+
+    # `owner_pid` runs an infinite `(loop [] (recur))`, so it must still be
+    # alive here. If it is not, the run aborted early (a real bug) rather
+    # than this check merely losing a race with scheduler delay -- fail with
+    # that distinction instead of the opaque ArgumentError `:erlang.trace/3`
+    # raises on a dead pid.
+    assert Process.alive?(owner_pid),
+           "owner #{inspect(owner_pid)} exited before tracing could start; " <>
+             "the infinite-loop run ended early instead of merely running late"
+
     assert :erlang.trace(owner_pid, true, [:call]) == 1
 
     owner_ref = Process.monitor(owner_pid)

--- a/test/ptc_runner/kernel/run_coordinator_execution_test.exs
+++ b/test/ptc_runner/kernel/run_coordinator_execution_test.exs
@@ -406,8 +406,24 @@ defmodule PtcRunner.Kernel.RunCoordinatorExecutionTest do
   test "caller death aborts the worker and stops both owner-backed sinks", %{
     tmp_dir: directory
   } do
+    # `(loop [] (recur))` is NOT actually infinite: PTC-Lisp hard-caps
+    # loop/recur at exactly 1_000 jumps (`PtcRunner.Lisp.Eval.Context`'s
+    # `loop_limit`, not configurable via manifest limits), and an empty body
+    # blows through that cap in well under a second. This test's whole
+    # premise -- that the run is still in flight when `Process.exit(caller,
+    # :kill)` fires below -- was racing that natural completion, and could
+    # lose even outside full-suite load (reproduced failing >50% of runs
+    # combined with just 3 other test files). Give each of the 1_000
+    # iterations real work so reaching the cap on its own takes several
+    # seconds; the test still finishes fast because it interrupts the run
+    # long before that. `evaluation_timeout_ms` doesn't apply here (that
+    # governs subordinate mission evaluations, not this top-level workflow
+    # call, which uses `workflow_timeout_ms` -- already a 30s default).
     {prepared, catalog} =
-      prepared_run("(loop [] (recur))", inspection_capture: true)
+      prepared_run(
+        "(loop [i 0 acc 0] (if (< i 1000) (recur (inc i) (+ acc (reduce + 0 (range 20000)))) acc))",
+        inspection_capture: true
+      )
 
     inspection_path = Path.join(directory, "run.inspection.jsonl")
 
@@ -442,17 +458,6 @@ defmodule PtcRunner.Kernel.RunCoordinatorExecutionTest do
     Code.ensure_loaded!(EventSink)
     assert :erlang.trace_pattern({EventSink, :finalize_and_events, 2}, true, [:local]) == 1
 
-    # `owner_pid` runs an infinite `(loop [] (recur))`, so it must still be
-    # alive here. If it is not, the run aborted early (a real bug) rather
-    # than this check merely losing a race with scheduler delay -- fail with
-    # that distinction instead of the opaque ArgumentError `:erlang.trace/3`
-    # raises on a dead pid.
-    assert Process.alive?(owner_pid),
-           "owner #{inspect(owner_pid)} exited before tracing could start; " <>
-             "the infinite-loop run ended early instead of merely running late"
-
-    assert :erlang.trace(owner_pid, true, [:call]) == 1
-
     owner_ref = Process.monitor(owner_pid)
     worker_ref = Process.monitor(state.worker_pid)
     event_sink_ref = Process.monitor(event_sink.pid)
@@ -460,6 +465,22 @@ defmodule PtcRunner.Kernel.RunCoordinatorExecutionTest do
     activity_ref = Process.monitor(prepared.provider_activity.owner)
 
     try do
+      # `owner_pid` is running a loop built to take several seconds to reach
+      # its 1_000-iteration cap (see the comment above this test's
+      # `prepared_run/2` call), so it must still be alive here. If it is not,
+      # something ended the run
+      # far earlier than that -- fail with that distinction instead of the
+      # opaque ArgumentError `:erlang.trace/3` raises on a dead pid. Both
+      # checks stay inside this `try` so a failure here still runs the
+      # `after` cleanup below -- otherwise the global
+      # `:erlang.trace_pattern/3` enabled above would leak into every later
+      # test in the suite.
+      assert Process.alive?(owner_pid),
+             "owner #{inspect(owner_pid)} exited before tracing could start; " <>
+               "the run ended far earlier than its ~6s natural completion"
+
+      assert :erlang.trace(owner_pid, true, [:call]) == 1
+
       Process.exit(caller, :kill)
 
       assert_receive {:DOWN, ^caller_ref, :process, ^caller, :killed}
@@ -475,6 +496,13 @@ defmodule PtcRunner.Kernel.RunCoordinatorExecutionTest do
       assert_receive {:DOWN, ^activity_ref, :process, _pid, :normal}, 5_000
       assert_receive {:DOWN, ^owner_ref, :process, ^owner_pid, :normal}, 5_000
       refute_received {:execution_result, _result}
+    rescue
+      e in ArgumentError ->
+        flunk(
+          "owner #{inspect(owner_pid)} exited between the liveness check and " <>
+            ":erlang.trace/3 (#{Exception.message(e)}); treat as a real early-abort " <>
+            "signal, not scheduler delay"
+        )
     after
       stop_trace(owner_pid)
       :erlang.trace_pattern({EventSink, :finalize_and_events, 2}, false, [:local])
@@ -551,13 +579,13 @@ defmodule PtcRunner.Kernel.RunCoordinatorExecutionTest do
       "input" => %{"value" => %{}}
     }
 
-    {limit_opts, request_opts} = Keyword.split(opts, [:normal_event_bytes])
+    {limit_opts, request_opts} =
+      Keyword.split(opts, [:normal_event_bytes, :evaluation_timeout_ms])
 
-    manifest =
-      case Keyword.fetch(limit_opts, :normal_event_bytes) do
-        {:ok, bytes} -> Map.put(manifest, "limits", %{"normal_event_bytes" => bytes})
-        :error -> manifest
-      end
+    limits =
+      Map.new(limit_opts, fn {name, value} -> {Atom.to_string(name), value} end)
+
+    manifest = if limits == %{}, do: manifest, else: Map.put(manifest, "limits", limits)
 
     documents = %{
       "ptc.json" => Jason.encode!(manifest),

--- a/test/ptc_runner/kernel/run_coordinator_execution_test.exs
+++ b/test/ptc_runner/kernel/run_coordinator_execution_test.exs
@@ -2,6 +2,7 @@ defmodule PtcRunner.Kernel.RunCoordinatorExecutionTest do
   use ExUnit.Case, async: false
 
   import PtcRunner.TestSupport.Eventually, only: [assert_eventually: 1]
+  import PtcRunner.TestSupport.TestHelpers, only: [long_running_body: 0]
 
   alias PtcRunner.Kernel.ApplicationPackage
   alias PtcRunner.Kernel.Capability
@@ -406,44 +407,31 @@ defmodule PtcRunner.Kernel.RunCoordinatorExecutionTest do
   test "caller death aborts the worker and stops both owner-backed sinks", %{
     tmp_dir: directory
   } do
-    # `(loop [] (recur))` is NOT actually infinite: PTC-Lisp hard-caps
-    # loop/recur at exactly 1_000 jumps (`PtcRunner.Lisp.Eval.Context`'s
-    # `loop_limit`, not configurable via manifest limits), and an empty body
-    # blows through that cap in well under a second. This test's whole
-    # premise -- that the run is still in flight when `Process.exit(caller,
-    # :kill)` fires below -- was racing that natural completion, and could
-    # lose even outside full-suite load (reproduced failing >50% of runs
-    # combined with just 3 other test files).
+    # This test's premise -- that the run is still in flight when
+    # `Process.exit(caller, :kill)` fires below -- used to rest on
+    # `(loop [] (recur))`, which is not the infinite loop it looks like (see
+    # `long_running_body/1`). It was really racing that loop's natural
+    # completion, and could lose even outside full-suite load (reproduced
+    # failing >50% of runs combined with just 3 other test files).
     #
-    # Give each of the 1_000 iterations real work so reaching the cap on its
-    # own takes roughly 6s on this machine (measured); the test still
-    # finishes fast because it interrupts the run long before that. This is
-    # still a calibrated duration, not a deterministic guarantee -- a
-    # sufficiently slower or more loaded machine could still lose the race
-    # -- but 6s is a large multiple of any plausible harness-setup delay
-    # between here and the `Process.alive?` check below, so a real
-    # regression is far more likely to explain a failure than hardware
-    # variance. `evaluation_timeout_ms` doesn't apply here (that governs
-    # subordinate mission evaluations, not this top-level workflow call,
-    # which uses `workflow_timeout_ms` -- already a 30s default, unrelated
-    # to this loop's own budget).
+    # `repeats: 1` (~6s) is deliberately the smallest useful margin rather
+    # than something larger: `Runner.execute_workflow/4` calls
+    # `Lisp.run_native/2` without `link: true`, so `Process.exit(worker_pid,
+    # :kill)` below (via the ExecutionSessionOwner abort path) does not
+    # itself terminate the underlying sandbox process -- it only monitors
+    # it. On any test failure before that point, this loop's sandbox keeps
+    # running, unlinked, until its own deadline. That is a real gap
+    # (arguably the workflow path should link like `repl_session.ex` does),
+    # but fixing it is a production change beyond what a flaky-test fix
+    # warrants -- keeping this loop short bounds the cost of the gap
+    # instead. 6s still dwarfs any plausible harness-setup delay between
+    # here and the `Process.alive?` check below, so a real regression is a
+    # far likelier explanation for a failure than hardware variance.
     #
-    # Kept deliberately short rather than pushed higher for more margin:
-    # `Runner.execute_workflow/3` calls `Lisp.run_native/2` without
-    # `link: true`, so `Process.exit(worker_pid, :kill)` below (via the
-    # ExecutionSessionOwner abort path) does not itself terminate the
-    # underlying sandbox process -- only monitors it. On any test failure
-    # before that point, this loop's sandbox process keeps running,
-    # unlinked, until its own `workflow_timeout_ms` deadline. That's a real
-    # gap (arguably the workflow path should link like
-    # `ReplSession`/`repl_session.ex` does), but fixing it is a production
-    # change beyond what a flaky-test fix warrants -- keeping this loop's
-    # duration short bounds the cost of that gap instead.
-    {prepared, catalog} =
-      prepared_run(
-        "(loop [i 0 acc 0] (if (< i 1000) (recur (inc i) (+ acc (reduce + 0 (range 20000)))) acc))",
-        inspection_capture: true
-      )
+    # `evaluation_timeout_ms` does not apply here: that governs subordinate
+    # mission evaluations, not this top-level workflow call, which uses
+    # `workflow_timeout_ms` (a 30s default, unrelated to this loop's budget).
+    {prepared, catalog} = prepared_run(long_running_body(), inspection_capture: true)
 
     inspection_path = Path.join(directory, "run.inspection.jsonl")
 

--- a/test/ptc_runner/kernel/run_coordinator_execution_test.exs
+++ b/test/ptc_runner/kernel/run_coordinator_execution_test.exs
@@ -452,6 +452,13 @@ defmodule PtcRunner.Kernel.RunCoordinatorExecutionTest do
         send(parent, {:execution_result, ExecutionSessionOwner.await(owner)})
       end)
 
+    # Registered immediately, before any assertion below can fail: caller
+    # death is exactly this test's own mechanism for aborting the run, so
+    # this is a safe no-op on the pass path (caller is already dead by
+    # then) and, on any earlier failure, stops the ~30s CPU-heavy loop
+    # instead of leaving it running unlinked until its own deadline.
+    on_exit(fn -> if Process.alive?(caller), do: Process.exit(caller, :kill) end)
+
     caller_ref = Process.monitor(caller)
     assert_receive {:execution_owner, owner}, 5_000
     owner_pid = ExecutionSessionOwner.pid(owner)
@@ -465,6 +472,15 @@ defmodule PtcRunner.Kernel.RunCoordinatorExecutionTest do
 
     Code.ensure_loaded!(EventSink)
     assert :erlang.trace_pattern({EventSink, :finalize_and_events, 2}, true, [:local]) == 1
+
+    # Registered immediately: this is a VM-global trace pattern, so ANY
+    # later failure in this test -- including the five `Process.monitor/1`
+    # calls right below, before the `try` -- must not leave it enabled and
+    # contaminating every later test in the suite. `on_exit` always runs,
+    # unlike the `try/after` below which only protects its own block.
+    on_exit(fn ->
+      :erlang.trace_pattern({EventSink, :finalize_and_events, 2}, false, [:local])
+    end)
 
     owner_ref = Process.monitor(owner_pid)
     worker_ref = Process.monitor(state.worker_pid)
@@ -511,8 +527,9 @@ defmodule PtcRunner.Kernel.RunCoordinatorExecutionTest do
             "signal, not scheduler delay"
         )
     after
+      # The global trace_pattern's disable is handled by the `on_exit`
+      # above, unconditionally -- no need to duplicate it here.
       stop_trace(owner_pid)
-      :erlang.trace_pattern({EventSink, :finalize_and_events, 2}, false, [:local])
     end
 
     assert :ok = PublicationAuthority.abort(authority)

--- a/test/ptc_runner/lisp/eval/parallel_runner_test.exs
+++ b/test/ptc_runner/lisp/eval/parallel_runner_test.exs
@@ -559,7 +559,13 @@ defmodule PtcRunner.Lisp.Eval.ParallelRunnerTest do
           wait_for_go()
       end
 
-      deadline = System.monotonic_time(:millisecond) + 250
+      # The monitor rendezvous above removes the unbounded-handshake race,
+      # but item :success still has to get its (trivial) work scheduled
+      # before this deadline fires -- a pure scheduler stall could still
+      # lose that race with a tight budget. Since item :blocked always
+      # blocks until the deadline regardless of its value, a generous
+      # deadline costs nothing here; it isn't racing anything but a stall.
+      deadline = System.monotonic_time(:millisecond) + 2_000
 
       assert {:error,
               [

--- a/test/ptc_runner/lisp/eval/parallel_runner_test.exs
+++ b/test/ptc_runner/lisp/eval/parallel_runner_test.exs
@@ -533,12 +533,16 @@ defmodule PtcRunner.Lisp.Eval.ParallelRunnerTest do
       end
 
       # Wide margin: unlike the other deadline tests, this one blocks the
-      # coordinator itself on a cross-process handshake (the `receive` at
-      # line 515) before the second item can even be spawned. Under full
-      # suite load that handshake alone can eat tens of ms, so a tight
-      # budget here (previously 50ms) flakes on scheduler contention that
-      # has nothing to do with the behaviour under test.
-      deadline = System.monotonic_time(:millisecond) + 250
+      # coordinator itself on an UNBOUNDED cross-process handshake (the
+      # `receive` at line 515, no timeout) before the second item can even
+      # be spawned. Under full suite load that handshake alone can eat
+      # hundreds of ms, so a tight budget here (originally 50ms) flakes on
+      # scheduler contention that has nothing to do with the behaviour
+      # under test. This margin is still not a guarantee -- the handshake
+      # has no upper bound -- just a large enough window to make the
+      # failure rare in practice; a controllable clock/barrier would be a
+      # real fix but is a larger change than this test is worth.
+      deadline = System.monotonic_time(:millisecond) + 1_000
 
       assert {:error,
               [

--- a/test/ptc_runner/lisp/eval/parallel_runner_test.exs
+++ b/test/ptc_runner/lisp/eval/parallel_runner_test.exs
@@ -495,37 +495,67 @@ defmodule PtcRunner.Lisp.Eval.ParallelRunnerTest do
     end
 
     test "timeout retains a successful envelope from a still-live sibling" do
+      counter = :atomics.new(1, [])
       effects = Effects.empty() |> Effects.record_print("retained")
 
-      # A monitor-based rendezvous instead of a wall-clock margin: item
-      # :blocked waits for `gate` to go down (item :success stops it right
-      # after producing its result) before it starts genuinely blocking.
+      # A monitor-based rendezvous instead of a wall-clock margin: the
+      # :blocked worker waits for `gate` to go down (the :success worker
+      # stops it right after `worker.()` -- and so its `:worker_result` --
+      # has been sent) before it starts genuinely blocking.
       # `Process.monitor/1` delivers an immediate `:DOWN` for an
-      # already-dead process, so this is race-free regardless of which
-      # item's worker the coordinator happens to schedule first -- no
-      # deadline margin has to cover the handshake, only the trivial
-      # `:success` work itself.
+      # already-dead process, so this is race-free regardless of
+      # scheduling. Both waits happen inside the SPAWNED processes, not in
+      # `spawn_fun` itself, so neither can block `fill_window/1` and eat
+      # into the shared deadline the way the old message-based handshake
+      # did.
+      #
+      # `spawn_fun` (not `fun`) is what keeps the :success worker alive
+      # after sending its result via `wait_for_go/0` -- required so its
+      # entry is still in `state.live`, tagged with a completed result, when
+      # the shared deadline fires for the :blocked sibling. That is the
+      # "still-live sibling" this test is named for: without it, the
+      # :success worker would exit immediately, its result would already be
+      # in `state.results` by the time of the timeout, and this would stop
+      # covering the code path it claims to.
       {:ok, gate} = Agent.start_link(fn -> :ok end)
+
+      spawn_fun = fn worker, opts ->
+        case :atomics.add_get(counter, 1, 1) - 1 do
+          0 ->
+            Process.spawn(
+              fn ->
+                worker.()
+                Agent.stop(gate)
+                wait_for_go()
+              end,
+              opts
+            )
+
+          1 ->
+            Process.spawn(
+              fn ->
+                gate_ref = Process.monitor(gate)
+
+                receive do
+                  {:DOWN, ^gate_ref, :process, ^gate, _reason} -> :ok
+                end
+
+                worker.()
+              end,
+              opts
+            )
+        end
+      end
 
       fun = fn
         :success ->
-          envelope =
-            Envelope.success(:done,
-              effects: effects,
-              child_trace_id: "retained-child",
-              child_step: %{id: "retained-step"}
-            )
-
-          Agent.stop(gate)
-          envelope
+          Envelope.success(:done,
+            effects: effects,
+            child_trace_id: "retained-child",
+            child_step: %{id: "retained-step"}
+          )
 
         :blocked ->
-          gate_ref = Process.monitor(gate)
-
-          receive do
-            {:DOWN, ^gate_ref, :process, ^gate, _reason} -> :ok
-          end
-
           wait_for_go()
       end
 
@@ -545,7 +575,7 @@ defmodule PtcRunner.Lisp.Eval.ParallelRunnerTest do
                ParallelRunner.run(
                  [:success, :blocked],
                  fun,
-                 base_opts(max_concurrency: 2, deadline_mono: deadline)
+                 base_opts(max_concurrency: 2, deadline_mono: deadline, spawn_fun: spawn_fun)
                )
     end
 

--- a/test/ptc_runner/lisp/eval/parallel_runner_test.exs
+++ b/test/ptc_runner/lisp/eval/parallel_runner_test.exs
@@ -532,7 +532,13 @@ defmodule PtcRunner.Lisp.Eval.ParallelRunnerTest do
           wait_for_go()
       end
 
-      deadline = System.monotonic_time(:millisecond) + 50
+      # Wide margin: unlike the other deadline tests, this one blocks the
+      # coordinator itself on a cross-process handshake (the `receive` at
+      # line 515) before the second item can even be spawned. Under full
+      # suite load that handshake alone can eat tens of ms, so a tight
+      # budget here (previously 50ms) flakes on scheduler contention that
+      # has nothing to do with the behaviour under test.
+      deadline = System.monotonic_time(:millisecond) + 250
 
       assert {:error,
               [

--- a/test/ptc_runner/lisp/eval/parallel_runner_test.exs
+++ b/test/ptc_runner/lisp/eval/parallel_runner_test.exs
@@ -495,54 +495,41 @@ defmodule PtcRunner.Lisp.Eval.ParallelRunnerTest do
     end
 
     test "timeout retains a successful envelope from a still-live sibling" do
-      counter = :atomics.new(1, [])
-      runner = self()
       effects = Effects.empty() |> Effects.record_print("retained")
 
-      spawn_fun = fn worker, opts ->
-        case :atomics.add_get(counter, 1, 1) - 1 do
-          0 ->
-            Process.spawn(
-              fn ->
-                worker.()
-                send(runner, :success_sent)
-                wait_for_go()
-              end,
-              opts
-            )
-
-          1 ->
-            receive do
-              :success_sent -> :ok
-            end
-
-            Process.spawn(fn -> worker.() end, opts)
-        end
-      end
+      # A monitor-based rendezvous instead of a wall-clock margin: item
+      # :blocked waits for `gate` to go down (item :success stops it right
+      # after producing its result) before it starts genuinely blocking.
+      # `Process.monitor/1` delivers an immediate `:DOWN` for an
+      # already-dead process, so this is race-free regardless of which
+      # item's worker the coordinator happens to schedule first -- no
+      # deadline margin has to cover the handshake, only the trivial
+      # `:success` work itself.
+      {:ok, gate} = Agent.start_link(fn -> :ok end)
 
       fun = fn
         :success ->
-          Envelope.success(:done,
-            effects: effects,
-            child_trace_id: "retained-child",
-            child_step: %{id: "retained-step"}
-          )
+          envelope =
+            Envelope.success(:done,
+              effects: effects,
+              child_trace_id: "retained-child",
+              child_step: %{id: "retained-step"}
+            )
+
+          Agent.stop(gate)
+          envelope
 
         :blocked ->
+          gate_ref = Process.monitor(gate)
+
+          receive do
+            {:DOWN, ^gate_ref, :process, ^gate, _reason} -> :ok
+          end
+
           wait_for_go()
       end
 
-      # Wide margin: unlike the other deadline tests, this one blocks the
-      # coordinator itself on an UNBOUNDED cross-process handshake (the
-      # `receive` at line 515, no timeout) before the second item can even
-      # be spawned. Under full suite load that handshake alone can eat
-      # hundreds of ms, so a tight budget here (originally 50ms) flakes on
-      # scheduler contention that has nothing to do with the behaviour
-      # under test. This margin is still not a guarantee -- the handshake
-      # has no upper bound -- just a large enough window to make the
-      # failure rare in practice; a controllable clock/barrier would be a
-      # real fix but is a larger change than this test is worth.
-      deadline = System.monotonic_time(:millisecond) + 1_000
+      deadline = System.monotonic_time(:millisecond) + 250
 
       assert {:error,
               [
@@ -558,7 +545,7 @@ defmodule PtcRunner.Lisp.Eval.ParallelRunnerTest do
                ParallelRunner.run(
                  [:success, :blocked],
                  fun,
-                 base_opts(max_concurrency: 2, deadline_mono: deadline, spawn_fun: spawn_fun)
+                 base_opts(max_concurrency: 2, deadline_mono: deadline)
                )
     end
 

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -20,4 +20,38 @@ defmodule PtcRunner.TestSupport.TestHelpers do
   end
 
   def stop_quietly(_), do: :ok
+
+  @doc """
+  A PTC-Lisp entry body that genuinely occupies its worker while a test
+  inspects the run in flight.
+
+  `(loop [] (recur))` reads like an infinite loop and has been used across this
+  suite as one, but it is not: PTC-Lisp hard-caps `loop`/`recur` at exactly
+  1_000 jumps (`PtcRunner.Lisp.Eval.Context`'s `loop_limit`, which is not
+  reachable through manifest limits), and an empty body burns through that cap
+  in well under a second. Any test that kills a caller, traces an owner, or
+  calls `:sys.get_state/1` on a session "while the run blocks" is really racing
+  that natural completion, and loses under full-suite load — surfacing as an
+  `ArgumentError` or a `:noproc` exit on an already-exited process rather than
+  as an obvious timeout.
+
+  This gives each of the 1_000 iterations real work instead. `repeats` scales
+  that work roughly linearly: 1 lands near 6s on a developer machine, 5 near
+  30s. Callers should pick the smallest value that clears their own setup
+  overhead by a wide margin — the duration is calibrated, not guaranteed, so
+  the margin is what separates a real regression from hardware variance.
+
+  Prefer a shorter body on paths that do not pass `link: true` to
+  `PtcRunner.Sandbox` (notably `Runner.execute_workflow/4`): there, killing the
+  caller does not tear the sandbox process down, so an early test failure
+  leaves this loop running unlinked until its own deadline.
+  """
+  def long_running_body(repeats \\ 1) when is_integer(repeats) and repeats >= 1 do
+    work =
+      "(reduce + 0 (range 20000))"
+      |> List.duplicate(repeats)
+      |> Enum.join(" ")
+
+    "(loop [i 0 acc 0] (if (< i 1000) (recur (inc i) (+ acc #{work})) acc))"
+  end
 end


### PR DESCRIPTION
Test-only. Removes the timing races behind a family of full-suite-load flakes,
several of which share a single root cause.

## The shared root cause

`(loop [] (recur))` reads as an infinite loop, and this suite used it as one to
hold a run in flight while a test inspected or killed it. It is not: PTC-Lisp
hard-caps `loop`/`recur` at exactly 1_000 jumps (`Lisp.Eval.Context`'s
`loop_limit`, not reachable through manifest limits), so an empty body burns
through the cap in well under a second.

Every test built on that premise was really racing the loop's natural
completion. It surfaces under load not as an obvious timeout but as an
`ArgumentError` from `:erlang.trace/3` or a `:noproc` exit from
`:sys.get_state/1` — i.e. as "inspecting an already-exited process", which
reads like an unrelated defect.

Six sites across four files relied on it. `TestSupport.TestHelpers.long_running_body/1`
now gives each of the 1_000 iterations real work (`repeats` scales it: 1 is
~6s, 5 is ~30s) and carries the rationale in one place instead of per site.

`RunCoordinatorExecutionTest` deliberately takes the *smallest* useful margin:
`Runner.execute_workflow/4` calls `Lisp.run_native/2` without `link: true`, so
killing the caller does not tear down the underlying sandbox — a short loop
bounds the cost of that gap. `ReplSessionTest` can safely take the heavier body
because `Evaluation.evaluate_with_lease/6` does pass `link: true`. That
asymmetry is a real production gap, left for a separate PR rather than folded in
here.

## Other races fixed

- **`ParallelRunnerTest`** — replaced a wall-clock deadline with a monitor-based
  rendezvous (`Agent.start_link` + `Process.monitor`), preserving the
  still-live-sibling coverage the original timing depended on.
- **`DispatcherEffectTest`** — one test restructured to `Task.await` first and
  `assert_received` after, making it fully deterministic. The other had its
  `assert_receive` bound *inverted*: it sat below the dispatch's own
  `timeout_ms`, so a callback that started late but legitimately still failed.
- **Unconditional cleanup** — `on_exit` registered immediately after spawn for
  the VM-global `:erlang.trace_pattern/3` and the CPU-heavy workers, so an
  early failure cannot leak trace state into every later test or leave a
  multi-second loop running.
- **`assert Process.alive?`** before tracing, with a `rescue ArgumentError ->
  flunk` for the residual TOCTOU window, so an early abort reports as an early
  abort instead of an opaque `ArgumentError`.

## Verification

- Full root suite green under the pre-push gates (5851 tests).
- The four originally-reported files: 5/5 consecutive clean runs.
- `ProviderExecutionLifecycleTest`, which failed a full-suite pre-push run
  before this change, passes 6/6 in isolation after it.
- Five rounds of `codex-independent-review`, each round's findings folded in.

https://claude.ai/code/session_01V1dzaPNUM8eak2Xgdo4TYS