### PR TITLE
fix(inspection): retain trace-marked partial artifacts

### DIFF
--- a/docs/trace-log-contract.md
+++ b/docs/trace-log-contract.md
@@ -490,7 +490,8 @@ JSON object with this exact envelope:
 Keys are exact. `sequence` is positive and strictly increasing within the
 artifact. The timestamp is UTC ISO 8601. `correlation` contains exactly one
 of `capability_id`, `evaluation_id`, or `component_id`. Capability and
-evaluation values must occur in the canonical trace for the same run; a
+evaluation values must occur in the canonical trace for the same run unless
+that trace explicitly proves the corresponding start events were dropped. A
 component value must occur in the canonical `run-started` prelude component
 IDs for the record's environment. V1 record types and payloads are:
 
@@ -529,13 +530,14 @@ the Kernel `Error.details` map computed for that failure. Their `environment`
 is always `"workflow"`, and their `evaluation_id` must match a canonical
 `evaluation-started` event with `environment: "workflow"` for the same run.
 
-The input record is accepted before the callback starts, and the source record
-is accepted before evaluation starts. The output record is accepted after
-normalization and before the canonical stop event. A missing output therefore
-means the attempt was interrupted; the loader does not synthesize one. Failure
-to accept a required input/source record prevents execution. Failure after an
-external read has completed fails the run but cannot retroactively undo that
-read.
+The input record is accepted before the callback starts. A subordinate
+`evaluation-started` event is attempted before its source record is accepted,
+and the source record is accepted before Lisp execution starts. The output
+record is accepted after normalization and before the canonical stop event. A
+missing output therefore means the attempt was interrupted; the loader does
+not synthesize one. Failure to accept a required input/source record prevents
+execution. Failure after an external read has completed fails the run but
+cannot retroactively undo that read.
 
 Artifact validation rejects ambiguous joins before persistence or Viewer
 pinning. There may be at most one input and one output for a capability ID, one
@@ -549,11 +551,28 @@ validation is authoritative. There may likewise be at most one
 `execution-prints` and one `execution-error` for a given `evaluation_id`; a run
 with no `println` output and no execution-phase failure emits neither.
 
+A normal trace can prove a missing correlation only through both of its
+terminal loss records: the one `events-dropped.data.counts` map and
+`run-stopped.data.usage.events_dropped` must agree, and the count for
+`capability-started` or `evaluation-started` must cover every distinct missing
+ID of that kind. Missing evaluation IDs also retain their expected environment;
+one dropped event cannot cover conflicting workflow and mission records. The
+runtime emits each correlated private record only after attempting its
+corresponding start event, so this typed count is authoritative evidence of
+trace loss. The `events-dropped` marker and `run-stopped` must be the final two
+events in that order, matching atomic EventSink finalization. The canonical
+marker flags the paired inspection artifact as partial. Missing proof,
+insufficient counts, duplicate canonical IDs, or an existing event whose
+correlation fields disagree all fail closed.
+
 The host enables capture independently of manifest event policy and selects a
 fixed exact destination. The destination is restricted to `0600` before content
 is written. Per-record and aggregate byte ceilings apply before persistence.
-Capture is either disabled or required/fail-closed; there is no silent partial-
-capture mode. Retention belongs to the host in 0.x.
+Inspection capture is either disabled or required/fail-closed; the inspection
+sink never silently drops its own records. A trace-budget loss is different:
+the canonical trace marks it explicitly, and a fully retained inspection stream
+may be persisted as the trace-marked partial correlation overlay described
+above. Retention belongs to the host in 0.x.
 
 Installed defaults are 2,000,000 encoded bytes per record and 16,000,000
 encoded bytes for the artifact; a host may lower them but a manifest cannot

--- a/lib/ptc_runner/kernel/evaluation.ex
+++ b/lib/ptc_runner/kernel/evaluation.ex
@@ -211,14 +211,6 @@ defmodule PtcRunner.Kernel.Evaluation do
     source_bytes = byte_size(source)
 
     with :ok <-
-           inspection_source(
-             capture.inspection_sink,
-             evaluation_id,
-             source,
-             source_hash,
-             source_bytes
-           ),
-         :ok <-
            Events.emit(state, capture.event_sink, "evaluation-started", %{
              evaluation_id: evaluation_id,
              environment: :mission,
@@ -226,6 +218,14 @@ defmodule PtcRunner.Kernel.Evaluation do
              source_hash: source_hash,
              source_bytes: source_bytes
            }),
