### PR TITLE
fix(kernel): size command-owned ReqLLM pool

### DIFF
--- a/docs/guides/embedding-in-elixir.md
+++ b/docs/guides/embedding-in-elixir.md
@@ -97,17 +97,30 @@ already owns the prepared run and the session's lifecycle. There is no
 creator-owned variant.
 
 An embedded frontend that drives `ProviderRegistry` and `RunBuilder` directly
-does not pass through that gate, so it owns the admission itself:
+does not pass through that gate, so it owns the admission itself. For an
+otherwise-unconfigured default HTTP/1 ReqLLM pool:
 
 ```elixir
+installed_limits = PtcRunner.Kernel.Limits.installed_defaults()
 Application.put_env(:req_llm, :load_dotenv, false, persistent: true)
 Application.put_env(:llm_db, :load_dotenv, false, persistent: true)
+Application.put_env(:req_llm, :stream_pool_count, 1, persistent: true)
+Application.put_env(:req_llm, :stream_pool_size, installed_limits.live_provider_tasks,
+  persistent: true
+)
 {:ok, _started} = Application.ensure_all_started(:req_llm)
 ```
 
 Set `load_dotenv` to `false` first if the host resolves credentials itself; that
 is what the command-owned gate branch does before starting the application, and
 it keeps the dependency from reading a `.env` the host did not choose.
+The command-owned gate also gives ReqLLM's default HTTP/1 Finch pool one shard
+with one connection per installed `live_provider_tasks` slot. It uses the
+installed ceiling because the application constructs one VM-lifetime pool;
+the first manifest's narrower effective limit must not size every later run.
+Direct and host-owned embeddings own this geometry themselves. Explicit
+ReqLLM `:finch` pools or non-HTTP/1 protocol overrides retain ReqLLM's own
+precedence.
 
 A request issued while that application is stopped fails with a non-retryable
 `:internal` provider error naming the application, rather than a retryable

--- a/docs/guides/kernel-maintainer.md
+++ b/docs/guides/kernel-maintainer.md
@@ -389,7 +389,17 @@ the constructor directly. Such provider-bearing values are presently
 continuation state for the staged command pipeline. `RunBuilder.build_prepared/3`
 rejects them; the execution-session owner consumes one when it opens its
 sinks, `ProviderActiveSession` then marks the active lifecycle and opens the
-session. That marker proves consumption and lifecycle position, not by itself
+session. During application admission, a command-owned VM configures ReqLLM's
+default HTTP/1 Finch pool before starting it: one shard sized from the sealed
+catalog's installed `live_provider_tasks` ceiling. It deliberately does not use
+the prepared run's manifest-narrowed effective value, because ReqLLM constructs
+one VM-lifetime Finch tree at application startup. Explicit full Finch pools or
+a non-HTTP/1 protocol configuration keep ReqLLM's own precedence. Host-owned
+mode changes neither application configuration nor lifecycle. A later same-VM
+command therefore does not resize an already-running pool; matching that pool
+to changed host ceilings or concurrent runs belongs to the embedding host's
+aggregate-capacity contract. That marker proves consumption and
+lifecycle position, not by itself
 that provider-facing work was attempted. Active producers carry cumulative
 attempted-work evidence separately. The runtime registry, lifecycle value, and
 that same session are passed to

--- a/docs/guides/running-and-debugging.md
+++ b/docs/guides/running-and-debugging.md
@@ -49,7 +49,13 @@ endpoint-bearing `openai-compat:` selectors remain omitted.
 A fresh Mix invocation safely configures and starts a selected optional
 provider application only after the active provider lifecycle begins. A later `ptc run`
 invocation in the same VM reuses an already-running application as host-owned,
-so task chaining and `iex -S mix` do not require restarting the VM.
+so task chaining and `iex -S mix` do not require restarting the VM. For ReqLLM,
+the fresh command-owned start configures its default HTTP/1 Finch pool as one
+shard sized from the installed `live_provider_tasks` ceiling. A manifest may
+narrow its own effective limit but does not resize that VM-lifetime pool. Later
+host-owned commands keep the already-running application's configuration, so
+an embedding that changes installed ceilings in one VM owns the corresponding
+aggregate pool-capacity policy.
 
 ## Run a manifest
 

--- a/lib/ptc_runner/kernel/provider_application_gate.ex
+++ b/lib/ptc_runner/kernel/provider_application_gate.ex
@@ -152,7 +152,7 @@ defmodule PtcRunner.Kernel.ProviderApplicationGate do
     protocols = Application.get_env(:req_llm, :stream_pool_protocols, [:http1])
     finch = Application.get_env(:req_llm, :finch, [])
 
