### PR TITLE
fix(agent): retain contention taxonomy through pcalls

### DIFF
--- a/docs/guides/kernel-maintainer.md
+++ b/docs/guides/kernel-maintainer.md
@@ -994,7 +994,10 @@ provider call happens outside the lease, so branches overlap freely until they
 reach `kernel/eval-source`. Admission is deliberately not queued — queuing
 requires an absolute caller deadline that `reserve_evaluation/1` does not yet
 receive, and without one a queued branch would spend the parallel deadline
-waiting.
+waiting. `pmap` and `pcalls` still reject `fail` as a worker control signal, but
+they retain its bounded, payload-free failure taxonomy. A concurrent agent
+admission refusal therefore remains publicly classifiable as
+`evaluation-unavailable` without exposing the failure value.
 
 Each `PtcRunner.Kernel.Capability` freezes its public identity, effect,
 visibility, bounded schemas, validator, and trusted callback. Environment

--- a/docs/guides/running-and-debugging.md
+++ b/docs/guides/running-and-debugging.md
@@ -459,9 +459,12 @@ The known failure kinds are `invalid-input`, `invalid-prompt`,
 
 So `(fail "the invoice total did not balance")` publishes nothing, while
 `(fail {:kind "assertion-failed" :detail "the invoice total did not balance"})`
-publishes `assertion-failed`. Prefer the second shape. It costs one key and it
-is the difference between a caller knowing what class of thing went wrong and
-knowing only that something did.
+publishes only `failure_kind: "assertion-failed"`. Prefer the second shape. It
+costs one key and it is the difference between a caller knowing what class of
+thing went wrong and knowing only that something did. The same projection
+survives when `pmap` or `pcalls` rejects a worker's `fail` control signal; the
+parallel error remains the terminal reason while its safe failure taxonomy
+identifies the underlying framework failure.
 
 **When provider-backed detail is needed**, rerun with `--inspect`:
 

--- a/docs/guides/running-and-debugging.md
+++ b/docs/guides/running-and-debugging.md
@@ -442,10 +442,13 @@ text — but it means a workflow that fails on purpose reports
 `execution/workflow_failed`, "the workflow failed", and no trace of whatever the
 workflow was trying to say.
 
-**Your `fail` value decides how much survives.** The value passes through a
-failure taxonomy that keeps a classification and discards everything else:
+**Your `fail` value decides how much survives in the Kernel API and canonical
+trace.** The command envelope remains the fixed `execution/workflow_failed`
+diagnostic described above. `PtcRunner.Kernel.run/2` and the canonical
+`run-stopped` event instead pass the value through a failure taxonomy that
+keeps a classification and discards everything else:
 
-| `(fail …)` value | What the envelope carries |
+| `(fail …)` value | What `Kernel.Error.details` and `run-stopped` carry |
 | --- | --- |
 | a string, or any non-map | nothing |
 | a map with a `kind` naming a known failure kind | that kind, readable |

--- a/lib/ptc_runner/kernel/runner.ex
+++ b/lib/ptc_runner/kernel/runner.ex
@@ -544,12 +544,15 @@ defmodule PtcRunner.Kernel.Runner do
 
   defp maybe_put_failure_taxonomy(
          stopped_data,
-         {:error, %Error{reason: :explicit_failure, details: details}}
-       ) do
-    Map.merge(
-      stopped_data,
-      Map.take(details, [:failure_kind, :failure_kind_fingerprint])
-    )
+         {:error, %Error{reason: reason, details: details}}
+       )
+       when reason in [:explicit_failure, :pmap_error, :pcalls_error] do
+    taxonomy =
+      details
+      |> Map.take([:failure_kind, :failure_kind_fingerprint])
+      |> SafeMetadata.retain_failure_taxonomy()
+
+    Map.merge(stopped_data, taxonomy)
   end
 
   defp maybe_put_failure_taxonomy(stopped_data, _result), do: stopped_data

--- a/lib/ptc_runner/kernel/runner.ex
+++ b/lib/ptc_runner/kernel/runner.ex
@@ -665,11 +665,13 @@ defmodule PtcRunner.Kernel.Runner do
 
   defp workflow_error_details(fail, _timeout_ms, _limits, sink)
        when not is_nil(sink) do
