### PR TITLE
Make suite-load-flaky tests deterministic; fix the wedged-mutation bug one was reporting

### DIFF
--- a/lib/ptc_runner/kernel/deadline.ex
+++ b/lib/ptc_runner/kernel/deadline.ex
@@ -47,6 +47,26 @@ defmodule PtcRunner.Kernel.Deadline do
       when is_integer(current_ms),
       do: current_ms >= expires_at_ms
 
+  # Matches TokenManager's @response_transition_timeout_ms: the allowance a
+  # response transition already gets once its caller's own budget is gone.
+  @terminalization_floor_ms 5_000
+
+  @doc """
+  Budget for recording an outcome that must outlive the caller's deadline.
+
+  A worker that crossed a dispatch fence has to report how the dispatch
+  ended even when it learns that outcome after the caller's cutoff.
+  Budgeting that report with `max(remaining, 1)` gave the store call one
+  millisecond once the deadline had passed; under load the call timed out,
+  the discarded report left the mutation lease `:dispatched`, and every
+  later acquire returned `:mutation_indeterminate`. The floor keeps any
+  longer live budget and never lets the report's allowance collapse with
+  the caller's.
+  """
+  @spec terminalization(integer()) :: t()
+  def terminalization(expires_at_ms) when is_integer(expires_at_ms),
+    do: new(max(expires_at_ms - now_ms(), @terminalization_floor_ms))
+
   @doc "Selects the earlier of two already-anchored deadlines."
   @spec earliest(t(), t()) :: t()
   def earliest(

--- a/lib/ptc_runner/kernel/deadline.ex
+++ b/lib/ptc_runner/kernel/deadline.ex
@@ -64,8 +64,12 @@ defmodule PtcRunner.Kernel.Deadline do
   the caller's.
   """
   @spec terminalization(integer()) :: t()
-  def terminalization(expires_at_ms) when is_integer(expires_at_ms),
-    do: new(max(expires_at_ms - now_ms(), @terminalization_floor_ms))
+  def terminalization(expires_at_ms) when is_integer(expires_at_ms) do
+    # One clock sample: computing "remaining" and re-anchoring with new/1
+    # would read the clock twice, and preemption between the reads extends
+    # a live absolute cutoff — the drift this module exists to forbid.
+    from_expires_at(max(expires_at_ms, now_ms() + @terminalization_floor_ms))
+  end
 
   @doc "Selects the earlier of two already-anchored deadlines."
   @spec earliest(t(), t()) :: t()

--- a/lib/ptc_runner/kernel/mcp_oauth/authorization.ex
+++ b/lib/ptc_runner/kernel/mcp_oauth/authorization.ex
@@ -232,7 +232,7 @@ defmodule PtcRunner.Kernel.MCPOAuth.Authorization do
         end
 
       {:error, _reason} = error ->
-        cancel_consumed_flow(context, pending)
+        cancel_consumed_flow(context, pending, Deadline.terminalization(pending.deadline_ms))
         error
     end
   end
@@ -350,26 +350,31 @@ defmodule PtcRunner.Kernel.MCPOAuth.Authorization do
     {:error, closed_token_error(reason)}
   end
 
+  # One terminalization budget covers the whole cleanup: minting a second
+  # deadline for the flow cancellation would let an unresponsive store
+  # consume the floor twice for one terminal transition.
   defp fail_before_code_dispatch(context, pending, lease) do
+    deadline = Deadline.terminalization(pending.deadline_ms)
+
     _ =
       Store.fail_mutation(
         context.store,
         pending.key,
         lease.fence,
         :not_dispatched,
-        Deadline.terminalization(pending.deadline_ms)
+        deadline
       )
 
-    cancel_consumed_flow(context, pending)
+    cancel_consumed_flow(context, pending, deadline)
   end
 
-  defp cancel_consumed_flow(context, pending) do
+  defp cancel_consumed_flow(context, pending, deadline) do
     _ =
       Store.cancel_flow(
         context.store,
         pending.key,
         pending.flow_id,
-        Deadline.terminalization(pending.deadline_ms)
+        deadline
       )
 
     :ok

--- a/lib/ptc_runner/kernel/mcp_oauth/authorization.ex
+++ b/lib/ptc_runner/kernel/mcp_oauth/authorization.ex
@@ -308,7 +308,7 @@ defmodule PtcRunner.Kernel.MCPOAuth.Authorization do
               pending.key,
               lease.fence,
               :possibly_dispatched,
-              Deadline.new(max(remaining(pending.deadline_ms), 1))
+              Deadline.terminalization(pending.deadline_ms)
             )
 
           {:error, :authorization_failed}
@@ -320,7 +320,7 @@ defmodule PtcRunner.Kernel.MCPOAuth.Authorization do
           pending.key,
           lease.fence,
           :possibly_dispatched,
-          Deadline.new(max(remaining(pending.deadline_ms), 1))
+          Deadline.terminalization(pending.deadline_ms)
         )
 
       {:error, :mcp_authorization_required}
@@ -344,7 +344,7 @@ defmodule PtcRunner.Kernel.MCPOAuth.Authorization do
         pending.key,
         lease.fence,
         outcome,
-        Deadline.new(max(remaining(pending.deadline_ms), 1))
+        Deadline.terminalization(pending.deadline_ms)
       )
 
     {:error, closed_token_error(reason)}
@@ -357,7 +357,7 @@ defmodule PtcRunner.Kernel.MCPOAuth.Authorization do
         pending.key,
         lease.fence,
         :not_dispatched,
-        Deadline.new(max(remaining(pending.deadline_ms), 1))
+        Deadline.terminalization(pending.deadline_ms)
       )
 
     cancel_consumed_flow(context, pending)
@@ -369,7 +369,7 @@ defmodule PtcRunner.Kernel.MCPOAuth.Authorization do
         context.store,
         pending.key,
         pending.flow_id,
-        Deadline.new(max(remaining(pending.deadline_ms), 1))
+        Deadline.terminalization(pending.deadline_ms)
       )
 
     :ok

--- a/lib/ptc_runner/kernel/mcp_oauth/network_policy.ex
+++ b/lib/ptc_runner/kernel/mcp_oauth/network_policy.ex
@@ -53,7 +53,8 @@ defmodule PtcRunner.Kernel.MCPOAuth.NetworkPolicy do
       )
 
     with true <- is_function(resolver, 1),
-         true <- is_integer(deadline_ms) and deadline_ms > System.monotonic_time(:millisecond),
+         true <- is_integer(deadline_ms),
+         :live <- deadline_state(deadline_ms),
          {:ok, target} <- target(url),
          true <- origin_allowed?(target.origin, authority),
          {:ok, addresses} <- safe_resolve(resolver, target.hostname, deadline_ms),
@@ -65,11 +66,21 @@ defmodule PtcRunner.Kernel.MCPOAuth.NetworkPolicy do
       {:ok, Map.put(target, :addresses, addresses)}
     else
       {:error, :resolution_failed} = error -> error
+      :expired -> {:error, :resolution_failed}
       _denied -> {:error, :egress_denied}
     end
   end
 
   def resolve(_url, _authority, _opts), do: {:error, :egress_denied}
+
+  # An already-expired deadline is a resolution-time failure, not an egress
+  # verdict: the clock running out before DNS is consulted is
+  # indistinguishable from resolution timing out one instruction later, and
+  # classifying it the same way keeps the error deterministic under
+  # scheduling delay instead of depending on where the caller was preempted.
+  defp deadline_state(deadline_ms) do
+    if deadline_ms > System.monotonic_time(:millisecond), do: :live, else: :expired
+  end
 
   @doc "Builds a connected-peer verifier for one approved DNS answer."
   @spec peer_verifier([address()]) :: (address() -> :ok | {:error, :peer_rejected})

--- a/lib/ptc_runner/kernel/mcp_oauth/token_manager.ex
+++ b/lib/ptc_runner/kernel/mcp_oauth/token_manager.ex
@@ -559,7 +559,7 @@ defmodule PtcRunner.Kernel.MCPOAuth.TokenManager do
                 config.key,
                 lease.fence,
                 :possibly_dispatched,
-                Deadline.new(max(remaining(deadline_ms), 1))
+                terminalization_deadline(deadline_ms)
               )
 
             {:error, :mcp_authorization_required}
@@ -572,7 +572,7 @@ defmodule PtcRunner.Kernel.MCPOAuth.TokenManager do
             config.key,
             lease.fence,
             :possibly_dispatched,
-            Deadline.new(max(remaining(deadline_ms), 1))
+            terminalization_deadline(deadline_ms)
           )
 
         {:error, :mcp_authorization_required}
@@ -601,7 +601,7 @@ defmodule PtcRunner.Kernel.MCPOAuth.TokenManager do
         config.key,
         lease.fence,
         outcome,
-        Deadline.new(max(remaining(deadline_ms), 1))
+        terminalization_deadline(deadline_ms)
       )
 
     {:error, close_reason(reason)}
@@ -722,7 +722,7 @@ defmodule PtcRunner.Kernel.MCPOAuth.TokenManager do
         config.key,
         lease.fence,
         :not_dispatched,
-        Deadline.new(max(remaining(deadline_ms), 1))
+        terminalization_deadline(deadline_ms)
       )
 
     :ok
@@ -740,6 +740,16 @@ defmodule PtcRunner.Kernel.MCPOAuth.TokenManager do
 
   defp remaining(deadline_ms),
     do: max(deadline_ms - System.monotonic_time(:millisecond), 1)
+
+  # Recording a mutation outcome is an obligation that survives the caller's
+  # deadline: a refresh failure learned after the deadline previously got
+  # `max(remaining, 1)` — a 1ms store-call budget — and when that call timed
+  # out under load the discarded report left the lease :dispatched forever,
+  # surfacing as :mutation_indeterminate on every later acquire. Floor the
+  # budget at the response-transition timeout, the same allowance reject/4
+  # and require_scopes/4 already get for post-deadline persistence.
+  defp terminalization_deadline(deadline_ms),
+    do: Deadline.new(max(remaining(deadline_ms), @response_transition_timeout_ms))
 
   defp response_transition_deadline,
     do: System.monotonic_time(:millisecond) + @response_transition_timeout_ms

--- a/lib/ptc_runner/kernel/mcp_oauth/token_manager.ex
+++ b/lib/ptc_runner/kernel/mcp_oauth/token_manager.ex
@@ -559,7 +559,7 @@ defmodule PtcRunner.Kernel.MCPOAuth.TokenManager do
                 config.key,
                 lease.fence,
                 :possibly_dispatched,
-                terminalization_deadline(deadline_ms)
+                Deadline.terminalization(deadline_ms)
               )
 
             {:error, :mcp_authorization_required}
@@ -572,7 +572,7 @@ defmodule PtcRunner.Kernel.MCPOAuth.TokenManager do
             config.key,
             lease.fence,
             :possibly_dispatched,
-            terminalization_deadline(deadline_ms)
+            Deadline.terminalization(deadline_ms)
           )
 
         {:error, :mcp_authorization_required}
@@ -601,7 +601,7 @@ defmodule PtcRunner.Kernel.MCPOAuth.TokenManager do
         config.key,
         lease.fence,
         outcome,
-        terminalization_deadline(deadline_ms)
+        Deadline.terminalization(deadline_ms)
       )
 
     {:error, close_reason(reason)}
@@ -722,7 +722,7 @@ defmodule PtcRunner.Kernel.MCPOAuth.TokenManager do
         config.key,
         lease.fence,
         :not_dispatched,
-        terminalization_deadline(deadline_ms)
+        Deadline.terminalization(deadline_ms)
       )
 
     :ok
@@ -740,16 +740,6 @@ defmodule PtcRunner.Kernel.MCPOAuth.TokenManager do
 
   defp remaining(deadline_ms),
     do: max(deadline_ms - System.monotonic_time(:millisecond), 1)
-
-  # Recording a mutation outcome is an obligation that survives the caller's
-  # deadline: a refresh failure learned after the deadline previously got
-  # `max(remaining, 1)` — a 1ms store-call budget — and when that call timed
-  # out under load the discarded report left the lease :dispatched forever,
-  # surfacing as :mutation_indeterminate on every later acquire. Floor the
-  # budget at the response-transition timeout, the same allowance reject/4
-  # and require_scopes/4 already get for post-deadline persistence.
-  defp terminalization_deadline(deadline_ms),
-    do: Deadline.new(max(remaining(deadline_ms), @response_transition_timeout_ms))
 
   defp response_transition_deadline,
     do: System.monotonic_time(:millisecond) + @response_transition_timeout_ms

--- a/test/ptc_runner/kernel/deadline_test.exs
+++ b/test/ptc_runner/kernel/deadline_test.exs
@@ -50,4 +50,15 @@ defmodule PtcRunner.Kernel.DeadlineTest do
     assert_raise FunctionClauseError, fn -> Deadline.new(0) end
     assert_raise FunctionClauseError, fn -> Deadline.new(-1, 0) end
   end
+
+  test "terminalization floors an expired cutoff and preserves a longer live one" do
+    now = System.monotonic_time(:millisecond)
+
+    floored = Deadline.terminalization(now - 60_000)
+    assert Deadline.expires_at(floored) >= now + 4_000
+    assert Deadline.expires_at(floored) <= now + 6_000
+
+    distant = now + 60_000
+    assert Deadline.expires_at(Deadline.terminalization(distant)) == distant
+  end
 end

--- a/test/ptc_runner/kernel/mcp_oauth/network_policy_test.exs
+++ b/test/ptc_runner/kernel/mcp_oauth/network_policy_test.exs
@@ -138,13 +138,18 @@ defmodule PtcRunner.Kernel.MCPOAuth.NetworkPolicyTest do
 
     deadline_ms = System.monotonic_time(:millisecond) + 20
 
+    # Under scheduler load the 20ms may already be spent before resolve/3
+    # checks the clock; the expired-deadline path now also classifies as
+    # :resolution_failed, so either interleaving yields the same error.
     assert {:error, :resolution_failed} =
              NetworkPolicy.resolve("https://auth.example/token", authority,
                resolver: resolver,
                deadline_ms: deadline_ms
              )
 
-    assert System.monotonic_time(:millisecond) - deadline_ms < 500
+    # Proves the never-returning resolver did not block us indefinitely.
+    # Generous: this measures wall time across scheduling, not promptness.
+    assert System.monotonic_time(:millisecond) - deadline_ms < 5_000
   end
 
   test "classifies representative reserved IPv4 and IPv6 ranges" do

--- a/test/ptc_runner/kernel/mcp_oauth/token_manager_test.exs
+++ b/test/ptc_runner/kernel/mcp_oauth/token_manager_test.exs
@@ -264,16 +264,23 @@ defmodule PtcRunner.Kernel.MCPOAuth.TokenManagerTest do
     wait_ms = max(deadline - System.monotonic_time(:millisecond) + 10, 10)
     Process.send_after(self(), :deadline_passed, wait_ms)
     assert_receive :deadline_passed, wait_ms + 100
+
+    # Suspend the store across the failure report. The report is issued
+    # after the caller's deadline, so with the old max(remaining, 1) budget
+    # its store call had one millisecond to live — this stall deterministically
+    # exceeded it, the discarded report left the lease :dispatched, and the
+    # acquire below wedged on :mutation_indeterminate forever. The
+    # Deadline.terminalization/1 floor rides out the stall.
+    :ok = :sys.suspend(context.memory.pid)
     send(refresh_worker, :return_failure)
+    Process.send_after(self(), :stall_elapsed, 100)
+    assert_receive :stall_elapsed
+    :ok = :sys.resume(context.memory.pid)
 
     assert_receive {:refresh_result, {:error, :mcp_authorization_required}}
 
-    # Terminalization runs synchronously in the refresh caller before
-    # {:refresh_result, _} is sent, so this acquire is deterministic — but
-    # only because terminalization_deadline/1 floors the post-deadline
-    # store-call budget. With the old 1ms budget the report was lost under
-    # load and this acquire wedged on :mutation_indeterminate forever; if
-    # this assertion starts failing again, suspect that budget first.
+    # Terminalization completes in the refresh caller before
+    # {:refresh_result, _} is sent, so this acquire is deterministic.
     assert {:ok, _lease} =
              Store.acquire_mutation(
                context.store,

--- a/test/ptc_runner/kernel/mcp_oauth/token_manager_test.exs
+++ b/test/ptc_runner/kernel/mcp_oauth/token_manager_test.exs
@@ -268,6 +268,12 @@ defmodule PtcRunner.Kernel.MCPOAuth.TokenManagerTest do
 
     assert_receive {:refresh_result, {:error, :mcp_authorization_required}}
 
+    # Terminalization runs synchronously in the refresh caller before
+    # {:refresh_result, _} is sent, so this acquire is deterministic — but
+    # only because terminalization_deadline/1 floors the post-deadline
+    # store-call budget. With the old 1ms budget the report was lost under
+    # load and this acquire wedged on :mutation_indeterminate forever; if
+    # this assertion starts failing again, suspect that budget first.
     assert {:ok, _lease} =
              Store.acquire_mutation(
                context.store,

--- a/test/ptc_runner/kernel/publication_authority_test.exs
+++ b/test/ptc_runner/kernel/publication_authority_test.exs
@@ -1,6 +1,8 @@
 defmodule PtcRunner.Kernel.PublicationAuthorityTest do
   use ExUnit.Case, async: false
 
+  import PtcRunner.TestSupport.Eventually, only: [assert_eventually: 1]
+
   alias PtcRunner.Kernel.CommandEngine
   alias PtcRunner.Kernel.CommandOutcome
   alias PtcRunner.Kernel.CommandPreparation
@@ -187,16 +189,15 @@ defmodule PtcRunner.Kernel.PublicationAuthorityTest do
   test "exclusive handle operations remain owned across caller processes", %{tmp_dir: dir} do
     target = Path.join(dir, "cross-process.jsonl")
     assert {:ok, handle} = PublicationHandle.reserve(target, :trace, 0o600)
-    parent = self()
 
-    spawn(fn -> send(parent, {:write, PublicationHandle.write(handle, "[]\n")}) end)
-    assert_receive {:write, :ok}
+    # Each operation runs in its own process — that cross-process hop is the
+    # point of the test. Await completion rather than racing a receive
+    # deadline against fsync latency: this flaked in CI when `publish`'s
+    # fsync+rename exceeded the previous fire-and-forget window.
+    assert :ok = Task.async(fn -> PublicationHandle.write(handle, "[]\n") end) |> Task.await()
+    assert :ok = Task.async(fn -> PublicationHandle.sync(handle) end) |> Task.await()
+    assert :ok = Task.async(fn -> PublicationHandle.publish(handle) end) |> Task.await()
 
-    spawn(fn -> send(parent, {:sync, PublicationHandle.sync(handle)}) end)
-    assert_receive {:sync, :ok}
-
-    spawn(fn -> send(parent, {:publish, PublicationHandle.publish(handle)}) end)
-    assert_receive {:publish, :ok}
     assert File.read!(target) == "[]\n"
     assert :ok = PublicationHandle.close(handle)
   end
@@ -217,11 +218,18 @@ defmodule PtcRunner.Kernel.PublicationAuthorityTest do
                  )
 
         send(parent, {:authority, authority})
-        assert_receive :release
+
+        # A deadline here would make the *caller* die with an assertion
+        # failure if the parent is slow to claim, turning a scheduling
+        # hiccup into a bogus abnormal-exit for the :DOWN check below. The
+        # test's own timeout bounds this receive.
+        receive do
+          :release -> :ok
+        end
       end)
 
     caller_ref = Process.monitor(caller)
-    assert_receive {:authority, authority}, 1_000
+    assert_receive {:authority, authority}
 
     assert {:ok, lease} = PublicationAuthority.claim(authority)
     send(caller, :release)
@@ -386,9 +394,12 @@ defmodule PtcRunner.Kernel.PublicationAuthorityTest do
       end)
 
     creator_ref = Process.monitor(creator)
-    assert_receive :authorized, 1_000
+    assert_receive :authorized
     assert_receive {:DOWN, ^creator_ref, :process, ^creator, :normal}
-    refute File.exists?(target)
+
+    # Reclamation runs when the *owner* observes the creator's death; our own
+    # :DOWN above is delivered independently, so poll rather than racing it.
+    assert_eventually(fn -> not File.exists?(target) end)
 
     assert {:ok, authority} = authorize_after_creator_cleanup(target)
 
@@ -417,8 +428,11 @@ defmodule PtcRunner.Kernel.PublicationAuthorityTest do
     claimant_ref = Process.monitor(claimant)
     assert_receive :claimed
     assert_receive {:DOWN, ^claimant_ref, :process, ^claimant, :normal}
-    refute PublicationAuthority.authorized?(authority)
-    refute File.exists?(target)
+
+    # Cleanup is triggered by the owner's monitor on the claimant, which is
+    # not ordered against our own :DOWN — poll for the settled state.
+    assert_eventually(fn -> not PublicationAuthority.authorized?(authority) end)
+    assert_eventually(fn -> not File.exists?(target) end)
   end
 
   test "unreserved authority rejects duplicate destination keys before allocation" do
@@ -629,24 +643,15 @@ defmodule PtcRunner.Kernel.PublicationAuthorityTest do
   defp restore_env(name, nil), do: System.delete_env(name)
   defp restore_env(name, value), do: System.put_env(name, value)
 
-  defp authorize_after_creator_cleanup(target, attempts \\ 100)
-
-  defp authorize_after_creator_cleanup(_target, 0),
-    do: {:error, :creator_cleanup_timeout}
-
-  defp authorize_after_creator_cleanup(target, attempts) do
-    case PublicationAuthority.authorize(
-           "creator-reuse-#{attempts}",
-           [trace: target],
-           :normal,
-           :normal
-         ) do
-      {:error, :destination_exists} ->
-        :erlang.yield()
-        authorize_after_creator_cleanup(target, attempts - 1)
-
-      result ->
-        result
-    end
+  # An attempt-counted yield loop expires in microseconds under scheduler
+  # load (the failure mode Eventually's moduledoc documents); the wall-clock
+  # poll returns the authorization as soon as the owner's reclamation lands.
+  defp authorize_after_creator_cleanup(target) do
+    assert_eventually(fn ->
+      case PublicationAuthority.authorize("creator-reuse", [trace: target], :normal, :normal) do
+        {:ok, authority} -> {:ok, authority}
+        {:error, :destination_exists} -> false
+      end
+    end)
   end
 end

--- a/test/support/eventually.ex
+++ b/test/support/eventually.ex
@@ -61,12 +61,15 @@ defmodule PtcRunner.TestSupport.Eventually do
   @doc """
   Asserts `predicate` returns a truthy value within the module's budget.
 
-  Returns `:ok` as soon as it holds. Fails the test if the deadline passes
-  first, naming the budget that was spent. The budget is deliberately not a
-  parameter: every call site wants "as long as a loaded runner might need",
-  and no caller has yet wanted anything else.
+  Returns the first truthy value the predicate produces, so a poll that has
+  to *acquire* something (an authorization, a lease) can hand it back rather
+  than forcing the caller to fetch it again after the race it just waited
+  out. Fails the test if the deadline passes first, naming the budget that
+  was spent. The budget is deliberately not a parameter: every call site
+  wants "as long as a loaded runner might need", and no caller has yet
+  wanted anything else.
   """
-  @spec assert_eventually((-> as_boolean(term()))) :: :ok
+  @spec assert_eventually((-> as_boolean(term()))) :: as_boolean(term())
   def assert_eventually(predicate) when is_function(predicate, 0) do
     started_at_ms = System.monotonic_time(:millisecond)
     poll(predicate, started_at_ms + @default_timeout_ms, started_at_ms + @yield_phase_ms)
@@ -74,8 +77,8 @@ defmodule PtcRunner.TestSupport.Eventually do
 
   defp poll(predicate, deadline_ms, yield_until_ms) do
     cond do
-      predicate.() ->
-        :ok
+      value = predicate.() ->
+        value
 
       System.monotonic_time(:millisecond) >= deadline_ms ->
         flunk("condition did not become true within #{@default_timeout_ms}ms")

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -39,9 +39,18 @@ exclusions = [:skip, :e2e, :clojure, :soak, :nightly]
 # `{:error, ...}` returns from `Lisp.run/2` calls that should always
 # succeed. Capping at `schedulers_online()` halves the contention while
 # preserving parallelism.
+# `assert_receive`'s 100ms default is a failure deadline, not a wait: a
+# message that arrives returns immediately, so raising it costs a passing
+# suite nothing (the same argument as test/support/eventually.ex) while a
+# saturated CI runner gets real margin. Many of these windows bound a whole
+# spawned operation — fsync, dispatch, discovery — not just message delivery,
+# which is how 100ms flaked in CI. `refute_receive_timeout` is deliberately
+# left at its default: refute_receive always waits its full window, so
+# raising it would slow every passing run.
 ExUnit.configure(
   exclude: exclusions,
-  max_cases: System.schedulers_online()
+  max_cases: System.schedulers_online(),
+  assert_receive_timeout: 5_000
 )
 
 ExUnit.start()


### PR DESCRIPTION
Root-causes every recorded full-suite-only flake instead of quarantining them, and fixes two real kernel bugs the flakes were reporting. Follow-up to the flake discussion on #1282.

## The production bug (TokenManager / Authorization)

Recording a mutation outcome is an obligation that survives the caller's deadline — but all nine terminalization sites (four `fail_mutation` in TokenManager, four plus `cancel_flow` in Authorization) budgeted the store call with `Deadline.new(max(remaining, 1))`: **one millisecond** once the caller's deadline had passed. Under load that call timed out, the `_ =` discarded the report, and the lease stayed `:dispatched` forever — every later `acquire_mutation` returned `:mutation_indeterminate`. That was the recorded TokenManagerTest flake: not a test bug, a permanent-wedge bug with a flaky reporter.

The budget now lives once as `Deadline.terminalization/1` (floor 5s, matching the response-transition allowance; single clock sample so preemption cannot extend a live cutoff; one budget covers a fail+cancel cleanup pair). The regression test suspends the store across the failure report so the old budget provably dies — verified: it fails 1/1 with the old expression restored, passes with the fix — no reliance on incidental scheduler pressure.

## The determinism fixes

- **PublicationAuthorityTest** (the CI flake on #1282): spawned handle operations now `Task.await` completion instead of racing a 100ms receive window against fsync; the transfer caller blocks in a plain `receive` so a slow parent can't kill it into a bogus abnormal exit; post-`:DOWN` cleanup assertions poll via `Eventually` (the owner's monitor is not ordered against the test's own `:DOWN`); the attempt-counted authorize retry became a wall-clock poll.
- **NetworkPolicy**: an already-expired deadline now classifies as `:resolution_failed` rather than `:egress_denied` — expiring before the DNS lookup is indistinguishable from resolution timing out one instruction later, so the classification no longer depends on where the caller was preempted. All three `resolve` callers treat the two errors uniformly; an expired deadline still never dispatches.
- **Eventually.assert_eventually** returns the predicate's first truthy value, so acquiring polls can hand back what they waited for (new `Deadline.terminalization` unit test pins floor + live-cutoff preservation).
- **test_helper**: `assert_receive_timeout: 5_000`. A failure deadline is spent only when the message never arrives, so a passing suite pays nothing — and many of the 65 default-window call sites bound a whole spawned operation (fsync, dispatch), not just message delivery. `refute_receive_timeout` deliberately stays at its default: `refute_receive` always waits its full window.

## Why not tag them `:nightly`

These tests guard the kernel's single-owner/authority invariants — and one of them was reporting a real wedge bug. ExUnit has no retry, so a flaky tag can only mean exclusion from PR gates; `test_helper.exs` already documents how excluding `:slow` silently dropped ten correctness tests. The fixes above remove the flakiness without removing the coverage.

## Verification

- Full suite green ×3 during development; final rebased run had one unrelated failure — the stdio UTF-8 locale test from #1274, now filed with diagnosis as #1285 (fixture boots a full BEAM under load; passes isolated and in other same-day runs).
- `mix dialyzer` clean; credo clean; regression test verified to bite (fails on the old code 1/1).
- Three rounds of `codex-independent-review`: round 1 found the authorization-path P1 and demanded a deterministic regression test (both addressed); round 2 found the double clock sample and doubled cleanup budget (both fixed); round 3 clean. One review suggestion deliberately declined: duplicating the stalled-store test through the authorization flow's loopback scaffolding — both paths converge on the single shared `Deadline.terminalization/1` the test already pins.