### PR TITLE
fix(kernel): align pmap with provider task limits

### DIFF
--- a/docs/guides/kernel-maintainer.md
+++ b/docs/guides/kernel-maintainer.md
@@ -1145,7 +1145,10 @@ diverge. `PtcRunner.Kernel.Limits`, `RunState`, `BoundedWorker`, and
 ordering. Mission compilation and source checking explicitly use
 `evaluation_heap_words` as `Lisp.run_native/2`'s `compile_max_heap`; callers
 that do not set it compile under their own `:max_heap`, so no ambient
-application default can move a sealed run's compile ceiling.
+application default can move a sealed run's compile ceiling. Workflow, mission,
+and REPL execution likewise pass the effective `live_provider_tasks` limit as
+Lisp's global `max_parallel_workers`, so `pmap` and `pcalls` batch at the same
+ceiling that bounds their concurrent provider callbacks.
 
 Standalone `PtcRunner.Kernel.ReplSession` is process-affine. Passing its public
 value does not transfer ownership. A product that needs transferable or

--- a/docs/ptc-lisp-specification.md
+++ b/docs/ptc-lisp-specification.md
@@ -1745,6 +1745,10 @@ as a `[key value]` pair passed to the predicate. They return a **vector** of
   an error context; concurrently returned secondary failures are not retained
 - The local scheduling window defaults to `2 × CPU cores`; the program-wide
   worker cap in §15.2 is the hard aggregate bound
+- Kernel-owned evaluations set that worker cap to the run's effective
+  `live_provider_tasks` ceiling. A wider collection is processed in bounded
+  batches, so parallel tool calls do not race for a smaller provider-task
+  budget
 - The whole operation, including nested parallel calls, shares one default
   5-second deadline
 
@@ -4147,6 +4151,10 @@ cap is NOT divided by concurrency). The number of such workers alive at
 once, across the whole program and at every nesting depth, is bounded by
 a shared slot budget of `Max Parallel Workers`. Aggregate live parallel
 heap is therefore bounded by `Max Parallel Workers × Worker Max Heap`.
+For Kernel-owned workflow, mission, and REPL evaluations,
+`Max Parallel Workers` is set explicitly from the effective
+`live_provider_tasks` run limit; the default of 8 in the table applies to
+direct `PtcRunner.Lisp` callers.
 
 - A worker that exceeds its fixed heap cap is killed; the program fails
   with `:memory_exceeded`.

--- a/lib/ptc_runner/kernel/evaluation.ex
+++ b/lib/ptc_runner/kernel/evaluation.ex
@@ -320,6 +320,7 @@ defmodule PtcRunner.Kernel.Evaluation do
       compile_max_heap: limits.evaluation_heap_words,
       run_deadline_ms: deadline_ms,
       max_heap: limits.evaluation_heap_words,
+      max_parallel_workers: limits.live_provider_tasks,
       max_program_bytes: limits.subordinate_source_bytes,
       filter_context: false,
       caller: :kernel,

--- a/lib/ptc_runner/kernel/limits.ex
+++ b/lib/ptc_runner/kernel/limits.ex
@@ -14,7 +14,9 @@ defmodule PtcRunner.Kernel.Limits do
     workflow and subordinate evaluations;
   - `workflow_heap_words`, `evaluation_heap_words`, and
     `provider_heap_words` are per-process heap ceilings;
-  - `live_provider_tasks` bounds concurrent provider callback processes;
+  - `live_provider_tasks` bounds concurrent provider callback processes and is
+    passed to Kernel-owned Lisp evaluations as their global `pmap`/`pcalls`
+    worker capacity;
   - `workflow_capability_calls` and `mission_capability_calls` are total call
     quotas, with matching `*_per_name` quotas;
   - `subordinate_evaluations`, `subordinate_source_checks`, and

--- a/lib/ptc_runner/kernel/repl_session.ex
+++ b/lib/ptc_runner/kernel/repl_session.ex
@@ -589,6 +589,7 @@ defmodule PtcRunner.Kernel.ReplSession do
       compile_timeout: timeout_ms,
       run_deadline_ms: System.monotonic_time(:millisecond) + timeout_ms,
       max_heap: limits.evaluation_heap_words,
+      max_parallel_workers: limits.live_provider_tasks,
       max_program_bytes: limits.subordinate_source_bytes,
       max_tool_call_result_bytes: limits.capability_result_bytes,
       preserve_runtime_callables: true,

--- a/lib/ptc_runner/kernel/runner.ex
+++ b/lib/ptc_runner/kernel/runner.ex
@@ -203,6 +203,7 @@ defmodule PtcRunner.Kernel.Runner do
       compile_timeout: timeout_ms,
       run_deadline_ms: deadline_ms,
       max_heap: config.limits.workflow_heap_words,