-    protocols == [:http1] and not Keyword.has_key?(finch, :pools)
+    protocols == [:http1] and Keyword.keyword?(finch) and not Keyword.has_key?(finch, :pools)
   end
 
   defp start_requirements(requirements) do

--- a/lib/ptc_runner/kernel/provider_application_gate.ex
+++ b/lib/ptc_runner/kernel/provider_application_gate.ex
@@ -5,11 +5,16 @@ defmodule PtcRunner.Kernel.ProviderApplicationGate do
 
   A host-owned application must already be running. A command-owned VM rejects
   an inherited target, disables dotenv loading for both `:req_llm` and
-  `:llm_db`, and starts the selected target without stopping it at session
-  close. The command VM owns the resulting application processes until VM
-  shutdown. Once selected applications are admitted, adapter-owned VM-global
-  metadata is warmed before the run clock begins, so its one-time load does not
-  consume a bounded provider worker's heap.
+  `:llm_db`, configures ReqLLM's default HTTP/1 Finch pool as one shard sized
+  from the installed `live_provider_tasks` ceiling, and starts the selected
+  target without stopping it at session close. A manifest-narrowed effective
+  limit does not resize that VM-lifetime pool. Explicit ReqLLM Finch pools or a
+  non-HTTP/1 protocol configuration retain their dependency-defined precedence.
+  The command VM owns
+  the resulting application processes until VM shutdown. Once selected
+  applications are admitted, adapter-owned VM-global metadata is warmed before
+  the run clock begins, so its one-time load does not consume a bounded provider
+  worker's heap.
 
   OTP application startup is deliberately synchronous here:
   `Application.ensure_all_started/1` is not cancellable and offers no timeout.
@@ -25,6 +30,7 @@ defmodule PtcRunner.Kernel.ProviderApplicationGate do
   alias PtcRunner.Kernel.CommandDiagnostic
   alias PtcRunner.Kernel.CommandSubject
   alias PtcRunner.Kernel.InstallationCatalog
+  alias PtcRunner.Kernel.Limits
   alias PtcRunner.Kernel.PreparedRun
   alias PtcRunner.Kernel.ProviderRuntimeServices
 
@@ -41,7 +47,11 @@ defmodule PtcRunner.Kernel.ProviderApplicationGate do
          true <- ProviderRuntimeServices.bound_to?(services, catalog.runtime_binding) do
       requirements = requirements(prepared, catalog)
 
-      case admit_requirements(requirements, services.provider_application_mode) do
+      case admit_requirements(
+             requirements,
+             services.provider_application_mode,
+             catalog.installed_limits
+           ) do
         :ok -> warm_requirements(requirements)
         {:error, name, activity} -> {:error, unavailable_diagnostic(name, activity)}
       end
@@ -88,9 +98,9 @@ defmodule PtcRunner.Kernel.ProviderApplicationGate do
     |> Enum.uniq_by(&elem(&1, 1))
   end
 
-  defp admit_requirements([], _mode), do: :ok
+  defp admit_requirements([], _mode, _installed_limits), do: :ok
 
