### PR TITLE
fix(cli): preserve standalone UTF-8 output

### DIFF
--- a/docs/guides/running-and-debugging.md
+++ b/docs/guides/running-and-debugging.md
@@ -284,6 +284,12 @@ suppresses, or replaces the command's normal terminal rendering.
 
 ### Stable standalone process contract
 
+One-shot stdout and stderr are UTF-8 streams. The runtime-included release
+writes their rendered text through its Unicode-mode terminal devices, so
+non-ASCII help, diagnostics, and JSON result strings retain their exact bytes.
+This presentation contract does not change the raw-byte treatment required by
+child stdio transports.
+
 When `--envelope` names a destination, the standalone `ptc` command additionally
 writes one V1 JSON command envelope there. When the arguments parse, every
 ordinary or caught path produces exactly one envelope — except a failure to

--- a/lib/ptc_runner/standalone_cli.ex
+++ b/lib/ptc_runner/standalone_cli.ex
@@ -21,8 +21,8 @@ defmodule PtcRunner.StandaloneCLI do
   @spec main([binary()]) :: no_return()
   def main(argv) do
     presentation = execute(argv)
-    if presentation.stdout != "", do: IO.binwrite(:stdio, presentation.stdout)
-    if presentation.stderr != "", do: IO.binwrite(:stderr, presentation.stderr)
+    if presentation.stdout != "", do: IO.write(:stdio, presentation.stdout)
+    if presentation.stderr != "", do: IO.write(:stderr, presentation.stderr)
     System.halt(presentation.exit_status)
   end
 end

--- a/scripts/verify_standalone_release.sh
+++ b/scripts/verify_standalone_release.sh
@@ -30,7 +30,7 @@ cat > "$application_root/ptc.json" <<'EOF'
     "components": [{"id": "smoke.main", "path": "main.clj"}],
     "entry": "smoke.main/run"
   },
-  "input": {"value": {"smoke": true}},
+  "input": {"value": {"city": "Malmö", "note": "café — 5 €"}},
   "providers": {"workflow": [], "mission": []}
 }
 EOF
@@ -90,6 +90,7 @@ grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$' "$release_tmp_dir/version.stdout"
 
 "$command_bin" help > "$release_tmp_dir/help.stdout"
 grep -q '^Usage:$' "$release_tmp_dir/help.stdout"
+grep -Fqx '  --help    — show root help' "$release_tmp_dir/help.stdout"
 for command in init validate run doctor models repl; do
   grep -q "ptc $command" "$release_tmp_dir/help.stdout"
   "$command_bin" help "$command" > "$release_tmp_dir/help-$command.stdout"
@@ -103,7 +104,7 @@ grep -qx 'created main.clj, ptc.json' "$release_tmp_dir/init.stdout"
 grep -q '"provider_activity":false' "$release_tmp_dir/validate.stdout"
 
 "$command_bin" run "$application_root/ptc.json" > "$release_tmp_dir/run.stdout"
-printf '%s\n' '{"smoke":true}' > "$release_tmp_dir/run.expected"
+printf '%s\n' '{"city":"Malmö","note":"café — 5 €"}' > "$release_tmp_dir/run.expected"
 cmp "$release_tmp_dir/run.expected" "$release_tmp_dir/run.stdout"
 
 envelope_path="$release_tmp_dir/run-envelope.json"


### PR DESCRIPTION
## Summary

- write standalone one-shot command presentations through Unicode-aware `IO.write/2`
- verify byte-exact non-ASCII help and JSON result output in the assembled release
- document the UTF-8 stdout/stderr contract without changing raw child-transport semantics

## Root cause

The release VM configures its standard devices for Unicode. `IO.binwrite/2` is the wrong API for encoded devices: already UTF-8 presentation binaries were interpreted byte-by-byte and re-encoded, producing valid-but-wrong JSON mojibake. The Mix frontend already used `IO.write/2`.

## Impact

Standalone `run`, help, validate, doctor, models, and init output now preserves non-ASCII text exactly on stdout and stderr. Artifact file publication and MCP stdio raw-byte paths are unchanged.

Fixes #1244.

## Review

One cumulative, base-guarded independent Codex review completed with no actionable findings.

## Validation

- regression reproduced before the implementation change with `bash scripts/verify_standalone_release.sh`
- assembled-release regression passed after the fix, including `Malmö`, `café — 5 €`, and the help em dash
- `MIX_ENV=dev mix docs --warnings-as-errors`
- focused rerun of the one scheduler-sensitive OAuth test passed
- `PTC_PRE_PUSH_MAX_CASES=2 git push -u origin codex/issue-1244` passed the complete pre-push gate:
  - 5,945 root tests
  - generated documentation/schema and conformance checks
  - upstream audit, Credo, Dialyzer, and unused-dependency checks
  - 72 Viewer tests
  - 40 launcher tests plus package/containment checks
