### PR TITLE
fix(oauth): bound wedged manager cleanup

### DIFF
--- a/docs/guides/kernel-maintainer.md
+++ b/docs/guides/kernel-maintainer.md
@@ -1341,6 +1341,11 @@ continued failure makes transport shutdown fail while the runtime keeps the
 shared fence. When provider acquisition fails before it can return a close
 handle, the supervised OAuth cleanup owner adopts the token manager and retries
 that bounded shutdown, so the retained fence cannot become an orphaned process.
+The cleanup owner keeps retrying answered persistence failures because those
+attempts can still make progress. A consecutive streak of unanswered close
+timeouts instead has a five-minute slot budget; exhaustion terminates the
+linked worker abnormally so its manager is reclaimed and the node-global slot
+is released. Any answered persistence failure breaks the timeout streak.
 An ordinary or malformed dynamic `403` that is not one valid satisfiable
 `insufficient_scope` challenge is a non-retryable authentication or
 authorization result; it is not mislabeled as a retryable transport failure.

--- a/lib/ptc_runner/kernel/mcp_oauth/manager_cleanup.ex
+++ b/lib/ptc_runner/kernel/mcp_oauth/manager_cleanup.ex
@@ -4,10 +4,13 @@ defmodule PtcRunner.Kernel.MCPOAuth.ManagerCleanup do
 
   This owner serializes adoption and gives each manager exactly one linked
   cleanup worker, including across concurrent or repeated adoption attempts.
-  The worker retries bounded close calls with capped exponential backoff. If
-  this owner restarts, OTP terminates the linked workers, which in turn
-  terminate their linked managers rather than leaving unreachable credential
-  owners alive.
+  The worker retries bounded close calls with capped exponential backoff.
+  Consecutive close timeouts have a finite cleanup-slot budget and reclaim a
+  manager abnormally when it is exhausted. A persistence failure resets that
+  timeout streak and remains retryable without a cleanup deadline. If this
+  owner restarts, OTP terminates the linked workers, which in turn terminate
+  their linked managers rather than leaving unreachable credential owners
+  alive.
   Provider cleanup uses `adopt/2` to confirm both worker ownership and removal
   from the registrar's force-close set as one caller-visible handoff. Worker
   registration is serialized here, while registrar calls run as deduplicated

--- a/lib/ptc_runner/kernel/mcp_oauth/manager_cleanup_worker.ex
+++ b/lib/ptc_runner/kernel/mcp_oauth/manager_cleanup_worker.ex
@@ -7,6 +7,7 @@ defmodule PtcRunner.Kernel.MCPOAuth.ManagerCleanupWorker do
 
   @initial_retry_ms 250
   @maximum_retry_ms 30_000
+  @timeout_deadline_ms 300_000
 
   @spec child_spec(TokenManager.t()) :: Supervisor.child_spec()
   def child_spec(%TokenManager{pid: pid} = manager) do
@@ -19,15 +20,25 @@ defmodule PtcRunner.Kernel.MCPOAuth.ManagerCleanupWorker do
     }
   end
 
-  @spec start_link(TokenManager.t()) :: GenServer.on_start()
-  def start_link(%TokenManager{} = manager),
-    do: GenServer.start_link(__MODULE__, manager)
+  @spec start_link(TokenManager.t(), keyword()) :: GenServer.on_start()
+  def start_link(%TokenManager{} = manager, opts \\ []) do
+    timeout_deadline_ms = Keyword.get(opts, :timeout_deadline_ms, @timeout_deadline_ms)
+    GenServer.start_link(__MODULE__, {manager, timeout_deadline_ms})
+  end
 
   @impl GenServer
-  def init(%TokenManager{pid: pid} = manager) do
+  def init({%TokenManager{pid: pid} = manager, timeout_deadline_ms})
+      when is_integer(timeout_deadline_ms) and timeout_deadline_ms > 0 do
     Process.link(pid)
     send(self(), :close)
-    {:ok, %{manager: manager, retry_ms: @initial_retry_ms}}
+
+    {:ok,
+     %{
+       manager: manager,
+       retry_ms: @initial_retry_ms,
+       timeout_deadline_ms: timeout_deadline_ms,
+       timeout_deadline: nil
+     }}
   rescue
     ErlangError ->
       # Linking is the atomic ownership handoff. A manager that exited before
@@ -37,17 +48,46 @@ defmodule PtcRunner.Kernel.MCPOAuth.ManagerCleanupWorker do
 
   @impl GenServer
   def handle_info(:close, state) do
-    case TokenManager.close(state.manager) do
-      :ok ->
-        {:stop, :normal, state}
+    now = System.monotonic_time(:millisecond)
+    deadline = state.timeout_deadline || now + state.timeout_deadline_ms
+    remaining = deadline - now
 
