### PR TITLE
fix(kernel): make contract corrections actionable

### DIFF
--- a/docs/guides/building-agents.md
+++ b/docs/guides/building-agents.md
@@ -454,6 +454,17 @@ executable values cross only as inert display labels.
 shows a complete credential-free run of this protocol against a signature
 violation.
 
+When `agent.main` rejects a terminal candidate against the manifest result
+contract, the correlated tool result instead carries bounded structural
+diagnostics. At each retained failing closed-object path it can name the sorted
+keys that schema allows, the required schema keys missing there, and only the
+count of undeclared submitted keys. An open-object path can still name missing
+required schema keys, but never treats valid extension keys as undeclared. It
+never echoes an undeclared key or submitted value. The rendered diagnostic is
+capped at 32,768 characters with an explicit truncation marker before it enters
+model history, then the whole prospective request is checked against
+`max_transcript_chars` as usual.
+
 The loop also bounds the whole prospective request before dispatch.
 `max_transcript_chars` defaults to 262,144, accepts positive values through
 1,000,000, and measures the JSON-encoded `system`, accumulated correlated

--- a/docs/guides/kernel-maintainer.md
+++ b/docs/guides/kernel-maintainer.md
@@ -836,6 +836,17 @@ contract's sealed classification authority and are authorized only against the
 selected tagged-union branch that produced the classification. The public
 classification map omits the internal branch selector; separate attested
 evidence supplies the exact branch schema used to construct the authority.
+That same selected schema enriches at most one retained violation per object
+path with applicable local facts. An actual object can receive sorted, bounded
+missing names. A closed object schema additionally supplies sorted, bounded
+allowed names and a local undeclared-key count; an open schema never treats
+extension keys as undeclared. Enrichment walks only the already authorized
+typed path; it never creates a second raw-path channel. `ExecutionInput`
+therefore converts the enriched violation's segments into the same attested
+`CommandPath` and preserves the schema-derived facts on that record. Non-object
+values receive allowed-key guidance only for a closed object schema. The agent
+prelude independently caps the complete rendered correction diagnostic before
+adding it to model history.
 `ExecutionInput` carries that authority with the bounded rejection
 classification;
 `CommandEngine` binds that authority to the diagnostic source independently of

--- a/docs/guides/manifests-and-capabilities.md
+++ b/docs/guides/manifests-and-capabilities.md
@@ -187,11 +187,14 @@ without repeating the run under private inspection. The command reports it as:
 ```text
 {:error,
  {:result_contract_failed,
-  %{value_kind: :object, discriminator: "decision", matched_branch: "no-change",
-    missing_required: [], undeclared_key_count: 0,
+  %{value_kind: :object, discriminator: "kind", matched_branch: "report",
     violations: [
-      %{segments: [{:property, "rationale"}], kind: :maxLength},
-      %{segments: [{:property, "evidence"}, {:index, 0}], kind: :required}
+      %{segments: [{:property, "timeline"}, {:index, 2}],
+        kind: :boolean_schema,
+        allowed_keys: ["citations", "observed_at", "statement"],
+        missing_required: ["observed_at", "statement"],
+        undeclared_key_count: 2},
+      %{segments: [{:property, "timeline"}, {:index, 2}], kind: :required}
     ]}}}
 ```
 
@@ -221,14 +224,37 @@ index. At the first undeclared or structurally inconsistent segment,
 classification stops at the safe parent, so caller-authored property names
 never enter the report.
 
-Every other name comes from the compiled schema too: the discriminator, the
-branch whose `const` the value carried, and that branch's unmet `required` keys
-as `missing_required`. The value contributes only its JSON kind and
-`undeclared_key_count`, a number. The rejected value and its field values stay
-out of the error entirely.
+Exactly one retained violation at each object path carries applicable local
+correction guidance. For a closed object schema, `allowed_keys` is its sorted
+property-name set and `undeclared_key_count` counts submitted keys outside that
+local set. When the rejected node is an object, `missing_required` lists its
+absent schema-required names. An explicitly open object can still report those
+missing names, but omits `allowed_keys` and the undeclared count because
+extension keys are valid. These facts are path-local; there are no root-only
+missing or undeclared summaries that can contradict a nested violation. A
+closed-object type mismatch still receives schema-only `allowed_keys`, but no
+missing or undeclared claim is made about a non-object value.
 
