### PR TITLE
perf(cli): accelerate mix ptc startup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,14 @@ how it was verified.
 
 ## Commands
 
+- `mix ptc ...` — the root-project command path skips dependency validation for fast
+  startup while still compiling changed root sources and shipped preludes.
+  This optimization is root-only; downstream projects retain Mix's normal
+  dependency validation.
+  After changing `mix.exs`, `mix.lock`, dependency sources, or either local
+  path dependency (`ptc_runner_launcher/` or `ptc_viewer/`), run a normal
+  `mix compile` once. Runtime manifests, host configuration, external inputs,
+  and component override descriptors and sources remain live.
 - `mix precommit` — comprehensive local quality gate (format, compile, compile
   cycles, stable-CLI callers, credo, duplication, spec, generated-artifact
   staleness, root/Viewer/launcher tests, core-package and standalone release

--- a/docs/guides/kernel-maintainer.md
+++ b/docs/guides/kernel-maintainer.md
@@ -994,18 +994,27 @@ spellings. Exact raw contract bytes remain part of content identity, while the
 `ptc_semantic_revision` is `sem1-` plus lowercase SHA-256 over the generated
 semantic-build projection and the exact Elixir, OTP, ERTS, BEAM architecture,
 compiled scheduler-derived pmap default, conditionally compiled semantic-module
-presence, and consuming-build dependency-artifact projection. Dependency
+presence, and an explicit runtime-dependency verification mode. Development
+and test builds use `build_projection` mode: the checked-in publisher dependency
+projection remains part of the identity, but constructing a short-lived command
+does not reopen and hash every compiled dependency artifact. All other build
+environments use `verified` mode and add the consuming-build dependency-artifact
+projection, so custom release environments such as `staging` remain safe by
+default. The modes are part of the hashed input and therefore cannot collide.
+
+Verified mode starts from audited runtime roots, traverses required, included,
+and optional `.app` metadata, records absent optional applications, and follows
+the required closure of every application that is present. Dependency
 presence, regular-file identity, the complete owner/group/other execute mask,
 and the bytes under each present dependency's compiled `ebin` and `priv`
-directories are captured once under the trusted immutable-build assumption.
-Artifact bytes are hashed in bounded chunks, so runtime revision construction
-does not retain the complete dependency closure in memory.
-Starting from audited runtime roots, the projection traverses required,
-included, and optional `.app` metadata, records absent optional applications,
-and follows the required closure of every application that is present.
-Compatible downstream resolutions, scheduler-dependent compiled defaults,
-conditional-compilation outcomes, optional-dependency presence, and
-execute-mask changes therefore cannot reuse the publisher's revision.
+directories are captured once under the trusted immutable-release assumption.
+Artifact bytes are hashed in bounded chunks, so revision construction does not
+retain the complete dependency closure in memory. Compatible downstream
+resolutions, scheduler-dependent compiled defaults, conditional-compilation
+outcomes, optional-dependency presence, and execute-mask changes therefore
+cannot reuse a verified release revision. Repository releases are compiled with
+`MIX_ENV=prod`; the standalone-release verification asserts that verified mode
+was compiled into the artifact.
 `priv/semantic_build_inventory.exs` owns the classified source boundaries,
 code-owned Mix application defaults, explicit semantic files, conditionally
 compiled semantic modules, runtime roots, publisher dependency closure, and
@@ -1026,12 +1035,13 @@ cover the whole source closure, so regenerating it per branch made every pair
 of concurrent branches conflict. Between releases the committed projection may
 therefore lag the tree. That is safe for the checks that consume it —
 `ApplicationPackage.valid?/1` compares a package's recorded revision against
-`SemanticRevision.current()`, and both read the same compiled constant, so the
-comparison stays self-consistent regardless of the file's age. What lags is the
-accuracy of the identity as a description of the source, which is precisely
-what the release gate re-establishes. This revision is conservative:
-comments, refactors, dependency changes, or runtime patch changes may produce a
-new value even when observed behavior is unchanged.
+`SemanticRevision.current()`, and both read the same compiled constant and
+mode, so the comparison stays self-consistent regardless of the file's age.
+What lags in a development build is the accuracy of the identity as a
+description of the source and consuming dependency artifacts, which is
+precisely what the production compile and release gate re-establish. A verified
+revision is conservative: comments, refactors, dependency changes, or runtime
+patch changes may produce a new value even when observed behavior is unchanged.
 
 ## Bundles, environments, and capabilities
 

--- a/lib/ptc_runner/kernel/semantic_revision.ex
+++ b/lib/ptc_runner/kernel/semantic_revision.ex
@@ -3,13 +3,14 @@ defmodule PtcRunner.Kernel.SemanticRevision do
   Conservative code-owned PTC execution-semantics revision.
 
   The generated build projection covers the checked-in semantic source
-  inventory and publisher dependency lock identities. Starting from audited
-  runtime roots, the runtime projection follows required, included, and
-  optional application metadata and adds the exact Elixir, OTP, ERTS, BEAM
-  architecture, conditionally compiled semantic-module presence, and resolved
-  regular-file artifact identities, including executable classification. The
-  final revision is deliberately stricter than observed behavioral
-  equivalence.
+  inventory and publisher dependency lock identities. Every build adds the
+  exact Elixir, OTP, ERTS, BEAM architecture, compiled scheduler default, and
+  conditionally compiled semantic-module presence. Release-oriented builds also
+  follow audited runtime roots through required, included, and optional
+  application metadata and add resolved regular-file artifact identities,
+  including executable classification. The verified revision is
+  deliberately stricter than observed behavioral equivalence; development and
+  test builds avoid that release-only filesystem audit.
   """
 
   alias PtcRunner.Kernel.TypedCanonicalJSON
@@ -30,12 +31,22 @@ defmodule PtcRunner.Kernel.SemanticRevision do
   @domain <<"ptc.semantic-revision.v1", 0>>
   @dependency_domain <<"ptc.runtime-dependency-artifacts.v1", 0>>
   @artifact_chunk_bytes 65_536
+  # Keep the decision in the compiled module so package consumers get the same
+  # fast dev/test behavior without adding application configuration. Any custom
+  # environment remains release-safe by default.
+  @runtime_dependency_artifacts_verified Mix.env() not in [:dev, :test]
+  @runtime_dependency_artifact_mode if(@runtime_dependency_artifacts_verified,
+                                      do: :verified,
+                                      else: :build_projection
+                                    )
 
   @spec current() :: binary()
   @doc "Returns the semantic revision for this build and running BEAM."
   def current do
     runtime_identity = runtime_identity()
-    storage_key = {__MODULE__, :current, @build_identity, runtime_identity}
+
+    storage_key =
+      {__MODULE__, :current, @build_identity, @runtime_dependency_artifact_mode, runtime_identity}
 
     case :persistent_term.get(storage_key, :missing) do
       :missing ->
@@ -55,6 +66,10 @@ defmodule PtcRunner.Kernel.SemanticRevision do
         revision
     end
   end
+
+  @doc false
+  @spec runtime_dependency_artifacts_verified?() :: boolean()
+  def runtime_dependency_artifacts_verified?, do: @runtime_dependency_artifacts_verified
 
   @spec revision_for(map(), map()) :: binary()
   @doc false
@@ -118,15 +133,26 @@ defmodule PtcRunner.Kernel.SemanticRevision do
          {elixir, erts, otp_release, system_architecture, compiled_pmap_max_concurrency}
        ) do
     %{
-      "actual_runtime_dependencies" => actual_dependency_projection(@actual_dependency_roots),
       "compiled_pmap_max_concurrency" => compiled_pmap_max_concurrency,
       "compiled_semantic_features" =>
         actual_compile_feature_projection(@conditional_semantic_modules),
       "elixir" => elixir,
       "erts" => erts,
       "otp_release" => otp_release,
+      "runtime_dependency_artifacts" => runtime_dependency_artifacts(),
       "system_architecture" => system_architecture
     }
+  end
+
+  defp runtime_dependency_artifacts do
+    if @runtime_dependency_artifacts_verified do
+      %{
+        "mode" => Atom.to_string(@runtime_dependency_artifact_mode),
+        "dependencies" => actual_dependency_projection(@actual_dependency_roots)
+      }
+    else
+      %{"mode" => Atom.to_string(@runtime_dependency_artifact_mode)}
+    end
   end
 
   defp collect_dependency(app, resolver, dependencies) do

--- a/lib/ptc_runner/mix_command_runtime.ex
+++ b/lib/ptc_runner/mix_command_runtime.ex
@@ -1,6 +1,8 @@
 defmodule PtcRunner.MixCommandRuntime do
   @moduledoc false
 
+  @root_project :"Elixir.PtcRunner.MixProject"
+
   alias PtcRunner.Dotenv
   alias PtcRunner.Kernel.CommandArguments
   alias PtcRunner.Kernel.CommandRuntime
@@ -17,7 +19,7 @@ defmodule PtcRunner.MixCommandRuntime do
   @doc false
   @spec bootstrap() :: :ok | {:error, :command_bootstrap_failed}
   def bootstrap do
-    Mix.Task.run("app.config")
+    Mix.Task.run("app.config", app_config_args())
 
     case Application.ensure_all_started(:ptc_runner) do
       {:ok, _started} -> :ok
@@ -28,6 +30,15 @@ defmodule PtcRunner.MixCommandRuntime do
   catch
     _kind, _reason -> {:error, :command_bootstrap_failed}
   end
+
+  @doc false
+  @spec app_config_args() :: [binary()]
+  def app_config_args, do: app_config_args(Mix.Project.get())
+
+  @doc false
+  @spec app_config_args(module() | nil) :: [binary()]
+  def app_config_args(@root_project), do: ["--no-deps-check"]
+  def app_config_args(_project), do: []
 
   @doc false
   @spec options() :: keyword()

--- a/mix.exs
+++ b/mix.exs
@@ -175,6 +175,7 @@ defmodule PtcRunner.MixProject do
 
   defp aliases do
     [
+      ptc: &run_ptc/1,
       precommit: [
         "format --check-formatted",
         "compile --warnings-as-errors",
@@ -245,6 +246,22 @@ defmodule PtcRunner.MixProject do
       ]
     ]
   end
+
+  defp run_ptc(args) do
+    Mix.Task.run(ptc_prepare_task(args), ["--no-deps-check"])
+    Mix.Task.run("ptc", args)
+  end
+
+  # These raw forms are only preparation hints; the shared parser remains the
+  # authority for acceptance and rendering. They cover the common commands
+  # whose frontend deliberately never starts the application runtime.
+  defp ptc_prepare_task([]), do: "compile"
+
+  defp ptc_prepare_task([command | _rest])
+       when command in ["help", "version", "--version", "repl"],
+       do: "compile"
+
+  defp ptc_prepare_task(_args), do: "app.config"
 
   defp releases do
     [

--- a/scripts/verify_standalone_release.sh
+++ b/scripts/verify_standalone_release.sh
@@ -84,6 +84,9 @@ MIX_ENV=prod mix release ptc_runner --overwrite --path "$release_root"
 test -x "$command_bin"
 test -d "$release_root/erts-$(elixir -e 'IO.write(:erlang.system_info(:version))')"
 find "$release_root/lib" -maxdepth 1 -type d -name 'req_llm-*' -print -quit | grep -q .
+"$release_root/bin/ptc_runner" eval '
+  true = PtcRunner.Kernel.SemanticRevision.runtime_dependency_artifacts_verified?()
+'
 
 "$command_bin" --version > "$release_tmp_dir/version.stdout"
 grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$' "$release_tmp_dir/version.stdout"

--- a/test/mix/tasks/ptc_test.exs
+++ b/test/mix/tasks/ptc_test.exs
@@ -9,6 +9,13 @@ defmodule Mix.Tasks.PtcTest do
   alias PtcRunner.Kernel.CommandFrontend
   alias PtcRunner.Kernel.CommandRenderer
   alias PtcRunner.MixCommandAdapter
+  alias PtcRunner.MixCommandRuntime
+
+  test "only the root project bootstrap skips dependency checks" do
+    assert MixCommandRuntime.app_config_args(PtcRunner.MixProject) == ["--no-deps-check"]
+    assert MixCommandRuntime.app_config_args(Downstream.MixProject) == []
+    assert MixCommandRuntime.app_config_args(nil) == []
+  end
 
   @root Path.expand("../../..", __DIR__)
 

--- a/test/ptc_runner/kernel/semantic_revision_test.exs
+++ b/test/ptc_runner/kernel/semantic_revision_test.exs
@@ -4,6 +4,10 @@ defmodule PtcRunner.Kernel.SemanticRevisionTest do
   alias PtcRunner.Kernel.BoundedWorker
   alias PtcRunner.Kernel.SemanticRevision
 
+  test "non-production builds skip consuming dependency artifact verification" do
+    refute SemanticRevision.runtime_dependency_artifacts_verified?()
+  end
+
   test "the checked-in source projection includes code-owned Mix application defaults" do
     assert Enum.any?(
              SemanticRevision.build_projection()["sources"],


### PR DESCRIPTION
Fixes #1336

## Summary

- make the root project's ordinary `mix ptc` path use the fast dependency-check behavior by default while still compiling changed root sources
- keep downstream consumers on Mix's normal dependency validation
- avoid reopening and hashing the compiled runtime dependency closure in dev/test semantic revisions
- retain verified dependency-artifact revisions for every non-dev/test build and assert verified mode in the production standalone release
- document the fast-path dependency caveat in `AGENTS.md` and the semantic revision modes in the maintainer guide

Runtime manifests, host configuration, inputs, and component/prelude overrides remain live.

## Performance

Five warm wall-clock samples per command on Apple Silicon macOS; values below are medians. The final set included one 7.66 s system/cold outlier for `--version`, which the median excludes.

| Command | Before | After | Reduction |
|---|---:|---:|---:|
| `mix ptc --version` | 3.03 s | 1.26 s | 58% |
| `mix ptc help` | 2.77 s | 1.24 s | 55% |
| `mix ptc repl --describe-profile inspection-analysis-v2` | 2.71 s | 1.21 s | 55% |
| `mix ptc validate examples/kernel-tutorial/01-orders/ptc.json` | 3.72 s | 1.41 s | 62% |

The one-second goal is reachable in the fastest warm samples (0.81–0.99 s), but not a consistent bound on this machine. Semantic revision construction itself dropped to about 15 ms in dev/test.

## Verification

- `mix precommit`
  - 6,197 root tests passed
  - 74 Viewer tests passed
  - 40 launcher tests passed
  - core package and standalone production release verification passed
- `MIX_ENV=dev mix docs --warnings-as-errors`
- pre-push gate passed, including the same root/Viewer/launcher suites, Credo, generated-artifact checks, upstream audit, Dialyzer, and unused-dependency check
- three independent Codex review rounds completed; findings were addressed within the requested review cap
