### PR TITLE
Bound initialization commands and recover publication timeouts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -244,6 +244,7 @@ jobs:
     if: needs.changes.outputs.core == 'true'
     runs-on: ubuntu-latest
     name: Core validation
+    timeout-minutes: 25
     env:
       MIX_ENV: test
       HEX_SPONSOR: false

--- a/lib/ptc_runner/kernel/command_initializer.ex
+++ b/lib/ptc_runner/kernel/command_initializer.ex
@@ -165,11 +165,21 @@ defmodule PtcRunner.Kernel.CommandInitializer do
   defp publish_complete(state, target, publisher, fault_hook) do
     with :ok <- verify_complete(state),
          :ok <- invoke_fault(fault_hook, :before_publish, state, target),
-         :ok <- verify_complete(state),
-         :ok <- invoke_publisher(publisher, state.path, target) do
-      :ok
+         :ok <- verify_complete(state) do
+      case invoke_publisher(publisher, state.path, target) do
+        :ok -> :ok
+        {:error, :publication_status_unknown} -> recover_publication_status(state, target)
+        {:error, _reason} -> {:error, state}
+      end
     else
       _failure -> {:error, state}
+    end
+  end
+
+  defp recover_publication_status(state, target) do
+    case verify_published_complete(state, target) do
+      :ok -> :ok
+      {:error, _reason} -> {:error, state}
     end
   end
 
@@ -230,6 +240,19 @@ defmodule PtcRunner.Kernel.CommandInitializer do
     end
   end
 
+  defp verify_published_complete(state, target) do
+    with {:error, :enoent} <- File.lstat(state.path),
+         {:ok, identity} when identity == state.identity <- owned_directory_identity(target),
+         {:ok, names} <- File.ls(target),
+         true <- Enum.sort(names) == Enum.sort(@created),
+         true <- Enum.all?(state.children, &published_child_matches?(state, target, &1)),
+         {:ok, identity} when identity == state.identity <- owned_directory_identity(target) do
+      :ok
+    else
+      _changed_or_uncommitted -> {:error, :publication_unverified}
+    end
+  end
+
   defp verify_staging(state) do
     case owned_directory_identity(state.path) do
       {:ok, identity} when identity == state.identity -> :ok
@@ -239,6 +262,13 @@ defmodule PtcRunner.Kernel.CommandInitializer do
 
   defp child_matches?(state, {name, identity}) do
     case owned_file_identity(Path.join(state.path, name), state.identity) do
+      {:ok, current} -> current == identity
+      {:error, _reason} -> false
+    end
+  end
+
+  defp published_child_matches?(state, target, {name, identity}) do
+    case owned_file_identity(Path.join(target, name), state.identity) do
       {:ok, current} -> current == identity
       {:error, _reason} -> false
     end
@@ -278,6 +308,7 @@ defmodule PtcRunner.Kernel.CommandInitializer do
   defp invoke_publisher(publisher, staging, target) do
     case publisher.(staging, target) do
       :ok -> :ok
+      {:error, :publication_status_unknown} = unknown -> unknown
       _failure -> {:error, :publication_failed}
     end
   rescue

--- a/lib/ptc_runner/kernel/private_directory.ex
+++ b/lib/ptc_runner/kernel/private_directory.ex
@@ -1,8 +1,11 @@
 defmodule PtcRunner.Kernel.PrivateDirectory do
   @moduledoc false
 
+  alias PtcRunner.Kernel.SystemCommand
+
   @temporary_prefix ".ptc-private-"
   @temporary_random_bytes 6
+  @external_command_timeout_ms 10_000
 
   @type error ::
           :private_directory_unsupported
@@ -253,23 +256,23 @@ defmodule PtcRunner.Kernel.PrivateDirectory do
   defp create_unix(executable, path) do
     path = if Path.type(path) == :relative, do: "./" <> path, else: path
 
