### PR TITLE
fix(kernel): route workflow prints and error detail into inspection artifact

### DIFF
--- a/docs/trace-log-contract.md
+++ b/docs/trace-log-contract.md
@@ -501,6 +501,15 @@ IDs for the record's environment. V1 record types and payloads are:
 | `evaluation-source` | `evaluation_id` | `environment`, `program_kind`, `source`, `source_hash`, `source_bytes` |
 | `prelude-source` | `component_id` | `environment`, `source`, `source_hash`, `source_bytes` |
 
+V3 adds two workflow execution-phase diagnostics, correlated by the top-level
+workflow evaluation's `evaluation_id` rather than a capability or subordinate
+evaluation:
+
+| Record type | Correlation | Exact payload fields |
+| --- | --- | --- |
+| `execution-prints` | `evaluation_id` | `environment`, `prints`, `truncated` |
+| `execution-error` | `evaluation_id` | `environment`, `kind`, `reason`, `details` |
+
 Enums and map keys are normalized to JSON strings before retention. `result` is
 the bounded Dispatcher envelope returned to Lisp, so `llm-request` input/output
 records contain the provider-neutral model request and normalized response, and
@@ -510,7 +519,13 @@ increment. Its hash and byte count must equal the corresponding canonical
 `evaluation-started` fields. `prelude-source` records carry the exact
 effective source of every frozen workflow and mission component, one record
 per component in frozen order, emitted by the manifest-backed builder before