-Ordinary contracts are closed, bounded object schemas. The supported keywords
-are `type`, `title`, `description`, `properties`, `required`,
+Each allowed or missing list retains at most 32 names and at most 4,096 bytes in
+deterministic JSON encoding. When a sorted prefix is retained, the violation
+also carries `allowed_key_count`/`allowed_keys_truncated` or
+`missing_required_count`/`missing_required_truncated`. The complete
+model-facing structural-diagnostics rendering is separately capped at 32,768
+characters and ends with `(contract diagnostics truncated)` when necessary;
+the prospective encoded-request size check remains authoritative for a
+caller-narrowed or already-full transcript.
+
+Every published name comes from the compiled schema: the discriminator, the
+branch `const`, safe path properties, allowed keys, and missing required keys.
+The value contributes only its JSON kind, required-key absence, array indices,
+and numeric undeclared counts. The rejected value, its field values, and its
+undeclared field names stay out of the error entirely. The reserved result
+validator exposes only this bounded classification; it does not expose the
+whole contract or add a route for `ValueContract.describe/1`.
+
+Ordinary contracts are bounded object schemas and are closed by default;
+`additionalProperties: true` explicitly opens an object. The supported
+keywords are `type`, `title`, `description`, `properties`, `required`,
 `additionalProperties`, `items`, `enum`, `const`, numeric and length bounds.
 String schemas may additionally use the single asserted
 `"format": "sha256"` for an algorithm-qualified lowercase digest; arbitrary

--- a/docs/guides/running-and-debugging.md
+++ b/docs/guides/running-and-debugging.md
@@ -478,6 +478,15 @@ survives when `pmap` or `pcalls` rejects a worker's `fail` control signal; the
 parallel error remains the terminal reason while its safe failure taxonomy
 identifies the underlying framework failure.
 
