### PR TITLE
docs: put a live model run on the first screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,20 @@ anything dangerous in the first place.
 > PtcRunner is a 0.x project under active development. Breaking changes are
 > expected.
 
+## Try it
+
+From the repository root:
+
+```console
+mix deps.get
+mix ptc run examples/kernel-tutorial/01-orders/ptc.json
+```
+
+The example loads JSON input, runs a PTC-Lisp function, and returns a JSON
+result. It needs no model credentials and no host code. Two more commands add
+an API key and get a model to write the program instead:
+[Quickstart](docs/guides/quickstart.md).
+
 ## Why it is safe
 
 Most code-mode implementations generate Python or JavaScript and put a container
@@ -162,21 +176,6 @@ promoted preludes automatically is future work. The important property holds
 either way: a candidate can change how existing tools are used, but cannot grant
 itself new tools or credentials.
 
-## Try it
-
-From the repository root:
-
-```console
-mix deps.get
-mix ptc run examples/kernel-tutorial/01-orders/ptc.json
-```
-
-The example loads JSON input, runs a PTC-Lisp function, and returns a JSON
-result. It needs no model credentials and no host code. See
-[Getting started](docs/guides/getting-started.md) for the walkthrough and trace
-commands, then [Building agents](docs/guides/building-agents.md) for a live
-model-generated program.
-
 ## Availability
 
 The product runs from a source checkout with Elixir and Mix or as a locally
@@ -194,16 +193,18 @@ the target machine.
 
 Read these in order. Each one owns its topic and links onward.
 
-1. [Getting started](docs/guides/getting-started.md) — run a credential-free
+1. [Quickstart](docs/guides/quickstart.md) — four commands from a clone to a
+   live model writing and running a program.
+2. [Getting started](docs/guides/getting-started.md) — run a credential-free
    PTC-Lisp workflow and inspect its result and trace.
-2. [Manifests and capabilities](docs/guides/manifests-and-capabilities.md) —
+3. [Manifests and capabilities](docs/guides/manifests-and-capabilities.md) —
    assemble components, data, providers, limits, contracts, and event policy.
-3. [Host configuration](docs/guides/host-configuration.md) — the operator
+4. [Host configuration](docs/guides/host-configuration.md) — the operator
    document: credentials, provider sources, transports, data classes, and
    installed ceilings.
-4. [Building agents](docs/guides/building-agents.md) — put orchestration and
+5. [Building agents](docs/guides/building-agents.md) — put orchestration and
    agent policy in PTC-Lisp while keeping mission authority narrow.
-5. [Running and debugging](docs/guides/running-and-debugging.md) — the
+6. [Running and debugging](docs/guides/running-and-debugging.md) — the
    commands, results, traces, private inspection, and development Viewer.
 
 ### Going further
@@ -227,9 +228,16 @@ Runnable projects live under
 [PTC-Lisp specification](docs/ptc-lisp-specification.md),
 [function reference](docs/function-reference.md),
 [signature syntax](docs/signature-syntax.md),
-[TraceLog contract](docs/trace-log-contract.md),
-[conformance report](docs/conformance/index.md), and the
-[Kernel maintainer guide](docs/guides/kernel-maintainer.md).
+[TraceLog contract](docs/trace-log-contract.md), and the
+[conformance report](docs/conformance/index.md).
+
+### Maintainers
+
+For changing PtcRunner rather than using it:
+[Kernel maintainer guide](docs/guides/kernel-maintainer.md),
+[coding agent review workflow](docs/guides/coding-agent-review-workflow.md),
+[duplication gate](docs/guides/duplication-gate.md), and
+[documentation guidelines](docs/guides/documentation-guidelines.md).
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -220,8 +220,10 @@ Read these in order. Each one owns its topic and links onward.
 ### Examples
 
 Runnable projects live under
-[`examples/kernel-tutorial/`](examples/kernel-tutorial/README.md) and
-[`examples/kernel-inspection-lab/`](examples/kernel-inspection-lab/README.md).
+[`examples/kernel-tutorial/`](examples/kernel-tutorial/README.md),
+[`examples/kernel-inspection-lab/`](examples/kernel-inspection-lab/README.md),
+and
+[`examples/named-mission-reader-writer/`](examples/named-mission-reader-writer/README.md).
 
 ### Reference
 

--- a/docs/guides/building-agents.md
+++ b/docs/guides/building-agents.md
@@ -5,7 +5,8 @@ Kernel provides bounded execution and authority; PTC-Lisp libraries define how
 an agent prompts a model, handles feedback, retries, delegates work, remembers
 successful state, and decides when to return or fail.
 
