### PR TITLE
fix(kernel): fail closed on callback termination

### DIFF
--- a/docs/guides/building-agents.md
+++ b/docs/guides/building-agents.md
@@ -523,6 +523,12 @@ dispatched, every non-success remains non-retryable and carries
 Cancellation does not prove rollback. Deterministic failures that prove no
 transport send was attempted omit mutation state.
 
+Capability implementations must return expected transient failures as typed
+`ProviderError` values with `retryable?: true`. Callback raises, exits, throws,
+and monitored provider-process deaths are contained by the Dispatcher but are
+unclassified failures, so they default to non-retryable. Dispatcher-observed
+provider timeouts remain retryable for read and workflow calls.
+
 Some read-side provider failures are terminal even though repeating an ordinary
 read would otherwise be effect-safe. In particular, the MCP adapter never asks
 the model to correct or repeat an `input_required` exchange: policy refusal,

--- a/lib/ptc_runner/kernel/capability.ex
+++ b/lib/ptc_runner/kernel/capability.ex
@@ -7,6 +7,10 @@ defmodule PtcRunner.Kernel.Capability do
   budget reservation, and provider invocation. `output_schema`, when present,
   checks successful values before they return to Lisp. `callback` returns
   `{:ok, json_value}` or `{:error, %PtcRunner.Kernel.ProviderError{}}`.
+  Expected transient failures must use `ProviderError` with an explicit
+  `retryable?: true`. The dispatcher contains callback raises, exits, throws,
+  and monitored process deaths, but these unclassified failures default to
+  non-retryable.
   One-argument callbacks receive only normalized arguments. Trusted
   two-argument callbacks additionally receive a dispatcher-owned invocation
   context for private observation and safe trace propagation; that context

--- a/lib/ptc_runner/kernel/dispatcher.ex
+++ b/lib/ptc_runner/kernel/dispatcher.ex
@@ -9,12 +9,15 @@ defmodule PtcRunner.Kernel.Dispatcher do
   run closure so late results cannot re-enter Lisp.
 
   Mission failures after callback entry are classified with the capability's
-  declared effect. Read failures keep their provider retry policy. Write and
-  unknown failures are non-retryable and carry
-  `mutation_state: :indeterminate` when invocation may have reached external
-  state. A trusted `ProviderError` with `dispatch_provenance: :not_dispatched`
-  preserves its specific pre-dispatch policy without exposing that internal
-  provenance. Workflow capabilities retain their provider-owned retry policy.
+  declared effect. Read failures keep an explicit typed provider retry policy.
+  Unclassified callback raises, exits, throws, and monitored process deaths
+  default to non-retryable in both environments; Dispatcher-owned provider
+  timeouts remain retryable. Write and unknown failures are non-retryable and
+  carry `mutation_state: :indeterminate` when invocation may have reached
+  external state. A trusted `ProviderError` with
+  `dispatch_provenance: :not_dispatched` preserves its specific pre-dispatch
+  policy without exposing that internal provenance. Workflow capabilities also
+  retain explicit provider-owned retry policy.
   Before a mission provider publishes a terminal policy failure, its monitored
   callback records that classification in RunState so a subsequent evaluator
   kill cannot make the agent repeat the call.
@@ -693,7 +696,7 @@ defmodule PtcRunner.Kernel.Dispatcher do
       status: :error,
       kind: :provider_error,
       reason: normalize_exit(reason),
-      retryable?: true
+      retryable?: false
     }
   end
 
@@ -763,7 +766,7 @@ defmodule PtcRunner.Kernel.Dispatcher do
 
   defp normalize_result(_state, environment, capability, {:raised, reason}) do
     post_invocation_failure(
-      %{status: :error, kind: :provider_error, reason: reason, retryable?: true},
+      %{status: :error, kind: :provider_error, reason: reason, retryable?: false},
       environment,
       capability
     )

--- a/test/ptc_runner/kernel/core_contract_test.exs
+++ b/test/ptc_runner/kernel/core_contract_test.exs
@@ -1,6 +1,8 @@
 defmodule PtcRunner.Kernel.CoreContractTest do
   use ExUnit.Case, async: true
 
