### PR TITLE
Force the launcher's make path in repository checkouts (stale native binary)

### DIFF
--- a/docs/development-setup.md
+++ b/docs/development-setup.md
@@ -29,7 +29,12 @@ lockfile differs from the main checkout's copy.
 For build staleness the seed is never an authority: Mix revalidates `deps/`
 and `_build/` against `mix.lock` and source digests, and dialyxir revalidates
 the project PLT against the module set, so a stale seed costs a rebuild
-rather than a wrong answer. The seeded PLT's dialyxir hash file is
+rather than a wrong answer. The launcher's native executable is covered by
+this rule only because repository checkouts force elixir_make's build path
+(`force_build?/0` in `ptc_runner_launcher/mix.exs`): the precompiler flow
+otherwise trusts any artifact already present in priv, which once let a
+seeded pre-change binary answer `--publish-directory-noreplace` with a usage
+error through every warm build. The seeded PLT's dialyxir hash file is
 deliberately not copied (the first `mix dialyzer` run must re-check the PLT
 instead of trusting the hash), and each copied PLT must fully decode as an
 external term before promotion, so a torn copy taken while a concurrent

--- a/ptc_runner_launcher/mix.exs
+++ b/ptc_runner_launcher/mix.exs
@@ -25,7 +25,16 @@ defmodule PtcRunnerLauncher.MixProject do
       make_precompiler_url: precompiled_url(),
       make_precompiler_filename: "ptc_runner_launcher",
       make_precompiler_priv_paths: ["ptc_runner_launcher"],