-Read [Getting started](getting-started.md) first for a credential-free run.
+Read [Getting started](getting-started.md) first for a credential-free run, or
+the [Quickstart](quickstart.md) if you only need the commands.
 [Manifests and capabilities](manifests-and-capabilities.md) documents the
 manifest keys used throughout this guide,
 [Host configuration](host-configuration.md) documents the operator document and

--- a/docs/guides/coding-agent-review-workflow.md
+++ b/docs/guides/coding-agent-review-workflow.md
@@ -1,5 +1,8 @@
 # Coding agent review workflow
 
+**Audience: people changing PtcRunner itself.** It describes how this
+repository reviews its own changes.
+
 Use this workflow when a change requires an independent Codex review. Its goal
 is to find substantive defects without repeatedly paying for cold reviews of
 the same code. Review complements design, tests, Dialyzer, and repository

--- a/docs/guides/documentation-guidelines.md
+++ b/docs/guides/documentation-guidelines.md
@@ -1,7 +1,8 @@
 # Documentation guidelines
 
-Use this guide when writing module documentation, guides, specifications, and
-plans. `AGENTS.md` remains the canonical repository instruction file.
+**Audience: people changing PtcRunner itself.** Use this guide when writing
+module documentation, guides, specifications, and plans in this repository.
+`AGENTS.md` remains the canonical repository instruction file.
 
 ## Choose the right documentation layer
 

--- a/docs/guides/duplication-gate.md
+++ b/docs/guides/duplication-gate.md
@@ -1,5 +1,8 @@
 # Duplication gate
 
