### PR TITLE
fix(kernel): explain rejected capability arguments

### DIFF
--- a/docs/guides/building-agents.md
+++ b/docs/guides/building-agents.md
@@ -507,8 +507,11 @@ that evaluator-owned provenance separately. Rebuilding, copying, or
 destructuring an equal error-shaped map after a read does not qualify. The
 shipped PTC-Lisp loop then gives the model one correction turn. An error-shaped
 value after an unrelated read is still terminal, as is any failure after a
-`write` or undeclared effect. Correction feedback includes only the bounded
-`kind` and `reason` classification, never provider details.
+`write` or undeclared effect. Correction feedback always includes the bounded
+`kind` and `reason` classification. An input-schema rejection may additionally
+name up to three schema-declared argument paths, violated keywords, and small
+declared bounds or expected sets. Submitted values, undeclared property names,
+opaque semantic-validator reasons, and provider details remain withheld.
 
 When a failure is genuinely unsafe to retry, the shipped loop still does not
 repeat the program — but it no longer discards the run either. It spends one

--- a/docs/guides/building-agents.md
+++ b/docs/guides/building-agents.md
@@ -510,8 +510,19 @@ value after an unrelated read is still terminal, as is any failure after a
 `write` or undeclared effect. Correction feedback always includes the bounded
 `kind` and `reason` classification. An input-schema rejection may additionally
 name up to three schema-declared argument paths, violated keywords, and small
-declared bounds or expected sets. Submitted values, undeclared property names,
-opaque semantic-validator reasons, and provider details remain withheld.
+declared numeric, string-length, or item-count bounds. Enum and const literals,
+submitted values, undeclared property names, opaque semantic-validator reasons,
+and provider details remain withheld. These bounded details are part of the
+ordinary `tool/...` error map, so plain PTC-Lisp workflows can inspect them too;
+they are not added to the canonical trace.
+
+If the bounded host validator times out, exhausts its heap, crashes, or returns
+an unrecognized result, the call instead returns
+`capability_unavailable/input_validation_unavailable`. This is not evidence
+that the model's arguments violate the schema: it charges neither a protocol
+error nor a capability call. The shipped agent loop uses evaluator-owned call
+provenance to fail the outer workflow immediately, without asking the model for
+a correction or spending another provider turn.
 
 When a failure is genuinely unsafe to retry, the shipped loop still does not
 repeat the program — but it no longer discards the run either. It spends one

--- a/docs/guides/kernel-maintainer.md
+++ b/docs/guides/kernel-maintainer.md
@@ -1155,16 +1155,31 @@ sandbox for malicious BEAM code.
 When a model-authored call fails the capability's compiled input schema before
 callback entry, Dispatcher retains at most three correction facts for the agent
 loop: the schema-declared argument path, the violated keyword, and a small
-declared bound or expected set when one fits. Paths are resolved through the
-frozen schema, the root is `$`, array positions are rendered as `[]`, and
+declared numeric, string-length, or item-count bound when one fits. Enum and
+const literals are always omitted. Paths are resolved through the frozen
+schema, the root is `$`, array positions are rendered as `[]`, and
 non-identifier names use JSON-quoted bracket notation so punctuation and
-controls cannot alter path structure. Explanations are omitted when the
-submitted structure or raw error set exceeds its fixed work budget; large
-structures use a separately bounded boolean validation whose timeout and heap
-headroom derive from the run's effective workflow and evaluation limits.
-Submitted values and undeclared property names are never copied into feedback.
-A capability's custom semantic validator remains opaque because its rejection
-reason is not a schema-authored fact.
+controls cannot alter path structure. The bounded candidate set is sorted
+before the first three facts are retained. Explanations are omitted when the
+submitted structure or raw error set exceeds its fixed work budget.
+
+Dispatcher enforces `capability_argument_bytes` before entering JSV. Validation
+and bounded projection then run in one worker whose timeout is the minimum of
+the requested call timeout, remaining run time, the authority environment's
+timeout, and the enclosing execution deadline after a small result-handoff
+reserve. The execution context supplies the heap ceiling: ordinary workflow
+runs use the workflow heap, while mission evaluation and REPL execution use
+the evaluation heap even though REPL capabilities retain workflow authority.
+Proven invalidity is distinct from timeout, heap exhaustion, a validator crash,
+or an unrecognized validator result. Those operational failures return
+`capability_unavailable/input_validation_unavailable` without reserving a
+capability call, charging `protocol_errors`, invoking the callback, or emitting
+capability lifecycle events. The evaluator records that result's host
+provenance privately so `agent.core` fails the outer workflow without a
+correction turn. The low-level cause is not public. Submitted values,
+undeclared property names, and enum or const literals never enter feedback or
+canonical events. A capability's custom semantic validator remains opaque
+because its rejection reason is not a schema-authored fact.
 
 Limits are host-enforced ceilings. `PtcRunner.Kernel.LimitCatalog` is the
 checked-in authority for every field's public name, scope, compiled and

--- a/docs/guides/kernel-maintainer.md
+++ b/docs/guides/kernel-maintainer.md
@@ -1152,6 +1152,20 @@ before connector cleanup. Providers are trusted host extensions: the Kernel
 contains ordinary faults and bounded results, but it is not a security
 sandbox for malicious BEAM code.
 
+When a model-authored call fails the capability's compiled input schema before
+callback entry, Dispatcher retains at most three correction facts for the agent
+loop: the schema-declared argument path, the violated keyword, and a small
+declared bound or expected set when one fits. Paths are resolved through the
+frozen schema, the root is `$`, array positions are rendered as `[]`, and
+non-identifier names use JSON-quoted bracket notation so punctuation and
+controls cannot alter path structure. Explanations are omitted when the
+submitted structure or raw error set exceeds its fixed work budget; large
+structures use a separately bounded boolean validation whose timeout and heap
+headroom derive from the run's effective workflow and evaluation limits.
+Submitted values and undeclared property names are never copied into feedback.
+A capability's custom semantic validator remains opaque because its rejection
+reason is not a schema-authored fact.
+
 Limits are host-enforced ceilings. `PtcRunner.Kernel.LimitCatalog` is the
 checked-in authority for every field's public name, scope, compiled and
 installed defaults, inclusive range, and effective-identity participation.

--- a/docs/guides/running-and-debugging.md
+++ b/docs/guides/running-and-debugging.md
@@ -456,7 +456,8 @@ keeps a classification and discards everything else:
 
 The known failure kinds are `invalid-input`, `invalid-prompt`,
 `invalid-transcript`, `transcript-limit`, `turn-limit`, `model-program-failed`,
-`non-retryable-evaluation`, `evaluation-unavailable`, `llm-provider-error`,
+`non-retryable-evaluation`, `evaluation-unavailable`, `capability-unavailable`,
+`llm-provider-error`,
 `protocol-error`, `provider-error`, `capability-error`, `assertion-failed`, and
 `unknown-action`.
 

--- a/lib/ptc_runner/kernel/dispatcher.ex
+++ b/lib/ptc_runner/kernel/dispatcher.ex
@@ -22,7 +22,10 @@ defmodule PtcRunner.Kernel.Dispatcher do
   A pre-callback input-schema rejection may add up to three schema-authored
   argument violations to the Lisp error envelope. The rejected arguments,
   undeclared property names, and opaque semantic-validator reasons remain
