### PR TITLE
fix(inspection): expose execution errors and prints

### DIFF
--- a/docs/guides/kernel-repl.md
+++ b/docs/guides/kernel-repl.md
@@ -237,22 +237,35 @@ mix ptc repl \
 layers, and their shared `cap` dependency. Alongside the ordinary `log/*`
 functions, it exports one-page private queries:
 
-- `inspection/runs`;
-- `inspection/model-exchanges`;
-- `inspection/capability-calls`;
-- `inspection/generated-sources`;
-- `inspection/effective-preludes`; and
-- `inspection/provider-exchanges`.
+- `(inspection/runs options-map)`;
+- `(inspection/model-exchanges run-id cursor)`;
+- `(inspection/capability-calls run-id cursor)`;
+- `(inspection/generated-sources run-id cursor)`;
+- `(inspection/effective-preludes run-id cursor)`;
+- `(inspection/provider-exchanges run-id cursor)`;
+- `(inspection/execution-prints run-id cursor)`; and
+- `(inspection/execution-errors run-id cursor)`.
 
-Each collection returns an opaque `next_cursor` for a later page. The
-`inspection.analysis/*` namespace provides bounded whole-result variants:
+Pass `nil` as the initial cursor for a run-scoped query. Each collection
+returns an opaque `next_cursor`; pass that value to the same function to read a
+later page:
 
-- `inspection.analysis/all-runs`;
-- `inspection.analysis/all-model-exchanges`;
-- `inspection.analysis/all-capability-calls`;
-- `inspection.analysis/all-generated-sources`;
-- `inspection.analysis/all-effective-preludes`; and
-- `inspection.analysis/all-provider-exchanges`.
+```clojure
+(def page (inspection/model-exchanges run-id nil))
+(inspection/model-exchanges run-id (get page "next_cursor"))
+```
+
+The `inspection.analysis/*` namespace provides bounded whole-result variants.
+Its last argument is the maximum number of pages to collect:
+
+- `(inspection.analysis/all-runs options-map max-pages)`;
+- `(inspection.analysis/all-model-exchanges run-id max-pages)`;
+- `(inspection.analysis/all-capability-calls run-id max-pages)`;
+- `(inspection.analysis/all-generated-sources run-id max-pages)`;
+- `(inspection.analysis/all-effective-preludes run-id max-pages)`;
+- `(inspection.analysis/all-provider-exchanges run-id max-pages)`;
+- `(inspection.analysis/all-execution-prints run-id max-pages)`; and
+- `(inspection.analysis/all-execution-errors run-id max-pages)`.
 
 For example:
 
@@ -262,12 +275,13 @@ For example:
 (inspection.analysis/all-model-exchanges run-id 10)
 (inspection.analysis/all-generated-sources run-id 10)
 (inspection.analysis/all-provider-exchanges run-id 10)
