### PR TITLE
fix(cli): close Checkpoint D review findings

### DIFF
--- a/lib/ptc_runner/kernel/artifact_publisher.ex
+++ b/lib/ptc_runner/kernel/artifact_publisher.ex
@@ -17,6 +17,7 @@ defmodule PtcRunner.Kernel.ArtifactPublisher do
           required(:written) => [atom()],
           required(:failed) => [atom()],
           required(:withheld) => [atom()],
+          required(:secondary_errors) => [term()],
           optional(:result) => term(),
           optional(:error) => term()
         }
@@ -37,7 +38,8 @@ defmodule PtcRunner.Kernel.ArtifactPublisher do
       artifact_state: states,
       written: [],
       failed: [],
-      withheld: []
+      withheld: [],
+      secondary_errors: []
     }
 
     result =
@@ -71,6 +73,7 @@ defmodule PtcRunner.Kernel.ArtifactPublisher do
          written: [],
          failed: [],
          withheld: @artifact_names,
+         secondary_errors: [],
          error: :invalid_execution_outcome
        }}
 
@@ -85,6 +88,8 @@ defmodule PtcRunner.Kernel.ArtifactPublisher do
     with {:ok, report} <- maybe_cleanup_recovery(evidence, authority, report),
          {:ok, report} <- publish_observations(evidence, authority, report, hooks) do
       {:error, Map.put(report, :error, evidence.result_contract)}
+    else
+      {:error, report} -> {:error, preserve_primary_error(report, evidence.result_contract)}
     end
   end
 
@@ -527,6 +532,20 @@ defmodule PtcRunner.Kernel.ArtifactPublisher do
   end
 
   defp hook(hooks, key), do: Map.get(hooks, key)
+
+  defp preserve_primary_error(report, primary) do
+    secondary = Map.fetch!(report, :error)
+
+    report
+    |> Map.put(:error, primary)
+    |> Map.update!(:secondary_errors, &(&1 ++ [secondary]))
+  end
+
+  defp attach_failure_result(
+         %{error: {:error, {:result_contract_failed, _details}}} = report,
+         _evidence
+       ),
+       do: report
 
   defp attach_failure_result(report, evidence) do
     if failure_result_required?(report) do

--- a/lib/ptc_runner/kernel/owner_status_redaction.ex
+++ b/lib/ptc_runner/kernel/owner_status_redaction.ex
@@ -1,0 +1,19 @@
+defmodule PtcRunner.Kernel.OwnerStatusRedaction do
+  @moduledoc false
+
+  defmacro __using__(_opts) do
+    quote do
+      if {:format_status, 1} in GenServer.behaviour_info(:callbacks) do
+        @impl GenServer
+        def format_status(_status),
+          do: %{state: :redacted, message: :redacted, reason: :redacted, log: []}
+      else
+        def format_status(_status),
+          do: %{state: :redacted, message: :redacted, reason: :redacted, log: []}
+      end
+
+      @impl GenServer
+      def format_status(_reason, _status), do: [data: [{~c"State", :redacted}]]
+    end
+  end
+end

--- a/lib/ptc_runner/kernel/publication_claim_owner.ex
+++ b/lib/ptc_runner/kernel/publication_claim_owner.ex
@@ -2,6 +2,7 @@ defmodule PtcRunner.Kernel.PublicationClaimOwner do
   @moduledoc false
 
   use GenServer
+  use PtcRunner.Kernel.OwnerStatusRedaction
 
   @type lease :: {pid(), reference()}
 
@@ -102,6 +103,11 @@ defmodule PtcRunner.Kernel.PublicationClaimOwner do
     result = cleanup_handles(state.handles)
     {:stop, :normal, result, %{state | handles: %{}}}
   end
+
+  def handle_call(_request, _from, state), do: {:reply, {:error, :terminal}, state}
+
+  @impl GenServer
+  def handle_cast(_message, state), do: {:noreply, state}
 
   @impl GenServer
   def handle_info({:DOWN, ref, :process, _claimant, _reason}, %{claimant_ref: ref} = state) do