+         :ok <-
+           inspection_source(
+             capture.inspection_sink,
+             evaluation_id,
+             source,
+             source_hash,
+             source_bytes
+           ),
          :ok <- after_started(after_started_hook) do
       result =
         execute_with_lease(

--- a/lib/ptc_runner/kernel/inspection_artifact.ex
+++ b/lib/ptc_runner/kernel/inspection_artifact.ex
@@ -19,7 +19,12 @@ defmodule PtcRunner.Kernel.InspectionArtifact do
   V3 vocabulary. V2 adds paired MCP request/response bodies correlated to an
   existing capability attempt. V3 adds `execution-prints` and `execution-error`,
   correlated by a canonical workflow `evaluation-started` event's
-  `evaluation_id` rather than a capability attempt.
+  `evaluation_id` rather than a capability attempt. A missing capability or
+  evaluation correlation is accepted only when the same canonical trace's
+  `events-dropped` marker and terminal usage agree on enough dropped events of
+  that exact type. The retained trace marker therefore identifies the
+  inspection artifact as partial; an existing but mismatched correlation still
+  fails closed.
 
   Secure publication is supported on Unix hosts with POSIX-compatible `mkdir`
   and `id` executables available on `PATH`; persistence fails closed when those
@@ -555,18 +560,8 @@ defmodule PtcRunner.Kernel.InspectionArtifact do
           event_value(event, :trace_id) == first["trace_id"]
       end)
 
-    with {:ok, capabilities} <- canonical_capabilities(events) do
-      evaluations =
-        Enum.reduce(events, %{}, fn event, evaluations ->
-          id = event_data(event, :evaluation_id)
-          hash = event_data(event, :source_hash)
-          bytes = event_data(event, :source_bytes)
-
-          if is_binary(id) and is_binary(hash) and is_integer(bytes),
-            do: Map.put(evaluations, id, {hash, bytes}),
-            else: evaluations
-        end)
-
+    with {:ok, capabilities} <- canonical_capabilities(events),
+         {:ok, evaluations} <- canonical_evaluations(events) do
       prelude_components =
         Enum.reduce(events, %{}, fn event, acc ->
           acc
@@ -574,51 +569,13 @@ defmodule PtcRunner.Kernel.InspectionArtifact do
           |> merge_prelude_ids("mission", event_data(event, :mission_prelude))
         end)
 
-      workflow_evaluation_ids =
-        events
-        |> Enum.filter(fn event ->
-          event_value(event, :type) == "evaluation-started" and
-            event_data(event, :environment) |> string_value() == "workflow"
-        end)
-        |> Enum.map(&event_data(&1, :evaluation_id))
-        |> Enum.filter(&is_binary/1)
-        |> MapSet.new()
-
-      if Enum.all?(records, fn
-           %{
-             "correlation" => %{"capability_id" => id},
-             "payload" => %{"environment" => environment, "name" => name}
-           } ->
-             Map.get(capabilities, id) == {environment, name}
-
-           %{
-             "record_type" => record_type,
-             "correlation" => %{"capability_id" => id, "request_id" => request_id}
-           }
-           when record_type in ["mcp-request", "mcp-response"] ->
-             Map.has_key?(capabilities, id) and valid_request_id?(request_id)
-
-           %{
-             "correlation" => %{"evaluation_id" => id},
-             "payload" => %{"source_hash" => hash, "source_bytes" => bytes}
-           } ->
-             Map.get(evaluations, id) == {hash, bytes}
-
-           %{
-             "record_type" => record_type,
-             "correlation" => %{"evaluation_id" => id}
-           }
-           when record_type in ["execution-prints", "execution-error"] ->
-             MapSet.member?(workflow_evaluation_ids, id)
-
-           %{
-             "correlation" => %{"component_id" => id},
-             "payload" => %{"environment" => environment}
-           } ->
-             MapSet.member?(Map.get(prelude_components, environment, MapSet.new()), id)
-         end),
-         do: :ok,
-         else: {:error, :inspection_correlation_missing}
+      validate_record_correlations(
+        records,
+        capabilities,
+        evaluations,
+        prelude_components,
+        proven_dropped_counts(events)
+      )
     end
   end
 
@@ -631,8 +588,7 @@ defmodule PtcRunner.Kernel.InspectionArtifact do
       name = event_data(event, :name)
 
       cond do