-  withheld.
+  withheld. Enum and const literals are never included. If bounded schema
+  validation itself becomes unavailable, Dispatcher returns the distinct
+  `capability_unavailable/input_validation_unavailable` category without
+  charging protocol or capability-call budgets or emitting capability events.
   """
 
   alias PtcRunner.Kernel.Capability
@@ -35,6 +38,8 @@ defmodule PtcRunner.Kernel.Dispatcher do
   alias PtcRunner.Kernel.RunState
   alias PtcRunner.Lisp.AmbiguousArguments
   alias PtcRunner.Lisp.RetainedSize
+
+  @validation_handoff_ms 25
 
   @doc "Dispatches one environment-local capability with optional event collection."
   @spec dispatch(RunState.t(), :workflow | :mission, map(), binary(), map(), non_neg_integer()) ::
@@ -91,6 +96,53 @@ defmodule PtcRunner.Kernel.Dispatcher do
   def dispatch(
         state,
         environment,
+        %{capabilities: capabilities},
+        name,
+        arguments,
+        %{
+          timeout_ms: timeout_ms,
+          validation_heap_words: validation_heap_words,
+          evaluation_lease: evaluation_lease,
+          validation_deadline_ms: validation_deadline_ms
+        } = dispatch_context,
+        event_sink,
+        inspection_sink
+      )
+      when environment in [:workflow, :mission] and is_binary(name) and is_map(arguments) and
+             not is_struct(arguments, AmbiguousArguments) and
+             is_integer(timeout_ms) and is_integer(validation_heap_words) and
+             validation_heap_words > 0 and
+             (is_reference(evaluation_lease) or is_nil(evaluation_lease)) and
+             (is_integer(validation_deadline_ms) or is_nil(validation_deadline_ms)) do
+    dispatch_with_context(
+      state,
+      environment,
+      capabilities,
+      name,
+      arguments,
+      dispatch_context,
+      event_sink,
+      inspection_sink
+    )
+  end
+
+  def dispatch(
+        state,
+        environment,
+        %{capabilities: _capabilities},
+        _name,
+        %AmbiguousArguments{},
+        %{evaluation_lease: evaluation_lease},
+        event_sink,
+        _inspection_sink
+      )
+      when environment in [:workflow, :mission] do
+    protocol_error(state, event_sink, :ambiguous_arguments, environment, evaluation_lease)
+  end
+
+  def dispatch(
+        state,
+        environment,
         %{capabilities: _capabilities},
         _name,
         %AmbiguousArguments{},
@@ -111,7 +163,8 @@ defmodule PtcRunner.Kernel.Dispatcher do
         timeout_ms,
         event_sink,
         inspection_sink
-      ) do
+      )
+      when is_integer(timeout_ms) do
     dispatch_with_lease(
       state,
       environment,
@@ -156,14 +209,57 @@ defmodule PtcRunner.Kernel.Dispatcher do
       )
       when environment in [:workflow, :mission] and is_binary(name) and is_map(arguments) and
              is_integer(timeout_ms) do
+    limits = state_limits(state)
+
+    dispatch(
+      state,
+      environment,
+      %{capabilities: capabilities},
+      name,
+      arguments,
+      %{
+        timeout_ms: timeout_ms,
+        validation_heap_words: validation_heap_words(limits, environment),
+        evaluation_lease: lease,
+        validation_deadline_ms: nil
+      },
+      event_sink,
+      inspection_sink
+    )
+  end
+
+  defp dispatch_with_context(
+         state,
+         environment,
+         capabilities,
+         name,
+         arguments,
+         %{
+           timeout_ms: timeout_ms,
+           validation_heap_words: validation_heap_words,
+           evaluation_lease: evaluation_lease,
+           validation_deadline_ms: validation_deadline_ms
+         },
+         event_sink,
+         inspection_sink
+       ) do
     # Advisory pre-authentication keeps a dead evaluation's lingering call
     # away from validators and protocol accounting; reserve_capability/4
     # atomically re-checks the same lease.
-    with true <- authenticated?(state, environment, lease),
+    with true <- authenticated?(state, environment, evaluation_lease),
          %Capability{} = capability <- Map.get(capabilities, name),
-         :ok <- validate(capability, arguments, state, environment),
          :ok <- validate_size(arguments, capability_argument_limit(state)),
-         :ok <- RunState.reserve_capability(state, environment, name, lease) do
+         :ok <-
+           validate(
+             capability,
+             arguments,
+             state,
+             environment,
+             timeout_ms,
+             validation_heap_words,
+             validation_deadline_ms
+           ),
+         :ok <- RunState.reserve_capability(state, environment, name, evaluation_lease) do
       invoke_with_events(
         state,
         capability,
@@ -178,16 +274,33 @@ defmodule PtcRunner.Kernel.Dispatcher do
         %{status: :error, kind: :capability_denied, reason: :capability_absent, retryable?: false}
 
       {:error, :invalid_arguments, []} ->
-        protocol_error(state, event_sink, :invalid_arguments, environment, lease)
+        protocol_error(state, event_sink, :invalid_arguments, environment, evaluation_lease)
 
       {:error, :invalid_arguments, violations} ->
-        protocol_error(state, event_sink, :invalid_arguments, environment, lease, violations)
+        protocol_error(
+          state,
+          event_sink,
+          :invalid_arguments,
+          environment,
+          evaluation_lease,
+          violations
+        )
 
       {:error, :invalid_arguments} ->
-        protocol_error(state, event_sink, :invalid_arguments, environment, lease)
+        protocol_error(state, event_sink, :invalid_arguments, environment, evaluation_lease)
+
+      {:error, :input_validation_unavailable} ->
+        _ = mark_terminal_host_failure(state, environment, evaluation_lease)
+
+        %{
+          status: :error,
+          kind: :capability_unavailable,
+          reason: :input_validation_unavailable,
+          retryable?: false
+        }
 
       {:error, :argument_exceeded} ->
-        protocol_error(state, event_sink, :argument_exceeded, environment, lease)
+        protocol_error(state, event_sink, :argument_exceeded, environment, evaluation_lease)
 
       {:error, :limit_exceeded} ->
         limit_error(state, event_sink, :capability_quota)
@@ -576,29 +689,66 @@ defmodule PtcRunner.Kernel.Dispatcher do
 
   defp terminal_provider_failure?(_result), do: false
 
-  defp validate(%Capability{} = capability, arguments, state, environment) do
+  defp validate(
+         %Capability{} = capability,
+         arguments,
+         state,
+         environment,
+         requested_timeout_ms,
+         validation_heap_words,
+         validation_deadline_ms
+       ) do
     limits = state_limits(state)
 
-    case JSONSchema.validate(
-           capability.input_validator,
-           capability.input_schema,
-           arguments,
-           validation_timeout_ms(limits, environment),
-           validation_heap_words(limits)
-         ) do
-      :ok -> semantic_validate(capability, arguments)
-      {:error, violations} -> {:error, :invalid_arguments, violations}
+    dispatch_timeout_ms =
+      min(
+        requested_timeout_ms,
+        min(validation_timeout_ms(limits, environment), RunState.remaining_ms(state))
+      )
+
+    validation_timeout_ms =
+      validation_worker_timeout_ms(dispatch_timeout_ms, validation_deadline_ms)
+
+    cond do
+      dispatch_timeout_ms <= 0 ->
+        {:error, :run_closed}
+
+      validation_timeout_ms <= 0 ->
+        {:error, :input_validation_unavailable}
+
+      true ->
+        case JSONSchema.validate(
+               capability.input_validator,
+               capability.input_schema,
+               arguments,
+               validation_timeout_ms,
+               validation_heap_words
+             ) do
+          :ok -> semantic_validate(capability, arguments)
+          {:invalid, violations} -> {:error, :invalid_arguments, violations}
+          {:unavailable, _internal_cause} -> {:error, :input_validation_unavailable}
+        end
     end
   end
 
   defp validation_timeout_ms(limits, :workflow), do: limits.workflow_timeout_ms
   defp validation_timeout_ms(limits, :mission), do: limits.evaluation_timeout_ms
 
-  # Schema validation is host work shared by workflow and mission calls. Use
-  # the larger effective evaluator ceiling without converting byte limits into
-  # words or granting an oversized, not-yet-admitted argument extra heap.
-  defp validation_heap_words(limits),
-    do: max(limits.workflow_heap_words, limits.evaluation_heap_words)
+  defp validation_worker_timeout_ms(timeout_ms, nil), do: timeout_ms
+
+  defp validation_worker_timeout_ms(timeout_ms, deadline_ms) when is_integer(deadline_ms) do
+    remaining_ms = deadline_ms - System.monotonic_time(:millisecond) - @validation_handoff_ms
+    min(timeout_ms, max(remaining_ms, 0))
+  end
+
+  defp validation_heap_words(limits, :workflow), do: limits.workflow_heap_words
+  defp validation_heap_words(limits, :mission), do: limits.evaluation_heap_words
+
+  defp mark_terminal_host_failure(state, :mission, evaluation_lease)
+       when is_reference(evaluation_lease),
+       do: RunState.mark_evaluation_terminal_host_failure(state, evaluation_lease)
+
+  defp mark_terminal_host_failure(_state, _environment, _evaluation_lease), do: :ok
 
   defp semantic_validate(%Capability{validate: nil}, _arguments), do: :ok
 
@@ -618,8 +768,16 @@ defmodule PtcRunner.Kernel.Dispatcher do
 
   defp validate_size(value, cap) do
     case RetainedSize.bytes_with_cap(value, cap) do
-      bytes when is_integer(bytes) and bytes <= cap -> :ok
-      _ -> {:error, :argument_exceeded}
+      bytes when is_integer(bytes) and bytes <= cap ->
+        :ok
+
+      :oversized ->
+        if json_value?(value),
+          do: {:error, :argument_exceeded},
+          else: {:error, :invalid_arguments}
+
+      _ ->
+        {:error, :argument_exceeded}
     end
   end
 
@@ -658,5 +816,9 @@ defmodule PtcRunner.Kernel.Dispatcher do
   defp capability_result_limit(state), do: state_limits(state).capability_result_bytes
   defp state_limits(state), do: RunState.limits(state)
 
-  defp json_value?(value), do: JSONValue.value?(value)
+  defp json_value?(value) do
+    JSONValue.value?(value)
+  rescue
+    _exception -> false
+  end
 end

--- a/lib/ptc_runner/kernel/dispatcher.ex
+++ b/lib/ptc_runner/kernel/dispatcher.ex
@@ -18,6 +18,11 @@ defmodule PtcRunner.Kernel.Dispatcher do
   Before a mission provider publishes a terminal policy failure, its monitored
   callback records that classification in RunState so a subsequent evaluator
   kill cannot make the agent repeat the call.
+
+  A pre-callback input-schema rejection may add up to three schema-authored
+  argument violations to the Lisp error envelope. The rejected arguments,
+  undeclared property names, and opaque semantic-validator reasons remain
+  withheld.
   """
 
   alias PtcRunner.Kernel.Capability
@@ -156,7 +161,7 @@ defmodule PtcRunner.Kernel.Dispatcher do
     # atomically re-checks the same lease.
     with true <- authenticated?(state, environment, lease),
          %Capability{} = capability <- Map.get(capabilities, name),
-         :ok <- validate(capability, arguments),
+         :ok <- validate(capability, arguments, state, environment),
          :ok <- validate_size(arguments, capability_argument_limit(state)),
          :ok <- RunState.reserve_capability(state, environment, name, lease) do
       invoke_with_events(
@@ -171,6 +176,12 @@ defmodule PtcRunner.Kernel.Dispatcher do
     else
       nil ->
         %{status: :error, kind: :capability_denied, reason: :capability_absent, retryable?: false}
+
+      {:error, :invalid_arguments, []} ->
+        protocol_error(state, event_sink, :invalid_arguments, environment, lease)
+
+      {:error, :invalid_arguments, violations} ->
+        protocol_error(state, event_sink, :invalid_arguments, environment, lease, violations)
 
       {:error, :invalid_arguments} ->
         protocol_error(state, event_sink, :invalid_arguments, environment, lease)
@@ -565,11 +576,29 @@ defmodule PtcRunner.Kernel.Dispatcher do
 
   defp terminal_provider_failure?(_result), do: false
 
-  defp validate(%Capability{} = capability, arguments) do
-    if JSONSchema.valid?(capability.input_validator, arguments),
-      do: semantic_validate(capability, arguments),
-      else: {:error, :invalid_arguments}
+  defp validate(%Capability{} = capability, arguments, state, environment) do
+    limits = state_limits(state)
+
+    case JSONSchema.validate(
+           capability.input_validator,
+           capability.input_schema,
+           arguments,
+           validation_timeout_ms(limits, environment),
+           validation_heap_words(limits)
+         ) do
+      :ok -> semantic_validate(capability, arguments)
+      {:error, violations} -> {:error, :invalid_arguments, violations}
+    end
   end
+
+  defp validation_timeout_ms(limits, :workflow), do: limits.workflow_timeout_ms
+  defp validation_timeout_ms(limits, :mission), do: limits.evaluation_timeout_ms
+
+  # Schema validation is host work shared by workflow and mission calls. Use
+  # the larger effective evaluator ceiling without converting byte limits into
+  # words or granting an oversized, not-yet-admitted argument extra heap.
+  defp validation_heap_words(limits),
+    do: max(limits.workflow_heap_words, limits.evaluation_heap_words)
 
   defp semantic_validate(%Capability{validate: nil}, _arguments), do: :ok
 
@@ -597,11 +626,17 @@ defmodule PtcRunner.Kernel.Dispatcher do
   # Authentication and accounting are one atomic owner operation: a mission
   # call whose evaluation died mid-validation must not spend the next
   # evaluation's shared protocol-error budget.
-  defp protocol_error(state, event_sink, reason, environment, lease) do
+  defp protocol_error(state, event_sink, reason, environment, lease, details \\ nil) do
     case RunState.protocol_error(state, environment, lease) do
-      :ok -> %{status: :error, kind: :protocol_error, reason: reason, retryable?: false}
-      {:error, :stale_evaluation} -> stale_evaluation_error()
-      {:error, :protocol_error_limit} -> limit_error(state, event_sink, :protocol_errors)
+      :ok ->
+        result = %{status: :error, kind: :protocol_error, reason: reason, retryable?: false}
+        if is_nil(details), do: result, else: Map.put(result, :details, details)
+
+      {:error, :stale_evaluation} ->
+        stale_evaluation_error()
+
+      {:error, :protocol_error_limit} ->
+        limit_error(state, event_sink, :protocol_errors)
     end
   end
 

--- a/lib/ptc_runner/kernel/evaluation.ex
+++ b/lib/ptc_runner/kernel/evaluation.ex
@@ -330,7 +330,8 @@ defmodule PtcRunner.Kernel.Evaluation do
           timeout_ms,
           capture.event_sink,
           capture.inspection_sink,
-          lease
+          lease,
+          deadline_ms
         ),
       prelude: bundle_prelude(environment),
       timeout: timeout_ms,
@@ -361,14 +362,17 @@ defmodule PtcRunner.Kernel.Evaluation do
           projection_boundary
         )
         |> put_terminal_provider_failure(step)
+        |> put_terminal_host_failure(step)
 
       {:ok, step} ->
         commit_result(state, lease, history, step, projection_boundary)
         |> put_terminal_provider_failure(step)
+        |> put_terminal_host_failure(step)
 
       {:error, step} ->
         release_failure(state, environment, lease, step, mission_calls_before)
         |> put_terminal_provider_failure(step)
+        |> put_terminal_host_failure(step)
     end
   end
 
@@ -543,8 +547,13 @@ defmodule PtcRunner.Kernel.Evaluation do
         nil -> result
       end
 
-    if evaluation_status.terminal_provider_failure?,
-      do: Map.put(result, :terminal_provider_failure?, true),
+    result =
+      if evaluation_status.terminal_provider_failure?,
+        do: Map.put(result, :terminal_provider_failure?, true),
+        else: result
+
+    if evaluation_status.terminal_host_failure?,
+      do: Map.put(result, :terminal_host_failure?, true),
       else: result
   end
 
@@ -658,6 +667,31 @@ defmodule PtcRunner.Kernel.Evaluation do
     end)
   end
 
