### PR TITLE
docs: correct generated-artifact remediation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,8 +63,10 @@ how it was verified.
   `precommit`, and are repeated here because an ordinary push does not run
   `precommit` — without them a `lib/` edit can clear every local gate and still
   fail CI on an artifact you were never prompted to regenerate. When one fires,
-  run `mix regen` and stage the result. Do not run `mix prepush` immediately
-  before an ordinary push;
+  run its matching write form — `mix ptc.gen_docs` for generated docs and
+  schemas, or `mix ptc.conformance_report --write-inventory` for
+  `conformance_inventory.json` — then stage the result. Do not run `mix prepush`
+  immediately before an ordinary push;
   invoke it directly only for diagnosis or when hooks are unavailable. PR CI
   runs the same checks as individual steps. On a resource-constrained machine,
   `PTC_PRE_PUSH_MAX_CASES=2 git push` keeps every gate enabled while reducing

--- a/test/repository_instructions_test.exs
+++ b/test/repository_instructions_test.exs
@@ -1,0 +1,13 @@
+defmodule PtcRunner.RepositoryInstructionsTest do
+  use ExUnit.Case, async: true
+
+  @instructions File.read!(Path.expand("../AGENTS.md", __DIR__))
+  [_, commands_and_rest] = String.split(@instructions, "## Commands", parts: 2)
+  [commands, _rest] = String.split(commands_and_rest, "### Fresh worktree setup", parts: 2)
+  @commands commands
+
+  test "ordinary generated-artifact guidance excludes release-only regeneration" do
+    assert @commands =~ "`mix ptc.gen_docs`"
+    refute @commands =~ "`mix regen`"
+  end
+end


### PR DESCRIPTION
## What changed

- point feature-branch generated-doc/schema failures to `mix ptc.gen_docs`
- point conformance inventory failures to `mix ptc.conformance_report --write-inventory`
- add a regression test that keeps the Commands section from recommending release-only `mix regen`

## Root cause

Commit `62329b5e` introduced a local merge driver and `mix regen` because `priv/semantic_build_projection.json` hashes the whole semantic source closure, so unrelated branches rewrote and conflicted on the same lines.

PR #1200 / commit `7b3fda95` then added all three generated-artifact checks to the pre-push path and documented one generic remedy: `mix regen`.

Commit `f3cf7d8d` later moved semantic-projection validation to the release gate after finding that 131 of the previous 200 commits rewrote it. GitHub cannot use the locally configured merge driver, so feature branches had to stop regenerating the projection entirely to avoid recurring PR conflicts. That commit made `mix regen` release-only, but left the earlier generic remediation in the Commands section.

The result was contradictory guidance and, when followed, an auto-staged projection change that could reintroduce the exact PR conflicts the release-only policy was designed to prevent.

## Impact

Contributors now use the generator matching the check that failed and do not touch the semantic projection on feature branches.

## Verification

- regression test failed before the documentation fix and passes after it
- `mix test test/repository_instructions_test.exs --trace`
- `MIX_ENV=dev mix docs --warnings-as-errors`
- `mix precommit`
- full pre-push hook: 5,948 root tests, 72 Viewer tests, 40 launcher tests, generated-artifact checks, Credo, upstream audit, Dialyzer, unused dependencies, and launcher packaging

Closes #1242