### PR TITLE
fix(test): stop excluding :slow globally, add a narrow :nightly tag

### DIFF
--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -11,7 +11,8 @@ changes skip the expensive gate. Unknown paths select every gate, and
 `FORCE_FULL_PRE_PUSH=1` explicitly forces the complete gate.
 
 For an ordinary push, run `git push` and let the hook execute the complete gate
-once. Run `mix prepush` directly only to diagnose that portion of the gate or
+once. "Complete" excludes `:nightly` tests, which cost tens of seconds each and
+run in the `Nightly` workflow instead; everything else runs. Run `mix prepush` directly only to diagnose that portion of the gate or
 when hooks are unavailable; do not run it immediately before a normal
 `git push`.
 

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -403,7 +403,10 @@ run_project_gates() {
     return 0
   fi
 
-  echo "  ⏳ Running full test suite..."
+  # "except `:nightly`" is not a hedge: `:nightly` tests cost tens of seconds
+  # each and run in the `Nightly` workflow instead. Every other tag this hook
+  # would otherwise skip still runs here.
+  echo "  ⏳ Running the test suite (all but :nightly)..."
   local test_start=$SECONDS
   if ! mix test --exclude clojure "${TEST_OPTIONS[@]}" 2>&1; then
     echo "  ❌ Tests failed in $label. Re-run: (cd $proj && mix test --exclude clojure ${TEST_OPTIONS[*]})"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,13 +1,18 @@
-name: Slow
+name: Nightly
 
-# `:slow` tests are excluded from `mix test` by default and are not a per-PR
+# `:nightly` tests are excluded from `mix test` by default and are not a per-PR
 # gate. Each one compiles a project or drives a real subprocess, so they cost
 # seconds apiece and land on the serial side of the suite: three of them were
 # 40% of the 177.8 s `async: false` floor that set the PR suite's wall clock.
 #
-# They still have to run, and daily is the right cadence: unlike the weekly
-# soak suite their signal is a per-commit verdict, not a trend, so a break
-# should surface within a day of the commit that caused it.
+# They still have to run, and daily is the right cadence. The downstream-consumer
+# test is a genuine per-commit verdict, so a break should surface within a day of
+# the commit that caused it rather than a week; the benchmark's signal is a trend
+# and daily suits it too.
+#
+# Reserve `:nightly` for tests that cost tens of seconds. It is not a synonym for
+# `:slow`, which only skips the fast pre-commit path -- see `test/test_helper.exs`
+# for why conflating the two quietly dropped ten correctness tests from every PR.
 #
 # Like `soak.yml` this lives outside `test.yml` so it can be dispatched on its
 # own and so a red run never blocks an unrelated pull request.
@@ -20,13 +25,13 @@ permissions:
   contents: read
 
 concurrency:
-  group: slow-${{ github.ref }}
+  group: nightly-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
-  slow:
+  nightly:
     runs-on: ubuntu-latest
-    name: Slow tests
+    name: Nightly tests
     # The downstream-consumer test builds a fresh project under MIX_ENV=prod
     # against PtcRunner as a path dependency, so it pays a full cold compile
     # whenever the cached `_build` misses.
@@ -48,5 +53,5 @@ jobs:
       - name: Compile
         run: mix compile --warnings-as-errors
 
-      - name: Run the slow test suite
-        run: mix slow
+      - name: Run the nightly test suite
+        run: mix nightly

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,11 +73,18 @@ how it was verified.
   ExUnit concurrency.
 - `mix test --include e2e` — E2E tests (requires `OPENROUTER_API_KEY`;
   the MCP tests also require the local server described below).
-- `mix slow` — the `:slow` tests, excluded from `mix test` by default because
-  each compiles a project or drives a real subprocess. The nightly `Slow`
-  workflow runs them; run it locally when you touch a Mix task, the git hooks,
-  or the stdio transport. Never add `--trace` (or `--slowest`, which implies
-  it) to a suite you want to finish quickly: it pins `--max-cases` to 1.
+- `mix nightly` — the `:nightly` tests, excluded from `mix test` by default.
+  The `Nightly` workflow runs them daily; run it locally when you touch the
+  `mix ptc run` downstream path or the benchmark task. Never add `--trace` (or
+  `--slowest`, which implies it) to a suite you want to finish quickly: it
+  pins `--max-cases` to 1.
+- Two tags, two meanings, and they must not be conflated. `:nightly` means
+  "costs tens of seconds; excluded everywhere but the `Nightly` workflow" —
+  apply it sparingly, because it removes a test from every PR gate. `:slow`
+  means only "skip on the fast pre-commit path" and is read solely by
+  `.githooks/pre-commit`; those tests still run in `precommit`, pre-push, and
+  CI. Excluding `:slow` globally once dropped ten correctness tests from every
+  PR to save 14.2 s.
 - Fix all failures before committing/pushing.
 
 ### Fresh worktree setup

--- a/mix.exs
+++ b/mix.exs
@@ -87,7 +87,7 @@ defmodule PtcRunner.MixProject do
         prepush: :test,
         coverage: :test,
         soak: :test,
-        slow: :test
+        nightly: :test
       ]
     ]
   end