+  defp put_terminal_host_failure(result, step) do
+    if terminal_host_failure?(step),
+      do: Map.put(result, :terminal_host_failure?, true),
+      else: result
+  end
+
+  defp terminal_host_failure?(step) do
+    step
+    |> Map.get(:tool_calls, [])
+    |> List.wrap()
+    |> Enum.any?(fn
+      %{
+        result: %{
+          status: :error,
+          kind: :capability_unavailable,
+          reason: :input_validation_unavailable
+        }
+      } ->
+        true
+
+      _call ->
+        false
+    end)
+  end
+
   defp mission_capability_call_count(state), do: call_total(mission_capability_calls(state))
 
   defp mission_capability_calls(state) do
@@ -688,15 +722,29 @@ defmodule PtcRunner.Kernel.Evaluation do
   end
 
   @doc false
-  def mission_tools(environment, state, timeout_ms, event_sink, inspection_sink, lease \\ nil) do
+  def mission_tools(
+        environment,
+        state,
+        timeout_ms,
+        event_sink,
+        inspection_sink,
+        evaluation_lease \\ nil,
+        validation_deadline_ms \\ nil
+      ) do
+    limits = RunState.limits(state)
+
     state
     |> ToolGrant.capability_callbacks(
       :mission,
       environment,
-      timeout_ms,
+      %{
+        timeout_ms: timeout_ms,
+        validation_heap_words: limits.evaluation_heap_words,
+        evaluation_lease: evaluation_lease,
+        validation_deadline_ms: validation_deadline_ms
+      },
       event_sink,
-      inspection_sink,
-      lease: lease
+      inspection_sink
     )
     |> Map.new(fn {name, callback} -> {name, %TrustedTool{function: callback}} end)
   end

--- a/lib/ptc_runner/kernel/json_schema.ex
+++ b/lib/ptc_runner/kernel/json_schema.ex
@@ -26,7 +26,10 @@ defmodule PtcRunner.Kernel.JSONSchema do
   JSV. Runtime validation delegates to the compiled JSV root. Input rejection
   may retain a small explanation containing only schema-declared paths,
   keywords, and bounds; submitted values and undeclared property names never
-  enter that explanation.
+  enter that explanation. Validation and explanation projection run together
+  in one time- and heap-bounded worker. Proven schema invalidity is distinct
+  from validator timeout, heap exhaustion, crashes, and malformed validator
+  results.
   """
 
   alias PtcRunner.Kernel.BoundedWorker
@@ -45,8 +48,8 @@ defmodule PtcRunner.Kernel.JSONSchema do
   @max_explanation_errors 64
   @max_argument_bytes 512
   @max_expected_bytes 256
-  @max_expected_members 8
   @simple_argument_segment ~r/\A[A-Za-z_][A-Za-z0-9_]*\z/
+  @expected_constraints ~w(minimum maximum minLength maxLength minItems maxItems)
 
   @constraint_keys %{
     type: "type",
@@ -103,41 +106,37 @@ defmodule PtcRunner.Kernel.JSONSchema do
 
   @doc "Validates a value and returns only bounded, schema-authored rejection facts."
   @spec validate(compiled(), map(), term(), pos_integer(), pos_integer()) ::
-          :ok | {:error, [violation()]}
+          :ok | {:invalid, [violation()]} | {:unavailable, atom()}
   def validate(root, schema, value, timeout_ms, max_heap_words)
       when is_map(schema) and not is_struct(schema) and is_integer(timeout_ms) and
              timeout_ms > 0 and is_integer(max_heap_words) and max_heap_words > 0 do
-    if match?({:ok, _remaining}, explanation_value_budget(value, @max_explanation_nodes)) do
-      validate_with_details(root, schema, value)
-    else
-      validate_without_details(root, value, timeout_ms, max_heap_words)
-    end
-  end
+    explain? = match?({:ok, _remaining}, explanation_value_budget(value, @max_explanation_nodes))
 
-  defp validate_with_details(root, schema, value) do
-    case JSV.validate(value, root, cast: false) do
-      {:ok, _validated} ->
-        :ok
-
-      {:error, %JSV.ValidationError{errors: errors}} ->
-        {:error, project_violations(errors, schema)}
-    end
-  rescue
-    _exception -> {:error, []}
-  end
-
-  # A large submitted value can make JSV's raw error term exceed the evaluator
-  # heap ceiling by itself. Validate such values in a separately bounded worker
-  # with enough headroom for the admitted capability-argument ceiling, and
-  # discard every diagnostic. Resource exhaustion fails closed as invalid.
-  defp validate_without_details(root, value, timeout_ms, max_heap_words) do
-    case BoundedWorker.run(fn -> valid?(root, value) end,
+    case BoundedWorker.run(fn -> validate_value(root, schema, value, explain?) end,
            timeout_ms: timeout_ms,
            max_heap_words: max_heap_words,
            cancel_with_caller: true
          ) do
-      {:ok, true} -> :ok
-      _invalid_or_exhausted -> {:error, []}
+      {:ok, :ok} -> :ok
+      {:ok, {:invalid, violations}} when is_list(violations) -> {:invalid, violations}
+      {:ok, {:unavailable, cause}} when is_atom(cause) -> {:unavailable, cause}
+      {:ok, _unexpected} -> {:unavailable, :unexpected_validator_result}
+      {:error, cause} -> {:unavailable, cause}
+    end
+  end
+
+  defp validate_value(root, schema, value, explain?) do
+    if JSONValue.value?(value) do
+      case JSV.validate(value, root, cast: false) do
+        {:ok, _validated} ->
+          :ok
+
+        {:error, %JSV.ValidationError{errors: errors}} ->
+          violations = if explain?, do: project_violations(errors, schema), else: []
+          {:invalid, violations}
+      end
+    else
+      {:invalid, []}
     end
   end
 
@@ -177,7 +176,8 @@ defmodule PtcRunner.Kernel.JSONSchema do
   # list: one invalid array element creates one formatted message, and a valid-
   # size argument can contain thousands of them. Refuse explanation work before
   # projecting any candidate when the raw cardinality exceeds the fixed budget.
-  # Otherwise select at most three safe schema facts with constant extra space.
+  # Otherwise canonicalize the bounded candidate set before selecting three,
+  # so upstream validator ordering cannot change the retained subset.
   defp project_violations(errors, schema) when is_list(errors) do
     if explanation_error_budget?(errors, @max_explanation_errors) do
       select_violations(errors, schema)
@@ -194,20 +194,11 @@ defmodule PtcRunner.Kernel.JSONSchema do
 
   defp select_violations(errors, schema) do
     errors
-    |> Enum.reduce_while([], fn error, violations ->
-      case project_violation(error, schema) do
-        nil ->
-          {:cont, violations}
-
-        violation ->
-          retained = if violation in violations, do: violations, else: [violation | violations]
-
-          if length(retained) == @max_violations,
-            do: {:halt, retained},
-            else: {:cont, retained}
-      end
-    end)
+    |> Enum.map(&project_violation(&1, schema))
+    |> Enum.reject(&is_nil/1)
+    |> Enum.uniq()
     |> Enum.sort_by(&{&1.argument, &1.constraint})
+    |> Enum.take(@max_violations)
   end
 
   defp project_violation(error, schema) do
@@ -219,7 +210,7 @@ defmodule PtcRunner.Kernel.JSONSchema do
          {:ok, declared} <- Map.fetch(node, constraint) do
       violation = %{argument: argument, constraint: constraint}
 
-      case project_expected(declared) do
+      case project_expected(constraint, declared) do
         {:ok, expected} -> Map.put(violation, :expected, expected)
         :omit -> violation
       end
@@ -286,13 +277,8 @@ defmodule PtcRunner.Kernel.JSONSchema do
     end
   end
 
-  defp project_expected(value) do
-    bounded_shape? =
-      scalar?(value) or
-        (is_list(value) and length(value) <= @max_expected_members and
-           Enum.all?(value, &scalar?/1))
-
-    with true <- bounded_shape?,
+  defp project_expected(constraint, value) when constraint in @expected_constraints do
+    with true <- is_number(value),
          {:ok, encoded} <- DeterministicJSON.encode(value),
          true <- byte_size(encoded) <= @max_expected_bytes do
       {:ok, value}
@@ -301,8 +287,7 @@ defmodule PtcRunner.Kernel.JSONSchema do
     end
   end
 
-  defp scalar?(value),
-    do: is_nil(value) or is_boolean(value) or is_number(value) or is_binary(value)
+  defp project_expected(_constraint, _value), do: :omit
 
   defp normalize(_schema, depth) when depth > @max_depth, do: {:error, :invalid_schema}
 

--- a/lib/ptc_runner/kernel/json_schema.ex
+++ b/lib/ptc_runner/kernel/json_schema.ex
@@ -23,10 +23,13 @@ defmodule PtcRunner.Kernel.JSONSchema do
 
   Each normalized schema is at most 64 KiB with maximum depth 16, 128
   properties per object, and 256 enum members. Schemas are compiled once with
-  JSV. Runtime validation delegates to the compiled JSV root; this module does
-  not evaluate schemas.
+  JSV. Runtime validation delegates to the compiled JSV root. Input rejection
+  may retain a small explanation containing only schema-declared paths,
+  keywords, and bounds; submitted values and undeclared property names never
+  enter that explanation.
   """
 
+  alias PtcRunner.Kernel.BoundedWorker
   alias PtcRunner.Kernel.DeterministicJSON
   alias PtcRunner.Kernel.JSONSchema.SHA256Format
   alias PtcRunner.Kernel.JSONValue
@@ -37,8 +40,35 @@ defmodule PtcRunner.Kernel.JSONSchema do
   @max_depth 16
   @max_properties 128
   @max_enum_members 256
+  @max_violations 3
+  @max_explanation_nodes 64
+  @max_explanation_errors 64
+  @max_argument_bytes 512
+  @max_expected_bytes 256
+  @max_expected_members 8
+  @simple_argument_segment ~r/\A[A-Za-z_][A-Za-z0-9_]*\z/
+
+  @constraint_keys %{
+    type: "type",
+    enum: "enum",
+    const: "const",
+    minimum: "minimum",
+    maximum: "maximum",
+    minLength: "minLength",
+    maxLength: "maxLength",
+    minItems: "minItems",
+    maxItems: "maxItems",
+    format: "format",
+    required: "required",
+    additionalProperties: "additionalProperties"
+  }
 
   @type compiled :: JSV.Root.t()
