### PR TITLE
perf(test): run nine independent test modules concurrently

### DIFF
--- a/test/ptc_runner/kernel/artifact_publisher_test.exs
+++ b/test/ptc_runner/kernel/artifact_publisher_test.exs
@@ -1,5 +1,5 @@
 defmodule PtcRunner.Kernel.ArtifactPublisherTest do
-  use ExUnit.Case, async: false
+  use ExUnit.Case, async: true
 
   alias PtcRunner.Kernel.ProviderRegistry
   alias PtcRunner.Kernel.PublicationAuthority

--- a/test/ptc_runner/kernel/provider_acquisition_test.exs
+++ b/test/ptc_runner/kernel/provider_acquisition_test.exs
@@ -1,5 +1,5 @@
 defmodule PtcRunner.Kernel.ProviderAcquisitionTest do
-  use ExUnit.Case, async: false
+  use ExUnit.Case, async: true
 
   alias PtcRunner.Kernel.ApplicationPackage
   alias PtcRunner.Kernel.Capability

--- a/test/ptc_runner/kernel/provider_connectivity_test.exs
+++ b/test/ptc_runner/kernel/provider_connectivity_test.exs
@@ -1,5 +1,5 @@
 defmodule PtcRunner.Kernel.ProviderConnectivityTest do
-  use ExUnit.Case, async: false
+  use ExUnit.Case, async: true
 
   alias PtcRunner.Kernel.ApplicationPackage
   alias PtcRunner.Kernel.Capability

--- a/test/ptc_runner/kernel/provider_declaration_test.exs
+++ b/test/ptc_runner/kernel/provider_declaration_test.exs
@@ -1,5 +1,5 @@
 defmodule PtcRunner.Kernel.ProviderDeclarationTest do
-  use ExUnit.Case, async: false
+  use ExUnit.Case, async: true
 
   alias PtcRunner.Kernel.ApplicationPackage
   alias PtcRunner.Kernel.CommandEngine

--- a/test/ptc_runner/kernel/publication_authority_test.exs
+++ b/test/ptc_runner/kernel/publication_authority_test.exs
@@ -1,5 +1,5 @@
 defmodule PtcRunner.Kernel.PublicationAuthorityTest do
-  use ExUnit.Case, async: false
+  use ExUnit.Case, async: true
 
   alias PtcRunner.Kernel.CommandEngine
   alias PtcRunner.Kernel.CommandOutcome

--- a/test/ptc_runner/kernel/repo_analyst_application_test.exs
+++ b/test/ptc_runner/kernel/repo_analyst_application_test.exs
@@ -1,5 +1,5 @@
 defmodule PtcRunner.Kernel.RepoAnalystApplicationTest do
-  use ExUnit.Case, async: false
+  use ExUnit.Case, async: true
 
   @moduledoc """
   Covers the `repo-analyst` application package as files rather than runtime.

--- a/test/ptc_runner/kernel/tutorial_examples_test.exs
+++ b/test/ptc_runner/kernel/tutorial_examples_test.exs
@@ -1,5 +1,5 @@
 defmodule PtcRunner.Kernel.TutorialExamplesTest do
-  use ExUnit.Case, async: false
+  use ExUnit.Case, async: true
 
   alias PtcRunner.Kernel.HostConfig
   alias PtcRunner.Kernel.Manifest

--- a/test/ptc_runner/kernel/viewer_adapter_test.exs
+++ b/test/ptc_runner/kernel/viewer_adapter_test.exs
@@ -1,5 +1,5 @@
 defmodule PtcRunner.Kernel.ViewerAdapterTest do
-  use ExUnit.Case, async: false
+  use ExUnit.Case, async: true
 
   alias PtcRunner.Kernel.TraceLog
   alias PtcRunner.Kernel.ViewerAdapter

--- a/test/ptc_runner/lisp/java/oracle_fixtures_test.exs
+++ b/test/ptc_runner/lisp/java/oracle_fixtures_test.exs
@@ -1,5 +1,5 @@
 defmodule PtcRunner.Lisp.Java.OracleFixturesTest do
-  use ExUnit.Case, async: false
+  use ExUnit.Case, async: true
 
   alias PtcRunner.Lisp.Java.Oracle.Config
   alias PtcRunner.Lisp.Java.Oracle.Fixtures


### PR DESCRIPTION
Test-only. Moves nine `async: false` modules into the parallel lane.

## Why

The root suite spends most of its wall clock serialized. Measured on a
10-core machine: ~4800 async tests finish in ~21s, while 730 tests in 54
`async: false` files take ~140s — 13% of the tests holding ~85% of the
time, with cores idle.

Most of that serialization is not load-bearing. Of the 54 files, 14 never
run outside `--include e2e/soak`, and exactly one — `mcp_source_test` —
documents a reason (real TCP with short deadlines; correctly sync). The
rest carry no comment at all, which suggests copy-paste rather than a
constraint.

## What was converted

Nine files with no VM-global state: `@tag :tmp_dir` for isolation, per-pid
`:erlang.trace/3` rather than VM-wide `:erlang.trace_pattern/3`, and no
`System.put_env`, `Application.put_env`, `:persistent_term.put`,
`Logger.configure`, `:telemetry.attach`, subprocesses, or network timing.

## What was dropped, and why it is recorded

Two candidate groups passed the static audit and were disproved by running
them. Recorded so they are not retried:

- **`test/mix/tasks/*` (4 files)** — `Mix.shell()` is global and
  `Mix.Task.run/2` is idempotent per run-state, so concurrent Mix task
  tests steal each other's `capture_io` output. This survived **four clean
  full-suite runs** before a scoped run caught it.
- **`mcp_http_cancellation`** — asserts on timeout behaviour, so it fails
  under the contention its own concurrency creates. Same class as
  `mcp_source_test`.

Also excluded by inspection: `mcp_stdio_transport` (33s standalone, the
single biggest remaining win, but subprocess-per-test with a known `:epipe`
flake — worth its own change), the three other subprocess-spawning files,
`execution_session_owner_privacy` (asserts on `capture_log`, which would
collect concurrent tests' output), and `lisp_telemetry` / `viewer_repl_http`
(`:telemetry.attach` is a global handler registry).

## Measurements

Six runs of each, same tree (`b87638cf`), same machine, fresh seed per run:

| | Total (avg) | Serial lane (avg) |
|---|---|---|
| main | 160.7s | 139.9s |
| this branch | 141.4s | 118.9s |

**~12%** off the suite; the serial lane drops ~21s, which is what these
nine files are worth.

## On flakiness — stated plainly

main ran 6/6 clean. This branch ran 5/6, failing once on
`MCPOAuth.NetworkPolicyTest` "bounds a resolver that never returns by the
supplied absolute deadline" — a **documented pre-existing load flake**, not
in this change's set.

Across 12 runs of this branch, four distinct failures appeared
(`CoreContractTest`, `BoundedWorkerTest`, `TokenManagerTest`,
`NetworkPolicyTest`). **None is in the converted set**, and each already had
its current async setting on main. But 1-in-6 against 0-in-6 is weak
evidence, and it would be convenient rather than honest to conclude the
added concurrency has no effect. If it does exacerbate these latent races,
that is a real cost of this change — the races are genuine bugs that
parallelism reveals rather than creates, but reviewers should weigh it.

https://claude.ai/code/session_01V1dzaPNUM8eak2Xgdo4TYS