-    case EventSink.policy(sink) do
-      :normal -> :normal
-      _private_or_unavailable -> :private
-    end
-    |> workflow_error_details_for_class(fail)
+    details =
+      case EventSink.policy(sink) do
+        :normal -> workflow_error_details_for_class(:normal, fail)
+        _private_or_unavailable -> workflow_error_details_for_class(:private, fail)
+      end
+
+    Map.merge(details, SafeMetadata.retain_failure_taxonomy(fail.details))
   end
 
   defp workflow_error_details_for_class(:private, _fail),

--- a/lib/ptc_runner/kernel/safe_metadata.ex
+++ b/lib/ptc_runner/kernel/safe_metadata.ex
@@ -102,6 +102,19 @@ defmodule PtcRunner.Kernel.SafeMetadata do
 
   def failure_taxonomy(_value), do: %{}
 
+  @doc false
+  @spec retain_failure_taxonomy(term()) :: map()
+  def retain_failure_taxonomy(%{failure_kind: kind} = taxonomy)
+      when map_size(taxonomy) == 1 and kind in @failure_kinds,
+      do: taxonomy
+
+  def retain_failure_taxonomy(%{failure_kind_fingerprint: fingerprint} = taxonomy)
+      when map_size(taxonomy) == 1 and is_binary(fingerprint) do
+    if fingerprint?(fingerprint), do: taxonomy, else: %{}
+  end
+
+  def retain_failure_taxonomy(_taxonomy), do: %{}
+
   @spec fingerprint(binary()) :: binary()
   @doc "Returns the canonical non-reversible fingerprint for one bounded identifier."
   def fingerprint(value) when is_binary(value) do

--- a/lib/ptc_runner/lisp.ex
+++ b/lib/ptc_runner/lisp.ex
@@ -50,6 +50,7 @@ defmodule PtcRunner.Lisp do
   }
 
   alias PtcRunner.Kernel.Program
+  alias PtcRunner.Kernel.SafeMetadata
   alias PtcRunner.Lisp.Eval.Context, as: EvalContext
   alias PtcRunner.Lisp.Eval.Effects
   alias PtcRunner.Lisp.Eval.Helpers
@@ -1473,6 +1474,12 @@ defmodule PtcRunner.Lisp do
   defp error_details({:prelude_contract_error, _message, details}) when is_map(details),
     do: details
 