+  @type violation :: %{
+          required(:argument) => binary(),
+          required(:constraint) => binary(),
+          optional(:expected) => term()
+        }
 
   @dialects [
     "https://json-schema.org/draft/2020-12/schema",
@@ -70,6 +100,209 @@ defmodule PtcRunner.Kernel.JSONSchema do
   rescue
     _exception -> false
   end
+
+  @doc "Validates a value and returns only bounded, schema-authored rejection facts."
+  @spec validate(compiled(), map(), term(), pos_integer(), pos_integer()) ::
+          :ok | {:error, [violation()]}
+  def validate(root, schema, value, timeout_ms, max_heap_words)
+      when is_map(schema) and not is_struct(schema) and is_integer(timeout_ms) and
+             timeout_ms > 0 and is_integer(max_heap_words) and max_heap_words > 0 do
+    if match?({:ok, _remaining}, explanation_value_budget(value, @max_explanation_nodes)) do
+      validate_with_details(root, schema, value)
+    else
+      validate_without_details(root, value, timeout_ms, max_heap_words)
+    end
+  end
+
+  defp validate_with_details(root, schema, value) do
+    case JSV.validate(value, root, cast: false) do
+      {:ok, _validated} ->
+        :ok
+
+      {:error, %JSV.ValidationError{errors: errors}} ->
+        {:error, project_violations(errors, schema)}
+    end
+  rescue
+    _exception -> {:error, []}
+  end
+
+  # A large submitted value can make JSV's raw error term exceed the evaluator
+  # heap ceiling by itself. Validate such values in a separately bounded worker
+  # with enough headroom for the admitted capability-argument ceiling, and
+  # discard every diagnostic. Resource exhaustion fails closed as invalid.
+  defp validate_without_details(root, value, timeout_ms, max_heap_words) do
+    case BoundedWorker.run(fn -> valid?(root, value) end,
+           timeout_ms: timeout_ms,
+           max_heap_words: max_heap_words,
+           cancel_with_caller: true
+         ) do
+      {:ok, true} -> :ok
+      _invalid_or_exhausted -> {:error, []}
+    end
+  end
+
+  defp explanation_value_budget(_value, remaining) when remaining < 1, do: :over
+
+  defp explanation_value_budget(value, remaining)
+       when is_nil(value) or is_boolean(value) or is_number(value) or is_binary(value),
+       do: {:ok, remaining - 1}
+
+  defp explanation_value_budget(value, remaining) when is_list(value),
+    do: explanation_list_budget(value, remaining - 1)
+
+  defp explanation_value_budget(value, remaining) when is_map(value) and not is_struct(value) do
+    Enum.reduce_while(value, {:ok, remaining - 1}, fn {_key, child}, {:ok, budget} ->
+      case explanation_value_budget(child, budget) do
+        {:ok, next_budget} -> {:cont, {:ok, next_budget}}
+        :over -> {:halt, :over}
+      end
+    end)
+  end
+
+  defp explanation_value_budget(_value, _remaining), do: :over
+
+  defp explanation_list_budget([], remaining), do: {:ok, remaining}
+  defp explanation_list_budget(_values, remaining) when remaining < 1, do: :over
+
+  defp explanation_list_budget([value | rest], remaining) do
+    case explanation_value_budget(value, remaining) do
+      {:ok, next_remaining} -> explanation_list_budget(rest, next_remaining)
+      :over -> :over
+    end
+  end
+
+  defp explanation_list_budget(_improper_tail, _remaining), do: :over
+
+  # JSV has already accumulated its raw errors. Do not normalize that whole
+  # list: one invalid array element creates one formatted message, and a valid-
+  # size argument can contain thousands of them. Refuse explanation work before
+  # projecting any candidate when the raw cardinality exceeds the fixed budget.
+  # Otherwise select at most three safe schema facts with constant extra space.
+  defp project_violations(errors, schema) when is_list(errors) do
+    if explanation_error_budget?(errors, @max_explanation_errors) do
+      select_violations(errors, schema)
+    else
+      []
+    end
+  end
+
+  defp explanation_error_budget?([], _remaining), do: true
+  defp explanation_error_budget?([_error | _rest], 0), do: false
+
+  defp explanation_error_budget?([_error | rest], remaining),
+    do: explanation_error_budget?(rest, remaining - 1)
+
+  defp select_violations(errors, schema) do
+    errors
+    |> Enum.reduce_while([], fn error, violations ->
+      case project_violation(error, schema) do
+        nil ->
+          {:cont, violations}
+
+        violation ->
+          retained = if violation in violations, do: violations, else: [violation | violations]
+
+          if length(retained) == @max_violations,
+            do: {:halt, retained},
+            else: {:cont, retained}
+      end
+    end)
+    |> Enum.sort_by(&{&1.argument, &1.constraint})
+  end
+
+  defp project_violation(error, schema) do
+    with kind when is_atom(kind) <- Map.get(error, :kind),
+         {:ok, constraint} <- Map.fetch(@constraint_keys, kind),
+         schema_path when is_list(schema_path) <- Map.get(error, :schema_path),
+         {:ok, node, path} <- schema_context(schema, schema_path),
+         {:ok, argument} <- render_argument(path),
+         {:ok, declared} <- Map.fetch(node, constraint) do
+      violation = %{argument: argument, constraint: constraint}
+
+      case project_expected(declared) do
+        {:ok, expected} -> Map.put(violation, :expected, expected)
+        :omit -> violation
+      end
+    else
+      _unsupported_or_unresolved -> nil
+    end
+  end
+
+  # JSV's raw schema path contains only schema-owned tokens and does not carry
+  # the rejected value. Resolve every property and item step against the frozen
+  # schema before retaining it. Array positions become `[]`, because a
+  # submitted index is not a declared schema fact.
+  defp schema_context(schema, schema_path),
+    do: schema_path |> Enum.reverse() |> walk_schema_context(schema, [])
+
+  defp walk_schema_context([], node, path), do: {:ok, node, Enum.reverse(path)}
+
+  defp walk_schema_context([:root | rest], node, path),
+    do: walk_schema_context(rest, node, path)
+
+  defp walk_schema_context([{:properties, name} | rest], %{"properties" => properties}, path)
+       when is_map(properties) do
+    case Map.fetch(properties, name) do
+      {:ok, child} -> walk_schema_context(rest, child, [name | path])
+      :error -> :error
+    end
+  end
+
+  defp walk_schema_context([:items | rest], %{"items" => child}, path),
+    do: walk_schema_context(rest, child, [:item | path])
+
+  defp walk_schema_context(_segments, _node, _path), do: :error
+
+  defp render_argument([]), do: {:ok, "$"}
+
+  defp render_argument(path) do
+    with {:ok, argument} <-
+           Enum.reduce_while(path, {:ok, ""}, fn
+             :item, {:ok, rendered} ->
+               {:cont, {:ok, rendered <> "[]"}}
+
+             name, {:ok, rendered} ->
+               case append_property(rendered, name) do
+                 {:ok, next} -> {:cont, {:ok, next}}
+                 :error -> {:halt, :error}
+               end
+           end),
+         true <- byte_size(argument) <= @max_argument_bytes do
+      {:ok, argument}
+    else
+      _invalid_or_too_large -> :error
+    end
+  end
+
+  defp append_property(rendered, name) when is_binary(name) do
+    if Regex.match?(@simple_argument_segment, name) do
+      separator = if rendered == "", do: "", else: "."
+      {:ok, rendered <> separator <> name}
+    else
+      case DeterministicJSON.encode(name) do
+        {:ok, encoded} -> {:ok, rendered <> "[" <> encoded <> "]"}
+        {:error, _reason} -> :error
+      end
+    end
+  end
+
+  defp project_expected(value) do
+    bounded_shape? =
+      scalar?(value) or
+        (is_list(value) and length(value) <= @max_expected_members and
+           Enum.all?(value, &scalar?/1))
+
+    with true <- bounded_shape?,
+         {:ok, encoded} <- DeterministicJSON.encode(value),
+         true <- byte_size(encoded) <= @max_expected_bytes do
+      {:ok, value}
+    else
+      _too_large_or_structured -> :omit
+    end
+  end
+
+  defp scalar?(value),
+    do: is_nil(value) or is_boolean(value) or is_number(value) or is_binary(value)
 
   defp normalize(_schema, depth) when depth > @max_depth, do: {:error, :invalid_schema}
 

--- a/lib/ptc_runner/kernel/repl_session.ex
+++ b/lib/ptc_runner/kernel/repl_session.ex
@@ -577,17 +577,18 @@ defmodule PtcRunner.Kernel.ReplSession do
   defp run_lisp(session, memory, history, source) do
     limits = session.config.limits
     timeout_ms = min(limits.evaluation_timeout_ms, RunState.remaining_ms(session.state))
+    deadline_ms = System.monotonic_time(:millisecond) + timeout_ms
 
     Lisp.run_native(source,
       caller: :repl,
       context: session.config.input,
       memory: memory,
       turn_history: history,
-      tools: tools(session),
+      tools: tools(session, deadline_ms),
       prelude: prelude(session.config.workflow_environment),
       timeout: timeout_ms,
       compile_timeout: timeout_ms,
-      run_deadline_ms: System.monotonic_time(:millisecond) + timeout_ms,
+      run_deadline_ms: deadline_ms,
       pmap_timeout: limits.parallel_timeout_ms,
       max_heap: limits.evaluation_heap_words,
       max_parallel_workers: limits.live_provider_tasks,
@@ -599,14 +600,19 @@ defmodule PtcRunner.Kernel.ReplSession do
     )
   end
 
-  defp tools(session) do
+  defp tools(session, validation_deadline_ms) do
     timeout_ms = session.config.limits.evaluation_timeout_ms
 
     ToolGrant.capability_callbacks(
       session.state,
       :workflow,
       session.config.workflow_environment,
-      timeout_ms,
+      %{
+        timeout_ms: timeout_ms,
+        validation_heap_words: session.config.limits.evaluation_heap_words,
+        evaluation_lease: nil,
+        validation_deadline_ms: validation_deadline_ms
+      },
       session.config.event_sink,
       session.config.inspection_sink
     )

--- a/lib/ptc_runner/kernel/run_state.ex
+++ b/lib/ptc_runner/kernel/run_state.ex
@@ -40,10 +40,10 @@ defmodule PtcRunner.Kernel.RunState do
   budget, so exiting with the owner is the safe outcome and they stay unguarded.
   What is reported is the same for any exit, including a call timeout; a reply
   the owner actually sent is always passed through, so a mismatched token still
-  reaches the caller unchanged. A provider process atomically records terminal policy
-  classification against the active evaluation before publishing its result;
-  that evaluation-scoped bit therefore survives a later sandbox timeout or heap
-  kill and is cleared with the lease.
+  reaches the caller unchanged. Provider and pre-dispatch validation processes
+  atomically record terminal classifications against the active evaluation
+  before publishing their results; those evaluation-scoped bits therefore
+  survive a later sandbox timeout or heap kill and are cleared with the lease.
   """
   use GenServer
 
@@ -216,6 +216,11 @@ defmodule PtcRunner.Kernel.RunState do
   def mark_evaluation_terminal_provider_failure(state),
     do: safe_call(state, :mark_evaluation_terminal_provider_failure, :ok)
 
+  @doc false
+  @spec mark_evaluation_terminal_host_failure(t(), reference()) :: :ok | {:error, :closed}
+  def mark_evaluation_terminal_host_failure(state, evaluation_lease),
+    do: safe_call(state, {:mark_evaluation_terminal_host_failure, evaluation_lease}, :ok)
+
   @spec reserve_evaluation(t()) :: {:ok, map(), [term()], reference()} | {:error, atom()}
   @doc "Atomically reserves and returns native subordinate memory and turn history."
   def reserve_evaluation(state), do: reserve_evaluation(state, :fail_fast)
@@ -264,7 +269,12 @@ defmodule PtcRunner.Kernel.RunState do
 
   @doc false
   @spec release_evaluation_status(t(), reference()) ::
-          {:ok, %{terminal_provider_failure?: boolean()}} | {:error, atom()}
+          {:ok,
+           %{
+             terminal_provider_failure?: boolean(),
+             terminal_host_failure?: boolean()
+           }}
+          | {:error, atom()}
   def release_evaluation_status(state, lease),
     do: call(state, {:release_evaluation_status, lease})
 
@@ -419,6 +429,7 @@ defmodule PtcRunner.Kernel.RunState do
        evaluation_lease: nil,
        evaluation_release_waiter: nil,
        evaluation_terminal_provider_failure?: false,
+       evaluation_terminal_host_failure?: false,
        admission_queue: :queue.new(),
        reservations: %{}
      }}
@@ -524,6 +535,23 @@ defmodule PtcRunner.Kernel.RunState do
     {:reply, :ok, state}
   end
 
+  def handle_call(
+        {token, {:mark_evaluation_terminal_host_failure, evaluation_lease}},
+        _from,
+        %{token: token} = state
+      ) do
+    state =
+      case state.evaluation_lease do
+        {^evaluation_lease, _owner, _monitor_ref} when is_reference(evaluation_lease) ->
+          %{state | evaluation_terminal_host_failure?: true}
+
+        _other ->
+          state
+      end
+
+    {:reply, :ok, state}
+  end
+
   def handle_call({token, :reserve_evaluation}, {caller, _tag}, %{token: token} = state) do
     cond do
       state.closed? ->
@@ -547,7 +575,8 @@ defmodule PtcRunner.Kernel.RunState do
            | evaluations: state.evaluations + 1,
              evaluation_lease: lease,
              evaluation_release_waiter: nil,
-             evaluation_terminal_provider_failure?: false
+             evaluation_terminal_provider_failure?: false,
+             evaluation_terminal_host_failure?: false
          }}
     end
   end
@@ -1101,7 +1130,10 @@ defmodule PtcRunner.Kernel.RunState do
   end
 
   defp evaluation_status(state) do
-    %{terminal_provider_failure?: state.evaluation_terminal_provider_failure?}
+    %{
+      terminal_provider_failure?: state.evaluation_terminal_provider_failure?,
+      terminal_host_failure?: state.evaluation_terminal_host_failure?
+    }
   end
 
   defp maybe_complete_evaluation_release(%{evaluation_release_waiter: nil} = state), do: state
@@ -1137,7 +1169,12 @@ defmodule PtcRunner.Kernel.RunState do
   defp clear_evaluation(state) do
     state = resolve_release_waiter(state)
 
-    %{state | evaluation_lease: nil, evaluation_terminal_provider_failure?: false}
+    %{
+      state
+      | evaluation_lease: nil,
+        evaluation_terminal_provider_failure?: false,
+        evaluation_terminal_host_failure?: false
+    }
     |> admit_from_queue()
   end
 
@@ -1232,7 +1269,8 @@ defmodule PtcRunner.Kernel.RunState do
       | evaluations: state.evaluations + 1,
         evaluation_lease: lease,
         evaluation_release_waiter: nil,
-        evaluation_terminal_provider_failure?: false
+        evaluation_terminal_provider_failure?: false,
+        evaluation_terminal_host_failure?: false
     }
   end
 

--- a/lib/ptc_runner/kernel/runner.ex
+++ b/lib/ptc_runner/kernel/runner.ex
@@ -198,7 +198,7 @@ defmodule PtcRunner.Kernel.Runner do
   defp execute_workflow(entry_source, config, state, timeout_ms, deadline_ms, evaluation_id) do
     opts = [
       context: config.input,
-      tools: workflow_tools(config, state),
+      tools: workflow_tools(config, state, deadline_ms),
       prelude: bundle_prelude(config.workflow_environment),
       timeout: timeout_ms,
       compile_timeout: timeout_ms,
@@ -433,12 +433,17 @@ defmodule PtcRunner.Kernel.Runner do
     end
   end
 
-  defp workflow_tools(config, state) do
+  defp workflow_tools(config, state, validation_deadline_ms) do
     state
     |> ToolGrant.capability_callbacks(
       :workflow,
       config.workflow_environment,
-      config.limits.workflow_timeout_ms,
+      %{
+        timeout_ms: config.limits.workflow_timeout_ms,
+        validation_heap_words: config.limits.workflow_heap_words,
+        evaluation_lease: nil,
+        validation_deadline_ms: validation_deadline_ms
+      },
       config.event_sink,
       config.inspection_sink
     )

--- a/lib/ptc_runner/kernel/safe_metadata.ex
+++ b/lib/ptc_runner/kernel/safe_metadata.ex
@@ -34,6 +34,7 @@ defmodule PtcRunner.Kernel.SafeMetadata do
     protocol-error
     provider-error
     capability-error
+    capability-unavailable
     assertion-failed
     unknown-action
   )

--- a/lib/ptc_runner/kernel/tool_grant.ex
+++ b/lib/ptc_runner/kernel/tool_grant.ex
@@ -22,6 +22,7 @@ defmodule PtcRunner.Kernel.ToolGrant do
 
   alias PtcRunner.Kernel.Dispatcher
   alias PtcRunner.Kernel.Environment
+  alias PtcRunner.Kernel.RunState
   alias PtcRunner.Kernel.RuntimeTools
 
   @doc """
@@ -35,11 +36,48 @@ defmodule PtcRunner.Kernel.ToolGrant do
           term(),
           :workflow | :mission,
           map(),
-          non_neg_integer(),
+          %{
+            timeout_ms: non_neg_integer(),
+            validation_heap_words: pos_integer(),
+            evaluation_lease: reference() | nil,
+            validation_deadline_ms: integer() | nil
+          },
           term(),
-          term(),
-          keyword()
+          term()
         ) :: %{binary() => (map() -> map())}
