### PR TITLE
fix(test): accept narrated agent turns

### DIFF
--- a/test/ptc_runner/kernel/agent_library_test.exs
+++ b/test/ptc_runner/kernel/agent_library_test.exs
@@ -496,9 +496,9 @@ defmodule PtcRunner.Kernel.AgentLibraryTest do
     refute_receive {:agent_request, _request}
   end
 
-  test "agent.core persists a defn across a correlated intermediate turn" do
+  test "agent.core persists narration and a defn across a correlated intermediate turn" do
     define = %{
-      content: nil,
+      content: "I will define the helper before using it.",
       tool_calls: [
         %{
           id: "define-add-one",
@@ -536,7 +536,7 @@ defmodule PtcRunner.Kernel.AgentLibraryTest do
              %{"role" => "user", "content" => "Build then use a helper"},
              %{
                "role" => "assistant",
-               "content" => nil,
+               "content" => "I will define the helper before using it.",
                "tool_calls" => [public_call]
              },
              %{

--- a/test/ptc_runner/kernel/repo_analyst_live_e2e_test.exs
+++ b/test/ptc_runner/kernel/repo_analyst_live_e2e_test.exs
@@ -347,7 +347,7 @@ defmodule PtcRunner.Kernel.RepoAnalystLiveE2ETest do
                      [
                        %{
                          "role" => "assistant",
-                         "content" => nil,
+                         "content" => value["content"],
                          "tool_calls" => [tool_call]
                        },
                        %{


### PR DESCRIPTION
## Summary

- align the repo-analyst live E2E transcript assertion with the agent runtime's preserved narration contract
- keep the exact message ordering, tool-call, and tool-result correlation checks
- strengthen the deterministic correlated-turn integration test to prove narration reaches the next request

## Root cause

`agent.native` and `agent.core` intentionally accept and preserve assistant narration alongside a valid `run_ptc_lisp` tool call. The live E2E assertion still hard-coded the assistant content to `nil`, so a correct run failed whenever DeepSeek included narration.

This addresses Part 1 of #1303 only. The optional-server test classification in Part 2 is unchanged.

## Verification

- `mix test test/ptc_runner/kernel/agent_library_test.exs` — 50 passed
- `mix precommit` — passed, including 6,166 root tests, 73 Viewer tests, and 40 launcher tests
- pre-push hook — passed documentation, root tests, Credo, generated-artifact checks, upstream audit, Dialyzer, and Viewer tests

The live OpenRouter E2E compiled but was not executed locally because this worktree has no `OPENROUTER_API_KEY`; scheduled E2E CI remains the live-provider verification.