--- a/lib/ptc_runner/kernel/publication_handle_owner.ex
+++ b/lib/ptc_runner/kernel/publication_handle_owner.ex
@@ -2,6 +2,7 @@ defmodule PtcRunner.Kernel.PublicationHandleOwner do
   @moduledoc false
 
   use GenServer
+  use PtcRunner.Kernel.OwnerStatusRedaction
 
   alias PtcRunner.Kernel.PublicationHandle
 
@@ -73,6 +74,12 @@ defmodule PtcRunner.Kernel.PublicationHandleOwner do
 
   def handle_call({:operation, _operation}, _from, state),
     do: {:reply, {:error, :publication_cleanup_failed}, state}
+
+  def handle_call(_request, _from, state),
+    do: {:reply, {:error, :publication_failed}, state}
+
+  @impl GenServer
+  def handle_cast(_message, state), do: {:noreply, state}
 
   defp operation_reply(:sync_and_retain, %PublicationHandle{kind: :recovery} = handle, state),
     do: sync_and_retain_reply(handle, state, :sync_and_retain)

--- a/test/ptc_runner/kernel/artifact_publisher_test.exs
+++ b/test/ptc_runner/kernel/artifact_publisher_test.exs
@@ -48,6 +48,54 @@ defmodule PtcRunner.Kernel.ArtifactPublisherTest do
   end
 
   @tag :tmp_dir
+  test "result-contract failure remains primary when trace publication also fails", %{
+    tmp_dir: dir
+  } do
+    trace = Path.join(dir, "contract-failure.jsonl")
+
+    {built, registry} =
+      build!(
+        dir,
+        "contract-and-publication-failure",
+        :normal,
+        trace,
+        nil,
+        nil,
+        :policy,
+        body: ~S|{"answer" "wrong"}|,
+        result_schema: %{
+          "type" => "object",
+          "required" => ["answer"],
+          "properties" => %{"answer" => %{"type" => "integer"}}
+        }
+      )
+
+    assert {:ok, outcome} = RunBuilder.execute_built(built)
+
+    fault = fn
+      :after_validation -> {:error, :partial_write}
+      _stage -> :ok
+    end
+
+    assert {:error, report} =
+             RunBuilder.publish_execution_report(
+               outcome,
+               built.publication_authority,
+               %{trace: fault}
+             )
+
+    assert {:error, {:result_contract_failed, _details}} = report.error
+    assert report.secondary_errors == [{:trace, :partial_write}]
+    assert report.failed == [:trace]
+    assert Enum.sort(report.withheld) == [:inspection, :result]
+    refute Map.has_key?(report, :result)
+    refute inspect(report) =~ dir
+
+    assert :ok = PublicationAuthority.abort(built.publication_authority)
+    assert :ok = ProviderRegistry.close(registry)
+  end
+
+  @tag :tmp_dir
   test "explicit normal and private trace destinations append across runs", %{tmp_dir: dir} do
     for {policy, suffix} <- [{:normal, ".jsonl"}, {:private, ".private.jsonl"}] do
       trace = Path.join(dir, "append#{suffix}")
@@ -696,22 +744,29 @@ defmodule PtcRunner.Kernel.ArtifactPublisherTest do
          inspection,
          output,
          result_destination \\ :policy,
-         body \\ nil
+         fixture \\ nil
        ) do
     root = Path.join(dir, name)
     File.mkdir!(root)
+    {body, result_schema} = fixture_parts(fixture)
     expression = body || "\"#{name}\""
     File.write!(Path.join(root, "main.clj"), "(ns main) (defn run [_] (return #{expression}))")
 