+      max_parallel_workers: config.limits.live_provider_tasks,
       max_program_bytes: config.limits.entry_source_bytes,
       filter_context: false,
       caller: :kernel

--- a/test/ptc_runner/kernel/mcp_remote_e2e_test.exs
+++ b/test/ptc_runner/kernel/mcp_remote_e2e_test.exs
@@ -44,7 +44,8 @@ defmodule PtcRunner.Kernel.MCPRemoteE2ETest do
       Limits.new(
         run_duration_ms: 90_000,
         workflow_timeout_ms: 90_000,
-        evaluation_timeout_ms: 30_000
+        evaluation_timeout_ms: 30_000,
+        live_provider_tasks: 1
       )
 
     {:ok, %{capabilities: [capability], snapshot: snapshot, close: close}} =
@@ -88,18 +89,25 @@ defmodule PtcRunner.Kernel.MCPRemoteE2ETest do
       )
 
     source =
-      ~S|(return (tool/kernel-eval {"kind" :source "source" "(return (tool/time.city {\"city\" \"nyc\"}))"}))|
+      ~S|(return (tool/kernel-eval {"kind" :source "source" "(return (pmap (fn [city] (tool/time.city {\"city\" city \"delay_ms\" 100})) [\"nyc\" \"sf\" \"boston\" \"nyc\"]))"}))|
 
     assert {:ok,
             %{
               value: %{
                 "status" => "ok",
-                "value" => %{"outcome" => "returned", "value" => value}
+                "value" => %{"outcome" => "returned", "value" => values}
               }
             }} =
              Kernel.run(source, config)
 
-    assert %{"status" => "ok", "value" => %{"text" => [entry | _]}} = value
-    assert is_binary(entry) and entry != ""
+    assert 4 == length(values)
+
+    assert Enum.all?(values, fn
+             %{"status" => "ok", "value" => %{"text" => [entry | _]}} ->
+               is_binary(entry) and entry != ""
+
+             _other ->
+               false
+           end)
   end
 end

--- a/test/ptc_runner/kernel/parallel_provider_limit_test.exs
+++ b/test/ptc_runner/kernel/parallel_provider_limit_test.exs
@@ -1,0 +1,136 @@
+defmodule PtcRunner.Kernel.ParallelProviderLimitTest do
+  use ExUnit.Case, async: false
+
+  alias PtcRunner.Kernel
+  alias PtcRunner.Kernel.Capability
+  alias PtcRunner.Kernel.EventSink
+  alias PtcRunner.Kernel.Limits
+  alias PtcRunner.Kernel.MissionEnvironment
+  alias PtcRunner.Kernel.ReplSession
+  alias PtcRunner.Kernel.RunConfig
+  alias PtcRunner.Kernel.WorkflowEnvironment
+
+  @input_schema %{
+    "type" => "object",
+    "properties" => %{"id" => %{"type" => "integer"}},
+    "required" => ["id"],
+    "additionalProperties" => false
+  }
+
+  test "effective live provider task ceiling bounds workflow pmap width" do
+    parent = self()
+    config = provider_config(parent, "pmap-provider-width", :manual_release)
+
+    run = Task.async(fn -> Kernel.run(pmap_source(), config) end)
+    started = receive_and_release_providers(4)
+
+    assert {:ok, %{value: values}} = Task.await(run, 5_000)
+    assert_provider_ids(started, values)
+  end
+
+  test "effective live provider task ceiling bounds REPL pmap width" do
+    parent = self()
+
+    {owner, owner_ref} =
+      spawn_monitor(fn ->
+        config = provider_config(parent, "repl-pmap-provider-width", :delayed_release)
+        {:ok, session} = ReplSession.new(config: config)
+        result = ReplSession.eval(session, pmap_source())
+        send(parent, {:repl_result, result})
+      end)
+
+    on_exit(fn -> if Process.alive?(owner), do: Process.exit(owner, :kill) end)
+
+    assert_receive {:repl_result, result}, 5_000
+    assert {:ok, %{return: {:__ptc_return__, values}}, _session} = result
+    assert_receive {:DOWN, ^owner_ref, :process, ^owner, :normal}, 5_000
+    started = receive_started_providers(4)
+    assert_provider_ids(started, values)
+  end
+
+  defp provider_config(parent, run_id, release_mode) do
+    {:ok, capability} =
+      Capability.new(
+        name: "gated",
+        input_schema: @input_schema,
+        callback: fn %{"id" => id} ->
+          send(parent, {:provider_started, id, self()})
+          await_release(release_mode)
+          {:ok, %{"id" => id}}
+        end
+      )
+
+    {:ok, workflow} = WorkflowEnvironment.new(capabilities: [capability])
+    {:ok, mission} = MissionEnvironment.new([])
+
+    {:ok, limits} =
+      Limits.new(
+        live_provider_tasks: 1,
+        workflow_timeout_ms: 5_000,
+        evaluation_timeout_ms: 5_000,
+        run_duration_ms: 5_000
+      )
+
+    {:ok, sink} = EventSink.start(:normal, limits, run_id: run_id)
+
+    {:ok, config} =
+      RunConfig.new(
+        workflow_environment: workflow,
+        mission_environment: mission,
+        input: %{},
+        limits: limits,
+        event_sink: sink
+      )
+
+    config
+  end
+
+  defp pmap_source do
+    ~S|(return (pmap (fn [id] (tool/gated {"id" id})) [1 2 3 4]))|
+  end
+
+  defp receive_and_release_providers(count) do
+    for _batch <- 1..count do
+      provider = receive_provider()
+      release_provider(provider)
+      provider
+    end
+  end
+
+  defp receive_started_providers(count) do
+    for _provider <- 1..count, do: receive_provider()
+  end
+
+  defp receive_provider do
+    assert_receive {:provider_started, id, pid}, 1_000
+    {id, pid}
+  end
+
+  defp release_provider({_id, pid}), do: send(pid, :release)
+
+  defp await_release(:manual_release) do
+    receive do
+      :release -> :ok
+    end
+  end
+
+  defp await_release(:delayed_release) do
+    Process.send_after(self(), :release, 100)
+    await_release(:manual_release)
+  end
+
+  defp assert_provider_ids(started, values) do
+    assert [1, 2, 3, 4] == started |> Enum.map(&elem(&1, 0)) |> Enum.sort()
+
+    assert [1, 2, 3, 4] ==
+             values
+             |> Enum.map(&provider_id/1)
+             |> Enum.sort()
+  end
+
+  defp provider_id(result) do
+    result
+    |> Map.get(:value, Map.get(result, "value"))
+    |> Map.fetch!("id")
+  end
+end

