### PR TITLE
fix(scripts): pin the core-package check to the prod build

### DIFF
--- a/scripts/verify_core_package.sh
+++ b/scripts/verify_core_package.sh
@@ -64,9 +64,23 @@ done
 cp "$project_root/mix.lock" "$package_tmp_dir/source/mix.lock"
 mkdir -p "$package_tmp_dir/build/lib"
 
-active_build_lib="$project_root/_build/${MIX_ENV:-dev}/lib"
-test -d "$active_build_lib"
-test -d "$active_build_lib/jason"
+# The packaged source is compiled at `prod` below, so its dependency beams
+# must come from the project's own `prod` build — and this script has to build
+# that itself. Ambient MIX_ENV must not choose it: `mix precommit` runs at
+# `test` and `mix cmd` exports no MIX_ENV, so `_build/${MIX_ENV:-dev}` checked
+# whichever environment the caller's shell happened to have compiled, and in a
+# worktree that had only ever run the gate it failed with no diagnosis.
+# `verify_standalone_release.sh` builds the same tree next, so this is paid
+# once.
+build_env=prod
+MIX_ENV="$build_env" mix deps.compile
+
+active_build_lib="$project_root/_build/$build_env/lib"
+
+if [[ ! -d "$active_build_lib/jason" ]]; then
+  echo "no compiled $build_env dependencies at $active_build_lib" >&2
+  exit 1
+fi
 
 for dependency in "$active_build_lib"/*; do
   name="$(basename "$dependency")"


### PR DESCRIPTION
## The defect

`scripts/verify_core_package.sh` built its dependency symlink farm from:

```bash
active_build_lib="$project_root/_build/${MIX_ENV:-dev}/lib"
test -d "$active_build_lib"
test -d "$active_build_lib/jason"
```

Nothing sets `MIX_ENV` for this script. `mix precommit` runs at `test` (`preferred_cli_env`), and `mix cmd` does not export `MIX_ENV` to its child — verified empirically, not assumed. So the check read whichever environment the caller's shell happened to have compiled last.

Two consequences:

1. **In a worktree that has only ever run the gate there is no `_build/dev`.** The script exits 1 from a bare `test -d` with no output — indistinguishable from a genuinely missing dependency, and reported as one.
2. **Re-running it from a shell with a warm dev build "passes" — but it is not a rerun of the same check.** A different `MIX_ENV` means a different `_build/<env>/lib`, hence a different dep set handed to the final `MIX_ENV=prod mix compile` (`ex_doc` is dev-only; `credo`/`ex_slop`/`stream_data` are dev+test; none are prod). Same bytes, different subject. So "it passes in a fresh process" could never establish that the failure was false.

CI has the same hole from the other side: `core-release` sets `MIX_ENV: test` at the job level, so it has been compiling the packaged source against **test-env** dependency beams — not what a consumer gets.

## The fix

Pin the source tree to `prod` and compile it in the script:

```bash
build_env=prod
MIX_ENV="$build_env" mix deps.compile
```

`prod` is the environment the packaged source is compiled at ten lines below, and the one consumers build against. `verify_standalone_release.sh` builds the same prod tree on the next line of the alias, so the compile is paid once and reused rather than added — in CI the two steps now agree on what they verify. The missing-deps guard now names what it could not find instead of exiting silently.

## Verification

Reproduced first in a **cold worktree with no `_build` at all** — the exact state that produced the silent failure — then re-ran after the fix:

| ambient `MIX_ENV` | before | after |
|---|---|---|
| unset | exit 1, no output | exit 0 |
| `test` | exit 1 (no `_build/test` yet in a cold tree) | exit 0 |
| `dev` | exit 1 (no `_build/dev` yet in a cold tree) | exit 0 |

All three now produce only `_build/prod`, so the outcome no longer depends on the caller's environment. `shellcheck` clean.

Not run: full `mix precommit`. No Elixir source is touched; the change is confined to this script, which was exercised end-to-end four times.