### PR TITLE
fix(agent): fail fast on refused subordinate evaluation

### DIFF
--- a/docs/guides/building-agents.md
+++ b/docs/guides/building-agents.md
@@ -155,6 +155,14 @@ the workflow. This distinction prevents a candidate crash from disappearing
 while also preventing a provider outage from being scored against a candidate.
 `run-value` retains its existing fail-on-subject-failure behavior.
 
+A subordinate evaluation that is never admitted is one of those host failures.
+A run holds a single evaluation lease, so a second concurrent
+`kernel/eval-source` is refused while the first is running, as is any
+evaluation once `subordinate_evaluations` is spent. The loop fails the workflow
+as `evaluation-unavailable` and does not spend a turn or another model call on
+it — the model cannot rewrite its program to clear either condition. Agent
+loops running concurrently under `pcalls` therefore fail fast on contention.
+
 ### The prompt is a separate policy seam
 
 `agent.prompt` owns the system text independently of the retry and evaluation

--- a/docs/guides/kernel-maintainer.md
+++ b/docs/guides/kernel-maintainer.md
@@ -963,6 +963,20 @@ mission capability, and mutate no continuation. Source is bounded before it is
 hashed; an oversized request exposes only its byte count. The trusted-tool
 ledger likewise retains only source identity for accepted-size requests.
 
+A run holds exactly one evaluation lease. `RunState.reserve_evaluation/1`
+refuses admission with `:busy` while another caller holds it, and with
+`:limit_exceeded` once `subordinate_evaluations` is spent; a refusal charges no
+budget. Both are host conditions rather than anything a generated program did,
+so callers must not present them to a model as a correctable program error.
+The shipped `agent.core` loop fails the outer workflow as
+`evaluation-unavailable` instead of spending a turn. That makes concurrent
+agent loops under `pcalls` fail fast on contention rather than serialize: the
+provider call happens outside the lease, so branches overlap freely until they
+reach `kernel/eval-source`. Admission is deliberately not queued — queuing
+requires an absolute caller deadline that `reserve_evaluation/1` does not yet
+receive, and without one a queued branch would spend the parallel deadline
+waiting.
+
 Each `PtcRunner.Kernel.Capability` freezes its public identity, effect,
 visibility, bounded schemas, validator, and trusted callback. Environment
 membership grants authority; descriptions and remote annotations do not.

--- a/docs/guides/running-and-debugging.md
+++ b/docs/guides/running-and-debugging.md
@@ -453,8 +453,9 @@ failure taxonomy that keeps a classification and discards everything else:
 
 The known failure kinds are `invalid-input`, `invalid-prompt`,
 `invalid-transcript`, `transcript-limit`, `turn-limit`, `model-program-failed`,
-`non-retryable-evaluation`, `llm-provider-error`, `protocol-error`,
-`provider-error`, `capability-error`, `assertion-failed`, and `unknown-action`.
+`non-retryable-evaluation`, `evaluation-unavailable`, `llm-provider-error`,
+`protocol-error`, `provider-error`, `capability-error`, `assertion-failed`, and
+`unknown-action`.
 
 So `(fail "the invoice total did not balance")` publishes nothing, while
 `(fail {:kind "assertion-failed" :detail "the invoice total did not balance"})`

--- a/lib/ptc_runner/kernel/safe_metadata.ex
+++ b/lib/ptc_runner/kernel/safe_metadata.ex
@@ -29,6 +29,7 @@ defmodule PtcRunner.Kernel.SafeMetadata do
     turn-limit
     model-program-failed
     non-retryable-evaluation
+    evaluation-unavailable
     llm-provider-error
     protocol-error
     provider-error

--- a/priv/preludes/kernel/agent.core.clj
+++ b/priv/preludes/kernel/agent.core.clj
@@ -150,6 +150,18 @@
                                next-prompt-state
                                closing?))
                       (subject-failure :turn-limit :intermediate-result))