-      {:error, _reason} ->
-        Process.send_after(self(), :close, state.retry_ms)
-        {:noreply, %{state | retry_ms: min(state.retry_ms * 2, @maximum_retry_ms)}}
+    if remaining <= 0 do
+      timeout_exhausted(state, deadline)
+    else
+      case TokenManager.close(state.manager, remaining) do
+        :ok ->
+          {:stop, :normal, state}
+
+        {:error, :persistence_failed} ->
+          retry(%{state | timeout_deadline: nil})
+
+        {:error, :timeout} ->
+          retry_timeout(state, deadline)
+      end
     end
   end
 
   def handle_info(_message, state), do: {:noreply, state}
+
+  defp retry_timeout(state, deadline) do
+    now = System.monotonic_time(:millisecond)
+    remaining = deadline - now
+
+    if remaining <= 0 do
+      timeout_exhausted(state, deadline)
+    else
+      retry(%{state | timeout_deadline: deadline}, min(state.retry_ms, remaining))
+    end
+  end
+
+  defp timeout_exhausted(state, deadline),
+    do: {:stop, :cleanup_timeout_exhausted, %{state | timeout_deadline: deadline}}
+
+  defp retry(state, delay_ms \\ nil) do
+    Process.send_after(self(), :close, delay_ms || state.retry_ms)
+    {:noreply, %{state | retry_ms: min(state.retry_ms * 2, @maximum_retry_ms)}}
+  end
 
   if {:format_status, 1} in GenServer.behaviour_info(:callbacks) do
     @impl GenServer

--- a/lib/ptc_runner/kernel/mcp_oauth/token_manager.ex
+++ b/lib/ptc_runner/kernel/mcp_oauth/token_manager.ex
@@ -200,8 +200,13 @@ defmodule PtcRunner.Kernel.MCPOAuth.TokenManager do
     do: {:error, :invalid_scope_challenge}
 
   @spec close(t()) :: :ok | {:error, :persistence_failed | :timeout}
-  def close(%__MODULE__{pid: pid}) do
-    GenServer.call(pid, :close, @close_timeout_ms)
+  def close(%__MODULE__{} = manager), do: close(manager, @close_timeout_ms)
+
+  @doc false
+  @spec close(t(), pos_integer()) :: :ok | {:error, :persistence_failed | :timeout}
+  def close(%__MODULE__{pid: pid}, timeout_ms)
+      when is_integer(timeout_ms) and timeout_ms > 0 do
+    GenServer.call(pid, :close, min(timeout_ms, @close_timeout_ms))
   catch
     :exit, {:timeout, _detail} -> {:error, :timeout}
     :exit, _reason -> :ok