+  def capability_callbacks(
+        state,
+        kind,
+        environment,
+        dispatch_context,
+        event_sink,
+        inspection_sink
+      )
+      when kind in [:workflow, :mission] and is_map(dispatch_context) do
+    build_callbacks(
+      state,
+      kind,
+      environment,
+      dispatch_context,
+      event_sink,
+      inspection_sink
+    )
+  end
+
+  @doc false
+  def capability_callbacks(
+        state,
+        kind,
+        environment,
+        timeout_ms,
+        event_sink,
+        inspection_sink
+      )
+      when kind in [:workflow, :mission] and is_integer(timeout_ms) do
+    capability_callbacks(state, kind, environment, timeout_ms, event_sink, inspection_sink, [])
+  end
+
+  @doc false
   def capability_callbacks(
         state,
         kind,
@@ -47,32 +85,64 @@ defmodule PtcRunner.Kernel.ToolGrant do
         timeout_ms,
         event_sink,
         inspection_sink,
-        opts \\ []
+        opts
       )
-      when kind in [:workflow, :mission] do
+      when kind in [:workflow, :mission] and is_integer(timeout_ms) and is_list(opts) do
     # Mission grants carry the lease of the evaluation constructing them, so
     # a call surviving that evaluation's death is rejected as stale instead
     # of being attributed to the next admitted evaluation.
     lease = Keyword.get(opts, :lease)
+    limits = RunState.limits(state)
 
+    build_callbacks(
+      state,
+      kind,
+      environment,
+      %{
+        timeout_ms: timeout_ms,
+        validation_heap_words: validation_heap_words(limits, kind),
+        evaluation_lease: lease,
+        validation_deadline_ms: nil
+      },
+      event_sink,
+      inspection_sink
+    )
+  end
+
+  defp build_callbacks(
+         state,
+         kind,
+         environment,
+         dispatch_context,
+         event_sink,
+         inspection_sink
+       ) do
     environment.capabilities
     |> Map.new(fn {name, capability} ->
       view = Environment.capability_view(name, capability)
 
       callback = fn arguments ->
-        Dispatcher.dispatch_with_lease(
+        Dispatcher.dispatch(
           state,
           kind,
           view,
           name,
           arguments,
-          timeout_ms,
-          {event_sink, inspection_sink, lease}
+          dispatch_context,
+          event_sink,
+          inspection_sink
         )
       end
 
       {name, callback}
     end)
-    |> Map.merge(RuntimeTools.tools(state, environment, event_sink, kind, lease: lease))
+    |> Map.merge(
+      RuntimeTools.tools(state, environment, event_sink, kind,
+        lease: dispatch_context.evaluation_lease
+      )
+    )
   end
+
+  defp validation_heap_words(limits, :workflow), do: limits.workflow_heap_words
+  defp validation_heap_words(limits, :mission), do: limits.evaluation_heap_words
 end

--- a/priv/preludes/kernel/agent.core.clj
+++ b/priv/preludes/kernel/agent.core.clj
@@ -103,13 +103,16 @@
                 ;; are not argument mistakes the model can correct. The Kernel
                 ;; derives this provenance from the private capability ledger,
                 ;; so it applies even when a later expression fails.
-                (if (true? (get evaluation :terminal-provider-failure?))
-                  (subject-failure
-                    :model-program-failed
-                    (if (= :failed (get evaluation :outcome))
-                      (get evaluation :value)
-                      :terminal-provider-failure))
-                  (case (get evaluation :outcome)
+                (if (true? (get evaluation :terminal-host-failure?))
+                  (fail (result/error :capability-unavailable
+                                      :input-validation-unavailable))
+                  (if (true? (get evaluation :terminal-provider-failure?))
+                    (subject-failure
+                      :model-program-failed
+                      (if (= :failed (get evaluation :outcome))
+                        (get evaluation :value)
+                        :terminal-provider-failure))
+                    (case (get evaluation :outcome)
                     :returned
                     (if validate-result?
                       (let [validation (kernel/validate-result (get evaluation :value))]
@@ -193,7 +196,7 @@
                                    (agent.feedback/evaluation-error evaluation))
                                  next-prompt-state
                                  closing?))
-                        (subject-failure :turn-limit :evaluation-error))))))
+                        (subject-failure :turn-limit :evaluation-error)))))))
 
               :protocol-error
               (if (agent.retry/retry? turn max-turns)

--- a/priv/preludes/kernel/agent.feedback.clj
+++ b/priv/preludes/kernel/agent.feedback.clj
@@ -41,10 +41,26 @@
          (if message (str "; message=" message) "")
          ". Send one corrected run_ptc_lisp call.")))
 
+(defn- argument-violation [violation]
+  (str (get violation :argument) " violates " (get violation :constraint)
+       (if (contains? violation :expected)
+         (str " " (pr-str (get violation :expected)))
+         "")))
+
+(defn- argument-violation-feedback [error]
+  (let [violations (if (and (= "protocol_error" (get error :kind))
+                            (= "invalid_arguments" (get error :reason)))
+                     (get error :details)
+                     nil)]
+    (if (seq violations)
+      (str "; violations=" (join "; " (map argument-violation violations)))
+      "")))
+
 (defn capability-error [evaluation]
   (let [error (get evaluation :value)]
     (str "The capability call failed without an unsafe effect. "
          "kind=" (get error :kind) "; reason=" (get error :reason)
+         (argument-violation-feedback error)
          ". Send one corrected run_ptc_lisp call with corrected capability arguments.")))
 
 (defn non-retryable [evaluation]

--- a/test/ptc_runner/kernel/agent_library_test.exs
+++ b/test/ptc_runner/kernel/agent_library_test.exs
@@ -1688,6 +1688,112 @@ defmodule PtcRunner.Kernel.AgentLibraryTest do
            )
   end
 