@@ -214,13 +214,13 @@ defmodule PtcRunner.MixProject do
       coverage: [
         "test --cover"
       ],
-      # Tests that compile a project or drive a real subprocess. Excluded from
-      # `mix test` by default (test/test_helper.exs) because a handful of them
-      # dominated the suite's serial wall clock; the nightly `Slow` workflow
-      # runs them. `--trace` is retained here: these tests exceed the default
-      # 60 s per-test timeout, and trace mode sets the timeout to `:infinity`.
-      slow: [
-        "test --only slow --trace"
+      # Tests costing tens of seconds each. Excluded from `mix test` by default
+      # (test/test_helper.exs); the `Nightly` workflow runs them. `--trace` is
+      # retained here and only here: these tests exceed the default 60 s
+      # per-test timeout, and trace mode sets the timeout to `:infinity`.
+      # Everywhere else `--trace` is a bug -- it pins `--max-cases` to 1.
+      nightly: [
+        "test --only nightly --trace"
       ],
       # Memory-leak soak suite. Excluded from `mix test` by default
       # (test/test_helper.exs) because it is long-running and its signal is a

--- a/test/mix/tasks/bench_check_test.exs
+++ b/test/mix/tasks/bench_check_test.exs
@@ -1,11 +1,12 @@
 defmodule Mix.Tasks.Bench.CheckTest do
   use ExUnit.Case, async: false
 
-  # `:slow` because both tests execute the real benchmark task rather than a
-  # stub: even at `--samples 1 --warmup 0` the module cost 24.0 s of the CI
-  # suite's 177.8 s serial floor, second only to the downstream-consumer
-  # build. The nightly `Slow` workflow runs it.
-  @moduletag :slow
+  # `:nightly` because both tests execute the real benchmark task rather than a
+  # stub: even at `--samples 1 --warmup 0` the module cost 25.5 s of the CI
+  # suite's 177.8 s serial floor, second only to the downstream-consumer build.
+  # A benchmark's per-commit signal is a trend, not a verdict, so the `Nightly`
+  # workflow is the right home for it.
+  @moduletag :nightly
 
   alias Mix.Tasks.Bench.Check
 

--- a/test/mix/tasks/ptc_run_downstream_test.exs
+++ b/test/mix/tasks/ptc_run_downstream_test.exs
@@ -11,13 +11,14 @@ defmodule Mix.Tasks.Ptc.RunDownstreamTest do
   # recompile it whenever the library sources change.
   @build_path Path.join(@root, "_build/downstream_consumer")
 
-  # `:slow` because the assertion is only observable through a real `mix ptc run`
-  # in a separate OS process against a real prod build. The cached build above
-  # holds a warm run to ~5.5 s, but the cache is per-worktree and PtcRunner is a
-  # path dependency, so a fresh clone or any library change pays the full
-  # compile: 36.4 s measured on a cold `_build/downstream_consumer`.
+  # `:nightly` because the assertion is only observable through a real
+  # `mix ptc run` in a separate OS process against a real prod build. The cached
+  # build above holds a warm run to ~5.5 s, but the cache is per-worktree and
+  # PtcRunner is a path dependency, so a fresh clone or any library change pays
+  # the full compile: 61.1 s measured on CI, where the cache misses on every
+  # library change. That is the single most expensive test in the suite.
   @tag :tmp_dir
-  @tag :slow
+  @tag :nightly
   test "starts only the PtcRunner core when a downstream project depends on req_llm", %{
     tmp_dir: dir
   } do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -13,13 +13,22 @@ end
 # - :clojure tests require Babashka and are excluded by default, run with --include clojure
 # - :soak tests are long-running memory soak tests, excluded by default.
 #   Run with: `mix test --only soak` (see test/soak/README.md)
-# - :slow tests cost seconds each because they compile a project or drive a
-#   real subprocess. They are excluded by default and run in the nightly
-#   `Slow` workflow with `mix slow`. Excluding them here rather than only in
-#   the pre-commit hook is what lets the per-PR suite run in parallel: the
-#   suite is 69% `async: false`, so its wall clock is a serial floor, and
-#   three `:slow` files were 40% of that floor.
-exclusions = [:skip, :e2e, :clojure, :soak, :slow]
+# - :nightly tests are excluded by default and run only in the `Nightly`
+#   workflow via `mix nightly`. Reserve the tag for tests whose cost is
+#   measured in tens of seconds: today the downstream-consumer build (61.1 s)
+#   and the benchmark task (25.5 s), which together were 40% of the CI suite's
+#   177.8 s `async: false` serial floor.
+#
+#   `:nightly` is deliberately NOT `:slow`. `:slow` means only "skip on the
+#   fast pre-commit path" and is consumed solely by `.githooks/pre-commit`;
+#   those tests still run in `precommit`, pre-push, and CI. Excluding `:slow`
+#   globally removed ten correctness tests -- cross-runtime append leases,
+#   hard-link lease aliasing, concurrent same-path appends, input-size
+#   bounding, and the pre-push gate's own tests -- from every PR gate to save
+#   14.2 s in total. That is the wrong trade, and it is why the two tags are
+#   separate: a tag that means "expensive" must not silently also mean
+#   "unverified on pull requests".
+exclusions = [:skip, :e2e, :clojure, :soak, :nightly]
 
 # Run clojure conformance tests: mix test --include clojure
 #


### PR DESCRIPTION
Fixes a coverage regression I introduced in #1255, found by codex review.

#1255 added `:slow` to the default ExUnit exclusions. That over-reached: `:slow` already meant "skip on the fast pre-commit path" and was read only by `.githooks/pre-commit`, whose comment said those tests still run in `precommit`, pre-push, and CI. Excluding it globally pulled **ten correctness tests** out of every PR gate — cross-runtime append leases, hard-link lease aliasing, concurrent same-path appends, input-size bounding, and the pre-push gate's own tests.

### The trade, measured
| moved out of the PR gate | cost |
|---|---|
| downstream-consumer build (1 test) | 61.1s |
| benchmark task (2 tests) | 25.5s |
| **the other 10 tests** | **14.2s** |

Ten correctness tests left the PR gate to buy 14 seconds.

### Fix
Two concerns, two tags:
- `:nightly` — costs tens of seconds; excluded everywhere but the `Nightly` workflow. Applied only to the two expensive files.
- `:slow` — back to meaning only "skip the fast pre-commit path".

A tag that means "expensive" must not silently also mean "unverified on pull requests".

`slow.yml` → `nightly.yml`; `mix slow` → `mix nightly`.

Also fixes two claims #1255 invalidated (codex P2): `.githooks/pre-push` announced a "full test suite", `.githooks/README.md` promised a "complete gate".

### Verified
- `mix test --include nightly` → 5958 passed
- default `mix test` → 5955 (= 5958 − 3) ✓
- `mix test --only slow` → exactly the 10 restored tests
- `mix nightly` → exactly 3

Net PR-gate cost of restoring them: ~14s on CI.