### PR TITLE
feat(kernel): give the envelope span field a producer

### DIFF
--- a/docs/guides/kernel-maintainer.md
+++ b/docs/guides/kernel-maintainer.md
@@ -605,6 +605,18 @@ retain their workflow or mission occurrence.
 A non-null byte span is admitted only when its
 `CommandSource` was constructed with the exact trusted source bytes and the
 exclusive end offset is within that retained byte bound.
+Component compilation is the one producer of that span. When the prelude
+compiler can attribute a failure to a single top-level form,
+`PtcRunner.Lisp.Prelude.ErrorSpan` resolves that form's byte range from the raw
+component text, and `bundle/compile_failed` carries it against provenance bound
+to the same bytes. Failures no single form owns — parse errors, whole-bundle
+limits — keep the null span. Spans are best-effort by design: an unresolvable
+one is dropped rather than guessed, because a wrong range points a reader at
+innocent code.
+`notes` stays pinned to the empty list. The published V1 schema fixes it as
+`{"const": []}`, so any populated array makes an envelope invalid for a strict
+V1 consumer; a diagnostic that has to report a rejected value against its bound
+needs a later envelope version, not a relaxed V1.
 The command-specific host loader preserves closed phase-2 causes instead of
 projecting every failure to `host_invalid`: inaccessible files are
 `host_unavailable`, invalid bytes/JSON are `host_invalid`, structural failures

--- a/lib/ptc_runner/kernel/bundle_compiler.ex
+++ b/lib/ptc_runner/kernel/bundle_compiler.ex
@@ -13,6 +13,7 @@ defmodule PtcRunner.Kernel.BundleCompiler do
   alias PtcRunner.Kernel.FrozenBundle
   alias PtcRunner.Lisp.Parser
   alias PtcRunner.Lisp.Prelude.Compiler
+  alias PtcRunner.Lisp.Prelude.ValidationError
 
   @bundle_hash_domain <<"ptc.frozen-bundle.v2", 0>>
   @max_components 128
@@ -228,7 +229,8 @@ defmodule PtcRunner.Kernel.BundleCompiler do
             %{
               reason: :component_compile_error,
               id: component.id,
-              details: error_message(error)
+              details: error_message(error),
+              span: failure_span(error, component.source)
             }}}
       end
     end)
@@ -344,4 +346,15 @@ defmodule PtcRunner.Kernel.BundleCompiler do
     do: String.slice(message, 0, 4_096)
 
   defp error_message(error), do: inspect(error, limit: 10, printable_limit: 4_096)
+
+  # The byte range of the top-level form the compiler blamed, in the exclusive
+  # end-offset form command diagnostics carry. Bounded against the component's
+  # own source so a diagnostic can never claim a range the source cannot hold;
+  # anything unlocatable stays `nil`, exactly as before.
+  defp failure_span(%ValidationError{span: {offset, length}}, source)
+       when is_binary(source) and offset >= 0 and length >= 0 and
+              offset + length <= byte_size(source),
+       do: %{start_byte: offset, end_byte: offset + length}
+
+  defp failure_span(_error, _source), do: nil
 end

--- a/lib/ptc_runner/kernel/command_diagnostic.ex
+++ b/lib/ptc_runner/kernel/command_diagnostic.ex
@@ -6,6 +6,11 @@ defmodule PtcRunner.Kernel.CommandDiagnostic do
   Contract-authorized paths must also match the sealed contract authority bound
   to their source classification. Rendering never inspects a lower-level
   reason or rejected value.