+(inspection.analysis/all-execution-errors run-id 10)
 ```
 
 Exact model messages, generated source, capability arguments/results,
-effective preludes, and MCP request/response bodies may appear on the
-authorized terminal. They are private data: do not paste or redirect them to a
-public sink.
+effective preludes, MCP request/response bodies, execution prints, and
+execution error details may appear on the authorized terminal. They are
+private data: do not paste or redirect them to a public sink.
 
 The attached-terminal check is an **accident guard, not access control**. It
 cannot distinguish a human terminal from a pseudo-terminal allocated by

--- a/docs/guides/manifests-and-capabilities.md
+++ b/docs/guides/manifests-and-capabilities.md
@@ -390,7 +390,8 @@ evidence back to a mission. A `ptc_trace_snapshot` alias named `history` derives
 `history.list-runs`, `history.get-run`, `history.list-turns`, and
 `history.counters`. A `ptc_inspection_snapshot` alias derives `list-runs`,
 `model-exchanges`, `capability-calls`, `generated-sources`,
-`effective-preludes`, and `provider-exchanges`.
+`effective-preludes`, `provider-exchanges`, `execution-prints`, and
+`execution-errors`.
 [Kernel REPL](kernel-repl.md#private-inspection-mission-sessions) shows the
 queries in use, and the
 [TraceLog contract](../trace-log-contract.md#query-contract) is normative for

--- a/lib/ptc_runner/kernel/inspection_analysis_profile.ex
+++ b/lib/ptc_runner/kernel/inspection_analysis_profile.ex
@@ -30,6 +30,8 @@ defmodule PtcRunner.Kernel.InspectionAnalysisProfile do
   @inspection_capabilities ~w(
     inspection-capability-calls
     inspection-effective-preludes
+    inspection-execution-errors
+    inspection-execution-prints
     inspection-generated-sources
     inspection-list-runs
     inspection-model-exchanges

--- a/lib/ptc_runner/kernel/inspection_capability.ex
+++ b/lib/ptc_runner/kernel/inspection_capability.ex
@@ -3,7 +3,7 @@ defmodule PtcRunner.Kernel.InspectionCapability do
   Fixed read-only capabilities over one private `InspectionSnapshot`.
 
   Profile-backed sessions receive stable `inspection-*` names. A manifest
-  installation derives the same six operations from its selected alias as
+  installation derives the same eight operations from its selected alias as
   `<alias>.<operation>`. Both forms retain only an opaque snapshot handle and
   delegate to the same query layer. Every result carries the frozen capture's
   `snapshot_hash`, matching the provider snapshot's `content_snapshot_hash`,
@@ -20,7 +20,9 @@ defmodule PtcRunner.Kernel.InspectionCapability do
     :capability_calls,
     :generated_sources,
     :effective_preludes,
-    :provider_exchanges
+    :provider_exchanges,
+    :execution_prints,
+    :execution_errors
   ]
 
   @doc false
@@ -64,6 +66,8 @@ defmodule PtcRunner.Kernel.InspectionCapability do
   defp capability_name(:profile, :generated_sources), do: "inspection-generated-sources"
   defp capability_name(:profile, :effective_preludes), do: "inspection-effective-preludes"
   defp capability_name(:profile, :provider_exchanges), do: "inspection-provider-exchanges"
+  defp capability_name(:profile, :execution_prints), do: "inspection-execution-prints"
+  defp capability_name(:profile, :execution_errors), do: "inspection-execution-errors"
 
   defp capability_name({:provider, provider}, operation),
     do: provider <> "." <> operation_name(operation)
@@ -74,6 +78,8 @@ defmodule PtcRunner.Kernel.InspectionCapability do
   defp operation_name(:generated_sources), do: "generated-sources"
   defp operation_name(:effective_preludes), do: "effective-preludes"
   defp operation_name(:provider_exchanges), do: "provider-exchanges"
+  defp operation_name(:execution_prints), do: "execution-prints"
+  defp operation_name(:execution_errors), do: "execution-errors"
 
   defp capability(snapshot, name, operation) do
     Capability.new(

--- a/lib/ptc_runner/kernel/inspection_query.ex
+++ b/lib/ptc_runner/kernel/inspection_query.ex
@@ -20,9 +20,9 @@ defmodule PtcRunner.Kernel.InspectionQuery do
   be copied into `base_source_hash` without reinterpretation.
 
   V3 execution-phase diagnostics (`execution-prints`, `execution-error`) are
-  counted in each `list_runs` row's `counts` but are not an independent
-  collection: a raw artifact load remains the way to read their bounded
-  `prints` list and `details` map for one `evaluation_id`.
+  exposed as run-scoped collections alongside their counts in each `list_runs`
+  row. Their items retain the correlated `evaluation_id`, sequence, timestamp,
+  environment, and exact bounded diagnostic payload.
   V4 projections include `mission_name` on every mission-owned result so
   repeated component and capability names remain unambiguous.
   """
@@ -36,7 +36,9 @@ defmodule PtcRunner.Kernel.InspectionQuery do
     :capability_calls,
     :generated_sources,
     :effective_preludes,
-    :provider_exchanges
+    :provider_exchanges,
+    :execution_prints,
+    :execution_errors
   ]
 
   @type operation ::
@@ -46,6 +48,8 @@ defmodule PtcRunner.Kernel.InspectionQuery do
           | :generated_sources
           | :effective_preludes
           | :provider_exchanges
+          | :execution_prints
+          | :execution_errors
 
   @spec compile([[map()]], binary()) ::
           {:ok, %{source_id: binary(), collections: map()}} | {:error, atom()}
@@ -103,14 +107,24 @@ defmodule PtcRunner.Kernel.InspectionQuery do
         |> records_of_type("prelude-source")
         |> Enum.map(&prelude_item/1)
 
+      execution_prints =
+        records
+        |> records_of_type("execution-prints")
+        |> Enum.map(&execution_item/1)
+
+      execution_errors =
+        records
+        |> records_of_type("execution-error")
+        |> Enum.map(&execution_item/1)
+
       counts = %{
         "model_exchanges" => length(model_exchanges),
         "capability_calls" => length(capability_calls),
         "generated_sources" => length(generated_sources),
         "effective_preludes" => length(effective_preludes),
         "provider_exchanges" => length(provider_pairs),
-        "execution_prints" => length(records_of_type(records, "execution-prints")),
-        "execution_errors" => length(records_of_type(records, "execution-error"))
+        "execution_prints" => length(execution_prints),
+        "execution_errors" => length(execution_errors)
       }
 
       {:ok,
@@ -128,7 +142,9 @@ defmodule PtcRunner.Kernel.InspectionQuery do
          capability_calls: capability_calls,
          generated_sources: generated_sources,
          effective_preludes: effective_preludes,
-         provider_exchanges: provider_pairs
+         provider_exchanges: provider_pairs,
+         execution_prints: execution_prints,
+         execution_errors: execution_errors
        }}
     end
   end
@@ -271,6 +287,17 @@ defmodule PtcRunner.Kernel.InspectionQuery do
     }
   end
 
+  defp execution_item(record) do
+    %{
+      "run_id" => record["run_id"],
+      "trace_id" => record["trace_id"],
+      "evaluation_id" => record["correlation"]["evaluation_id"],
+      "sequence" => record["sequence"],
+      "timestamp" => record["timestamp"]
+    }
+    |> Map.merge(record["payload"])
+  end
+
   defp descriptor_hash(hash), do: "sha256:" <> hash
 
   defp model_exchange?(%{"environment" => "workflow", "name" => "llm-request"}), do: true
@@ -286,7 +313,9 @@ defmodule PtcRunner.Kernel.InspectionQuery do
       capability_calls: merge_collection(compiled, :capability_calls),
       generated_sources: merge_collection(compiled, :generated_sources),
       effective_preludes: merge_collection(compiled, :effective_preludes),
-      provider_exchanges: merge_collection(compiled, :provider_exchanges)
+      provider_exchanges: merge_collection(compiled, :provider_exchanges),
+      execution_prints: merge_collection(compiled, :execution_prints),
+      execution_errors: merge_collection(compiled, :execution_errors)
     }
   end
 
@@ -313,7 +342,9 @@ defmodule PtcRunner.Kernel.InspectionQuery do
               :capability_calls,
               :generated_sources,
               :effective_preludes,
-              :provider_exchanges
+              :provider_exchanges,
+              :execution_prints,
+              :execution_errors
             ] do
     with :ok <- validate_keys(arguments, ~w(run_id limit cursor order)),
          true <- valid_string?(run_id),

--- a/lib/ptc_runner/kernel/inspection_snapshot.ex
+++ b/lib/ptc_runner/kernel/inspection_snapshot.ex
@@ -39,7 +39,9 @@ defmodule PtcRunner.Kernel.InspectionSnapshot do
     :capability_calls,
     :generated_sources,
     :effective_preludes,
-    :provider_exchanges
+    :provider_exchanges,
+    :execution_prints,
+    :execution_errors
   ]
 
   @enforce_keys [:pid, :token]

--- a/priv/preludes/kernel/inspection.analysis.clj
+++ b/priv/preludes/kernel/inspection.analysis.clj
@@ -44,3 +44,17 @@
   (cap/collect-pages
     (fn [cursor] (inspection/provider-exchanges run-id cursor))
     max-pages))
+
+(defn all-execution-prints
+  "Reads one run's execution prints until exhausted or `max-pages` is reached."
+  [run-id max-pages]
+  (cap/collect-pages
+    (fn [cursor] (inspection/execution-prints run-id cursor))
+    max-pages))
+
+(defn all-execution-errors
+  "Reads one run's execution errors until exhausted or `max-pages` is reached."
+  [run-id max-pages]
+  (cap/collect-pages
+    (fn [cursor] (inspection/execution-errors run-id cursor))
+    max-pages))

--- a/priv/preludes/kernel/inspection.core.clj
+++ b/priv/preludes/kernel/inspection.core.clj
@@ -27,3 +27,13 @@
   (cap/unwrap!
     (tool/inspection-provider-exchanges
       (cap/with-cursor {"run_id" run-id "limit" 100} cursor))))
+
+(defn execution-prints [run-id cursor]
+  (cap/unwrap!
+    (tool/inspection-execution-prints
+      (cap/with-cursor {"run_id" run-id "limit" 100} cursor))))
+
+(defn execution-errors [run-id cursor]
+  (cap/unwrap!
+    (tool/inspection-execution-errors
+      (cap/with-cursor {"run_id" run-id "limit" 100} cursor))))

--- a/test/ptc_runner/kernel/cap_agent_main_test.exs
+++ b/test/ptc_runner/kernel/cap_agent_main_test.exs
@@ -181,7 +181,9 @@ defmodule PtcRunner.Kernel.CapAgentMainTest do
             "inspection.analysis/all-capability-calls",
             "inspection.analysis/all-generated-sources",
             "inspection.analysis/all-effective-preludes",
-            "inspection.analysis/all-provider-exchanges"
+            "inspection.analysis/all-provider-exchanges",
+            "inspection.analysis/all-execution-prints",
+            "inspection.analysis/all-execution-errors"
           ] do
         assert {:ok, _export} = Prelude.fetch_export(bundle.prelude, ref)
       end

--- a/test/ptc_runner/kernel/inspection_analysis_profile_test.exs
+++ b/test/ptc_runner/kernel/inspection_analysis_profile_test.exs
@@ -262,6 +262,8 @@ defmodule PtcRunner.Kernel.InspectionAnalysisProfileTest do
       %{"run_id" => fixture.run_id},
       %{"run_id" => fixture.run_id},
       %{"run_id" => fixture.run_id},
+      %{"run_id" => fixture.run_id},
+      %{"run_id" => fixture.run_id},
       %{"run_id" => fixture.run_id}
     ]
 
@@ -270,7 +272,8 @@ defmodule PtcRunner.Kernel.InspectionAnalysisProfileTest do
       assert profile.callback.(query) == manifest.callback.(query)
     end)
 
-    provider_exchanges = List.last(profile_capabilities)
+    provider_exchanges =
+      Enum.find(profile_capabilities, &(&1.name == "inspection-provider-exchanges"))
 
     assert {:ok,
             %{
@@ -374,6 +377,43 @@ defmodule PtcRunner.Kernel.InspectionAnalysisProfileTest do
     assert exchange["response"]["result"]["content"] == [
              %{"type" => "text", "text" => "private-tool-result-#{fixture.run_id}"}
            ]
+
+    execution_id = "workflow-eval-#{fixture.run_id}"
+    execution_print = "private-print-#{fixture.run_id}"
+
+    assert {:ok,
+            %{
+              value: %{
+                "complete?" => true,
+                "items" => [
+                  %{
+                    "evaluation_id" => ^execution_id,
+                    "prints" => [^execution_print]
+                  }
+                ]
+              }
+            }} =
+             AnalysisSession.evaluate(
+               session,
+               ~s|(inspection.analysis/all-execution-prints "#{fixture.run_id}" 2)|
+             )
+
+    assert {:ok,
+            %{
+              value: %{
+                "items" => [
+                  %{
+                    "evaluation_id" => ^execution_id,
+                    "kind" => "limit_exceeded",
+                    "reason" => "timeout"
+                  }
+                ]
+              }
+            }} =
+             AnalysisSession.evaluate(
+               session,
+               ~s|(inspection/execution-errors "#{fixture.run_id}" nil)|
+             )
 
     assert {:ok, %{lifecycle: :closed}} = AnalysisSession.close(session)
     assert File.regular?(trace_path)

--- a/test/ptc_runner/kernel/inspection_snapshot_test.exs
+++ b/test/ptc_runner/kernel/inspection_snapshot_test.exs
@@ -13,6 +13,7 @@ defmodule PtcRunner.Kernel.InspectionSnapshotTest do
   alias PtcRunner.Kernel.InspectionSnapshot
   alias PtcRunner.Kernel.RunBuilder
   alias PtcRunner.Kernel.TraceSnapshot
+  alias PtcRunner.TestSupport.PrivateInspectionFixture
   alias PtcRunner.TestSupport.RunLifecycle
 
   @source "(return 42)"
@@ -248,6 +249,8 @@ defmodule PtcRunner.Kernel.InspectionSnapshotTest do
       %{"run_id" => "v2-run"},
       %{"run_id" => "v2-run"},
       %{"run_id" => "v2-run"},
+      %{"run_id" => "v2-run"},
+      %{"run_id" => "v2-run"},
       %{"run_id" => "v2-run"}
     ]
 
@@ -263,6 +266,49 @@ defmodule PtcRunner.Kernel.InspectionSnapshotTest do
                "run_id" => "v2-run",
                "limit" => 1
              })
+  end
+
+  @tag :tmp_dir
+  test "V3 execution diagnostics are exposed as bounded run-scoped queries", %{tmp_dir: root} do
+    {trace, inspection} = source_directories(root)
+    write_run(trace, inspection, "v3-run", 3)
+
+    {:ok, trace_snapshot} = TraceSnapshot.start({:directory, trace}, owner: self())
+
+    {:ok, snapshot} =
+      InspectionSnapshot.start({:directory, inspection}, trace_snapshot, owner: self())
+
+    on_exit(fn ->
+      InspectionSnapshot.stop(snapshot)
+      TraceSnapshot.stop(trace_snapshot)
+    end)
+
+    assert {:ok,
+            %{
+              "items" => [
+                %{
+                  "evaluation_id" => "workflow-eval-v3-run",
+                  "environment" => "workflow",
+                  "prints" => ["private-print-v3-run"],
+                  "truncated" => false
+                }
+              ],
+              "next_cursor" => nil
+            }} = InspectionSnapshot.query(snapshot, :execution_prints, %{"run_id" => "v3-run"})
+
+    assert {:ok,
+            %{
+              "items" => [
+                %{
+                  "evaluation_id" => "workflow-eval-v3-run",
+                  "environment" => "workflow",
+                  "kind" => "limit_exceeded",
+                  "reason" => "timeout",
+                  "details" => %{"limit" => "run_duration_ms", "limit_ms" => 1_000}
+                }
+              ],
+              "next_cursor" => nil
+            }} = InspectionSnapshot.query(snapshot, :execution_errors, %{"run_id" => "v3-run"})
   end
 
   @tag :tmp_dir
@@ -331,7 +377,9 @@ defmodule PtcRunner.Kernel.InspectionSnapshotTest do
              "inspection-capability-calls",
              "inspection-generated-sources",
              "inspection-effective-preludes",
-             "inspection-provider-exchanges"
+             "inspection-provider-exchanges",
+             "inspection-execution-prints",
+             "inspection-execution-errors"
            ]
 
     assert Enum.map(provider_capabilities, & &1.name) == [
@@ -340,10 +388,13 @@ defmodule PtcRunner.Kernel.InspectionSnapshotTest do
              "private.capability-calls",
              "private.generated-sources",
              "private.effective-preludes",
-             "private.provider-exchanges"
+             "private.provider-exchanges",
+             "private.execution-prints",
+             "private.execution-errors"
            ]
 
-    provider_exchange = List.last(provider_capabilities)
+    provider_exchange =
+      Enum.find(provider_capabilities, &(&1.name == "private.provider-exchanges"))
 
     assert {:ok, %{"items" => []}} =
              provider_exchange.callback.(%{"run_id" => "named"})
@@ -766,7 +817,7 @@ defmodule PtcRunner.Kernel.InspectionSnapshotTest do
       arguments: %{"path" => "private-#{run_id}.txt"}
     })
 
-    if version == 2 do
+    if version in [2, 3] do
       emit!(sink, "mcp-request", %{capability_id: "tool-#{run_id}", request_id: 7}, %{
         transport: :stdio,
         body: %{
@@ -837,6 +888,10 @@ defmodule PtcRunner.Kernel.InspectionSnapshotTest do
       source_bytes: byte_size(@source)
     })
 
+    if version == 3 do
+      PrivateInspectionFixture.emit_execution_diagnostics!(sink, run_id)
+    end
+
     {:ok, records} = InspectionSink.records(sink)
     path = Path.join(directory, "#{run_id}.inspection.jsonl")
     :ok = InspectionArtifact.persist(path, records, events)
@@ -894,7 +949,8 @@ defmodule PtcRunner.Kernel.InspectionSnapshotTest do
         "source_hash" => @source_hash,
         "source_bytes" => byte_size(@source)
       }),
-      event(run_id, 5, "run-stopped", %{"outcome" => "ok"})
+      PrivateInspectionFixture.workflow_evaluation_event(run_id, 5),
+      event(run_id, 6, "run-stopped", %{"outcome" => "ok"})
     ]
   end
 

--- a/test/support/private_inspection_fixture.ex
+++ b/test/support/private_inspection_fixture.ex
@@ -47,7 +47,8 @@ defmodule PtcRunner.TestSupport.PrivateInspectionFixture do
         "source_hash" => @source_hash,
         "source_bytes" => byte_size(@source)
       }),
-      event(run_id, 5, "run-stopped", %{"outcome" => "ok"})
+      workflow_evaluation_event(run_id, 5),
+      event(run_id, 6, "run-stopped", %{"outcome" => "failed"})
     ]
   end
 
@@ -56,7 +57,7 @@ defmodule PtcRunner.TestSupport.PrivateInspectionFixture do
       InspectionSink.start(
         run_id: run_id,
         trace_id: "trace-#{run_id}",
-        schema_version: 2
+        schema_version: 3
       )
 
     emit!(sink, "capability-input", %{capability_id: "llm-#{run_id}"}, %{
@@ -122,10 +123,37 @@ defmodule PtcRunner.TestSupport.PrivateInspectionFixture do
       source_bytes: byte_size(@source)
     })
 
+    emit_execution_diagnostics!(sink, run_id)
+
     {:ok, records} = InspectionSink.records(sink)
     path = Path.join(directory, "#{run_id}.inspection.jsonl")
     :ok = InspectionArtifact.persist(path, records, events)
     :ok = InspectionSink.stop(sink)
+  end
+
+  def emit_execution_diagnostics!(sink, run_id) do
+    emit!(sink, "execution-prints", %{evaluation_id: "workflow-eval-#{run_id}"}, %{
+      environment: :workflow,
+      prints: ["private-print-#{run_id}"],
+      truncated: false
+    })
+
+    emit!(sink, "execution-error", %{evaluation_id: "workflow-eval-#{run_id}"}, %{
+      environment: :workflow,
+      kind: :limit_exceeded,
+      reason: :timeout,
+      details: %{"limit" => "run_duration_ms", "limit_ms" => 1_000}
+    })
+  end
+
+  def workflow_evaluation_event(run_id, sequence) do
+    event(run_id, sequence, "evaluation-started", %{
+      "evaluation_id" => "workflow-eval-#{run_id}",
+      "environment" => "workflow",
+      "program_kind" => "ptc-lisp",
+      "source_hash" => @source_hash,
+      "source_bytes" => byte_size(@source)
+    })
   end
 
   defp emit!(sink, type, correlation, payload),


### PR DESCRIPTION
## Summary

- add bounded, run-scoped inspection queries for V3 execution prints and errors
- expose matching fixed-profile capabilities, manifest alias operations, and `inspection.analysis/all-*` traversal helpers
- document every private query signature, initial cursor usage, and page bounds

## Root cause and impact

The inspection compiler counted `execution-prints` and `execution-error` records but did not retain them in query collections, and the capability/profile/prelude allowlists had no corresponding operations. Investigators therefore had to leave the private analysis profile and parse raw JSONL. The guide also showed only the options-map shape used by `inspection/runs`, leaving the positional `run-id`/`cursor` convention undocumented.

This change makes the already-captured diagnostics available through the same immutable snapshot, cursor binding, paging limits, and private-result policy as the other inspection evidence.

## Validation

- `mix test test/ptc_runner/kernel/inspection_snapshot_test.exs test/ptc_runner/kernel/inspection_analysis_profile_test.exs test/ptc_runner/kernel/cap_agent_main_test.exs`
- `MIX_ENV=dev mix docs --warnings-as-errors`
- `mix precommit`
- `PTC_PRE_PUSH_MAX_CASES=2 git push` (full pre-push tests, generated-artifact checks, upstream audit, Credo, Dialyzer, and Viewer tests)

Closes #1300
Closes #1305