### PR TITLE
fix(kernel): remove a publication reservation exactly once

### DIFF
--- a/docs/guides/kernel-maintainer.md
+++ b/docs/guides/kernel-maintainer.md
@@ -679,7 +679,12 @@ Failures after the sync boundary retain the complete recovery value; if the
 recovery name cannot be proven reachable, the state is
 `finalization_uncertain`. Failure before a valid result, including provider
 cleanup failure, never materializes result bytes and removes the empty
-reservation only after verifying its captured identity.
+reservation only after verifying its captured identity. That identity check is
+trustworthy exactly once: staging and reservation names are derived from the
+destination, so a later run reserves the same names — and, on filesystems that
+recycle inode numbers, the same identities. Each handle owner therefore removes
+those names at most once and afterwards only releases its descriptor, so
+teardown of an abandoned run can never reclaim a reservation a later run holds.
 
 If identity verification or unlinking fails while removing an empty or partial
 reservation, the publisher leaves the name untouched, reports result state

--- a/lib/ptc_runner/kernel/publication_claim_owner.ex
+++ b/lib/ptc_runner/kernel/publication_claim_owner.ex
@@ -130,9 +130,7 @@ defmodule PtcRunner.Kernel.PublicationClaimOwner do
   defp cleanup_handles(handles) do
     results =
       Enum.map(handles, fn {_identity, handle} ->
-        result = PublicationHandle.discard(handle)
-        _ = PublicationHandle.close(handle)
-        result
+        PublicationHandle.discard(handle)
       end)
 
     if Enum.all?(results, &(&1 == :ok)), do: :ok, else: {:error, :publication_cleanup_failed}

--- a/lib/ptc_runner/kernel/publication_handle.ex
+++ b/lib/ptc_runner/kernel/publication_handle.ex
@@ -285,6 +285,15 @@ defmodule PtcRunner.Kernel.PublicationHandle do
     :close
   end
 
+  # Releases the device without touching the filesystem. Staging and
+  # reservation names are reused by later handles for the same destination, so
+  # a handle whose removal already succeeded must never identity-check and
+  # remove those names a second time.
+  defp direct_execute(handle, :close_device) do
+    _ = :file.close(handle.device)
+    :close
+  end
+
   defp direct_write(%__MODULE__{} = handle, bytes) do
     with {:ok, bytes} <- binary_iodata(bytes),
          :ok <- direct_verify(handle),

--- a/lib/ptc_runner/kernel/publication_handle_owner.ex
+++ b/lib/ptc_runner/kernel/publication_handle_owner.ex
@@ -32,7 +32,12 @@ defmodule PtcRunner.Kernel.PublicationHandleOwner do
   @impl GenServer
   def init(controller) do
     {:ok,
-     %{controller_ref: Process.monitor(controller), handle: nil, preserve_on_cleanup?: false}}
+     %{
+       controller_ref: Process.monitor(controller),
+       handle: nil,
+       preserve_on_cleanup?: false,
+       removed?: false
+     }}
   end
 
   @impl GenServer
@@ -104,13 +109,26 @@ defmodule PtcRunner.Kernel.PublicationHandleOwner do
 
   defp operation_reply(:discard, handle, %{preserve_on_cleanup?: true} = state) do
     _ = PublicationHandle.owner_execute(handle, :close)
-    {:reply, :ok, %{state | handle: nil}}
+    {:stop, :normal, :ok, %{state | handle: nil}}
   end
 
   defp operation_reply(:discard, handle, state) do
     result = PublicationHandle.owner_execute(handle, :remove)
-    _ = PublicationHandle.owner_execute(handle, :close)
-    {:reply, result, %{state | handle: nil}}
+    _ = PublicationHandle.owner_execute(handle, close_after(result))
+    {:stop, :normal, result, %{state | handle: nil}}
+  end
+
+  defp operation_reply(operation, %PublicationHandle{} = handle, state)
+       when operation in [:remove, :unlink] do
+    case PublicationHandle.owner_execute(handle, operation) do
+      :ok -> {:reply, :ok, %{state | removed?: true}}
+      result -> {:reply, result, state}
+    end
+  end
+
+  defp operation_reply(:close, %PublicationHandle{} = handle, %{removed?: true} = state) do
+    _ = PublicationHandle.owner_execute(handle, :close_device)
+    {:stop, :normal, :ok, %{state | handle: nil}}
   end
 
   defp operation_reply(operation, handle, state) do
@@ -141,23 +159,43 @@ defmodule PtcRunner.Kernel.PublicationHandleOwner do
 
   @impl GenServer
   def handle_info({:DOWN, ref, :process, _controller, _reason}, %{controller_ref: ref} = state) do
-    _ = cleanup(state.handle, state.preserve_on_cleanup?)
+    _ = cleanup(state.handle, state)
     {:stop, :normal, %{state | handle: nil}}
   end
 
   def handle_info(_message, state), do: {:noreply, state}
 
   @impl GenServer
-  def terminate(_reason, %{handle: handle, preserve_on_cleanup?: preserve?}),
-    do: cleanup(handle, preserve?)
+  def terminate(_reason, %{handle: handle} = state), do: cleanup(handle, state)
 
-  defp cleanup(nil, _preserve?), do: :ok
+  defp cleanup(nil, _state), do: :ok
 
-  defp cleanup(handle, preserve?) do
-    unless preserve?, do: _ = PublicationHandle.owner_execute(handle, :remove)
+  defp cleanup(handle, %{preserve_on_cleanup?: true}) do
     _ = PublicationHandle.owner_execute(handle, :close)
     :ok
   rescue
     _exception -> :ok
   end