-        event_value(event, :type) != "capability-started" or not is_binary(id) or
-          environment not in ["workflow", "mission"] or not is_binary(name) ->
+        event_value(event, :type) != "capability-started" or not is_binary(id) ->
           {:cont, {:ok, capabilities}}
 
         Map.has_key?(capabilities, id) ->
@@ -643,6 +599,217 @@ defmodule PtcRunner.Kernel.InspectionArtifact do
       end
     end)
   end
+
+  defp canonical_evaluations(events) do
+    Enum.reduce_while(events, {:ok, %{}}, fn event, {:ok, evaluations} ->
+      id = event_data(event, :evaluation_id)
+      environment = event_data(event, :environment) |> string_value()
+
+      cond do
+        event_value(event, :type) != "evaluation-started" or not is_binary(id) ->
+          {:cont, {:ok, evaluations}}
+
+        Map.has_key?(evaluations, id) ->
+          {:halt, {:error, :inspection_correlation_missing}}
+
+        true ->
+          source = {event_data(event, :source_hash), event_data(event, :source_bytes)}
+          {:cont, {:ok, Map.put(evaluations, id, {environment, source})}}
+      end
+    end)
+  end
+
+  defp validate_record_correlations(
+         records,
+         capabilities,
+         evaluations,
+         prelude_components,
+         dropped
+       ) do
+    initial = %{capabilities: MapSet.new(), evaluations: %{}}
+
+    records
+    |> Enum.reduce_while({:ok, initial}, fn record, {:ok, missing} ->
+      validate_record_correlation(
+        record,
+        capabilities,
+        evaluations,
+        prelude_components,
+        missing
+      )
+    end)
+    |> case do
+      {:ok, missing} -> validate_missing_correlations(missing, dropped)
+      {:error, :inspection_correlation_missing} = error -> error
+    end
+  end
+
+  defp validate_record_correlation(
+         %{
+           "correlation" => %{"capability_id" => id},
+           "payload" => %{"environment" => environment, "name" => name}
+         },
+         capabilities,
+         _evaluations,
+         _prelude_components,
+         missing
+       ) do
+    correlate_or_mark_missing(capabilities, id, {environment, name}, missing, :capabilities)
+  end
+
+  defp validate_record_correlation(
+         %{
+           "record_type" => record_type,
+           "correlation" => %{"capability_id" => id, "request_id" => request_id}
+         },
+         capabilities,
+         _evaluations,
+         _prelude_components,
+         missing
+       )
+       when record_type in ["mcp-request", "mcp-response"] do
+    if valid_request_id?(request_id),
+      do:
+        correlate_or_mark_missing(
+          capabilities,
+          id,
+          :any,
+          missing,
+          :capabilities,
+          fn _actual, :any -> true end
+        ),
+      else: missing_correlation()
+  end
+
+  defp validate_record_correlation(
+         %{
+           "record_type" => "evaluation-source",
+           "correlation" => %{"evaluation_id" => id},
+           "payload" => %{"source_hash" => hash, "source_bytes" => bytes}
+         },
+         _capabilities,
+         evaluations,
+         _prelude_components,
+         missing
+       ),
+       do:
+         correlate_evaluation_or_mark_missing(
+           evaluations,
+           id,
+           {"mission", {hash, bytes}},
+           missing
+         )
+
+  defp validate_record_correlation(
+         %{
+           "record_type" => record_type,
+           "correlation" => %{"evaluation_id" => id}
+         },
+         _capabilities,
+         evaluations,
+         _prelude_components,
+         missing
+       )
+       when record_type in ["execution-prints", "execution-error"],
+       do: correlate_evaluation_or_mark_missing(evaluations, id, {"workflow", :any}, missing)
+
+  defp validate_record_correlation(
+         %{
+           "correlation" => %{"component_id" => id},
+           "payload" => %{"environment" => environment}
+         },
+         _capabilities,
+         _evaluations,
+         prelude_components,
+         missing
+       ) do
+    if MapSet.member?(Map.get(prelude_components, environment, MapSet.new()), id),
+      do: {:cont, {:ok, missing}},
+      else: missing_correlation()
+  end
+
+  defp validate_record_correlation(
+         _record,
+         _capabilities,
+         _evaluations,
+         _prelude_components,
+         _missing
+       ),
+       do: missing_correlation()
+
+  defp correlate_or_mark_missing(canonical, id, expected, missing, field, matcher \\ &(&1 == &2)) do
+    case Map.fetch(canonical, id) do
+      {:ok, actual} ->
+        if matcher.(actual, expected),
+          do: {:cont, {:ok, missing}},
+          else: missing_correlation()
+
+      :error ->
+        {:cont, {:ok, Map.update!(missing, field, &MapSet.put(&1, id))}}
+    end
+  end
+
+  defp correlate_evaluation_or_mark_missing(canonical, id, expected, missing) do
+    case Map.fetch(canonical, id) do
+      {:ok, actual} ->
+        if evaluation_matches?(actual, expected),
+          do: {:cont, {:ok, missing}},
+          else: missing_correlation()
+
+      :error ->
+        case Map.fetch(missing.evaluations, id) do
+          :error ->
+            {:cont, {:ok, put_in(missing, [:evaluations, id], elem(expected, 0))}}
+
+          {:ok, environment} when environment == elem(expected, 0) ->
+            {:cont, {:ok, missing}}
+
+          {:ok, _conflicting_environment} ->
+            missing_correlation()
+        end
+    end
+  end
+
+  defp evaluation_matches?({"workflow", _source}, {"workflow", :any}), do: true
+  defp evaluation_matches?(actual, expected), do: actual == expected
+
+  defp validate_missing_correlations(missing, dropped) do
+    if MapSet.size(missing.capabilities) <= Map.get(dropped, "capability-started", 0) and
+         map_size(missing.evaluations) <= Map.get(dropped, "evaluation-started", 0),
+       do: :ok,
+       else: {:error, :inspection_correlation_missing}
+  end
+
+  defp proven_dropped_counts(events) do
+    markers = Enum.filter(events, &(event_value(&1, :type) == "events-dropped"))
+    stopped = Enum.filter(events, &(event_value(&1, :type) == "run-stopped"))
+
+    with [marker, terminal] <- Enum.take(events, -2),
+         "events-dropped" <- event_value(marker, :type),
+         "run-stopped" <- event_value(terminal, :type),
+         [^marker] <- markers,
+         [^terminal] <- stopped,
+         {:ok, marker_counts} <- event_counts(event_data(marker, :counts)),
+         usage when is_map(usage) <- event_data(terminal, :usage),
+         {:ok, terminal_counts} <- event_counts(map_value(usage, :events_dropped)),
+         true <- marker_counts == terminal_counts do
+      marker_counts
+    else
+      _unproven -> %{}
+    end
+  end
+
+  defp event_counts(counts) when is_map(counts) and not is_struct(counts) do
+    if Enum.all?(counts, fn {type, count} ->
+         is_binary(type) and is_integer(count) and count > 0
+       end),
+       do: {:ok, counts},
+       else: :error
+  end
+
+  defp event_counts(_counts), do: :error
+
+  defp missing_correlation, do: {:halt, {:error, :inspection_correlation_missing}}
 
   defp merge_prelude_ids(acc, environment, prelude) when is_map(prelude) do
     ids =
