### PR TITLE
fix(inspection): report unsupported schema versions

### DIFF
--- a/docs/guides/kernel-repl.md
+++ b/docs/guides/kernel-repl.md
@@ -212,6 +212,10 @@ directories must be physically separate, including through ancestors and
 symlink aliases. Inspection capture validates every private artifact against
 the corresponding run in the immutable canonical trace capture; malformed,
 replaced, uncorrelated, or oversized input rejects the whole private source.
+An artifact from an unsupported inspection schema also rejects the whole
+source, and setup reports both the artifact's declared version and the version
+supported by the running build. Use a matching PtcRunner build to inspect the
+retained artifact, or regenerate it with the current build.
 
 ### Private analysis without a terminal
 

--- a/docs/guides/running-and-debugging.md
+++ b/docs/guides/running-and-debugging.md
@@ -681,7 +681,9 @@ The Viewer binds to loopback, pins the selected inspection file, and can enable
 a bounded log-analysis REPL over an immutable trace capture. It is currently a
 development/test path dependency and is not included in the published Hex
 package. Treat this command as source-checkout tooling until standalone Viewer
-packaging is released.
+packaging is released. If the selected inspection artifact uses an unsupported
+schema, Viewer startup reports both the artifact version and the version
+supported by the running PtcRunner build.
 
 See [`ptc_viewer/README.md`](../../ptc_viewer/README.md) for the Viewer's HTTP
 API, configuration, and programmatic start/stop.

--- a/lib/ptc_runner/kernel/acquisition_reason.ex
+++ b/lib/ptc_runner/kernel/acquisition_reason.ex
@@ -173,6 +173,9 @@ defmodule PtcRunner.Kernel.AcquisitionReason do
   def diagnostic({:source_retained_limit_exceeded, _limit}, occurrence),
     do: subject_diagnostic(:local_preflight, :environment_unavailable, :local, occurrence)
 
+  def diagnostic({:unsupported_inspection_schema_version, _details}, occurrence),
+    do: subject_diagnostic(:local_preflight, :environment_unavailable, :local, occurrence)
+
   def diagnostic(reason, occurrence) when reason in @environment_reasons,
     do: subject_diagnostic(:local_preflight, :environment_unavailable, :local, occurrence)
 

--- a/lib/ptc_runner/kernel/analysis_session_builder.ex
+++ b/lib/ptc_runner/kernel/analysis_session_builder.ex
@@ -45,6 +45,8 @@ defmodule PtcRunner.Kernel.AnalysisSessionBuilder do
              measured_bytes: pos_integer(),
              limit_bytes: pos_integer()
            }}
