### PR TITLE
perf(ci): run the test suite in parallel and move :slow tests nightly

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -99,8 +99,11 @@ run_project_gates() {
   fi
 
   # Scoped tests for changed test files — a single `mix test` invocation for
-  # all of them. `:slow` (heavy subprocess/integration) tests are skipped on
-  # the fast pre-commit path; they still run in `mix precommit`, pre-push, and CI.
+  # all of them. `:slow` (heavy subprocess/integration) tests are now excluded
+  # by `test/test_helper.exs` for every entry point, so `--exclude slow` below
+  # is redundant but kept explicit, matching `--exclude clojure`. They run in
+  # the nightly `Slow` workflow (`mix slow`), not in `precommit`, pre-push, or
+  # the per-PR CI suite.
   local changed_tests
   if [ "$proj" = "." ]; then
     changed_tests=$(echo "$staged" | grep -E '^test/.*_test\.exs$' || true)

--- a/.github/workflows/slow.yml
+++ b/.github/workflows/slow.yml
@@ -1,0 +1,52 @@
+name: Slow
+
+# `:slow` tests are excluded from `mix test` by default and are not a per-PR
+# gate. Each one compiles a project or drives a real subprocess, so they cost
+# seconds apiece and land on the serial side of the suite: three of them were
+# 40% of the 177.8 s `async: false` floor that set the PR suite's wall clock.
+#
+# They still have to run, and daily is the right cadence: unlike the weekly
+# soak suite their signal is a per-commit verdict, not a trend, so a break
+# should surface within a day of the commit that caused it.
+#
+# Like `soak.yml` this lives outside `test.yml` so it can be dispatched on its
+# own and so a red run never blocks an unrelated pull request.
+on:
+  schedule:
+    - cron: "41 2 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: slow-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  slow:
+    runs-on: ubuntu-latest
+    name: Slow tests
+    # The downstream-consumer test builds a fresh project under MIX_ENV=prod
+    # against PtcRunner as a path dependency, so it pays a full cold compile
+    # whenever the cached `_build` misses.
+    timeout-minutes: 30
+    env:
+      MIX_ENV: test
+      HEX_SPONSOR: false
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Elixir environment
+        uses: ./.github/actions/setup-elixir
+        with:
+          cache-plt: 'false'
+          install-babashka: 'false'
+
+      - name: Compile
+        run: mix compile --warnings-as-errors
+
+      - name: Run the slow test suite
+        run: mix slow

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -271,8 +271,19 @@ jobs:
       - name: Check stable CLI transitional callers
         run: mix run --no-start scripts/check_stable_cli_transition.exs
 
+      # No `--trace` here, and none may be reintroduced: it sets `--max-cases`
+      # to 1 (`Mix.Tasks.Test` docs; `ExUnit.max_cases/1`), which ran this
+      # suite single-threaded on a 4-vCPU runner for 259 s. `--slowest` and
+      # `--slowest-modules` imply `--trace` too, so they are not a substitute
+      # for the per-test timings this drops; get those from a local run or the
+      # nightly `Slow` workflow.
+      #
+      # Dropping `--trace` also restores the default 60 s per-test timeout,
+      # which trace mode had set to `:infinity`. That is why the `:slow`
+      # exclusion in `test/test_helper.exs` is part of the same change: the
+      # slowest test took 61.3 s and would now time out here.
       - name: Run tests
-        run: mix test --max-failures 1 --trace --warnings-as-errors
+        run: mix test --max-failures 1 --warnings-as-errors
 
       - name: Verify core release package
         run: bash scripts/verify_core_package.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,11 @@ how it was verified.
   ExUnit concurrency.
 - `mix test --include e2e` — E2E tests (requires `OPENROUTER_API_KEY`;
   the MCP tests also require the local server described below).
+- `mix slow` — the `:slow` tests, excluded from `mix test` by default because
+  each compiles a project or drives a real subprocess. The nightly `Slow`
+  workflow runs them; run it locally when you touch a Mix task, the git hooks,
+  or the stdio transport. Never add `--trace` (or `--slowest`, which implies
+  it) to a suite you want to finish quickly: it pins `--max-cases` to 1.
 - Fix all failures before committing/pushing.
 
 ### Fresh worktree setup

--- a/mix.exs
+++ b/mix.exs
@@ -82,7 +82,13 @@ defmodule PtcRunner.MixProject do
 
   def cli do
     [
-      preferred_envs: [precommit: :test, prepush: :test, coverage: :test, soak: :test]
+      preferred_envs: [
+        precommit: :test,
+        prepush: :test,
+        coverage: :test,
+        soak: :test,
+        slow: :test
+      ]
     ]
   end
 
@@ -207,6 +213,14 @@ defmodule PtcRunner.MixProject do
       ],
       coverage: [
         "test --cover"
+      ],
+      # Tests that compile a project or drive a real subprocess. Excluded from
+      # `mix test` by default (test/test_helper.exs) because a handful of them
+      # dominated the suite's serial wall clock; the nightly `Slow` workflow
+      # runs them. `--trace` is retained here: these tests exceed the default
+      # 60 s per-test timeout, and trace mode sets the timeout to `:infinity`.
+      slow: [
+        "test --only slow --trace"
       ],
       # Memory-leak soak suite. Excluded from `mix test` by default
       # (test/test_helper.exs) because it is long-running and its signal is a

