### PR TITLE
perf(ci): split Core validation into four parallel jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -282,12 +282,14 @@ jobs:
       # suite single-threaded on a 4-vCPU runner for 259 s. `--slowest` and
       # `--slowest-modules` imply `--trace` too, so they are not a substitute
       # for the per-test timings this drops; get those from a local run or the
-      # nightly `Slow` workflow.
+      # `Nightly` workflow.
       #
       # Dropping `--trace` also restores the default 60 s per-test timeout,
-      # which trace mode had set to `:infinity`. That is why the `:slow`
-      # exclusion in `test/test_helper.exs` is part of the same change: the
-      # slowest test took 61.3 s and would now time out here.
+      # which trace mode had set to `:infinity`. That is what the `:nightly`
+      # exclusion in `test/test_helper.exs` pairs with: the slowest test takes
+      # 61.1 s and would otherwise time out here. `:nightly` is a narrow tag --
+      # do not reach for it to make this step faster, because every test it
+      # covers stops being verified on pull requests.
       - name: Run tests
         run: mix test --max-failures 1 --warnings-as-errors
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -239,12 +239,24 @@ jobs:
           mix test test/ptc_runner/kernel/filesystem_mcp_e2e_test.exs \
             --include e2e --trace --warnings-as-errors
 
-  core:
+  # `Core validation` used to be one job running tests, Dialyzer, release
+  # verification, and the lint/staleness checks in series: 438 s, and the whole
+  # CI critical path, because every other job finishes in under two minutes.
+  # These four concerns share no state, so they are four jobs. Nothing is
+  # dropped -- the same commands run, and `required` still demands all of them.
+  #
+  # The cost is one Elixir setup per job instead of one for all four. That is
+  # billed minutes, not wall clock, and the split is worth roughly 4-5x the
+  # setup it adds.
+  #
+  # `cache-plt` is requested only by the Dialyzer job: the PLT is useless to
+  # the others and restoring it would put a cache download on their path.
+  core-test:
     needs: changes
     if: needs.changes.outputs.core == 'true'
     runs-on: ubuntu-latest
-    name: Core validation
-    timeout-minutes: 25
+    name: Core tests
+    timeout-minutes: 20
     env:
       MIX_ENV: test
       HEX_SPONSOR: false
@@ -253,23 +265,17 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Setup Java environment
-        uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: "21.0.11+10.0.LTS"
-
+      # No Java or Babashka here: every test that shells out to a JVM or to
+      # `bb` is tagged `:clojure` and excluded from `mix test` by default, so
+      # installing them would only slow the critical path down.
       - name: Setup Elixir environment
         uses: ./.github/actions/setup-elixir
+        with:
+          cache-plt: 'false'
+          install-babashka: 'false'
 
       - name: Compile
         run: mix compile --warnings-as-errors
-
-      - name: Check compile-time dependency cycles
-        run: mix xref graph --format cycles --label compile-connected --fail-above 0
-
-      - name: Check stable CLI transitional callers
-        run: mix run --no-start scripts/check_stable_cli_transition.exs
 
       # No `--trace` here, and none may be reintroduced: it sets `--max-cases`
       # to 1 (`Mix.Tasks.Test` docs; `ExUnit.max_cases/1`), which ran this
@@ -285,11 +291,43 @@ jobs:
       - name: Run tests
         run: mix test --max-failures 1 --warnings-as-errors
 
-      - name: Verify core release package
-        run: bash scripts/verify_core_package.sh
+  core-static:
+    needs: changes
+    if: needs.changes.outputs.core == 'true'
+    runs-on: ubuntu-latest
+    name: Core static analysis
+    timeout-minutes: 20
+    env:
+      MIX_ENV: test
+      HEX_SPONSOR: false
 
-      - name: Verify assembled standalone release
-        run: bash scripts/verify_standalone_release.sh
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      # `mix ptc.audit_upstream` reports SKIP and passes when it cannot find a
+      # `java` or a `bb`/`clojure`/`clj` executable -- it does not fail. Both
+      # toolchains must therefore stay on whichever job runs it, or the audit
+      # silently degrades into a no-op that still shows green.
+      - name: Setup Java environment
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "21.0.11+10.0.LTS"
+
+      - name: Setup Elixir environment
+        uses: ./.github/actions/setup-elixir
+        with:
+          cache-plt: 'false'
+
+      - name: Compile
+        run: mix compile --warnings-as-errors
+
+      - name: Check compile-time dependency cycles
+        run: mix xref graph --format cycles --label compile-connected --fail-above 0
+
+      - name: Check stable CLI transitional callers
+        run: mix run --no-start scripts/check_stable_cli_transition.exs
 
       - name: Check code is formatted
         run: mix format --check-formatted
@@ -311,11 +349,56 @@ jobs:
       - name: Audit upstream compatibility metadata
         run: mix ptc.audit_upstream
 
+      - name: Check unused dependencies
+        run: mix deps.unlock --check-unused
+
+  core-dialyzer:
+    needs: changes
+    if: needs.changes.outputs.core == 'true'
+    runs-on: ubuntu-latest
+    name: Core Dialyzer
+    timeout-minutes: 20
+    env:
+      MIX_ENV: test
+      HEX_SPONSOR: false
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Elixir environment
+        uses: ./.github/actions/setup-elixir
+        with:
+          install-babashka: 'false'
+
       - name: Dialyzer
         run: mix dialyzer --format github
 
-      - name: Check unused dependencies
-        run: mix deps.unlock --check-unused
+  core-release:
+    needs: changes
+    if: needs.changes.outputs.core == 'true'
+    runs-on: ubuntu-latest
+    name: Core release verification
+    timeout-minutes: 20
+    env:
+      MIX_ENV: test
+      HEX_SPONSOR: false
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Elixir environment
+        uses: ./.github/actions/setup-elixir
+        with:
+          cache-plt: 'false'
+          install-babashka: 'false'
+
+      - name: Verify core release package
+        run: bash scripts/verify_core_package.sh
+
+      - name: Verify assembled standalone release
+        run: bash scripts/verify_standalone_release.sh
 
   ex-dna-candidate:
     needs: changes
@@ -454,7 +537,10 @@ jobs:
     if: always()
     needs:
       - changes
-      - core
+      - core-test
+      - core-static
+      - core-dialyzer
+      - core-release
       - viewer
       - docs
       - mcp-stdio-launcher


### PR DESCRIPTION
Follow-up to #1255. `Core validation` ran tests, Dialyzer, release verification, and lint/staleness in series — 438 s, and the entire CI critical path, since every other job finishes in under two minutes.

Now four jobs: `core-test`, `core-static`, `core-dialyzer`, `core-release`.

**No gate dropped or weakened.** A diff of the `run:` commands before/after is empty (15 commands in, 15 out plus a second `mix compile`), and `required` now demands all four.

### Two load-bearing setup details
- `mix ptc.audit_upstream` reports **SKIP and exits 0** when no `java` or `bb`/`clojure`/`clj` is found (`check_java/0`, `check_clojure/0`). Putting it on a job without both would have made the audit a green no-op — so `core-static` keeps Java + the default Babashka install.
- `cache-plt` is requested only by `core-dialyzer`; restoring the PLT elsewhere would put a cache download on the critical path.
- `core-test` drops Java and Babashka: every test shelling out to a JVM or `bb` is `:clojure`-tagged and excluded.

### Expected
Critical path becomes the test job, ~155 s; whole run ~465 s → ~200 s. Trades one Elixir setup per job (billed minutes) for wall clock.

This PR's own run is the measurement.