-  defp admit_requirements(requirements, :host_owned) do
+  defp admit_requirements(requirements, :host_owned, _installed_limits) do
     running = Application.started_applications() |> MapSet.new(&elem(&1, 0))
 
     case Enum.find(requirements, fn {_name, application} ->
@@ -101,7 +111,7 @@ defmodule PtcRunner.Kernel.ProviderApplicationGate do
     end
   end
 
-  defp admit_requirements(requirements, :command_vm) do
+  defp admit_requirements(requirements, :command_vm, installed_limits) do
     running = Application.started_applications() |> MapSet.new(&elem(&1, 0))
 
     case Enum.find(requirements, fn {_name, application} ->
@@ -111,10 +121,38 @@ defmodule PtcRunner.Kernel.ProviderApplicationGate do
         {:error, name, false}
 
       nil ->
-        Application.put_env(:req_llm, :load_dotenv, false, persistent: true)
-        Application.put_env(:llm_db, :load_dotenv, false, persistent: true)
+        :ok = configure_command_vm_req_llm(installed_limits)
         start_requirements(requirements)
     end
+  end
+
+  @doc false
+  @spec configure_command_vm_req_llm(Limits.t()) :: :ok
+  def configure_command_vm_req_llm(%Limits{live_provider_tasks: pool_size} = installed_limits) do
+    if Limits.valid?(installed_limits) do
+      Application.put_env(:req_llm, :load_dotenv, false, persistent: true)
+      Application.put_env(:llm_db, :load_dotenv, false, persistent: true)
+
+      if command_owned_default_http1_pool?() do
+        Application.put_env(:req_llm, :stream_pool_count, 1, persistent: true)
+        Application.put_env(:req_llm, :stream_pool_size, pool_size, persistent: true)
+      end
+
+      :ok
+    else
+      raise ArgumentError, "invalid installed limits for command-owned ReqLLM configuration"
+    end
+  end
+
+  def configure_command_vm_req_llm(_installed_limits) do
+    raise ArgumentError, "invalid installed limits for command-owned ReqLLM configuration"
+  end
+
+  defp command_owned_default_http1_pool? do
+    protocols = Application.get_env(:req_llm, :stream_pool_protocols, [:http1])
+    finch = Application.get_env(:req_llm, :finch, [])
+
+    protocols == [:http1] and not Keyword.has_key?(finch, :pools)
   end
 
   defp start_requirements(requirements) do

--- a/test/ptc_runner/kernel/command_engine_test.exs
+++ b/test/ptc_runner/kernel/command_engine_test.exs
@@ -35,6 +35,7 @@ defmodule PtcRunner.Kernel.CommandEngineTest do
   alias PtcRunner.Kernel.RunRequest
   alias PtcRunner.Kernel.ValueContract
   alias PtcRunner.Kernel.ValueContractClassification
+  alias PtcRunner.TestSupport.LLMSupport
 
   @zero_entropy <<0::128>>
   @stdio_root Path.expand("../../..", __DIR__)
@@ -732,10 +733,7 @@ defmodule PtcRunner.Kernel.CommandEngineTest do
     previous_environment = System.get_env(environment_name)
     System.delete_env(environment_name)
 
-    initially_running =
-      Application.started_applications()
-      |> Enum.map(&elem(&1, 0))
-      |> MapSet.new()
+    provider_applications = LLMSupport.snapshot_provider_applications()
 
     previous =
       for key <- [
@@ -747,8 +745,7 @@ defmodule PtcRunner.Kernel.CommandEngineTest do
           into: %{},
           do: {key, Application.fetch_env(:ptc_runner, key)}
 
-    if MapSet.member?(initially_running, :req_llm), do: Application.stop(:req_llm)
-    if MapSet.member?(initially_running, :llm_db), do: Application.stop(:llm_db)
+    :ok = LLMSupport.stop_provider_applications()
 
     Application.put_env(:ptc_runner, :llm_adapter, PtcRunner.TestSupport.HostLLMAdapter)
     Application.put_env(:ptc_runner, :host_llm_test_owner, self())
@@ -762,22 +759,12 @@ defmodule PtcRunner.Kernel.CommandEngineTest do
         do: System.put_env(environment_name, previous_environment),
         else: System.delete_env(environment_name)
 
-      if :req_llm in Enum.map(Application.started_applications(), &elem(&1, 0)),
-        do: Application.stop(:req_llm)
-
-      if :llm_db in Enum.map(Application.started_applications(), &elem(&1, 0)),
-        do: Application.stop(:llm_db)
-
       Enum.each(previous, fn
         {key, {:ok, value}} -> Application.put_env(:ptc_runner, key, value)
         {key, :error} -> Application.delete_env(:ptc_runner, key)
       end)
 
-      if MapSet.member?(initially_running, :llm_db),
-        do: Application.ensure_all_started(:llm_db)
-
-      if MapSet.member?(initially_running, :req_llm),
-        do: Application.ensure_all_started(:req_llm)
+      LLMSupport.restore_provider_applications(provider_applications)
     end)
 
     host_path =

--- a/test/ptc_runner/kernel/concurrent_agent_contention_live_e2e_test.exs
+++ b/test/ptc_runner/kernel/concurrent_agent_contention_live_e2e_test.exs
@@ -1,6 +1,6 @@
 defmodule PtcRunner.Kernel.ConcurrentAgentContentionLiveE2ETest do
   @moduledoc """
-  The closure criterion for issue #1241: four `agent.core` loops under `pcalls`
+  The closure criterion for issues #1241 and #1287: eight `agent.core` loops under `pcalls`
   against a live provider must not burn `run_duration_ms`.
 
   The deterministic half of #1241 is pinned elsewhere — `agent_evaluation_
@@ -16,7 +16,7 @@ defmodule PtcRunner.Kernel.ConcurrentAgentContentionLiveE2ETest do
   - `:ok` — every agent returned its model-authored value;
   - `:admission` — a typed `evaluation-unavailable`, the queue's bounded
     expiry, which is a fast failure and therefore not the reported symptom;
-  - `:provider` — the live provider failed one branch (a rate limit on four
+  - `:provider` — the live provider failed one branch (a rate limit on eight
     concurrent requests will do it), which `fail`-inside-`pcalls` turns into a
     whole-run failure; a fact about the provider, not the queue;
   - `:deadline` — the run burned `run_duration_ms`. **This is the symptom.**
@@ -46,7 +46,7 @@ defmodule PtcRunner.Kernel.ConcurrentAgentContentionLiveE2ETest do
 
   @host Path.expand("../../../examples/kernel-tutorial/ptc-host.json", __DIR__)
 
-  @agents 4
+  @agents 8
   @max_turns 2
   @run_duration_ms 150_000
   @runs String.to_integer(System.get_env("PTC_CONTENTION_RUNS", "2"))
@@ -57,6 +57,8 @@ defmodule PtcRunner.Kernel.ConcurrentAgentContentionLiveE2ETest do
   setup_all do
     :ok = PtcRunner.Dotenv.load()
     :ok = LLMSupport.admit_provider_application!()
+    assert Application.get_env(:req_llm, :stream_pool_count) == 1
+    assert Application.get_env(:req_llm, :stream_pool_size) == 8
 
     if System.get_env("OPENROUTER_API_KEY") do
       :ok
@@ -183,7 +185,7 @@ defmodule PtcRunner.Kernel.ConcurrentAgentContentionLiveE2ETest do
       String.contains?(rendered, "evaluation-unavailable") ->
         %{class: :admission, detail: rendered}
 
-      # A live provider that rate-limits or drops one of the four concurrent
+      # A live provider that rate-limits or drops one of the eight concurrent
       # requests fails that branch, and `fail` inside `pcalls` aborts the run.
       # That is the provider, not the admission queue — named separately so it
       # cannot be mistaken for either a pass or the reported hang.

--- a/test/ptc_runner/kernel/mcp_remote_agent_e2e_test.exs
+++ b/test/ptc_runner/kernel/mcp_remote_agent_e2e_test.exs
@@ -27,7 +27,7 @@ defmodule PtcRunner.Kernel.MCPRemoteAgentE2ETest do
     :ok = PtcRunner.Dotenv.load()
     # Host installation admits a provider application through the prepared-run
     # path; a directly registered builder has to start it itself.
-    {:ok, _started} = Application.ensure_all_started(:req_llm)
+    :ok = LLMSupport.admit_provider_application!()
     :ok
   end
 

--- a/test/ptc_runner/kernel/provider_active_session_test.exs
+++ b/test/ptc_runner/kernel/provider_active_session_test.exs
@@ -21,6 +21,8 @@ defmodule PtcRunner.Kernel.ProviderActiveSessionTest do
   alias PtcRunner.Kernel.RunBuilder
   alias PtcRunner.Kernel.RunCoordinator
   alias PtcRunner.Kernel.SelectionRules
+  alias PtcRunner.TestSupport.LLMSupport
+  alias PtcRunner.TestSupport.MCPHTTPFixture
 
   test "active validators run in declaration order after activity is marked" do
     parent = self()
@@ -1063,11 +1065,154 @@ defmodule PtcRunner.Kernel.ProviderActiveSessionTest do
     end)
   end
 
+  test "command VM sizes one ReqLLM pool from the installed provider ceiling" do
+    restore_provider_applications_on_exit()
+    stop_provider_applications()
+    Application.delete_env(:req_llm, :finch, persistent: true)
+    Application.delete_env(:req_llm, :stream_pool_protocols, persistent: true)
+
+    {:ok, installed_limits} = Limits.installed(live_provider_tasks: 6)
+
+    {:ok, prepared, catalog} =
+      fixture(
+        fn _selection, _context -> :ok end,
+        ["first"],
+        installed_limits,
+        "installed-pool-v1",
+        :req_llm,
+        [],
+        %{"live_provider_tasks" => 2}
+      )
+
+    assert prepared.request.package.limits.live_provider_tasks == 2
+    assert catalog.installed_limits.live_provider_tasks == 6
+    assert {:ok, session} = open_owned(prepared, catalog, services(:command_vm))
+
+    assert Application.get_env(:req_llm, :stream_pool_count) == 1
+    assert Application.get_env(:req_llm, :stream_pool_size) == 6
+
+    assert %{default: default_pool} =
+             ReqLLM.Application.get_finch_config() |> Keyword.fetch!(:pools)
+
+    assert Keyword.fetch!(default_pool, :count) == 1
+    assert Keyword.fetch!(default_pool, :size) == 6
+
+    close(session, prepared)
+  end
+
+  test "one command-owned ReqLLM pool admits eight simultaneously held requests" do
+    restore_provider_applications_on_exit()
+    stop_provider_applications()
+    Application.delete_env(:req_llm, :finch, persistent: true)
+    Application.delete_env(:req_llm, :stream_pool_protocols, persistent: true)
+
+    {:ok, prepared, catalog} =
+      fixture(fn _selection, _context -> :ok end, ["first"], nil, "pool-contention-v1", :req_llm)
+
+    assert {:ok, session} = open_owned(prepared, catalog, services(:command_vm))
+
+    parent = self()
+    release_gate = spawn(fn -> receive do: (:release -> :ok) end)
+
+    server =
+      MCPHTTPFixture.start(fn _request ->
+        release_ref = Process.monitor(release_gate)
+        send(parent, {:held_finch_request, self()})
+
+        receive do
+          {:DOWN, ^release_ref, :process, ^release_gate, _reason} -> {200, [], "ok"}
+        end
+      end)
+
+    start_ref = make_ref()
+    shared_hash_key = make_ref()
+
+    requesters =
+      Enum.map(1..8, fn _index ->
+        spawn_monitor(fn ->
+          send(parent, {:finch_request_ready, self()})
+
+          receive do
+            {:start_finch_request, ^start_ref} ->
+              request = Finch.build(:get, server.endpoint)
+
+              result =
+                Finch.request(request, ReqLLM.Finch,
+                  pool_strategy: {Finch.Pool.Strategy.Hash, shared_hash_key},
+                  pool_timeout: 2_000,
+                  receive_timeout: 2_000
+                )
+
+              send(parent, {:finch_request_result, self(), result})
+          end
+        end)
+      end)
+
+    try do
+      requester_pids = Enum.map(requesters, &elem(&1, 0))
+
+      Enum.each(requester_pids, fn requester ->
+        assert_receive {:finch_request_ready, ^requester}
+      end)
+
+      Enum.each(requester_pids, &send(&1, {:start_finch_request, start_ref}))
+
+      held = collect_held_finch_requests(8, Deadline.new(1_000), [])
+      assert length(held) == 8
+
+      send(release_gate, :release)
+
+      Enum.each(requester_pids, fn requester ->
+        assert_receive {:finch_request_result, ^requester, {:ok, %Finch.Response{status: 200}}},
+                       2_000
+      end)
+    after
+      if Process.alive?(release_gate), do: Process.exit(release_gate, :kill)
+      server.close.()
+
+      Enum.each(requesters, fn {pid, monitor} ->
+        if Process.alive?(pid), do: Process.exit(pid, :kill)
+        Process.demonitor(monitor, [:flush])
+      end)
+
+      close(session, prepared)
+    end
+  end
+
+  test "command VM preserves an explicit HTTP/2 ReqLLM pool" do
+    restore_provider_applications_on_exit()
+    stop_provider_applications()
+    Application.delete_env(:req_llm, :finch, persistent: true)
+    Application.put_env(:req_llm, :stream_pool_protocols, [:http2], persistent: true)
+    Application.put_env(:req_llm, :stream_pool_count, 3, persistent: true)
+    Application.put_env(:req_llm, :stream_pool_size, 4, persistent: true)
+
+    {:ok, prepared, catalog} =
+      fixture(fn _selection, _context -> :ok end, ["first"], nil, "http2-pool-v1", :req_llm)
+
+    assert {:ok, session} = open_owned(prepared, catalog, services(:command_vm))
+    assert Application.get_env(:req_llm, :stream_pool_protocols) == [:http2]
+    assert Application.get_env(:req_llm, :stream_pool_count) == 3
+    assert Application.get_env(:req_llm, :stream_pool_size) == 4
+
+    assert %{default: default_pool} =
+             ReqLLM.Application.get_finch_config() |> Keyword.fetch!(:pools)
+
+    assert Keyword.fetch!(default_pool, :protocols) == [:http2]
+    assert Keyword.fetch!(default_pool, :count) == 3
+    assert Keyword.fetch!(default_pool, :size) == 4
+
+    close(session, prepared)
+  end
+
   test "command VM mode rejects a prestarted target while host-owned mode accepts it" do
     restore_provider_applications_on_exit()
     stop_provider_applications()
     Application.put_env(:req_llm, :load_dotenv, false, persistent: true)
     Application.put_env(:llm_db, :load_dotenv, false, persistent: true)
+    Application.put_env(:req_llm, :stream_pool_count, 3, persistent: true)
+    Application.put_env(:req_llm, :stream_pool_size, 4, persistent: true)
+    Application.put_env(:req_llm, :finch, [name: ReqLLM.Finch], persistent: true)
     assert {:ok, _started} = Application.ensure_all_started(:req_llm)
 
     {:ok, command_prepared, command_catalog} =
@@ -1081,27 +1226,46 @@ defmodule PtcRunner.Kernel.ProviderActiveSessionTest do
                services(:command_vm)
              )
 
+    assert Application.get_env(:req_llm, :stream_pool_count) == 3
+    assert Application.get_env(:req_llm, :stream_pool_size) == 4
+    assert Application.get_env(:req_llm, :finch) == [name: ReqLLM.Finch]
+
     {:ok, host_prepared, host_catalog} =
       fixture(fn _selection, _context -> :ok end, ["first"], nil, "host-v1", :req_llm)
 
     assert {:ok, session} =
              open_owned(host_prepared, host_catalog, services(:host_owned))
 
+    assert Application.get_env(:req_llm, :stream_pool_count) == 3
+    assert Application.get_env(:req_llm, :stream_pool_size) == 4
+    assert Application.get_env(:req_llm, :finch) == [name: ReqLLM.Finch]
+
     close(session, host_prepared)
+  end
+
+  test "provider-free command VM admission leaves ReqLLM configuration unchanged" do
+    restore_provider_applications_on_exit()
+    stop_provider_applications()
+    Application.put_env(:req_llm, :stream_pool_count, 3, persistent: true)
+    Application.put_env(:req_llm, :stream_pool_size, 4, persistent: true)
+    Application.put_env(:req_llm, :finch, [name: ReqLLM.Finch], persistent: true)
+
+    {:ok, prepared, catalog} = fixture(fn _selection, _context -> :ok end)
+    assert {:ok, session} = open_owned(prepared, catalog, services(:command_vm))
+
+    assert Application.get_env(:req_llm, :stream_pool_count) == 3
+    assert Application.get_env(:req_llm, :stream_pool_size) == 4
+    assert Application.get_env(:req_llm, :finch) == [name: ReqLLM.Finch]
+    refute :req_llm in started_applications()
+
+    close(session, prepared)
   end
 
   test "command VM startup failures preserve attempted provider activity" do
     restore_provider_applications_on_exit()
     stop_provider_applications()
-    previous_pool_size = Application.get_env(:req_llm, :stream_pool_size)
-    Application.put_env(:req_llm, :stream_pool_size, 0, persistent: true)
-
-    on_exit(fn ->
-      if previous_pool_size,
-        do:
-          Application.put_env(:req_llm, :stream_pool_size, previous_pool_size, persistent: true),
-        else: Application.delete_env(:req_llm, :stream_pool_size, persistent: true)
-    end)
+    Application.delete_env(:req_llm, :finch, persistent: true)
+    Application.put_env(:req_llm, :stream_pool_protocols, [:invalid], persistent: true)
 
     {:ok, prepared, catalog} =
       fixture(fn _selection, _context -> :ok end, ["first"], nil, "command-v1", :req_llm)
@@ -1110,6 +1274,8 @@ defmodule PtcRunner.Kernel.ProviderActiveSessionTest do
             %CommandDiagnostic{code: :provider_application_unavailable, provider_activity: true}} =
              open_owned(prepared, catalog, services(:command_vm))
 
+    assert Application.get_env(:req_llm, :stream_pool_count) == nil
+    assert Application.get_env(:req_llm, :stream_pool_size) == nil
     assert ProviderActivity.value(prepared.provider_activity) == true
     assert :ok = PreparedRun.close(prepared)
   end
@@ -1135,7 +1301,8 @@ defmodule PtcRunner.Kernel.ProviderActiveSessionTest do
          limits \\ nil,
          revision \\ "custom-v1",
          provider_application \\ nil,
-         credential_names \\ []
+         credential_names \\ [],
+         manifest_limits \\ %{}
        ) do
     limits = limits || Limits.installed_defaults()
     {:ok, rules} = rules()
@@ -1200,7 +1367,8 @@ defmodule PtcRunner.Kernel.ProviderActiveSessionTest do
             %{"name" => name, "config" => %{"mode" => mode}}
           end),
         "mission" => []
-      }
+      },
+      "limits" => manifest_limits
     }
 
     documents = %{
@@ -1449,26 +1617,29 @@ defmodule PtcRunner.Kernel.ProviderActiveSessionTest do
     do: Application.started_applications() |> Enum.map(&elem(&1, 0))
 
   defp stop_provider_applications do
-    running = started_applications()
-
-    if :req_llm in running, do: Application.stop(:req_llm)
-    if :llm_db in running, do: Application.stop(:llm_db)
+    LLMSupport.stop_provider_applications()
   end
 
   defp restore_provider_applications_on_exit do
-    initially_running = MapSet.new(started_applications())
+    snapshot = LLMSupport.snapshot_provider_applications()
+    on_exit(fn -> LLMSupport.restore_provider_applications(snapshot) end)
+  end
 
-    on_exit(fn ->
-      stop_provider_applications()
-      Application.put_env(:req_llm, :load_dotenv, false, persistent: true)
-      Application.put_env(:llm_db, :load_dotenv, false, persistent: true)
+  defp collect_held_finch_requests(0, _deadline, held), do: held
 
-      if MapSet.member?(initially_running, :llm_db),
-        do: Application.ensure_all_started(:llm_db)
+  defp collect_held_finch_requests(remaining, deadline, held) do
+    case Deadline.remaining(deadline) do
+      0 ->
+        held
 
-      if MapSet.member?(initially_running, :req_llm),
-        do: Application.ensure_all_started(:req_llm)
-    end)
+      timeout_ms ->
+        receive do
+          {:held_finch_request, holder} ->
+            collect_held_finch_requests(remaining - 1, deadline, [holder | held])
+        after
+          timeout_ms -> held
+        end
+    end
   end
 
   defp restore_env(key, nil), do: Application.delete_env(:ptc_runner, key)

--- a/test/ptc_runner/kernel/provider_active_session_test.exs
+++ b/test/ptc_runner/kernel/provider_active_session_test.exs
@@ -1140,7 +1140,7 @@ defmodule PtcRunner.Kernel.ProviderActiveSessionTest do
                 Finch.request(request, ReqLLM.Finch,
                   pool_strategy: {Finch.Pool.Strategy.Hash, shared_hash_key},
                   pool_timeout: 2_000,
-                  receive_timeout: 2_000
+                  receive_timeout: 10_000
                 )
 
               send(parent, {:finch_request_result, self(), result})
@@ -1157,7 +1157,11 @@ defmodule PtcRunner.Kernel.ProviderActiveSessionTest do
 
       Enum.each(requester_pids, &send(&1, {:start_finch_request, start_ref}))
 
-      held = collect_held_finch_requests(8, Deadline.new(1_000), [])
+      # The observation window deliberately exceeds the pool checkout timeout:
+      # the old eight-by-one geometry can admit only one request for this shared
+      # hash key before its seven waiters time out, while the one-by-eight pool
+      # admits all eight even on a loaded CI scheduler.
+      held = collect_held_finch_requests(8, Deadline.new(5_000), [])
       assert length(held) == 8
 
       send(release_gate, :release)
@@ -1264,8 +1268,8 @@ defmodule PtcRunner.Kernel.ProviderActiveSessionTest do
   test "command VM startup failures preserve attempted provider activity" do
     restore_provider_applications_on_exit()
     stop_provider_applications()
-    Application.delete_env(:req_llm, :finch, persistent: true)
-    Application.put_env(:req_llm, :stream_pool_protocols, [:invalid], persistent: true)
+    Application.put_env(:req_llm, :finch, %{}, persistent: true)
+    Application.delete_env(:req_llm, :stream_pool_protocols, persistent: true)
 
     {:ok, prepared, catalog} =
       fixture(fn _selection, _context -> :ok end, ["first"], nil, "command-v1", :req_llm)

--- a/test/ptc_runner/kernel/provider_execution_oauth_test.exs
+++ b/test/ptc_runner/kernel/provider_execution_oauth_test.exs
@@ -25,6 +25,7 @@ defmodule PtcRunner.Kernel.ProviderExecutionOAuthTest do
   alias PtcRunner.Kernel.ProviderSession
   alias PtcRunner.Kernel.PublicationAuthority
   alias PtcRunner.Kernel.RunCoordinator
+  alias PtcRunner.TestSupport.LLMSupport
   alias PtcRunner.TestSupport.MCPHTTPFixture
 
   test "OAuth setup and each requested target use their exact independent deadlines" do
@@ -501,26 +502,9 @@ defmodule PtcRunner.Kernel.ProviderExecutionOAuthTest do
   end
 
   defp isolate_provider_applications do
-    initially_started =
-      Application.started_applications()
-      |> MapSet.new(&elem(&1, 0))
-
-    if MapSet.member?(initially_started, :req_llm), do: Application.stop(:req_llm)
-    if MapSet.member?(initially_started, :llm_db), do: Application.stop(:llm_db)
-
-    on_exit(fn ->
-      if :req_llm in Enum.map(Application.started_applications(), &elem(&1, 0)),
-        do: Application.stop(:req_llm)
-
-      if :llm_db in Enum.map(Application.started_applications(), &elem(&1, 0)),
-        do: Application.stop(:llm_db)
-
-      if MapSet.member?(initially_started, :llm_db),
-        do: Application.ensure_all_started(:llm_db)
-
-      if MapSet.member?(initially_started, :req_llm),
-        do: Application.ensure_all_started(:req_llm)
-    end)
+    snapshot = LLMSupport.snapshot_provider_applications()
+    :ok = LLMSupport.stop_provider_applications()
+    on_exit(fn -> LLMSupport.restore_provider_applications(snapshot) end)
   end
 
   test "one unauthorized selection refuses before another one's interaction opens" do

--- a/test/support/llm_support.ex
+++ b/test/support/llm_support.ex
@@ -9,6 +9,8 @@ defmodule PtcRunner.TestSupport.LLMSupport do
   - API key validation
   """
 
+  alias PtcRunner.Kernel.Limits
+  alias PtcRunner.Kernel.ProviderApplicationGate
   alias PtcRunner.LLM.Registry
   alias PtcRunner.LLM.ReqLLMAdapter
 
@@ -23,14 +25,52 @@ defmodule PtcRunner.TestSupport.LLMSupport do
   The core application starts no provider dependency, and a run normally admits
   one through `PtcRunner.Kernel.ProviderApplicationGate`. Tests that drive
   `ProviderRegistry` or `RunBuilder` without that gate must admit it here, and
-  disable both dependency dotenv readers exactly as the command-owned gate
-  branch does, so no unchosen `.env` is read.
+  apply the same dependency dotenv and installed-default pool configuration as
+  the command-owned gate, so no unchosen `.env` is read and live contention
+  exercises the production geometry.
   """
   @spec admit_provider_application!() :: :ok
   def admit_provider_application! do
-    Application.put_env(:req_llm, :load_dotenv, false, persistent: true)
-    Application.put_env(:llm_db, :load_dotenv, false, persistent: true)
+    stop_provider_applications()
+    :ok = ProviderApplicationGate.configure_command_vm_req_llm(Limits.installed_defaults())
     {:ok, _started} = Application.ensure_all_started(:req_llm)
+    :ok
+  end
+
+  @doc false
+  def snapshot_provider_applications do
+    %{
+      running: Application.started_applications() |> MapSet.new(&elem(&1, 0)),
+      req_llm_env: snapshot_application_env(:req_llm, req_llm_env_keys()),
+      llm_db_env: snapshot_application_env(:llm_db, [:load_dotenv])
+    }
+  end
+
+  @doc false
+  def stop_provider_applications do
+    running = Application.started_applications() |> MapSet.new(&elem(&1, 0))
+
+    if MapSet.member?(running, :req_llm), do: Application.stop(:req_llm)
+    if MapSet.member?(running, :llm_db), do: Application.stop(:llm_db)
+    :ok
+  end
+
+  @doc false
+  def restore_provider_applications(%{
+        running: initially_running,
+        req_llm_env: req_llm_env,
+        llm_db_env: llm_db_env
+      }) do
+    :ok = stop_provider_applications()
+    restore_application_env(:req_llm, req_llm_env)
+    restore_application_env(:llm_db, llm_db_env)
+
+    if MapSet.member?(initially_running, :llm_db),
+      do: Application.ensure_all_started(:llm_db)
+
+    if MapSet.member?(initially_running, :req_llm),
+      do: Application.ensure_all_started(:req_llm)
+
     :ok
   end
 
@@ -101,6 +141,19 @@ defmodule PtcRunner.TestSupport.LLMSupport do
     |> String.replace(opening_pattern, "")
     |> String.replace(~r/\s*```$/i, "")
     |> String.trim()
+  end
+
+  defp req_llm_env_keys,
+    do: [:finch, :load_dotenv, :stream_pool_count, :stream_pool_protocols, :stream_pool_size]
+
+  defp snapshot_application_env(application, keys),
+    do: Map.new(keys, &{&1, Application.fetch_env(application, &1)})
+
+  defp restore_application_env(application, snapshot) do
+    Enum.each(snapshot, fn
+      {key, {:ok, value}} -> Application.put_env(application, key, value, persistent: true)
+      {key, :error} -> Application.delete_env(application, key, persistent: true)
+    end)
   end
 
   @doc """


### PR DESCRIPTION
## Summary

- configure the command-owned ReqLLM default HTTP/1 Finch pool as one shard sized from the installed `live_provider_tasks` ceiling
- preserve explicit Finch pools, non-HTTP/1 transport configuration, and the host-owned lifecycle boundary
- add deterministic eight-held-request regression coverage, widen the live sanity test to eight agents, and isolate provider application state across tests
- document command-owned versus host-owned pool capacity and installed versus effective limits
- rebase onto `origin/main` after merged PR #1292 implemented issue #1240

## Why

ReqLLM's prior default geometry used eight one-connection pools. Finch hashes requests to one pool, so simultaneous requests could collide on the same one-connection shard and time out despite idle capacity elsewhere.

## Verification

- `mix precommit`
- full pre-push hook with `PTC_PRE_PUSH_MAX_CASES=2`
- 10 repeated runs of the deterministic Finch contention regression
- live DeepSeek E2E: both eight-agent contention runs and both kernel-boundary tests passed
- independent implementation plan review
- three independent implementation reviews; final follow-up reported no actionable findings

Closes #1287