--- a/test/mix/tasks/bench_check_test.exs
+++ b/test/mix/tasks/bench_check_test.exs
@@ -1,6 +1,12 @@
 defmodule Mix.Tasks.Bench.CheckTest do
   use ExUnit.Case, async: false
 
+  # `:slow` because both tests execute the real benchmark task rather than a
+  # stub: even at `--samples 1 --warmup 0` the module cost 24.0 s of the CI
+  # suite's 177.8 s serial floor, second only to the downstream-consumer
+  # build. The nightly `Slow` workflow runs it.
+  @moduletag :slow
+
   alias Mix.Tasks.Bench.Check
 
   setup do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -13,7 +13,13 @@ end
 # - :clojure tests require Babashka and are excluded by default, run with --include clojure
 # - :soak tests are long-running memory soak tests, excluded by default.
 #   Run with: `mix test --only soak` (see test/soak/README.md)
-exclusions = [:skip, :e2e, :clojure, :soak]
+# - :slow tests cost seconds each because they compile a project or drive a
+#   real subprocess. They are excluded by default and run in the nightly
+#   `Slow` workflow with `mix slow`. Excluding them here rather than only in
+#   the pre-commit hook is what lets the per-PR suite run in parallel: the
+#   suite is 69% `async: false`, so its wall clock is a serial floor, and
+#   three `:slow` files were 40% of that floor.
+exclusions = [:skip, :e2e, :clojure, :soak, :slow]
 
 # Run clojure conformance tests: mix test --include clojure
 #


### PR DESCRIPTION
`--trace` in the CI test step pins `--max-cases` to 1, so the whole suite ran single-threaded on a 4-vCPU runner (259 s; ExUnit reported 81.2 s of it as async work with no way to overlap).

Removing `--trace` restores the default 60 s per-test timeout that trace mode had set to `:infinity`, so the `:slow` exclusion must land in the same commit. `ptc_run_downstream_test.exs` was already tagged `:slow` but nothing consumed the tag — `:slow` is absent from the `test_helper.exs` exclusions — so it ran in CI at 61.3 s and would now exceed the restored timeout. `bench_check_test.exs` gains the tag at 24.0 s.

Those two files were 40% of the suite's 177.8 s `async: false` floor, which is what sets its wall clock: only 31% of suite time is in `async: true` modules.

New nightly `Slow` workflow runs `mix slow`, which keeps `--trace` because those tests are expected to exceed 60 s.

### Verified
- Full suite **153.0 s → 123.0 s** locally, 5938 passed, no timeouts
- `mix slow` runs 13 tests in 80.3 s
- The CI number is what this PR's own run measures — see the `Core validation` job

### Note
`--slowest`/`--slowest-modules` are **not** substitutes for the per-test timings this drops; both imply `--trace`.