### PR TITLE
fix(ci): repair nightly integration E2Es

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -78,6 +78,10 @@ jobs:
           if [ "${{ github.event_name }}" = "schedule" ] || [ "${{ inputs.test_type }}" = "e2e" ]; then
             bash test/support/mcp_go_stateless/with_server.sh \
               mix test --include e2e --trace
+            PTC_TEST_MCP_OAUTH=1 \
+              bash test/support/mcp_go_stateless/with_server.sh \
+                mix test test/ptc_runner/kernel/mcp_oauth_remote_e2e_test.exs \
+                  --include e2e --trace
           else
             mix test --include integration --trace
           fi

--- a/test/ptc_runner/kernel/github_mcp_e2e_test.exs
+++ b/test/ptc_runner/kernel/github_mcp_e2e_test.exs
@@ -34,10 +34,23 @@ defmodule PtcRunner.Kernel.GitHubMCPE2ETest do
         ])
       end)
 
-    assert run_output == ""
     envelope = envelope_path |> File.read!() |> Jason.decode!()
+    assert Jason.decode!(run_output) == envelope["result"]["value"]
     assert envelope["status"] == "ok"
-    assert envelope["result"]["value"] =~ "PtcRunner"
+
+    assert %{
+             "status" => "ok",
+             "value" => %{
+               "outcome" => "returned",
+               "value" => %{
+                 "status" => "ok",
+                 "value" => %{"resources" => [%{"text" => readme} | _]}
+               }
+             }
+           } = envelope["result"]["value"]
+
+    assert readme =~ "# PtcRunner"
+    refute run_output =~ token
     refute File.read!(envelope_path) =~ token
     trace = Path.join(Path.dirname(paths.trace), envelope["run_ref"] <> ".jsonl")
     refute File.read!(trace) =~ token

--- a/test/ptc_runner/kernel/mcp_oauth_remote_e2e_test.exs
+++ b/test/ptc_runner/kernel/mcp_oauth_remote_e2e_test.exs
@@ -14,6 +14,10 @@ defmodule PtcRunner.Kernel.MCPOAuthRemoteE2ETest do
   @moduletag :e2e
   @moduletag timeout: 120_000
 
+  unless System.get_env("PTC_TEST_MCP_OAUTH") == "1" do
+    @moduletag skip: "requires the OAuth-enabled Go MCP harness"
+  end
+
   alias PtcRunner.Kernel
   alias PtcRunner.Kernel.Deadline
   alias PtcRunner.Kernel.EventSink

--- a/test/ptc_runner/kernel/repo_analyst_evaluation_e2e_test.exs
+++ b/test/ptc_runner/kernel/repo_analyst_evaluation_e2e_test.exs
@@ -87,7 +87,8 @@ defmodule PtcRunner.Kernel.RepoAnalystEvaluationE2ETest do
     assert evaluation.value["regressed_cases"] == ["motivating.paged-evidence"]
   end
 
-  test "the shipped replay manifest and dedicated host config run unchanged" do
+  @tag :tmp_dir
+  test "the shipped replay manifest and dedicated host config run unchanged", %{tmp_dir: dir} do
     {:ok, host} = HostConfig.load(@evaluation_host)
 
     {:ok, registry} =
@@ -99,7 +100,9 @@ defmodule PtcRunner.Kernel.RepoAnalystEvaluationE2ETest do
     assert {:ok, result} =
              @replay_manifest
              |> ApplicationPackage.request_directory(installed_limits: registry.installed_limits)
-             |> RunLifecycle.build(registry)
+             |> RunLifecycle.build(registry,
+               private_output: Path.join(dir, "trial-result.private.json")
+             )
              |> RunLifecycle.execute()
 
     assert result.value["status"] == "scored"
@@ -167,29 +170,44 @@ defmodule PtcRunner.Kernel.RepoAnalystEvaluationE2ETest do
   defp run_pair(manifest, pair) do
     baseline_trace = Path.join(pair.directory, "baseline.private.jsonl")
     candidate_trace = Path.join(pair.directory, "candidate.private.jsonl")
+    baseline_output = Path.join(pair.directory, "baseline.joined.json")
+    candidate_output = Path.join(pair.directory, "candidate.joined.json")
+    baseline_result = baseline_output <> ".result"
+    candidate_result = candidate_output <> ".result"
 
-    baseline =
-      run_trial(manifest, pair.registry, pair.baseline_input_path, baseline_trace)
+    :ok =
+      run_trial(
+        manifest,
+        pair.registry,
+        pair.baseline_input_path,
+        baseline_trace,
+        baseline_result
+      )
 