+  @type unsupported_schema_error ::
+          PtcRunner.Kernel.InspectionArtifact.unsupported_schema_error()
 
   @common_options [
     :persistence_fault_hook,
@@ -73,7 +75,8 @@ defmodule PtcRunner.Kernel.AnalysisSessionBuilder do
   including through symlinks and ancestor aliases.
   """
   @spec start(binary(), resources(), destination()) ::
-          {:ok, AnalysisSession.t(), map()} | {:error, atom() | retained_limit_error()}
+          {:ok, AnalysisSession.t(), map()}
+          | {:error, atom() | retained_limit_error() | unsupported_schema_error()}
   def start(profile_id, resources, destination),
     do: start(profile_id, resources, destination, [])
 
@@ -512,6 +515,9 @@ defmodule PtcRunner.Kernel.AnalysisSessionBuilder do
   end
 
   defp normalize_error(reason, _recipe) when is_atom(reason), do: reason
+
+  defp normalize_error({:unsupported_inspection_schema_version, _details} = reason, _recipe),
+    do: reason
 
   defp normalize_error(
          {:source_retained_limit_exceeded,

--- a/lib/ptc_runner/kernel/inspection_artifact.ex
+++ b/lib/ptc_runner/kernel/inspection_artifact.ex
@@ -26,6 +26,10 @@ defmodule PtcRunner.Kernel.InspectionArtifact do
   inspection artifact as partial; an existing but mismatched correlation still
   fails closed.
 
+  A syntactically decoded artifact whose records uniformly declare another
+  integer schema version is rejected with both the declared and supported
+  versions. It is not validated against a deleted historical vocabulary.
+
   Secure publication is supported on Unix hosts with POSIX-compatible `mkdir`
   and `id` executables available on `PATH`; persistence fails closed when those
   authority/mode primitives are unavailable, a physical or lexical ancestor
@@ -44,8 +48,13 @@ defmodule PtcRunner.Kernel.InspectionArtifact do
 
   @max_bytes 16_000_000
   @max_record_bytes 2_000_000
+  @schema_version 5
   @suffix ".inspection.jsonl"
   @envelope_keys ~w(schema_version run_id trace_id sequence timestamp record_type correlation payload)
+
+  @type unsupported_schema_error ::
+          {:unsupported_inspection_schema_version,
+           %{artifact_version: integer(), supported_version: pos_integer()}}
 
   @spec preflight_destination(term()) ::
           :ok
@@ -163,7 +172,8 @@ defmodule PtcRunner.Kernel.InspectionArtifact do
     end
   end
 
-  @spec load(binary(), keyword()) :: {:ok, [map()]} | {:error, atom()}
+  @spec load(binary(), keyword()) ::
+          {:ok, [map()]} | {:error, atom() | unsupported_schema_error()}
   @doc "Loads one exact fixed artifact with optional lower aggregate and per-record limits."
   def load(path, opts \\ [])
 
@@ -175,7 +185,7 @@ defmodule PtcRunner.Kernel.InspectionArtifact do
 
   @doc false
   @spec load(binary(), keyword(), nil | (-> term())) ::
-          {:ok, [map()]} | {:error, atom()}
+          {:ok, [map()]} | {:error, atom() | unsupported_schema_error()}
   def load(path, opts, verification_hook)
       when is_binary(path) and is_list(opts) and
              (is_nil(verification_hook) or is_function(verification_hook, 0)) do
@@ -187,7 +197,7 @@ defmodule PtcRunner.Kernel.InspectionArtifact do
   @doc false
   @spec load(binary(), keyword(), nil | (-> term()), (:file.io_device(), non_neg_integer() ->
                                                         {:ok, binary()} | :eof | {:error, term()})) ::
-          {:ok, [map()]} | {:error, atom()}
+          {:ok, [map()]} | {:error, atom() | unsupported_schema_error()}
   def load(path, opts, verification_hook, reader)
       when is_binary(path) and is_list(opts) and
              (is_nil(verification_hook) or is_function(verification_hook, 0)) and
@@ -209,6 +219,7 @@ defmodule PtcRunner.Kernel.InspectionArtifact do
          :ok <- unchanged(before, opened),
          :ok <- unchanged(before, after_read),
          {:ok, records} <- decode(content, max_record_bytes),
+         :ok <- validate_loaded_schema_version(records),
          :ok <- validate_records(records) do
       {:ok, records}
     else
@@ -301,6 +312,24 @@ defmodule PtcRunner.Kernel.InspectionArtifact do
   end
 
   defp ordered_value(value), do: {:ok, value}
+
+  defp validate_loaded_schema_version([]), do: :ok
+
+  defp validate_loaded_schema_version([first | _rest] = records) do
+    artifact_version = first["schema_version"]
+
+    if is_integer(artifact_version) and artifact_version != @schema_version and
+         Enum.all?(records, fn record ->
+           is_map(record) and Enum.sort(Map.keys(record)) == Enum.sort(@envelope_keys) and
+             record["schema_version"] == artifact_version
+         end) do
+      {:error,
+       {:unsupported_inspection_schema_version,
+        %{artifact_version: artifact_version, supported_version: @schema_version}}}
+    else
+      :ok
+    end
+  end
 
   defp validate_records([]), do: {:error, :invalid_inspection_artifact}
 
@@ -469,7 +498,7 @@ defmodule PtcRunner.Kernel.InspectionArtifact do
   defp valid_record?(record, run_id, trace_id, schema_version, sequence) do
     MCPProtocol.within_inspection_document_depth?(record) and
       is_map(record) and Map.keys(record) |> Enum.sort() == Enum.sort(@envelope_keys) and
-      schema_version == 5 and record["schema_version"] == schema_version and
+      schema_version == @schema_version and record["schema_version"] == schema_version and
       record["run_id"] == run_id and
       record["trace_id"] == trace_id and is_binary(run_id) and is_binary(trace_id) and
       record["sequence"] == sequence and valid_timestamp?(record["timestamp"]) and

--- a/lib/ptc_runner/kernel/inspection_snapshot.ex
+++ b/lib/ptc_runner/kernel/inspection_snapshot.ex
@@ -66,8 +66,10 @@ defmodule PtcRunner.Kernel.InspectionSnapshot do
              limit_bytes: pos_integer()
            }}
 
+  @type unsupported_schema_error :: InspectionArtifact.unsupported_schema_error()
+
   @spec start({:directory, binary()}, trace_snapshot(), keyword()) ::
-          {:ok, t()} | {:error, atom() | retained_limit_error()}
+          {:ok, t()} | {:error, atom() | retained_limit_error() | unsupported_schema_error()}
   def start(source, trace_snapshot, opts \\ [])
 
   def start({:directory, directory}, %TraceSnapshot{} = trace_snapshot, opts)
@@ -117,6 +119,7 @@ defmodule PtcRunner.Kernel.InspectionSnapshot do
            ) do
         {:ok, pid} -> {:ok, %__MODULE__{pid: pid, token: token}}
         {:error, {:source_retained_limit_exceeded, _details} = reason} -> {:error, reason}
+        {:error, {:unsupported_inspection_schema_version, _details} = reason} -> {:error, reason}
         {:error, reason} when is_atom(reason) -> {:error, reason}
         {:error, _reason} -> {:error, :source_unavailable}
       end
@@ -313,6 +316,9 @@ defmodule PtcRunner.Kernel.InspectionSnapshot do
 
       :oversized ->
         {:error, :source_retained_limit_exceeded}
+
+      {:error, {:unsupported_inspection_schema_version, _details} = reason} ->
+        {:error, reason}
 
       {:error, reason} when is_atom(reason) ->
         {:error, normalize_capture_error(reason)}

--- a/lib/ptc_runner/kernel/viewer_adapter.ex
+++ b/lib/ptc_runner/kernel/viewer_adapter.ex
@@ -20,7 +20,8 @@ defmodule PtcRunner.Kernel.ViewerAdapter do
   @opaque inspection_grant :: {:inspection_v1, binary(), [map()]}
 
   @spec pin_inspection(binary(), TraceLog.source()) ::
-          {:ok, inspection_grant()} | {:error, atom()}
+          {:ok, inspection_grant()}
+          | {:error, atom() | InspectionArtifact.unsupported_schema_error()}
   @doc "Pins one artifact only after validating it against its canonical run."
   def pin_inspection(path, trace_source) when is_binary(path) do
     with {:ok, [%{"run_id" => run_id, "trace_id" => trace_id} | _rest] = records} <-

--- a/lib/ptc_runner/repl_frontend.ex
+++ b/lib/ptc_runner/repl_frontend.ex
@@ -511,6 +511,16 @@ defmodule PtcRunner.ReplFrontend do
   defp profile_setup_error(:empty_inspection_resource),
     do: empty_resource_error("inspection", "*.inspection.jsonl records")
 
+  defp profile_setup_error(
+         {:unsupported_inspection_schema_version,
+          %{artifact_version: artifact_version, supported_version: supported_version}}
+       )
+       when is_integer(artifact_version) and is_integer(supported_version) do
+    "ptc repl profile setup failed: an inspection artifact declares schema version " <>
+      "#{artifact_version}; this build supports version #{supported_version}. " <>
+      "Use a matching PtcRunner build or regenerate the artifact."
+  end
+
   defp profile_setup_error(reason) when is_atom(reason),
     do: "ptc repl profile setup failed: #{reason}"
 

--- a/ptc_viewer/lib/ptc_viewer/server.ex
+++ b/ptc_viewer/lib/ptc_viewer/server.ex
@@ -274,6 +274,15 @@ defmodule PtcViewer.Server do
 
   defp normalize_pin_result({:ok, source}) when not is_nil(source), do: {:ok, source}
   defp normalize_pin_result({:error, reason}) when is_atom(reason), do: {:error, reason}
+
+  defp normalize_pin_result(
+         {:error,
+          {:unsupported_inspection_schema_version,
+           %{artifact_version: artifact_version, supported_version: supported_version}}} = error
+       )
+       when is_integer(artifact_version) and is_integer(supported_version),
+       do: error
+
   defp normalize_pin_result(_invalid), do: {:error, :inspection_adapter_failure}
 
   defp attach_inspection_store(nil, _owner), do: :ok

--- a/ptc_viewer/test/ptc_viewer/server_test.exs
+++ b/ptc_viewer/test/ptc_viewer/server_test.exs
@@ -1,7 +1,17 @@
 defmodule PtcViewer.ServerTest do
   use ExUnit.Case, async: false
 
-  alias PtcViewer.TestReplAdapter
+  alias PtcViewer.{TestInspectionAdapter, TestReplAdapter}
+
+  test "inspection startup preserves an unsupported schema version error" do
+    assert {:error,
+            {:unsupported_inspection_schema_version, %{artifact_version: 4, supported_version: 5}}} =
+             PtcViewer.start(
+               inspection_file: "run.inspection.jsonl",
+               inspection_adapter: TestInspectionAdapter,
+               open: false
+             )
+  end
 
   test "requested REPL connection and feature failures fail startup" do
     assert {:error, :connection_rejected} =

--- a/ptc_viewer/test/support/inspection_test_adapter.ex
+++ b/ptc_viewer/test/support/inspection_test_adapter.ex
@@ -1,0 +1,10 @@
+defmodule PtcViewer.TestInspectionAdapter do
+  @moduledoc false
+
+  def pin_inspection(_path, _trace_source) do
+    {:error,
+     {:unsupported_inspection_schema_version, %{artifact_version: 4, supported_version: 5}}}
+  end
+
+  def inspection(_source, _run_id), do: {:error, :not_called}
+end

--- a/test/mix/tasks/ptc_repl_test.exs
+++ b/test/mix/tasks/ptc_repl_test.exs
@@ -438,6 +438,37 @@ defmodule PtcRunner.ReplFrontendTest do
   end
 
   @tag :tmp_dir
+  test "inspection profile setup explains an unsupported artifact schema", %{
+    tmp_dir: directory
+  } do
+    fixture = PrivateInspectionFixture.create!(directory, "old-schema")
+    PrivateInspectionFixture.rewrite_schema!(fixture.inspection, 4)
+
+    message =
+      ~r/ptc repl profile setup failed: an inspection artifact declares schema version 4; this build supports version 5/
+
+    capture_io(fn ->
+      assert_raise Mix.Error, message, fn ->
+        run_repl([
+          "--profile",
+          "inspection-analysis-v2",
+          "--resource",
+          "traces=#{fixture.traces}",
+          "--resource",
+          "inspection=#{fixture.inspection}",
+          "--session-trace-dir",
+          fixture.output,
+          "--private-unattended",
+          "--format",
+          "jsonl",
+          "-e",
+          "(return 42)"
+        ])
+      end
+    end)
+  end
+
+  @tag :tmp_dir
   test "profile evals share mission state and persist outside the source", %{tmp_dir: directory} do
     source = Path.join(directory, "source")
     output_directory = Path.join(directory, "output")

--- a/test/ptc_runner/kernel/acquisition_reason_test.exs
+++ b/test/ptc_runner/kernel/acquisition_reason_test.exs
@@ -104,6 +104,17 @@ defmodule PtcRunner.Kernel.AcquisitionReasonTest do
     assert diagnostic.subject.operation == :local
   end
 
+  test "an unsupported inspection schema tuple remains a local environment failure" do
+    reason =
+      {:unsupported_inspection_schema_version, %{artifact_version: 4, supported_version: 5}}
+
+    diagnostic = AcquisitionReason.diagnostic(reason, @occurrence)
+
+    assert diagnostic.phase == :local_preflight
+    assert diagnostic.code == :environment_unavailable
+    assert diagnostic.subject.operation == :local
+  end
+
   test "a malformed occurrence is this module's defect, not an escaping exception" do
     # Classification runs inside an acquisition loop holding provisional roots,
     # so it must not raise past them.

--- a/test/ptc_runner/kernel/host_installation_test.exs
+++ b/test/ptc_runner/kernel/host_installation_test.exs
@@ -1091,6 +1091,10 @@ defmodule PtcRunner.Kernel.HostInstallationTest do
         marker,
         "mcp-unicode"
       ])
+      # This test exercises locale propagation, not the default startup
+      # deadline. Booting an Elixir source fixture can exceed five seconds
+      # while the full CI suite is under load.
+      |> put_in(["install", "workspace", "transport", "start_timeout_ms"], 20_000)
       |> put_in(["install", "workspace", "transport", "inherit_environment"], true)
       |> put_in(["install", "workspace", "tools"], %{
         "unicode" => %{"as" => "workspace.unicode", "effect" => "read"}

--- a/test/ptc_runner/kernel/inspection_sink_test.exs
+++ b/test/ptc_runner/kernel/inspection_sink_test.exs
@@ -791,6 +791,25 @@ defmodule PtcRunner.Kernel.InspectionSinkTest do
 
     assert {:error, :invalid_inspection_artifact} = InspectionArtifact.load(wrong_type)
 
+    unsupported = Path.join(dir, "unsupported.inspection.jsonl")
+
+    File.write!(
+      unsupported,
+      Enum.map_join(records, "\n", fn record ->
+        record |> Map.put("schema_version", 4) |> Jason.encode!()
+      end) <> "\n"
+    )
+
+    assert {:error,
+            {:unsupported_inspection_schema_version, %{artifact_version: 4, supported_version: 5}}} =
+             InspectionArtifact.load(unsupported)
+
+    mixed = Path.join(dir, "mixed-schema.inspection.jsonl")
+    first = records |> hd() |> Map.put("schema_version", 4)
+    second = Map.put(hd(records), "sequence", 2)
+    File.write!(mixed, Enum.map_join([first, second], "\n", &Jason.encode!/1) <> "\n")
+    assert {:error, :invalid_inspection_artifact} = InspectionArtifact.load(mixed)
+
     capability_input = %{
       "schema_version" => 5,
       "run_id" => "run-1",

--- a/test/ptc_runner/kernel/inspection_snapshot_test.exs
+++ b/test/ptc_runner/kernel/inspection_snapshot_test.exs
@@ -733,6 +733,19 @@ defmodule PtcRunner.Kernel.InspectionSnapshotTest do
   end
 
   @tag :tmp_dir
+  test "an unsupported inspection schema remains distinguishable during capture", %{tmp_dir: root} do
+    {trace, inspection} = source_directories(root)
+    write_run(trace, inspection, "unsupported", :basic)
+    PrivateInspectionFixture.rewrite_schema!(inspection, 4)
+    {:ok, trace_snapshot} = TraceSnapshot.start({:directory, trace}, owner: self())
+    on_exit(fn -> TraceSnapshot.stop(trace_snapshot) end)
+
+    assert {:error,
+            {:unsupported_inspection_schema_version, %{artifact_version: 4, supported_version: 5}}} =
+             InspectionSnapshot.start({:directory, inspection}, trace_snapshot, owner: self())
+  end
+
+  @tag :tmp_dir
   test "encoded, retained, result, and file ceilings are independent", %{tmp_dir: root} do
     {trace, inspection} = source_directories(root)
     write_run(trace, inspection, "bounded", :basic)

--- a/test/support/private_inspection_fixture.ex
+++ b/test/support/private_inspection_fixture.ex
@@ -46,6 +46,26 @@ defmodule PtcRunner.TestSupport.PrivateInspectionFixture do
     Map.put(fixture, :result_hash, result_hash)
   end
 
+  def rewrite_schema!(directory, schema_version) when is_integer(schema_version) do
+    directory
+    |> Path.join("*.inspection.jsonl")
+    |> Path.wildcard()
+    |> Enum.each(fn path ->
+      rewritten =
+        path
+        |> File.stream!()
+        |> Enum.map_join(fn line ->
+          line
+          |> Jason.decode!()
+          |> Map.put("schema_version", schema_version)
+          |> Jason.encode!()
+          |> Kernel.<>("\n")
+        end)
+
+      File.write!(path, rewritten)
+    end)
+  end
+
   def canonical_events(run_id) do
     [
       event(run_id, 1, "run-started", %{


### PR DESCRIPTION
Closes #1330

## Summary

- distinguish a well-formed inspection artifact with an unsupported schema version from a malformed artifact
- preserve the declared and supported versions through snapshot acquisition, analysis-profile setup, CLI rendering, and Viewer startup
- tell users to use a matching PtcRunner build or regenerate the artifact
- retain fail-closed behavior for mixed-version or otherwise malformed sources
- give the locale-propagation test fixture sufficient startup headroom under loaded CI without changing the production timeout default

## Root cause

`InspectionArtifact.load/2` previously collapsed every record-validation failure to `:invalid_inspection_artifact`. Higher layers then normalized that to `:invalid_snapshot`, so `mix ptc repl` could not explain that the artifact was valid but produced by an incompatible PtcRunner version.

The first CI run also exposed an unrelated brittle test deadline: the locale-propagation test boots an Elixir source fixture under the transport's 5-second default. Under full-suite runner load that fixture exceeded the deadline and returned `:mcp_timeout`. The test now uses a 20-second startup ceiling because timeout behavior is outside its scope; runtime defaults remain unchanged.

## Review

- independent cumulative review found one Viewer normalization gap
- one follow-up review confirmed the gap was fixed and reported no remaining actionable findings
- the user-requested maximum of two independent reviews was respected; the later CI-only test deadline adjustment was verified by the failing seed and repository gates

## Verification

- exact CI command: `mix test --seed 449303 --max-cases 4 --max-failures 1 --warnings-as-errors`
- focused failing test at `test/ptc_runner/kernel/host_installation_test.exs:1080`
- `mix precommit`
- `MIX_ENV=dev mix docs --warnings-as-errors`
- pre-commit hook: root and Viewer scoped checks
- pre-push hook: 6,205 root tests, 74 Viewer tests, Credo, generated-artifact checks, upstream API audit, Dialyzer, and unused-dependency checks