+  import PtcRunner.TestSupport.Eventually, only: [assert_eventually: 1]
+
   alias PtcRunner.Kernel
   alias PtcRunner.Kernel.Capability
   alias PtcRunner.Kernel.Component
@@ -374,12 +376,55 @@ defmodule PtcRunner.Kernel.CoreContractTest do
     {:ok, state} = RunState.start(limits)
 
     for _attempt <- 1..4 do
-      assert %{status: :error, kind: :provider_error, reason: :provider_exit} =
-               Dispatcher.dispatch(state, :workflow, environment, "tiny-heap", %{}, 100)
+      assert %{
+               status: :error,
+               kind: :provider_error,
+               reason: :provider_exit,
+               retryable?: false
+             } =
+               dispatch_after_provider_down(state, fn ->
+                 Dispatcher.dispatch(state, :workflow, environment, "tiny-heap", %{}, 100)
+               end)
     end
 
     assert :ok = RunState.reserve_capability(state, :workflow, "tiny-heap")
     assert :ok = RunState.release_provider_slot(state)
+  end
+
+  test "write mission provider death before tracker attachment omits mutation state" do
+    {:ok, capability} =
+      Capability.new(
+        name: "tiny-heap-write",
+        input_schema: @input_schema,
+        effect: :write,
+        callback: fn _ -> {:ok, true} end
+      )
+
+    {:ok, environment} = MissionEnvironment.new(capabilities: [capability])
+    {:ok, limits} = Limits.new(provider_heap_words: 100)
+    {:ok, state} = RunState.start(limits)
+    {:ok, _memory, _history, lease} = RunState.reserve_evaluation(state)
+
+    assert %{
+             status: :error,
+             kind: :provider_error,
+             reason: :provider_exit,
+             retryable?: false
+           } =
+             result =
+             dispatch_after_provider_down(state, fn ->
+               Dispatcher.dispatch_with_lease(
+                 state,
+                 :mission,
+                 environment,
+                 "tiny-heap-write",
+                 %{},
+                 100,
+                 {nil, nil, lease}
+               )
+             end)
+
+    refute Map.has_key?(result, :mutation_state)
   end
 
   test "provider attachment after run closure is rejected and releases its reservation" do
@@ -3365,5 +3410,41 @@ defmodule PtcRunner.Kernel.CoreContractTest do
     assert :ok = RunState.reserve_capability(state, :workflow, "read")
     assert :ok = RunState.close(state)
     assert {:error, :run_closed} = RunState.finish_provider(state)
+  end
+
+  defp dispatch_after_provider_down(state, dispatch) do
+    tracker = state.provider_tracker.pid
+    :ok = :sys.suspend(tracker)
+
+    task =
+      Task.async(fn ->
+        receive do
+          :dispatch -> dispatch.()
+        end
+      end)
+
+    try do
+      send(task.pid, :dispatch)
+
+      assert_eventually(fn -> is_pid(pending_provider_attachment(tracker)) end)
+      provider = pending_provider_attachment(tracker)
+      provider_ref = Process.monitor(provider)
+      assert_receive {:DOWN, ^provider_ref, :process, ^provider, _reason}
+
+      :ok = :sys.resume(tracker)
+      Task.await(task)
+    after
+      if Process.alive?(tracker), do: :sys.resume(tracker)
+      if Process.alive?(task.pid), do: Task.shutdown(task, :brutal_kill)
+    end
+  end
+
+  defp pending_provider_attachment(tracker) do
+    {:messages, messages} = Process.info(tracker, :messages)
+
+    Enum.find_value(messages, fn
+      {:"$gen_call", _from, {_token, {:attach, provider}}} -> provider
+      _message -> nil
+    end)
   end
 end

--- a/test/ptc_runner/kernel/dispatcher_effect_test.exs
+++ b/test/ptc_runner/kernel/dispatcher_effect_test.exs
@@ -152,17 +152,60 @@ defmodule PtcRunner.Kernel.DispatcherEffectTest do
              EventSink.events(sink) |> Enum.find(&(&1.type == "limit-exceeded"))
   end
 