-      make_force_build: System.get_env("PTC_RUNNER_LAUNCHER_BUILD_FROM_SOURCE") == "1",
+      # Hex consumers restore the checksum-pinned precompiled artifact; a
+      # repository checkout must always take the make path instead. The
+      # precompiler skip trusts any artifact already present in priv
+      # regardless of age, which let a binary compiled before an Aug 2026
+      # c_src change satisfy every warm build: `mix compile` kept vending a
+      # launcher that answered `--publish-directory-noreplace` with a usage
+      # error while the test suite blamed publication. make's own
+      # source-vs-binary mtime check is the staleness authority here, and a
+      # fresh binary makes it a no-op.
+      make_force_build: force_build?(),
       make_env: %{"MACOSX_DEPLOYMENT_TARGET" => @release_config.macos_deployment_target},
       cc_precompiler: [
         compilers: precompiled_targets()
@@ -39,6 +48,15 @@ defmodule PtcRunnerLauncher.MixProject do
 
   defp elixirc_paths(:test), do: ["lib", "test/support"]
   defp elixirc_paths(_env), do: ["lib"]
+
+  # True for any git checkout of this repository — a linked worktree carries
+  # a `.git` file rather than a directory, hence exists?/1 and not dir?/1.
+  # The Hex tarball ships without `../.git`, so package consumers keep the
+  # precompiled-restore path.
+  defp force_build? do
+    System.get_env("PTC_RUNNER_LAUNCHER_BUILD_FROM_SOURCE") == "1" or
+      File.exists?(Path.expand("../.git", __DIR__))
+  end
 
   defp deps do
     [

--- a/ptc_runner_launcher/mix.exs
+++ b/ptc_runner_launcher/mix.exs
@@ -49,13 +49,19 @@ defmodule PtcRunnerLauncher.MixProject do
   defp elixirc_paths(:test), do: ["lib", "test/support"]
   defp elixirc_paths(_env), do: ["lib"]
 
-  # True for any git checkout of this repository — a linked worktree carries
-  # a `.git` file rather than a directory, hence exists?/1 and not dir?/1.
-  # The Hex tarball ships without `../.git`, so package consumers keep the
-  # precompiled-restore path.
+  # Default: true for any git checkout of this repository — a linked
+  # worktree carries a `.git` file rather than a directory, hence exists?/1
+  # and not dir?/1 — while the Hex tarball ships without `../.git`, so
+  # package consumers keep the precompiled-restore path. "1" forces the
+  # source build anywhere; "0" forces the precompiled flow even from a
+  # checkout, which scripts/verify_precompiled.sh needs to exercise the
+  # download and checksum paths this default would otherwise bypass.
   defp force_build? do
-    System.get_env("PTC_RUNNER_LAUNCHER_BUILD_FROM_SOURCE") == "1" or
-      File.exists?(Path.expand("../.git", __DIR__))
+    case System.get_env("PTC_RUNNER_LAUNCHER_BUILD_FROM_SOURCE") do
+      "1" -> true
+      "0" -> false
+      _unset -> File.exists?(Path.expand("../.git", __DIR__))
+    end
   end
 
   defp deps do

--- a/ptc_runner_launcher/scripts/verify_precompiled.sh
+++ b/ptc_runner_launcher/scripts/verify_precompiled.sh
@@ -116,7 +116,11 @@ clear_proxy=(
   https_proxy=
 )
 
-PTC_RUNNER_LAUNCHER_PRECOMPILED_URL="$precompiled_url" \
+# BUILD_FROM_SOURCE=0 overrides the repository-checkout force-build default
+# in mix.exs: this script runs from the checkout but must exercise the
+# precompiled download path that default would bypass.
+PTC_RUNNER_LAUNCHER_BUILD_FROM_SOURCE=0 \
+  PTC_RUNNER_LAUNCHER_PRECOMPILED_URL="$precompiled_url" \
   ELIXIR_MAKE_CACHE_DIR="$download_cache" \
   MIX_BUILD_PATH="$download_build" \
   MIX_ENV=prod \
@@ -178,7 +182,8 @@ printf '\0' >>"$archive"
 
 rm -rf "$download_build" "$download_cache"
 
-PTC_RUNNER_LAUNCHER_PRECOMPILED_URL="$precompiled_url" \
+PTC_RUNNER_LAUNCHER_BUILD_FROM_SOURCE=0 \
+  PTC_RUNNER_LAUNCHER_PRECOMPILED_URL="$precompiled_url" \
   ELIXIR_MAKE_CACHE_DIR="$download_cache" \
   MIX_BUILD_PATH="$download_build" \
   MIX_ENV=prod \
@@ -212,6 +217,7 @@ unlisted_build="$verification_tmp_dir/unlisted-build"
 TARGET_ARCH=unlisted \
   TARGET_OS=linux \
   TARGET_ABI=gnu \
+  PTC_RUNNER_LAUNCHER_BUILD_FROM_SOURCE=0 \
   PTC_RUNNER_LAUNCHER_PRECOMPILED_URL="http://127.0.0.1:1/@{artefact_filename}" \
   MIX_BUILD_PATH="$unlisted_build" \
   MIX_ENV=prod \


### PR DESCRIPTION
## Problem

elixir_make's precompiler flow treats any artifact already present in `priv` as satisfying the build — no source-vs-binary staleness check. A launcher binary compiled **2026-07-29** sat in the main checkout's `_build` after the **2026-08-09** `c_src` change added `--publish-directory-noreplace`, so every warm build kept vending a launcher that answers the new flag with a usage error (exit 64). Symptom: six `CommandInitializerTest` failures blaming `initialization_failed` in the publication phase — on any warm checkout, while CI (cold, fresh build) stayed green. Worktree seeding (#1281) then faithfully propagated the stale binary into fresh worktrees that would otherwise have built correctly. `force_build` was previously only set inside the launcher's own `mix precommit`.

## Fix

`force_build?/0` in `ptc_runner_launcher/mix.exs` takes the make path for any git checkout of this repository (`../.git` exists — a *file* in linked worktrees, hence `File.exists?/1` not `dir?/1`), restoring make's own mtime staleness authority; a fresh binary makes it a no-op. Hex tarballs ship without `../.git` and keep the checksum-pinned precompiled restore.

`PTC_RUNNER_LAUNCHER_BUILD_FROM_SOURCE` now carries three states: `1` forces source anywhere (unchanged), `0` forces the precompiled flow even from a checkout, unset falls to checkout detection. `scripts/verify_precompiled.sh` pins its download, tampered-checksum, and unlisted-target stages to `0` — those stages assert the very download path the checkout default now bypasses (found as a P1 by independent review).

## Verification

- End-to-end regression demo: a worktree seeded with the stale Jul-29 binary rebuilt it on a plain `mix compile` and all 14 `CommandInitializerTest` + 40 launcher tests pass; without the fix the same tree failed 6 of them.
- `scripts/verify_precompiled.sh` passes end-to-end from the checkout, with the "Downloading precompiled NIF" assertion firing in both its download and tampered stages.
- `codex-independent-review`: initial P1 fixed, follow-up clean.

## Note for your local checkout

Your main checkout at `~/projects/ptc_runner` currently holds this stale binary; after this merges, the next `mix compile` there rebuilds it automatically. (I did not touch the main checkout.)