-    manifest = %{
-      "version" => 1,
-      "workflow" => %{
-        "components" => [%{"id" => "main", "path" => "main.clj"}],
-        "entry" => "main/run"
-      },
-      "input" => %{"value" => %{}},
-      "events" => %{"policy" => Atom.to_string(policy), "run_id" => name}
-    }
+    if result_schema do
+      File.write!(Path.join(root, "result.schema.json"), Jason.encode!(result_schema))
+    end
+
+    manifest =
+      %{
+        "version" => 1,
+        "workflow" => %{
+          "components" => [%{"id" => "main", "path" => "main.clj"}],
+          "entry" => "main/run"
+        },
+        "input" => %{"value" => %{}},
+        "events" => %{"policy" => Atom.to_string(policy), "run_id" => name}
+      }
+      |> maybe_put_result_contract(result_schema)
 
     manifest_path = Path.join(root, "ptc.json")
     File.write!(manifest_path, Jason.encode!(manifest))
@@ -733,6 +788,19 @@ defmodule PtcRunner.Kernel.ArtifactPublisherTest do
   defp maybe_put(opts, key, value), do: Keyword.put(opts, key, value)
   defp maybe_put(opts, _key, _value, false), do: opts
   defp maybe_put(opts, key, value, true), do: Keyword.put(opts, key, value)
