### PR TITLE
fix(kernel): clean dead REPL session access

### DIFF
--- a/docs/guides/embedding-in-elixir.md
+++ b/docs/guides/embedding-in-elixir.md
@@ -170,6 +170,10 @@ projection; its memory is not the authoritative continuation and must not be
 threaded back into the session. Preflight errors preserve the committed public
 memory view, and projection is validated before continuation commit.
 
+If the internal owner terminates before or during teardown, `close/1` reports
+`{:error, :session_closed}` and `abort/2` returns `:ok`; both paths also remove
+the creator-side lookup entry for the dead session.
+
 If provider cleanup fails after terminal finalization, `close/1` and `abort/2`
 return `{:error, :provider_cleanup_failed, events}` so the host can persist the
 frozen batch before reporting the error. The Mix frontend does this for normal

--- a/lib/ptc_runner/kernel/repl_session.ex
+++ b/lib/ptc_runner/kernel/repl_session.ex
@@ -865,7 +865,7 @@ defmodule PtcRunner.Kernel.ReplSession do
 
   defp owned_session(session) do
     with {:ok, pid, token} <- access_resources(session),
-         {:ok, config, state} <- ReplSessionOwner.resources(pid, token) do
+         {:ok, config, state} <- owner_resources(session, pid, token) do
       {:ok,
        Map.merge(Map.from_struct(session), %{
          owner_pid: pid,
@@ -878,6 +878,18 @@ defmodule PtcRunner.Kernel.ReplSession do
          errors: bounded_counter(session.errors)
        })}
     end
+  end
+
+  defp owner_resources(session, pid, token) do
+    ReplSessionOwner.resources(pid, token)
+  catch
+    :exit, reason ->
+      if Process.alive?(pid) do
+        exit(reason)
+      else
+        close_access(session)
+        {:error, :session_closed}
+      end
   end
 
   defp register_access(pid, token) do

--- a/test/ptc_runner/kernel/repl_session_test.exs
+++ b/test/ptc_runner/kernel/repl_session_test.exs
@@ -626,6 +626,54 @@ defmodule PtcRunner.Kernel.ReplSessionTest do
     assert_receive {:DOWN, ^creator_ref, :process, ^creator, :normal}, 5_000
   end
 
+  test "closing after session-owner death removes the creator access entry" do
+    {:ok, close_session} = ReplSession.new()
+    [{close_id, {close_owner, close_token}}] = :ets.lookup(close_session.access, close_session.id)
+    assert is_reference(close_token)
+    close_ref = Process.monitor(close_owner)
+    Process.exit(close_owner, :kill)
+    assert_receive {:DOWN, ^close_ref, :process, ^close_owner, :killed}, 5_000
+
+    assert {:error, :session_closed} = ReplSession.close(close_session)
+    assert :ets.lookup(close_session.access, close_id) == []
+
+    {:ok, abort_session} = ReplSession.new()
+    [{abort_id, {abort_owner, abort_token}}] = :ets.lookup(abort_session.access, abort_session.id)
+    assert is_reference(abort_token)
+    abort_ref = Process.monitor(abort_owner)
+    Process.exit(abort_owner, :kill)
+    assert_receive {:DOWN, ^abort_ref, :process, ^abort_owner, :killed}, 5_000
+
+    assert :ok = ReplSession.abort(abort_session, :frontend_exit)
+    assert :ets.lookup(abort_session.access, abort_id) == []
+  end
+
+  test "owner death during resource lookup removes the creator access entry" do
+    {:ok, session} = ReplSession.new()
+    [{id, {owner, token}}] = :ets.lookup(session.access, session.id)
+    :ok = :sys.suspend(owner)
+    creator = self()
+
+    {tracer, tracer_ref} =
+      spawn_monitor(fn ->
+        receive do
+          {:trace, ^creator, :send, {:"$gen_call", _from, {^token, :resources}}, ^owner} ->
+            Process.exit(owner, :kill)
+        end
+      end)
+
+    assert 1 = :erlang.trace(creator, true, [:send, {:tracer, tracer}])
+
+    try do
+      assert {:error, :session_closed} = ReplSession.close(session)
+    after
+      assert 1 = :erlang.trace(creator, false, [:send])
+    end
+
+    assert_receive {:DOWN, ^tracer_ref, :process, ^tracer, :normal}, 5_000
+    assert :ets.lookup(session.access, id) == []
+  end
+
   test "session owner rejects a run state not bound to its configured sinks" do
     {:ok, workflow} = WorkflowEnvironment.new([])
     {:ok, mission} = MissionEnvironment.new([])


### PR DESCRIPTION
## Summary

- remove creator-side REPL access entries when the internal session owner dies before or during resource lookup
- preserve the original exit when the owner is still alive, avoiding false session-closed cleanup on ambiguous call failures
- add deterministic regression coverage for close, abort, and in-flight owner death
- document teardown behavior and regenerate the semantic build projection

## Root cause

`ReplSession.close/1` and `abort/2` resolved owner resources before entering their cleanup paths. If `ReplSessionOwner.resources/2` exited because the owner was already dead—or died while the call was in flight—the creator-private ETS entry could remain indefinitely.

## Verification

- `mix precommit`
- `MIX_ENV=dev mix docs --warnings-as-errors`
- full pre-push hook with `PTC_PRE_PUSH_MAX_CASES=2` (5,853 root tests, Dialyzer, generated artifacts, upstream audit, and 72 Viewer tests)

Closes #1201