-  test "mission callback raises, exits, and process deaths are effect-aware" do
+  test "raised mission callbacks are non-retryable" do
+    assert_unclassified_mission_failure(fn -> raise "private failure" end, :exception)
+  end
+
+  test "exiting mission callbacks are non-retryable" do
+    assert_unclassified_mission_failure(fn -> exit(:private_failure) end, :exit)
+  end
+
+  test "throwing mission callbacks are non-retryable" do
+    assert_unclassified_mission_failure(fn -> throw(:private_failure) end, :throw)
+  end
+
+  test "killed mission provider processes are non-retryable" do
+    assert_unclassified_mission_failure(
+      fn -> Process.exit(self(), :kill) end,
+      :provider_heap_exceeded
+    )
+  end
+
+  test "abnormally exiting mission provider processes are non-retryable" do
+    assert_unclassified_mission_failure(
+      fn ->
+        spawn_link(fn -> exit(:private_failure) end)
+
+        receive do
+          :never -> {:ok, nil}
+        end
+      end,
+      :provider_exit
+    )
+  end
+
+  test "unclassified workflow callback termination is non-retryable" do
     cases = [
       {fn -> raise "private failure" end, :exception},
       {fn -> exit(:private_failure) end, :exit},
-      {fn -> Process.exit(self(), :kill) end, :provider_heap_exceeded}
+      {fn -> throw(:private_failure) end, :throw},
+      {fn -> Process.exit(self(), :kill) end, :provider_heap_exceeded},
+      {fn ->
+         spawn_link(fn -> exit(:private_failure) end)
+
+         receive do
+           :never -> {:ok, nil}
+         end
+       end, :provider_exit}
     ]
 
-    for {callback, reason} <- cases,
-        effect <- @effects do
-      result = dispatch_mission(effect, callback)
-      assert_effect_failure(result, effect, %{kind: :provider_error, reason: reason}, true)
+    for {callback, reason} <- cases do
+      assert %{
+               status: :error,
+               kind: :provider_error,
+               reason: ^reason,
+               retryable?: false
+             } = dispatch_workflow(callback)
     end
   end
 
@@ -471,6 +514,14 @@ defmodule PtcRunner.Kernel.DispatcherEffectTest do
     )
   end
 
+  defp dispatch_workflow(callback) do
+    {:ok, state} = RunState.start(Limits.defaults())
+    {:ok, capability} = capability(:read, callback)
+    {:ok, environment} = WorkflowEnvironment.new(capabilities: [capability])
+
+    Dispatcher.dispatch(state, :workflow, environment, capability.name, %{}, 100)
+  end
+
   defp dispatch_mission_with_events(limit_opts, timeout_ms, callback) do
     {:ok, limits} = Limits.new(limit_opts)
     {:ok, state} = RunState.start(limits)
@@ -521,6 +572,19 @@ defmodule PtcRunner.Kernel.DispatcherEffectTest do
     else
       assert result.retryable? == false
       assert result.mutation_state == :indeterminate
+    end
+  end
+
+  defp assert_unclassified_mission_failure(callback, reason) do
+    for effect <- @effects do
+      result = dispatch_mission(effect, callback)
+
+      assert_effect_failure(
+        result,
+        effect,
+        %{kind: :provider_error, reason: reason},
+        false
+      )
     end
   end
 end


### PR DESCRIPTION
Closes #1318

## Summary

- default unclassified callback raises, exits, throws, and monitored provider-process deaths to non-retryable
- preserve explicit `ProviderError` retry policy, dispatcher timeout policy, and mission mutation provenance
- add workflow, mission-effect, and deterministic pre-attachment lifecycle regression coverage
- document the provider-author contract

## Verification

- `mix precommit`
  - root: 6,199 passed
  - Viewer: 73 passed
  - launcher: 40 passed
  - quality, generated-artifact, packaging, and standalone-release gates passed
- pre-push hook
  - all-but-nightly root suite: 6,199 passed
  - Credo, generated artifacts, upstream audit, Dialyzer, and Viewer tests passed

## Independent review

- plan reviewed twice
- implementation reviewed three times
- cumulative review found one scheduler-dependent pre-attachment fixture; it was replaced with a deterministic tracker-suspension/queued-attachment test and approved on follow-up
- no actionable findings remain
- residual test-only coupling: the deterministic helper intentionally inspects the private tracker PID and OTP `GenServer.call` envelope to select the pre-attachment death branch