+
+  `notes` is reserved and always empty: the published V1 envelope schema pins
+  it to `{"const": []}`, so a populated array would invalidate the envelope for
+  every strict V1 consumer. Reporting a rejected value against the bound it
+  broke is a later-version change, not a producer-side one.
   """
 
   alias PtcRunner.Kernel.CommandPath

--- a/lib/ptc_runner/kernel/run_coordinator.ex
+++ b/lib/ptc_runner/kernel/run_coordinator.ex
@@ -259,16 +259,19 @@ defmodule PtcRunner.Kernel.RunCoordinator do
   defp bundle_diagnostic(failure, components),
     do: diagnostic(:bundle, :bundle_invalid, source_opts(failure, components))
 
-  defp source_opts(%{id: id}, components) when is_binary(id) do
+  defp source_opts(%{id: id} = failure, components) when is_binary(id) do
     case Enum.find(components, &match?(%Component{id: ^id}, &1)) do
-      %Component{} = component -> component_source_opts(component)
+      %Component{} = component -> component_source_opts(component, Map.get(failure, :span))
       nil -> []
     end
   end
 
   defp source_opts(_failure, _components), do: []
 
-  defp component_source_opts(%Component{id: id, origin: origin}) do
+  # Provenance is bound to the exact component bytes the compiler read, which
+  # is what admits a span at all: `CommandDiagnostic` refuses one whose end
+  # offset exceeds the source's attested byte bound.
+  defp component_source_opts(%Component{id: id, origin: origin, source: bytes}, span) do
     name =
       cond do
         ApplicationSource.valid_name?(origin) -> origin
@@ -281,10 +284,17 @@ defmodule PtcRunner.Kernel.RunCoordinator do
         []
 
       safe_name ->
-        {:ok, source} = CommandSource.new(:component, safe_name)
-        [source: source]
+        source = CommandSource.with_bytes(:component, safe_name, bytes)
+        [source: source] ++ span_opts(span, bytes)
     end
   end
+
+  defp span_opts(%{start_byte: start_byte, end_byte: end_byte}, bytes)
+       when is_integer(start_byte) and is_integer(end_byte) and start_byte >= 0 and
+              end_byte >= start_byte and end_byte <= byte_size(bytes),
+       do: [span: %{start_byte: start_byte, end_byte: end_byte}]
+
+  defp span_opts(_span, _bytes), do: []
 
   @doc false
   @spec validate_entry(PtcRunner.Kernel.FrozenBundle.t(), binary()) ::

--- a/lib/ptc_runner/lisp/prelude/compiler.ex
+++ b/lib/ptc_runner/lisp/prelude/compiler.ex
@@ -36,6 +36,7 @@ defmodule PtcRunner.Lisp.Prelude.Compiler do
   alias PtcRunner.Lisp.Eval
   alias PtcRunner.Lisp.Parser
   alias PtcRunner.Lisp.Prelude
+  alias PtcRunner.Lisp.Prelude.ErrorSpan
   alias PtcRunner.Lisp.Prelude.Export
   alias PtcRunner.Lisp.Prelude.Spec
   alias PtcRunner.Lisp.Prelude.ValidationError
@@ -75,6 +76,13 @@ defmodule PtcRunner.Lisp.Prelude.Compiler do
   def compile(source, opts \\ [])
 
   def compile(source, opts) when is_binary(source) and is_list(opts) do
+    case compile_source(source, opts) do
+      {:ok, prelude} -> {:ok, prelude}
+      {:error, %ValidationError{} = error} -> {:error, ErrorSpan.resolve(error, source)}
+    end
+  end
+
+  defp compile_source(source, opts) do
     with {:ok, {:program, forms}} <- parse(source),
          {:ok, specs, ns_meta} <- collect_specs(forms),
          :ok <- validate_spec_effects(specs),
@@ -364,11 +372,16 @@ defmodule PtcRunner.Lisp.Prelude.Compiler do
   defp collect_specs(forms) do
     initial = %{current_ns: nil, ns_meta: %{}, specs: []}
 
+    # Tagging the offending form's position HERE, rather than at each of the
+    # ~30 error sites below, is what lets `ErrorSpan` turn any walk-phase
+    # failure into a byte span without every site knowing its own position.
     forms
-    |> Enum.reduce_while({:ok, initial}, fn form, {:ok, acc} ->
+    |> Enum.with_index()
+    |> Enum.reduce_while({:ok, initial}, fn {form, index}, {:ok, acc} ->
       case handle_form(form, acc) do
         {:ok, acc2} -> {:cont, {:ok, acc2}}
-        {:error, _} = err -> {:halt, err}
+        {:error, %ValidationError{} = error} -> {:halt, {:error, %{error | form_index: index}}}
+        {:error, _other} = err -> {:halt, err}
       end
     end)
     |> case do

--- a/lib/ptc_runner/lisp/prelude/error_span.ex
+++ b/lib/ptc_runner/lisp/prelude/error_span.ex
@@ -1,0 +1,109 @@
+defmodule PtcRunner.Lisp.Prelude.ErrorSpan do
+  @moduledoc ~S"""
+  Resolves a `%PtcRunner.Lisp.Prelude.ValidationError{}` to the byte span of
+  the top-level form it blames.
+
+  `PtcRunner.Lisp.Prelude.Compiler` walks PARSED forms, which carry no source
+  positions; `PtcRunner.Lisp.Prelude.FormScanner` walks the RAW TEXT and
+  carries nothing else. This module is the single seam between them, applied
+  once at the compile boundary so no error site has to know about byte offsets.
+
+  ## How a failure is located
+
+  In order of precision, using whichever locator the error already carries:
+
+    1. `form_index` — the position of the top-level form the compiler was
+       processing. `FormScanner.scan/1` cross-checks its own form list against
+       `PtcRunner.Lisp.Parser` head-by-head and refuses to return at all on any
+       disagreement, so a successful scan is positionally aligned with the
+       parsed forms the compiler walked. That check is what makes indexing by
+       position safe.
+    2. `ref` (`"namespace/symbol"`) — for failures raised after the walk, when
+       only the offending definition is known. Resolved to the first `def`,
+       `defn`, or `defn-` form with that name under that namespace.
+    3. `namespace` — resolved to the `(ns ...)` form that declares it.
+
+  Resolution is best-effort and always fails OPEN to `nil`: a source this
+  module cannot scan, an out-of-range index, or an unresolvable name leaves
+  the error exactly as it was. A diagnostic without a span is the status quo;
+  a diagnostic with a WRONG span would point a reader at innocent code.
+  """
+
+  alias PtcRunner.Lisp.Prelude.FormScanner
+  alias PtcRunner.Lisp.Prelude.ValidationError
+
+  @naming_heads ["def", "defn", "defn-"]
+
+  @doc """
+  Returns `error` with `span` filled in when the offending top-level form can
+  be located in `source`, and unchanged otherwise.
+  """
+  @spec resolve(ValidationError.t(), binary()) :: ValidationError.t()
+  def resolve(%ValidationError{} = error, source) when is_binary(source) do
+    if locatable?(error) do
+      case FormScanner.scan(source) do
+        {:ok, %{forms: forms}} -> %{error | span: locate(error, forms)}
+        {:error, _reason} -> error
+      end
+    else
+      error
+    end
+  end
+
+  defp locatable?(%ValidationError{form_index: index, ref: ref, namespace: namespace}),
+    do: not is_nil(index) or not is_nil(ref) or not is_nil(namespace)
+
+  defp locate(%ValidationError{form_index: index}, forms) when is_integer(index) do
+    case Enum.at(forms, index) do
+      %{span: span} -> span
+      nil -> nil
+    end
+  end
+
+  defp locate(%ValidationError{ref: ref, namespace: namespace}, forms) do
+    case split_ref(ref) do
+      {ref_namespace, symbol} -> definition_span(forms, ref_namespace, symbol)
+      nil -> namespace_span(forms, namespace)
+    end
+  end
+
+  # A ref is always built as "namespace/symbol", and neither part can itself
+  # contain a "/" — a qualified symbol is not a legal definition name.
+  defp split_ref(ref) when is_binary(ref) do
+    case String.split(ref, "/") do
+      [namespace, symbol] when namespace != "" and symbol != "" -> {namespace, symbol}
+      _other -> nil
+    end
+  end
+
+  defp split_ref(_ref), do: nil
+
+  # Definitions belong to the namespace opened by the closest preceding
+  # `(ns ...)` form, mirroring the compiler's `current_ns` walk.
+  defp definition_span(forms, namespace, symbol) do
+    forms
+    |> Enum.reduce_while(nil, fn form, current_ns ->
+      cond do
+        form.head == "ns" -> {:cont, form.name}
+        current_ns == namespace and definition?(form, symbol) -> {:halt, form.span}
+        true -> {:cont, current_ns}
+      end
+    end)
+    |> case do
+      {_offset, _length} = span -> span
+      _unresolved -> nil
+    end
+  end
+
+  defp definition?(%{head: head, name: name}, symbol),
+    do: head in @naming_heads and name == symbol
+
+  defp namespace_span(_forms, nil), do: nil
+
+  defp namespace_span(forms, namespace) do
+    case Enum.find(forms, &(&1.head == "ns" and &1.name == namespace)) do
+      %{span: span} -> span
+      nil -> nil
+    end
+  end
+end

--- a/lib/ptc_runner/lisp/prelude/error_span.ex
+++ b/lib/ptc_runner/lisp/prelude/error_span.ex
@@ -19,8 +19,13 @@ defmodule PtcRunner.Lisp.Prelude.ErrorSpan do
        parsed forms the compiler walked. That check is what makes indexing by
        position safe.
     2. `ref` (`"namespace/symbol"`) — for failures raised after the walk, when
-       only the offending definition is known. Resolved to the first `def`,
-       `defn`, or `defn-` form with that name under that namespace.
+       only the offending definition is known. Resolved to the `def`, `defn`,
+       or `defn-` form with that name under that namespace, but only when
+       exactly one form matches: a name is unique only once duplicates have
+       been rejected, and some ref-carrying failures are raised before that
+       check runs. `:duplicate_ref` is the one exception, because it IS the
+       duplicate report — it resolves to the last matching form, the
+       redefinition that collided.
     3. `namespace` — resolved to the `(ns ...)` form that declares it.
 
   Resolution is best-effort and always fails OPEN to `nil`: a source this
@@ -53,16 +58,20 @@ defmodule PtcRunner.Lisp.Prelude.ErrorSpan do
   defp locatable?(%ValidationError{form_index: index, ref: ref, namespace: namespace}),
     do: not is_nil(index) or not is_nil(ref) or not is_nil(namespace)
 
-  defp locate(%ValidationError{form_index: index}, forms) when is_integer(index) do
+  # `Enum.at/2` counts a negative index from the END of the list, which would
+  # turn a nonsense index into a valid-looking span for an unrelated form.
+  defp locate(%ValidationError{form_index: index}, forms) when is_integer(index) and index >= 0 do
     case Enum.at(forms, index) do
       %{span: span} -> span
       nil -> nil
     end
   end
 
-  defp locate(%ValidationError{ref: ref, namespace: namespace}, forms) do
+  defp locate(%ValidationError{form_index: index}, _forms) when is_integer(index), do: nil
+
+  defp locate(%ValidationError{reason: reason, ref: ref, namespace: namespace}, forms) do
     case split_ref(ref) do
-      {ref_namespace, symbol} -> definition_span(forms, ref_namespace, symbol)
+      {ref_namespace, symbol} -> definition_span(reason, forms, ref_namespace, symbol)
       nil -> namespace_span(forms, namespace)
     end
   end
@@ -78,21 +87,32 @@ defmodule PtcRunner.Lisp.Prelude.ErrorSpan do
 
   defp split_ref(_ref), do: nil
 
+  # A ref names a definition, and a name is only unique once the compiler has
+  # rejected duplicates — a check that runs AFTER some ref-carrying failures.
+  # So resolve a ref only when it matches exactly one definition. The one
+  # exception is the duplicate itself: `:duplicate_ref` exists precisely
+  # because the name was redefined, and the redefinition is the later form.
+  defp definition_span(reason, forms, namespace, symbol) do
+    case definition_spans(forms, namespace, symbol) do
+      [span] -> span
+      [_first | _rest] = spans when reason == :duplicate_ref -> List.last(spans)
+      _ambiguous_or_missing -> nil
+    end
+  end
+
   # Definitions belong to the namespace opened by the closest preceding
   # `(ns ...)` form, mirroring the compiler's `current_ns` walk.
-  defp definition_span(forms, namespace, symbol) do
+  defp definition_spans(forms, namespace, symbol) do
     forms
-    |> Enum.reduce_while(nil, fn form, current_ns ->
+    |> Enum.reduce({nil, []}, fn form, {current_ns, spans} ->
       cond do
-        form.head == "ns" -> {:cont, form.name}
-        current_ns == namespace and definition?(form, symbol) -> {:halt, form.span}
-        true -> {:cont, current_ns}
+        form.head == "ns" -> {form.name, spans}
+        current_ns == namespace and definition?(form, symbol) -> {current_ns, [form.span | spans]}
+        true -> {current_ns, spans}
       end
     end)
-    |> case do
-      {_offset, _length} = span -> span
-      _unresolved -> nil
-    end
+    |> elem(1)
+    |> Enum.reverse()
   end
 
   defp definition?(%{head: head, name: name}, symbol),

--- a/lib/ptc_runner/lisp/prelude/validation_error.ex
+++ b/lib/ptc_runner/lisp/prelude/validation_error.ex
@@ -26,6 +26,13 @@ defmodule PtcRunner.Lisp.Prelude.ValidationError do
       symbol, or value. Must not contain secrets.
     * `namespace` — the declaring namespace when known, else `nil`.
     * `ref` — the offending export ref when known, else `nil`.
+    * `form_index` — zero-based position of the offending TOP-LEVEL form in
+      the compiled source, when the failure was raised while walking one, else
+      `nil`. Set by `Compiler`'s top-level walk, never by an error site.
+    * `span` — `{offset, length}` byte span of that offending top-level form
+      in the compiled source, or `nil` when the failure cannot be attributed
+      to one form (parse errors, whole-bundle failures). Resolved once, at the
+      compile boundary, by `PtcRunner.Lisp.Prelude.ErrorSpan`.
   """
 
   @type reason ::