-execution begins.
+execution begins. `execution-prints` and `execution-error` are emitted only
+when the top-level workflow evaluation fails: `prints` is the run's bounded
+`println` output (at most 128 entries and 65,536 encoded bytes, matching
+`PtcRunner.Kernel.AnalysisSession`'s result projection) and `details` is the
+Kernel `Error.details` map computed for that failure. Their `environment` is
+always `"workflow"`, and their `evaluation_id` must match a canonical
+`evaluation-started` event with `environment: "workflow"` for the same run.
 
 The input record is accepted before the callback starts, and the source record
 is accepted before evaluation starts. The output record is accepted after
@@ -528,7 +543,9 @@ output is valid only as an interrupted attempt. Private capability name and
 environment must match the canonical `capability-started` event carrying the
 same ID, and canonical capability-start IDs must themselves be unique. Browser
 indexing also refuses to overwrite a prior identity defensively, but server
-validation is authoritative.
+validation is authoritative. There may likewise be at most one
+`execution-prints` and one `execution-error` for a given `evaluation_id`; a run
+that never reaches an execution-phase failure emits neither.
 
 The host enables capture independently of manifest event policy and selects a
 fixed exact destination. The destination is restricted to `0600` before content

--- a/lib/ptc_runner/kernel/analysis_session.ex
+++ b/lib/ptc_runner/kernel/analysis_session.ex
@@ -22,6 +22,7 @@ defmodule PtcRunner.Kernel.AnalysisSession do
   alias PtcRunner.Kernel.AnalysisAssembly
   alias PtcRunner.Kernel.AnalysisProfileRegistry
   alias PtcRunner.Kernel.AnalysisResources
+  alias PtcRunner.Kernel.BoundedPrints
   alias PtcRunner.Kernel.BoundedWorker
   alias PtcRunner.Kernel.Evaluation
   alias PtcRunner.Kernel.EventSink
@@ -451,26 +452,7 @@ defmodule PtcRunner.Kernel.AnalysisSession do
     end
   end
 
-  defp bounded_prints(prints) when is_list(prints) do
-    {bounded, _count, _encoded_bytes, truncated?} =
-      Enum.reduce_while(prints, {[], 0, 2, false}, fn print,
-                                                      {acc, count, encoded_bytes, _truncated?} ->
-        print = if is_binary(print) and String.valid?(print), do: print, else: ""
-        {:ok, encoded_print} = Jason.encode(print)
-        separator_bytes = if count == 0, do: 0, else: 1
-        next_bytes = encoded_bytes + separator_bytes + byte_size(encoded_print)
-
-        if count < @prints_count and next_bytes <= @prints_bytes do
-          {:cont, {[print | acc], count + 1, next_bytes, false}}
-        else
-          {:halt, {acc, count, encoded_bytes, true}}
-        end
-      end)
-
-    {Enum.reverse(bounded), truncated?}
-  end
-
-  defp bounded_prints(_prints), do: {[], true}
+  defp bounded_prints(prints), do: BoundedPrints.bound(prints, @prints_count, @prints_bytes)
 
   defp error_projection(%{outcome: outcome}, _state, _source)
        when outcome in [:continued, :returned],

--- a/lib/ptc_runner/kernel/bounded_prints.ex
+++ b/lib/ptc_runner/kernel/bounded_prints.ex
@@ -1,0 +1,39 @@
+defmodule PtcRunner.Kernel.BoundedPrints do
+  @moduledoc """
+  Shared bound for projecting a raw `println` list into a caller-facing form.
+
+  One rule for "how many prints, and how many bytes" is used everywhere a
+  `PtcRunner.Lisp.Result.t()`'s `prints` list crosses into a bounded owner-facing
+  projection: `PtcRunner.Kernel.AnalysisSession` result projection and
+  `PtcRunner.Kernel.Runner` execution-phase inspection capture. A non-binary or
+  invalid-UTF-8 entry is retained as an empty string rather than dropped, so
+  bounded position and count stay aligned with the source list.
+  """
+
+  @spec bound([term()], pos_integer(), pos_integer()) :: {[String.t()], boolean()}
+  @doc "Bounds `prints` to at most `max_count` entries and `max_bytes` JSON-encoded bytes."
+  def bound(prints, max_count, max_bytes)
+      when is_list(prints) and is_integer(max_count) and max_count > 0 and
+             is_integer(max_bytes) and max_bytes > 0 do
+    {bounded, _count, _encoded_bytes, truncated?} =
+      Enum.reduce_while(prints, {[], 0, 2, false}, fn print,
+                                                      {acc, count, encoded_bytes, _truncated?} ->
+        print = if is_binary(print) and String.valid?(print), do: print, else: ""
+        {:ok, encoded_print} = Jason.encode(print)
+        separator_bytes = if count == 0, do: 0, else: 1
+        next_bytes = encoded_bytes + separator_bytes + byte_size(encoded_print)
+
+        if count < max_count and next_bytes <= max_bytes do
+          {:cont, {[print | acc], count + 1, next_bytes, false}}
+        else
+          {:halt, {acc, count, encoded_bytes, true}}
+        end
+      end)
+
+    {Enum.reverse(bounded), truncated?}
+  end
+
+  def bound(_prints, max_count, max_bytes)
+      when is_integer(max_count) and max_count > 0 and is_integer(max_bytes) and max_bytes > 0,
+      do: {[], true}
+end

--- a/lib/ptc_runner/kernel/inspection_artifact.ex
+++ b/lib/ptc_runner/kernel/inspection_artifact.ex
@@ -15,9 +15,11 @@ defmodule PtcRunner.Kernel.InspectionArtifact do
   whose bytes must match. It rejects symlinks,
   changed files, content above 16 MB, any record above 2,000,000 encoded bytes,
   excessive structural depth, malformed lines, mixed identities or schema
-  versions, non-contiguous sequences, and records outside the exact V1 or V2
-  vocabulary. V2 adds paired MCP request/response bodies correlated to an
-  existing capability attempt.
+  versions, non-contiguous sequences, and records outside the exact V1, V2, or
+  V3 vocabulary. V2 adds paired MCP request/response bodies correlated to an
+  existing capability attempt. V3 adds `execution-prints` and `execution-error`,
+  correlated by a canonical workflow `evaluation-started` event's
+  `evaluation_id` rather than a capability attempt.
 
   Secure publication is supported on Unix hosts with POSIX-compatible `mkdir`
   and `id` executables available on `PATH`; persistence fails closed when those
@@ -29,6 +31,7 @@ defmodule PtcRunner.Kernel.InspectionArtifact do
   """
 
   alias Jason.OrderedObject
+  alias PtcRunner.Kernel.InspectionRecordTypes
   alias PtcRunner.Kernel.MCPProtocol
   alias PtcRunner.Kernel.PrivateDirectory
   alias PtcRunner.Kernel.PublicationHandle
@@ -36,8 +39,6 @@ defmodule PtcRunner.Kernel.InspectionArtifact do
   @max_bytes 16_000_000
   @max_record_bytes 2_000_000
   @suffix ".inspection.jsonl"
-  @record_types_v1 ~w(capability-input capability-output evaluation-source prelude-source)
-  @record_types_v2 @record_types_v1 ++ ~w(mcp-request mcp-response)
   @envelope_keys ~w(schema_version run_id trace_id sequence timestamp record_type correlation payload)
 
   @spec preflight_destination(term()) ::
@@ -324,7 +325,9 @@ defmodule PtcRunner.Kernel.InspectionArtifact do
       mcp_requests: %{},
       mcp_responses: MapSet.new(),
       evaluations: MapSet.new(),
-      preludes: MapSet.new()
+      preludes: MapSet.new(),
+      execution_prints: MapSet.new(),
+      execution_errors: MapSet.new()
     }
 
     records
@@ -417,6 +420,18 @@ defmodule PtcRunner.Kernel.InspectionArtifact do
        ),
        do: unique_record(state, :preludes, {environment, id})
 
+  defp validate_record_join(
+         %{"record_type" => "execution-prints", "correlation" => %{"evaluation_id" => id}},
+         state
+       ),
+       do: unique_record(state, :execution_prints, id)
+
+  defp validate_record_join(
+         %{"record_type" => "execution-error", "correlation" => %{"evaluation_id" => id}},
+         state
+       ),
+       do: unique_record(state, :execution_errors, id)
+
   defp invalid_record_join, do: {:halt, {:error, :invalid_inspection_artifact}}
 
   defp unique_record(state, field, key) do
@@ -432,7 +447,7 @@ defmodule PtcRunner.Kernel.InspectionArtifact do
   defp valid_record?(record, run_id, trace_id, schema_version, sequence) do
     MCPProtocol.within_inspection_document_depth?(record) and
       is_map(record) and Map.keys(record) |> Enum.sort() == Enum.sort(@envelope_keys) and
-      schema_version in [1, 2] and record["schema_version"] == schema_version and
+      schema_version in [1, 2, 3] and record["schema_version"] == schema_version and
       record["run_id"] == run_id and
       record["trace_id"] == trace_id and is_binary(run_id) and is_binary(trace_id) and
       record["sequence"] == sequence and valid_timestamp?(record["timestamp"]) and
@@ -507,6 +522,28 @@ defmodule PtcRunner.Kernel.InspectionArtifact do
       payload["source_hash"] == sha256(payload["source"])
   end
 
+  defp valid_shape?(%{
+         "record_type" => "execution-prints",
+         "correlation" => %{"evaluation_id" => id},
+         "payload" => payload
+       }) do
+    exact_keys?(payload, ~w(environment prints truncated)) and
+      valid_id?(id) and payload["environment"] == "workflow" and
+      is_list(payload["prints"]) and Enum.all?(payload["prints"], &is_binary/1) and
+      is_boolean(payload["truncated"])
+  end
+
+  defp valid_shape?(%{
+         "record_type" => "execution-error",
+         "correlation" => %{"evaluation_id" => id},
+         "payload" => payload
+       }) do
+    exact_keys?(payload, ~w(environment kind reason details)) and
+      valid_id?(id) and payload["environment"] == "workflow" and
+      valid_id?(payload["kind"]) and valid_id?(payload["reason"]) and
+      is_map(payload["details"])
+  end
+
   defp valid_shape?(_record), do: false
 
   @spec validate_correlations([map()], [map()]) :: :ok | {:error, :inspection_correlation_missing}
@@ -537,6 +574,16 @@ defmodule PtcRunner.Kernel.InspectionArtifact do
           |> merge_prelude_ids("mission", event_data(event, :mission_prelude))
         end)
 
+      workflow_evaluation_ids =
+        events
+        |> Enum.filter(fn event ->
+          event_value(event, :type) == "evaluation-started" and
+            event_data(event, :environment) |> string_value() == "workflow"
+        end)
+        |> Enum.map(&event_data(&1, :evaluation_id))
+        |> Enum.filter(&is_binary/1)
+        |> MapSet.new()
+
       if Enum.all?(records, fn
            %{
              "correlation" => %{"capability_id" => id},
@@ -556,6 +603,13 @@ defmodule PtcRunner.Kernel.InspectionArtifact do
              "payload" => %{"source_hash" => hash, "source_bytes" => bytes}
            } ->
              Map.get(evaluations, id) == {hash, bytes}
+
+           %{
+             "record_type" => record_type,
+             "correlation" => %{"evaluation_id" => id}
+           }
+           when record_type in ["execution-prints", "execution-error"] ->
+             MapSet.member?(workflow_evaluation_ids, id)
 
            %{
              "correlation" => %{"component_id" => id},
@@ -802,8 +856,7 @@ defmodule PtcRunner.Kernel.InspectionArtifact do
     do: match?({:ok, _datetime, 0}, DateTime.from_iso8601(timestamp))
 
   defp valid_timestamp?(_timestamp), do: false
-  defp record_types(1), do: @record_types_v1
-  defp record_types(2), do: @record_types_v2
+  defp record_types(schema_version), do: InspectionRecordTypes.for_schema_version(schema_version)
   defp valid_request_id?(id), do: is_integer(id) and id > 0
   defp valid_id?(id), do: is_binary(id) and byte_size(id) in 1..256 and String.valid?(id)
   defp sha256(value), do: :crypto.hash(:sha256, value) |> Base.encode16(case: :lower)

--- a/lib/ptc_runner/kernel/inspection_query.ex
+++ b/lib/ptc_runner/kernel/inspection_query.ex
@@ -18,6 +18,11 @@ defmodule PtcRunner.Kernel.InspectionQuery do
   results expose those hashes with the `sha256:` algorithm prefix required by
   trusted component-override descriptors, so an effective-prelude result can
   be copied into `base_source_hash` without reinterpretation.
+
+  V3 execution-phase diagnostics (`execution-prints`, `execution-error`) are
+  counted in each `list_runs` row's `counts` but are not an independent
+  collection: a raw artifact load remains the way to read their bounded
+  `prints` list and `details` map for one `evaluation_id`.
   """
 
   @default_limit 100
@@ -101,7 +106,9 @@ defmodule PtcRunner.Kernel.InspectionQuery do
         "capability_calls" => length(capability_calls),
         "generated_sources" => length(generated_sources),
         "effective_preludes" => length(effective_preludes),
-        "provider_exchanges" => length(provider_pairs)
+        "provider_exchanges" => length(provider_pairs),
+        "execution_prints" => length(records_of_type(records, "execution-prints")),
+        "execution_errors" => length(records_of_type(records, "execution-error"))
       }
 
       {:ok,

--- a/lib/ptc_runner/kernel/inspection_record_types.ex
+++ b/lib/ptc_runner/kernel/inspection_record_types.ex
@@ -1,0 +1,21 @@
+defmodule PtcRunner.Kernel.InspectionRecordTypes do
+  @moduledoc """
+  The closed private inspection record vocabulary, by schema version.
+
+  `PtcRunner.Kernel.InspectionSink` (retention) and
+  `PtcRunner.Kernel.InspectionArtifact` (persistence and loading) must accept
+  and reject the exact same record types for a given schema version; drift
+  between two independent copies of that vocabulary is a defect, not a
+  divergence either module is free to make on its own.
+  """
+
+  @v1 ~w(capability-input capability-output evaluation-source prelude-source)
+  @v2 @v1 ++ ~w(mcp-request mcp-response)
+  @v3 @v2 ++ ~w(execution-prints execution-error)
+
+  @spec for_schema_version(1 | 2 | 3) :: [binary()]
+  @doc "Returns the exact record types admitted at the given schema version."
+  def for_schema_version(1), do: @v1
+  def for_schema_version(2), do: @v2
+  def for_schema_version(3), do: @v3
+end

--- a/lib/ptc_runner/kernel/inspection_sink.ex
+++ b/lib/ptc_runner/kernel/inspection_sink.ex
@@ -4,10 +4,13 @@ defmodule PtcRunner.Kernel.InspectionSink do
 
   Capture is host-enabled and fail-closed. Version 1 accepts capability-input,
   capability-output, subordinate evaluation-source, and prelude-source.
-  Version 2 adds correlated exact MCP request and response bodies. It
-  normalizes atom keys and enum values to JSON strings, assigns the run
-  identity, sequence, and UTC timestamp, and rejects a record before retention
-  when either its retained or encoded size exceeds the installed bounds.
+  Version 2 adds correlated exact MCP request and response bodies. Version 3
+  adds workflow execution-phase diagnostics — `execution-prints` and
+  `execution-error`, correlated by the workflow `evaluation_id` — captured only
+  when the top-level workflow evaluation fails. It normalizes atom keys and
+  enum values to JSON strings, assigns the run identity, sequence, and UTC
+  timestamp, and rejects a record before retention when either its retained or
+  encoded size exceeds the installed bounds.
 
   This sink is independent of Logger, Telemetry, EventSink policy, manifests,
   and Lisp. Records remain private until the host explicitly persists them as
@@ -16,6 +19,7 @@ defmodule PtcRunner.Kernel.InspectionSink do
 
   use GenServer
 
+  alias PtcRunner.Kernel.InspectionRecordTypes
   alias PtcRunner.Kernel.JSONValue
   alias PtcRunner.Kernel.MCPProtocol
   alias PtcRunner.Kernel.OwnerHandoff
@@ -23,8 +27,6 @@ defmodule PtcRunner.Kernel.InspectionSink do
 
   @default_record_bytes 2_000_000
   @default_total_bytes 16_000_000
-  @record_types_v1 ~w(capability-input capability-output evaluation-source prelude-source)
-  @record_types_v2 @record_types_v1 ++ ~w(mcp-request mcp-response)
   @stop_timeout_ms 5_000
 
   @enforce_keys [:pid, :token]
@@ -50,7 +52,7 @@ defmodule PtcRunner.Kernel.InspectionSink do
     max_record_bytes = Keyword.get(opts, :max_record_bytes, @default_record_bytes)
     max_total_bytes = Keyword.get(opts, :max_total_bytes, @default_total_bytes)
 
-    if Keyword.keys(opts) -- allowed == [] and schema_version in [1, 2] and valid_id?(run_id) and
+    if Keyword.keys(opts) -- allowed == [] and schema_version in [1, 2, 3] and valid_id?(run_id) and
          valid_id?(trace_id) and
          is_integer(max_record_bytes) and max_record_bytes > 0 and
          max_record_bytes <= @default_record_bytes and is_integer(max_total_bytes) and
@@ -107,6 +109,17 @@ defmodule PtcRunner.Kernel.InspectionSink do
           {:ok, %{run_id: binary(), trace_id: binary()}} | {:error, :inspection_sink_error}
   def identity(sink), do: call(sink, :identity)
 
+  @spec schema_version(t()) :: {:ok, 1 | 2 | 3} | {:error, :inspection_sink_error}
+  @doc """
+  Returns the sink's negotiated schema version.
+
+  A caller emitting a record type introduced after V1 should check this first
+  and skip emission entirely on an older sink, the same as it would for a `nil`
+  sink — the record's vocabulary is a version the sink predates, not a runtime
+  failure worth failing the run closed over.
+  """
+  def schema_version(sink), do: call(sink, :schema_version)
+
   @doc false
   @spec stop_timeout_ms() :: pos_integer()
   def stop_timeout_ms, do: @stop_timeout_ms
@@ -160,6 +173,9 @@ defmodule PtcRunner.Kernel.InspectionSink do
 
   def handle_call({token, :identity}, _from, %{token: token} = state),
     do: {:reply, {:ok, Map.take(state, [:run_id, :trace_id])}, state}
+
+  def handle_call({token, :schema_version}, _from, %{token: token} = state),
+    do: {:reply, {:ok, state.schema_version}, state}
 
   def handle_call({token, :owner?}, {caller, _tag}, %{token: token} = state),
     do: {:reply, caller == state.owner, state}
@@ -337,6 +353,26 @@ defmodule PtcRunner.Kernel.InspectionSink do
     ok_or_error(valid?)
   end
 
+  defp shape("execution-prints", %{"evaluation_id" => id}, payload) do
+    valid? =
+      exact_payload(payload, ~w(environment prints truncated)) and valid_id?(id) and
+        payload["environment"] == "workflow" and
+        is_list(payload["prints"]) and Enum.all?(payload["prints"], &is_binary/1) and
+        is_boolean(payload["truncated"])
+
+    ok_or_error(valid?)
+  end
+
+  defp shape("execution-error", %{"evaluation_id" => id}, payload) do
+    valid? =
+      exact_payload(payload, ~w(environment kind reason details)) and valid_id?(id) and
+        payload["environment"] == "workflow" and
+        valid_id?(payload["kind"]) and valid_id?(payload["reason"]) and
+        is_map(payload["details"])
+
+    ok_or_error(valid?)
+  end
+
   defp shape(_record_type, _correlation, _payload), do: {:error, :invalid_record}
 
   defp exact_payload(payload, keys) do
@@ -348,8 +384,7 @@ defmodule PtcRunner.Kernel.InspectionSink do
       valid_id?(payload["name"]) and is_map(payload[value_key])
   end
 
-  defp record_types(1), do: @record_types_v1
-  defp record_types(2), do: @record_types_v2
+  defp record_types(schema_version), do: InspectionRecordTypes.for_schema_version(schema_version)
   defp valid_request_id?(id), do: is_integer(id) and id > 0
 
   defp ok_or_error(true), do: :ok

--- a/lib/ptc_runner/kernel/run_builder.ex
+++ b/lib/ptc_runner/kernel/run_builder.ex
@@ -1321,7 +1321,7 @@ defmodule PtcRunner.Kernel.RunBuilder do
           InspectionSink.start(
             run_id: identity.run_id,
             trace_id: identity.trace_id,
-            schema_version: 2,
+            schema_version: 3,
             owner: owner
           )
         end

--- a/lib/ptc_runner/kernel/runner.ex
+++ b/lib/ptc_runner/kernel/runner.ex
@@ -7,10 +7,12 @@ defmodule PtcRunner.Kernel.Runner do
   projection, and terminal error normalization.
   """
 
+  alias PtcRunner.Kernel.BoundedPrints
   alias PtcRunner.Kernel.DeterministicJSON
   alias PtcRunner.Kernel.Error
   alias PtcRunner.Kernel.Events
   alias PtcRunner.Kernel.EventSink
+  alias PtcRunner.Kernel.InspectionSink
   alias PtcRunner.Kernel.ProjectionError
   alias PtcRunner.Kernel.Result
   alias PtcRunner.Kernel.RunConfig
@@ -21,6 +23,11 @@ defmodule PtcRunner.Kernel.Runner do
   alias PtcRunner.Kernel.ToolGrant
   alias PtcRunner.Lisp
   alias PtcRunner.Lisp.RetainedSize
+
+  # Matches the bound `PtcRunner.Kernel.AnalysisSession` already applies when
+  # projecting `prints` into a caller-facing result.
+  @execution_prints_count 128
+  @execution_prints_bytes 65_536
 
   @spec run(binary(), RunConfig.t()) :: {:ok, Result.t()} | {:error, Error.t()}
   @doc "Executes one validated run configuration and always tears down run state."
@@ -167,7 +174,9 @@ defmodule PtcRunner.Kernel.Runner do
            environment: :workflow
          }) do
       :ok ->
-        result = execute_workflow(entry_source, config, state, timeout_ms, deadline_ms)
+        result =
+          execute_workflow(entry_source, config, state, timeout_ms, deadline_ms, evaluation_id)
+
         _ = maybe_emit_workflow_limit(state, config.event_sink, result)
 
         _ =
@@ -185,7 +194,7 @@ defmodule PtcRunner.Kernel.Runner do
     end
   end
 
-  defp execute_workflow(entry_source, config, state, timeout_ms, deadline_ms) do
+  defp execute_workflow(entry_source, config, state, timeout_ms, deadline_ms, evaluation_id) do
     opts = [
       context: config.input,
       tools: workflow_tools(config, state),
@@ -200,14 +209,19 @@ defmodule PtcRunner.Kernel.Runner do
     ]
 
     case Lisp.run_native(entry_source, opts) do
-      {:ok, %{return: {:__ptc_fail__, value}}} ->
-        {:error,
-         %Error{
-           kind: :workflow_failed,
-           reason: :explicit_failure,
-           details: SafeMetadata.failure_taxonomy(value),
-           usage: RunState.usage(state)
-         }}
+      {:ok, %{return: {:__ptc_fail__, value}} = step} ->
+        capture_execution_failure(
+          config,
+          state,
+          evaluation_id,
+          step,
+          %Error{
+            kind: :workflow_failed,
+            reason: :explicit_failure,
+            details: SafeMetadata.failure_taxonomy(value),
+            usage: RunState.usage(state)
+          }
+        )
 
       {:ok, step} ->
         with {:ok, value} <-
@@ -223,52 +237,142 @@ defmodule PtcRunner.Kernel.Runner do
                evaluation_memory: RunState.evaluation_memory_summary(state)
              }}
           else
-            {:error,
-             %Error{
-               kind: :limit_exceeded,
-               reason: :terminal_result_exceeded,
-               details: %{},
-               usage: RunState.usage(state)
-             }}
+            capture_execution_failure(
+              config,
+              state,
+              evaluation_id,
+              step,
+              %Error{
+                kind: :limit_exceeded,
+                reason: :terminal_result_exceeded,
+                details: %{},
+                usage: RunState.usage(state)
+              }
+            )
           end
         else
           {:error, :invalid_result_projection} ->
-            {:error,
-             %Error{
-               kind: :workflow_failed,
-               reason: :invalid_result_projection,
-               details: %{result_projection: true},
-               usage: RunState.usage(state)
-             }}
+            capture_execution_failure(
+              config,
+              state,
+              evaluation_id,
+              step,
+              %Error{
+                kind: :workflow_failed,
+                reason: :invalid_result_projection,
+                details: %{result_projection: true},
+                usage: RunState.usage(state)
+              }
+            )
 
           {:error, reason} ->
-            {:error,
-             %Error{
-               kind: :workflow_failed,
-               reason: ProjectionError.kind(reason),
-               details: %{
-                 result_projection: true,
-                 projection_error: inspect(reason, limit: 10)
-               },
-               usage: RunState.usage(state)
-             }}
+            capture_execution_failure(
+              config,
+              state,
+              evaluation_id,
+              step,
+              %Error{
+                kind: :workflow_failed,
+                reason: ProjectionError.kind(reason),
+                details: %{
+                  result_projection: true,
+                  projection_error: inspect(reason, limit: 10)
+                },
+                usage: RunState.usage(state)
+              }
+            )
         end
 
       {:error, step} ->
-        {:error,
-         %Error{
-           kind: workflow_error_kind(step.fail.reason),
-           reason: step.fail.reason,
-           details:
-             workflow_error_details(
-               step.fail,
-               timeout_ms,
-               config.limits,
-               config.event_sink
-             ),
-           usage: RunState.usage(state)
-         }}
+        capture_execution_failure(
+          config,
+          state,
+          evaluation_id,
+          step,
+          %Error{
+            kind: workflow_error_kind(step.fail.reason),
+            reason: step.fail.reason,
+            details:
+              workflow_error_details(
+                step.fail,
+                timeout_ms,
+                config.limits,
+                config.event_sink
+              ),
+            usage: RunState.usage(state)
+          }
+        )
     end
+  end
+
+  # Routes `step.prints` and the built `%Error{}.details` into the private
+  # inspection artifact, correlated by the workflow `evaluation_id`. Neither
+  # ever reaches the public envelope or canonical trace: the sink is the
+  # `0600` artifact, not an event. A capture failure fails the run closed the
+  # same way a capability's inspection capture does, by marking `RunState` so
+  # `apply_terminal_failure/2` replaces the result after this returns.
+  defp capture_execution_failure(config, state, evaluation_id, step, %Error{} = error) do
+    case emit_execution_diagnostics(config.inspection_sink, evaluation_id, step.prints, error) do
+      :ok ->
+        :ok
+
+      {:error, :inspection_sink_error} ->
+        :ok = RunState.fail(state, :inspection_sink_error, :inspection_sink_error)
+    end
+
+    {:error, error}
+  end
+
+  defp emit_execution_diagnostics(nil, _evaluation_id, _prints, _error), do: :ok
+
+  # A sink built before V3 does not understand these record types. A workflow
+  # failure is not an opt-in feature the way selecting an MCP provider is —
+  # every run eventually fails one — so an older sink skips capture the same
+  # as a `nil` sink would, instead of failing every such run closed.
+  defp emit_execution_diagnostics(sink, evaluation_id, prints, error) do
+    case InspectionSink.schema_version(sink) do
+      {:ok, schema_version} when schema_version >= 3 ->
+        with :ok <- emit_execution_prints(sink, evaluation_id, prints) do
+          emit_execution_error(sink, evaluation_id, error)
+        end
+
+      {:ok, _older_schema_version} ->
+        :ok
+
+      {:error, :inspection_sink_error} = error ->
+        error
+    end
+  end
+
+  defp emit_execution_prints(_sink, _evaluation_id, []), do: :ok
+
+  defp emit_execution_prints(sink, evaluation_id, prints) do
+    {bounded, truncated?} =
+      BoundedPrints.bound(prints, @execution_prints_count, @execution_prints_bytes)
+
+    InspectionSink.emit(
+      sink,
+      "execution-prints",
+      %{evaluation_id: evaluation_id},
+      %{environment: :workflow, prints: bounded, truncated: truncated?}
+    )
+  end
+
+  defp emit_execution_error(_sink, _evaluation_id, %Error{details: details})
+       when map_size(details) == 0,
+       do: :ok
+
+  defp emit_execution_error(sink, evaluation_id, %Error{
+         kind: kind,
+         reason: reason,
+         details: details
+       }) do
+    InspectionSink.emit(
+      sink,
+      "execution-error",
+      %{evaluation_id: evaluation_id},
+      %{environment: :workflow, kind: kind, reason: reason, details: details}
+    )
   end
 
   defp project_result(value, :native), do: {:ok, value}

--- a/test/ptc_runner/kernel/inspection_sink_test.exs
+++ b/test/ptc_runner/kernel/inspection_sink_test.exs
@@ -801,6 +801,103 @@ defmodule PtcRunner.Kernel.InspectionSinkTest do
     assert %{"records" => ^records} = Jason.decode!(response.resp_body)
   end
 
+  @tag :tmp_dir
+  test "a provider-free execution failure captures prints and error detail outside canonical trace",
+       %{tmp_dir: dir} do
+    File.write!(
+      Path.join(dir, "workflow.clj"),
+      ~S|(ns app) (defn run [input] (println "CHECKPOINT" {:seen input}) #{1 2 3})|
+    )
+
+    manifest = %{
+      "version" => 1,
+      "workflow" => %{
+        "components" => [%{"id" => "app", "path" => "workflow.clj"}],
+        "entry" => "app/run"
+      },
+      "input" => %{"value" => %{"seen" => "checkpoint-input"}},
+      "events" => %{"policy" => "private"}
+    }
+
+    manifest_path = Path.join(dir, "ptc.json")
+    trace_path = Path.join(dir, "run.private.jsonl")
+    inspection_path = Path.join(dir, "run.inspection.jsonl")
+    File.write!(manifest_path, Jason.encode!(manifest))
+
+    {:ok, registry} = ProviderRegistry.new(%{})
+
+    assert {:error, %PtcRunner.Kernel.Error{kind: :workflow_failed}} =
+             manifest_path
+             |> ApplicationPackage.request_directory(
+               inspection_capture: true,
+               result_projection: :json,
+               installed_limits: registry.installed_limits
+             )
+             |> RunLifecycle.build(registry,
+               trace_path: trace_path,
+               inspect: inspection_path
+             )
+             |> RunLifecycle.execute()
+
+    assert {:ok, records} = InspectionArtifact.load(inspection_path)
+
+    prints_record = Enum.find(records, &(&1["record_type"] == "execution-prints"))
+    error_record = Enum.find(records, &(&1["record_type"] == "execution-error"))
+
+    assert prints_record["payload"] == %{
+             "environment" => "workflow",
+             "prints" => [~S|CHECKPOINT {:seen {"seen" "checkpoint-input"}}|],
+             "truncated" => false
+           }
+
+    assert error_record["payload"]["environment"] == "workflow"
+    assert error_record["payload"]["kind"] == "workflow_failed"
+    assert is_map(error_record["payload"]["details"])
+    assert map_size(error_record["payload"]["details"]) > 0
+
+    trace_lines = trace_path |> File.read!() |> String.split("\n", trim: true)
+    refute Enum.any?(trace_lines, &String.contains?(&1, "CHECKPOINT"))
+    refute Enum.any?(trace_lines, &String.contains?(&1, "checkpoint-input"))
+
+    evaluation_started =
+      trace_lines
+      |> Enum.map(&Jason.decode!/1)
+      |> Enum.find(
+        &(&1["type"] == "evaluation-started" and &1["data"]["environment"] == "workflow")
+      )
+
+    assert evaluation_started["data"]["evaluation_id"] ==
+             prints_record["correlation"]["evaluation_id"]
+
+    assert evaluation_started["data"]["evaluation_id"] ==
+             error_record["correlation"]["evaluation_id"]
+
+    assert {:ok, inspection_source} =
+             ViewerAdapter.pin_inspection(inspection_path, {:private_file, trace_path})
+
+    {:ok, inspection_store} = PtcViewer.InspectionStore.start(inspection_source)
+
+    on_exit(fn ->
+      if Process.alive?(inspection_store), do: PtcViewer.InspectionStore.stop(inspection_store)
+    end)
+
+    viewer_opts = [
+      trace_dir: dir,
+      kernel_trace_adapter: ViewerAdapter,
+      inspection_store: inspection_store,
+      inspection_adapter: ViewerAdapter
+    ]
+
+    response =
+      Plug.Test.conn(:get, "/api/inspection/runs/#{evaluation_started["run_id"]}")
+      |> PtcViewer.Router.call(PtcViewer.Router.init(viewer_opts))
+
+    assert response.status == 200
+    assert %{"records" => viewed_records} = Jason.decode!(response.resp_body)
+    assert Enum.any?(viewed_records, &(&1["record_type"] == "execution-prints"))
+    assert Enum.any?(viewed_records, &(&1["record_type"] == "execution-error"))
+  end
+
   defp emit_small(sink, capability_id) do
     InspectionSink.emit(
       sink,

--- a/test/ptc_runner/kernel/inspection_sink_test.exs
+++ b/test/ptc_runner/kernel/inspection_sink_test.exs
@@ -132,6 +132,69 @@ defmodule PtcRunner.Kernel.InspectionSinkTest do
     assert response_record["payload"]["body"] == response
   end
 
+  test "V3 retains correlated execution-prints and execution-error records while V2 rejects them" do
+    {:ok, v2} = InspectionSink.start(run_id: "run-1", trace_id: "trace-1", schema_version: 2)
+
+    assert {:error, :inspection_sink_error} =
+             InspectionSink.emit(
+               v2,
+               "execution-prints",
+               %{evaluation_id: "eval-1"},
+               %{environment: :workflow, prints: ["CHECKPOINT"], truncated: false}
+             )
+
+    {:ok, v3} = InspectionSink.start(run_id: "run-1", trace_id: "trace-1", schema_version: 3)
+
+    assert :ok =
+             InspectionSink.emit(
+               v3,
+               "execution-prints",
+               %{evaluation_id: "eval-1"},
+               %{environment: :workflow, prints: ["CHECKPOINT"], truncated: false}
+             )
+
+    assert :ok =
+             InspectionSink.emit(
+               v3,
+               "execution-error",
+               %{evaluation_id: "eval-1"},
+               %{
+                 environment: :workflow,
+                 kind: :workflow_failed,
+                 reason: :invalid_result_projection,
+                 details: %{result_projection: true, projection_error: "some inspected reason"}
+               }
+             )
+
+    assert {:ok, [prints_record, error_record]} = InspectionSink.records(v3)
+    assert prints_record["schema_version"] == 3
+    assert prints_record["correlation"] == %{"evaluation_id" => "eval-1"}
+
+    assert prints_record["payload"] == %{
+             "environment" => "workflow",
+             "prints" => ["CHECKPOINT"],
+             "truncated" => false
+           }
+
+    assert error_record["payload"] == %{
+             "environment" => "workflow",
+             "kind" => "workflow_failed",
+             "reason" => "invalid_result_projection",
+             "details" => %{
+               "result_projection" => true,
+               "projection_error" => "some inspected reason"
+             }
+           }
+
+    assert {:error, :inspection_sink_error} =
+             InspectionSink.emit(
+               v3,
+               "execution-prints",
+               %{evaluation_id: "eval-2"},
+               %{environment: :mission, prints: ["nope"], truncated: false}
+             )
+  end
+
   test "enforces installed per-record and aggregate encoded byte ceilings" do
     {:ok, record_limited} =
       InspectionSink.start(

--- a/test/ptc_runner/kernel/mcp_source_test.exs
+++ b/test/ptc_runner/kernel/mcp_source_test.exs
@@ -561,7 +561,7 @@ defmodule PtcRunner.Kernel.MCPSourceTest do
     assert Enum.map(requests, & &1["correlation"]) |> MapSet.new() ==
              Enum.map(responses, & &1["correlation"]) |> MapSet.new()
 
-    assert Enum.all?(requests ++ responses, &(&1["schema_version"] == 2))
+    assert Enum.all?(requests ++ responses, &(&1["schema_version"] == 3))
 
     encoded_inspection = File.read!(inspection_path)
     refute encoded_inspection =~ "Bearer fixture-secret"


### PR DESCRIPTION
## Summary

Fixes #1232 (code fix only — the two documentation corrections described in that issue are handled in a separate PR, per the issue's own suggested split).

A provider-free workflow failure had nowhere to observe anything: `PtcRunner.Kernel.Runner.execute_workflow/5` built `step.prints` on both the success and error paths but never read it, and the failure detail it already assembles at the invalid-result-projection sites (`runner.ex:249-252`, including `inspect/2` output over an author-supplied projection reason) was thrown away after being built. Before this change, `--inspect` on a failing provider-free run produced exactly one `prelude-source` record and nothing else.

- **New V3 inspection record types**: `execution-prints` and `execution-error`, correlated by the workflow `evaluation_id` (not a capability attempt or subordinate evaluation). Added to `InspectionSink` (retention) and `InspectionArtifact` (persistence/loading), with their shared per-version vocabulary extracted into `PtcRunner.Kernel.InspectionRecordTypes` to keep the two validators from drifting.
- **Runner wiring**: `execute_workflow/5` now routes `step.prints` (bounded to 128 entries / 65,536 encoded bytes — the same bound `AnalysisSession` already applies) and the built `%Error{}.details` into the sink at every failure branch: explicit `(fail ...)`, the terminal-result-size limit, both result-projection failure branches, and the runtime/timeout branch.
- **Backward compatibility**: an inspection sink built before V3 (most commonly an explicit embedding config) skips this new capture instead of failing every such run closed — a workflow failure isn't an opt-in feature the way selecting an MCP provider is, so `InspectionSink.schema_version/1` lets the runner check first. A genuinely dead sink still fails closed the same way capability capture already does.
- **Hard constraint preserved**: neither `prints` nor `details` ever reaches the public command envelope or the canonical trace — only the `0600` `.inspection.jsonl` artifact.

## What changed

- `lib/ptc_runner/kernel/bounded_prints.ex` (new) — extracted the prints-bounding rule shared by `AnalysisSession` and `Runner`.
- `lib/ptc_runner/kernel/inspection_record_types.ex` (new) — the shared closed record-type vocabulary by schema version.
- `lib/ptc_runner/kernel/inspection_sink.ex`, `inspection_artifact.ex` — V3 vocabulary, shape validation, uniqueness, and correlation against the canonical workflow `evaluation-started` event.
- `lib/ptc_runner/kernel/inspection_query.ex` — `execution_prints`/`execution_errors` counts in each run's summary (no new queryable operation; out of scope for this fix).
- `lib/ptc_runner/kernel/run_builder.ex` — sinks now open at schema version 3.
- `lib/ptc_runner/kernel/runner.ex` — the actual routing fix.
- `docs/trace-log-contract.md` — documents the two new V3 record types.
- Tests in `inspection_sink_test.exs` (V3 sink-level round trip + a failing-first end-to-end integration test) and a one-line fix in `mcp_source_test.exs` for the schema-version default bump.

The Viewer (`ptc_viewer/`) needed **no code changes** — its rendering is already generic over `record_type`, confirmed by extending the existing Viewer-integration test to assert both new record types render through `PtcViewer.Router`.

## Verification

- **Failing-first test**: `test/ptc_runner/kernel/inspection_sink_test.exs` — confirmed red without the `runner.ex` change (via a scratch revert), green with it.
- `mix test` (root + `ptc_viewer`): full suite green except two failures confirmed pre-existing and environment-specific to this sandbox, unrelated to this change (reproduced identically on unmodified `main`): an IPv6-connectivity test (`:eafnosupport` — no IPv6 support in the container) and a root-permissions test that simulates a `chmod`-denied write (harmless as root).
- `mix precommit`: format, compile --warnings-as-errors, xref cycles, `credo --strict`, the duplication gate, `ptc.validate_spec`, `ptc.gen_docs --check`, `ptc.conformance_report --check-inventory`, root + Viewer tests, and the launcher's own precommit all pass. The pipeline's final release-smoke-test script fails identically on unmodified `main` in this sandbox (a pre-existing, environment-specific issue, not something this diff touches or can fix) — verified separately in isolation and via `mix cmd`, where it passes cleanly.
- `MIX_ENV=dev mix docs --warnings-as-errors`: clean.
- **Manual end-to-end** (the exact repro from the issue): scaffolded via `mix ptc init`, replaced `main.clj` with
  ```clojure
  (ns main)
  (defn run [input]
    (println "CHECKPOINT" {:seen input})
    #{1 2 3})
  ```
  and ran `mix ptc run ptc.json --trace-dir T --inspect I.jsonl`. Before this change the artifact holds exactly one `prelude-source` record. After: `prelude-source`, `execution-prints` (containing the CHECKPOINT text), and `execution-error` (containing the projection-error detail) — all three correlated by the same `evaluation_id`. Confirmed via `grep` that neither the canonical trace nor the `--envelope` output contains the print text, and that the inspection artifact is `0600`.

## Duplication-gate note

Adding the `record_types(3)` clause to both `InspectionSink` and `InspectionArtifact` pushed a pre-existing small duplicate (the `record_types/1` lookup) over the gate's threshold. Extracted the shared logic into `InspectionRecordTypes` rather than re-blessing the baseline, per `docs/guides/duplication-gate.md`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VQD5aNMMvGis2t9kjfaFg8)_