+
+  defp maybe_put_result_contract(manifest, nil), do: manifest
+
+  defp maybe_put_result_contract(manifest, _schema) do
+    Map.put(manifest, "contracts", %{
+      "result_schema" => %{"path" => "result.schema.json"}
+    })
+  end
+
+  defp fixture_parts(fixture) when is_list(fixture),
+    do: {Keyword.get(fixture, :body), Keyword.get(fixture, :result_schema)}
+
+  defp fixture_parts(body), do: {body, nil}
 
   defp trace_event(run_id, sequence, type) do
     %{

--- a/test/ptc_runner/kernel/owner_status_privacy_test.exs
+++ b/test/ptc_runner/kernel/owner_status_privacy_test.exs
@@ -10,6 +10,7 @@ defmodule PtcRunner.Kernel.OwnerStatusPrivacyTest do
   alias PtcRunner.Kernel.Limits
   alias PtcRunner.Kernel.MCPRequestContext
   alias PtcRunner.Kernel.PublicationAuthority
+  alias PtcRunner.Kernel.PublicationHandle
   alias PtcRunner.Kernel.RunCoordinator
   alias PtcRunner.Kernel.RunState
 
@@ -33,9 +34,12 @@ defmodule PtcRunner.Kernel.OwnerStatusPrivacyTest do
     :ok
   end
 
-  test "owner callback fallbacks reject unexpected messages without logging private data" do
+  @tag :tmp_dir
+  test "owner callback fallbacks reject unexpected messages without logging private data", %{
+    tmp_dir: directory
+  } do
     marker = "PRIVATE_FALLBACK_MARKER"
-    owners = start_owners(marker)
+    owners = start_owners(marker, directory)
 
     assert {:error, :closed} = GenServer.call(owners.store, {:unexpected, marker})
     assert {:error, :inspection_sink_error} = GenServer.call(owners.sink.pid, marker)
@@ -45,6 +49,12 @@ defmodule PtcRunner.Kernel.OwnerStatusPrivacyTest do
     assert {:error, :execution_session_unavailable} =
              GenServer.call(owners.execution, {:unexpected, marker})
 
+    assert {:error, :publication_failed} =
+             GenServer.call(owners.publication_handle, {:unexpected, marker})
+
+    assert {:error, :terminal} =
+             GenServer.call(owners.publication_claim, {:unexpected, marker})
+
     Enum.each(owner_pids(owners), &GenServer.cast(&1, {:unexpected, marker}))
     Enum.each(owner_pids(owners), &:sys.get_status/1)
 
@@ -53,17 +63,20 @@ defmodule PtcRunner.Kernel.OwnerStatusPrivacyTest do
     refute_receive {:logger_probe, _event}
   end
 
-  test "OTP status and every crash Logger event redact private owner state" do
+  @tag :tmp_dir
+  test "OTP status and every crash Logger event redact private owner state", %{tmp_dir: directory} do
     markers = %{
       store: "PRIVATE_INSPECTION_STORE_MARKER",
       sink: "PRIVATE_INSPECTION_RECORD_MARKER",
       run_state: "PRIVATE_EVALUATION_MEMORY_MARKER",
       endpoint: "PRIVATE_MCP_ENDPOINT_MARKER",
       header: "PRIVATE_MCP_HEADER_MARKER",
-      execution: "PRIVATE_EXECUTION_INPUT_MARKER"
+      execution: "PRIVATE_EXECUTION_INPUT_MARKER",
+      publication_handle: "PRIVATE_PUBLICATION_HANDLE_PATH_MARKER",
+      publication_claim: "PRIVATE_PUBLICATION_CLAIM_PATH_MARKER"
     }
 
-    owners = start_owners(markers)
+    owners = start_owners(markers, directory)
 
     Enum.each(owner_pids(owners), fn pid ->
       status = :sys.get_status(pid)
@@ -92,18 +105,23 @@ defmodule PtcRunner.Kernel.OwnerStatusPrivacyTest do
     end)
   end
 
-  defp start_owners(marker) when is_binary(marker) do
-    start_owners(%{
-      store: marker,
-      sink: marker,
-      run_state: marker,
-      endpoint: marker,
-      header: marker,
-      execution: marker
-    })
+  defp start_owners(marker, directory) when is_binary(marker) do
+    start_owners(
+      %{
+        store: marker,
+        sink: marker,
+        run_state: marker,
+        endpoint: marker,
+        header: marker,
+        execution: marker,
+        publication_handle: marker,
+        publication_claim: marker
+      },
+      directory
+    )
   end
 
-  defp start_owners(markers) do
+  defp start_owners(markers, directory) do
     {:ok, store} = PtcViewer.InspectionStore.start({:pinned, markers.store})
     {:ok, sink} = InspectionSink.start(run_id: "run-1", trace_id: "trace-1")
 
@@ -136,13 +154,30 @@ defmodule PtcRunner.Kernel.OwnerStatusPrivacyTest do
 
     {execution, execution_catalog} = start_execution_owner(markers.execution)
 
+    {:ok, publication_handle} =
+      PublicationHandle.reserve(
+        Path.join(directory, markers.publication_handle <> ".jsonl"),
+        :trace,
+        0o644
+      )
+
+    {:ok, publication_authority} =
+      PublicationAuthority.authorize(
+        "owner-status-privacy",
+        [trace: Path.join(directory, markers.publication_claim <> ".jsonl")],
+        :normal,
+        :normal
+      )
+
     owners = %{
       store: store,
       sink: sink,
       run_state: run_state,
       mcp: mcp,
       execution: execution,
-      execution_catalog: execution_catalog
+      execution_catalog: execution_catalog,
+      publication_handle: publication_handle.owner,
+      publication_claim: publication_authority.claim_owner
     }
 
     on_exit(fn ->
@@ -154,7 +189,15 @@ defmodule PtcRunner.Kernel.OwnerStatusPrivacyTest do
   end
 
   defp owner_pids(owners),
-    do: [owners.store, owners.sink.pid, owners.run_state.pid, owners.mcp.pid, owners.execution]
+    do: [
+      owners.store,
+      owners.sink.pid,
+      owners.run_state.pid,
+      owners.mcp.pid,
+      owners.execution,
+      owners.publication_handle,
+      owners.publication_claim
+    ]
 
   defp start_execution_owner(marker) do
     manifest = %{

--- a/test/ptc_runner/kernel/publication_authority_test.exs
+++ b/test/ptc_runner/kernel/publication_authority_test.exs
@@ -7,6 +7,9 @@ defmodule PtcRunner.Kernel.PublicationAuthorityTest do
   alias PtcRunner.Kernel.ProviderActivity
   alias PtcRunner.Kernel.PublicationAuthority
   alias PtcRunner.Kernel.PublicationHandle
+  alias PtcRunner.Kernel.RunBuilder
+  alias PtcRunner.Kernel.RunCoordinator
+  alias PtcRunner.Kernel.TraceLog
 
   @tag :tmp_dir
   test "phase six reserves exact normal trace names before provider activity", %{tmp_dir: dir} do
@@ -61,6 +64,46 @@ defmodule PtcRunner.Kernel.PublicationAuthorityTest do
     assert :ok = PublicationAuthority.abort(authority)
     assert :ok = CommandPreparation.close(preparation)
     refute File.exists?(PublicationHandle.path(recovery))
+  end
+
+  @tag :tmp_dir
+  test "trace-directory destinations publish and discover exact normal and private names", %{
+    tmp_dir: dir
+  } do
+    Enum.each([:normal, :private], fn policy ->
+      traces = Path.join(dir, "#{policy}-traces")
+      File.mkdir!(traces)
+
+      overrides =
+        if policy == :private,
+          do: %{"events" => %{"policy" => "private"}},
+          else: %{}
+
+      application = application!(dir, "#{policy}-discovery", overrides)
+
+      argv =
+        ["run", application, "--trace-dir", traces]
+        |> maybe_private_output(policy, Path.join(dir, "#{policy}-result.json"))
+
+      assert {:ok, preparation} = CommandEngine.prepare(argv)
+      assert {:ok, authority} = CommandEngine.preflight(preparation)
+      assert {:ok, outcome} = RunCoordinator.execute(preparation.prepared_run, authority)
+      assert {:ok, report} = RunBuilder.publish_execution_report(outcome, authority)
+      assert report.artifact_state["trace"] == "written"
+      assert :ok = PublicationAuthority.close(authority)
+
+      suffix = if policy == :private, do: ".private.jsonl", else: ".jsonl"
+      assert File.ls!(traces) == [preparation.run_ref <> suffix]
+
+      source = if policy == :private, do: {:private_directory, traces}, else: {:directory, traces}
+      assert {:ok, trace_log} = TraceLog.new(source: source)
+
+      assert {:ok, %{"items" => [%{"run_id" => run_ref}]}} =
+               TraceLog.query(trace_log, :list_runs, %{})
+
+      assert run_ref == preparation.run_ref
+      assert :ok = CommandPreparation.close(preparation)
+    end)
   end
 
   @tag :tmp_dir
@@ -423,6 +466,11 @@ defmodule PtcRunner.Kernel.PublicationAuthorityTest do
     File.write!(path, Jason.encode!(manifest))
     path
   end
+
+  defp maybe_private_output(argv, :normal, _output), do: argv
+
+  defp maybe_private_output(argv, :private, output),
+    do: argv ++ ["--private-output", output]
 
   defp authorize_after_creator_cleanup(target, attempts \\ 100)
 


### PR DESCRIPTION
Follow-up to merged PR #1202. This closes the remaining actionable findings from the Checkpoint D independent review.

Changes:
- preserve result-contract failure as the primary diagnostic when trace or inspection publication also fails, retaining publication failure as secondary evidence and withholding the invalid result;
- redact publication handle and claim owner OTP status, crash logs, and unexpected messages without changing cleanup ownership;
- add end-to-end normal/private trace-directory publication and TraceLog discovery coverage for the exact run-ref filenames.

Plan and generated state:
- current main records Checkpoints A-D complete and Checkpoint E next;
- the follow-up does not restore the completed Checkpoint D implementation record removed by 0f271a49;
- the branch does not modify priv/semantic_build_projection.json, following the release-only projection policy introduced by f3cf7d8d.

Verification:
- focused publication/privacy/authority tests: 42 passed on the final rebased tree;
- ERL_FLAGS="+S 2" mix precommit: 5853 root, 72 Viewer, 36 launcher tests passed, with all static/generated/package gates;
- MIX_ENV=test mix dialyzer: 0 errors;
- MIX_ENV=dev mix docs --warnings-as-errors: passed;
- normal pre-push hooks at two-case concurrency: passed before the final build-policy-only rebase;
- final integration review against origin/main f3cf7d8d: no findings; range-diff proved the seven code/test patches unchanged and only the obsolete projection update removed.

This PR should not be merged automatically.