@@ -46,15 +53,24 @@ defmodule PtcRunner.Lisp.Prelude.ValidationError do
           | :dependency_cycle
           | :prelude_attach_failed
 
+  @type byte_span :: {non_neg_integer(), non_neg_integer()}
+
   @type t :: %__MODULE__{
           reason: reason(),
           message: String.t(),
           namespace: String.t() | nil,
-          ref: String.t() | nil
+          ref: String.t() | nil,
+          form_index: non_neg_integer() | nil,
+          span: byte_span() | nil
         }
 
   @enforce_keys [:reason, :message]
-  defstruct reason: nil, message: nil, namespace: nil, ref: nil
+  defstruct reason: nil,
+            message: nil,
+            namespace: nil,
+            ref: nil,
+            form_index: nil,
+            span: nil
 
   @doc "Builds a validation error."
   @spec new(reason(), String.t(), keyword()) :: t()

--- a/test/ptc_runner/kernel/command_engine_test.exs
+++ b/test/ptc_runner/kernel/command_engine_test.exs
@@ -4678,6 +4678,44 @@ defmodule PtcRunner.Kernel.CommandEngineTest do
   end
 
   @tag :tmp_dir
+  test "a locatable compile failure carries the offending form's byte span", %{
+    tmp_dir: directory
+  } do
+    source = """
+    (ns app)
+
+    (defn run [input] (return input))
+
+    (defn broken)
+    """
+
+    path =
+      write_application(directory, "located-compile-failure", valid_manifest(), %{
+        "main.clj" => source
+      })
+
+    outcome = assert_error(["validate", path], "bundle", "compile_failed")
+
+    assert %{"start_byte" => start_byte, "end_byte" => end_byte} =
+             outcome.envelope["error"]["span"]
+
+    # The offsets are only worth emitting if they cut the source at the form a
+    # reader has to fix, so slice rather than assert the numbers.
+    assert binary_part(source, start_byte, end_byte - start_byte) == "(defn broken)"
+
+    # A component whose failure cannot be attributed to one form keeps the
+    # null span every envelope carried before spans had producers.
+    unlocatable =
+      write_application(directory, "unlocatable-compile-failure", valid_manifest(), %{
+        "main.clj" => "(ns app) ("
+      })
+
+    assert assert_error(["validate", unlocatable], "bundle", "compile_failed").envelope["error"][
+             "span"
+           ] == nil
+  end
+
+  @tag :tmp_dir
   test "application failures retain safe external-input and override provenance", %{
     tmp_dir: directory
   } do