@@ -663,6 +830,8 @@ defmodule PtcRunner.Kernel.InspectionArtifact do
       _data -> nil
     end
   end
+
+  defp map_value(map, key), do: Map.get(map, key) || Map.get(map, Atom.to_string(key))
 
   defp string_value(value) when is_atom(value), do: Atom.to_string(value)
   defp string_value(value) when is_binary(value), do: value

--- a/test/ptc_runner/kernel/artifact_publisher_test.exs
+++ b/test/ptc_runner/kernel/artifact_publisher_test.exs
@@ -2,14 +2,18 @@ defmodule PtcRunner.Kernel.ArtifactPublisherTest do
   use ExUnit.Case, async: true
 
   alias PtcRunner.Kernel.ApplicationPackage
+  alias PtcRunner.Kernel.ArtifactPublisher
   alias PtcRunner.Kernel.CommandRunOutcome
   alias PtcRunner.Kernel.ExecutionOutcome
+  alias PtcRunner.Kernel.InspectionArtifact
   alias PtcRunner.Kernel.ProviderRegistry
   alias PtcRunner.Kernel.PublicationAuthority
   alias PtcRunner.Kernel.PublicationHandle
   alias PtcRunner.Kernel.Result
+  alias PtcRunner.Kernel.ResultArtifact
   alias PtcRunner.Kernel.RunBuilder
   alias PtcRunner.Kernel.TraceLog
