### PR TITLE
fix(kernel): stop a killed REPL owner orphaning its run state

### DIFF
--- a/lib/ptc_runner/kernel/repl_session_owner.ex
+++ b/lib/ptc_runner/kernel/repl_session_owner.ex
@@ -53,6 +53,20 @@ defmodule PtcRunner.Kernel.ReplSessionOwner do
 
   @impl GenServer
   def init({token, owner, config, run_state}) do
+    # `terminate/2` stops the run state, but it does not run on an untrappable
+    # exit, so a brutally killed owner used to orphan its run state and the
+    # `ProviderTaskTracker` every run state starts (#1209). Cleanup that only
+    # holds when `terminate/2` runs is not cleanup.
+    #
+    # The link makes the guarantee a VM-level one: the owner's exit signal
+    # reaches the run state whatever killed the owner, and the tracker follows
+    # because it already monitors the run state as a lifecycle. Trapping exits
+    # keeps the link one-directional in effect: a run state that dies on its own
+    # arrives as a message this module ignores, rather than taking the owner
+    # down and destroying its ability to report why a close failed.
+    Process.flag(:trap_exit, true)
+    Process.link(run_state.pid)
+
     {:ok,
      %{
        token: token,
@@ -86,6 +100,23 @@ defmodule PtcRunner.Kernel.ReplSessionOwner do
   @impl GenServer
   def handle_info({:DOWN, ref, :process, _pid, _reason}, %{owner_ref: ref} = state),
     do: {:stop, :normal, state}
+
+  # A run state that dies on its own is *ignored* here, deliberately.
+  #
+  # The link exists for one direction only: owner dies -> run state dies. In the
+  # other direction the owner must stay alive, because a caller closing a
+  # session whose run state died still has to be told why — and provider
+  # cleanup failures are reported through that close, not through the owner's
+  # own exit. Stopping here instead turned
+  # `{:error, :provider_cleanup_failed}` into `{:error, :session_closed}` and
+  # broke the race that `ProviderLifecycleTest` pins down.
+  #
+  # Trapping exits is what makes ignoring possible: without it this signal
+  # would kill the owner outright. So the trap preserves the pre-#1209
+  # behaviour on run-state death while the link adds the missing guarantee on
+  # owner death.
+  def handle_info({:EXIT, pid, _reason}, %{run_state: %{pid: pid}} = state),
+    do: {:noreply, state}
 
   def handle_info(_message, state), do: {:noreply, state}
 

--- a/test/soak/lifecycle/repl_session_soak_test.exs
+++ b/test/soak/lifecycle/repl_session_soak_test.exs
@@ -78,18 +78,12 @@ defmodule PtcRunner.Soak.ReplSessionSoakTest do
   end
 
   describe "owner death" do
-    # Currently failing, and correctly so: this variant found a real leak.
-    # `close/1` and `abort/2` only reach `close_access/1` after
-    # `owned_session/1` succeeds, and `owned_session/1` exits when the owner is
-    # already dead — so an abnormally terminated owner leaves its access entry
-    # in the creator's table permanently. Reproduced standalone at 5 sessions,
-    # 5 permanent entries with dead pids.
-    #
-    # Skipped rather than deleted: the reproduction is the valuable part, and
-    # the fix is a production behaviour change that belongs in its own PR.
-    # Remove this tag as part of fixing
-    # https://github.com/andreasronge/ptc_runner/issues/1201.
-    @tag :skip
+    # #1201 fixed the creator-side access entry this variant first caught.
+    # Removing that skip exposed a second leak the first had been masking: the
+    # owner monitors only its *creator* (`repl_session_owner.ex:60`) and nothing
+    # links or monitors the `RunState` it was handed, so abnormal owner death
+    # orphans both it and the `ProviderTaskTracker` every `RunState` starts.
+    # See https://github.com/andreasronge/ptc_runner/issues/1209.
     test "killing the ReplSessionOwner leaves no entry behind", context do
       LifecycleSoak.soak!(
         [


### PR DESCRIPTION
Closes #1209. Follow-up to #1203, which found this, and to #1201, which was masking it.

## The leak

`ReplSessionOwner.terminate/2` stops its run state — but **`terminate/2` does not run on an untrappable exit**. The owner monitored only its *creator*, and neither linked nor monitored the `RunState` it was handed, so a brutally killed owner left that run state alive, and with it the `ProviderTaskTracker` every `RunState` starts (`run_state.ex:995`).

`close/1` could not reap them either: `close_run_state/1` sits inside `close_owned/1`, reached only once `owned_session/1` has succeeded — which is exactly what fails when the owner is already dead.

Cleanup that only holds when `terminate/2` runs is not cleanup.

## The fix

The owner links the run state, making the guarantee VM-level: the exit signal reaches it whatever killed the owner, and the tracker follows because it already monitors the run state as a lifecycle.

**The link is wanted in one direction only, and getting that wrong is the interesting part.** Trapping exits is what makes the reverse direction ignorable — a run state that dies on its own arrives as a message the owner drops, preserving the previous behaviour exactly.

A first attempt stopped the owner on that signal instead. It looked tidier and was wrong: it turned `{:error, :provider_cleanup_failed}` into `{:error, :session_closed}` and broke the race `ProviderLifecycleTest:1267` pins down. A caller closing a session whose run state died still has to be told *why*. The existing catch-all `handle_info/2` would have swallowed the signal silently either way, so the clause is explicit and sits ahead of it.

## How it was found

The soak variant added in #1203 found two leaks in succession. The first was the creator-side ETS access entry (#1201, fixed by `b277be67`); removing that skip exposed this one underneath it.

Both were invisible to the soak's original ledger, because neither the run state nor its tracker is reachable from the public `%ReplSession{}` handle — they had to be read out of live owner state. That gap was itself found by a ledger-completeness sweep, after the same class of defect turned up three times in #1203.

The `@tag :skip` is removed and the owner-death variant now gates.

## Verification

- REPL soak family **3/3 on three consecutive runs** — previously 2/3, failing with a live `RunState` 5 s after its cycle returned.
- `provider_lifecycle_test.exs` + `provider_session_test.exs` + `repl_session_test.exs`: **120 passed**, including the race that caught the first attempt.
- Full suite: 5880/5881. The single failure is `MCPOAuth.NetworkPolicyTest`, a known suite-load flake — it passes in isolation and sits nowhere near this two-file diff.
- `mix precommit` green.

https://claude.ai/code/session_01BZr9hhf995c5FziKVBCxFT