--- a/test/ptc_runner/lisp/prelude/compiler_test.exs
+++ b/test/ptc_runner/lisp/prelude/compiler_test.exs
@@ -4,6 +4,7 @@ defmodule PtcRunner.Lisp.Prelude.CompilerTest do
   alias PtcRunner.Lisp
   alias PtcRunner.Lisp.Prelude
   alias PtcRunner.Lisp.Prelude.Compiler
+  alias PtcRunner.Lisp.Prelude.ErrorSpan
   alias PtcRunner.Lisp.Prelude.Export
 
   # ============================================================
@@ -872,6 +873,54 @@ defmodule PtcRunner.Lisp.Prelude.CompilerTest do
 
       assert error.reason == :parse_error
       assert error.span == nil
+    end
+
+    test "a duplicate definition spans the redefinition that collided" do
+      source = """
+      (ns crm "doc")
+      (defn a [] 1)
+      (defn a [] 2)
+      """
+
+      assert {error, slice} = failing_slice(source)
+      assert error.reason == :duplicate_ref
+      assert slice == "(defn a [] 2)"
+    end
+
+    test "an ambiguous ref resolves to no span rather than an innocent namesake" do
+      # `dep_ref_in_def` is raised BEFORE duplicate names are rejected, so its
+      # ref matches two forms here and only the second one is at fault. A span
+      # on the first would send a reader to code that is not the problem.
+      source = """
+      (ns audit "doc")
+      (def a 1)
+      (def a (base/helper 1))
+      """
+
+      assert {:error, %Prelude.ValidationError{} = error} =
+               Compiler.compile(source,
+                 deps: [dep_base()],
+                 namespace_deps: %{"audit" => ["base"]}
+               )
+
+      assert error.reason == :dep_ref_in_def
+      assert error.ref == "audit/a"
+      assert error.span == nil
+    end
+
+    test "a negative form index resolves to no span rather than the last form" do
+      source = """
+      (ns crm "doc")
+      (defn a [] 1)
+      """
+
+      error = %Prelude.ValidationError{
+        reason: :compile_error,
+        message: "synthetic",
+        form_index: -1
+      }
+
+      assert ErrorSpan.resolve(error, source).span == nil
     end
 
     test "a successful compile is unaffected by span resolution" do

