### PR TITLE
fix(test): return VM-global ReqLLM configuration to the admitting scope

### DIFF
--- a/test/ptc_runner/kernel/provider_active_session_test.exs
+++ b/test/ptc_runner/kernel/provider_active_session_test.exs
@@ -1270,6 +1270,11 @@ defmodule PtcRunner.Kernel.ProviderActiveSessionTest do
     stop_provider_applications()
     Application.put_env(:req_llm, :finch, %{}, persistent: true)
     Application.delete_env(:req_llm, :stream_pool_protocols, persistent: true)
+    # Seeded rather than deleted: the subject is that a failed start leaves the
+    # pool geometry exactly as it found it, which an absent key cannot tell
+    # apart from a start that wrote the same value another test had left behind.
+    Application.put_env(:req_llm, :stream_pool_count, 5, persistent: true)
+    Application.put_env(:req_llm, :stream_pool_size, 6, persistent: true)
 
     {:ok, prepared, catalog} =
       fixture(fn _selection, _context -> :ok end, ["first"], nil, "command-v1", :req_llm)
@@ -1278,8 +1283,8 @@ defmodule PtcRunner.Kernel.ProviderActiveSessionTest do
             %CommandDiagnostic{code: :provider_application_unavailable, provider_activity: true}} =
              open_owned(prepared, catalog, services(:command_vm))
 
-    assert Application.get_env(:req_llm, :stream_pool_count) == nil
-    assert Application.get_env(:req_llm, :stream_pool_size) == nil
+    assert Application.get_env(:req_llm, :stream_pool_count) == 5
+    assert Application.get_env(:req_llm, :stream_pool_size) == 6
     assert ProviderActivity.value(prepared.provider_activity) == true
     assert :ok = PreparedRun.close(prepared)
   end

--- a/test/ptc_runner/kernel/provider_application_admission_test.exs
+++ b/test/ptc_runner/kernel/provider_application_admission_test.exs
@@ -1,0 +1,30 @@
+defmodule PtcRunner.Kernel.ProviderApplicationAdmissionTest do
+  use ExUnit.Case, async: false
+
+  alias PtcRunner.Kernel.Limits
+  alias PtcRunner.TestSupport.LLMSupport
+
+  # `LLMSupport.admit_provider_application!/0` stands in for the command-owned
+  # gate in modules that build providers directly, so it applies the same
+  # VM-global, persistent ReqLLM pool geometry the gate does. This module pins
+  # that geometry, and — by admitting from `setup_all` the way every live module
+  # does — that the admission is undone when the admitting scope exits. An
+  # admission that outlives its module hands its pool configuration to every
+  # later test in the VM; that is how a passing suite still failed
+  # `ProviderActiveSessionTest`'s startup-failure assertion under `--include
+  # e2e`, where a live module ran first.
+  setup_all do
+    :ok = LLMSupport.admit_provider_application!()
+    :ok
+  end
+
+  test "admission applies the command-owned pool geometry" do
+    assert Application.get_env(:req_llm, :stream_pool_count) == 1
+
+    assert Application.get_env(:req_llm, :stream_pool_size) ==
+             Limits.installed_defaults().live_provider_tasks
+
+    assert Application.get_env(:req_llm, :load_dotenv) == false
+    assert :req_llm in Enum.map(Application.started_applications(), &elem(&1, 0))
+  end
+end

--- a/test/support/llm_support.ex
+++ b/test/support/llm_support.ex
@@ -28,9 +28,18 @@ defmodule PtcRunner.TestSupport.LLMSupport do
   apply the same dependency dotenv and installed-default pool configuration as
   the command-owned gate, so no unchosen `.env` is read and live contention
   exercises the production geometry.
+
+  That configuration is VM-global and persistent, so the admitting scope owns
+  undoing it: the caller's `on_exit` restores the application environment and
+  running set this admission found. Without that, a live module's command-owned
+  pool geometry outlives it and every later test in the same VM inherits it —
+  which is why this belongs here rather than in each caller.
   """
   @spec admit_provider_application!() :: :ok
   def admit_provider_application! do
+    snapshot = snapshot_provider_applications()
+    ExUnit.Callbacks.on_exit(fn -> restore_provider_applications(snapshot) end)
+
     stop_provider_applications()
     :ok = ProviderApplicationGate.configure_command_vm_req_llm(Limits.installed_defaults())
     {:ok, _started} = Application.ensure_all_started(:req_llm)


### PR DESCRIPTION
## Summary

The nightly **Integration Tests** workflow fails on `main`. One of its two failures is deterministic:

```
test command VM startup failures preserve attempted provider activity (PtcRunner.Kernel.ProviderActiveSessionTest)
     test/ptc_runner/kernel/provider_active_session_test.exs:1268
     code:  assert Application.get_env(:req_llm, :stream_pool_count) == nil
     left:  1
```

## Root cause

`LLMSupport.admit_provider_application!/0` stands in for the command-owned gate and, since #1291, applies the gate's persistent VM-global ReqLLM pool geometry. Five live modules admit from `setup_all`; none of them undid it. The geometry therefore outlived each module and every later test in the same VM inherited it. The `Core tests` job excludes `:e2e`, so nothing there ever ran a leaking module first — only the integration workflow, which runs everything, sees it.

## Change

- Register the restore where the admission happens, so the admitting scope owns undoing what it did.
- Seed the assertion's own baseline rather than asserting `nil`, so it states its real subject: a failed start leaves the pool geometry exactly as it found it. An absent key cannot distinguish that from a start that wrote the value a previous test left behind.
- Add `ProviderApplicationAdmissionTest`, which pins the admitted geometry against `Limits.installed_defaults()` and, by admitting from `setup_all` the way live modules do, exercises the restore.

## Verification

- Staged a module pair (a synthetic module that only admits, then `ProviderActiveSessionTest`) under `--seed 0`: reproduces the CI failure verbatim before the change, passes after, and passes with the helper fix alone.
- `mix precommit`.

Not fixed here — the integration workflow's other failure is a live-model bound, `assert length(evaluations) in 1..8` in `repo_analyst_live_e2e_test.exs:388`, which saw 9 exploration turns. That is a stochastic ceiling on model behaviour, not a regression, and wants its own decision about what the bound should be.

https://claude.ai/code/session_01EmJPFceRXWWyK4BqnorA2Y