+  test "facade correction feedback omits enum and const literals" do
+    invalid = %{
+      content: nil,
+      tool_calls: [
+        %{
+          id: "invalid-facade-arguments",
+          name: "run_ptc_lisp",
+          args: %{
+            "program" => ~S|(api/choose "submitted-enum-sentinel" "submitted-const-sentinel")|
+          }
+        }
+      ]
+    }
+
+    corrected = %{
+      content: nil,
+      tool_calls: [
+        %{id: "corrected", name: "run_ptc_lisp", args: %{"program" => ~S|(return 1)|}}
+      ]
+    }
+
+    mission_source = """
+    (ns api "Mission facade" {:visibility :prompt})
+    (defn choose
+      {:signature "(mode :string, version :string) -> :map" :effect :read}
+      [mode version]
+      (fail (tool/raw-choice {"mode" mode "version" version})))
+    """
+
+    {:ok, raw_choice} =
+      Capability.new(
+        name: "raw-choice",
+        effect: :read,
+        input_schema: %{
+          "type" => "object",
+          "properties" => %{
+            "mode" => %{"type" => "string", "enum" => ["enum-schema-sentinel"]},
+            "version" => %{"type" => "string", "const" => "const-schema-sentinel"}
+          },
+          "required" => ["mode", "version"]
+        },
+        callback: fn _ -> flunk("invalid arguments must not reach the callback") end
+      )
+
+    {:ok, config} =
+      agent_config([invalid, corrected], [],
+        mission_source: mission_source,
+        mission_capabilities: [raw_choice]
+      )
+
+    assert {:ok, %{value: %{"ok" => true, "value" => 1}}} =
+             Kernel.run(~S|(agent.core/run "Choose safely" {"max_turns" 2})|, config)
+
+    assert_receive {:agent_request, first}
+    first_visible = Jason.encode!(first)
+    refute first_visible =~ "tool/raw-choice"
+    refute first_visible =~ "enum-schema-sentinel"
+    refute first_visible =~ "const-schema-sentinel"
+
+    assert_receive {:agent_request, second}
+    correction = List.last(second["messages"])["content"]
+    assert correction =~ "mode violates enum"
+    assert correction =~ "version violates const"
+    refute correction =~ "enum-schema-sentinel"
+    refute correction =~ "const-schema-sentinel"
+    refute correction =~ "submitted-enum-sentinel"
+    refute correction =~ "submitted-const-sentinel"
+  end
+
+  test "agent.core fails validation unavailability without another provider turn" do
+    response = %{
+      content: nil,
+      tool_calls: [
+        %{
+          id: "validator-unavailable",
+          name: "run_ptc_lisp",
+          args: %{"program" => ~S|(fail (tool/unstable {"value" 1}))|}
+        }
+      ]
+    }
+
+    {:ok, unstable} =
+      Capability.new(
+        name: "unstable",
+        effect: :read,
+        input_schema: %{
+          "type" => "object",
+          "properties" => %{"value" => %{"type" => "integer"}}
+        },
+        callback: fn _ -> flunk("unavailable validation must not invoke the callback") end
+      )
+
+    unstable = %{unstable | input_validator: :forced_validator_failure}
+    {:ok, config} = agent_config([response, @recovered], [], mission_capabilities: [unstable])
+
+    assert {:error,
+            %{
+              kind: :workflow_failed,
+              reason: :explicit_failure,
+              details: %{failure_kind: "capability-unavailable"}
+            }} = Kernel.run(~S|(agent.core/run "Read once" {"max_turns" 3})|, config)
+
+    assert_receive {:agent_request, _first}
+    refute_receive {:agent_request, _second}
+  end
+
   test "default prompt renders nested direct-capability schema documentation" do
     response = %{
       content: nil,

--- a/test/ptc_runner/kernel/agent_library_test.exs
+++ b/test/ptc_runner/kernel/agent_library_test.exs
@@ -1231,6 +1231,54 @@ defmodule PtcRunner.Kernel.AgentLibraryTest do
     refute feedback =~ "private provider detail"
   end
 
+  test "agent.core receives a declared bound after rejecting capability arguments" do
+    parent = self()
+
+    rejected_call = %{
+      content: nil,
+      tool_calls: [
+        %{
+          id: "oversized-page",
+          name: "run_ptc_lisp",
+          args: %{
+            "program" =>
+              ~S|(let [response (tool/paged_lookup {"limit" 700})] (if (= :ok (get response :status)) (get response :value) (fail response)))|
+          }
+        }
+      ]
+    }
+
+    {:ok, paged_lookup} =
+      Capability.new(
+        name: "paged_lookup",
+        effect: :read,
+        input_schema: %{
+          "type" => "object",
+          "properties" => %{
+            "limit" => %{"type" => "integer", "minimum" => 1, "maximum" => 50}
+          }
+        },
+        callback: fn _arguments ->
+          send(parent, :unexpected_paged_lookup)
+          {:ok, nil}
+        end
+      )
+
+    {:ok, config} =
+      agent_config([rejected_call, @recovered], [], mission_capabilities: [paged_lookup])
+
+    assert {:ok, %{value: %{"ok" => true, "value" => "ok"}}} =
+             Kernel.run(~S|(agent.core/run "Correct the paged lookup" {"max_turns" 3})|, config)
+
+    assert_receive {:agent_request, _first}
+    assert_receive {:agent_request, second}
+    refute_received :unexpected_paged_lookup
+
+    feedback = second["messages"] |> List.last() |> Map.fetch!("content")
+    assert feedback =~ "limit violates maximum 50"
+    refute feedback =~ "700"
+  end
+
   test "agent.core does not correct a capability failure after an unsafe effect" do
     parent = self()
 

--- a/test/ptc_runner/kernel/core_contract_test.exs
+++ b/test/ptc_runner/kernel/core_contract_test.exs
@@ -204,12 +204,43 @@ defmodule PtcRunner.Kernel.CoreContractTest do
     assert %{status: :error, kind: :provider_error, reason: :denied} =
              Task.await(dispatch, 2_000)
 
-    assert_receive {:evaluation_released, {:ok, %{terminal_provider_failure?: true}}}
+    assert_receive {:evaluation_released,
+                    {:ok,
+                     %{
+                       terminal_provider_failure?: true,
+                       terminal_host_failure?: false
+                     }}}
 
     assert {:ok, %{}, [], next_lease} = RunState.reserve_evaluation(state)
 
-    assert {:ok, %{terminal_provider_failure?: false}} =
+    assert {:ok,
+            %{
+              terminal_provider_failure?: false,
+              terminal_host_failure?: false
+            }} =
              RunState.release_evaluation_status(state, next_lease)
+  end
+
+  test "evaluation host-failure status is scoped to the exact active lease" do
+    {:ok, state} = RunState.start(Limits.defaults())
+    assert {:ok, %{}, [], lease} = RunState.reserve_evaluation(state)
+
+    assert :ok = RunState.mark_evaluation_terminal_host_failure(state, make_ref())
+
+    assert {:ok,
+            %{
+              terminal_provider_failure?: false,
+              terminal_host_failure?: false
+            }} = RunState.release_evaluation_status(state, lease)
+
+    assert {:ok, %{}, [], next_lease} = RunState.reserve_evaluation(state)
+    assert :ok = RunState.mark_evaluation_terminal_host_failure(state, next_lease)
+
+    assert {:ok,
+            %{
+              terminal_provider_failure?: false,
+              terminal_host_failure?: true
+            }} = RunState.release_evaluation_status(state, next_lease)
   end
 
   test "continuation commit applies separate memory and exact-history ceilings atomically" do
@@ -2416,6 +2447,43 @@ defmodule PtcRunner.Kernel.CoreContractTest do
              outcome: :evaluation_error,
              retryable?: true,
              terminal_provider_failure?: true
+           } = result
+
+    assert result.kind in [:timeout, :memory_exceeded]
+  end
+
+  test "sandbox kills retain input-validation unavailability outside the evaluator" do
+    {:ok, unstable} =
+      Capability.new(
+        name: "unstable",
+        effect: :read,
+        input_schema: @input_schema,
+        callback: fn _ -> flunk("unavailable validation must prevent callback entry") end
+      )
+
+    unstable = %{unstable | input_validator: :forced_validator_failure}
+    {:ok, mission} = MissionEnvironment.new(capabilities: [unstable])
+
+    {:ok, limits} =
+      Limits.new(
+        evaluation_timeout_ms: 500,
+        evaluation_heap_words: 100_000_000
+      )
+
+    {:ok, state} = RunState.start(limits)
+
+    result =
+      Evaluation.evaluate_source(
+        state,
+        mission,
+        ~S|(do (tool/unstable {}) (reduce + (range 0 100000000)))|,
+        500
+      )
+
+    assert %{
+             outcome: :evaluation_error,
+             retryable?: true,
+             terminal_host_failure?: true
            } = result
 
     assert result.kind in [:timeout, :memory_exceeded]