+**Audience: people changing PtcRunner itself.** This gate runs over this
+repository's own source; it is not part of the runtime an application uses.
+
 `mix precommit` and CI run `scripts/duplication_gate.sh check`, which detects
 copy-pasted code with [ExDNA](https://github.com/elixir-vibe/ex_dna) and
 compares the result against `.duplication-baseline.json`.

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -1,8 +1,12 @@
 # Getting started
 
-This guide runs a complete credential-free PtcRunner workflow. The workflow is
-written in PTC-Lisp, receives JSON input, and returns a bounded JSON value plus
-runtime usage. No model key and no host code are required.
+This guide runs a complete PtcRunner workflow and reads it line by line. It
+starts credential-free — the first workflow is written in PTC-Lisp, receives
+JSON input, and returns a bounded JSON value plus runtime usage — and ends at a
+live model call.
+
+If you would rather see that model call first and read afterwards, the
+[Quickstart](quickstart.md) gets there in four commands.
 
 PTC-Lisp is a small, eager, bounded subset of Clojure, with a few additions for
 agent execution such as `return`, `fail`, `tool/...` capability calls, and the
@@ -16,7 +20,7 @@ runtime-included release through `bin/ptc`.
 
 ## Create a minimal application
 
-The shared command surface accepts `ptc init DIRECTORY`. From a source checkout:
+`ptc init DIRECTORY` creates an empty application. From a source checkout:
 
 ```console
 mix ptc init hello-ptc
@@ -50,13 +54,10 @@ stable contract:
 }
 ```
 
-The complete scaffold is validated in memory and assembled in an owner-only
-sibling directory. Publication uses an atomic no-replace rename, so an
-existing directory or symlink is never merged, overwritten, or removed. A
-failed initialization remains path-free, but distinguishes an existing target,
-a missing parent directory, and an unusable parent directory. Other staging or
-publication failures return `initialization_failed`; a clean pre-publication
-failure can be retried.
+The scaffold is validated before any filesystem access and published with an
+atomic no-replace rename, so an existing directory or symlink is never merged
+or overwritten. [Running and debugging](running-and-debugging.md#commands)
+lists what a refused initialization reports.
 
 ## Run the example
 
@@ -78,9 +79,10 @@ The command prints the compact JSON result value:
 }
 ```
 
-The rest of the result reports remaining time, capability calls, subordinate
-evaluations, protocol errors, retained continuation state, and dropped events.
-Values such as remaining time vary between runs.
+The rest of the result reports usage — remaining time, capability calls,
+evaluations, and dropped events — which
+[Running and debugging](running-and-debugging.md#understand-results-and-errors)
+breaks down field by field. Values such as remaining time vary between runs.
 
 ## Read the project
 
@@ -152,11 +154,11 @@ mix ptc repl \
   -e '(log.analysis/all-runs {"limit" 50} 10)'
 ```
 
-The profile receives an immutable capture and has no filesystem, network,
-model, private-inspection, or nested-evaluation authority. The final argument
-is a page bound. The result carries the immutable source's `snapshot_hash`.
-The returned `complete?` field is `false` if that bound stops the traversal
-before the captured source is exhausted.
+The profile queries one frozen capture of that directory and has no filesystem,
+network, model, private-inspection, or nested-evaluation authority. The final
+argument is a page bound; the
+[Kernel REPL guide](kernel-repl.md#log-analysis-mission-sessions) documents the
+`complete?` and `snapshot_hash` fields the result carries.
 
 ## Try the language directly
 
@@ -169,21 +171,62 @@ mix ptc repl \
   -e '(+ *1 5)'
 ```
 
-Successful definitions and the three most recent ordinary values persist for
-one session. Failed forms do not publish their candidate definitions.
+Successful definitions and the three most recent values persist for one
+session, and a failed form leaves that state untouched. The
+[Kernel REPL guide](kernel-repl.md) covers the other session modes.
+
+## Call a model
+
+Everything above is deterministic. Adding a model takes one credential and one
+extra flag.
+
+Copy `.env.example` to the Git-ignored `.env` and set `OPENROUTER_API_KEY` to
+your [OpenRouter](https://openrouter.ai/keys) key. That is the only setup step;
+[Host configuration](host-configuration.md#credentials) documents the three
+declaration forms and how to move off `.env` for a real deployment.
+
+```console
+mix ptc run examples/kernel-tutorial/02-deepseek-extract/ptc.json \
+  --host-config examples/kernel-tutorial/ptc-host.json
+```
+
+```json
+{"model_output":"{\"project\":\"Atlas\",\"owner\":\"Priya\",\"risk\":\"delayed vendor security approval\"}","note":"model_output is model text; validate or parse it before production use"}
+```
+
+The model's exact wording varies between runs; the result shape does not.
+
+`--host-config` names the operator document that gives the manifest's
+`deepseek` alias a model and a credential. The manifest selects that alias and
+may narrow it, but cannot name a model, endpoint, or key. Here the human wrote
+the request and owns the output policy; the model only returned data, and that
+data is untrusted text until you parse and validate it.
+
+Let the model write the program instead:
+
+```console
+mix ptc run examples/kernel-tutorial/04-multi-turn-agent/ptc.json \
+  --host-config examples/kernel-tutorial/ptc-host.json
+```
+
+```json
+{"ok":true,"value":42}
+```
+
+The model authored PTC-Lisp across two turns and the runtime evaluated it in
+the confined mission environment.
 
 ## Next steps
 
 Continue in this order:
 
-1. [Manifests and capabilities](manifests-and-capabilities.md) documents the
+1. [Building agents](building-agents.md) explains the agent loop, the
+   correction protocol, and confined model-authored mission programs.
+2. [Manifests and capabilities](manifests-and-capabilities.md) documents the
    declarative authority boundary — components, input, contracts, providers,
    limits, and event policy.
-2. [Host configuration](host-configuration.md) is the operator document that
-   installs providers and supplies credentials. You need it before any example
-   that calls a model.
-3. [Building agents](building-agents.md) explains model calls and confined
-   model-authored mission programs.
+3. [Host configuration](host-configuration.md) is the operator document that
+   installs providers, supplies credentials, and sets ceilings.
 4. [Running and debugging](running-and-debugging.md) covers commands, traces,
    private inspection, and the development Viewer.
 

--- a/docs/guides/kernel-maintainer.md
+++ b/docs/guides/kernel-maintainer.md
@@ -1,12 +1,15 @@
 # Kernel maintainer guide
 
+**Audience: people changing PtcRunner itself.** Nothing here is needed to build
+an application on it.
+
 This guide is the architectural map for the implemented Kernel. It explains
 ownership and responsibility boundaries without duplicating field-level API
 reference. Exact options, return values, limits, state transitions, and error
 atoms belong in the owning `PtcRunner.Kernel.*` or `PtcRunner.Lisp.*` module
 documentation.
 
-For application authoring, start with
+For application authoring, start with the [Quickstart](quickstart.md),
 [Getting started](getting-started.md), the
 [manifest guide](manifests-and-capabilities.md),
 [Host configuration](host-configuration.md),

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -1,0 +1,93 @@
+# Quickstart
+
+Four commands, from a clone to a program the model wrote and the runtime ran.
+This page only performs the steps; every "why" is a link.
+
+You need Elixir and Erlang/OTP, and an
+[OpenRouter](https://openrouter.ai/keys) API key for the model step. `mise
+install` installs the pinned toolchain versions; `docs/development-setup.md`
+covers a machine that has neither.
+
+## 1. Run a workflow with no credentials
+
+```console
+git clone https://github.com/andreasronge/ptc_runner
+cd ptc_runner
+mix deps.get
+mix ptc run examples/kernel-tutorial/01-orders/ptc.json
+```
+
+```json
+{"order_count":3,"paid_count":2,"paid_total":335.75,"pending_ids":["A-101"]}
+```
+
+That is a PTC-Lisp function reading JSON input. No model, no host document, no
+network. The first run compiles the dependencies and the project, which took
+about 90 seconds from a fresh clone; later runs start in a few seconds.
+
+## 2. Supply a model credential
+
+```console
+cp .env.example .env
+chmod 600 .env
+```
+
+Set `OPENROUTER_API_KEY` in `.env` to your key. `.env` is Git-ignored, and
+credentials never belong in a manifest, a PTC-Lisp file, or a trace.
+[Host configuration](host-configuration.md#credentials) documents the three
+declaration forms and how to move off `.env` for a real deployment.
+
+## 3. Let the model write the program
+
+```console
+mix ptc run examples/kernel-tutorial/04-multi-turn-agent/ptc.json \
+  --host-config examples/kernel-tutorial/ptc-host.json
+```
+
+```json
+{"ok":true,"value":42}
+```
+
+The model was given a task, wrote PTC-Lisp, and the runtime evaluated that
+program in the confined mission environment over two turns. Two live model
+calls cost a fraction of a cent.
+
+[`ptc-host.json`](../../examples/kernel-tutorial/ptc-host.json) is the operator
+document: it maps the `deepseek` alias to a model and binds it to the
+credential. The manifest selects that alias and may narrow it, but cannot name
+a model, endpoint, or key. That asymmetry is the whole security argument, laid
+out in the [README](../../README.md#why-it-is-safe).
+
+## If step 3 fails
+
+A missing or unreadable key aborts before the run:
+
+```text
+** (Mix) error: active_preflight/credential_unavailable: a required provider
+credential is unavailable
+```
+
+It means `OPENROUTER_API_KEY` was not visible to the command. The message does
+not yet name the variable or the alias
+([#1166](https://github.com/andreasronge/ptc_runner/issues/1166)), and
+`ptc doctor --connect` aborts the same way instead of reporting a failed check
+([#1302](https://github.com/andreasronge/ptc_runner/issues/1302)). Once the key
+is in place, that command confirms it:
+
+```console
+mix ptc doctor examples/kernel-tutorial/04-multi-turn-agent/ptc.json \
+  --host-config examples/kernel-tutorial/ptc-host.json --connect
+```
+
+Every check reports `pass`, including `provider/deepseek/credentials`.
+
+## Next
+
+- [Getting started](getting-started.md) — the same ground at walking pace: the
+  manifest, the entry function, results, traces, and the REPL.
+- [Building agents](building-agents.md) — the agent loop, the correction
+  protocol, and giving a model a small mission API.
+- [`examples/kernel-tutorial/`](../../examples/kernel-tutorial/README.md) — the
+  other four examples. `02-deepseek-extract` calls a model without generating
+  code, `03-file-agent` gives the model one MCP tool and needs Node, and
+  `05-signature-feedback` is credential-free.

--- a/docs/guides/running-and-debugging.md
+++ b/docs/guides/running-and-debugging.md
@@ -35,7 +35,13 @@ rendering paths.
 [Getting started](getting-started.md#create-a-minimal-application).
 Initialization validates the scaffold before filesystem access and publishes
 the completed directory atomically without replacing an existing directory or
-symlink.
+symlink. A refused initialization leaves the filesystem untouched and names the
+condition that stopped it: `publication/initialization_target_exists` for an
+existing target, `publication/initialization_parent_missing` or
+`publication/initialization_parent_unusable` for the parent directory, and
+`publication/initialization_failed` when no safe public cause can be disclosed.
+Every failure reported before publication can be retried once its condition is
+resolved.
 
 Run `mix ptc help COMMAND` or `bin/ptc help COMMAND` for help generated from the
 same per-command declarations the strict parser accepts.

--- a/examples/kernel-tutorial/03-file-agent/ptc.json
+++ b/examples/kernel-tutorial/03-file-agent/ptc.json
@@ -49,7 +49,10 @@
         }
       ],
       "data": {
-      }
+      },
+      "providers": [
+        "workspace"
+      ]
     }
   }
 }

--- a/examples/kernel-tutorial/04-multi-turn-agent/ptc.json
+++ b/examples/kernel-tutorial/04-multi-turn-agent/ptc.json
@@ -22,5 +22,8 @@
     "model": "openrouter:deepseek/deepseek-v4-flash",
     "provider": "openrouter",
     "tags": {"mode": "agent"}
+  },
+  "missions": {
+    "default": {"components": []}
   }
 }

--- a/examples/kernel-tutorial/README.md
+++ b/examples/kernel-tutorial/README.md
@@ -1,10 +1,12 @@
 # Kernel tutorial examples
 
-Run these examples from the repository root. Start with the credential-free
-walkthrough in
-[`docs/guides/getting-started.md`](../../docs/guides/getting-started.md), then
-use [`docs/guides/building-agents.md`](../../docs/guides/building-agents.md)
-for the live model examples.
+Run these examples from the repository root.
+[`docs/guides/quickstart.md`](../../docs/guides/quickstart.md) is the shortest
+path from a clone to a live model run;
+[`docs/guides/getting-started.md`](../../docs/guides/getting-started.md) walks
+through the same examples in detail, and
+[`docs/guides/building-agents.md`](../../docs/guides/building-agents.md)
+explains the agent examples.
 
 Examples 01 and 05 are credential-free and select no providers:
 

--- a/mix.exs
+++ b/mix.exs
@@ -386,6 +386,7 @@ defmodule PtcRunner.MixProject do
           "docs/signature-syntax.md",
           "docs/trace-log-contract.md",
           "docs/conformance/index.md",
+          "docs/guides/quickstart.md",
           "docs/guides/getting-started.md",
           "docs/guides/manifests-and-capabilities.md",
           "docs/guides/host-configuration.md",
@@ -401,7 +402,7 @@ defmodule PtcRunner.MixProject do
         ] ++ Path.wildcard("docs/conformance/*-audit.md"),
       groups_for_extras: [
         Maintainers:
-          ~r/docs\/guides\/(coding-agent-review-workflow|duplication-gate|kernel-maintainer)\.md/,
+          ~r/docs\/guides\/(coding-agent-review-workflow|documentation-guidelines|duplication-gate|kernel-maintainer)\.md/,
         Contracts: ~r/docs\/trace-log-contract\.md/,
         Guides: ~r/docs\/guides\/.+\.md/,
         Reference: ~r/docs\/(ptc-lisp|clojure|function-reference|java-|signature-).+\.md/,


### PR DESCRIPTION
Adds the missing on-ramp altitude to the documentation, and fixes the two
shipped tutorial examples the quickstart depends on. Refs #1307 and #1311
(closes neither).

Rebased onto `08064932` (#1298, named mission environments). That rebase was
clean, but it invalidated the page this PR is built around — see
"What the rebase changed" below.

## The problem, measured

Every page was written at reference altitude. `getting-started.md` prescribed
getting-started → manifests-and-capabilities → host-configuration →
building-agents, and flagged host-configuration as required "before any example
that calls a model". That chain is 11,671 words. The commands actually required
are four. Credential setup lived ~300 lines into `building-agents.md`, which is
the most common hard blocker and the hardest thing on the path to find.

## Reading path to a live model run

| | Before | After |
| --- | --- | --- |
| Prescribed path | getting-started + manifests + host-config + building-agents | quickstart |
| Words | 11,671 | 430 |
| Commands to a live model run | 4, spread across 4 guides | 4, on one page |
| `## Try it` in README.md | line 165 of 255 | line 18 of 266 |

`getting-started.md` grew from 720 to 906 words and now ends at a live model
call, so the slow path also reaches the point without a second guide.

## What changed

1. **README**: `## Try it` moved above `## Why it is safe`. The safety argument
   is byte-identical; only its position changed.
2. **New `docs/guides/quickstart.md`** (430 words, one screen): clone →
   credential → live model run, with a link out for every "why". Registered in
   the `extras` list in `mix.exs` and listed first in the README's guides.
3. **Credential setup** is in the quickstart and in getting-started. The
   quickstart performs the steps and links to
   `host-configuration.md#credentials`, which remains canonical for the three
   declaration forms.
4. **`getting-started.md`** ends at a model call (`02-deepseek-extract`, then
   `04-multi-turn-agent` for a model-authored program) instead of stopping two
   guides short, and its "Next steps" no longer demands three guides first.
5. **Spec-register prose moved to the guides that own it**: the initialization
   failure taxonomy to `running-and-debugging.md#commands`, the log-analysis
   profile's `complete?`/`snapshot_hash` contract to `kernel-repl.md`.
6. **Audience markers** on `kernel-maintainer.md`, `duplication-gate.md`,
   `coding-agent-review-workflow.md` and `documentation-guidelines.md`; the
   README lists them under a new "Maintainers" heading instead of mixing the
   Kernel guide into "Reference", and `documentation-guidelines.md` joins the
   other three in the ExDoc `Maintainers` group.

## What the rebase changed

#1298 broke two shipped tutorial examples, on `main`, reproducible in a clean
clone of `08064932` with only `OPENROUTER_API_KEY` set:

```console
mix ptc run examples/kernel-tutorial/04-multi-turn-agent/ptc.json --host-config …
** (Mix) error: execution/workflow_failed: the workflow failed

mix ptc run examples/kernel-tutorial/03-file-agent/ptc.json --host-config …
** (Mix) error: internal/internal_error: the command failed internally
```

Example 04 is this quickstart's live model step, so the page was false as
written. Filed as #1311; the manifest half is fixed here in a second commit:

- **04** was never migrated to the named-mission form. `agent.core/run` selects
  the mission named `default` when the option is omitted, and `default` carries
  no authority unless declared, so the manifest now declares an empty one.
- **03** was migrated but its mission never received the `workspace` occurrence
  from `providers.mission`. The grant is now declared.

The tutorial e2e suite covers exactly these three live examples and is **1/3
passing on `08064932`, 3/3 with this PR**. It is tagged `:e2e`, so neither
`mix test` nor `mix precommit` runs it — which is how a manifest-shape
migration passed every gate while breaking every shipped agent example.

#1311 stays open for the second defect: an under-granted mission surfaces as
`internal/internal_error` with `"usage": null` rather than a bounded diagnostic
naming the mission and the missing grant.

The README also now lists `examples/named-mission-reader-writer/`, which #1298
added without linking from the examples index.

## Verification

Every quickstart command was run in order in a genuine fresh clone, which also
closes one of the coverage gaps #1307 recorded. Re-run in full after the
rebase:

| Step | Result |
| --- | --- |
| `git clone` + `mix deps.get` | 9.5 s (warm hex cache) |
| `mix ptc run …/01-orders/ptc.json` | exact JSON on the page, **91 s cold** |
| `cp .env.example .env` + set key | documented path, not a copied `.env` |
| `mix ptc run …/04-multi-turn-agent/ptc.json` | `{"ok":true,"value":42}`, 15 s, 5/5 clean across both bases |
| `mix ptc doctor … --connect` | all seven checks `pass` |

`02-deepseek-extract`, `03-file-agent` and `05-signature-feedback` were also run
live for the claims made about them. The credential-failure text quoted on the
quickstart was reproduced by removing `.env`. The tutorial e2e suite passes 3/3.

`MIX_ENV=dev mix docs --warnings-as-errors` and `mix precommit` both pass on the
final tree.

My first draft claimed "about half a minute" for the first run, from a seeded
worktree. The cold clone measured 91 s, and the page now says so.

## Left out

- **Error-message fixes are out of scope** (#1166, #1302). The quickstart's
  troubleshooting section names `active_preflight/credential_unavailable`,
  explains that it means `OPENROUTER_API_KEY` is not visible, and references
  both issues rather than pretending the message is helpful.
- **The `internal_error` class bug** from #1311 — that is a `lib/` change.
- **The README's "two environments" framing** still describes a singular
  mission, which #1298 made imprecise. Left alone deliberately: this PR moves
  the safety argument without rewriting it, and rewording it is #1298 follow-up.
- **ExDoc rewrites every relative `…/README.md` link to the project
  `readme.html`**, so the examples links land on the project README on HexDocs.
  Pre-existing; linking the directory instead fails `--warnings-as-errors`, so
  the fix is a repo-wide link-convention change.
- **`kernel-maintainer.md` was not split.** It is 12,886 words, a third of the
  guide corpus; it now says who it is for, which was the item in scope.

https://claude.ai/code/session_01V7zi59AFWpaNSAQaQ7eQBt
