### PR TITLE
feat(cli): add declaration-only models command

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -267,6 +267,9 @@ jobs:
       - name: Check compile-time dependency cycles
         run: mix xref graph --format cycles --label compile-connected --fail-above 0
 
+      - name: Check stable CLI transitional callers
+        run: mix run --no-start scripts/check_stable_cli_transition.exs
+
       - name: Run tests
         run: mix test --max-failures 1 --trace --warnings-as-errors
 
@@ -425,6 +428,9 @@ jobs:
         with:
           cache-plt: 'false'
           install-babashka: 'false'
+
+      - name: Check stable CLI transitional callers
+        run: mix run --no-start scripts/check_stable_cli_transition.exs
 
       - name: Build documentation
         run: mix docs --warnings-as-errors

--- a/docs/guides/kernel-maintainer.md
+++ b/docs/guides/kernel-maintainer.md
@@ -449,6 +449,12 @@ VM setup: it neither loads a `.env` nor starts an optional provider
 application, because it cannot prove it owns the VM it was called in, so a
 connect against a stopped optional application reports
 `active_preflight/provider_application_unavailable` rather than starting one.
+Successful `models` is terminal as well. It loads one bounded host document,
+constructs its inert installation catalog, and projects
+`PtcRunner.Kernel.InstallationCatalog.public_installations/1` in alias order. It
+never invokes a local check, selection validator, builder, credential resolver,
+OAuth service, provider application, process, port, or network operation, and
+it closes the inert catalog before returning the sealed outcome.
 Successful `run` preparation returns a sealed
 `PtcRunner.Kernel.CommandPreparation`, not a bare `PreparedRun`. That wrapper
 retains the original command reference, inert

--- a/docs/guides/running-and-debugging.md
+++ b/docs/guides/running-and-debugging.md
@@ -282,6 +282,14 @@ The command never renders an inspected exception, arbitrary callback result,
 credential, private value, provider response, selector, or filesystem path into
 either public stream.
 
+The shared command core already implements `ptc models --host-config HOST.json`
+through `PtcRunner.Kernel.CommandEngine`. It reads one bounded host document and
+returns the installed aliases in lexical order with only their public source,
+revision, data-class, accepted-class, and destination declarations. Listing
+models invokes no provider callback, credential or OAuth service, optional
+application, process, port, or network operation. The standalone process
+wrapper that exposes this core as an executable remains release work.
+
 With `--trace-dir DIR`, the command-generated `run_ref` is also the complete
 trace stem. A normal trace is exactly `<run_ref>.jsonl`; a private trace is
 exactly `<run_ref>.private.jsonl`. The envelope's `artifact_class` selects which

--- a/lib/ptc_runner/kernel/command_engine.ex
+++ b/lib/ptc_runner/kernel/command_engine.ex
@@ -9,7 +9,9 @@ defmodule PtcRunner.Kernel.CommandEngine do
 
   Every command it completes in full is inert except one: `doctor --connect`
   runs a real connectivity operation and may contact a provider and incur cost,
-  which is what the `doctor` help notice warns about. It still performs no
+  which is what the `doctor` help notice warns about. `models` loads one bounded
+  host document and returns only its ordered public installation declarations;
+  it invokes no provider callback or runtime service. The engine performs no
   frontend VM setup of its own — it neither loads a `.env` nor starts an
   optional provider application — because it cannot prove it owns the VM it was
   called in.
@@ -74,11 +76,6 @@ defmodule PtcRunner.Kernel.CommandEngine do
 
   def preflight(_preparation),
     do: {:error, outcome(:run, generated_or_safe_ref(), :internal, :internal_error)}
-
-  @doc false
-  @spec authorize(CommandPreparation.t()) ::
-          {:ok, PublicationAuthority.t()} | {:error, CommandOutcome.t()}
-  def authorize(%CommandPreparation{} = preparation), do: preflight(preparation)
 
   @doc false
   @spec request(binary(), InstallationCatalog.t(), keyword()) ::
@@ -216,30 +213,52 @@ defmodule PtcRunner.Kernel.CommandEngine do
          run_ref,
          _destinations
        ) do
-    case catalog(Map.get(options, :host_config)) do
-      {:ok, host, catalog} ->
-        try do
-          result = doctor_mode_outcome(arguments, run_ref, host, catalog)
-          InstallationCatalog.close(catalog)
-          result
-        rescue
-          exception ->
-            InstallationCatalog.close(catalog)
-            reraise exception, __STACKTRACE__
-        catch
-          kind, reason ->
-            InstallationCatalog.close(catalog)
-            :erlang.raise(kind, reason, __STACKTRACE__)
-        end
-
+    case with_catalog(Map.get(options, :host_config), fn host, catalog ->
+           doctor_mode_outcome(arguments, run_ref, host, catalog)
+         end) do
       {:error, %CommandDiagnostic{} = diagnostic} ->
         {:error, arguments_outcome(arguments, run_ref, diagnostic)}
+
+      result ->
+        result
     end
   end
 