--- a/test/ptc_runner/lisp/prelude/compiler_test.exs
+++ b/test/ptc_runner/lisp/prelude/compiler_test.exs
@@ -811,4 +811,71 @@ defmodule PtcRunner.Lisp.Prelude.CompilerTest do
       assert error.message =~ "provided both"
     end
   end
+
+  # ============================================================
+  # Failure spans
+  # ============================================================
+
+  describe "compile/2 failure spans" do
+    # The oracle everywhere below is the SLICE, never the offsets: a span is
+    # only useful if cutting the source at it yields the form a reader should
+    # be looking at.
+    defp failing_slice(source, opts \\ []) do
+      assert {:error, %Prelude.ValidationError{} = error} = Compiler.compile(source, opts)
+      {offset, length} = error.span
+      {error, binary_part(source, offset, length)}
+    end
+
+    test "a failure raised while walking a top-level form spans that form" do
+      source = """
+      (ns crm "doc")
+
+      (defn fine [x] x)
+
+      (defn broken)
+      """
+
+      assert {error, slice} = failing_slice(source)
+      assert error.reason == :invalid_signature
+      assert slice == "(defn broken)"
+    end
+
+    test "a failure raised after the walk spans the definition its ref names" do
+      source = """
+      (ns cfg "doc")
+      (def fine 1)
+      (def answer {:type ":int"} "forty-two")
+      """
+
+      assert {error, slice} = failing_slice(source)
+      assert error.ref == "cfg/answer"
+      assert slice == ~S[(def answer {:type ":int"} "forty-two")]
+    end
+
+    test "a namespace-level failure spans the declaring (ns ...) form" do
+      source = """
+      (ns first-ns "doc")
+      (defn a [] 1)
+      (ns crm "doc")
+      (defn b [] 2)
+      """
+
+      assert {error, slice} = failing_slice(source, namespace_deps: %{"crm" => ["missing"]})
+      assert error.reason == :unknown_dependency
+      assert slice == ~S[(ns crm "doc")]
+    end
+
+    test "a parse error carries no span, because no form can be blamed" do
+      unbalanced = "(ns crm \"doc\") (defn a [] (+ 1)"
+
+      assert {:error, %Prelude.ValidationError{} = error} = Compiler.compile(unbalanced)
+
+      assert error.reason == :parse_error
+      assert error.span == nil
+    end
+
+    test "a successful compile is unaffected by span resolution" do
+      assert {:ok, %Prelude{}} = Compiler.compile("(ns crm \"doc\") (defn a [] 1)")
+    end
+  end
 end