+  alias PtcRunner.Kernel.ViewerAdapter
   alias PtcRunner.TestSupport.RunLifecycle
 
   @tag :tmp_dir
@@ -66,6 +70,88 @@ defmodule PtcRunner.Kernel.ArtifactPublisherTest do
 
     assert :ok = PublicationAuthority.abort(built.publication_authority)
     assert :ok = ProviderRegistry.close(registry)
+  end
+
+  @tag :tmp_dir
+  test "trace-proven event loss preserves the partial inspection and successful result", %{
+    tmp_dir: dir
+  } do
+    trace = Path.join(dir, "partial.jsonl")
+    inspection = Path.join(dir, "partial.inspection.jsonl")
+    output = Path.join(dir, "result.json")
+    run_id = "partial-publication"
+    trace_id = "trace-partial-publication"
+    timestamp = "2026-08-11T00:00:00Z"
+    counts = %{"capability-started" => 1, "capability-stopped" => 1}
+    value = %{"answer" => 42}
+    {:ok, encoded} = ResultArtifact.prepare(value, :normal, :normal)
+    result_hash = "sha256:" <> Base.encode16(:crypto.hash(:sha256, encoded), case: :lower)
+
+    records = [
+      %{
+        "schema_version" => 1,
+        "run_id" => run_id,
+        "trace_id" => trace_id,
+        "sequence" => 1,
+        "timestamp" => timestamp,
+        "record_type" => "capability-input",
+        "correlation" => %{"capability_id" => "cap-dropped"},
+        "payload" => %{
+          "environment" => "mission",
+          "name" => "evidence.get",
+          "arguments" => %{"id" => 42}
+        }
+      }
+    ]
+
+    events = [
+      trace_event(run_id, trace_id, 1, "run-started", %{}),
+      trace_event(run_id, trace_id, 2, "events-dropped", %{"counts" => counts}),
+      trace_event(run_id, trace_id, 3, "run-stopped", %{
+        "outcome" => "ok",
+        "reason" => nil,
+        "result_hash" => result_hash,
+        "usage" => %{"events_dropped" => counts}
+      })
+    ]
+
+    evidence = %{
+      result:
+        {:ok, %Result{value: value, usage: %{events_dropped: counts}, evaluation_memory: %{}}},
+      result_class: :normal,
+      result_contract: :ok,
+      terminal_batch: {:ok, events},
+      inspection: {:ok, records}
+    }
+
+    assert {:ok, authority} =
+             PublicationAuthority.authorize(
+               "cmd-00000000000000000000000000",
+               [trace: trace, inspect: inspection, output: output],
+               :normal,
+               :normal
+             )
+
+    assert {:ok, report} = ArtifactPublisher.publish(evidence, authority)
+
+    assert report.artifact_state == %{
+             "trace" => "written",
+             "inspection" => "written",
+             "result" => "written"
+           }
+
+    assert Jason.decode!(File.read!(output)) == value
+    assert {:ok, ^records} = InspectionArtifact.load(inspection)
+    assert {:ok, _source} = ViewerAdapter.pin_inspection(inspection, {:file, trace})
+
+    trace_types =
+      trace
+      |> File.read!()
+      |> String.split("\n", trim: true)
+      |> Enum.map(&Jason.decode!(&1)["type"])
+
+    assert trace_types == ["run-started", "events-dropped", "run-stopped"]
+    assert :ok = PublicationAuthority.close(authority)
   end
 
   @tag :tmp_dir
@@ -933,6 +1019,18 @@ defmodule PtcRunner.Kernel.ArtifactPublisherTest do
       "timestamp" => "2026-07-12T12:00:00Z",
       "type" => type,
       "data" => %{}
+    }
+  end
+
+  defp trace_event(run_id, trace_id, sequence, type, data) do
+    %{
+      "schema_version" => 1,
+      "run_id" => run_id,
+      "trace_id" => trace_id,
+      "sequence" => sequence,
+      "timestamp" => "2026-08-11T00:00:00Z",
+      "type" => type,
+      "data" => data
     }
   end
 

--- a/test/ptc_runner/kernel/core_contract_test.exs
+++ b/test/ptc_runner/kernel/core_contract_test.exs
@@ -10,6 +10,7 @@ defmodule PtcRunner.Kernel.CoreContractTest do
   alias PtcRunner.Kernel.Evaluation
   alias PtcRunner.Kernel.EventSink
   alias PtcRunner.Kernel.FrozenBundle