+Input and result contract failures follow the same public/private split. Their
+public classification may name schema-declared missing keys at a safe typed
+path. At a closed-object path it may also name allowed keys and count undeclared
+keys; an open-object path never classifies extension keys as undeclared. It
+never names an undeclared submitted key or copies a submitted value. Use
+private inspection when the exact rejected candidate is authorized and
+necessary; normal command diagnostics and agent correction feedback remain
+schema-derived and bounded.
+
 **When provider-backed detail is needed**, rerun with `--inspect`:
 
 ```console

--- a/lib/ptc_runner/kernel/value_contract.ex
+++ b/lib/ptc_runner/kernel/value_contract.ex
@@ -31,6 +31,8 @@ defmodule PtcRunner.Kernel.ValueContract do
   @max_contract_bytes 65_536
   @max_discriminator_bytes 128
   @max_violations 8
+  @max_diagnostic_names 32
+  @max_diagnostic_name_bytes 4_096
 
   @enforce_keys [:schema, :validator, :attestation]
   defstruct @enforce_keys
@@ -105,9 +107,10 @@ defmodule PtcRunner.Kernel.ValueContract do
 
   Every reported name comes from the compiled schema rather than from the
   value: the discriminator's name, the branch whose `const` the value carries,
-  and the schema-declared required keys that branch did not find. The only
-  facts derived from the value itself are its JSON kind and the count of keys
-  the branch does not declare — a type name and a number, never content.
+  and bounded, sorted allowed and missing key lists at retained object paths.
+  The only facts derived from the value itself are its JSON kind, required-key
+  absence, and per-object counts of keys the schema does not declare — types,
+  booleans, and numbers, never caller-authored content.
 
   A rejected result is deliberately withheld from the public error, so without
   this an operator cannot tell a missing key from a wrong shape without
@@ -115,7 +118,13 @@ defmodule PtcRunner.Kernel.ValueContract do
 
   `violations` locates faults, it does not enumerate them: when several array
   elements fail the same way, the reported set may name fewer of them than
-  actually failed. It is a diagnosis, not a validation report.
+  actually failed. It is a diagnosis, not a validation report. At most eight
+  violations are retained. One violation at each retained object path carries
+  applicable local facts. Closed paths add `allowed_keys` and any undeclared
+  count; actual objects add any missing required keys. Open paths never label
+  valid extension keys undeclared. Schema-name lists keep at most 32 names and
+  4,096 encoded bytes; truncated lists carry their total count and an explicit
+  truncation flag.
   """
   def classify(%__MODULE__{} = contract, value) do
     if not sealed?(contract), do: raise(ArgumentError, "invalid value contract")
@@ -140,8 +149,11 @@ defmodule PtcRunner.Kernel.ValueContract do
     shape =
       case Map.fetch(schema, "oneOf") do
         {:ok, branches} -> classify_union(branches, value)
-        :error -> classify_object(schema, value)
+        :error -> %{}
       end
+
+    branch_index = Map.get(shape, :branch_index)
+    path_schema = selected_path_schema(schema, branch_index)
 
     classification =
       shape
@@ -154,10 +166,12 @@ defmodule PtcRunner.Kernel.ValueContract do
       |> Map.put(:json_value, JSONValue.value?(value))
       |> Map.put(
         :violations,
-        violations(validator, value, schema, Map.get(shape, :branch_index))
+        validator
+        |> violations(value, schema, branch_index)
+        |> enrich_object_violations(path_schema, value)
       )
 
-    {classification, classification_evidence(contract, Map.get(shape, :branch_index))}
+    {classification, classification_evidence(contract, branch_index)}
   rescue
     _exception -> {%{value_kind: :unknown}, nil}
   end
@@ -363,16 +377,168 @@ defmodule PtcRunner.Kernel.ValueContract do
     end
   end
 
+  # Object guidance is attached to the existing schema-authorized violation
+  # path so input classifications keep using the same attested CommandPath
+  # channel. JSV can emit several keywords for one object; enrich only the first
+  # retained record at each path so long schema names are not repeated.
+  defp enrich_object_violations(violations, schema, value) when is_map(schema) do
+    {enriched, _seen} =
+      Enum.map_reduce(violations, MapSet.new(), fn violation, seen ->
+        segments = Map.get(violation, :segments)
+
+        if not is_list(segments) or MapSet.member?(seen, segments) do
+          {violation, seen}
+        else
+          case schema_value_at_path(schema, value, segments) do
+            {:ok, %{"type" => "object"} = object_schema, object_value} ->
+              {
+                object_diagnostic(violation, object_schema, object_value),
+                MapSet.put(seen, segments)
+              }
+
+            :error ->
+              {violation, seen}
+
+            {:ok, _other_schema, _other_value} ->
+              {violation, seen}
+          end
+        end
+      end)
+
+    enriched
+  end
+
+  defp enrich_object_violations(violations, _schema, _value), do: violations
+
+  defp schema_value_at_path(schema, value, []), do: {:ok, schema, value}
+
+  defp schema_value_at_path(
+         %{"type" => "object", "properties" => properties},
+         value,
+         [{:property, name} | rest]
+       )
+       when is_map(properties) and is_map(value) and not is_struct(value) do
+    with {:ok, child_schema} <- Map.fetch(properties, name),
+         {:ok, child_value} <- Map.fetch(value, name) do
+      schema_value_at_path(child_schema, child_value, rest)
+    end
+  end
+
+  defp schema_value_at_path(
+         %{"type" => "array", "items" => items},
+         value,
+         [{:index, index} | rest]
+       )
+       when is_list(value) and is_integer(index) and index >= 0 do
+    case Enum.fetch(value, index) do
+      {:ok, child_value} -> schema_value_at_path(items, child_value, rest)
+      :error -> :error
+    end
+  end
+
+  defp schema_value_at_path(_schema, _value, _segments), do: :error
+
+  defp object_diagnostic(violation, schema, value) do
+    violation
+    |> put_missing_required(schema, value)
+    |> put_closed_object_diagnostic(schema, value)
+  end
+
+  defp put_missing_required(violation, schema, value)
+       when is_map(value) and not is_struct(value) do
+    missing_required =
+      schema
+      |> Map.get("required", [])
+      |> Enum.reject(&Map.has_key?(value, &1))
+      |> Enum.sort()
+
+    maybe_put_missing_required(violation, missing_required)
+  end
+
+  defp put_missing_required(violation, _schema, _value), do: violation
+
+  defp put_closed_object_diagnostic(violation, %{"additionalProperties" => false} = schema, value) do
+    allowed_keys = schema |> Map.get("properties", %{}) |> Map.keys() |> Enum.sort()
+
+    violation
+    |> put_name_diagnostic(
+      :allowed_keys,
+      :allowed_key_count,
+      :allowed_keys_truncated,
+      allowed_keys
+    )
+    |> put_undeclared_key_count(value, MapSet.new(allowed_keys))
+  end
+
+  defp put_closed_object_diagnostic(violation, _schema, _value), do: violation
+
+  defp put_undeclared_key_count(violation, value, allowed)
+       when is_map(value) and not is_struct(value) do
+    undeclared_key_count =
+      Enum.count(value, fn {name, _child} -> not MapSet.member?(allowed, name) end)
+
+    maybe_put_undeclared_key_count(violation, undeclared_key_count)
+  end
+
+  defp put_undeclared_key_count(violation, _value, _allowed), do: violation
+
+  defp maybe_put_missing_required(violation, []), do: violation
+
+  defp maybe_put_missing_required(violation, missing_required) do
+    put_name_diagnostic(
+      violation,
+      :missing_required,
+      :missing_required_count,
+      :missing_required_truncated,
+      missing_required
+    )
+  end
+
+  defp maybe_put_undeclared_key_count(violation, 0), do: violation
+
+  defp maybe_put_undeclared_key_count(violation, count),
+    do: Map.put(violation, :undeclared_key_count, count)
+
+  defp put_name_diagnostic(violation, list_key, count_key, truncated_key, names) do
+    {retained, encoded_bytes} =
+      Enum.reduce_while(names, {[], 2}, fn name, {retained, bytes} ->
+        separator_bytes = if retained == [], do: 0, else: 1
+
+        case DeterministicJSON.encode(name) do
+          {:ok, encoded} ->
+            next_bytes = bytes + separator_bytes + byte_size(encoded)
+
+            if length(retained) < @max_diagnostic_names and
+                 next_bytes <= @max_diagnostic_name_bytes do
+              {:cont, {[name | retained], next_bytes}}
+            else
+              {:halt, {retained, bytes}}
+            end
+
+          {:error, _reason} ->
+            {:halt, {retained, bytes}}
+        end
+      end)
+
+    retained = Enum.reverse(retained)
+    violation = Map.put(violation, list_key, retained)
+
+    if length(retained) == length(names) and encoded_bytes <= @max_diagnostic_name_bytes do
+      violation
+    else
+      violation
+      |> Map.put(count_key, length(names))
+      |> Map.put(truncated_key, true)
+    end
+  end
+
   defp classify_union(branches, value) do
     with {:ok, name} <- shared_discriminator(branches),
          true <- is_map(value),
          {:ok, tag} when is_binary(tag) <- Map.fetch(value, name),
          index when is_integer(index) <-
            Enum.find_index(branches, &(get_in(&1, ["properties", name, "const"]) == tag)) do
-      Map.merge(
-        %{discriminator: name, matched_branch: tag, branch_index: index},
-        classify_object(Enum.at(branches, index), value)
-      )
+      %{discriminator: name, matched_branch: tag, branch_index: index}
     else
       _other ->
         %{
@@ -382,19 +548,6 @@ defmodule PtcRunner.Kernel.ValueContract do
         }
     end
   end
-
-  defp classify_object(schema, value) when is_map(value) do
-    required = Map.get(schema, "required", [])
-    declared = schema |> Map.get("properties", %{}) |> Map.keys() |> MapSet.new()
-
-    %{
-      missing_required: Enum.reject(required, &Map.has_key?(value, &1)),
-      undeclared_key_count: Enum.count(Map.keys(value), &(not MapSet.member?(declared, &1)))
-    }
-  end
-
-  defp classify_object(schema, _value),
-    do: %{missing_required: Map.get(schema, "required", []), undeclared_key_count: 0}
 
   defp discriminator_name(branches) do
     case shared_discriminator(branches) do

--- a/priv/preludes/kernel/agent.feedback.clj
+++ b/priv/preludes/kernel/agent.feedback.clj
@@ -1,13 +1,19 @@
 (ns agent.feedback "Bounded correction messages for agent workflows." {:visibility :prompt})
 
 (defn- observation-truncation-marker [] "\n... (observation truncated)")
+(defn- contract-diagnostic-truncation-marker [] "\n... (contract diagnostics truncated)")
+(defn- contract-diagnostic-max-chars [] 32768)
 
-(defn- cap-observation [body max-chars]
-  (let [marker (observation-truncation-marker)]
+(defn- cap-with-marker [body max-chars marker]
     (if (<= (count body) max-chars)
       body
-      (str (subs body 0 (- max-chars (count marker)))
-           marker))))
+      (if (<= max-chars (count marker))
+        (subs marker 0 max-chars)
+        (str (subs body 0 (- max-chars (count marker)))
+             marker))))
+
+(defn- cap-observation [body max-chars]
+  (cap-with-marker body max-chars (observation-truncation-marker)))
 
 (defn success [evaluation max-chars]
   (let [value-preview (pr-str (get evaluation :value))
@@ -71,6 +77,10 @@
        "you have already gathered, using return or fail on this turn."))
 
 (defn result-contract [validation]
-  (str "The returned value did not satisfy the application result contract. "
-       "Structural diagnostics: " (pr-str (get validation :details))
-       ". Send one corrected run_ptc_lisp call that returns a contract-valid value."))
+  (let [diagnostics (pr-str (get validation :details))
+        bounded (cap-with-marker diagnostics
+                                 (contract-diagnostic-max-chars)
+                                 (contract-diagnostic-truncation-marker))]
+    (str "The returned value did not satisfy the application result contract. "
+         "Structural diagnostics: " bounded
+         ". Send one corrected run_ptc_lisp call that returns a contract-valid value.")))

--- a/test/ptc_runner/kernel/agent_library_test.exs
+++ b/test/ptc_runner/kernel/agent_library_test.exs
@@ -233,7 +233,8 @@ defmodule PtcRunner.Kernel.AgentLibraryTest do
           id: "invalid-result",
           name: "run_ptc_lisp",
           args: %{
-            "program" => ~S|(return {"decision" "propose-change" "evidence" [{"resource" ""}]})|
+            "program" =>
+              ~S|(return {"decision" "propose-change" "evidence" [{"uri" "private-value"}]})|
           }
         }
       ]
@@ -298,10 +299,84 @@ defmodule PtcRunner.Kernel.AgentLibraryTest do
     assert_receive {:agent_request, _first_request}
     assert_receive {:agent_request, second_request}
 
-    assert List.last(second_request["messages"])["content"] =~
-             "did not satisfy the application result contract"
+    correction = List.last(second_request["messages"])["content"]
 
-    assert List.last(second_request["messages"])["content"] =~ "minLength"
+    assert correction =~ "did not satisfy the application result contract"
+    assert correction =~ "allowed_keys"
+    assert correction =~ "missing_required"
+    assert correction =~ "resource"
+    refute correction =~ "uri"
+    refute correction =~ "private-value"
+  end
+
+  test "agent.main bounds escape-heavy result-contract correction feedback" do
+    long_key = String.duplicate(~S|\"|, 2_500)
+    encoded_key = Jason.encode!(long_key)
+    invalid_items = Enum.map_join(1..8, " ", fn _index -> "42" end)
+    corrected_items = Enum.map_join(1..8, " ", fn _index -> ~S|{"answer" 1}| end)
+
+    invalid = %{
+      content: nil,
+      tool_calls: [
+        %{
+          id: "large-invalid-result",
+          name: "run_ptc_lisp",
+          args: %{"program" => "(return {#{encoded_key} [#{invalid_items}]})"}
+        }
+      ]
+    }
+
+    corrected = %{
+      content: nil,
+      tool_calls: [
+        %{
+          id: "large-corrected-result",
+          name: "run_ptc_lisp",
+          args: %{"program" => "(return {#{encoded_key} [#{corrected_items}]})"}
+        }
+      ]
+    }
+
+    assert {:ok, result_contract} =
+             ValueContract.compile(%{
+               "type" => "object",
+               "properties" => %{
+                 long_key => %{
+                   "type" => "array",
+                   "items" => %{
+                     "type" => "object",
+                     "properties" => %{"answer" => %{"type" => "integer"}},
+                     "required" => ["answer"]
+                   }
+                 }
+               },
+               "required" => [long_key]
+             })
+
+    input = %{
+      "input" => %{
+        "task" => "Return one application value",
+        "agent" => %{"max_turns" => 2}
+      }
+    }
+
+    {:ok, config} =
+      agent_config([invalid, corrected], [],
+        agent_main: true,
+        input: input,
+        result_contract: result_contract
+      )
+
+    assert {:ok, %{value: value}} = Kernel.run("(agent.main/run data/input)", config)
+    assert length(value[long_key]) == 8
+
+    assert_receive {:agent_request, _first_request}
+    assert_receive {:agent_request, second_request}
+
+    correction = List.last(second_request["messages"])["content"]
+    assert correction =~ "... (contract diagnostics truncated)"
+    assert String.length(correction) <= 33_000
+    assert byte_size(Jason.encode!(second_request)) < 262_144
   end
 
   test "agent.main validates keyword-keyed candidates through the kernel JSON projection" do

--- a/test/ptc_runner/kernel/manifest_test.exs
+++ b/test/ptc_runner/kernel/manifest_test.exs
@@ -199,8 +199,7 @@ defmodule PtcRunner.Kernel.ManifestTest do
     assert nil == loaded.contracts.result
 
     assert {:error,
-            {:source_role, :external_input,
-             {:input_contract_failed, %{missing_required: ["question"]}}}} =
+            {:source_role, :external_input, {:input_contract_failed, external_classification}}} =
              path
              |> ApplicationPackage.request_directory(
                installed_limits: registry.installed_limits,
@@ -208,6 +207,11 @@ defmodule PtcRunner.Kernel.ManifestTest do
                input_authority: :normal
              )
              |> RunLifecycle.build(registry)
+
+    assert Enum.any?(
+             external_classification.violations,
+             &(&1[:missing_required] == ["question"])
+           )
 
     refute_receive :provider_prepared
 
@@ -226,10 +230,15 @@ defmodule PtcRunner.Kernel.ManifestTest do
     invalid_initial = put_in(manifest, ["input", "value"], %{"other" => "invalid"})
     File.write!(path, Jason.encode!(invalid_initial))
 
-    assert {:error, {:input_contract_failed, %{missing_required: ["question"]}}} =
+    assert {:error, {:input_contract_failed, initial_classification}} =
              path
              |> ApplicationPackage.request_directory(installed_limits: registry.installed_limits)
              |> RunLifecycle.build(registry)
+
+    assert Enum.any?(
+             initial_classification.violations,
+             &(&1[:missing_required] == ["question"])
+           )
 
     refute_receive :provider_prepared
   end

--- a/test/ptc_runner/kernel/value_contract_test.exs
+++ b/test/ptc_runner/kernel/value_contract_test.exs
@@ -62,8 +62,7 @@ defmodule PtcRunner.Kernel.ValueContractTest do
 
     assert %{
              value_kind: :object,
-             matched_branch: "propose-change",
-             missing_required: ["candidate"]
+             matched_branch: "propose-change"
            } =
              classified =
              ValueContract.classify(contract, %{
@@ -72,6 +71,15 @@ defmodule PtcRunner.Kernel.ValueContractTest do
              })
 
     refute Map.has_key?(classified, :branch_index)
+    refute Map.has_key?(classified, :missing_required)
+    refute Map.has_key?(classified, :undeclared_key_count)
+
+    assert Enum.any?(classified.violations, fn violation ->
+             violation[:segments] == [] and
+               violation[:allowed_keys] == ["candidate", "decision"] and
+               violation[:missing_required] == ["candidate"] and
+               violation[:undeclared_key_count] == 1
+           end)
 
     secret = "must-not-escape"
 
@@ -79,12 +87,15 @@ defmodule PtcRunner.Kernel.ValueContractTest do
       ValueContract.classify(contract, %{"decision" => "no-change", secret => secret})
 
     refute inspect(leaked) =~ secret
-    assert leaked.undeclared_key_count == 1
 
-    # An undeclared key is reported by keyword and location only. Its name is
-    # model-authored, so naming it would put caller content into a public error
-    # by the same route the rejected value is withheld from.
-    assert Enum.any?(leaked.violations, &(&1.segments == []))
+    # An undeclared key is reported by count, safe location, and the schema's
+    # allowed names. Its caller-authored name never enters the public error.
+    assert Enum.any?(leaked.violations, fn violation ->
+             violation[:segments] == [] and
+               violation[:allowed_keys] == ["decision", "reason"] and
+               violation[:missing_required] == ["reason"] and
+               violation[:undeclared_key_count] == 1
+           end)
   end
 
   # Keyword keys are the commonest authoring mistake in PTC-Lisp, and they fail
@@ -134,12 +145,185 @@ defmodule PtcRunner.Kernel.ValueContractTest do
       })
 
     assert classification.matched_branch == "no-change"
-    assert classification.missing_required == ["reason"]
+
+    assert Enum.any?(classification.violations, fn violation ->
+             violation[:segments] == [] and
+               violation[:allowed_keys] == ["decision", "reason"] and
+               violation[:missing_required] == ["reason"]
+           end)
 
     refute Enum.any?(
              classification.violations,
              &(&1.kind == :const and &1.segments == [{:property, "decision"}])
            )
+  end
+
+  test "reports nested object diagnostics without caller-authored keys or values" do
+    assert {:ok, contract} = ValueContract.compile(nested_report_schema())
+
+    caller_key_a = "submitted-timestamp"
+    caller_key_b = "submitted-description"
+    caller_value = "private-value"
+
+    classification =
+      ValueContract.classify(contract, %{
+        "kind" => "report",
+        "timeline" => [
+          %{
+            caller_key_a => caller_value,
+            caller_key_b => caller_value,
+            "citations" => []
+          },
+          %{
+            caller_key_a => caller_value,
+            "statement" => "second item",
+            "citations" => []
+          }
+        ]
+      })
+
+    refute Map.has_key?(classification, :missing_required)
+    refute Map.has_key?(classification, :undeclared_key_count)
+
+    diagnostics =
+      Enum.filter(classification.violations, &Map.has_key?(&1, :allowed_keys))
+
+    assert Enum.any?(diagnostics, fn violation ->
+             violation.segments == [{:property, "timeline"}, {:index, 0}] and
+               violation.allowed_keys == ["citations", "observed_at", "statement"] and
+               violation.missing_required == ["observed_at", "statement"] and
+               violation.undeclared_key_count == 2
+           end)
+
+    assert Enum.any?(diagnostics, fn violation ->
+             violation.segments == [{:property, "timeline"}, {:index, 1}] and
+               violation.allowed_keys == ["citations", "observed_at", "statement"] and
+               violation.missing_required == ["observed_at"] and
+               violation.undeclared_key_count == 1
+           end)
+
+    rendered = inspect(classification)
+    refute rendered =~ caller_key_a
+    refute rendered =~ caller_key_b
+    refute rendered =~ caller_value
+  end
+
+  test "does not call extension keys undeclared in an open root object" do
+    assert {:ok, contract} =
+             ValueContract.compile(%{
+               "type" => "object",
+               "additionalProperties" => true,
+               "properties" => %{"required_key" => %{"type" => "string"}},
+               "required" => ["required_key"]
+             })
+
+    classification = ValueContract.classify(contract, %{"extension" => "private-value"})
+    diagnostic = Enum.find(classification.violations, &(&1.segments == []))
+
+    assert diagnostic.missing_required == ["required_key"]
+    refute Map.has_key?(diagnostic, :allowed_keys)
+    refute Map.has_key?(diagnostic, :undeclared_key_count)
+    refute inspect(classification) =~ "extension"
+    refute inspect(classification) =~ "private-value"
+  end
+
+  test "does not call extension keys undeclared in a nested open object" do
+    assert {:ok, contract} =
+             ValueContract.compile(%{
+               "type" => "object",
+               "properties" => %{
+                 "payload" => %{
+                   "type" => "object",
+                   "additionalProperties" => true,
+                   "properties" => %{"required_key" => %{"type" => "string"}},
+                   "required" => ["required_key"]
+                 }
+               },
+               "required" => ["payload"]
+             })
+
+    classification =
+      ValueContract.classify(contract, %{
+        "payload" => %{"extension" => "private-value"}
+      })
+
+    diagnostic =
+      Enum.find(
+        classification.violations,
+        &(&1.segments == [{:property, "payload"}])
+      )
+
+    assert diagnostic.missing_required == ["required_key"]
+    refute Map.has_key?(diagnostic, :allowed_keys)
+    refute Map.has_key?(diagnostic, :undeclared_key_count)
+    refute inspect(classification) =~ "extension"
+    refute inspect(classification) =~ "private-value"
+  end
+
+  test "bounds sorted schema-name guidance by count and encoded bytes" do
+    short_names = for index <- 1..40, do: "field-#{String.pad_leading("#{index}", 2, "0")}"
+
+    assert {:ok, count_contract} =
+             ValueContract.compile(%{
+               "type" => "object",
+               "properties" => Map.new(short_names, &{&1, %{"type" => "string"}}),
+               "required" => short_names
+             })
+
+    count_classification = ValueContract.classify(count_contract, %{"caller-only" => "hidden"})
+
+    count_diagnostic =
+      Enum.find(count_classification.violations, &Map.has_key?(&1, :allowed_keys))
+
+    assert count_diagnostic.allowed_keys == Enum.take(Enum.sort(short_names), 32)
+    assert count_diagnostic.allowed_key_count == 40
+    assert count_diagnostic.allowed_keys_truncated
+    assert count_diagnostic.missing_required == Enum.take(Enum.sort(short_names), 32)
+    assert count_diagnostic.missing_required_count == 40
+    assert count_diagnostic.missing_required_truncated
+    refute inspect(count_classification) =~ "caller-only"
+
+    long_names = ["a" <> String.duplicate("x", 2_999), "b" <> String.duplicate("y", 2_999)]
+
+    assert {:ok, byte_contract} =
+             ValueContract.compile(%{
+               "type" => "object",
+               "properties" => Map.new(long_names, &{&1, %{"type" => "string"}})
+             })
+
+    byte_classification = ValueContract.classify(byte_contract, %{"caller-only" => "hidden"})
+    byte_diagnostic = Enum.find(byte_classification.violations, &Map.has_key?(&1, :allowed_keys))
+
+    assert byte_diagnostic.allowed_keys == [hd(long_names)]
+    assert byte_diagnostic.allowed_key_count == 2
+    assert byte_diagnostic.allowed_keys_truncated
+  end
+
+  test "object type failures carry only schema-derived allowed keys" do
+    assert {:ok, contract} =
+             ValueContract.compile(%{
+               "type" => "object",
+               "properties" => %{
+                 "payload" => %{
+                   "type" => "object",
+                   "properties" => %{"answer" => %{"type" => "integer"}},
+                   "required" => ["answer"]
+                 }
+               },
+               "required" => ["payload"]
+             })
+
+    classification = ValueContract.classify(contract, %{"payload" => 42})
+
+    assert %{allowed_keys: ["answer"]} =
+             diagnostic =
+             Enum.find(classification.violations, fn violation ->
+               violation.kind == :type and
+                 violation.segments == [{:property, "payload"}]
+             end)
+
+    refute Map.has_key?(diagnostic, :missing_required)
+    refute Map.has_key?(diagnostic, :undeclared_key_count)
   end
 
   test "retains only locally declared path segments and RFC 6901-escapes them" do
@@ -251,6 +435,37 @@ defmodule PtcRunner.Kernel.ValueContractTest do
              ])
   end
 
+  test "nested object diagnostics retain the selected branch's attested path" do
+    schema = %{
+      "oneOf" => [
+        nested_branch("left", "left_value"),
+        nested_branch("right", "right_value")
+      ]
+    }
+
+    assert {:ok, contract} = ValueContract.compile(schema)
+
+    assert {:error, {:input_contract_failed, classification}} =
+             ExecutionInput.new(
+               %{
+                 "kind" => "left",
+                 "payload" => %{"caller-only" => "private-value"}
+               },
+               :normal,
+               contract
+             )
+
+    assert %{allowed_keys: ["left_value"], missing_required: ["left_value"]} =
+             diagnostic =
+             Enum.find(classification.violations, &Map.has_key?(&1, :allowed_keys))
+
+    assert CommandPath.to_pointer(diagnostic.path) == "/payload"
+    refute Map.has_key?(diagnostic, :segments)
+    refute inspect(classification) =~ "right_value"
+    refute inspect(classification) =~ "caller-only"
+    refute inspect(classification) =~ "private-value"
+  end
+
   test "rejects ambiguous, mismatched, repeated, open, and excessive union branches" do
     [no_change, propose] = decision_schema()["oneOf"]
 
@@ -348,6 +563,54 @@ defmodule PtcRunner.Kernel.ValueContractTest do
           "required" => ["decision", "candidate"]
         }
       ]
+    }
+  end
+
+  defp nested_report_schema do
+    %{
+      "oneOf" => [
+        %{
+          "type" => "object",
+          "required" => ["kind", "timeline"],
+          "properties" => %{
+            "kind" => %{"type" => "string", "const" => "report"},
+            "timeline" => %{
+              "type" => "array",
+              "items" => %{
+                "type" => "object",
+                "required" => ["observed_at", "statement", "citations"],
+                "properties" => %{
+                  "observed_at" => %{"type" => "string"},
+                  "statement" => %{"type" => "string"},
+                  "citations" => %{"type" => "array", "items" => %{"type" => "string"}}
+                }
+              }
+            }
+          }
+        },
+        %{
+          "type" => "object",
+          "properties" => %{
+            "kind" => %{"type" => "string", "const" => "withheld"}
+          },
+          "required" => ["kind"]
+        }
+      ]
+    }
+  end
+
+  defp nested_branch(kind, field) do
+    %{
+      "type" => "object",
+      "properties" => %{
+        "kind" => %{"type" => "string", "const" => kind},
+        "payload" => %{
+          "type" => "object",
+          "properties" => %{field => %{"type" => "integer"}},
+          "required" => [field]
+        }
+      },
+      "required" => ["kind", "payload"]
     }
   end
 


### PR DESCRIPTION
## Summary

- attach sorted, count/byte-bounded schema-derived allowed and missing keys to retained nested object violations
- move missing/undeclared facts off misleading root summaries and onto their exact object paths, while treating explicitly open objects honestly
- preserve selected-branch path attestation and withhold all caller-authored keys and values
- cap complete model-facing result-contract diagnostics before they enter history
- document the user, privacy, contract, and maintainer behavior without adding a `ValueContract.describe/1` Kernel route

## Validation

- focused ValueContract, agent feedback, manifest, execution outcome, and result projection suites: 97 tests passed
- `MIX_ENV=dev mix docs --warnings-as-errors`
- `mix precommit` (6,128 root tests plus Viewer, launcher, package, and standalone release checks)
- pre-push hook (root tests, ExDoc, Credo, generated artifacts, upstream audit, Dialyzer, Viewer, and launcher checks)
- plan review: clean on pass 3
- implementation review: one P2 open-object finding fixed; clean on pass 2

Closes #1161