+
+  defp cleanup(handle, %{removed?: true}) do
+    _ = PublicationHandle.owner_execute(handle, :close_device)
+    :ok
+  rescue
+    _exception -> :ok
+  end
+
+  defp cleanup(handle, _state) do
+    result = PublicationHandle.owner_execute(handle, :remove)
+    _ = PublicationHandle.owner_execute(handle, close_after(result))
+    :ok
+  rescue
+    _exception -> :ok
+  end
+
+  # A successful removal already released the staging and reservation names.
+  # Both are derived from the destination and are reserved again by the next
+  # handle for that destination, so closing must not identity-check and remove
+  # them a second time.
+  defp close_after(:ok), do: :close_device
+  defp close_after(_result), do: :close
 end

--- a/test/ptc_runner/kernel/publication_authority_test.exs
+++ b/test/ptc_runner/kernel/publication_authority_test.exs
@@ -163,6 +163,27 @@ defmodule PtcRunner.Kernel.PublicationAuthorityTest do
   end
 
   @tag :tmp_dir
+  test "a removed handle never reclaims a reservation reserved again", %{tmp_dir: dir} do
+    target = Path.join(dir, "reused-reservation.jsonl")
+
+    # Reservation names are derived from the destination, so a later reservation
+    # for the same target reuses the name — and, on filesystems that recycle
+    # inode numbers, the identity — of the one just removed. Teardown of the
+    # earlier handle must not reach the later handle's reservation.
+    for _attempt <- 1..20 do
+      assert {:ok, removed} = PublicationHandle.reserve(target, :trace, 0o600)
+      assert :ok = PublicationHandle.remove(removed)
+
+      assert {:ok, reserved} = PublicationHandle.reserve(target, :trace, 0o600)
+      assert :ok = PublicationHandle.close(removed)
+
+      assert :ok = PublicationHandle.verify(reserved)
+      assert :ok = PublicationHandle.remove(reserved)
+      assert :ok = PublicationHandle.close(reserved)
+    end
+  end
+
+  @tag :tmp_dir
   test "exclusive handle operations remain owned across caller processes", %{tmp_dir: dir} do
     target = Path.join(dir, "cross-process.jsonl")
     assert {:ok, handle} = PublicationHandle.reserve(target, :trace, 0o600)


### PR DESCRIPTION
Fixes the intermittent CI failure in [run 31358285191](https://github.com/andreasronge/ptc_runner/actions/runs/31358285191/job/93361994903):

```
1) test creator death reclaims an unclaimed authority (PtcRunner.Kernel.PublicationAuthorityTest)
   test/ptc_runner/kernel/publication_authority_test.exs:350
   code:  assert :ok = PublicationAuthority.abort(authority)
   left:  :ok
   right: {:error, :publication_cleanup_failed}
```

The assertion was right; the bug is real. **A torn-down handle could delete a reservation directory that a different, live handle owned.**

## Root cause

Reservation and staging names are derived from the destination — `reservation_path/2` builds `.<sha256(parent identity, casefolded basename)>.ptc-reservation` — so the next handle for the same destination reserves the *same* names. Handles are identified only by `{major_device, minor_device, inode}`, so where the filesystem recycles inode numbers (ext4, as on the CI runner) the new reservation can also carry the *same identity*.

Teardown ran the identity-checked removal twice on one handle:

- `PublicationHandleOwner.operation_reply(:discard, ...)` executed `:remove` and then `:close`;
- `cleanup/2` (controller `:DOWN` / `terminate`) did the same;
- callers paired them across two calls (`command_envelope.ex`, `publication_authority.ex`, `publication_claim_owner.ex`) — `:remove` went through the generic clause, which keeps the handle, so the following `:close` really did run `direct_close/1` again.

`direct_remove/1` rmdirs the reservation last and then fsyncs the parent directory. In that window another run can reserve the same destination: its `mkdir` succeeds and reuses the just-freed inode. The stale handle's second `remove_reservation/1` then matches on that reused inode and rmdirs a reservation it no longer owns. The live handle's next operation fails `direct_verify/1` on the missing reservation → `{:error, :publication_cleanup_failed}`.

## Fix

Enforce **staging/reservation cleanup runs at most once per handle**, in the owner that serialises handle operations.

- `PublicationHandle`: new `:close_device` operation — releases the descriptor without touching the filesystem.
- `PublicationHandleOwner`: records a successful `:remove`/`:unlink` in `removed?`; afterwards `:close` (and `:DOWN`/`terminate` cleanup) only closes the device. `:discard` and the cleanup path close via `:close_device` when their removal succeeded, and `:discard` now stops its owner.
- `PublicationClaimOwner`: drops the follow-up `PublicationHandle.close/1`, which `:discard` stopping its owner makes dead.
- `docs/guides/kernel-maintainer.md`: documents the single-removal invariant next to the existing identity-check description.

No new `PublicationHandle` struct field, and `same_identity/2` is unchanged — adding ctime there would break `restrict/2`, which chmods staging after the identity is captured.

## Verification

- New regression test `a removed handle never reclaims a reservation reserved again` reserves, removes, reserves the same destination again, then closes the removed handle. It fails on the previous code (`verify/1` → `{:error, :publication_collision}`) and passes with the fix.
- `test/ptc_runner/kernel/publication_authority_test.exs` green, including repeated runs of the previously flaky `creator death reclaims an unclaimed authority`.
- `mix precommit`, `mix prepush` (Dialyzer: 0 errors), `MIX_ENV=dev mix docs --warnings-as-errors`.
- Two root-suite failures remain in this container and are environment-only — both reproduce unchanged on `main`: the IPv6 adapter test (`:eafnosupport`, no IPv6 here) and `ptc_repl_test.exs:627`, whose `chmod 0500` guard cannot fail for the root user this container runs as.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FoEVHfSsjyVGANLKT1yxBL)_