--- a/test/ptc_runner/kernel/dispatcher_argument_violation_test.exs
+++ b/test/ptc_runner/kernel/dispatcher_argument_violation_test.exs
@@ -1,0 +1,305 @@
+defmodule PtcRunner.Kernel.DispatcherArgumentViolationTest do
+  use ExUnit.Case, async: true
+
+  alias PtcRunner.Kernel.Capability
+  alias PtcRunner.Kernel.Dispatcher
+  alias PtcRunner.Kernel.EventSink
+  alias PtcRunner.Kernel.JSONSchema
+  alias PtcRunner.Kernel.Library
+  alias PtcRunner.Kernel.Limits
+  alias PtcRunner.Kernel.MissionEnvironment
+  alias PtcRunner.Kernel.RunConfig
+  alias PtcRunner.Kernel.RunState
+  alias PtcRunner.Kernel.WorkflowEnvironment
+  alias PtcRunner.Lisp
+  alias PtcRunner.Lisp.CoreToSource
+
+  test "schema rejection names the argument, violated keyword, and declared bound" do
+    result =
+      dispatch(
+        %{
+          "type" => "object",
+          "properties" => %{
+            "limit" => %{"type" => "integer", "minimum" => 1, "maximum" => 50}
+          }
+        },
+        %{"limit" => 700}
+      )
+
+    assert %{
+             status: :error,
+             kind: :protocol_error,
+             reason: :invalid_arguments,
+             details: [
+               %{argument: "limit", constraint: "maximum", expected: 50}
+             ]
+           } = result
+
+    feedback = render_capability_feedback(result)
+
+    assert feedback =~ "limit violates maximum 50"
+    refute feedback =~ "700"
+  end
+
+  test "rejection details never repeat undeclared keys or submitted values" do
+    result =
+      dispatch(
+        %{
+          "type" => "object",
+          "properties" => %{"query" => %{"type" => "string"}}
+        },
+        %{"undeclared_secret" => "submitted-secret-value"}
+      )
+
+    assert %{details: [%{argument: "$", constraint: "additionalProperties"}]} =
+             result
+
+    rendered = inspect(result)
+    refute rendered =~ "undeclared_secret"
+    refute rendered =~ "submitted-secret-value"
+  end
+
+  test "semantic validator rejection remains opaque" do
+    result =
+      dispatch(
+        %{
+          "type" => "object",
+          "properties" => %{"limit" => %{"type" => "integer", "maximum" => 50}}
+        },
+        %{"limit" => 10},
+        fn _arguments -> {:error, "private semantic reason"} end
+      )
+
+    assert %{status: :error, kind: :protocol_error, reason: :invalid_arguments} = result
+    refute Map.has_key?(result, :details)
+    refute render_capability_feedback(result) =~ "private semantic reason"
+  end
+
+  test "malformed nested lists fail closed as invalid arguments" do
+    result =
+      dispatch(
+        %{
+          "type" => "object",
+          "properties" => %{
+            "rows" => %{"type" => "array", "items" => %{"type" => "integer"}}
+          }
+        },
+        %{"rows" => [1 | 2]}
+      )
+
+    assert %{status: :error, kind: :protocol_error, reason: :invalid_arguments} = result
+  end
+
+  test "violation projection is bounded and omits oversized expected sets" do
+    properties =
+      Map.new(1..5, fn index ->
+        {"field_#{index}",
+         %{
+           "type" => "string",
+           "enum" => Enum.map(1..9, &"allowed_#{index}_#{&1}")
+         }}
+      end)
+
+    arguments = Map.new(1..5, &{"field_#{&1}", "submitted_#{&1}"})
+    result = dispatch(%{"type" => "object", "properties" => properties}, arguments)
+
+    assert %{details: violations} = result
+    assert length(violations) == 3
+    assert Enum.all?(violations, &(&1.constraint == "enum"))
+    assert Enum.all?(violations, &(not Map.has_key?(&1, :expected)))
+    refute inspect(result) =~ "submitted_"
+    refute inspect(result) =~ "allowed_"
+  end
+
+  test "nested and array argument paths come from the schema" do
+    result =
+      dispatch(
+        %{
+          "type" => "object",
+          "properties" => %{
+            "batch/list~set" => %{
+              "type" => "array",
+              "items" => %{
+                "type" => "object",
+                "properties" => %{
+                  "page/size~" => %{"type" => "integer", "minimum" => 1}
+                }
+              }
+            }
+          }
+        },
+        %{"batch/list~set" => [%{"page/size~" => 0}]}
+      )
+
+    assert %{
+             details: [
+               %{
+                 argument: ~S(["batch/list~set"][]["page/size~"]),
+                 constraint: "minimum",
+                 expected: 1
+               }
+             ]
+           } =
+             result
+  end
+
+  test "argument display distinguishes punctuation from structural path syntax" do
+    dotted =
+      dispatch(
+        %{
+          "type" => "object",
+          "properties" => %{
+            "a.b" => %{"type" => "integer", "maximum" => 1},
+            "a" => %{
+              "type" => "object",
+              "properties" => %{"b" => %{"type" => "integer", "maximum" => 1}}
+            },
+            "line\nbreak" => %{"type" => "integer", "maximum" => 1}
+          }
+        },
+        %{"a.b" => 2, "a" => %{"b" => 2}, "line\nbreak" => 2}
+      )
+
+    assert %{details: dotted_violations} = dotted
+
+    assert MapSet.new(Enum.map(dotted_violations, & &1.argument)) ==
+             MapSet.new([~S(["a.b"]), "a.b", ~S(["line\nbreak"])])
+
+    refute Enum.any?(dotted_violations, &String.contains?(&1.argument, "\n"))
+
+    array =
+      dispatch(
+        %{
+          "type" => "object",
+          "properties" => %{
+            "rows[]" => %{"type" => "integer", "minimum" => 1},
+            "rows" => %{"type" => "array", "items" => %{"type" => "integer", "minimum" => 1}}
+          }
+        },
+        %{"rows[]" => 0, "rows" => [0]}
+      )
+
+    assert %{details: array_violations} = array
+
+    assert MapSet.new(Enum.map(array_violations, & &1.argument)) ==
+             MapSet.new([~S(["rows[]"]), "rows[]"])
+
+    root =
+      dispatch(
+        %{
+          "type" => "object",
+          "properties" => %{
+            "arguments" => %{"type" => "object", "properties" => %{}}
+          }
+        },
+        %{"arguments" => %{"nested_unknown" => true}, "root_unknown" => true}
+      )
+
+    assert %{details: root_violations} = root
+
+    assert MapSet.new(Enum.map(root_violations, & &1.argument)) ==
+             MapSet.new(["$", "arguments"])
+
+    refute inspect(root) =~ "nested_unknown"
+    refute inspect(root) =~ "root_unknown"
+  end
+
+  test "explanation work stays within the evaluator heap for many repeated violations" do
+    {:ok, normalized, validator} =
+      JSONSchema.compile(%{
+        "type" => "object",
+        "properties" => %{
+          "rows" => %{"type" => "array", "items" => %{"type" => "integer", "minimum" => 1}}
+        }
+      })
+
+    arguments = %{"rows" => List.duplicate(0, 5_000)}
+    parent = self()
+    heap_words = Limits.defaults().evaluation_heap_words
+
+    {pid, ref} =
+      :erlang.spawn_opt(
+        fn ->
+          result =
+            JSONSchema.validate(
+              validator,
+              normalized,
+              arguments,
+              Limits.defaults().evaluation_timeout_ms,
+              Limits.defaults().workflow_heap_words
+            )
+
+          send(parent, {:validation_result, self(), result})
+        end,
+        [:monitor, {:max_heap_size, %{size: heap_words, kill: true, error_logger: false}}]
+      )
+
+    assert_receive {:validation_result, ^pid, {:error, []}}, 5_000
+
+    assert_receive {:DOWN, ^ref, :process, ^pid, :normal}, 5_000
+  end
+
+  test "large valid arguments honor raised validation bounds" do
+    {:ok, normalized, validator} =
+      JSONSchema.compile(%{
+        "type" => "object",
+        "properties" => %{
+          "rows" => %{"type" => "array", "items" => %{"type" => "integer"}}
+        }
+      })
+
+    arguments = %{"rows" => List.duplicate(0, 175_000)}
+
+    assert :ok = JSONSchema.validate(validator, normalized, arguments, 2_000, 16_000_000)
+  end
+
+  defp dispatch(schema, arguments, semantic_validator \\ nil) do
+    parent = self()
+
+    {:ok, capability} =
+      Capability.new(
+        name: "schema_checked",
+        effect: :read,
+        input_schema: schema,
+        validate: semantic_validator,
+        callback: fn submitted ->
+          send(parent, {:unexpected_callback, submitted})
+          {:ok, nil}
+        end
+      )
+
+    {:ok, environment} = WorkflowEnvironment.new(capabilities: [capability])
+    {:ok, state} = RunState.start(Limits.defaults())
+
+    result = Dispatcher.dispatch(state, :workflow, environment, capability.name, arguments, 100)
+    refute_received {:unexpected_callback, _submitted}
+    result
+  end
+
+  defp render_capability_feedback(result) do
+    {:ok, projected_result} = Lisp.project_boundary_value(result, :kernel_json)
+    {:ok, component} = Library.component("agent.feedback")
+    {:ok, bundle} = PtcRunner.Kernel.compile_bundle([component])
+    {:ok, workflow} = WorkflowEnvironment.new(bundle: bundle)
+    {:ok, mission} = MissionEnvironment.new([])
+    {:ok, limits} = Limits.new()
+    {:ok, sink} = EventSink.start(:normal, limits, run_id: "argument-violation-feedback")
+
+    {:ok, config} =
+      RunConfig.new(
+        workflow_environment: workflow,
+        mission_environment: mission,
+        input: %{},
+        limits: limits,
+        event_sink: sink
+      )
+
+    assert {:ok, %{value: feedback}} =
+             PtcRunner.Kernel.run(
+               "(return (agent.feedback/capability-error #{CoreToSource.format(%{value: projected_result})}))",
+               config
+             )
+
+    feedback
+  end
+end

--- a/test/ptc_runner/kernel/dispatcher_argument_violation_test.exs
+++ b/test/ptc_runner/kernel/dispatcher_argument_violation_test.exs
@@ -10,6 +10,7 @@ defmodule PtcRunner.Kernel.DispatcherArgumentViolationTest do
   alias PtcRunner.Kernel.MissionEnvironment
   alias PtcRunner.Kernel.RunConfig
   alias PtcRunner.Kernel.RunState
+  alias PtcRunner.Kernel.TraceLog
   alias PtcRunner.Kernel.WorkflowEnvironment
   alias PtcRunner.Lisp
   alias PtcRunner.Lisp.CoreToSource
@@ -111,6 +112,51 @@ defmodule PtcRunner.Kernel.DispatcherArgumentViolationTest do
     refute inspect(result) =~ "allowed_"
   end
 