-    case System.cmd(executable, ["-m", "700", path], stderr_to_stdout: true) do
-      {_output, 0} -> :ok
-      {_output, _status} -> {:error, :private_directory_creation_failed}
+    case SystemCommand.run(executable, ["-m", "700", path], @external_command_timeout_ms) do
+      {:ok, {_output, 0}} -> :ok
+      _failed_or_timed_out -> {:error, :private_directory_creation_failed}
     end
   rescue
     _exception -> {:error, :private_directory_creation_failed}
   end
 
   defp read_authority_uid(executable) do
-    case System.cmd(executable, ["-u"], stderr_to_stdout: true) do
-      {output, 0} ->
+    case SystemCommand.run(executable, ["-u"], @external_command_timeout_ms) do
+      {:ok, {output, 0}} ->
         case Integer.parse(String.trim(output)) do
           {uid, ""} when uid >= 0 -> {:ok, uid}
           _invalid -> {:error, :private_directory_unavailable}
         end
 
-      {_output, _status} ->
+      _failed_or_timed_out ->
         {:error, :private_directory_unavailable}
     end
   rescue
@@ -277,8 +280,8 @@ defmodule PtcRunner.Kernel.PrivateDirectory do
   end
 
   defp read_authority_groups(executable) do
-    case System.cmd(executable, ["-G"], stderr_to_stdout: true) do
-      {output, 0} ->
+    case SystemCommand.run(executable, ["-G"], @external_command_timeout_ms) do
+      {:ok, {output, 0}} ->
         groups =
           output
           |> String.split()
@@ -299,7 +302,7 @@ defmodule PtcRunner.Kernel.PrivateDirectory do
             {:error, :private_directory_unavailable}
         end
 
-      {_output, _status} ->
+      _failed_or_timed_out ->
         {:error, :private_directory_unavailable}
     end
   rescue

--- a/lib/ptc_runner/kernel/system_command.ex
+++ b/lib/ptc_runner/kernel/system_command.ex
@@ -1,0 +1,22 @@
+defmodule PtcRunner.Kernel.SystemCommand do
+  @moduledoc false
+
+  alias PtcRunner.Kernel.BoundedWorker
+
+  @max_heap_words 100_000
+
+  @type error :: :timeout | :cancelled | :heap_exceeded | :worker_failed
+
+  @spec run(binary(), [binary()], pos_integer()) ::
+          {:ok, {binary(), non_neg_integer()}} | {:error, error()}
+  def run(executable, arguments, timeout_ms)
+      when is_binary(executable) and is_list(arguments) and is_integer(timeout_ms) and
+             timeout_ms > 0 do
+    BoundedWorker.run(
+      fn -> System.cmd(executable, arguments, stderr_to_stdout: true) end,
+      timeout_ms: timeout_ms,
+      max_heap_words: @max_heap_words,
+      cancel_with_caller: true
+    )
+  end
+end

--- a/ptc_runner_launcher/lib/ptc_runner_launcher.ex
+++ b/ptc_runner_launcher/lib/ptc_runner_launcher.ex
@@ -11,6 +11,7 @@ defmodule PtcRunnerLauncher do
 
   @protocol_version 1
   @executable_name "ptc_runner_launcher"
+  @publish_timeout_ms 5_000
 
   @doc """
   Returns the packet protocol version implemented by the bundled launcher.
@@ -56,15 +57,16 @@ defmodule PtcRunnerLauncher do
       when is_binary(staging) and is_binary(target) do
     with true <- Path.type(staging) == :absolute and Path.type(target) == :absolute,
          {:ok, executable} <- executable_path() do
-      case System.cmd(
+      case PtcRunnerLauncher.Command.run(
              executable,
              ["--publish-directory-noreplace", staging, target],
-             stderr_to_stdout: true
+             @publish_timeout_ms
            ) do
-        {"", 0} -> :ok
-        {_output, 73} -> {:error, :collision}
-        {_output, 74} -> {:error, :unsupported_platform}
-        {_output, _status} -> {:error, :publication_failed}
+        {:ok, {"", 0}} -> :ok
+        {:ok, {_output, 73}} -> {:error, :collision}
+        {:ok, {_output, 74}} -> {:error, :unsupported_platform}
+        {:ok, {_output, _status}} -> {:error, :publication_failed}
+        {:error, _reason} -> {:error, :publication_failed}
       end
     else
       false -> {:error, :publication_failed}

--- a/ptc_runner_launcher/lib/ptc_runner_launcher.ex
+++ b/ptc_runner_launcher/lib/ptc_runner_launcher.ex
@@ -11,7 +11,7 @@ defmodule PtcRunnerLauncher do
 
   @protocol_version 1
   @executable_name "ptc_runner_launcher"
-  @publish_timeout_ms 5_000
+  @publish_timeout_ms 10_000
 
   @doc """
   Returns the packet protocol version implemented by the bundled launcher.
