### PR TITLE
test(kernel): give the provider-timeout dispatch a budget it can reach

### DIFF
--- a/test/ptc_runner/kernel/core_contract_test.exs
+++ b/test/ptc_runner/kernel/core_contract_test.exs
@@ -424,8 +424,15 @@ defmodule PtcRunner.Kernel.CoreContractTest do
     {:ok, limits} = Limits.new(live_provider_tasks: 1, run_duration_ms: 1_000)
     {:ok, state} = RunState.start(limits)
 
+    # The budget only has to outlast the dispatch's own pre-provider work, not
+    # the callback: it blocks until `:finish`, which never arrives. A 1 ms
+    # request cannot do that. The validation worker is given the requested
+    # budget minus the time already spent reaching it, so anything under a
+    # millisecond of setup — a cold JSON-schema validator, a loaded CI
+    # scheduler — collapses it to zero and reports the validator as
+    # unavailable instead of the provider as timed out.
     assert %{status: :error, kind: :timeout, reason: :provider_timeout} =
-             Dispatcher.dispatch(state, :workflow, environment, "slow", %{}, 1)
+             Dispatcher.dispatch(state, :workflow, environment, "slow", %{}, 100)
 
     assert_received :started
     assert :ok = RunState.close(state)


### PR DESCRIPTION
## Summary

`CoreContractTest:407` fails intermittently in the required `Core tests` job — twice in a row on #1293's checks, and it is not caused by that PR:

```
test timed-out provider results cannot consume another callback slot after closure
     code:  assert %{status: :error, kind: :timeout, reason: :provider_timeout} =
              Dispatcher.dispatch(state, :workflow, environment, "slow", %{}, 1)
     right: %{reason: :input_validation_unavailable, kind: :capability_unavailable, ...}
```

## Root cause

The requested budget covers more than the provider call. `Dispatcher` derives the validation worker's timeout as the requested budget minus the time already spent reaching it (`shared_validation_deadline/4` stamps a deadline, `validation_worker_timeout_ms/2` subtracts the elapsed time from it). With 1 ms requested, any setup at all — a cold JSON-schema validator, a loaded runner — leaves zero, and the dispatch correctly reports the validator as unavailable rather than the provider as timed out.

The product behaviour is right; the test's budget is not. Nothing about the subject needs a tight budget: the callback blocks on a `:finish` message that never arrives, so it times out at any budget.

## Verification

Run alone, nothing has warmed the validation path, and the failure is deterministic:

- `mix test test/ptc_runner/kernel/core_contract_test.exs:407` — fails on every attempt at 1 ms, and at 2 ms passes only by a single millisecond of slack.
- Same command at 100 ms — 3/3 passes; whole file 102/102.
- `mix precommit`.

Merging this unblocks #1293 and #1294, whose checks run against `main`.

https://claude.ai/code/session_01EmJPFceRXWWyK4BqnorA2Y