### PR TITLE
Speed up fresh-worktree gates: seed from the main checkout, summarize pre-push phases (#1281)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -326,6 +326,27 @@ echo "🔍 Running pre-push checks..."
 
 START_TIME=$(date +%s)
 
+# Per-phase durations, replayed as one compact block at the end. The inline
+# ✅ lines already carry the numbers, but a full run buries them under
+# minutes of test output; the summary is what a human actually reads when
+# deciding where the time went.
+PHASE_LABELS=()
+PHASE_TIMES=()
+record_phase() {
+  PHASE_LABELS+=("$1")
+  PHASE_TIMES+=("$2")
+}
+
+print_phase_summary() {
+  [ "${#PHASE_LABELS[@]}" -gt 0 ] || return 0
+  echo ""
+  echo "⏱  Phase timings:"
+  local i
+  for i in "${!PHASE_LABELS[@]}"; do
+    printf '   %-36s %5ss\n' "${PHASE_LABELS[$i]}" "${PHASE_TIMES[$i]}"
+  done
+}
+
 SCOPES_FILE="$(mktemp -t pre-push-scopes.XXXXXX)"
 "$HOOK_REPO_ROOT/scripts/classify_changes.sh" "$PTC_PRE_PUSH_PATHS_FILE" > "$SCOPES_FILE"
 # The classifier emits only fixed boolean assignments.
@@ -350,7 +371,9 @@ fi
 # this gate before long test and Dialyzer stages so a bad reference does not
 # waste the rest of the push cycle.
 if [ "$docs" = true ]; then
+  DOCS_START=$SECONDS
   run_docs_gate
+  record_phase "documentation (ExDoc)" $((SECONDS - DOCS_START))
 fi
 
 PROJECTS=()
@@ -398,7 +421,9 @@ run_project_gates() {
       popd > /dev/null
       exit 1
     fi
-    echo "  ✅ Launcher checks passed in $((SECONDS - launcher_start))s"
+    local launcher_secs=$((SECONDS - launcher_start))
+    echo "  ✅ Launcher checks passed in ${launcher_secs}s"
+    record_phase "launcher precommit" "$launcher_secs"
     popd > /dev/null
     return 0
   fi
@@ -413,7 +438,9 @@ run_project_gates() {
     popd > /dev/null
     exit 1
   fi
-  echo "  ✅ Tests passed in $((SECONDS - test_start))s"
+  local test_secs=$((SECONDS - test_start))
+  echo "  ✅ Tests passed in ${test_secs}s"
+  record_phase "$label tests" "$test_secs"
 
   if [ "$proj" = "." ]; then
     echo "  ⏳ Running canonical pre-push checks..."
@@ -423,7 +450,9 @@ run_project_gates() {
       popd > /dev/null
       exit 1
     fi
-    echo "  ✅ Pre-push checks passed in $((SECONDS - prepush_start))s"
+    local prepush_secs=$((SECONDS - prepush_start))
+    echo "  ✅ Pre-push checks passed in ${prepush_secs}s"
+    record_phase "root mix prepush (incl. dialyzer)" "$prepush_secs"
   # CWD is the project dir (we are inside `pushd "$proj"`), so check
   # `./mix.exs` rather than `$proj/mix.exs`. Passing `$proj` here would
   # resolve to a duplicated project path and silently skip Dialyzer for
@@ -436,7 +465,9 @@ run_project_gates() {
       popd > /dev/null
       exit 1
     fi
-    echo "  ✅ Dialyzer passed in $((SECONDS - dialyzer_start))s"
+    local dialyzer_secs=$((SECONDS - dialyzer_start))
+    echo "  ✅ Dialyzer passed in ${dialyzer_secs}s"
+    record_phase "$label dialyzer" "$dialyzer_secs"
   else
     echo "  ⏭️  Dialyzer not declared in ${label}mix.exs"
   fi
@@ -450,6 +481,8 @@ done
 
 END_TIME=$(date +%s)
 ELAPSED=$((END_TIME - START_TIME))
+
+print_phase_summary
 
 echo ""
 echo "✅ All pre-push checks passed in ${ELAPSED}s"

--- a/.gitignore
+++ b/.gitignore
@@ -17,8 +17,9 @@ examples/*/mix.lock
 # Temporary files, for example, from tests.
 /tmp/
 
-# Staging area for scripts/worktree.sh seeding; discarded on the next seed.
-/.worktree-seed-tmp/
+# Staging areas for scripts/worktree.sh seeding (one per seeding process);
+# inert if a crash leaves one behind, and safe to delete.
+/.worktree-seed-tmp*/
 
 # Scratch manifests and host documents from probing runs at the repository
 # root. Deliberately anchored: a committed fixture deeper in the tree that

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ examples/*/mix.lock
 # Temporary files, for example, from tests.
 /tmp/
 
+# Staging area for scripts/worktree.sh seeding; discarded on the next seed.
+/.worktree-seed-tmp/
+
 # Scratch manifests and host documents from probing runs at the repository
 # root. Deliberately anchored: a committed fixture deeper in the tree that
 # happens to end in .tmp.json should still be visible to Git.

--- a/docs/development-setup.md
+++ b/docs/development-setup.md
@@ -29,9 +29,18 @@ lockfile differs from the main checkout's copy.
 The seed is an optimization, never an authority: Mix revalidates `deps/` and
 `_build/` against `mix.lock` and source digests, and dialyxir revalidates the
 project PLT against the module set, so a stale seed costs a rebuild rather
-than a wrong answer. Copies are made with copy-on-write clones where the
-filesystem supports it (APFS/btrfs), and each worktree owns its copies —
-concurrent gates never share a writable artifact.
+than a wrong answer. (The seeded PLT's dialyxir hash file is deliberately not
+copied, so the first `mix dialyzer` run always re-checks the PLT instead of
+trusting the hash.) Copies are staged and promoted with an atomic rename —
+an interrupted seed leaves nothing half-copied — and each worktree owns its
+copies, so concurrent gates never share a writable artifact. Copies use
+copy-on-write clones where the filesystem supports it (APFS/btrfs).
+
+One deliberate trust boundary: seeding copies the main checkout's `deps/`
+trees as they are. If you have locally edited a dependency there, the edit
+travels with the seed — the same trust you accept when running gates in the
+main checkout itself. CI always builds from pristine dependencies and is
+unaffected.
 
 To warm the cache, keep the main checkout built: `mix compile` and
 `mix dialyzer` there make every subsequent worktree cheap. To fill gaps in an

--- a/docs/development-setup.md
+++ b/docs/development-setup.md
@@ -31,13 +31,15 @@ and `_build/` against `mix.lock` and source digests, and dialyxir revalidates
 the project PLT against the module set, so a stale seed costs a rebuild
 rather than a wrong answer. The seeded PLT's dialyxir hash file is
 deliberately not copied (the first `mix dialyzer` run must re-check the PLT
-instead of trusting the hash), and each copied PLT is byte-compared against
-its source after the clone, so a PLT caught mid-rewrite by a concurrent
-dialyzer run is discarded rather than promoted. Copies are staged under a
-per-process gitignored directory and promoted with an atomic rename — an
-interrupted seed leaves nothing half-copied — and each worktree owns its
-copies, so concurrent gates never share a writable artifact. Copies use
-copy-on-write clones where the filesystem supports it (APFS/btrfs).
+instead of trusting the hash), and each copied PLT must fully decode as an
+external term before promotion, so a torn copy taken while a concurrent
+dialyzer run was rewriting the source is discarded rather than promoted.
+Copies are staged under a per-process gitignored directory and promoted with
+atomic no-replace renames — neither an interrupted seed nor two concurrent
+ones can leave a half-copied artifact that later runs mistake for a built
+one — and each worktree owns its copies, so concurrent gates never share a
+writable artifact. Copies use copy-on-write clones where the filesystem
+supports it (APFS/btrfs).
 
 The one thing the seed takes on faith is dependency *fidelity*: it copies the
 main checkout's `deps/` trees as they are, so a locally edited dependency

--- a/docs/development-setup.md
+++ b/docs/development-setup.md
@@ -26,21 +26,26 @@ artifact saying whether it was seeded or why not — copy skipped, source not
 built, or already present — and skips seeding entirely when `mise.toml` or any
 lockfile differs from the main checkout's copy.
 
-The seed is an optimization, never an authority: Mix revalidates `deps/` and
-`_build/` against `mix.lock` and source digests, and dialyxir revalidates the
-project PLT against the module set, so a stale seed costs a rebuild rather
-than a wrong answer. (The seeded PLT's dialyxir hash file is deliberately not
-copied, so the first `mix dialyzer` run always re-checks the PLT instead of
-trusting the hash.) Copies are staged and promoted with an atomic rename —
-an interrupted seed leaves nothing half-copied — and each worktree owns its
+For build staleness the seed is never an authority: Mix revalidates `deps/`
+and `_build/` against `mix.lock` and source digests, and dialyxir revalidates
+the project PLT against the module set, so a stale seed costs a rebuild
+rather than a wrong answer. The seeded PLT's dialyxir hash file is
+deliberately not copied (the first `mix dialyzer` run must re-check the PLT
+instead of trusting the hash), and each copied PLT is byte-compared against
+its source after the clone, so a PLT caught mid-rewrite by a concurrent
+dialyzer run is discarded rather than promoted. Copies are staged under a
+per-process gitignored directory and promoted with an atomic rename — an
+interrupted seed leaves nothing half-copied — and each worktree owns its
 copies, so concurrent gates never share a writable artifact. Copies use
 copy-on-write clones where the filesystem supports it (APFS/btrfs).
 
-One deliberate trust boundary: seeding copies the main checkout's `deps/`
-trees as they are. If you have locally edited a dependency there, the edit
-travels with the seed — the same trust you accept when running gates in the
-main checkout itself. CI always builds from pristine dependencies and is
-unaffected.
+The one thing the seed takes on faith is dependency *fidelity*: it copies the
+main checkout's `deps/` trees as they are, so a locally edited dependency
+travels with the seed. This is a deliberate trust boundary — it is the same
+trust you accept when running gates in the main checkout itself, no tool
+rescans dependency sources against compiled artifacts anyway, and CI always
+builds from pristine dependencies. If you have edited a dependency in the
+main checkout, do not seed from it.
 
 To warm the cache, keep the main checkout built: `mix compile` and
 `mix dialyzer` there make every subsequent worktree cheap. To fill gaps in an

--- a/docs/development-setup.md
+++ b/docs/development-setup.md
@@ -34,6 +34,10 @@ deliberately not copied (the first `mix dialyzer` run must re-check the PLT
 instead of trusting the hash), and each copied PLT must fully decode as an
 external term before promotion, so a torn copy taken while a concurrent
 dialyzer run was rewriting the source is discarded rather than promoted.
+The decode proves the copy is whole, not that the PLT is current: a project
+PLT left stale by a toolchain bump seeds as-is and fails in the worktree
+exactly as it would have in the main checkout — the remedy in the section
+above applies unchanged.
 Copies are staged under a per-process gitignored directory and promoted with
 atomic no-replace renames — neither an interrupted seed nor two concurrent
 ones can leave a half-copied artifact that later runs mistake for a built

--- a/docs/development-setup.md
+++ b/docs/development-setup.md
@@ -17,6 +17,31 @@ mix deps.get
 mix compile
 ```
 
+## Worktree seeding
+
+`scripts/worktree.sh new` seeds a fresh worktree with the main checkout's
+`deps/`, `_build/`, and `priv/plts/` (root, Viewer, and launcher) so the
+commands above become incremental instead of cold. It prints one line per
+artifact saying whether it was seeded or why not — copy skipped, source not
+built, or already present — and skips seeding entirely when `mise.toml` or any
+lockfile differs from the main checkout's copy.
+
+The seed is an optimization, never an authority: Mix revalidates `deps/` and
+`_build/` against `mix.lock` and source digests, and dialyxir revalidates the
+project PLT against the module set, so a stale seed costs a rebuild rather
+than a wrong answer. Copies are made with copy-on-write clones where the
+filesystem supports it (APFS/btrfs), and each worktree owns its copies —
+concurrent gates never share a writable artifact.
+
+To warm the cache, keep the main checkout built: `mix compile` and
+`mix dialyzer` there make every subsequent worktree cheap. To fill gaps in an
+existing worktree (artifacts already present are left untouched):
+
+```bash
+scripts/worktree.sh seed          # seed the current worktree
+scripts/worktree.sh seed <dir>    # seed another worktree
+```
+
 ## Git hooks
 
 Run `./scripts/install-hooks.sh` once per clone. Linked worktrees share the

--- a/scripts/worktree.sh
+++ b/scripts/worktree.sh
@@ -75,9 +75,10 @@ idle_hours() {
   printf '%s' $(((now - newest) / 3600))
 }
 
-# The main worktree is always the first record git prints.
+# The main worktree is always the first record git prints. Strip the prefix
+# rather than taking field 2 so paths containing spaces survive.
 main_worktree() {
-  git worktree list --porcelain | awk '/^worktree /{print $2; exit}'
+  git worktree list --porcelain | awk '/^worktree /{sub(/^worktree /, ""); print; exit}'
 }
 
 # Flatten `git worktree list --porcelain` into `path<TAB>head<TAB>branch<TAB>flags`.
@@ -189,7 +190,7 @@ clone_tree() {
 }
 
 seed_worktree() {
-  local src="$1" dst="$2" file artifact seeded=0 start=$SECONDS
+  local src="$1" dst="$2" file artifact staging tmp seeded=0 start=$SECONDS
 
   for file in "${SEED_KEY_FILES[@]}"; do
     if ! cmp -s "$src/$file" "$dst/$file"; then
@@ -198,24 +199,45 @@ seed_worktree() {
     fi
   done
 
+  # Stage each copy and promote it with an atomic same-volume rename, so an
+  # interrupted seed can never leave a partial tree that a later run skips as
+  # "already present". A leftover staging dir (gitignored) from an interrupt
+  # is discarded here on the next run.
+  staging="$dst/.worktree-seed-tmp"
+  rm -rf "$staging"
+
   for artifact in "${SEED_ARTIFACTS[@]}"; do
+    tmp="$staging/${artifact//\//__}"
     if [ -L "$src/$artifact" ]; then
       echo "   ⏭️  $artifact — main checkout's copy is a symlink"
     elif [ ! -d "$src/$artifact" ]; then
       echo "   ⏭️  $artifact — not built in the main checkout"
-    elif [ -e "$dst/$artifact" ]; then
+    elif [ -e "$dst/$artifact" ] || [ -L "$dst/$artifact" ]; then
       echo "   ⏭️  $artifact — already present"
-    elif mkdir -p "$(dirname "$dst/$artifact")" &&
-      clone_tree "$src/$artifact" "$dst/$artifact"; then
+    elif mkdir -p "$staging" "$(dirname "$dst/$artifact")" &&
+      clone_tree "$src/$artifact" "$tmp" &&
+      scrub_seed_artifact "$artifact" "$tmp" &&
+      mv "$tmp" "$dst/$artifact"; then
       echo "   🌱 $artifact"
       seeded=$((seeded + 1))
     else
-      rm -rf "${dst:?}/${artifact:?}"
-      echo "   ⚠️  $artifact — copy failed; partial copy removed"
+      echo "   ⚠️  $artifact — copy failed; nothing promoted"
     fi
   done
 
+  rm -rf "$staging"
   echo "🌱 Seeded ${seeded} artifact(s) from $src in $((SECONDS - start))s"
+}
+
+# dialyxir skips its PLT check entirely when the stored dependency hash
+# matches (check_hash?/1 in mix/tasks/dialyzer.ex), and that hash covers the
+# app set, not the PLT file's integrity. Drop it from the seed so the first
+# dialyzer run in the new worktree always revalidates the copied PLT.
+scrub_seed_artifact() {
+  local artifact="$1" tree="$2"
+  if [ "$artifact" = "priv/plts" ]; then
+    rm -f "$tree"/*.hash
+  fi
 }
 
 cmd_seed() {

--- a/scripts/worktree.sh
+++ b/scripts/worktree.sh
@@ -217,12 +217,12 @@ seed_worktree() {
       echo "   ⏭️  $artifact — already present"
     elif mkdir -p "$staging" "$(dirname "$dst/$artifact")" &&
       clone_tree "$src/$artifact" "$tmp" &&
-      scrub_seed_artifact "$artifact" "$src/$artifact" "$tmp" &&
-      [ ! -e "$dst/$artifact" ] && mv "$tmp" "$dst/$artifact"; then
+      scrub_seed_artifact "$artifact" "$tmp" &&
+      promote_seed_artifact "$tmp" "$dst/$artifact"; then
       echo "   🌱 $artifact"
       seeded=$((seeded + 1))
     else
-      echo "   ⚠️  $artifact — copy failed or source changed mid-copy; nothing promoted"
+      echo "   ⚠️  $artifact — not promoted (copy failed, torn PLT, or lost a race)"
     fi
   done
 
@@ -238,18 +238,47 @@ seed_worktree() {
 #    dialyzer run in the new worktree always revalidates the copied PLT.
 # 2. A PLT cloned while the main checkout's dialyzer is rewriting it can be
 #    a torn copy, and dialyxir raises on an invalid PLT rather than
-#    rebuilding it. Byte-compare each staged PLT against its source after
-#    the clone: any concurrent write makes them diverge and the artifact is
-#    discarded — the worktree then simply builds its PLT the normal way.
+#    rebuilding it — each staged PLT must prove it decodes before promotion.
 scrub_seed_artifact() {
-  local artifact="$1" src_tree="$2" tmp_tree="$3" plt
+  local artifact="$1" tmp_tree="$2" plt
   if [ "$artifact" = "priv/plts" ]; then
     rm -f "$tmp_tree"/*.hash
     for plt in "$tmp_tree"/*.plt; do
       [ -e "$plt" ] || continue
-      cmp -s "$src_tree/$(basename "$plt")" "$plt" || return 1
+      plt_decodes "$plt" || return 1
     done
   fi
+}
+
+# A PLT file is a single external term (#file_plt{}), and binary_to_term
+# rejects both truncation and trailing garbage, so a successful decode of the
+# staged copy proves the snapshot is complete regardless of what the source's
+# writer was doing. Needs erl on PATH; without it the artifact is not seeded.
+plt_decodes() {
+  PTC_SEED_PLT="$1" erl -noshell -eval '
+    P = os:getenv("PTC_SEED_PLT"),
+    R = case file:read_file(P) of
+          {ok, Bin} -> try binary_to_term(Bin) of _ -> 0 catch _:_ -> 1 end;
+          _ -> 1
+        end,
+    halt(R).' 2>/dev/null
+}
+
+# Promotion must be a no-replace operation: a bare `mv` whose destination
+# sprang into existence (a concurrent seed) would move the staged tree
+# *inside* it and report success. `mkdir` is the atomic claim — it fails on
+# any existing entry, symlinks included — and each top-level entry then moves
+# in with an atomic same-volume rename. An interruption mid-promotion leaves
+# only whole top-level units (whole dep dirs, whole build envs, whole PLTs),
+# which Mix and dialyxir treat as merely not-yet-built.
+promote_seed_artifact() {
+  local tmp="$1" final="$2" entry
+  mkdir "$final" 2>/dev/null || return 1
+  for entry in "$tmp"/* "$tmp"/.[!.]* "$tmp"/..?*; do
+    { [ -e "$entry" ] || [ -L "$entry" ]; } || continue
+    mv "$entry" "$final/" || return 1
+  done
+  rmdir "$tmp"
 }
 
 cmd_seed() {

--- a/scripts/worktree.sh
+++ b/scripts/worktree.sh
@@ -201,9 +201,10 @@ seed_worktree() {
 
   # Stage each copy and promote it with an atomic same-volume rename, so an
   # interrupted seed can never leave a partial tree that a later run skips as
-  # "already present". A leftover staging dir (gitignored) from an interrupt
-  # is discarded here on the next run.
-  staging="$dst/.worktree-seed-tmp"
+  # "already present". The staging path carries this process's PID so two
+  # concurrent seeds of one destination cannot delete each other's work; a
+  # leftover dir from a crash is gitignored, inert, and safe to remove.
+  staging="$dst/.worktree-seed-tmp.$$"
   rm -rf "$staging"
 
   for artifact in "${SEED_ARTIFACTS[@]}"; do
@@ -216,12 +217,12 @@ seed_worktree() {
       echo "   ⏭️  $artifact — already present"
     elif mkdir -p "$staging" "$(dirname "$dst/$artifact")" &&
       clone_tree "$src/$artifact" "$tmp" &&
-      scrub_seed_artifact "$artifact" "$tmp" &&
-      mv "$tmp" "$dst/$artifact"; then
+      scrub_seed_artifact "$artifact" "$src/$artifact" "$tmp" &&
+      [ ! -e "$dst/$artifact" ] && mv "$tmp" "$dst/$artifact"; then
       echo "   🌱 $artifact"
       seeded=$((seeded + 1))
     else
-      echo "   ⚠️  $artifact — copy failed; nothing promoted"
+      echo "   ⚠️  $artifact — copy failed or source changed mid-copy; nothing promoted"
     fi
   done
 
@@ -229,14 +230,25 @@ seed_worktree() {
   echo "🌱 Seeded ${seeded} artifact(s) from $src in $((SECONDS - start))s"
 }
 
-# dialyxir skips its PLT check entirely when the stored dependency hash
-# matches (check_hash?/1 in mix/tasks/dialyzer.ex), and that hash covers the
-# app set, not the PLT file's integrity. Drop it from the seed so the first
-# dialyzer run in the new worktree always revalidates the copied PLT.
+# Two PLT-specific guards before promotion:
+#
+# 1. dialyxir skips its PLT check entirely when the stored dependency hash
+#    matches (check_hash?/1 in mix/tasks/dialyzer.ex), and that hash covers
+#    the app set, not the PLT file's integrity — drop it so the first
+#    dialyzer run in the new worktree always revalidates the copied PLT.
+# 2. A PLT cloned while the main checkout's dialyzer is rewriting it can be
+#    a torn copy, and dialyxir raises on an invalid PLT rather than
+#    rebuilding it. Byte-compare each staged PLT against its source after
+#    the clone: any concurrent write makes them diverge and the artifact is
+#    discarded — the worktree then simply builds its PLT the normal way.
 scrub_seed_artifact() {
-  local artifact="$1" tree="$2"
+  local artifact="$1" src_tree="$2" tmp_tree="$3" plt
   if [ "$artifact" = "priv/plts" ]; then
-    rm -f "$tree"/*.hash
+    rm -f "$tmp_tree"/*.hash
+    for plt in "$tmp_tree"/*.plt; do
+      [ -e "$plt" ] || continue
+      cmp -s "$src_tree/$(basename "$plt")" "$plt" || return 1
+    done
   fi
 }
 

--- a/scripts/worktree.sh
+++ b/scripts/worktree.sh
@@ -250,15 +250,24 @@ scrub_seed_artifact() {
   fi
 }
 
-# A PLT file is a single external term (#file_plt{}), and binary_to_term
-# rejects both truncation and trailing garbage, so a successful decode of the
-# staged copy proves the snapshot is complete regardless of what the source's
-# writer was doing. Needs erl on PATH; without it the artifact is not seeded.
+# A PLT file is a single external term, a #file_plt{} record. The staged copy
+# must decode as exactly that: `[used]` demands the term consume every byte
+# (bare binary_to_term/1 tolerates trailing garbage), and the record tag
+# rejects a complete-but-foreign term. Together they prove the snapshot is
+# whole regardless of what the source's writer was doing at the time. Needs
+# erl on PATH; without it the artifact is simply not seeded.
 plt_decodes() {
   PTC_SEED_PLT="$1" erl -noshell -eval '
     P = os:getenv("PTC_SEED_PLT"),
     R = case file:read_file(P) of
-          {ok, Bin} -> try binary_to_term(Bin) of _ -> 0 catch _:_ -> 1 end;
+          {ok, Bin} ->
+            try binary_to_term(Bin, [used]) of
+              {T, Used}
+                when is_tuple(T), element(1, T) =:= file_plt,
+                     Used =:= byte_size(Bin) -> 0;
+              _ -> 1
+            catch _:_ -> 1
+            end;
           _ -> 1
         end,
     halt(R).' 2>/dev/null

--- a/scripts/worktree.sh
+++ b/scripts/worktree.sh
@@ -4,6 +4,7 @@
 #
 #   scripts/worktree.sh gc [--yes] [--no-fetch] [--no-issues]
 #   scripts/worktree.sh new <branch> [issue-number]
+#   scripts/worktree.sh seed [<dir>]
 #
 # A worktree is a cache, not an artifact. `git worktree remove` never deletes
 # the branch, so a checkout whose commits are already in `origin/main` costs a
@@ -140,6 +141,96 @@ issue_of_branch() {
 issue_state() {
   local number="$1"
   gh issue view "$number" --json state --jq .state 2>/dev/null || true
+}
+
+# ----------------------------------------------------------------------
+# Seeding: copy build artifacts from the main checkout into a worktree.
+#
+# The main checkout is the cache. Its artifacts are transferable to another
+# checkout on this machine when the toolchain (mise.toml) and dependency sets
+# (the lockfiles) are byte-identical -- OS and architecture are constant on
+# one machine. Correctness never rests on that key: Mix revalidates deps and
+# _build against mix.lock and source digests, and dialyxir revalidates the
+# project PLT against the module set, so a stale seed costs a rebuild, never
+# a wrong answer. Each worktree owns its copies outright -- nothing writable
+# is ever shared, so concurrent gates cannot race.
+# ----------------------------------------------------------------------
+
+SEED_KEY_FILES=(mise.toml mix.lock ptc_viewer/mix.lock ptc_runner_launcher/mix.lock)
+
+# deps/_build make `mix deps.get` and `mix compile` incremental in all three
+# Mix projects; priv/plts carries the writable project PLT so dialyxir
+# updates it instead of re-adding ~1,500 modules (the core PLT is already
+# shared machine-wide via ~/.cache/ptc_runner -- see mix.exs).
+SEED_ARTIFACTS=(
+  deps
+  _build
+  priv/plts
+  ptc_viewer/deps
+  ptc_viewer/_build
+  ptc_runner_launcher/deps
+  ptc_runner_launcher/_build
+)
+
+# Copy-on-write clone where the filesystem supports it (APFS, btrfs, XFS);
+# plain copy otherwise. A clone is near-instant and shares blocks until
+# either side writes.
+clone_tree() {
+  local src="$1" dst="$2"
+  case "$(uname -s)" in
+    Darwin)
+      if ! cp -Rc "$src" "$dst" 2>/dev/null; then
+        rm -rf "${dst:?}"
+        cp -R "$src" "$dst"
+      fi
+      ;;
+    *) cp -R --reflink=auto "$src" "$dst" ;;
+  esac
+}
+
+seed_worktree() {
+  local src="$1" dst="$2" file artifact seeded=0 start=$SECONDS
+
+  for file in "${SEED_KEY_FILES[@]}"; do
+    if ! cmp -s "$src/$file" "$dst/$file"; then
+      echo "🌱 Seed skipped: $file differs from the main checkout's copy"
+      return 0
+    fi
+  done
+
+  for artifact in "${SEED_ARTIFACTS[@]}"; do
+    if [ -L "$src/$artifact" ]; then
+      echo "   ⏭️  $artifact — main checkout's copy is a symlink"
+    elif [ ! -d "$src/$artifact" ]; then
+      echo "   ⏭️  $artifact — not built in the main checkout"
+    elif [ -e "$dst/$artifact" ]; then
+      echo "   ⏭️  $artifact — already present"
+    elif mkdir -p "$(dirname "$dst/$artifact")" &&
+      clone_tree "$src/$artifact" "$dst/$artifact"; then
+      echo "   🌱 $artifact"
+      seeded=$((seeded + 1))
+    else
+      rm -rf "${dst:?}/${artifact:?}"
+      echo "   ⚠️  $artifact — copy failed; partial copy removed"
+    fi
+  done
+
+  echo "🌱 Seeded ${seeded} artifact(s) from $src in $((SECONDS - start))s"
+}
+
+cmd_seed() {
+  local dst="${1:-}" main_wt
+  main_wt="$(main_worktree)"
+  main_wt="$(cd "$main_wt" && pwd -P)"
+  if [ -z "$dst" ]; then
+    dst="$(git rev-parse --show-toplevel)"
+  fi
+  [ -d "$dst" ] || die "$dst does not exist"
+  # Physical paths: a tmpdir symlink (macOS /var -> /private/var) must not
+  # make the same checkout look like two different ones.
+  dst="$(cd "$dst" && pwd -P)"
+  [ "$dst" != "$main_wt" ] || die "refusing to seed the main checkout from itself"
+  seed_worktree "$main_wt" "$dst"
 }
 
 cmd_gc() {
@@ -290,6 +381,8 @@ cmd_new() {
   git fetch -q origin main
   git worktree add -b "$branch" "$dir" origin/main
 
+  seed_worktree "$main_wt" "$dir"
+
   if [ -n "$issue" ]; then
     gh issue edit "$issue" --add-assignee @me >/dev/null
     gh issue comment "$issue" --body "Claimed by an agent working in \`${branch}\` at \`${dir}\` on $(hostname -s), $(date -u +%Y-%m-%dT%H:%M:%SZ).
@@ -317,9 +410,17 @@ scripts/worktree.sh gc [--yes] [--idle-hours N] [--no-fetch] [--no-issues]
     one-line count, and nothing at all when there is nothing to reclaim.
 
 scripts/worktree.sh new <branch> [issue-number]
-    Create a worktree beside the main checkout, branched from origin/main.
-    With an issue number, verify it is open and unassigned, then assign it and
-    post a claim comment. The branch name must contain the issue number.
+    Create a worktree beside the main checkout, branched from origin/main,
+    and seed it with the main checkout's deps, _build, and project-PLT
+    artifacts when toolchain and lockfiles match (Mix revalidates them, so
+    a stale seed only costs a rebuild). With an issue number, verify it is
+    open and unassigned, then assign it and post a claim comment. The branch
+    name must contain the issue number.
+
+scripts/worktree.sh seed [<dir>]
+    Seed an existing worktree (default: the current one) from the main
+    checkout. Artifacts already present are left untouched, so this is safe
+    to re-run and only fills gaps.
 USAGE
 }
 
@@ -347,6 +448,7 @@ main() {
       cmd_gc
       ;;
     new) cmd_new "$@" ;;
+    seed) cmd_seed "$@" ;;
     ""| -h | --help | help) usage ;;
     *)
       usage >&2

--- a/test/githooks/pre_push_test.exs
+++ b/test/githooks/pre_push_test.exs
@@ -81,6 +81,10 @@ defmodule PtcRunner.GitHooks.PrePushTest do
     assert output =~ ~r/Tests passed in \d+s/
     assert output =~ ~r/Pre-push checks passed in \d+s/
 
+    assert output =~ "Phase timings:"
+    assert output =~ ~r/root \(:ptc_runner\) tests\s+\d+s/
+    assert output =~ ~r/root mix prepush \(incl\. dialyzer\)\s+\d+s/
+
     assert mix_marker |> File.read!() |> String.split("\n", trim: true) ==
              ["test --exclude clojure", "prepush"]
   end

--- a/test/scripts/worktree_seed_test.exs
+++ b/test/scripts/worktree_seed_test.exs
@@ -27,6 +27,32 @@ defmodule PtcRunner.Scripts.WorktreeSeedTest do
     assert File.read!(Path.join(worktree, "ptc_viewer/_build/test/marker")) == "viewer\n"
 
     assert output =~ "ptc_runner_launcher/deps — not built in the main checkout"
+    refute File.exists?(Path.join(worktree, ".worktree-seed-tmp"))
+  end
+
+  test "does not seed dialyxir's PLT hash file" do
+    %{main: main, worktree: worktree} = repo_with_worktree()
+
+    write!(main, "priv/plts/project.plt", "plt\n")
+    write!(main, "priv/plts/project.plt.hash", "hash\n")
+
+    {output, 0} = seed(main, worktree)
+
+    assert output =~ "🌱 priv/plts"
+    assert File.exists?(Path.join(worktree, "priv/plts/project.plt"))
+    refute File.exists?(Path.join(worktree, "priv/plts/project.plt.hash"))
+  end
+
+  test "treats a dangling destination symlink as present rather than replacing it" do
+    %{main: main, worktree: worktree} = repo_with_worktree()
+
+    write!(main, "deps/jason/mix.exs", "jason\n")
+    File.ln_s!("missing-target", Path.join(worktree, "deps"))
+
+    {output, 0} = seed(main, worktree)
+
+    assert output =~ "deps — already present"
+    assert File.lstat!(Path.join(worktree, "deps")).type == :symlink
   end
 
   test "skips seeding entirely when a lockfile differs" do
@@ -69,8 +95,10 @@ defmodule PtcRunner.Scripts.WorktreeSeedTest do
         "ptc-worktree-seed-#{System.unique_integer([:positive, :monotonic])}"
       )
 
-    main = Path.join(root, "main")
-    worktree = Path.join(root, "wt")
+    # Both paths carry a space so field-splitting bugs in the script's
+    # `git worktree list` parsing surface here rather than on a user's disk.
+    main = Path.join(root, "main checkout")
+    worktree = Path.join(root, "wt one")
     File.mkdir_p!(main)
     on_exit(fn -> File.rm_rf!(root) end)
 
@@ -81,7 +109,7 @@ defmodule PtcRunner.Scripts.WorktreeSeedTest do
     Enum.each(@key_files, &write!(main, &1, "pinned\n"))
     git!(main, ["add", "."])
     git!(main, ["commit", "--quiet", "-m", "base"])
-    git!(main, ["worktree", "add", "--quiet", worktree])
+    git!(main, ["worktree", "add", "--quiet", "--detach", worktree])
 
     %{main: main, worktree: worktree}
   end

--- a/test/scripts/worktree_seed_test.exs
+++ b/test/scripts/worktree_seed_test.exs
@@ -27,7 +27,19 @@ defmodule PtcRunner.Scripts.WorktreeSeedTest do
     assert File.read!(Path.join(worktree, "ptc_viewer/_build/test/marker")) == "viewer\n"
 
     assert output =~ "ptc_runner_launcher/deps — not built in the main checkout"
-    refute File.exists?(Path.join(worktree, ".worktree-seed-tmp"))
+    assert Path.wildcard(Path.join(worktree, ".worktree-seed-tmp*")) == []
+  end
+
+  test "discards a PLT whose source diverged from the copy" do
+    %{main: main, worktree: worktree} = repo_with_worktree()
+
+    write!(main, "priv/plts/project.plt", "plt\n")
+    fake_cmp = fake_cmp_reporting_divergence!(main)
+
+    {output, 0} = seed(main, worktree, env: [{"PATH", fake_cmp}])
+
+    assert output =~ "priv/plts — copy failed or source changed mid-copy"
+    refute File.exists?(Path.join(worktree, "priv/plts"))
   end
 
   test "does not seed dialyxir's PLT hash file" do
@@ -114,12 +126,32 @@ defmodule PtcRunner.Scripts.WorktreeSeedTest do
     %{main: main, worktree: worktree}
   end
 
-  defp seed(main, worktree) do
+  defp seed(main, worktree, opts \\ []) do
     System.cmd("bash", [@script, "seed", worktree],
       cd: main,
-      env: @git_env,
+      env: @git_env ++ Keyword.get(opts, :env, []),
       stderr_to_stdout: true
     )
+  end
+
+  # A PATH whose `cmp` reports divergence for .plt files only, standing in
+  # for a PLT that a concurrent dialyzer run rewrote while it was cloned.
+  # Every other cmp call (the seed's lockfile guard) passes through.
+  defp fake_cmp_reporting_divergence!(root) do
+    bin = Path.join(root, "fake-bin")
+    File.mkdir_p!(bin)
+    fake_cmp = Path.join(bin, "cmp")
+
+    File.write!(fake_cmp, """
+    #!/bin/sh
+    case "$*" in
+      *.plt*) exit 1 ;;
+      *) exec /usr/bin/cmp "$@" ;;
+    esac
+    """)
+
+    File.chmod!(fake_cmp, 0o755)
+    bin <> ":" <> System.fetch_env!("PATH")
   end
 
   defp write!(repo, path, contents) do

--- a/test/scripts/worktree_seed_test.exs
+++ b/test/scripts/worktree_seed_test.exs
@@ -55,6 +55,28 @@ defmodule PtcRunner.Scripts.WorktreeSeedTest do
     refute File.exists?(Path.join(worktree, "priv/plts"))
   end
 
+  test "discards a PLT that is a complete term but not a file_plt record" do
+    %{main: main, worktree: worktree} = repo_with_worktree()
+
+    write!(main, "priv/plts/project.plt", :erlang.term_to_binary(:not_a_plt))
+
+    {output, 0} = seed(main, worktree)
+
+    assert output =~ "priv/plts — not promoted"
+    refute File.exists?(Path.join(worktree, "priv/plts"))
+  end
+
+  test "discards a PLT with trailing bytes after the term" do
+    %{main: main, worktree: worktree} = repo_with_worktree()
+
+    write!(main, "priv/plts/project.plt", plt_binary() <> "garbage")
+
+    {output, 0} = seed(main, worktree)
+
+    assert output =~ "priv/plts — not promoted"
+    refute File.exists?(Path.join(worktree, "priv/plts"))
+  end
+
   test "treats a dangling destination symlink as present rather than replacing it" do
     %{main: main, worktree: worktree} = repo_with_worktree()
 

--- a/test/scripts/worktree_seed_test.exs
+++ b/test/scripts/worktree_seed_test.exs
@@ -1,0 +1,107 @@
+defmodule PtcRunner.Scripts.WorktreeSeedTest do
+  use ExUnit.Case, async: true
+
+  alias PtcRunner.TestSupport.GitEnv
+
+  @script Path.expand("../../scripts/worktree.sh", __DIR__)
+  @git_env GitEnv.clear()
+
+  @key_files ~w(mise.toml mix.lock ptc_viewer/mix.lock ptc_runner_launcher/mix.lock)
+
+  test "seeds a fresh worktree with the main checkout's build artifacts" do
+    %{main: main, worktree: worktree} = repo_with_worktree()
+
+    write!(main, "deps/jason/mix.exs", "jason\n")
+    write!(main, "_build/test/lib/ptc_runner/ebin/x.beam", "beam\n")
+    write!(main, "priv/plts/project.plt", "plt\n")
+    write!(main, "ptc_viewer/_build/test/marker", "viewer\n")
+
+    {output, 0} = seed(main, worktree)
+
+    assert output =~ "🌱 deps"
+    assert output =~ "🌱 _build"
+    assert output =~ "🌱 priv/plts"
+    assert output =~ ~r/Seeded 4 artifact\(s\)/
+    assert File.read!(Path.join(worktree, "deps/jason/mix.exs")) == "jason\n"
+    assert File.read!(Path.join(worktree, "priv/plts/project.plt")) == "plt\n"
+    assert File.read!(Path.join(worktree, "ptc_viewer/_build/test/marker")) == "viewer\n"
+
+    assert output =~ "ptc_runner_launcher/deps — not built in the main checkout"
+  end
+
+  test "skips seeding entirely when a lockfile differs" do
+    %{main: main, worktree: worktree} = repo_with_worktree()
+
+    write!(main, "deps/jason/mix.exs", "jason\n")
+    write!(worktree, "mix.lock", "diverged\n")
+
+    {output, 0} = seed(main, worktree)
+
+    assert output =~ "Seed skipped: mix.lock differs"
+    refute File.exists?(Path.join(worktree, "deps"))
+  end
+
+  test "leaves artifacts that are already present untouched" do
+    %{main: main, worktree: worktree} = repo_with_worktree()
+
+    write!(main, "deps/jason/mix.exs", "upstream\n")
+    write!(worktree, "deps/jason/mix.exs", "mine\n")
+
+    {output, 0} = seed(main, worktree)
+
+    assert output =~ "deps — already present"
+    assert File.read!(Path.join(worktree, "deps/jason/mix.exs")) == "mine\n"
+  end
+
+  test "refuses to seed the main checkout from itself" do
+    %{main: main} = repo_with_worktree()
+
+    {output, status} = seed(main, main)
+
+    assert status != 0
+    assert output =~ "refusing to seed the main checkout from itself"
+  end
+
+  defp repo_with_worktree do
+    root =
+      Path.join(
+        System.tmp_dir!(),
+        "ptc-worktree-seed-#{System.unique_integer([:positive, :monotonic])}"
+      )
+
+    main = Path.join(root, "main")
+    worktree = Path.join(root, "wt")
+    File.mkdir_p!(main)
+    on_exit(fn -> File.rm_rf!(root) end)
+
+    git!(main, ["init", "--quiet"])
+    git!(main, ["config", "user.email", "seed@example.test"])
+    git!(main, ["config", "user.name", "Seed Test"])
+
+    Enum.each(@key_files, &write!(main, &1, "pinned\n"))
+    git!(main, ["add", "."])
+    git!(main, ["commit", "--quiet", "-m", "base"])
+    git!(main, ["worktree", "add", "--quiet", worktree])
+
+    %{main: main, worktree: worktree}
+  end
+
+  defp seed(main, worktree) do
+    System.cmd("bash", [@script, "seed", worktree],
+      cd: main,
+      env: @git_env,
+      stderr_to_stdout: true
+    )
+  end
+
+  defp write!(repo, path, contents) do
+    full_path = Path.join(repo, path)
+    File.mkdir_p!(Path.dirname(full_path))
+    File.write!(full_path, contents)
+  end
+
+  defp git!(repo, args) do
+    {output, 0} = System.cmd("git", args, cd: repo, env: @git_env, stderr_to_stdout: true)
+    String.trim(output)
+  end
+end

--- a/test/scripts/worktree_seed_test.exs
+++ b/test/scripts/worktree_seed_test.exs
@@ -13,7 +13,7 @@ defmodule PtcRunner.Scripts.WorktreeSeedTest do
 
     write!(main, "deps/jason/mix.exs", "jason\n")
     write!(main, "_build/test/lib/ptc_runner/ebin/x.beam", "beam\n")
-    write!(main, "priv/plts/project.plt", "plt\n")
+    write!(main, "priv/plts/project.plt", plt_binary())
     write!(main, "ptc_viewer/_build/test/marker", "viewer\n")
 
     {output, 0} = seed(main, worktree)
@@ -23,29 +23,17 @@ defmodule PtcRunner.Scripts.WorktreeSeedTest do
     assert output =~ "🌱 priv/plts"
     assert output =~ ~r/Seeded 4 artifact\(s\)/
     assert File.read!(Path.join(worktree, "deps/jason/mix.exs")) == "jason\n"
-    assert File.read!(Path.join(worktree, "priv/plts/project.plt")) == "plt\n"
+    assert File.read!(Path.join(worktree, "priv/plts/project.plt")) == plt_binary()
     assert File.read!(Path.join(worktree, "ptc_viewer/_build/test/marker")) == "viewer\n"
 
     assert output =~ "ptc_runner_launcher/deps — not built in the main checkout"
     assert Path.wildcard(Path.join(worktree, ".worktree-seed-tmp*")) == []
   end
 
-  test "discards a PLT whose source diverged from the copy" do
-    %{main: main, worktree: worktree} = repo_with_worktree()
-
-    write!(main, "priv/plts/project.plt", "plt\n")
-    fake_cmp = fake_cmp_reporting_divergence!(main)
-
-    {output, 0} = seed(main, worktree, env: [{"PATH", fake_cmp}])
-
-    assert output =~ "priv/plts — copy failed or source changed mid-copy"
-    refute File.exists?(Path.join(worktree, "priv/plts"))
-  end
-
   test "does not seed dialyxir's PLT hash file" do
     %{main: main, worktree: worktree} = repo_with_worktree()
 
-    write!(main, "priv/plts/project.plt", "plt\n")
+    write!(main, "priv/plts/project.plt", plt_binary())
     write!(main, "priv/plts/project.plt.hash", "hash\n")
 
     {output, 0} = seed(main, worktree)
@@ -53,6 +41,18 @@ defmodule PtcRunner.Scripts.WorktreeSeedTest do
     assert output =~ "🌱 priv/plts"
     assert File.exists?(Path.join(worktree, "priv/plts/project.plt"))
     refute File.exists?(Path.join(worktree, "priv/plts/project.plt.hash"))
+  end
+
+  test "discards a torn PLT copy instead of promoting it" do
+    %{main: main, worktree: worktree} = repo_with_worktree()
+
+    truncated = binary_part(plt_binary(), 0, byte_size(plt_binary()) - 3)
+    write!(main, "priv/plts/project.plt", truncated)
+
+    {output, 0} = seed(main, worktree)
+
+    assert output =~ "priv/plts — not promoted"
+    refute File.exists?(Path.join(worktree, "priv/plts"))
   end
 
   test "treats a dangling destination symlink as present rather than replacing it" do
@@ -126,33 +126,17 @@ defmodule PtcRunner.Scripts.WorktreeSeedTest do
     %{main: main, worktree: worktree}
   end
 
-  defp seed(main, worktree, opts \\ []) do
+  defp seed(main, worktree) do
     System.cmd("bash", [@script, "seed", worktree],
       cd: main,
-      env: @git_env ++ Keyword.get(opts, :env, []),
+      env: @git_env,
       stderr_to_stdout: true
     )
   end
 
-  # A PATH whose `cmp` reports divergence for .plt files only, standing in
-  # for a PLT that a concurrent dialyzer run rewrote while it was cloned.
-  # Every other cmp call (the seed's lockfile guard) passes through.
-  defp fake_cmp_reporting_divergence!(root) do
-    bin = Path.join(root, "fake-bin")
-    File.mkdir_p!(bin)
-    fake_cmp = Path.join(bin, "cmp")
-
-    File.write!(fake_cmp, """
-    #!/bin/sh
-    case "$*" in
-      *.plt*) exit 1 ;;
-      *) exec /usr/bin/cmp "$@" ;;
-    esac
-    """)
-
-    File.chmod!(fake_cmp, 0o755)
-    bin <> ":" <> System.fetch_env!("PATH")
-  end
+  # Real PLTs are one external term; the seed proves a staged copy decodes
+  # before promoting it, so fixture PLTs must decode too.
+  defp plt_binary, do: :erlang.term_to_binary({:file_plt, :fixture})
 
   defp write!(repo, path, contents) do
     full_path = Path.join(repo, path)


### PR DESCRIPTION
Implements the low-complexity subset of #1281: fresh-worktree cache seeding and pre-push phase timings. Addresses #1281 (whether the remaining items justify keeping the issue open is your call).

## What changed

**Worktree seeding** (`scripts/worktree.sh`)
- `scripts/worktree.sh new` now seeds a fresh worktree from the main checkout: `deps/`, `_build/`, and `priv/plts/` for the root project, plus `deps/`/`_build/` for `ptc_viewer/` and `ptc_runner_launcher/`.
- New `scripts/worktree.sh seed [<dir>]` warms an existing worktree; artifacts already present are left untouched, so it is safe to re-run.
- Copies use copy-on-write clones where the filesystem supports it (`cp -Rc` on APFS, `--reflink=auto` elsewhere), with a plain-copy fallback. Every copy is staged under a per-process gitignored directory and promoted with atomic no-replace renames (`mkdir` claims the destination), so neither interruption nor concurrent seeds can leave a half-copied artifact that later runs mistake for a built one.
- Seeding is skipped entirely — with an explanatory line — when `mise.toml` or any of the three lockfiles differ from the main checkout's copy. Each artifact prints one hit/miss line: seeded, source not built, source is a symlink, already present, or not promoted.
- PLT-specific guards: dialyxir's `.hash` file is never seeded (it would let dialyxir skip PLT validation entirely — the hash covers the app set, not file integrity), and each staged PLT must decode as exactly one `file_plt` external term consuming every byte, so a torn copy taken while the main checkout's dialyzer was rewriting the source is discarded rather than promoted.

**Phase timing summary** (`.githooks/pre-push`)
- The hook already timed each phase inline; those lines are buried under minutes of test output. It now replays them as one compact `⏱ Phase timings:` block right before the final verdict.

**Docs** (`docs/development-setup.md`)
- New "Worktree seeding" section: what is copied, the guard key, why a stale seed is safe, and how to warm/inspect the cache (`mix compile` + `mix dialyzer` in the main checkout; `scripts/worktree.sh seed`).

## Why this is safe (issue acceptance criteria)

- **No gate is skipped or weakened.** The seed is never authoritative: Mix revalidates `deps/`/`_build/` against `mix.lock` and source digests, and dialyxir revalidates the project PLT against the module set. A stale seed costs a rebuild, never a wrong answer.
- **No shared writable artifact.** Each worktree owns its copies outright the moment the clone completes; concurrent gates in separate worktrees touch disjoint files. The machine-wide core PLT under `~/.cache/ptc_runner/` remains read-mostly and unchanged by this PR.
- **Automatic invalidation.** The `mise.toml`+lockfile guard keys the *decision to seed*; correctness-relevant invalidation stays where it already lives (Mix manifests, dialyxir PLT checks), so any correctness-relevant input change triggers a rebuild regardless of what was seeded.
- **Cache decisions are explained.** One line per artifact (hit/miss/why), plus a skip reason when the key differs.

## Measured (M-series laptop, dev env, same commit)

| | cold worktree | seeded worktree |
|---|---|---|
| seed | — | 49s (227MB, file-count bound even with APFS clones) |
| `mix deps.get` | 4s (Hex tarball cache) | 3s |
| `mix compile` | 89s (deps + project) | 22s (project only; dep compilation skipped) |
| `mix dialyzer` | ~54s per #1281 (47s PLT construction + 7s analysis) | 65s first run after recompile (updates seeded PLT; 7.9s analysis; ~1,100 dep modules not re-added) |

The seeded `_build` also carries the test-env build and the Viewer/launcher builds, which the cold path still has to produce before `mix test`/`mix precommit` — the table understates the total saving.

## Deliberately not done (kept out to avoid complexity)

- A separate content-addressed cache store: the main checkout *is* the cache, and keeping it built is the warming step.
- Dialyxir-internal PLT hit/miss diagnostics: would require patching the dep.
- Per-step timings inside the `mix precommit`/`mix prepush` aliases: would mean re-implementing alias semantics in a custom runner.

## Independent review

Five rounds of `codex-independent-review` (xhigh). Fixed from its findings: staged + atomic no-replace promotion (was: direct `mv`, which could nest into a concurrently-promoted dir or leave partials that later runs skip as "already present"), PLT `.hash` scrub, strict PLT term validation with exact byte consumption (codex was right that bare `binary_to_term/1` tolerates trailing garbage), space-safe `git worktree list` parsing (pre-existing bug), dangling-symlink preservation, per-process staging dirs.

Two consciously accepted residuals, both documented in `development-setup.md`:
- **Dependency fidelity**: seeded `deps/` trees are trusted as-is, so a locally edited dependency in the main checkout travels with the seed. Re-fetching pristine sources would not restore the gate (nothing rescans dep sources against already-compiled `_build` beams — it would only hide the mismatch), and content-verifying every dep file is the complexity this PR deliberately avoids. Same trust as running gates in the main checkout; CI builds pristine.
- **Stale-PLT arity**: the decode proves a copied PLT is whole, not that it matches the current OTP's `#file_plt{}` arity. A PLT left stale by a toolchain bump seeds as-is and fails in the worktree exactly as it would in the main checkout, with the same documented remedy. (Pinning the record arity would silently break seeding on the next OTP bump; `dialyzer:plt_info/1` validation would make the tests non-hermetic.)

## Verification

- New `test/scripts/worktree_seed_test.exs` integration tests (fixture repo + linked worktree, both paths containing spaces): seeding, lockfile-divergence skip, already-present preservation (including dangling symlinks), `.hash` scrub, torn/truncated/foreign/trailing-garbage PLT rejection, self-seed refusal, staging cleanup. One test caught a real missing-parent-directory bug during development.
- `test/githooks/pre_push_test.exs` extended to assert the phase-timing summary.
- `mix test test/scripts test/githooks` green (23 tests); `mix credo --strict` clean; duplication gate unchanged (61/61); `shellcheck` clean on both scripts; the strict decode verified against the real `project.plt`; dogfooded end-to-end by seeding this PR's own worktree and a scratch worktree (7 artifacts, 13s, hash correctly absent).