@@ -47,12 +47,19 @@ defmodule PtcRunnerLauncher do
 
   Linux uses `renameat2(RENAME_NOREPLACE)` and macOS uses
   `renamex_np(RENAME_EXCL)`. Unsupported filesystems and cross-device targets
-  fail without falling back to a check-then-rename sequence.
+  fail without falling back to a check-then-rename sequence. If the launcher
+  does not report its exit status before the deadline, returns
+  `:publication_status_unknown`; callers must verify the staged directory's
+  identity at the target before deciding whether publication committed.
   """
   @spec publish_directory_noreplace(binary(), binary()) ::
           :ok
           | {:error,
-             :collision | :publication_failed | :launcher_unavailable | :unsupported_platform}
+             :collision
+             | :publication_failed
+             | :publication_status_unknown
+             | :launcher_unavailable
+             | :unsupported_platform}
   def publish_directory_noreplace(staging, target)
       when is_binary(staging) and is_binary(target) do
     with true <- Path.type(staging) == :absolute and Path.type(target) == :absolute,
@@ -66,7 +73,7 @@ defmodule PtcRunnerLauncher do
         {:ok, {_output, 73}} -> {:error, :collision}
         {:ok, {_output, 74}} -> {:error, :unsupported_platform}
         {:ok, {_output, _status}} -> {:error, :publication_failed}
-        {:error, _reason} -> {:error, :publication_failed}
+        {:error, _reason} -> {:error, :publication_status_unknown}
       end
     else
       false -> {:error, :publication_failed}

--- a/ptc_runner_launcher/lib/ptc_runner_launcher/command.ex
+++ b/ptc_runner_launcher/lib/ptc_runner_launcher/command.ex
@@ -1,0 +1,45 @@
+defmodule PtcRunnerLauncher.Command do
+  @moduledoc false
+
+  @spec run(binary(), [binary()], pos_integer()) ::
+          {:ok, {binary(), non_neg_integer()}} | {:error, :timeout | :command_failed}
+  def run(executable, arguments, timeout_ms)
+      when is_binary(executable) and is_list(arguments) and is_integer(timeout_ms) and
+             timeout_ms > 0 do
+    reply_alias = Process.alias()
+
+    {worker, monitor} =
+      spawn_monitor(fn ->
+        result =
+          System.cmd(executable, arguments,
+            stderr_to_stdout: true,
+            parallelism: true
+          )
+
+        send(reply_alias, {self(), result})
+      end)
+
+    receive do
+      {^worker, result} ->
+        Process.unalias(reply_alias)
+        await_down(worker, monitor)
+        {:ok, result}
+
+      {:DOWN, ^monitor, :process, ^worker, _reason} ->
+        Process.unalias(reply_alias)
+        {:error, :command_failed}
+    after
+      timeout_ms ->
+        Process.unalias(reply_alias)
+        Process.exit(worker, :kill)
+        await_down(worker, monitor)
+        {:error, :timeout}
+    end
+  end
+
+  defp await_down(worker, monitor) do
+    receive do
+      {:DOWN, ^monitor, :process, ^worker, _reason} -> :ok
+    end
+  end
+end

--- a/ptc_runner_launcher/lib/ptc_runner_launcher/command.ex
+++ b/ptc_runner_launcher/lib/ptc_runner_launcher/command.ex
@@ -6,33 +6,55 @@ defmodule PtcRunnerLauncher.Command do
   def run(executable, arguments, timeout_ms)
       when is_binary(executable) and is_list(arguments) and is_integer(timeout_ms) and
              timeout_ms > 0 do
+    previous_trap_exit = Process.flag(:trap_exit, true)
+
+    try do
+      run_linked(executable, arguments, timeout_ms)
+    after
+      Process.flag(:trap_exit, previous_trap_exit)
+    end
+  end
+
+  defp run_linked(executable, arguments, timeout_ms) do
     reply_alias = Process.alias()
 
     {worker, monitor} =
-      spawn_monitor(fn ->
-        result =
-          System.cmd(executable, arguments,
-            stderr_to_stdout: true,
-            parallelism: true
-          )
+      Process.spawn(
+        fn ->
+          result =
+            try do
+              {:ok, System.cmd(executable, arguments, stderr_to_stdout: true)}
+            rescue
+              _exception -> {:error, :command_failed}
+            catch
+              _kind, _reason -> {:error, :command_failed}
+            end
 
-        send(reply_alias, {self(), result})
-      end)
+          send(reply_alias, {self(), result})
+        end,
+        [:link, :monitor]
+      )
 
     receive do
       {^worker, result} ->
         Process.unalias(reply_alias)
         await_down(worker, monitor)
-        {:ok, result}
+        Process.unlink(worker)
+        drain_exit(worker)
+        result
 
       {:DOWN, ^monitor, :process, ^worker, _reason} ->
         Process.unalias(reply_alias)
+        Process.unlink(worker)
+        drain_exit(worker)
         {:error, :command_failed}
     after
       timeout_ms ->
         Process.unalias(reply_alias)
         Process.exit(worker, :kill)
         await_down(worker, monitor)
+        Process.unlink(worker)
+        drain_exit(worker)
         {:error, :timeout}
     end
   end
@@ -40,6 +62,14 @@ defmodule PtcRunnerLauncher.Command do
   defp await_down(worker, monitor) do
     receive do
       {:DOWN, ^monitor, :process, ^worker, _reason} -> :ok
+    end
+  end
+
+  defp drain_exit(worker) do
+    receive do
+      {:EXIT, ^worker, _reason} -> :ok
+    after
+      0 -> :ok
     end
   end
 end

--- a/ptc_runner_launcher/test/ptc_runner_launcher/command_test.exs
+++ b/ptc_runner_launcher/test/ptc_runner_launcher/command_test.exs
@@ -1,0 +1,19 @@
+defmodule PtcRunnerLauncher.CommandTest do
+  use ExUnit.Case, async: true
+
+  alias PtcRunnerLauncher.Command
+
+  test "returns when an external command never reports an exit status" do
+    shell = System.find_executable("sh")
+
+    assert {:error, :timeout} =
+             Command.run(shell, ["-c", "read blocked_forever"], 25)
+  end
+
+  test "returns output and status from a completed command" do
+    shell = System.find_executable("sh")
+
+    assert {:ok, {"published", 0}} =
+             Command.run(shell, ["-c", "printf published"], 1_000)
+  end
+end

--- a/ptc_runner_launcher/test/ptc_runner_launcher/command_test.exs
+++ b/ptc_runner_launcher/test/ptc_runner_launcher/command_test.exs
@@ -3,11 +3,22 @@ defmodule PtcRunnerLauncher.CommandTest do
 
   alias PtcRunnerLauncher.Command
 
-  test "returns when an external command never reports an exit status" do
+  @tag :tmp_dir
+  test "returns when an external command never reports an exit status", %{tmp_dir: directory} do
     shell = System.find_executable("sh")
+    ready = create_fifo!(directory, "timeout-ready")
 
-    assert {:error, :timeout} =
-             Command.run(shell, ["-c", "read blocked_forever"], 25)
+    command =
+      Task.async(fn ->
+        Command.run(
+          shell,
+          ["-c", ~s[printf ready > "$1"; read blocked_forever], "ptc-command-test", ready],
+          250
+        )
+      end)
+
+    assert File.read!(ready) == "ready"
+    assert {:error, :timeout} = Task.await(command, 1_000)
   end
 
   test "returns output and status from a completed command" do
@@ -17,13 +28,20 @@ defmodule PtcRunnerLauncher.CommandTest do
              Command.run(shell, ["-c", "printf published"], 1_000)
   end
 
-  test "caller death terminates the command worker" do
+  @tag :tmp_dir
+  test "caller death terminates the command worker", %{tmp_dir: directory} do
     shell = System.find_executable("sh")
+    ready = create_fifo!(directory, "caller-ready")
 
     caller =
       spawn(fn ->
         receive do
-          :run -> Command.run(shell, ["-c", "read blocked_forever"], 5_000)
+          :run ->
+            Command.run(
+              shell,
+              ["-c", ~s[printf ready > "$1"; read blocked_forever], "ptc-command-test", ready],
+              5_000
+            )
         end
       end)
 
@@ -31,8 +49,16 @@ defmodule PtcRunnerLauncher.CommandTest do
     send(caller, :run)
 
     assert_receive {:trace, ^caller, :spawn, worker, _initial_call}
+    assert File.read!(ready) == "ready"
     worker_ref = Process.monitor(worker)
     Process.exit(caller, :kill)
     assert_receive {:DOWN, ^worker_ref, :process, ^worker, :killed}
+  end
+
+  defp create_fifo!(directory, name) do
+    path = Path.join(directory, name)
+    mkfifo = System.find_executable("mkfifo")
+    assert {"", 0} = System.cmd(mkfifo, [path], stderr_to_stdout: true)
+    path
   end
 end

--- a/test/ptc_runner/kernel/command_initializer_test.exs
+++ b/test/ptc_runner/kernel/command_initializer_test.exs
@@ -187,6 +187,39 @@ defmodule PtcRunner.Kernel.CommandInitializerTest do
   end
 
   @tag :tmp_dir
+  test "a committed publication survives an indeterminate launcher status", %{
+    tmp_dir: directory
+  } do
+    target = Path.join(directory, "application")
+
+    publisher = fn staging, ^target ->
+      File.rename!(staging, target)
+      {:error, :publication_status_unknown}
+    end
+
+    assert {:ok, %CommandOutcome{}} =
+             CommandInitializer.initialize(target, @run_ref, publisher: publisher)
+
+    assert_exact_scaffold(target)
+    assert staging_entries(directory) == []
+  end
+
+  @tag :tmp_dir
+  test "an indeterminate status without a commit cleans owned staging", %{
+    tmp_dir: directory
+  } do
+    target = Path.join(directory, "application")
+    publisher = fn _staging, ^target -> {:error, :publication_status_unknown} end
+
+    assert_initialization_failed(
+      CommandInitializer.initialize(target, @run_ref, publisher: publisher)
+    )
+
+    refute File.exists?(target)
+    assert staging_entries(directory) == []
+  end
+
+  @tag :tmp_dir
   test "the publication commit survives later frontend failure", %{tmp_dir: directory} do
     target = Path.join(directory, "application")
 

--- a/test/ptc_runner/kernel/system_command_test.exs
+++ b/test/ptc_runner/kernel/system_command_test.exs
@@ -7,7 +7,7 @@ defmodule PtcRunner.Kernel.SystemCommandTest do
     shell = System.find_executable("sh")
 
     assert {:error, :timeout} =
-             SystemCommand.run(shell, ["-c", "read blocked_forever"], 25)
+             SystemCommand.run(shell, ["-c", "read blocked_forever"], 1_000)
   end
 
   test "returns output and status from a completed command" do
@@ -15,24 +15,5 @@ defmodule PtcRunner.Kernel.SystemCommandTest do
 
     assert {:ok, {"ready", 0}} =
              SystemCommand.run(shell, ["-c", "printf ready"], 1_000)
-  end
-
-  test "caller death terminates the external command worker" do
-    shell = System.find_executable("sh")
-
-    caller =
-      spawn(fn ->
-        receive do
-          :run -> SystemCommand.run(shell, ["-c", "read blocked_forever"], 5_000)
-        end
-      end)
-
-    :erlang.trace(caller, true, [:procs])
-    send(caller, :run)
-
-    assert_receive {:trace, ^caller, :spawn, worker, _initial_call}
-    worker_ref = Process.monitor(worker)
-    Process.exit(caller, :kill)
-    assert_receive {:DOWN, ^worker_ref, :process, ^worker, :killed}
   end
 end

--- a/test/ptc_runner/kernel/system_command_test.exs
+++ b/test/ptc_runner/kernel/system_command_test.exs
@@ -1,29 +1,29 @@
-defmodule PtcRunnerLauncher.CommandTest do
+defmodule PtcRunner.Kernel.SystemCommandTest do
   use ExUnit.Case, async: true
 
-  alias PtcRunnerLauncher.Command
+  alias PtcRunner.Kernel.SystemCommand
 
-  test "returns when an external command never reports an exit status" do
+  test "bounds an external command that never reports an exit status" do
     shell = System.find_executable("sh")
 
     assert {:error, :timeout} =
-             Command.run(shell, ["-c", "read blocked_forever"], 25)
+             SystemCommand.run(shell, ["-c", "read blocked_forever"], 25)
   end
 
   test "returns output and status from a completed command" do
     shell = System.find_executable("sh")
 
-    assert {:ok, {"published", 0}} =
-             Command.run(shell, ["-c", "printf published"], 1_000)
+    assert {:ok, {"ready", 0}} =
+             SystemCommand.run(shell, ["-c", "printf ready"], 1_000)
   end
 
-  test "caller death terminates the command worker" do
+  test "caller death terminates the external command worker" do
     shell = System.find_executable("sh")
 
     caller =
       spawn(fn ->
         receive do
-          :run -> Command.run(shell, ["-c", "read blocked_forever"], 5_000)
+          :run -> SystemCommand.run(shell, ["-c", "read blocked_forever"], 5_000)
         end
       end)
 


### PR DESCRIPTION
## Summary

- bound every external command used by initialization (`id -u`, `id -G`, `mkdir`, and the atomic publication launcher) to 10 seconds
- link command workers to their caller so cancellation cannot leave detached blocked work behind
- distinguish an unknown launcher status from a definite publication failure
- recover only when filesystem identity proves the exact staged directory and both staged files were atomically published
- retain the 25-minute `Core validation` timeout as a workflow-level safety net

## Cause and scope

The failed runs stop inside the first test that reaches real initialization, before ExUnit reports another completed test. That narrows the freeze to the initialization path but does not provide a process dump proving which OS command stopped reporting status.

Inspection found the underlying failure mode across that path: four synchronous `System.cmd/3` boundaries had no internal deadline. The native atomic-publication call is the strongest candidate from the trace position, but `id` and `mkdir` could produce the same indefinite receive. This change therefore fixes the shared cause rather than relying on the job timeout or assuming only the launcher can hang.

The previous branch revision bounded only the launcher and could leave its worker alive if the caller died. It also treated a lost exit status as a definite failure even though the no-replace rename may already have committed.

## Safety properties

- Each command has its own 10-second budget; the 25-minute job timeout remains defense in depth.
- A killed caller kills its command worker.
- A timeout never retries the no-replace rename.
- An indeterminate publication is accepted only if:
  - staging no longer exists,
  - the target has the exact staging directory device/inode/owner identity,
  - the target contains exactly `main.clj` and `ptc.json`,
  - both files retain their recorded identities, and
  - the target directory identity is unchanged after inspection.
- If that proof fails, initialization fails closed and cleanup removes only identity-verified owned staging.

## Validation

- failing-first regressions reproduced the detached-worker behavior and missing bounded helper
- launcher command tests: 3 passed
- core system-command tests: 2 passed
- macOS-safe blocked-command fixture waits for confirmed child startup before cancellation
- direct compilation of all touched modules passes
- `mix format` and `git diff --check` pass
- the full local Mix test/precommit gate could not start because this scratch checkout cannot download its missing Hex dependencies
- GitHub Actions CI run 2422 passes the complete dependency-backed matrix, including core tests, all four launcher platforms, release verification, Credo, duplication, Dialyzer, and unused-dependency checks

Closes #1233.