-    candidate =
-      run_trial(manifest, pair.registry, pair.candidate_input_path, candidate_trace,
+    :ok =
+      run_trial(
+        manifest,
+        pair.registry,
+        pair.candidate_input_path,
+        candidate_trace,
+        candidate_result,
         component_override_descriptor: pair.descriptor_path
       )
 
     {
       join(
         pair.jq,
-        baseline,
+        baseline_result,
         baseline_trace,
         String.replace_suffix(baseline_trace, ".jsonl", ".inspection.jsonl"),
-        Path.join(pair.directory, "baseline.joined.json")
+        baseline_output
       ),
       join(
         pair.jq,
-        candidate,
+        candidate_result,
         candidate_trace,
         String.replace_suffix(candidate_trace, ".jsonl", ".inspection.jsonl"),
-        Path.join(pair.directory, "candidate.joined.json")
+        candidate_output
       )
     }
   end
@@ -244,13 +262,18 @@ defmodule PtcRunner.Kernel.RepoAnalystEvaluationE2ETest do
                input: relative(trials_path),
                input_authority: :private
              )
-             |> RunLifecycle.build(empty_registry)
+             |> RunLifecycle.build(empty_registry,
+               private_output: Path.join(directory, "aggregate.private.result.json")
+             )
              |> RunLifecycle.execute()
+
+    assert Jason.decode!(File.read!(Path.join(directory, "aggregate.private.result.json"))) ==
+             evaluation.value
 
     evaluation
   end
 
-  defp run_trial(manifest, registry, input_path, trace_path, opts \\ []) do
+  defp run_trial(manifest, registry, input_path, trace_path, result_path, opts \\ []) do
     inspection_path = String.replace_suffix(trace_path, ".jsonl", ".inspection.jsonl")
 
     request_opts =
@@ -261,7 +284,7 @@ defmodule PtcRunner.Kernel.RepoAnalystEvaluationE2ETest do
         inspection_capture: true
       ] ++ Keyword.take(opts, [:component_override_descriptor])
 
-    build_opts = [trace_path: trace_path, inspect: inspection_path]
+    build_opts = [trace_path: trace_path, inspect: inspection_path, private_output: result_path]
 
     case manifest
          |> ApplicationPackage.request_directory(request_opts)
@@ -269,18 +292,16 @@ defmodule PtcRunner.Kernel.RepoAnalystEvaluationE2ETest do
          |> RunLifecycle.execute() do
       {:ok, result} ->
         assert File.regular?(inspection_path)
-        result.value
+        assert Jason.decode!(File.read!(result_path)) == result.value
+        :ok
 
       {:error, error} ->
         flunk("trial failed: #{inspect(error)}")
     end
   end
 
-  defp join(jq, result, trace_path, inspection_path, output_path) do
-    result_path = output_path <> ".result"
-    {:ok, canonical} = DeterministicJSON.encode(result)
-    File.write!(result_path, canonical)
-    result_hash = "sha256:" <> Base.encode16(:crypto.hash(:sha256, canonical), case: :lower)
+  defp join(jq, result_path, trace_path, inspection_path, output_path) do
+    result_hash = result_path |> File.read!() |> sha256()
 
     {joined, 0} =
       System.cmd(


### PR DESCRIPTION
## Summary

- run the OAuth MCP E2E in a second OAuth-enabled Go harness invocation
- publish repo-analyst trial and aggregate results through owner-only private destinations, then join the actual persisted trial artifacts
- update the GitHub MCP E2E to validate the stable CLI rendering and nested result shape while retaining credential-leak assertions

## Root cause

[Nightly run 31463704050](https://github.com/andreasronge/ptc_runner/actions/runs/31463704050) exposed three stale test/workflow assumptions: the nightly harness was not started with OAuth for the OAuth test, private replay results had no authorized private destination, and `--envelope` was still expected to suppress the stable command's human rendering.

## Impact

The scheduled integration workflow now exercises both unauthenticated and OAuth MCP transport modes, and the repo-analyst E2Es follow the current private artifact publication contract instead of failing during result settlement.

## Verification

- `mix precommit`
- push-time root, Viewer, launcher, ExDoc, generated-artifact, upstream-audit, and Dialyzer gates
- repo-analyst evaluation E2Es: 4 passed
- OAuth Go MCP harness E2E: passed
- non-OAuth Go MCP harness E2E: passed, OAuth test skipped until its dedicated invocation
- GitHub MCP server v1.7.0 E2E against the authenticated API: passed
- stable Mix command tests: 13 passed