--- a/test/ptc_runner/kernel/mcp_oauth/manager_cleanup_worker_test.exs
+++ b/test/ptc_runner/kernel/mcp_oauth/manager_cleanup_worker_test.exs
@@ -1,0 +1,149 @@
+defmodule PtcRunner.Kernel.MCPOAuth.ManagerCleanupWorkerTest do
+  use ExUnit.Case, async: true
+
+  alias PtcRunner.Kernel.MCPOAuth.ManagerCleanupWorker
+  alias PtcRunner.Kernel.MCPOAuth.TokenManager
+
+  setup do
+    Process.flag(:trap_exit, true)
+    :ok
+  end
+
+  test "repeated timeouts exhaust the cleanup slot budget and reclaim the manager" do
+    manager = manager_replying(fn _attempt -> {:error, :timeout} end)
+    manager_ref = Process.monitor(manager.pid)
+
+    {:ok, worker} =
+      ManagerCleanupWorker.start_link(manager, timeout_deadline_ms: 500)
+
+    worker_ref = Process.monitor(worker)
+
+    assert_receive {:close_attempt, 1}
+    assert_receive {:close_attempt, 2}, 1_000
+
+    assert_receive {:DOWN, ^worker_ref, :process, ^worker, :cleanup_timeout_exhausted},
+                   1_000
+
+    assert_receive {:DOWN, ^manager_ref, :process, _pid, :cleanup_timeout_exhausted},
+                   1_000
+  end
+
+  test "a non-answering close cannot overrun the cleanup slot budget" do
+    manager = non_answering_manager()
+    manager_ref = Process.monitor(manager.pid)
+
+    {:ok, worker} =
+      ManagerCleanupWorker.start_link(manager, timeout_deadline_ms: 50)
+
+    worker_ref = Process.monitor(worker)
+
+    assert_receive {:close_attempt, 1}
+
+    assert_receive {:DOWN, ^worker_ref, :process, ^worker, :cleanup_timeout_exhausted},
+                   1_000
+
+    assert_receive {:DOWN, ^manager_ref, :process, _pid, :cleanup_timeout_exhausted},
+                   1_000
+  end
+
+  test "persistence failures keep retrying past the timeout budget" do
+    manager = manager_replying(fn _attempt -> {:error, :persistence_failed} end)
+
+    {:ok, worker} =
+      ManagerCleanupWorker.start_link(manager, timeout_deadline_ms: 50)
+
+    assert_receive {:close_attempt, 1}
+    assert_receive {:close_attempt, 2}, 1_000
+    assert_receive {:close_attempt, 3}, 1_000
+    assert Process.alive?(worker)
+    assert Process.alive?(manager.pid)
+
+    Process.unlink(worker)
+    Process.exit(worker, :shutdown)
+  end
+
+  test "a timeout followed by a successful close stops normally" do
+    manager =
+      manager_replying(fn attempt -> if attempt == 1, do: {:error, :timeout}, else: :ok end)
+
+    manager_ref = Process.monitor(manager.pid)
+
+    {:ok, worker} =
+      ManagerCleanupWorker.start_link(manager, timeout_deadline_ms: 5_000)
+
+    worker_ref = Process.monitor(worker)
+
+    assert_receive {:close_attempt, 1}
+    assert_receive {:close_attempt, 2}, 1_000
+    assert_receive {:DOWN, ^worker_ref, :process, ^worker, :normal}, 1_000
+    refute_receive {:DOWN, ^manager_ref, :process, _pid, _reason}, 100
+
+    Process.exit(manager.pid, :kill)
+  end
+
+  test "a persistence response breaks a consecutive timeout streak" do
+    manager =
+      manager_replying(fn
+        1 -> {:error, :timeout}
+        2 -> {:error, :persistence_failed}
+        3 -> {:error, :timeout}
+        _attempt -> :ok
+      end)
+
+    manager_ref = Process.monitor(manager.pid)
+
+    {:ok, worker} =
+      ManagerCleanupWorker.start_link(manager, timeout_deadline_ms: 1_500)
+
+    worker_ref = Process.monitor(worker)
+
+    for attempt <- 1..4 do
+      assert_receive {:close_attempt, ^attempt}, 1_500
+    end
+
+    assert_receive {:DOWN, ^worker_ref, :process, ^worker, :normal}, 1_000
+    refute_receive {:DOWN, ^manager_ref, :process, _pid, _reason}, 100
+
+    Process.exit(manager.pid, :kill)
+  end
+
+  defp manager_replying(reply_fun) do
+    test = self()
+
+    pid =
+      spawn(fn ->
+        reply_loop(test, reply_fun, 1)
+      end)
+
+    %TokenManager{pid: pid, resource: "https://example.test/resource"}
+  end
+
+  defp non_answering_manager do
+    test = self()
+    pid = spawn(fn -> non_reply_loop(test, 1) end)
+    %TokenManager{pid: pid, resource: "https://example.test/resource"}
+  end
+
+  defp reply_loop(test, reply_fun, attempt) do
+    receive do
+      {:"$gen_call", from, :close} ->
+        send(test, {:close_attempt, attempt})
+        GenServer.reply(from, reply_fun.(attempt))
+        reply_loop(test, reply_fun, attempt + 1)
+
+      _message ->
+        reply_loop(test, reply_fun, attempt)
+    end
+  end
+
+  defp non_reply_loop(test, attempt) do
+    receive do
+      {:"$gen_call", _from, :close} ->
+        send(test, {:close_attempt, attempt})
+        non_reply_loop(test, attempt + 1)
+
+      _message ->
+        non_reply_loop(test, attempt)
+    end
+  end
+end


### PR DESCRIPTION
Closes #1259.

## What changed

- bound only consecutive `TokenManager.close/1` timeouts in `ManagerCleanupWorker`
- keep `:persistence_failed` retries unbounded and reset the timeout streak whenever that answered failure is observed
- stop abnormally on timeout-budget exhaustion so the worker link reclaims the wedged manager and releases its cleanup slot
- cap each close call to the remaining five-minute production budget, with an injectable shorter budget for tests
- document the cleanup lifecycle contract in the Kernel maintainer guide

## Root cause and impact

The cleanup worker previously handled `:timeout` and `:persistence_failed` identically. A manager that never answered close calls therefore retained one of the node-global cleanup slots forever. This change reclaims only managers proven wedged by a continuous timeout streak; managers still answering with persistence failures retain their existing durable retry behavior.

## Test-first coverage

The regression tests were added before the implementation and initially failed because the worker had no injectable timeout bound. They now prove:

- repeated timeouts exhaust the budget and reclaim the linked manager abnormally
- a genuinely non-answering close cannot overrun the slot budget
- persistence failures continue retrying beyond that budget
- a timeout followed by recovery closes normally
- a persistence response breaks a timeout streak

## Validation

- independent cumulative Codex review: no actionable findings
- `MIX_ENV=dev mix docs --warnings-as-errors`
- focused OAuth tests: 33 passed
- `mix precommit`: clean with one scheduler after an unrelated timing-sensitive test passed at its exact location; root 6,031, Viewer 72, launcher 40
- duplication: baseline 61, current 61, new 0
- pre-push: root 6,031, Dialyzer 0 errors, Viewer 72