+  defp error_details({:pmap_error, _message, taxonomy}) when is_map(taxonomy),
+    do: SafeMetadata.retain_failure_taxonomy(taxonomy)
+
+  defp error_details({:pcalls_error, _index, _message, taxonomy}) when is_map(taxonomy),
+    do: SafeMetadata.retain_failure_taxonomy(taxonomy)
+
   defp error_details({category, _message, details})
        when category in [
               :unsupported_java_class,
@@ -1599,6 +1606,13 @@ defmodule PtcRunner.Lisp do
   end
 
   def format_error({:runtime_error, msg}), do: "Runtime error: #{msg}"
+
+  def format_error({:pmap_error, msg, _taxonomy}) when is_binary(msg),
+    do: format_error({:pmap_error, msg})
+
+  def format_error({:pcalls_error, index, msg, _taxonomy})
+      when is_integer(index) and is_binary(msg),
+      do: format_error({:pcalls_error, index, msg})
 
   def format_error({:tool_error, name, reason}),
     do: UntrustedRenderer.tool_failure(name, reason)

--- a/lib/ptc_runner/lisp/eval/apply.ex
+++ b/lib/ptc_runner/lisp/eval/apply.ex
@@ -1102,6 +1102,7 @@ defmodule PtcRunner.Lisp.Eval.Apply do
     case reason do
       {kind, _detail} -> kind in passthrough_hof_error_kinds()
       {kind, _detail, _data} -> kind in passthrough_hof_error_kinds()
+      {kind, _index, _detail, _data} -> kind in passthrough_hof_error_kinds()
       _other -> false
     end
   end

--- a/lib/ptc_runner/lisp/eval/helpers.ex
+++ b/lib/ptc_runner/lisp/eval/helpers.ex
@@ -5,6 +5,7 @@ defmodule PtcRunner.Lisp.Eval.Helpers do
   Provides type error formatting and type description utilities.
   """
 
+  alias PtcRunner.Kernel.SafeMetadata
   alias PtcRunner.Lisp.CoreAST
   alias PtcRunner.Lisp.Env
   alias PtcRunner.Lisp.Env.Builtin
@@ -308,6 +309,13 @@ defmodule PtcRunner.Lisp.Eval.Helpers do
   def sanitize_private_error({reason, _message, nil}) when reason in @stable_parallel_errors,
     do: {reason, stable_parallel_error_message(reason), nil}
 
+  def sanitize_private_error({:pmap_error, _message, taxonomy}) when is_map(taxonomy),
+    do: sanitize_private_parallel_failure(:pmap_error, nil, taxonomy)
+
+  def sanitize_private_error({:pcalls_error, index, _message, taxonomy})
+      when is_integer(index) and is_map(taxonomy),
+      do: sanitize_private_parallel_failure(:pcalls_error, index, taxonomy)
+
   def sanitize_private_error({:loop_limit_exceeded, limit}) when is_integer(limit),
     do: {:loop_limit_exceeded, limit}
 
@@ -401,6 +409,21 @@ defmodule PtcRunner.Lisp.Eval.Helpers do
 
   defp stable_parallel_error_message(:parallel_capacity_exceeded),
     do: "the parallel worker budget is exhausted; reduce nesting or collection size"
+
+  defp sanitize_private_parallel_failure(reason, index, taxonomy) do
+    case SafeMetadata.retain_failure_taxonomy(taxonomy) do
+      retained when map_size(retained) == 1 ->
+        message = "fail called inside #{if(reason == :pmap_error, do: "pmap", else: "pcalls")}"
+
+        case reason do
+          :pmap_error -> {:pmap_error, message, retained}
+          :pcalls_error -> {:pcalls_error, index, message, retained}
+        end
+
+      _invalid_or_empty ->
+        {:private_prelude_error, "private prelude evaluation failed"}
+    end
+  end
 
   defp sanitize_private_validation_details(details) when is_binary(details) do
     details

--- a/lib/ptc_runner/lisp/eval/parallel.ex
+++ b/lib/ptc_runner/lisp/eval/parallel.ex
@@ -8,6 +8,7 @@ defmodule PtcRunner.Lisp.Eval.Parallel do
   deadlines, cancellation, and monitor cleanup belong to `ParallelRunner`.
   """
 
+  alias PtcRunner.Kernel.SafeMetadata
   alias PtcRunner.Lisp.ChildResult
   alias PtcRunner.Lisp.Eval.Abort
   alias PtcRunner.Lisp.Eval.Apply
@@ -221,8 +222,8 @@ defmodule PtcRunner.Lisp.Eval.Parallel do
     |> classify_runner_error(type, index)
   end
 
-  defp classify_worker_failure({:worker_control, signal}, type, index),
-    do: parallel_worker_error(type, index, "#{signal} called inside #{type}")
+  defp classify_worker_failure({:worker_control, signal, taxonomy}, type, index),
+    do: parallel_worker_error(type, index, "#{signal} called inside #{type}", taxonomy)
 
   defp classify_worker_failure(reason, type, index),
     do: classify_runner_error(reason, type, index)
@@ -262,7 +263,9 @@ defmodule PtcRunner.Lisp.Eval.Parallel do
        do: error
 
   defp classify_runner_error({:pmap_error, _} = error, _type, _index), do: error
+  defp classify_runner_error({:pmap_error, _, %{}} = error, _type, _index), do: error
   defp classify_runner_error({:pcalls_error, _, _} = error, _type, _index), do: error
+  defp classify_runner_error({:pcalls_error, _, _, %{}} = error, _type, _index), do: error
 
   defp classify_runner_error(other, type, _index),
     do: {parallel_error_type(type), inspect(other)}
@@ -290,10 +293,17 @@ defmodule PtcRunner.Lisp.Eval.Parallel do
 
   defp captured_failure(
          :error,
+         %Abort{outcome: {:control, :fail, value, _context}},
+         _stacktrace
+       ),
+       do: {:worker_control, :fail, SafeMetadata.failure_taxonomy(value)}
+
+  defp captured_failure(
+         :error,
          %Abort{outcome: {:control, signal, _value, _context}},
          _stacktrace
        ),
-       do: {:worker_control, signal}
+       do: {:worker_control, signal, %{}}
 
   defp captured_failure(:error, error, stacktrace),
     do: {:unexpected_raise, :error, error, stacktrace}
@@ -312,6 +322,22 @@ defmodule PtcRunner.Lisp.Eval.Parallel do
        when is_binary(message),
        do: parallel_worker_error(type, index, message)
 
+  defp parallel_abort_error(
+         {:pmap_error, message, taxonomy},
+         type,
+         index
+       )
+       when is_binary(message) and is_map(taxonomy),
+       do: parallel_worker_error(type, index, message, taxonomy)
+
+  defp parallel_abort_error(
+         {:pcalls_error, _inner_index, message, taxonomy},
+         type,
+         index
+       )
+       when is_binary(message) and is_map(taxonomy),
+       do: parallel_worker_error(type, index, message, taxonomy)
+
   defp parallel_abort_error({_reason, message, _data}, type, index) when is_binary(message),
     do: parallel_worker_error(type, index, message)
 
@@ -323,6 +349,15 @@ defmodule PtcRunner.Lisp.Eval.Parallel do
 
   defp parallel_worker_error(:pmap, _index, message), do: {:pmap_error, message}
   defp parallel_worker_error(:pcalls, index, message), do: {:pcalls_error, index, message}
+
+  defp parallel_worker_error(type, index, message, taxonomy) when map_size(taxonomy) == 0,
+    do: parallel_worker_error(type, index, message)
+
+  defp parallel_worker_error(:pmap, _index, message, taxonomy),
+    do: {:pmap_error, message, taxonomy}
+
+  defp parallel_worker_error(:pcalls, index, message, taxonomy),
+    do: {:pcalls_error, index, message, taxonomy}
 
   defp parallel_error_type(:pmap), do: :pmap_error
   defp parallel_error_type(:pcalls), do: :pcalls_error

--- a/test/ptc_runner/kernel/agent_evaluation_contention_test.exs
+++ b/test/ptc_runner/kernel/agent_evaluation_contention_test.exs
@@ -19,6 +19,7 @@ defmodule PtcRunner.Kernel.AgentEvaluationContentionTest do
   alias PtcRunner.Kernel.MissionEnvironment
   alias PtcRunner.Kernel.RunConfig
   alias PtcRunner.Kernel.WorkflowEnvironment
+  alias PtcRunner.Lisp.Eval.Context, as: LispContext
 
   test "an exhausted evaluation budget fails the workflow instead of spending another turn" do
     {:ok, counter} = Agent.start_link(fn -> 0 end)
@@ -65,7 +66,8 @@ defmodule PtcRunner.Kernel.AgentEvaluationContentionTest do
   test "four concurrent agent loops do not retry against a held evaluation lease" do
     parent = self()
     {:ok, counter} = Agent.start_link(fn -> 0 end)
-    barrier = start_barrier(4)
+    expected_requests = min(4, LispContext.default_pmap_max_concurrency())
+    barrier = start_barrier(expected_requests)
 
     requester = fn _request ->
       request_number = Agent.get_and_update(counter, fn count -> {count + 1, count + 1} end)
@@ -118,14 +120,15 @@ defmodule PtcRunner.Kernel.AgentEvaluationContentionTest do
     assert error.reason == :pcalls_error
     assert error.details[:failure_kind] == "evaluation-unavailable"
 
-    assert Agent.get(counter, & &1) == 4,
-           "each agent must ask once and contention must not buy a fifth request"
+    assert Agent.get(counter, & &1) == expected_requests,
+           "each started agent must ask once and contention must not buy another request"
 
-    assert_received {:agent_request, 1}
-    assert_received {:agent_request, 2}
-    assert_received {:agent_request, 3}
-    assert_received {:agent_request, 4}
-    refute_received {:agent_request, 5}
+    for request_number <- 1..expected_requests do
+      assert_received {:agent_request, ^request_number}
+    end
+
+    unexpected_request = expected_requests + 1
+    refute_received {:agent_request, ^unexpected_request}
   end
 
   defp start_barrier(expected) do

--- a/test/ptc_runner/kernel/agent_evaluation_contention_test.exs
+++ b/test/ptc_runner/kernel/agent_evaluation_contention_test.exs
@@ -63,10 +63,14 @@ defmodule PtcRunner.Kernel.AgentEvaluationContentionTest do
   end
 
   test "four concurrent agent loops do not retry against a held evaluation lease" do
+    parent = self()
     {:ok, counter} = Agent.start_link(fn -> 0 end)
+    barrier = start_barrier(4)
 
     requester = fn _request ->
-      Agent.update(counter, &(&1 + 1))
+      request_number = Agent.get_and_update(counter, fn count -> {count + 1, count + 1} end)
+      send(parent, {:agent_request, request_number})
+      await_barrier(barrier)
 
       {:ok,
        %{
@@ -111,9 +115,41 @@ defmodule PtcRunner.Kernel.AgentEvaluationContentionTest do
 
     assert {:error, error} = Kernel.run(source, config)
     assert error.kind == :workflow_failed
+    assert error.reason == :pcalls_error
+    assert error.details[:failure_kind] == "evaluation-unavailable"
 
-    assert Agent.get(counter, & &1) <= 4,
-           "each agent may ask the model once; contention must not buy extra turns"
+    assert Agent.get(counter, & &1) == 4,
+           "each agent must ask once and contention must not buy a fifth request"
+
+    assert_received {:agent_request, 1}
+    assert_received {:agent_request, 2}
+    assert_received {:agent_request, 3}
+    assert_received {:agent_request, 4}
+    refute_received {:agent_request, 5}
+  end
+
+  defp start_barrier(expected) do
+    spawn_link(fn -> collect_barrier_waiters(expected, []) end)
+  end
+
+  defp collect_barrier_waiters(0, waiters) do
+    Enum.each(waiters, fn {caller, ref} -> send(caller, {:barrier_released, ref}) end)
+  end
+
+  defp collect_barrier_waiters(remaining, waiters) do
+    receive do
+      {:barrier_arrive, caller, ref} ->
+        collect_barrier_waiters(remaining - 1, [{caller, ref} | waiters])
+    end
+  end
+
+  defp await_barrier(barrier) do
+    ref = make_ref()
+    send(barrier, {:barrier_arrive, self(), ref})
+
+    receive do
+      {:barrier_released, ^ref} -> :ok
+    end
   end
 
   defp build_config(requester, mission_capabilities, limit_overrides) do

--- a/test/ptc_runner/kernel/core_contract_test.exs
+++ b/test/ptc_runner/kernel/core_contract_test.exs
@@ -1693,6 +1693,69 @@ defmodule PtcRunner.Kernel.CoreContractTest do
     refute inspect(taxonomy) =~ "PRIVATE"
   end
 
+  test "parallel fail retains only bounded safe taxonomy" do
+    {:ok, workflow} = WorkflowEnvironment.new([])
+    {:ok, mission} = MissionEnvironment.new([])
+    {:ok, limits} = Limits.new()
+    secret = "PRIVATE_PARALLEL_FAILURE_DETAIL"
+
+    cases = [
+      {:pcalls, :pcalls_error,
+       ~s|(pcalls #(fail {:kind :evaluation-unavailable :reason "#{secret}"}))|},
+      {:pmap, :pmap_error,
+       ~s|(pmap (fn [_] (fail {:kind :evaluation-unavailable :reason "#{secret}"})) [1])|},
+      {:nested, :pcalls_error,
+       ~s|(pcalls #(pmap (fn [_] (fail {:kind :evaluation-unavailable :reason "#{secret}"})) [1]))|},
+      {:ordinary_hof, :pcalls_error,
+       ~s|(map (fn [_] (pcalls #(fail {:kind :evaluation-unavailable :reason "#{secret}"}))) [1])|}
+    ]
+
+    Enum.each(cases, fn {name, reason, source} ->
+      {:ok, sink} =
+        EventSink.start(:normal, limits, run_id: "parallel-failure-taxonomy-#{name}")
+
+      {:ok, config} =
+        RunConfig.new(
+          workflow_environment: workflow,
+          mission_environment: mission,
+          input: %{},
+          limits: limits,
+          event_sink: sink
+        )
+
+      assert {:error,
+              %{
+                reason: ^reason,
+                details: %{failure_kind: "evaluation-unavailable"}
+              } = error} = Kernel.run(source, config)
+
+      refute inspect(error) =~ secret
+      refute EventSink.events(sink) |> inspect() |> String.contains?(secret)
+    end)
+  end
+
+  test "parallel non-fail controls do not publish failure taxonomy" do
+    {:ok, workflow} = WorkflowEnvironment.new([])
+    {:ok, mission} = MissionEnvironment.new([])
+    {:ok, limits} = Limits.new()
+    {:ok, sink} = EventSink.start(:normal, limits, run_id: "parallel-return-control")
+
+    {:ok, config} =
+      RunConfig.new(
+        workflow_environment: workflow,
+        mission_environment: mission,
+        input: %{},
+        limits: limits,
+        event_sink: sink
+      )
+
+    assert {:error, %{reason: :pcalls_error, details: details}} =
+             Kernel.run(~S|(pcalls #(return {:kind :assertion-failed}))|, config)
+
+    refute Map.has_key?(details, :failure_kind)
+    refute Map.has_key?(details, :failure_kind_fingerprint)
+  end
+
   test "new Kernel workflow routes only granted capabilities through the dispatcher" do
     {:ok, add} =
       Capability.new(

--- a/test/ptc_runner/kernel/core_contract_test.exs
+++ b/test/ptc_runner/kernel/core_contract_test.exs
@@ -1729,6 +1729,9 @@ defmodule PtcRunner.Kernel.CoreContractTest do
                 details: %{failure_kind: "evaluation-unavailable"}
               } = error} = Kernel.run(source, config)
 
+      assert %{type: "run-stopped", data: %{failure_kind: "evaluation-unavailable"}} =
+               List.last(EventSink.events(sink))
+
       refute inspect(error) =~ secret
       refute EventSink.events(sink) |> inspect() |> String.contains?(secret)
     end)

--- a/test/ptc_runner/lisp/eval/outcome_test.exs
+++ b/test/ptc_runner/lisp/eval/outcome_test.exs
@@ -583,6 +583,31 @@ defmodule PtcRunner.Lisp.Eval.OutcomeTest do
     end
   end
 
+  test "private prelude parallel failures retain only bounded safe taxonomy" do
+    {:ok, prelude} =
+      Compiler.compile("""
+      (ns api "API" {:visibility :prompt})
+      (defn classified-pcalls []
+        (pcalls #(fail {:kind :evaluation-unavailable
+                        :reason "PRIVATE_PARALLEL_FAILURE"})))
+      (defn classified-pmap []
+        (pmap (fn [_]
+                (fail {:kind :evaluation-unavailable
+                       :reason "PRIVATE_PARALLEL_FAILURE"}))
+              [1]))
+      """)
+
+    for {source, reason} <- [
+          {"(api/classified-pcalls)", :pcalls_error},
+          {"(api/classified-pmap)", :pmap_error}
+        ] do
+      assert {:error, step} = Lisp.run(source, prelude: prelude)
+      assert step.fail.reason == reason
+      assert step.fail.details == %{failure_kind: "evaluation-unavailable"}
+      refute inspect(step.fail) =~ "PRIVATE_PARALLEL_FAILURE"
+    end
+  end
+
   test "private prelude adapters preserve stable resource classifications" do
     prelude = private_parallel_limit_prelude!()
 


### PR DESCRIPTION
## Summary

- preserve bounded, payload-free failure taxonomy when `fail` crosses `pmap`/`pcalls`, nested parallel calls, and ordinary HOF callbacks
- make the four-agent contention regression deterministic and prove contention does not buy an extra model turn
- document that admission remains fail-fast and is not queued

## Current issue status

PR #1267 already fixed the source-level `:busy` / `:limit_exceeded` retry behavior on current `main`. The remaining reproducible gap was that `pcalls` replaced the typed `evaluation-unavailable` failure with an unclassified `pcalls_error`.

I also reran the live four-agent scenario 30 times against current `main`: 27 successful runs and 3 fast contention failures, all completing in roughly 0.8–2.8 seconds. I could not reproduce the reported ~150 second hang. This PR therefore does not add a queue or speculative teardown changes; a queue would require an absolute caller deadline to avoid converting fail-fast contention into deadline burn.

## Verification

- focused parallel/contention suite: 168 passed
- `mix compile --warnings-as-errors`
- `MIX_ENV=dev mix docs --warnings-as-errors`
- `mix credo --strict`
- `mix dialyzer`
- `mix precommit` (5,993 root checks plus Viewer, launcher, package, and release gates)
- pre-push hook

Refs #1241
