### PR TITLE
test(mix): accept cold downstream build output

### DIFF
--- a/test/mix/tasks/ptc_run_downstream_test.exs
+++ b/test/mix/tasks/ptc_run_downstream_test.exs
@@ -53,7 +53,12 @@ defmodule Mix.Tasks.Ptc.RunDownstreamTest do
       )
 
     assert status == 0, output
-    assert %{"status" => "ok", "command" => "run"} = Jason.decode!(output)
+
+    assert %{"status" => "ok", "command" => "run"} =
+             output
+             |> String.split("\n", trim: true)
+             |> List.last()
+             |> Jason.decode!()
   end
 
   defp write_consumer_project(dir) do


### PR DESCRIPTION
## Summary

Fix the Core validation failure observed on Checkpoint E PR #1216.

A cold downstream `mix ptc.run` build emits normal Mix compilation progress before the task prints its compact JSON envelope. The real-process integration test decoded the entire combined output as JSON, so it failed on the leading `==>` line even though the command succeeded.

The test now:

- still requires process exit status `0`;
- decodes the final non-empty output line as the command envelope;
- still requires `status: ok` and `command: run`; and
- continues to fail on post-envelope noise or malformed terminal output.

Exact task-only stdout remains covered by `test/mix/tasks/ptc_run_test.exs`, which decodes the complete captured task output.

## Verification

- reproduced the downstream path after advancing a production source timestamp to trigger recompilation
- focused downstream real-process integration test
- formatting and warnings-as-errors compilation
- independent focused review: no actionable findings
- `mix precommit`: 5,893 root tests, 72 Viewer tests, 37 launcher tests, and all static/generated/package gates passed
- pre-push hook: same full suites plus strict Credo, generated artifact checks, upstream audit, and Dialyzer passed

## Stack

Base PR: #1216

This PR intentionally contains one test-only commit and targets `codex/checkpoint-e-complete`.