+
+                    ;; A refused admission is a host condition, not something
+                    ;; the model wrote: either another caller holds the run's
+                    ;; single evaluation lease, or the run has spent its
+                    ;; evaluation budget. Correcting the program cannot clear
+                    ;; either one, so this fails the outer workflow rather than
+                    ;; spending a turn and a model call on feedback the model
+                    ;; cannot act on.
+                    (:busy :limit_exceeded)
+                    (fail (result/error :evaluation-unavailable
+                                        (get evaluation :reason)))
+
                     (if (false? (get evaluation :retryable?))
                       ;; An unsafe failure forbids repeating the program, not
                       ;; salvaging the run. Spend one closing turn asking for a

--- a/test/ptc_runner/kernel/agent_evaluation_contention_test.exs
+++ b/test/ptc_runner/kernel/agent_evaluation_contention_test.exs
@@ -1,0 +1,150 @@
+defmodule PtcRunner.Kernel.AgentEvaluationContentionTest do
+  @moduledoc """
+  The agent loop must not treat a refused subordinate evaluation as a
+  correctable model-program error.
+
+  `RunState.reserve_evaluation/1` refuses admission when another evaluation
+  holds the run's single lease (`:busy`) or when the run has spent its
+  `subordinate_evaluations` budget (`:limit_exceeded`). Neither is anything the
+  model wrote, so neither may be fed back as feedback or spend a turn.
+  """
+  use ExUnit.Case, async: true
+
+  alias PtcRunner.Kernel
+  alias PtcRunner.Kernel.Capability
+  alias PtcRunner.Kernel.EventSink
+  alias PtcRunner.Kernel.Library
+  alias PtcRunner.Kernel.Limits
+  alias PtcRunner.Kernel.LLMCapability
+  alias PtcRunner.Kernel.MissionEnvironment
+  alias PtcRunner.Kernel.RunConfig
+  alias PtcRunner.Kernel.WorkflowEnvironment
+
+  test "an exhausted evaluation budget fails the workflow instead of spending another turn" do
+    {:ok, counter} = Agent.start_link(fn -> 0 end)
+
+    requester = fn _request ->
+      Agent.update(counter, &(&1 + 1))
+
+      {:ok,
+       %{
+         content: nil,
+         tool_calls: [
+           %{id: "c1", name: "run_ptc_lisp", args: %{"program" => "(return 42)"}}
+         ]
+       }}
+    end
+
+    {:ok, config, sink} = build_config(requester, [], subordinate_evaluations: 1)
+
+    # The workflow spends the run's only subordinate evaluation before the agent
+    # starts, so the agent's first `kernel/eval-source` is refused admission.
+    source = ~S"""
+    (do
+      (kernel/eval-source "(return 1)")
+      (return (agent.core/run-value "task" {"max_turns" 4})))
+    """
+
+    assert {:error, error} = Kernel.run(source, config)
+
+    assert error.kind == :workflow_failed
+    assert error.reason == :explicit_failure
+
+    assert error.details[:failure_kind] == "evaluation-unavailable",
+           "expected a typed host failure, got #{inspect(error.details)}"
+
+    assert Agent.get(counter, & &1) == 1,
+           "contention must not spend another model call"
+
+    refute Enum.any?(EventSink.events(sink), fn event ->
+             event.type == "workflow-annotation" and event.data[:data]["turn"] == 1
+           end),
+           "contention must not open a second agent turn"
+  end
+
+  test "four concurrent agent loops do not retry against a held evaluation lease" do
+    {:ok, counter} = Agent.start_link(fn -> 0 end)
+
+    requester = fn _request ->
+      Agent.update(counter, &(&1 + 1))
+
+      {:ok,
+       %{
+         content: nil,
+         tool_calls: [
+           %{
+             id: "c1",
+             name: "run_ptc_lisp",
+             args: %{"program" => "(return (tool/hold {}))"}
+           }
+         ]
+       }}
+    end
+
+    # Whichever branch wins the single evaluation lease parks inside this
+    # mission capability, so the other three deterministically meet `:busy`.
+    # It is released by run teardown, not by a timer.
+    {:ok, hold} =
+      Capability.new(
+        name: "hold",
+        description: "Holds the evaluation lease until the run tears down.",
+        input_schema: %{"type" => "object"},
+        callback: fn _args ->
+          receive do
+            :release -> {:ok, %{"held" => true}}
+          after
+            30_000 -> {:error, :hold_never_released}
+          end
+        end
+      )
+
+    {:ok, config, _sink} = build_config(requester, [hold], [])
+
+    source = ~S"""
+    (return
+      (pcalls
+        #(agent.core/run-value "task 1" {"max_turns" 2})
+        #(agent.core/run-value "task 2" {"max_turns" 2})
+        #(agent.core/run-value "task 3" {"max_turns" 2})
+        #(agent.core/run-value "task 4" {"max_turns" 2})))
+    """
+
+    assert {:error, error} = Kernel.run(source, config)
+    assert error.kind == :workflow_failed
+
+    assert Agent.get(counter, & &1) <= 4,
+           "each agent may ask the model once; contention must not buy extra turns"
+  end
+
+  defp build_config(requester, mission_capabilities, limit_overrides) do
+    {:ok, llm} = LLMCapability.new(requester: requester)
+
+    names =
+      ~w(agent.core agent.feedback agent.native agent.prompt agent.retry
+         kernel llm result workflow.event)
+
+    {:ok, components} = Library.components(names)
+    {:ok, bundle} = Kernel.compile_bundle(components)
+    {:ok, workflow} = WorkflowEnvironment.new(bundle: bundle, capabilities: [llm])
+    {:ok, mission} = MissionEnvironment.new(capabilities: mission_capabilities)
+
+    limit_overrides =
+      limit_overrides
+      |> Keyword.put_new(:evaluation_timeout_ms, 5_000)
+      |> Keyword.put_new(:run_duration_ms, 60_000)
+
+    {:ok, limits} = Limits.new(limit_overrides)
+    {:ok, sink} = EventSink.start(:normal, limits, run_id: "agent-contention")
+
+    {:ok, config} =
+      RunConfig.new(
+        workflow_environment: workflow,
+        mission_environment: mission,
+        input: %{},
+        limits: limits,
+        event_sink: sink
+      )
+
+    {:ok, config, sink}
+  end
+end


### PR DESCRIPTION
Step 1 of the revised plan for #1241: make evaluation contention a typed, fail-fast host failure. Steps 2–4 (instrument the 150 s hang, thread an absolute deadline into admission, then evaluate a bounded queue) stay open.

## The defect

A run holds exactly one evaluation lease. `RunState.reserve_evaluation/1` refuses admission with `:busy` while another caller holds it (`run_state.ex:467`), and with `:limit_exceeded` once `subordinate_evaluations` is spent (`:470`). `Evaluation` turns both into result maps carrying no `:retryable?` key (`evaluation.ex:178`, `:689`).

`agent.core` had no clause for either outcome, so both fell into the default branch (`agent.core.clj:153`), where `(false? (get evaluation :retryable?))` is false. Runtime contention was therefore handed to the model as a correctable program error via `agent.feedback/evaluation-error` — spending a turn and another model call on a fault no rewritten program can clear — and the loop finally reported `turn-limit`, misattributing a host condition to the subject. That contradicts `run-outcome*`'s own documented contract, which says quota and host failures fail the outer workflow.

Under `pcalls` the eventual `fail` also raises, and the raise reaches the caller as an opaque `pcalls_error`/`private_prelude_error` — which is why the issue's symptom hid its own cause.

## The change

- `priv/preludes/kernel/agent.core.clj` — `:busy` and `:limit_exceeded` now fail the outer workflow as `evaluation-unavailable`, before any feedback or turn accounting.
- `lib/ptc_runner/kernel/safe_metadata.ex` — `evaluation-unavailable` joins the public failure taxonomy, so the classification survives sanitization instead of being fingerprinted away.
- Guides updated: the failure-kind list, the agent-loop host-failure contract, and the lease's exclusivity and non-queuing rationale.

Admission is deliberately **not** queued. Queuing is only safe once admission receives an absolute caller deadline bounded by `min(pcalls_deadline, evaluation_deadline, run_deadline)`, with dead callers evicted, quota charged only on grant, and a distinct `:evaluation_admission_timeout`. `reserve_evaluation/1` receives no such deadline today, and with two live agents already measured at 4.1 s of a fixed 5 s parallel deadline, a queue would predictably spend that deadline waiting and obscure the hang under investigation.

## Behavior change worth calling out

The old retry path was an accidental, model-mediated retry-on-contention that let three and four concurrent loops *sometimes* succeed. They now fail deterministically. Measured on the issue's credential-free repro (150 ms simulated latency), `llm-request` counts show the difference:

| agents | before | after |
| --- | --- | --- |
| 2 | OK | OK |
| 3 | OK (retry hidden) | fail fast, 3 requests |
| 4 | OK (retry hidden) | fail fast, 4 requests |
| 8 | ERROR, 14 requests | fail fast, 8 requests |

Exactly one model call per agent after the change — contention buys no extra turns.

## Known remaining gap

Outside `pcalls` the public envelope now carries `failure_kind: "evaluation-unavailable"`. Inside `pcalls`, `fail` still degrades to `{:pcalls_error, i, "fail called inside pcalls"}` because `classify_worker_failure/3` discards the fail value (`parallel.ex:224`). The cause is typed at the source but still coarse at the parallel boundary; that is pre-existing language semantics, listed in #1241 as a related constraint, and left for its own change.

## Verification

Two regression tests in `test/ptc_runner/kernel/agent_evaluation_contention_test.exs`, both failing before the change:

- exhausted evaluation budget — deterministic, no concurrency; asserted `failure_kind: "turn-limit"` after **four** model calls before, `evaluation-unavailable` after **one** now.
- four concurrent agent loops against a lease held by a mission capability until teardown; asserts no agent buys extra turns.

Full `mix precommit` run (Elixir 1.20.2 / OTP 29.0.3, matching CI): format, no compile cycles, credo strict, duplication unchanged (`new=0`), conformance artifacts verified, Viewer 72 passed, launcher 40 passed, core-package and standalone release verified, `mix docs --warnings-as-errors` clean.

Three failures reproduce **on a clean tree** in this container and are unrelated: `MCPHTTPAdapterTest` IPv6 (no IPv6 here), `ReplFrontendTest` profile persistence, and `CoreContractTest` bundle-compile which times out under load. I could not run the live-model path, so nothing here speaks to the 150 s hang.

Refs #1241

---
_Generated by [Claude Code](https://claude.ai/code/session_01WDERDw2r5H8KmtEoxa2PSV)_