-  defp prepare_arguments(%CommandArguments{command: command} = arguments, run_ref, _destinations)
-       when command in [:init, :models],
-       do: {:error, arguments_outcome(arguments, run_ref, :internal, :internal_error)}
+  defp prepare_arguments(
+         %CommandArguments{command: :models, options: %{host_config: host_config}} = arguments,
+         run_ref,
+         _destinations
+       ) do
+    case with_catalog(host_config, fn _host, catalog ->
+           {:ok,
+            CommandOutcome.success(:models, run_ref, %{
+              "installations" => InstallationCatalog.public_installations(catalog)
+            })}
+         end) do
+      {:error, %CommandDiagnostic{} = diagnostic} ->
+        {:error, arguments_outcome(arguments, run_ref, diagnostic)}
+
+      result ->
+        result
+    end
+  end
+
+  defp prepare_arguments(%CommandArguments{command: :init} = arguments, run_ref, _destinations),
+    do: {:error, arguments_outcome(arguments, run_ref, :internal, :internal_error)}
+
+  defp with_catalog(host_config, callback) when is_function(callback, 2) do
+    case catalog(host_config) do
+      {:ok, host, catalog} ->
+        try do
+          callback.(host, catalog)
+        after
+          InstallationCatalog.close(catalog)
+        end
+
+      {:error, %CommandDiagnostic{} = diagnostic} ->
+        {:error, diagnostic}
+    end
+  end
 
   # `doctor --connect` is the one command this module completes that performs
   # provider work. The parser guarantees it both an application and a host

