### PR TITLE
fix(build): keep the launcher path dependency out of mix-file-only trees

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -162,8 +162,15 @@ defmodule PtcRunner.MixProject do
     end
   end
 
+  # The sentinel is the companion's own version file rather than its directory:
+  # `ptc_runner_launcher/mix.exs` evaluates `release_config.exs` while it is
+  # being loaded, so a directory holding only the mix file is an unloadable
+  # path dependency. Tooling that reconstructs a project from the mix files it
+  # fetched — Dependabot's Hex updater does exactly this — produces precisely
+  # that tree, and pointing at it fails the whole run before any dependency is
+  # resolved.
   defp local_launcher_checkout?(launcher_path) do
-    File.dir?(launcher_path) and
+    File.regular?(Path.join(launcher_path, "release_config.exs")) and
       (Mix.env() in [:dev, :test] or Enum.any?(System.argv(), &(&1 == "release")))
   end
 

--- a/test/mix/launcher_dep_test.exs
+++ b/test/mix/launcher_dep_test.exs
@@ -1,0 +1,47 @@
+defmodule PtcRunner.Mix.LauncherDepTest do
+  use ExUnit.Case, async: true
+
+  # Dependabot's Hex updater copies the mix files it fetched into a scratch
+  # directory and loads the project there. `ptc_runner_launcher/mix.exs` is
+  # fetched because the checkout declares it as a path dependency, but its
+  # sibling `release_config.exs` is not a mix file and never comes along, so
+  # every update run died in `Code.eval_file/1` before resolving a dependency.
+  @moduletag :tmp_dir
+  @moduletag :slow
+
+  @root Path.expand("../..", __DIR__)
+  @fetched_mix_files ["mix.exs", "mix.lock", "ptc_runner_launcher/mix.exs"]
+  @probe "Mix.Project.config()[:deps] |> List.keyfind(:ptc_runner_launcher, 0) |> inspect() |> IO.puts()"
+
+  test "the project loads from the mix files alone, without the launcher's version file", %{
+    tmp_dir: directory
+  } do
+    stage(directory, @fetched_mix_files)
+
+    assert {output, 0} = load_project(directory)
+    assert output =~ ~s({:ptc_runner_launcher, "~> 0.1.0", [optional: true]})
+  end
+
+  test "a complete launcher checkout is still used as a path dependency", %{tmp_dir: directory} do
+    stage(directory, ["ptc_runner_launcher/release_config.exs" | @fetched_mix_files])
+
+    assert {output, 0} = load_project(directory)
+    assert output =~ "path: \"ptc_runner_launcher\""
+  end
+
+  defp stage(directory, files) do
+    for file <- files do
+      target = Path.join(directory, file)
+      File.mkdir_p!(Path.dirname(target))
+      File.cp!(Path.join(@root, file), target)
+    end
+  end
+
+  defp load_project(directory) do
+    System.cmd("mix", ["run", "--no-deps-check", "--no-compile", "--no-start", "-e", @probe],
+      cd: directory,
+      env: [{"MIX_ENV", "dev"}, {"MIX_QUIET", "1"}],
+      stderr_to_stdout: true
+    )
+  end
+end


### PR DESCRIPTION
## Summary

The **Dependabot Updates** workflow has failed on every run on `main` ([latest](https://github.com/andreasronge/ptc_runner/actions/runs/31418826299)), so no dependency update has been proposed at all:

```
dependency_file_not_evaluatable
Error while loading project :ptc_runner_launcher at dependabot_tmp_dir/ptc_runner_launcher
** (Code.LoadError) could not load dependabot_tmp_dir/ptc_runner_launcher/release_config.exs. Reason: enoent
    dependabot_tmp_dir/ptc_runner_launcher/mix.exs:6: (module)
```

## Root cause

`launcher_dep/0` points at the companion whenever `ptc_runner_launcher/` exists, and `ptc_runner_launcher/mix.exs` evaluates its sibling `release_config.exs` at load time. Dependabot's Hex updater rebuilds the project from the mix files it fetched — `mix.exs`, `mix.lock`, and the path dependency's `mix.exs` — in a scratch directory. `release_config.exs` is not a mix file, so it never comes along, and the run dies while loading the project, before resolving a single dependency.

## Change

Make the version file, not the directory, the sentinel for a usable checkout. A real checkout and a `mix release` build are unchanged; a tree carrying only mix files falls back to the optional Hex requirement and loads.

Known limitation: the companion's own deps (`elixir_make`, `cc_precompiler`) stay outside Dependabot's reach — a second `dependabot.yml` entry for that directory would hit the same missing-file wall.

## Verification

- `test/mix/launcher_dep_test.exs` stages exactly the tree Dependabot builds and asserts the project loads; it reproduces the error above verbatim when the fix is reverted, and a second case pins that a complete checkout still resolves the path dependency.
- `mix precommit` (includes standalone-release and core-package verification).

https://claude.ai/code/session_01EmJPFceRXWWyK4BqnorA2Y