+  alias PtcRunner.Kernel.InspectionSink
   alias PtcRunner.Kernel.Library
   alias PtcRunner.Kernel.Limits
   alias PtcRunner.Kernel.MissionEnvironment
@@ -1454,6 +1455,33 @@ defmodule PtcRunner.Kernel.CoreContractTest do
              )
 
     assert %{defined_count: 0, history_count: 0} = RunState.evaluation_memory_summary(state)
+  end
+
+  test "failed subordinate evaluation start retains no unattempted inspection source" do
+    {:ok, mission} = MissionEnvironment.new([])
+    {:ok, limits} = Limits.new(normal_event_count: 1, normal_event_bytes: 20_000)
+    {:ok, state} = RunState.start(limits)
+    {:ok, event_sink} = EventSink.start(:private, limits, run_id: "full-before-evaluation")
+
+    {:ok, inspection_sink} =
+      InspectionSink.start(run_id: "full-before-evaluation", trace_id: "full-before-evaluation")
+
+    assert :ok = EventSink.emit(event_sink, "occupied", %{})
+
+    assert %{outcome: :evaluation_error, reason: :event_sink_error} =
+             Evaluation.evaluate_source_detailed(
+               state,
+               mission,
+               "(return 42)",
+               100,
+               event_sink,
+               inspection_sink
+             )
+
+    assert {:ok, []} = InspectionSink.records(inspection_sink)
+    assert :ok = InspectionSink.stop(inspection_sink)
+    assert :ok = EventSink.stop(event_sink)
+    assert :ok = RunState.stop(state)
   end
 
   test "Kernel rejects public projection collisions instead of losing entries" do

--- a/test/ptc_runner/kernel/inspection_sink_test.exs
+++ b/test/ptc_runner/kernel/inspection_sink_test.exs
@@ -372,6 +372,104 @@ defmodule PtcRunner.Kernel.InspectionSinkTest do
              )
   end
 
+  @tag :tmp_dir
+  test "artifacts accept only correlations proven missing by canonical dropped-event counts", %{
+    tmp_dir: dir
+  } do
+    {:ok, sink} = InspectionSink.start(run_id: "run-1", trace_id: "trace-1")
+    assert :ok = emit_small(sink, "cap-1")
+    assert :ok = emit_small(sink, "cap-2")
+    assert {:ok, records} = InspectionSink.records(sink)
+
+    partial_events = dropped_events(%{"capability-started" => 2})
+    path = Path.join(dir, "partial.inspection.jsonl")
+
+    conflicting_terminal_counts =
+      put_in(
+        partial_events,
+        [Access.at(2), "data", "usage", "events_dropped"],
+        %{"capability-started" => 1}
+      )
+
+    intervening_event =
+      List.insert_at(partial_events, 2, canonical_event(3, "workflow-annotation", %{}))
+
+    reversed_terminal_events =
+      [Enum.at(partial_events, 0), Enum.at(partial_events, 2), Enum.at(partial_events, 1)]
+
+    assert :ok = InspectionArtifact.validate_correlations(records, partial_events)
+    assert :ok = InspectionArtifact.persist(path, records, partial_events)
+    assert {:ok, ^records} = InspectionArtifact.load(path)
+
+    for events <- [
+          dropped_events(%{"capability-started" => 1}),
+          dropped_events(%{"capability-stopped" => 2}),
+          conflicting_terminal_counts,
+          intervening_event,
+          reversed_terminal_events,
+          Enum.reject(partial_events, &(&1["type"] == "events-dropped")),
+          Enum.reject(partial_events, &(&1["type"] == "run-stopped"))
+        ] do
+      assert {:error, :inspection_correlation_missing} =
+               InspectionArtifact.validate_correlations(records, events)
+    end
+
+    conflicting =
+      canonical_event(2, "capability-started", %{
+        "capability_id" => "cap-1",
+        "environment" => "workflow",
+        "name" => "other"
+      })
+
+    assert {:error, :inspection_correlation_missing} =
+             InspectionArtifact.validate_correlations(records, [conflicting | partial_events])
+
+    assert :ok = InspectionSink.stop(sink)
+
+    {:ok, evaluation_sink} =
+      InspectionSink.start(run_id: "run-1", trace_id: "trace-1", schema_version: 3)
+
+    assert :ok =
+             InspectionSink.emit(
+               evaluation_sink,
+               "evaluation-source",
+               %{evaluation_id: "eval-mission"},
+               %{
+                 environment: :mission,
+                 program_kind: :"ptc-lisp",
+                 source: @source,
+                 source_hash: @source_hash,
+                 source_bytes: byte_size(@source)
+               }
+             )
+
+    assert :ok =
+             InspectionSink.emit(
+               evaluation_sink,
+               "execution-prints",
+               %{evaluation_id: "eval-workflow"},
+               %{environment: :workflow, prints: ["partial"], truncated: false}
+             )
+
+    assert {:ok, evaluation_records} = InspectionSink.records(evaluation_sink)
+    evaluation_events = dropped_events(%{"evaluation-started" => 2})
+
+    assert :ok = InspectionArtifact.validate_correlations(evaluation_records, evaluation_events)
+
+    conflicting_evaluation_records =
+      Enum.map(evaluation_records, fn record ->
+        put_in(record, ["correlation", "evaluation_id"], "eval-shared")
+      end)
+
+    assert {:error, :inspection_correlation_missing} =
+             InspectionArtifact.validate_correlations(
+               conflicting_evaluation_records,
+               dropped_events(%{"evaluation-started" => 1})
+             )
+
+    assert :ok = InspectionSink.stop(evaluation_sink)
+  end
+
   test "rejects a non-MCP record above the artifact document-depth ceiling" do
     {:ok, sink} = InspectionSink.start(run_id: "run-1", trace_id: "trace-1")
     nested = Enum.reduce(1..64, true, fn _level, value -> [value] end)