+  test "enum and const literals are omitted even when small" do
+    result =
+      dispatch(
+        %{
+          "type" => "object",
+          "properties" => %{
+            "mode" => %{"type" => "string", "enum" => ["enum-sentinel"]},
+            "version" => %{"type" => "string", "const" => "const-sentinel"}
+          },
+          "required" => ["mode", "version"]
+        },
+        %{"mode" => "submitted-mode", "version" => "submitted-version"}
+      )
+
+    assert %{details: violations} = result
+
+    assert MapSet.new(violations) ==
+             MapSet.new([
+               %{argument: "mode", constraint: "enum"},
+               %{argument: "version", constraint: "const"}
+             ])
+
+    rendered = inspect(result)
+    refute rendered =~ "enum-sentinel"
+    refute rendered =~ "const-sentinel"
+    refute rendered =~ "submitted-"
+  end
+
+  test "bounded violation selection is canonical before truncation" do
+    properties =
+      Map.new(["zeta", "gamma", "beta", "alpha"], fn name ->
+        {name, %{"type" => "integer", "maximum" => 1}}
+      end)
+
+    arguments = Map.new(Map.keys(properties), &{&1, 2})
+
+    assert %{
+             details: [
+               %{argument: "alpha", constraint: "maximum", expected: 1},
+               %{argument: "beta", constraint: "maximum", expected: 1},
+               %{argument: "gamma", constraint: "maximum", expected: 1}
+             ]
+           } = dispatch(%{"type" => "object", "properties" => properties}, arguments)
+  end
+
   test "nested and array argument paths come from the schema" do
     result =
       dispatch(
@@ -204,53 +250,124 @@ defmodule PtcRunner.Kernel.DispatcherArgumentViolationTest do
     refute inspect(root) =~ "root_unknown"
   end
 
-  test "explanation work stays within the evaluator heap for many repeated violations" do
+  test "validation worker exhaustion is unavailable rather than invalid" do
     {:ok, normalized, validator} =
       JSONSchema.compile(%{
         "type" => "object",
-        "properties" => %{
-          "rows" => %{"type" => "array", "items" => %{"type" => "integer", "minimum" => 1}}
-        }
+        "properties" => %{"value" => %{"type" => "integer"}}
       })
 
-    arguments = %{"rows" => List.duplicate(0, 5_000)}
-    parent = self()
-    heap_words = Limits.defaults().evaluation_heap_words
-
-    {pid, ref} =
-      :erlang.spawn_opt(
-        fn ->
-          result =
-            JSONSchema.validate(
-              validator,
-              normalized,
-              arguments,
-              Limits.defaults().evaluation_timeout_ms,
-              Limits.defaults().workflow_heap_words
-            )
-
-          send(parent, {:validation_result, self(), result})
-        end,
-        [:monitor, {:max_heap_size, %{size: heap_words, kill: true, error_logger: false}}]
-      )
-
-    assert_receive {:validation_result, ^pid, {:error, []}}, 5_000
-
-    assert_receive {:DOWN, ^ref, :process, ^pid, :normal}, 5_000
+    assert {:unavailable, :heap_exceeded} =
+             JSONSchema.validate(validator, normalized, %{"value" => 1}, 1_000, 233)
   end
 
-  test "large valid arguments honor raised validation bounds" do
+  test "validation worker timeout is unavailable rather than invalid" do
     {:ok, normalized, validator} =
       JSONSchema.compile(%{
         "type" => "object",
         "properties" => %{
-          "rows" => %{"type" => "array", "items" => %{"type" => "integer"}}
+          "rows" => %{
+            "type" => "array",
+            "items" => %{"type" => "integer", "minimum" => 1}
+          }
         }
       })
 
-    arguments = %{"rows" => List.duplicate(0, 175_000)}
+    assert {:unavailable, :timeout} =
+             JSONSchema.validate(
+               validator,
+               normalized,
+               %{"rows" => List.duplicate(0, 10_000)},
+               1,
+               100_000_000
+             )
+  end
 
-    assert :ok = JSONSchema.validate(validator, normalized, arguments, 2_000, 16_000_000)
+  test "validator failure does not charge protocol or capability budgets" do
+    {result, state, sink} = dispatch_with_unavailable_validator(%{"value" => 1})
+
+    assert %{
+             status: :error,
+             kind: :capability_unavailable,
+             reason: :input_validation_unavailable,
+             retryable?: false
+           } = result
+
+    usage = RunState.usage(state)
+    assert usage.protocol_errors == 0
+    assert usage.capability_calls.workflow == %{}
+
+    refute Enum.any?(EventSink.events(sink), fn event ->
+             event.type in ["capability-started", "capability-stopped"]
+           end)
+  end
+
+  test "argument size admission precedes schema validation" do
+    limits = Limits.defaults()
+    arguments = %{"value" => String.duplicate("x", limits.capability_argument_bytes + 1)}
+    {result, state, _sink} = dispatch_with_unavailable_validator(arguments)
+
+    assert %{kind: :protocol_error, reason: :argument_exceeded} = result
+    assert RunState.usage(state).protocol_errors == 1
+  end
+
+  @tag :tmp_dir
+  test "plain Lisp receives details while the canonical trace omits them", %{tmp_dir: dir} do
+    enum_literal = "enum-trace-sentinel"
+    submitted = "submitted-trace-sentinel"
+
+    {:ok, capability} =
+      Capability.new(
+        name: "schema_checked",
+        effect: :read,
+        input_schema: %{
+          "type" => "object",
+          "properties" => %{"mode" => %{"type" => "string", "enum" => [enum_literal]}},
+          "required" => ["mode"]
+        },
+        callback: fn _ -> flunk("callback must not run") end
+      )
+
+    {:ok, workflow} = WorkflowEnvironment.new(capabilities: [capability])
+    {:ok, mission} = MissionEnvironment.new([])
+    {:ok, limits} = Limits.new()
+    {:ok, sink} = EventSink.start(:normal, limits, run_id: "schema-feedback-boundary")
+
+    {:ok, config} =
+      RunConfig.new(
+        workflow_environment: workflow,
+        mission_environment: mission,
+        input: %{},
+        limits: limits,
+        event_sink: sink
+      )
+
+    source =
+      ~s|(return (tool/schema_checked {"mode" "#{submitted}"}))|
+
+    assert {:ok,
+            %{
+              value: %{
+                "status" => "error",
+                "kind" => "protocol_error",
+                "reason" => "invalid_arguments",
+                "details" => [%{"argument" => "mode", "constraint" => "enum"}]
+              }
+            }} = PtcRunner.Kernel.run(source, config)
+
+    events = EventSink.events(sink)
+
+    refute Enum.any?(events, fn event ->
+             event.type in ["capability-started", "capability-stopped"]
+           end)
+
+    path = Path.join(dir, "canonical.jsonl")
+    assert :ok = TraceLog.append_jsonl(path, events)
+    canonical = File.read!(path)
+    refute canonical =~ enum_literal
+    refute canonical =~ submitted
+    refute canonical =~ "invalid_arguments"
+    refute canonical =~ ~s|"details":|
   end
 
   defp dispatch(schema, arguments, semantic_validator \\ nil) do
@@ -274,6 +391,45 @@ defmodule PtcRunner.Kernel.DispatcherArgumentViolationTest do
     result = Dispatcher.dispatch(state, :workflow, environment, capability.name, arguments, 100)
     refute_received {:unexpected_callback, _submitted}
     result
+  end
+
+  defp dispatch_with_unavailable_validator(arguments) do
+    parent = self()
+
+    {:ok, capability} =
+      Capability.new(
+        name: "schema_checked",
+        effect: :read,
+        input_schema: %{
+          "type" => "object",
+          "properties" => %{"value" => %{"type" => "integer"}}
+        },
+        callback: fn submitted ->
+          send(parent, {:unexpected_callback, submitted})
+          {:ok, nil}
+        end
+      )
+
+    capability = %{capability | input_validator: :forced_validator_failure}
+    {:ok, environment} = WorkflowEnvironment.new(capabilities: [capability])
+    {:ok, limits} = Limits.new()
+    {:ok, state} = RunState.start(limits)
+    {:ok, sink} = EventSink.start(:normal, limits, run_id: "validation-unavailable")
+
+    result =
+      Dispatcher.dispatch(
+        state,
+        :workflow,
+        environment,
+        capability.name,
+        arguments,
+        100,
+        sink,
+        nil
+      )
+
+    refute_received {:unexpected_callback, _submitted}
+    {result, state, sink}
   end
 
   defp render_capability_feedback(result) do

--- a/test/ptc_runner/kernel/repl_session_test.exs
+++ b/test/ptc_runner/kernel/repl_session_test.exs
@@ -20,6 +20,46 @@ defmodule PtcRunner.Kernel.ReplSessionTest do
 
   @input_schema %{"type" => "object", "additionalProperties" => true}
 
+  test "workflow-authorized REPL tools validate under the evaluation heap" do
+    {:ok, checked} =
+      Capability.new(
+        name: "checked",
+        input_schema: %{
+          "type" => "object",
+          "properties" => %{"value" => %{"type" => "integer"}},
+          "required" => ["value"]
+        },
+        callback: fn %{"value" => value} -> {:ok, %{"accepted" => value}} end
+      )
+
+    {:ok, workflow} = WorkflowEnvironment.new(capabilities: [checked])
+    {:ok, mission} = MissionEnvironment.new([])
+
+    # The deliberately tiny workflow ceiling makes the old authority-derived
+    # validator worker fail. REPL Lisp and its tool validation both belong to
+    # the evaluation resource class and must use that larger ceiling.
+    {:ok, limits} = Limits.new(workflow_heap_words: 233)
+    {:ok, sink} = EventSink.start(:normal, limits, run_id: "repl-validation-heap")
+
+    {:ok, config} =
+      RunConfig.new(
+        workflow_environment: workflow,
+        mission_environment: mission,
+        input: %{},
+        limits: limits,
+        event_sink: sink
+      )
+
+    {:ok, session} = ReplSession.new(config: config)
+
+    assert {:ok, step, session} =
+             ReplSession.eval(session, ~S|(tool/checked {"value" 1})|)
+
+    assert step.return == %{status: :ok, value: %{"accepted" => 1}}
+
+    assert {:ok, _events} = ReplSession.close(session)
+  end
+
   test "manifest sessions grant the Runner's workflow runtime tools" do
     # A reused manifest bundle must mean the same thing in the REPL as in the
     # Runner: shipped preludes require runtime tools (workflow-annotate,

--- a/test/ptc_runner/kernel/tool_grant_test.exs
+++ b/test/ptc_runner/kernel/tool_grant_test.exs
@@ -6,6 +6,7 @@ defmodule PtcRunner.Kernel.ToolGrantTest do
   alias PtcRunner.Kernel.MissionEnvironment
   alias PtcRunner.Kernel.RunState
   alias PtcRunner.Kernel.ToolGrant
+  alias PtcRunner.Kernel.WorkflowEnvironment
 
   @input_schema %{"type" => "object", "additionalProperties" => false}
 
@@ -34,7 +35,16 @@ defmodule PtcRunner.Kernel.ToolGrantTest do
       for n <- [1, 10, 50], into: %{} do
         environment = environment_with(Enum.map(1..n, &capability("cap-#{&1}")))
         {:ok, state} = RunState.start(Limits.defaults())
-        grant = ToolGrant.capability_callbacks(state, :mission, environment, 1_000, nil, nil)
+
+        grant =
+          ToolGrant.capability_callbacks(
+            state,
+            :mission,
+            environment,
+            dispatch_context(),
+            nil,
+            nil
+          )
 
         one_callback_words = grant |> Map.fetch!("cap-1") |> flat_words()
         total_words = flat_words(grant)
@@ -67,7 +77,16 @@ defmodule PtcRunner.Kernel.ToolGrantTest do
 
     environment = environment_with(capabilities)
     {:ok, state} = RunState.start(Limits.defaults())
-    grant = ToolGrant.capability_callbacks(state, :mission, environment, 1_000, nil, nil)
+
+    grant =
+      ToolGrant.capability_callbacks(
+        state,
+        :mission,
+        environment,
+        dispatch_context(),
+        nil,
+        nil
+      )
 
     # The pre-fix baseline for this profile's shape measured 552,708 words
     # (~4.4 MB) before evaluation started at all. A narrowed grant for the
@@ -76,15 +95,116 @@ defmodule PtcRunner.Kernel.ToolGrantTest do
     assert flat_words(grant) < 20_000
   end
 
+  test "a workflow grant can validate under the evaluator heap ceiling" do
+    {:ok, checked} =
+      Capability.new(
+        name: "checked",
+        input_schema: %{
+          "type" => "object",
+          "properties" => %{"value" => %{"type" => "integer"}}
+        },
+        callback: fn _arguments -> flunk("validation exhaustion must prevent callback entry") end
+      )
+
+    {:ok, environment} = WorkflowEnvironment.new(capabilities: [checked])
+    {:ok, state} = RunState.start(Limits.defaults())
+
+    # REPL callbacks have workflow authority, but run inside an evaluation
+    # sandbox. The explicit ceiling must therefore win over the authority's
+    # much larger workflow heap.
+    grant =
+      ToolGrant.capability_callbacks(
+        state,
+        :workflow,
+        environment,
+        dispatch_context(validation_heap_words: 233),
+        nil,
+        nil
+      )
+
+    assert %{
+             status: :error,
+             kind: :capability_unavailable,
+             reason: :input_validation_unavailable
+           } = grant["checked"].(%{"value" => 1})
+  end
+
+  test "validation deadline reserves time to persist terminal host provenance" do
+    {:ok, checked} =
+      Capability.new(
+        name: "checked",
+        effect: :read,
+        input_schema: %{
+          "type" => "object",
+          "properties" => %{
+            "rows" => %{
+              "type" => "array",
+              "items" => %{"type" => "integer", "minimum" => 1}
+            }
+          }
+        },
+        callback: fn _arguments -> flunk("validator timeout must prevent callback entry") end
+      )
+
+    {:ok, environment} = MissionEnvironment.new(capabilities: [checked])
+    {:ok, state} = RunState.start(Limits.defaults())
+    assert {:ok, %{}, [], lease} = RunState.reserve_evaluation(state)
+
+    grant =
+      ToolGrant.capability_callbacks(
+        state,
+        :mission,
+        environment,
+        dispatch_context(
+          validation_heap_words: 100_000_000,
+          evaluation_lease: lease,
+          validation_deadline_ms: System.monotonic_time(:millisecond) + 30
+        ),
+        nil,
+        nil
+      )
+
+    assert %{
+             status: :error,
+             kind: :capability_unavailable,
+             reason: :input_validation_unavailable
+           } = grant["checked"].(%{"rows" => List.duplicate(0, 10_000)})
+
+    assert {:ok, %{terminal_host_failure?: true}} =
+             RunState.release_evaluation_status(state, lease)
+  end
+
   defp callback_words(environment, name) do
     {:ok, state} = RunState.start(Limits.defaults())
-    grant = ToolGrant.capability_callbacks(state, :mission, environment, 1_000, nil, nil)
+
+    grant =
+      ToolGrant.capability_callbacks(
+        state,
+        :mission,
+        environment,
+        dispatch_context(),
+        nil,
+        nil
+      )
+
     grant |> Map.fetch!(name) |> flat_words()
   end
 
   defp environment_with(capabilities) do
     {:ok, environment} = MissionEnvironment.new(capabilities: capabilities)
     environment
+  end
+
+  defp dispatch_context(overrides \\ []) do
+    Map.merge(
+      %{
+        timeout_ms: 1_000,
+        validation_heap_words: Limits.defaults().evaluation_heap_words,
+        evaluation_lease: nil,
+        validation_deadline_ms: nil
+      },
+      Map.new(overrides)
+    )
   end
 
   defp capability(name, opts \\ []) do


### PR DESCRIPTION
Closes #1176.

## What changed

- retain up to three bounded, schema-authored argument violations when a capability input schema rejects a call
- surface the declared argument path, violated keyword, and small declared bound or expected set to the shipped agent correction loop
- keep submitted values, undeclared property names, provider details, and custom semantic-validator reasons opaque
- bound explanation work by input-node and raw-error budgets, falling back to separately bounded boolean validation for large inputs
- document the correction-feedback contract and add dispatcher plus end-to-end agent-loop coverage

## Root cause

Dispatcher previously collapsed every input-schema rejection to `invalid_arguments`, and the agent feedback prelude rendered only the error kind and reason. The model therefore could not tell which schema-declared argument or bound needed correction.

## Validation

- test-first regression coverage (initial focused assertions failed before implementation)
- independent cumulative Codex review; all actionable findings addressed
- `mix test` focused kernel/agent suite: 186 passed
- `MIX_ENV=dev mix docs --warnings-as-errors`
- `mix dialyzer`: 0 errors
- `mix precommit`: duplication baseline 62/current 62/new 0; 6,018 root tests, 72 Viewer tests, and 40 launcher tests passed; package and standalone-release checks passed
- pre-push hook with `PTC_PRE_PUSH_MAX_CASES=2`: all checks passed in 219 seconds