--- a/test/support/mcp_go_stateless/main.go
+++ b/test/support/mcp_go_stateless/main.go
@@ -30,7 +30,8 @@ import (
 )
 
 type cityTimeParams struct {
-	City string `json:"city" jsonschema:"City to get time for (nyc, sf, or boston)"`
+	City    string `json:"city" jsonschema:"City to get time for (nyc, sf, or boston)"`
+	DelayMS int    `json:"delay_ms,omitempty" jsonschema:"Optional bounded response delay in milliseconds (0 to 1000)"`
 }
 
 type oauthHarness struct {
@@ -307,10 +308,24 @@ func writeJSON(response http.ResponseWriter, value any) {
 }
 
 func cityTime(
-	_ context.Context,
+	ctx context.Context,
 	_ *mcp.CallToolRequest,
 	params *cityTimeParams,
 ) (*mcp.CallToolResult, any, error) {
+	if params.DelayMS < 0 || params.DelayMS > 1000 {
+		return nil, nil, fmt.Errorf("delay_ms must be between 0 and 1000")
+	}
+	if params.DelayMS > 0 {
+		timer := time.NewTimer(time.Duration(params.DelayMS) * time.Millisecond)
+		defer timer.Stop()
+
+		select {
+		case <-ctx.Done():
+			return nil, nil, ctx.Err()
+		case <-timer.C:
+		}
+	}
+
 	locations := map[string]string{
 		"nyc":    "America/New_York",
 		"sf":     "America/Los_Angeles",


### PR DESCRIPTION
## Summary

- derive Kernel-owned Lisp parallel worker capacity from the effective `live_provider_tasks` ceiling for workflow, subordinate mission, and REPL execution
- process wider `pmap`/`pcalls` inputs in bounded batches instead of racing provider callbacks for a smaller task budget
- add deterministic local regressions and a Go MCP end-to-end scenario with a bounded, context-aware response delay
- document the shared Kernel/Lisp concurrency contract

## Test-first evidence

Before the production change, the `live_provider_tasks: 1` regression returned one successful provider result and three `live_provider_tasks` errors. The Go MCP scenario reproduced the same failure. The REPL regression also failed until the review-requested REPL path was wired to the effective ceiling.

## Verification

- `mix test test/ptc_runner/kernel/parallel_provider_limit_test.exs test/ptc_runner/kernel/repl_session_test.exs test/ptc_runner/kernel/core_contract_test.exs` — 135 passed
- Go MCP end-to-end test — 1 passed
- independent Codex review and incremental follow-up — approved, no remaining findings
- `mix precommit` — 6,028 root tests, 72 Viewer tests, 40 launcher tests; duplication baseline 61/current 61/new 0
- `MIX_ENV=dev mix docs --warnings-as-errors`
- full pre-push hook with `PTC_PRE_PUSH_MAX_CASES=2` — passed; Dialyzer 0 errors

Fixes #1214