@@ -1031,6 +1129,18 @@ defmodule PtcRunner.Kernel.InspectionSinkTest do
         "name" => "read"
       }),
       canonical_event(4, "run-stopped", %{"outcome" => "ok"})
+    ]
+  end
+
+  defp dropped_events(counts) do
+    [
+      canonical_event(1, "run-started", %{}),
+      canonical_event(2, "events-dropped", %{"counts" => counts}),
+      canonical_event(3, "run-stopped", %{
+        "outcome" => "ok",
+        "reason" => nil,
+        "usage" => %{"events_dropped" => counts}
+      })
     ]
   end
 

--- a/test/ptc_runner/kernel/inspection_snapshot_test.exs
+++ b/test/ptc_runner/kernel/inspection_snapshot_test.exs
@@ -843,6 +843,8 @@ defmodule PtcRunner.Kernel.InspectionSnapshotTest do
       }),
       event(run_id, 4, "evaluation-started", %{
         "evaluation_id" => "eval-#{run_id}",
+        "environment" => "mission",
+        "program_kind" => "ptc-lisp",
         "source_hash" => @source_hash,
         "source_bytes" => byte_size(@source)
       }),

--- a/test/support/private_inspection_fixture.ex
+++ b/test/support/private_inspection_fixture.ex
@@ -42,6 +42,8 @@ defmodule PtcRunner.TestSupport.PrivateInspectionFixture do
       }),
       event(run_id, 4, "evaluation-started", %{
         "evaluation_id" => "eval-#{run_id}",
+        "environment" => "mission",
+        "program_kind" => "ptc-lisp",
         "source_hash" => @source_hash,
         "source_bytes" => byte_size(@source)
       }),


### PR DESCRIPTION
## Summary

- preserve successful results when private inspection correlations are missing only if the canonical trace proves the corresponding events were dropped
- require exact terminal `events-dropped` / `run-stopped` evidence with matching positive counts and environment-aware evaluation correlation
- persist and publish the trace-marked partial inspection artifact alongside the canonical trace and successful result
- record evaluation-start attempts before private source capture and document the partial-artifact contract

## Test-first evidence

- added failing correlation, event-ordering, evaluation-environment, and artifact-publication regressions before implementing the fixes
- added the shared inspection-analysis fixture coverage required by the reviewed contract

## Verification

- `mix precommit` — 6,029 root tests; Viewer and launcher suites; duplication 61/61, zero new; packages and standalone release
- `MIX_ENV=dev mix docs --warnings-as-errors`
- pre-push hook with `PTC_PRE_PUSH_MAX_CASES=2` — 6,029 root tests, Credo, generated artifacts, upstream audit, Dialyzer with zero errors, unused dependencies, and 72 Viewer tests
- independent Codex review plus focused follow-up; all actionable findings resolved

Fixes #1178