### PR DESCRIPTION
Closes #1266 (piece 1 in full, and answers piece 2).

## What this changes

The command envelope's `span` was fully built, validated, and schema-permitted with **zero producers** — every envelope ever emitted said `"span": null`. Component compilation now populates it.

- **`Prelude.Compiler`** tags a failure with the index of the top-level form it was walking. This happens once, in the walk itself, rather than at each of the ~30 error sites.
- **`Prelude.ErrorSpan`** (new) resolves that index — or a `ref`/`namespace`, for failures raised after the walk — to a byte range through `FormScanner`. The scanner cross-checks its own form list against the real parser head-by-head and refuses to return on any disagreement, which is what makes indexing by position safe rather than a guess.
- **`BundleCompiler`** forwards the range on `:component_compile_error`, bounded against the component's own bytes.
- **`RunCoordinator`** binds `bundle/compile_failed` provenance to those exact bytes with `CommandSource.with_bytes/3`, which is what lets `CommandDiagnostic`'s existing bounds check admit the span at all.

Resolution fails **open**: a source that will not scan, an out-of-range index, or an ambiguous name keeps the null span. A missing span is the status quo; a wrong one points a reader at innocent code.

No catalog row, schema, or contract version changes — the published V1 schema already permitted a span object on these rows, so `mix ptc.gen_docs --check` is clean.

## The `notes` half

Answered in the other direction, and recorded in `docs/guides/kernel-maintainer.md` and `CommandDiagnostic`'s moduledoc: V1 pins `notes` to `{"const": []}`, so a populated array invalidates the envelope for every strict V1 consumer. Reporting a rejected value against the bound it broke needs a later envelope version, not a producer. That settles the scheduling question #1266 raised for #1221 — the code and message there can improve now; the two numbers cannot travel until V1.1.

## Verification

- New compiler tests assert the **slice**, never the offsets: cutting the source at the resolved span must yield the offending form.
- A `validate` envelope carries a span that slices to `(defn broken)`, and stays schema-valid; an unlocatable parse failure keeps `"span": null`.
- `mix precommit` green end to end.

## Review

One `codex-independent-review` round (xhigh) found two ways an in-bounds span could still blame innocent code — an ambiguous ref (`dep_ref_in_def` is raised *before* duplicate names are rejected) and `Enum.at/2`'s negative-index reverse lookup. Both fixed with regression tests in the second commit; the follow-up round is clean.