--- a/mix.exs
+++ b/mix.exs
@@ -159,6 +159,7 @@ defmodule PtcRunner.MixProject do
       precommit: [
         "format --check-formatted",
         "compile --warnings-as-errors",
+        "run --no-start scripts/check_stable_cli_transition.exs",
         "xref graph --format cycles --label compile-connected --fail-above 0",
         "credo --strict",
         "cmd bash scripts/duplication_gate.sh check",

--- a/scripts/check_stable_cli_transition.exs
+++ b/scripts/check_stable_cli_transition.exs
@@ -1,0 +1,770 @@
+defmodule PtcRunner.StableCLITransitionCheck do
+  @moduledoc false
+
+  @root Path.expand("..", __DIR__)
+  @self Path.relative_to(__ENV__.file, @root)
+
+  # The inventory starts from Git's complete tracked/unignored file set rather
+  # than a hand-maintained directory list. That includes runtime and development
+  # source, tests, examples, retained documentation, generated artifacts, and
+  # package/CI inputs. Plans are excluded because they describe the deletion
+  # work itself.
+  @excluded_path_segments ["deps", "_build"]
+  @excluded_path_prefixes [".agents/", ".claude/skills/", ".codex/skills/"]
+
+  @expected_callers %{
+    "CommandEngine.authorize" => %{},
+    "CommandEngine.catalog" => %{
+      "lib/mix/tasks/ptc.run.ex" => 2,
+      "test/ptc_runner/kernel/command_engine_test.exs" => 3
+    },
+    "CommandEngine.request" => %{
+      "lib/mix/tasks/ptc.run.ex" => 1,
+      "test/ptc_runner/kernel/command_engine_test.exs" => 2
+    },
+    "Repl.persist_terminal_result" => %{"test/mix/tasks/ptc_repl_test.exs" => 1},
+    "Run.failure_message" => %{"test/mix/tasks/ptc_run_test.exs" => 5},
+    "RunBuilder.check_built" => %{},
+    "RunBuilder.check_built_claimed" => %{
+      "lib/ptc_runner/kernel/execution_session_owner.ex" => 1,
+      "lib/ptc_runner/kernel/provider_execution.ex" => 1
+    },
+    "RunBuilder.load_and_build" => %{
+      "lib/mix/tasks/ptc.repl.ex" => 1,
+      "test/ptc_runner/kernel/application_package_test.exs" => 1,
+      "test/ptc_runner/kernel/artifact_publisher_test.exs" => 1,
+      "test/ptc_runner/kernel/command_engine_test.exs" => 5,
+      "test/ptc_runner/kernel/component_override_test.exs" => 4,
+      "test/ptc_runner/kernel/filesystem_mcp_e2e_test.exs" => 1,
+      "test/ptc_runner/kernel/host_installation_test.exs" => 1,
+      "test/ptc_runner/kernel/inspection_snapshot_test.exs" => 2,
+      "test/ptc_runner/kernel/manifest_test.exs" => 9,
+      "test/ptc_runner/kernel/mcp_source_test.exs" => 66,
+      "test/ptc_runner/kernel/provider_lifecycle_test.exs" => 11,
+      "test/ptc_runner/kernel/repo_analyst_application_test.exs" => 1,
+      "test/ptc_runner/kernel/repo_analyst_e2e_test.exs" => 2,
+      "test/ptc_runner/kernel/run_builder_publication_test.exs" => 2
+    },
+    "RunBuilder.preflight_prepared" => %{"lib/mix/tasks/ptc.run.ex" => 1},
+    "RunBuilder.publish_execution" => %{
+      "lib/mix/tasks/ptc.run.ex" => 1,
+      "test/ptc_runner/kernel/artifact_publisher_test.exs" => 1,
+      "test/ptc_runner/kernel/run_builder_publication_test.exs" => 4,
+      "test/ptc_runner/kernel/run_coordinator_execution_test.exs" => 2
+    },
+    "RunBuilder.run" => %{
+      "examples/kernel-inspection-lab/support/lab.exs" => 1,
+      "test/ptc_runner/kernel/application_package_test.exs" => 1,
+      "test/ptc_runner/kernel/command_engine_test.exs" => 5,
+      "test/ptc_runner/kernel/component_override_test.exs" => 12,
+      "test/ptc_runner/kernel/filesystem_mcp_e2e_test.exs" => 1,
+      "test/ptc_runner/kernel/inspection_preflight_test.exs" => 14,
+      "test/ptc_runner/kernel/inspection_sink_test.exs" => 1,
+      "test/ptc_runner/kernel/llm_replay_test.exs" => 4,
+      "test/ptc_runner/kernel/manifest_test.exs" => 7,
+      "test/ptc_runner/kernel/mcp_remote_agent_e2e_test.exs" => 1,
+      "test/ptc_runner/kernel/mcp_source_test.exs" => 1,
+      "test/ptc_runner/kernel/provider_lifecycle_test.exs" => 3,
+      "test/ptc_runner/kernel/repo_analyst_e2e_test.exs" => 2,
+      "test/ptc_runner/kernel/repo_analyst_evaluation_e2e_test.exs" => 3,
+      "test/ptc_runner/kernel/tutorial_examples_e2e_test.exs" => 1,
+      "test/ptc_runner/kernel/tutorial_examples_test.exs" => 2
+    },
+    "RunBuilder.run_with_class" => %{
+      "test/ptc_runner/kernel/repo_analyst_live_e2e_test.exs" => 1
+    },
+    "RunCoordinator.check" => %{
+      "lib/mix/tasks/ptc.run.ex" => 2,
+      "test/ptc_runner/kernel/provider_connectivity_test.exs" => 1
+    }
+  }
+
+  @source_inventories [
+    {"RunBuilder transitional definitions",
+     ~r/(?:@spec|def) (?:load_and_build|run|run_with_class|preflight_prepared|publish_execution)\(/,
+     %{"lib/ptc_runner/kernel/run_builder.ex" => 12}},
+    {"CommandEngine transitional definitions", ~r/(?:@spec|def) (?:authorize|request|catalog)\(/,
+     %{"lib/ptc_runner/kernel/command_engine.ex" => 7}},
+    {"CommandEngine catalog local references", ~r/\bcatalog\(/,
+     %{"lib/ptc_runner/kernel/command_engine.ex" => 7}},
+    {"CommandEngine request local references", ~r/\brequest\(/,
+     %{"lib/ptc_runner/kernel/command_engine.ex" => 4}},
+    {"RunCoordinator check definitions", ~r/(?:@spec|def) check\(/,
+     %{"lib/ptc_runner/kernel/run_coordinator.ex" => 6}},
+    {"RunCoordinator check route", ~r/\bcheck\b/,
+     %{"lib/ptc_runner/kernel/run_coordinator.ex" => 13}},
+    {"RunBuilder check definitions", ~r/(?:@spec|def) check_built(?:_claimed)?\(/,
+     %{"lib/ptc_runner/kernel/run_builder.ex" => 6}},
+    {"RunBuilder check local references", ~r/\bcheck_built(?:_claimed)?\(/,
+     %{"lib/ptc_runner/kernel/run_builder.ex" => 7}},
+    {"execution-owner check route", ~r/:check|check_built/,
+     %{"lib/ptc_runner/kernel/execution_session_owner.ex" => 4}},
+    {"provider-execution check route", ~r/:check|check_built/,
+     %{"lib/ptc_runner/kernel/provider_execution.ex" => 6}},
+    {"provider-active-session check route", ~r/:check/,
+     %{"lib/ptc_runner/kernel/provider_active_session.ex" => 2}},
+    {"provider-session check route", ~r/:check/,
+     %{"lib/ptc_runner/kernel/provider_session.ex" => 7}},
+    {"Mix run check route", ~r/:check|RunCoordinator\.check|--check/,
+     %{"lib/mix/tasks/ptc.run.ex" => 10}},
+    {"Mix run failure seam", ~r/\bfailure_message\(/, %{"lib/mix/tasks/ptc.run.ex" => 5}},
+    {"Mix REPL persistence seam", ~r/\bpersist_terminal_result\(/,
+     %{"lib/mix/tasks/ptc.repl.ex" => 5}},
+    {"RunBuilder mission option plumbing", ~r/opts, :mission\b|:mission,|:mission\]/,
+     %{"lib/ptc_runner/kernel/run_builder.ex" => 4}},
+    {"RunBuilder private-mission option plumbing", ~r/private_mission/,
+     %{"lib/ptc_runner/kernel/run_builder.ex" => 5}},
+    {"RunBuilder trace option plumbing", ~r/opts, :trace\b|:trace,|:trace\]/,
+     %{"lib/ptc_runner/kernel/run_builder.ex" => 4}},
+    {"Mix run mission option plumbing", ~r/:mission\b/, %{"lib/mix/tasks/ptc.run.ex" => 4}},
+    {"Mix run private-mission option plumbing", ~r/private_mission/,
+     %{"lib/mix/tasks/ptc.run.ex" => 5}},
+    {"Mix run trace option plumbing", ~r/:trace\b/, %{"lib/mix/tasks/ptc.run.ex" => 2}}
+  ]
+
+  @mix_run_trace_pattern ~r/mix ptc\.run[^\n]*--trace(?=$|[ =])|^[ \t]*--trace(?=$|[ =])[^\n]*/m
+
+  @text_inventories [
+    {"legacy input option names", ~r/--mission|--private-mission/,
+     %{
+       "docs/guides/manifests-and-capabilities.md" => 3,
+       "docs/guides/running-and-debugging.md" => 2,
+       "lib/mix/tasks/ptc.run.ex" => 6,
+       "test/mix/tasks/ptc_run_test.exs" => 6
+     }},
+    {"Mix run trace syntax", @mix_run_trace_pattern,
+     %{
+       "docs/guides/building-agents.md" => 1,
+       "docs/guides/getting-started.md" => 1,
+       "docs/guides/kernel-repl.md" => 1,
+       "docs/guides/running-and-debugging.md" => 5,
+       "examples/viewer-demo/run.sh" => 1,
+       "lib/mix/tasks/ptc.run.ex" => 2
+     }},
+    {"RunBuilder transitional documentation", ~r/\b(?:load_and_build|check_built)\/[13]\b/,
+     %{
+       "docs/guides/kernel-maintainer.md" => 2,
+       "lib/ptc_runner/kernel/run_builder.ex" => 2
+     }}
+  ]
+
+  @legacy_option_keys [:mission, :private_mission, :trace]
+  @forbidden_source_references [
+    {"deleted CommandEngine.authorize/1 alias", "lib/ptc_runner/kernel/command_engine.ex",
+     ~r/(?:@spec|def) authorize\(/}
+  ]
+
+  # A dynamic entry records a transitional call whose option expression cannot
+  # be resolved to a closed keyword list locally. Keeping it in the frozen
+  # inventory makes that uncertainty explicit instead of silently omitting
+  # options assembled by a helper, comprehension, or caller-supplied tail.
+  @expected_legacy_call_options %{
+    "dynamic" => %{
+      "test/ptc_runner/kernel/artifact_publisher_test.exs" => 1,
+      "test/ptc_runner/kernel/inspection_preflight_test.exs" => 2,
+      "test/ptc_runner/kernel/repo_analyst_evaluation_e2e_test.exs" => 1
+    },
+    "mission" => %{
+      "test/ptc_runner/kernel/inspection_preflight_test.exs" => 1,
+      "test/ptc_runner/kernel/manifest_test.exs" => 2
+    },
+    "private_mission" => %{
+      "test/ptc_runner/kernel/repo_analyst_evaluation_e2e_test.exs" => 2
+    },
+    "trace" => %{
+      "examples/kernel-inspection-lab/support/lab.exs" => 1,
+      "test/ptc_runner/kernel/command_engine_test.exs" => 2,
+      "test/ptc_runner/kernel/inspection_preflight_test.exs" => 6,
+      "test/ptc_runner/kernel/inspection_sink_test.exs" => 1,
+      "test/ptc_runner/kernel/manifest_test.exs" => 1,
+      "test/ptc_runner/kernel/mcp_remote_agent_e2e_test.exs" => 1,
+      "test/ptc_runner/kernel/mcp_source_test.exs" => 1,
+      "test/ptc_runner/kernel/provider_lifecycle_test.exs" => 1,
+      "test/ptc_runner/kernel/repo_analyst_evaluation_e2e_test.exs" => 1,
+      "test/ptc_runner/kernel/repo_analyst_live_e2e_test.exs" => 1,
+      "test/ptc_runner/kernel/run_builder_publication_test.exs" => 1
+    }
+  }
+
+  def run! do
+    validate_scanners!()
+    files = scoped_files()
+    {callers, legacy_options} = elixir_inventories(files)
+
+    failures =
+      compare_group("caller", @expected_callers, callers) ++
+        compare_remote_text_callers(files) ++
+        compare_group("legacy call option", @expected_legacy_call_options, legacy_options) ++
+        compare_text_inventories(@source_inventories, files, :expected_files) ++
+        compare_text_inventories(@text_inventories, files, :all_files) ++
+        compare_forbidden_source_references()
+
+    case failures do
+      [] ->
+        IO.puts("Stable CLI transitional caller inventories are exact.")
+
+      failures ->
+        IO.puts(:stderr, Enum.join(failures, "\n\n"))
+        System.halt(1)
+    end
+  end
+
+  defp scoped_files do
+    {files, 0} =
+      System.cmd(
+        "git",
+        ["ls-files", "--cached", "--others", "--exclude-standard", "-z"],
+        cd: @root
+      )
+
+    files
+    |> String.split(<<0>>, trim: true)
+    |> Enum.filter(&File.regular?(Path.join(@root, &1)))
+    |> Enum.reject(
+      &(&1 == @self or String.starts_with?(&1, "docs/plans/") or
+          excluded_path?(&1))
+    )
+    |> Enum.sort()
+  end
+
+  defp excluded_path?(file) do
+    Enum.any?(@excluded_path_prefixes, &String.starts_with?(file, &1)) or
+      file
+      |> Path.split()
+      |> Enum.any?(&(&1 in @excluded_path_segments))
+  end
+
+  defp elixir_inventories(files) do
+    files
+    |> Enum.filter(&(Path.extname(&1) in [".ex", ".exs"]))
+    |> Enum.reduce({%{}, %{}}, fn file, inventories ->
+      source = File.read!(Path.join(@root, file))
+
+      if String.valid?(source) do
+        case Code.string_to_quoted(source, emit_warnings: false) do
+          {:ok, ast} -> collect_ast_inventories(ast, file, inventories)
+          {:error, _parse_error} -> inventories
+        end
+      else
+        inventories
+      end
+    end)
+    |> then(fn {callers, options} -> {normalize(callers), normalize(options)} end)
+  end
+
+  defp collect_ast_inventories(ast, file, {callers, options}) do
+    {inventories, _environment} =
+      scan_ast(ast, %{aliases: %{}, imports: %{}, bindings: %{}}, {callers, options}, file)
+
+    inventories
+  end
+
+  defp scan_ast({:__block__, _, expressions}, environment, inventories, file) do
+    Enum.reduce(expressions, {inventories, environment}, fn expression, {acc, env} ->
+      scan_ast(expression, env, acc, file)
+    end)
+  end
+
+  defp scan_ast({:alias, _, [module_ast | options]}, environment, inventories, _file) do
+    aliases = collect_alias(module_ast, List.first(options) || [], environment.aliases)
+    {inventories, %{environment | aliases: aliases}}
+  end
+
+  defp scan_ast({:import, _, [module_ast | options]}, environment, inventories, _file) do
+    imports =
+      case alias_parts(module_ast) do
+        nil ->
+          environment.imports
+
+        parts ->
+          Map.put(
+            environment.imports,
+            resolve_module(parts, environment.aliases),
+            List.first(options) || []
+          )
+      end
+
+    {inventories, %{environment | imports: imports}}
+  end
+
+  defp scan_ast({:=, _, [{name, _, context}, value]}, environment, inventories, file)
+       when is_atom(name) and is_atom(context) do
+    {inventories, _value_environment} = scan_ast(value, environment, inventories, file)
+    binding = legacy_option_binding(value, environment.bindings)
+    environment = %{environment | bindings: Map.put(environment.bindings, name, binding)}
+    {inventories, environment}
+  end
+
+  defp scan_ast({kind, _, [head, body]}, environment, inventories, file)
+       when kind in [:def, :defp, :defmacro, :defmacrop] and is_list(body) do
+    inventories = scan_definition_head(head, environment, inventories, file)
+    inner_environment = %{environment | bindings: %{}}
+    {inventories, _inner_environment} = scan_ast(body, inner_environment, inventories, file)
+    {inventories, environment}
+  end
+
+  defp scan_ast({:defmodule, _, [_module, body]}, environment, inventories, file)
+       when is_list(body) do
+    {inventories, _inner_environment} = scan_ast(body, environment, inventories, file)
+    {inventories, environment}
+  end
+
+  defp scan_ast({:fn, _, clauses}, environment, inventories, file) do
+    inventories = scan_children(clauses, %{environment | bindings: %{}}, inventories, file)
+    {inventories, environment}
+  end
+
+  defp scan_ast(
+         {:apply, _, [{:__aliases__, _, parts}, function, arguments]},
+         environment,
+         inventories,
+         file
+       )
+       when is_atom(function) and is_list(arguments) do
+    inventories =
+      collect_call(
+        resolve_module(parts, environment.aliases),
+        function,
+        arguments,
+        file,
+        inventories,
+        environment
+      )
+
+    {scan_children(arguments, environment, inventories, file), environment}
+  end
+
+  defp scan_ast(
+         {{:., _, [{:__aliases__, _, kernel_parts}, :apply]}, _,
+          [{:__aliases__, _, parts}, function, arguments]},
+         environment,
+         inventories,
+         file
+       )
+       when is_atom(function) and is_list(arguments) do
+    inventories =
+      if resolve_module(kernel_parts, environment.aliases) == [:Kernel] do
+        collect_call(
+          resolve_module(parts, environment.aliases),
+          function,
+          arguments,
+          file,
+          inventories,
+          environment
+        )
+      else
+        inventories
+      end
+
+    {scan_children(arguments, environment, inventories, file), environment}
+  end
+
+  defp scan_ast(
+         {{:., _, [:erlang, :apply]}, _, [{:__aliases__, _, parts}, function, arguments]},
+         environment,
+         inventories,
+         file
+       )
+       when is_atom(function) and is_list(arguments) do
+    inventories =
+      collect_call(
+        resolve_module(parts, environment.aliases),
+        function,
+        arguments,
+        file,
+        inventories,
+        environment
+      )
+
+    {scan_children(arguments, environment, inventories, file), environment}
+  end
+
+  defp scan_ast(
+         {{:., _, [{:__aliases__, _, parts}, function]}, _, arguments},
+         environment,
+         inventories,
+         file
+       )
+       when is_list(arguments) do
+    inventories =
+      collect_call(
+        resolve_module(parts, environment.aliases),
+        function,
+        arguments,
+        file,
+        inventories,
+        environment
+      )
+
+    {scan_children(arguments, environment, inventories, file), environment}
+  end
+
+  defp scan_ast(
+         {:&, _, [{:/, _, [{function, _, nil}, arity]}]},
+         environment,
+         inventories,
+         file
+       )
+       when is_atom(function) and is_integer(arity) and arity >= 0 do
+    inventories =
+      Enum.reduce(environment.imports, inventories, fn {module, options}, acc ->
+        if imported?(options, function, arity) do
+          collect_reference(module, function, file, acc)
+        else
+          acc
+        end
+      end)
+
+    {inventories, environment}
+  end
+
+  defp scan_ast({function, _, arguments}, environment, inventories, file)
+       when is_atom(function) and is_list(arguments) do
+    inventories =
+      Enum.reduce(environment.imports, inventories, fn {module, options}, acc ->
+        if imported?(options, function, length(arguments)) do
+          collect_call(module, function, arguments, file, acc, environment)
+        else
+          acc
+        end
+      end)
+
+    {scan_children(arguments, environment, inventories, file), environment}
+  end
+
+  defp scan_ast(list, environment, inventories, file) when is_list(list) do
+    {scan_children(list, environment, inventories, file), environment}
+  end
+
+  defp scan_ast(tuple, environment, inventories, file) when is_tuple(tuple) do
+    {scan_children(Tuple.to_list(tuple), environment, inventories, file), environment}
+  end
+
+  defp scan_ast(_literal, environment, inventories, _file), do: {inventories, environment}
+
+  defp scan_children(children, environment, inventories, file) do
+    Enum.reduce(children, inventories, fn child, acc ->
+      {acc, _child_environment} = scan_ast(child, environment, acc, file)
+      acc
+    end)
+  end
+
+  defp scan_definition_head({:when, _, [head | guards]}, environment, inventories, file) do
+    inventories = scan_definition_head(head, environment, inventories, file)
+    scan_children(guards, environment, inventories, file)
+  end
+
+  defp scan_definition_head({_name, _, arguments}, environment, inventories, file)
+       when is_list(arguments) do
+    scan_children(arguments, environment, inventories, file)
+  end
+
+  defp scan_definition_head(_head, _environment, inventories, _file), do: inventories
+
+  defp collect_call(module, function, arguments, file, {caller_acc, option_acc}, environment) do
+    {caller_acc, option_acc} =
+      collect_reference(module, function, file, {caller_acc, option_acc})
+
+    option_acc =
+      if module == [:PtcRunner, :Kernel, :RunBuilder] and
+           function in [:load_and_build, :run, :run_with_class] do
+        collect_legacy_options(arguments, file, option_acc, environment.bindings)
+      else
+        option_acc
+      end
+
+    {caller_acc, option_acc}
+  end
+
+  defp collect_reference(module, function, file, {caller_acc, option_acc}) do
+    caller = caller_key(module, function)
+    caller_acc = if caller, do: increment(caller_acc, caller, file), else: caller_acc
+    {caller_acc, option_acc}
+  end
+
+  defp collect_alias(module_ast, options, aliases) do
+    module_ast
+    |> alias_entries()
+    |> Enum.reduce(aliases, fn parts, acc ->
+      canonical = resolve_module(parts, acc)
+
+      local =
+        case Keyword.get(options, :as) do
+          {:__aliases__, _, as_parts} -> List.last(as_parts)
+          nil -> List.last(parts)
+        end
+
+      Map.put(acc, local, canonical)
+    end)
+  end
+
+  defp alias_entries({{:., _, [{:__aliases__, _, prefix}, :{}]}, _, grouped_aliases}) do
+    Enum.flat_map(grouped_aliases, fn alias_ast ->
+      case alias_parts(alias_ast) do
+        nil -> []
+        suffix -> [prefix ++ suffix]
+      end
+    end)
+  end
+
+  defp alias_entries(module_ast) do
+    case alias_parts(module_ast) do
+      nil -> []
+      parts -> [parts]
+    end
+  end
+
+  defp alias_parts({:__aliases__, _, parts}), do: parts
+  defp alias_parts(_other), do: nil
+
+  defp resolve_module([local | rest] = parts, aliases) do
+    case Map.fetch(aliases, local) do
+      {:ok, prefix} -> prefix ++ rest
+      :error -> parts
+    end
+  end
+
+  defp imported?(options, function, arity) do
+    signature = {function, arity}
+
+    cond do
+      only = Keyword.get(options, :only) -> signature in only
+      except = Keyword.get(options, :except) -> signature not in except
+      true -> true
+    end
+  end
+
+  defp caller_key([:PtcRunner, :Kernel, :RunBuilder], function)
+       when function in [
+              :load_and_build,
+              :run,
+              :run_with_class,
+              :preflight_prepared,
+              :publish_execution,
+              :check_built,
+              :check_built_claimed
+            ],
+       do: "RunBuilder.#{function}"
+
+  defp caller_key([:PtcRunner, :Kernel, :CommandEngine], function)
+       when function in [:authorize, :request, :catalog],
+       do: "CommandEngine.#{function}"
+
+  defp caller_key([:PtcRunner, :Kernel, :RunCoordinator], :check), do: "RunCoordinator.check"
+  defp caller_key([:Mix, :Tasks, :Ptc, :Run], :failure_message), do: "Run.failure_message"
+
+  defp caller_key([:Mix, :Tasks, :Ptc, :Repl], :persist_terminal_result),
+    do: "Repl.persist_terminal_result"
+
+  defp caller_key(_module, _function), do: nil
+
+  defp validate_scanners! do
+    assert_scan_count!(@mix_run_trace_pattern, "mix ptc.run ptc.json --trace run.jsonl", 1)
+    assert_scan_count!(@mix_run_trace_pattern, "  --trace=run.jsonl", 1)
+    assert_scan_count!(@mix_run_trace_pattern, "mix ptc.run ptc.json --trace-dir traces", 0)
+
+    source = """
+    defmodule ScannerFixture do
+      alias PtcRunner.Kernel.RunBuilder, as: Builder
+      alias PtcRunner.Kernel.{RunCoordinator, CommandEngine}
+
+      def exercise(catalog, runtime_opts) do
+        Builder.run("ptc.json", [])
+        apply(Builder, :load_and_build, ["ptc.json", catalog, []])
+        Kernel.apply(RunCoordinator, :check, [:prepared, :authority])
+        :erlang.apply(Builder, :run_with_class, ["ptc.json", catalog, []])
+
+        opts = [private_mission: "input.json", trace: "run.jsonl"] ++ runtime_opts
+        Builder.run("ptc.json", catalog, opts)
+
+        alias String, as: Builder
+        Builder.run("not a transitional call")
+      end
+
+      def imported(catalog) do
+        import PtcRunner.Kernel.CommandEngine, only: [request: 3]
+        request("ptc.json", catalog, [])
+        &request/3
+        &request/1_000_000_000
+      end
+
+      def import_does_not_leak(catalog), do: request("ptc.json", catalog, [])
+      def alias_does_not_leak(), do: Builder.run("ptc.json", [])
+    end
+    """
+
+    {:ok, ast} = Code.string_to_quoted(source)
+    {callers, options} = collect_ast_inventories(ast, "fixture.ex", {%{}, %{}})
+
+    expected = %{
+      "CommandEngine.request" => %{"fixture.ex" => 2},
+      "RunBuilder.load_and_build" => %{"fixture.ex" => 1},
+      "RunBuilder.run" => %{"fixture.ex" => 3},
+      "RunBuilder.run_with_class" => %{"fixture.ex" => 1},
+      "RunCoordinator.check" => %{"fixture.ex" => 1}
+    }
+
+    if normalize(callers) != expected do
+      raise "stable CLI alias/import scanner self-test failed"
+    end
+
+    expected_options = %{
+      "dynamic" => %{"fixture.ex" => 1},
+      "private_mission" => %{"fixture.ex" => 1},
+      "trace" => %{"fixture.ex" => 1}
+    }
+
+    if normalize(options) != expected_options do
+      raise "stable CLI indirect-option scanner self-test failed"
+    end
+  end
+
+  defp assert_scan_count!(pattern, source, expected) do
+    if length(Regex.scan(pattern, source)) != expected do
+      raise "stable CLI text scanner self-test failed for #{inspect(source)}"
+    end
+  end
+
+  defp collect_legacy_options(arguments, file, inventory, bindings) do
+    binding =
+      case arguments do
+        [_path, _registry, options | _rest] -> legacy_option_binding(options, bindings)
+        _other_arity -> empty_option_binding()
+      end
+
+    inventory =
+      Enum.reduce(binding.keys, inventory, fn key, acc ->
+        increment(acc, Atom.to_string(key), file)
+      end)
+
+    if binding.dynamic?, do: increment(inventory, "dynamic", file), else: inventory
+  end
+
+  defp legacy_option_binding(options, _bindings) when is_list(options) do
+    Enum.reduce(options, empty_option_binding(), fn
+      {key, _value}, binding when key in @legacy_option_keys ->
+        %{binding | keys: MapSet.put(binding.keys, key)}
+
+      {_key, _value}, binding ->
+        binding
+
+      _non_keyword, binding ->
+        %{binding | dynamic?: true}
+    end)
+  end
+
+  defp legacy_option_binding({:++, _, [left, right]}, bindings) do
+    merge_option_bindings(
+      legacy_option_binding(left, bindings),
+      legacy_option_binding(right, bindings)
+    )
+  end
+
+  defp legacy_option_binding({name, _, context}, bindings)
+       when is_atom(name) and is_atom(context),
+       do: Map.get(bindings, name, dynamic_option_binding())
+
+  defp legacy_option_binding(_options, _bindings), do: dynamic_option_binding()
+
+  defp empty_option_binding, do: %{keys: MapSet.new(), dynamic?: false}
+  defp dynamic_option_binding, do: %{keys: MapSet.new(), dynamic?: true}
+
+  defp merge_option_bindings(left, right) do
+    %{keys: MapSet.union(left.keys, right.keys), dynamic?: left.dynamic? or right.dynamic?}
+  end
+
+  defp increment(inventory, key, file) do
+    Map.update(inventory, key, %{file => 1}, fn files -> Map.update(files, file, 1, &(&1 + 1)) end)
+  end
+
+  defp normalize(inventory) do
+    Map.new(inventory, fn {key, files} -> {key, Map.new(Enum.sort(files))} end)
+  end
+
+  defp compare_text_inventories(inventories, files, scope) do
+    Enum.flat_map(inventories, fn {name, pattern, expected} ->
+      inventory_files = if scope == :expected_files, do: Map.keys(expected), else: files
+
+      actual =
+        inventory_files
+        |> Enum.reduce(%{}, fn file, acc ->
+          source = File.read!(Path.join(@root, file))
+
+          if String.valid?(source) do
+            case length(Regex.scan(pattern, source)) do
+              0 -> acc
+              count -> Map.put(acc, file, count)
+            end
+          else
+            acc
+          end
+        end)
+
+      compare("reference #{name}", expected, actual)
+    end)
+  end
+
+  # The AST inventory is authoritative for Elixir callers. Repeating the same
+  # exact remote-call inventory as text covers retained guides, generated
+  # artifacts, shell/JS/package inputs, and any other non-Elixir file without
+  # turning broad transitional words such as `check` or `mission` into noise.
+  defp compare_remote_text_callers(files) do
+    actual =
+      Map.new(@expected_callers, fn {caller, _expected} ->
+        pattern = Regex.compile!("\\b" <> Regex.escape(caller) <> "\\s*\\(")
+
+        counts =
+          Enum.reduce(files, %{}, fn file, acc ->
+            source = File.read!(Path.join(@root, file))
+
+            if String.valid?(source) do
+              case length(Regex.scan(pattern, source)) do
+                0 -> acc
+                count -> Map.put(acc, file, count)
+              end
+            else
+              acc
+            end
+          end)
+
+        {caller, counts}
+      end)
+
+    compare_group("text caller", @expected_callers, actual)
+  end
+
+  defp compare_forbidden_source_references do
+    Enum.flat_map(@forbidden_source_references, fn {name, file, pattern} ->
+      source = File.read!(Path.join(@root, file))
+
+      case Regex.scan(pattern, source) do
+        [] -> []
+        matches -> ["Stable CLI transitional #{name} reappeared (#{length(matches)} references)."]
+      end
+    end)
+  end
+
+  defp compare_group(kind, expected, actual) do
+    (Map.keys(expected) ++ Map.keys(actual))
+    |> Enum.uniq()
+    |> Enum.sort()
+    |> Enum.flat_map(fn name ->
+      compare("#{kind} #{name}", Map.get(expected, name, %{}), Map.get(actual, name, %{}))
+    end)
+  end
+
+  defp compare(_name, expected, actual) when expected == actual, do: []
+
+  defp compare(name, expected, actual) do
+    [
+      "Stable CLI transitional #{name} changed.",
+      "Expected: #{inspect(expected, pretty: true)}",
+      "Actual:   #{inspect(actual, pretty: true)}",
+      "Migrate or delete the caller with its transitional API; do not expand the inventory."
+    ]
+    |> Enum.join("\n")
+    |> List.wrap()
+  end
+end
+
+PtcRunner.StableCLITransitionCheck.run!()

--- a/test/ptc_runner/kernel/command_engine_test.exs
+++ b/test/ptc_runner/kernel/command_engine_test.exs
@@ -191,17 +191,7 @@ defmodule PtcRunner.Kernel.CommandEngineTest do
 
     host_path =
       write_host_config(directory, "inert-validate", %{
-        "install" => %{
-          "workspace" => %{
-            "source" => "mcp",
-            "installation_revision" => "inert-v1",
-            "transport" => %{
-              "type" => "stdio",
-              "command" => "ptc-nonexistent-executable-9f3a"
-            },
-            "tools" => %{"read" => %{"as" => "workspace.read", "effect" => "read"}}
-          }
-        }
+        "install" => %{"workspace" => inert_stdio_installation("inert-v1")}
       })
 
     assert {:error, %CommandOutcome{} = doctored} =
@@ -217,6 +207,76 @@ defmodule PtcRunner.Kernel.CommandEngineTest do
     assert validated.envelope["command"] == "validate"
     assert validated.envelope["result"]["provider_activity"] == false
     assert_schema_valid(validated.envelope)
+  end
+
+  @tag :tmp_dir
+  test "models projects declarations without invoking a hostile local callback", %{
+    tmp_dir: directory
+  } do
+    manifest =
+      valid_manifest(%{
+        "providers" => %{
+          "workflow" => [],
+          "mission" => [%{"name" => "zeta", "config" => %{}}]
+        }
+      })
+
+    application = write_application(directory, "inert-models", manifest)
+
+    host_path =
+      write_host_config(directory, "inert-models", %{
+        "install" => %{
+          "zeta" => inert_stdio_installation("zeta-v1"),
+          "alpha" => inert_stdio_installation("alpha-v1")
+        }
+      })
+
+    assert {:error, %CommandOutcome{} = doctored} =
+             CommandEngine.prepare(["doctor", application, "--host-config", host_path])
+
+    assert doctored.envelope["error"]["phase"] == "local_preflight"
+    assert doctored.envelope["error"]["provider_activity"] == false
+
+    assert {:ok, %CommandOutcome{} = modeled} =
+             CommandEngine.prepare(["models", "--host-config", host_path])
+
+    assert modeled.exit_status == 0
+    assert modeled.envelope["command"] == "models"
+
+    assert modeled.envelope["result"] == %{
+             "installations" => [
+               %{
+                 "alias" => "alpha",
+                 "source" => "mcp",
+                 "installation_revision" => "alpha-v1",
+                 "data_class" => "normal",
+                 "accepts_data" => ["normal"],
+                 "destinations" => ["mission"]
+               },
+               %{
+                 "alias" => "zeta",
+                 "source" => "mcp",
+                 "installation_revision" => "zeta-v1",
+                 "data_class" => "normal",
+                 "accepts_data" => ["normal"],
+                 "destinations" => ["mission"]
+               }
+             ]
+           }
+
+    assert_schema_valid(modeled.envelope)
+
+    assert {:error, %CommandOutcome{} = missing_host} =
+             CommandEngine.prepare([
+               "models",
+               "--host-config",
+               Path.join(directory, "missing-host.json")
+             ])
+
+    assert missing_host.envelope["error"]["phase"] == "host"
+    assert missing_host.envelope["error"]["code"] == "host_unavailable"
+    assert missing_host.envelope["error"]["provider_activity"] == false
+    assert_schema_valid(missing_host.envelope)
   end
 
   test "default doctor reports the environment without an application or host" do
@@ -4436,6 +4496,18 @@ defmodule PtcRunner.Kernel.CommandEngineTest do
           }
         }
       }
+    }
+  end
+
+  defp inert_stdio_installation(revision) do
+    %{
+      "source" => "mcp",
+      "installation_revision" => revision,
+      "transport" => %{
+        "type" => "stdio",
+        "command" => "ptc-nonexistent-executable-9f3a"
+      },
+      "tools" => %{"read" => %{"as" => "workspace.read", "effect" => "read"}}
     }
   end
 


### PR DESCRIPTION
## What

- implement the shared `models --host-config` CommandEngine path end-to-end
- project only selector-safe installation/model declarations, sorted deterministically
- return closed V1 outcomes without provider callbacks, credentials, OAuth, processes, ports, or network work
- close the installation catalog on success and failure
- remove the unused `CommandEngine.authorize/1` alias

## Checkpoint E inventory gate

- freeze exact AST caller sets for every E1 transitional API across runtime, tests, examples, retained guides, generated artifacts, and package/CI inputs
- freeze legacy mission/private-mission/trace option plumbing, including known indirect bindings and explicitly inventoried dynamic option expressions
- cover aliases, imports, captures, literal `apply/3`, `Kernel.apply/3`, and `:erlang.apply/3`
- run the gate in precommit plus core and documentation CI paths

## Ownership and privacy

`models` owns only the installation catalog and closes it on every exit. It does not create an `ExecutionSessionOwner` because it performs no execution, and it never opens a provider session. Output is limited to safe declaration metadata; host paths, credentials, selectors, callbacks, and provider responses are excluded.

## Documentation

Updated the kernel maintainer and running/debugging guides with the shared command boundary, lifecycle ownership, and privacy behavior.

## Verification

- focused CommandEngine integration tests: 86 passed
- `MIX_ENV=test mix compile --warnings-as-errors`
- `MIX_ENV=dev mix docs --warnings-as-errors`
- `ERL_FLAGS=+S\\ 2 mix precommit`: 5,882 root tests, 72 Viewer tests, 36 launcher tests, plus formatting, Xref, Credo, duplication, schema/spec, conformance, package, and archive gates
- pre-push hook with `PTC_PRE_PUSH_MAX_CASES=2`: full tests, docs, generated-artifact checks, upstream audit, Dialyzer, unused dependencies, Viewer, and launcher/package checks
- independent fresh cumulative Codex review plus focused follow-up: clean

## Remaining Checkpoint E work

- finish shared `init` and active `run` dispatch/lifecycle boundaries
- migrate `mix ptc.run` and the manifest REPL to shared sealed preparation and outcome projection
- remove `run --check` and the complete internal `:check` route while retaining `doctor --connect`
- delete the remaining path-backed RunBuilder conveniences, legacy option plumbing, frontend test seams, and their final callers in the same cutovers
- complete standalone/Mix parity and Checkpoint E gates; Checkpoint F packaging is intentionally out of scope