### PR TITLE
ci: unify local and GitHub gates

### DIFF
--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -4,10 +4,11 @@ Run `./scripts/install-hooks.sh` once per clone. The installed hooks are small
 wrappers around the tracked implementations in this directory, so hook updates
 take effect without reinstalling them.
 
-The pre-push hook classifies the pushed and dirty paths, then runs the relevant
-root, Viewer, launcher, or documentation gates. For mixed documentation and
-code changes, ExDoc runs before the longer test and Dialyzer stages. Plan-only
-changes skip the expensive gate. Unknown paths select every gate, and
+The pre-push hook classifies the pushed and dirty paths, then invokes the same
+repository-owned root, Viewer, launcher, release, or documentation entry
+points as GitHub Actions. For mixed documentation and code changes, ExDoc runs
+before the longer test and Dialyzer stages. Plan-only changes skip the
+expensive gate. Unknown paths select every gate, and
 `FORCE_FULL_PRE_PUSH=1` explicitly forces the complete gate.
 
 For an ordinary push, run `git push` and let the hook execute the complete gate
@@ -20,6 +21,7 @@ Fresh clones and worktrees should follow the bootstrap commands in `AGENTS.md`.
 Linked worktrees share installed hook wrappers but keep their own build and
 Dialyzer PLT directories.
 
-The hook uses the project's scheduler-count ExUnit concurrency. Do not reduce
-that pressure to make a failing push pass; reproduce the reported seed and fix
-the load-sensitive test instead.
+The core test entry point sets `CI=1` but uses the project's scheduler-count
+ExUnit concurrency. Do not reduce that pressure to make a failing push pass;
+reproduce the reported seed and fix the load-sensitive test instead. For a
+second, lower-concurrency signal, run `scripts/ci/core-tests.sh --schedulers 4`.

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -5,12 +5,9 @@
 #   1. Documentation routing: disposable plan-only changes skip the gate;
 #      other documentation-only changes run the ExDoc warnings gate.
 #   2. Otherwise: classify the affected contracts, run documentation first,
-#      then run the relevant root, Viewer, and launcher gates. Root changes
-#      invoke the canonical `mix prepush` alias for generated-artifact
-#      staleness, the upstream audit, Dialyzer, and the unused-dependency
-#      check. The staleness checks are shared with `precommit`, which an
-#      ordinary push does not run, so this hook is where a stale generated
-#      artifact is caught before CI rather than by it.
+#      then invoke the same repository-owned root, Viewer, and launcher gate
+#      scripts as GitHub Actions. The hook supplies changed paths; the scripts
+#      own commands and environment.
 #
 # Override:
 #   FORCE_FULL_PRE_PUSH=1 git push  → always run the full gate, even if
@@ -27,12 +24,10 @@ run_docs_gate() {
   echo ""
   echo "📚 Documentation"
 
-  if ! MIX_ENV=dev mix deps.get --check-locked; then
-    echo "❌ Documentation dependency setup failed. Fix the Mix error above before pushing."
+  if ! "$HOOK_REPO_ROOT/scripts/ci/docs.sh"; then
+    echo "❌ Documentation dependency setup or build failed. Fix the error above before pushing."
     return 1
   fi
-
-  MIX_ENV=dev mix docs --warnings-as-errors
 }
 
 # ----------------------------------------------------------------------
@@ -338,7 +333,8 @@ print_phase_summary() {
 }
 
 SCOPES_FILE="$(mktemp -t pre-push-scopes.XXXXXX)"
-"$HOOK_REPO_ROOT/scripts/classify_changes.sh" "$PTC_PRE_PUSH_PATHS_FILE" > "$SCOPES_FILE"
+"$HOOK_REPO_ROOT/scripts/ci/classify-changes.sh" \
+  "$PTC_PRE_PUSH_PATHS_FILE" > "$SCOPES_FILE"
 # The classifier emits only fixed boolean assignments.
 core=false
 launcher=false
@@ -354,114 +350,47 @@ rm -f "$SCOPES_FILE"
 # Documentation failures are deterministic and usually cheap to diagnose. Run
 # this gate before long test and Dialyzer stages so a bad reference does not
 # waste the rest of the push cycle.
-if [ "$docs" = true ]; then
+if [ "$docs" = true ] || [ "$core" = true ]; then
   DOCS_START=$SECONDS
   run_docs_gate
   record_phase "documentation (ExDoc)" $((SECONDS - DOCS_START))
 fi
 
-PROJECTS=()
+run_gate() {
+  local label="$1"
+  shift
+  echo ""
+  echo "📦 $label"
+  echo "  ⏳ Running repository CI entry point..."
+
+  local gate_start=$SECONDS
+  if ! "$@"; then
+    echo "  ❌ $label failed. Re-run: $*"
+    exit 1
+  fi
+
+  local gate_secs=$((SECONDS - gate_start))
+  echo "  ✅ $label passed in ${gate_secs}s"
+  record_phase "$label" "$gate_secs"
+}
+
 if [ "$core" = true ] || [ "$mcp_http" = true ] ||
    [ "$mcp_filesystem" = true ] || [ "$java" = true ]; then
-  PROJECTS+=(".")
+  run_gate "core tests" "$HOOK_REPO_ROOT/scripts/ci/core-tests.sh"
+  run_gate "core static analysis" "$HOOK_REPO_ROOT/scripts/ci/core-static.sh"
+  run_gate "core Dialyzer" "$HOOK_REPO_ROOT/scripts/ci/core-dialyzer.sh"
+  run_gate "core release verification" "$HOOK_REPO_ROOT/scripts/ci/core-release.sh"
 fi
 
 # Root trace and inspection contracts are consumed by the Viewer, so retain
 # Viewer coverage for core changes as well as Viewer-owned changes.
 if [ "$viewer" = true ] || [ "$core" = true ]; then
-  PROJECTS+=("ptc_viewer")
+  run_gate "Viewer validation" "$HOOK_REPO_ROOT/scripts/ci/viewer.sh"
 fi
 
 if [ "$launcher" = true ]; then
-  PROJECTS+=("ptc_runner_launcher")
+  run_gate "launcher validation" "$HOOK_REPO_ROOT/scripts/ci/launcher.sh"
 fi
-
-project_has_dep() {
-  local proj="$1" dep="$2"
-  grep -qE "\\{:${dep}," "${proj}/mix.exs" 2>/dev/null
-}
-
-run_project_gates() {
-  local proj="$1"
-  local label
-
-  if [ "$proj" = "." ]; then
-    label="root (:ptc_runner)"
-  else
-    label="$proj/"
-    [ -d "$proj" ] || return 0
-  fi
-
-  echo ""
-  echo "📦 Project: $label"
-
-  pushd "$proj" > /dev/null
-
-  if [ "$proj" = "ptc_runner_launcher" ]; then
-    echo "  ⏳ Running launcher package and containment gate..."
-    local launcher_start=$SECONDS
-    if ! mix precommit; then
-      echo "  ❌ Launcher checks failed. Re-run: (cd ptc_runner_launcher && mix precommit)"
-      popd > /dev/null
-      exit 1
-    fi
-    local launcher_secs=$((SECONDS - launcher_start))
-    echo "  ✅ Launcher checks passed in ${launcher_secs}s"
-    record_phase "launcher precommit" "$launcher_secs"
-    popd > /dev/null
-    return 0
-  fi
-
-  # "except `:nightly`" is not a hedge: `:nightly` tests cost tens of seconds
-  # each and run in the `Nightly` workflow instead. Every other tag this hook
-  # would otherwise skip still runs here.
-  echo "  ⏳ Running the test suite (all but :nightly)..."
-  local test_start=$SECONDS
-  if ! mix test --exclude clojure 2>&1; then
-    echo "  ❌ Tests failed in $label. Re-run: (cd $proj && mix test --exclude clojure)"
-    popd > /dev/null
-    exit 1
-  fi
-  local test_secs=$((SECONDS - test_start))
-  echo "  ✅ Tests passed in ${test_secs}s"
-  record_phase "$label tests" "$test_secs"
-
-  if [ "$proj" = "." ]; then
-    echo "  ⏳ Running canonical pre-push checks..."
-    local prepush_start=$SECONDS
-    if ! mix prepush; then
-      echo "  ❌ Pre-push checks failed in $label. Run: mix prepush"
-      popd > /dev/null
-      exit 1
-    fi
-    local prepush_secs=$((SECONDS - prepush_start))
-    echo "  ✅ Pre-push checks passed in ${prepush_secs}s"
-    record_phase "root mix prepush (incl. dialyzer)" "$prepush_secs"
-  # CWD is the project dir (we are inside `pushd "$proj"`), so check
-  # `./mix.exs` rather than `$proj/mix.exs`. Passing `$proj` here would
-  # resolve to a duplicated project path and silently skip Dialyzer for
-  # non-root projects.
-  elif project_has_dep "." "dialyxir"; then
-    echo "  ⏳ Running dialyzer (this may take a moment)..."
-    local dialyzer_start=$SECONDS
-    if ! mix dialyzer; then
-      echo "  ❌ Dialyzer found errors in $label. Run: (cd $proj && mix dialyzer)"
-      popd > /dev/null
-      exit 1
-    fi
-    local dialyzer_secs=$((SECONDS - dialyzer_start))
-    echo "  ✅ Dialyzer passed in ${dialyzer_secs}s"
-    record_phase "$label dialyzer" "$dialyzer_secs"
-  else
-    echo "  ⏭️  Dialyzer not declared in ${label}mix.exs"
-  fi
-
-  popd > /dev/null
-}
-
-for proj in "${PROJECTS[@]}"; do
-  run_project_gates "$proj"
-done
 
 END_TIME=$(date +%s)
 ELAPSED=$((END_TIME - START_TIME))

--- a/.github/actions/setup-elixir/action.yml
+++ b/.github/actions/setup-elixir/action.yml
@@ -37,7 +37,7 @@ runs:
           ${{ runner.os }}-${{ runner.arch }}-mix-${{ inputs.project-directory }}-env${{ env.MIX_ENV || 'dev' }}-otp${{ steps.setup-beam.outputs.otp-version }}-elixir${{ steps.setup-beam.outputs.elixir-version }}-
 
     - name: Get dependencies
-      run: mix deps.get
+      run: mix deps.get --check-locked
       working-directory: ${{ inputs.project-directory }}
       shell: bash
 

--- a/.github/workflows/launcher-release.yml
+++ b/.github/workflows/launcher-release.yml
@@ -75,13 +75,8 @@ jobs:
           cache-plt: 'false'
           install-babashka: 'false'
 
-      - name: Verify source package and process containment
-        working-directory: ptc_runner_launcher
-        run: mix precommit
-
-      - name: Build and verify precompiled artifact
-        working-directory: ptc_runner_launcher
-        run: bash scripts/verify_precompiled.sh "$RUNNER_TEMP/launcher-artifacts"
+      - name: Verify source package, process containment, and precompiled artifact
+        run: scripts/ci/launcher.sh "$RUNNER_TEMP/launcher-artifacts"
 
       - name: Upload launcher artifact
         uses: actions/upload-artifact@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
             fi
           fi
 
-          scripts/classify_changes.sh "$paths_file" | tee -a "$GITHUB_OUTPUT"
+          scripts/ci/classify-changes.sh "$paths_file" | tee -a "$GITHUB_OUTPUT"
 
   mcp-stdio-launcher:
     needs: changes
@@ -91,13 +91,8 @@ jobs:
           cache-plt: 'false'
           install-babashka: 'false'
 
-      - name: Verify launcher package and process containment
-        working-directory: ptc_runner_launcher
-        run: mix precommit
-
-      - name: Verify precompiled download, checksum, and source fallback
-        working-directory: ptc_runner_launcher
-        run: bash scripts/verify_precompiled.sh "$RUNNER_TEMP/launcher-artifacts"
+      - name: Verify launcher package, process containment, and precompiled fallback
+        run: scripts/ci/launcher.sh "$RUNNER_TEMP/launcher-artifacts"
 
       - name: Retain verified launcher artifact
         uses: actions/upload-artifact@v6
@@ -274,9 +269,6 @@ jobs:
           cache-plt: 'false'
           install-babashka: 'false'
 
-      - name: Compile
-        run: mix compile --warnings-as-errors
-
       # No `--trace` here, and none may be reintroduced: it sets `--max-cases`
       # to 1 (`Mix.Tasks.Test` docs; `ExUnit.max_cases/1`), which ran this
       # suite single-threaded on a 4-vCPU runner for 259 s. `--slowest` and
@@ -290,8 +282,8 @@ jobs:
       # 61.1 s and would otherwise time out here. `:nightly` is a narrow tag --
       # do not reach for it to make this step faster, because every test it
       # covers stops being verified on pull requests.
-      - name: Run tests
-        run: mix test --max-failures 1 --warnings-as-errors
+      - name: Compile and run tests
+        run: scripts/ci/core-tests.sh
 
   core-static:
     needs: changes
@@ -322,34 +314,8 @@ jobs:
         with:
           cache-plt: 'false'
 
-      - name: Compile
-        run: mix compile --warnings-as-errors
-
-      - name: Check compile-time dependency cycles
-        run: mix xref graph --format cycles --label compile-connected --fail-above 0
-
-      - name: Check code is formatted
-        run: mix format --check-formatted
-
-      - name: Run Credo
-        run: mix credo --strict
-
-      - name: Check for new code duplication
-        run: scripts/duplication_gate.sh check
-
-      - name: Validate the PTC-Lisp specification
-        run: mix ptc.validate_spec
-
-      - name: Check generated Java documentation and conformance inventory
-        run: |
-          mix ptc.gen_docs --check
-          mix ptc.conformance_report --check-inventory
-
-      - name: Audit upstream compatibility metadata
-        run: mix ptc.audit_upstream
-
-      - name: Check unused dependencies
-        run: mix deps.unlock --check-unused
+      - name: Run static analysis and generated-artifact checks
+        run: scripts/ci/core-static.sh
 
   core-dialyzer:
     needs: changes
@@ -371,7 +337,7 @@ jobs:
           install-babashka: 'false'
 
       - name: Dialyzer
-        run: mix dialyzer --format github
+        run: scripts/ci/core-dialyzer.sh
 
   core-release:
     needs: changes
@@ -393,11 +359,8 @@ jobs:
           cache-plt: 'false'
           install-babashka: 'false'
 
-      - name: Verify core release package
-        run: bash scripts/verify_core_package.sh
-
-      - name: Verify assembled standalone release
-        run: bash scripts/verify_standalone_release.sh
+      - name: Verify release packages
+        run: scripts/ci/core-release.sh
 
   ex-dna-candidate:
     needs: changes
@@ -499,13 +462,8 @@ jobs:
           cache-plt: 'false'
           install-babashka: 'false'
 
-      - name: Compile Viewer
-        working-directory: ptc_viewer
-        run: mix compile --warnings-as-errors
-
-      - name: Test Viewer
-        working-directory: ptc_viewer
-        run: mix test --warnings-as-errors
+      - name: Compile and test Viewer
+        run: scripts/ci/viewer.sh
 
   docs:
     needs: changes
@@ -527,7 +485,7 @@ jobs:
           install-babashka: 'false'
 
       - name: Build documentation
-        run: mix docs --warnings-as-errors
+        run: scripts/ci/docs.sh
 
   required:
     if: always()

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,22 +62,25 @@ how it was verified.
   staleness, root/Viewer/launcher tests, core-package and standalone release
   verification); run before every commit. Much broader than the fast,
   staged-file Git pre-commit hook; takes a few minutes in a fresh worktree.
+- `scripts/ci/core-tests.sh` — canonical core compile/test gate used by
+  `mix precommit`, pre-push, and GitHub Actions. It always sets `CI=1`, so
+  StreamData runs the same 300 cases locally and remotely, while retaining all
+  native schedulers by default. Use `scripts/ci/core-tests.sh --schedulers 4`
+  to reproduce GitHub's current CPU shape; this does not emulate Linux.
 - `MIX_ENV=dev mix docs --warnings-as-errors` — ExDoc reference and rendering
   gate; run when changing user-facing documentation. Generated-artifact
   staleness is checked separately, by both `mix precommit` and `mix prepush`.
 - `git push` — the tracked pre-push hook classifies pushed and dirty paths and
-  runs the relevant root, Viewer, launcher, or documentation gates. Root
-  changes run the root tests and `mix prepush` (credo, generated-artifact
-  staleness, upstream API audit, Dialyzer, unused-deps). Credo and the staleness
-  checks are also in `precommit`, and are repeated here because an ordinary push
-  does not run `precommit` — without them a `lib/` edit can clear every local
-  gate and still fail CI on an artifact you were never prompted to regenerate.
+  invokes the same repository-owned root, Viewer, launcher, release, and
+  documentation scripts as GitHub Actions. Root changes therefore use the
+  same compile/test flags, `CI=1` property count, static checks, Dialyzer
+  format, and release verification locally and remotely.
   When one fires, run its matching write form — `mix ptc.gen_docs` for
   generated docs and schemas, or `mix ptc.conformance_report --write-inventory`
   for `conformance_inventory.json` — then stage the result. Do not run
   `mix prepush` immediately before an ordinary push;
-  invoke it directly only for diagnosis or when hooks are unavailable. PR CI
-  runs the same checks as individual steps. The test suite uses
+  invoke it directly only for static/Dialyzer diagnosis or when hooks are
+  unavailable. PR CI runs the same scripts as individual jobs. The test suite uses
   `System.schedulers_online()` concurrent cases; do not reduce that pressure
   to make a failing push pass.
 - `mix test --include e2e` — E2E tests (requires `OPENROUTER_API_KEY`;

--- a/README.md
+++ b/README.md
@@ -254,11 +254,11 @@ git push
 
 Install hooks once per clone with `./scripts/install-hooks.sh`; linked
 worktrees share them. The tracked pre-push hook runs the complete push gate,
-including `mix prepush`, and validates documentation before longer stages.
-Run that Mix alias directly only to diagnose its slower audit, Dialyzer, and
-unused-dependency checks or when hooks are unavailable. The hook retains the
-project's scheduler-count ExUnit concurrency so load-sensitive failures remain
-visible locally.
+using the same repository-owned scripts as GitHub Actions, and validates
+documentation before longer stages. Run `mix prepush` directly only to diagnose
+its static and Dialyzer scripts or when hooks are unavailable. The core test
+script sets `CI=1` while retaining the project's scheduler-count ExUnit
+concurrency, so property and load-sensitive failures remain visible locally.
 
 ## License
 

--- a/docs/development-setup.md
+++ b/docs/development-setup.md
@@ -80,6 +80,27 @@ cannot be merged, and only the release gate checks it — so never regenerate it
 on a feature branch and never hand-merge it. Run `mix regen` on `main` before
 tagging. `.gitattributes` explains why.
 
+## Local CI modes
+
+GitHub Actions and the tracked hooks delegate deterministic gates to the
+scripts in `scripts/ci/`. Run the core gate directly when diagnosing a test
+failure:
+
+```bash
+scripts/ci/core-tests.sh
+```
+
+That command sets `CI=1`, including StreamData's 300-run setting, but retains
+the machine's native scheduler count for higher local pressure. A complementary
+four-scheduler run reproduces GitHub's current CPU shape:
+
+```bash
+scripts/ci/core-tests.sh --schedulers 4
+```
+
+The second command still runs on the local operating system. It is CPU-shape
+parity, not an Ubuntu container; OS-level parity remains a separate concern.
+
 ## Dialyzer PLT
 
 Outside CI the core PLT lives under `~/.cache/ptc_runner/` and is shared across

--- a/docs/guides/kernel-maintainer.md
+++ b/docs/guides/kernel-maintainer.md
@@ -1586,9 +1586,9 @@ Prefer contract-level integration tests over tests that mirror implementation:
 - tutorial/E2E tests — real user and provider flows.
 
 Run `mix precommit` before every commit. For an ordinary push, let the tracked
-pre-push hook run the full root/Viewer tests and the canonical `mix prepush`
-checks once. Invoke `mix prepush` directly only for diagnosis or when hooks are
-unavailable.
+pre-push hook invoke the same repository-owned root, Viewer, launcher, release,
+and documentation scripts as GitHub Actions. Invoke `mix prepush` directly only
+for static/Dialyzer diagnosis or when hooks are unavailable.
 
 Credential-free interoperability tests may run as focused push and
 pull-request jobs even when tagged `:e2e`. Secret-dependent and model-driven

--- a/lib/ptc_runner/kernel/analysis_session_builder.ex
+++ b/lib/ptc_runner/kernel/analysis_session_builder.ex
@@ -23,7 +23,9 @@ defmodule PtcRunner.Kernel.AnalysisSessionBuilder do
   human's terminal from a pseudo-terminal allocated by `script(1)`, `tmux`, or
   `ssh -t`, and because a same-UID caller can already read the inspection
   artifact directly. `private_unattended` makes deliberate non-interactive use
-  explicit and greppable instead of requiring that workaround.
+  explicit and greppable instead of requiring that workaround. Tests and
+  trusted embedding frontends may inject the detected state with
+  `terminal_attached:`; ordinary callers omit it and use the real terminal.
   """
 
   alias PtcRunner.Kernel.AnalysisAssembly
@@ -62,7 +64,8 @@ defmodule PtcRunner.Kernel.AnalysisSessionBuilder do
     :inspection_capture_hook,
     :inspection_listing_hook,
     :private_terminal,
-    :private_unattended
+    :private_unattended,
+    :terminal_attached
   ]
 
   @doc """
@@ -147,7 +150,8 @@ defmodule PtcRunner.Kernel.AnalysisSessionBuilder do
   defp valid_private_terminal?(opts),
     do:
       Keyword.get(opts, :private_terminal, false) in [true, false] and
-        Keyword.get(opts, :private_unattended, false) in [true, false]
+        Keyword.get(opts, :private_unattended, false) in [true, false] and
+        Keyword.get(opts, :terminal_attached, false) in [true, false]
 
   defp valid_optional_hook?(nil, _arity), do: true
   defp valid_optional_hook?(hook, arity), do: is_function(hook, arity)
@@ -155,6 +159,7 @@ defmodule PtcRunner.Kernel.AnalysisSessionBuilder do
   defp authorize_private_profile(recipe, opts) do
     terminal? = Keyword.get(opts, :private_terminal, false)
     unattended? = Keyword.get(opts, :private_unattended, false)
+    terminal_attached? = Keyword.get_lazy(opts, :terminal_attached, &AnalysisTerminal.attached?/0)
 
     case recipe.frontend().private_terminal do
       :required ->
@@ -162,7 +167,7 @@ defmodule PtcRunner.Kernel.AnalysisSessionBuilder do
           terminal? and unattended? -> {:error, :private_destination_conflict}
           unattended? -> :ok
           not terminal? -> {:error, :private_terminal_required}
-          not AnalysisTerminal.attached?() -> {:error, :interactive_terminal_required}
+          not terminal_attached? -> {:error, :interactive_terminal_required}
           true -> :ok
         end
 

--- a/lib/ptc_runner/mix_command_adapter.ex
+++ b/lib/ptc_runner/mix_command_adapter.ex
@@ -9,27 +9,35 @@ defmodule PtcRunner.MixCommandAdapter do
 
   @doc false
   @spec execute([binary()]) :: CommandPresentation.t()
-  def execute(args) when is_list(args),
+  def execute(args), do: execute(args, [])
+
+  @doc false
+  @spec execute([binary()], keyword()) :: CommandPresentation.t()
+  def execute(args, frontend_opts) when is_list(args) and is_list(frontend_opts),
     do:
       CommandRouter.execute(
         args,
         :mix,
         &MixCommandRuntime.bootstrap/1,
-        &run_one_shot/2
+        fn arguments, runtime -> run_one_shot(arguments, runtime, frontend_opts) end
       )
 
-  def execute(_args), do: execute([])
+  def execute(_args, _frontend_opts), do: execute([], [])
 
-  defp run_one_shot(%{command: :repl} = arguments, runtime),
-    do: ReplFrontend.run(arguments, runtime)
+  defp run_one_shot(%{command: :repl} = arguments, runtime, frontend_opts),
+    do: ReplFrontend.run(arguments, runtime, frontend_opts)
 
-  defp run_one_shot(%{command: :transcript} = arguments, runtime),
+  defp run_one_shot(%{command: :transcript} = arguments, runtime, _frontend_opts),
     do: TranscriptFrontend.run(arguments, runtime)
 
   @doc false
   @spec run_task([binary()]) :: CommandPresentation.t() | no_return()
-  def run_task(args) when is_list(args) do
-    presentation = execute(args)
+  def run_task(args), do: run_task(args, [])
+
+  @doc false
+  @spec run_task([binary()], keyword()) :: CommandPresentation.t() | no_return()
+  def run_task(args, frontend_opts) when is_list(args) and is_list(frontend_opts) do
+    presentation = execute(args, frontend_opts)
 
     case presentation.exit_status do
       0 ->

--- a/lib/ptc_runner/repl_frontend.ex
+++ b/lib/ptc_runner/repl_frontend.ex
@@ -84,41 +84,70 @@ defmodule PtcRunner.ReplFrontend do
   alias PtcRunner.ReplError
 
   @spec run(CommandArguments.t(), CommandRuntime.t()) :: :ok | {:error, binary()}
+  def run(arguments, runtime), do: run(arguments, runtime, [])
+
+  @doc false
+  @spec run(CommandArguments.t(), CommandRuntime.t(), keyword()) :: :ok | {:error, binary()}
   def run(
         %CommandArguments{command: :repl, application: script, ordered_options: opts},
-        %CommandRuntime{} = runtime
+        %CommandRuntime{} = runtime,
+        frontend_opts
       ) do
-    arguments = if is_binary(script), do: [script], else: []
+    if valid_frontend_opts?(frontend_opts) do
+      arguments = if is_binary(script), do: [script], else: []
+      terminal_attached? = terminal_attached?(frontend_opts)
 
-    case validate_command(opts, arguments, []) do
-      {:ok, :describe} ->
-        describe_profile(opts)
+      case validate_command(opts, arguments, [], terminal_attached?) do
+        {:ok, :describe} ->
+          describe_profile(opts)
 
-      {:ok, :profile} ->
-        run_profile_session(opts, arguments)
+        {:ok, :profile} ->
+          run_profile_session(
+            Keyword.put(opts, :terminal_attached, terminal_attached?),
+            arguments
+          )
 
-      {:ok, :manifest} ->
-        run_manifest_session(Keyword.put(opts, :command_runtime, runtime), arguments)
+        {:ok, :manifest} ->
+          opts =
+            opts
+            |> Keyword.put(:command_runtime, runtime)
+            |> Keyword.put(:terminal_attached, terminal_attached?)
 
-      {:ok, :direct} ->
-        run_direct_session(opts, arguments)
+          run_manifest_session(opts, arguments)
 
-      {:error, message} ->
-        command_error(opts, :cli, message)
+        {:ok, :direct} ->
+          run_direct_session(opts, arguments)
+
+        {:error, message} ->
+          command_error(opts, :cli, message)
+      end
+
+      :ok
+    else
+      {:error, "invalid repl frontend options"}
     end
-
-    :ok
   rescue
     error in ReplError -> {:error, error.message}
   end
 
-  defp validate_command(opts, arguments, invalid) do
+  def run(_arguments, _runtime, _frontend_opts), do: {:error, "invalid repl frontend options"}
+
+  defp valid_frontend_opts?(opts) do
+    Keyword.keyword?(opts) and Keyword.keys(opts) -- [:terminal_attached] == [] and
+      length(opts) == MapSet.size(MapSet.new(Keyword.keys(opts))) and
+      Keyword.get(opts, :terminal_attached, false) in [true, false]
+  end
+
+  defp terminal_attached?(opts),
+    do: Keyword.get_lazy(opts, :terminal_attached, &AnalysisTerminal.attached?/0)
+
+  defp validate_command(opts, arguments, invalid, terminal_attached?) do
     format = Keyword.get(opts, :format, "clojure")
     evals = Keyword.get_values(opts, :eval)
     resources = Keyword.get_values(opts, :resource)
 
     with :ok <- validate_common_command(arguments, invalid, evals, format) do
-      select_command(opts, arguments, evals, resources, format)
+      select_command(opts, arguments, evals, resources, format, terminal_attached?)
     end
   end
 
@@ -141,13 +170,20 @@ defmodule PtcRunner.ReplFrontend do
     end
   end
 
-  defp select_command(opts, arguments, evals, resources, format) do
+  defp select_command(opts, arguments, evals, resources, format, terminal_attached?) do
     cond do
       opts[:describe_profile] ->
         validate_description(opts, arguments)
 
       opts[:profile] ->
-        validate_profile_command(opts, arguments, evals, resources, format)
+        validate_profile_command(
+          opts,
+          arguments,
+          evals,
+          resources,
+          format,
+          terminal_attached?
+        )
 
       opts[:manifest] ->
         validate_manifest_command(opts, resources, format)
@@ -201,7 +237,14 @@ defmodule PtcRunner.ReplFrontend do
     end
   end
 
-  defp validate_profile_command(opts, arguments, evals, resources, format) do
+  defp validate_profile_command(
+         opts,
+         arguments,
+         evals,
+         resources,
+         format,
+         terminal_attached?
+       ) do
     with {:ok, recipe} <- AnalysisProfileRegistry.fetch(opts[:profile]),
          :ok <-
            validate_profile_combinations(
@@ -219,7 +262,7 @@ defmodule PtcRunner.ReplFrontend do
              continue_on_error: Keyword.get(opts, :continue_on_error, false),
              private_terminal: Keyword.get(opts, :private_terminal, false),
              private_unattended: Keyword.get(opts, :private_unattended, false),
-             terminal_attached: AnalysisTerminal.attached?()
+             terminal_attached: terminal_attached?
            }) do
       {:ok, :profile}
     else
@@ -576,7 +619,10 @@ defmodule PtcRunner.ReplFrontend do
         else: builder_options
 
     if Keyword.get(opts, :private_terminal, false),
-      do: Keyword.put(builder_options, :private_terminal, true),
+      do:
+        builder_options
+        |> Keyword.put(:private_terminal, true)
+        |> Keyword.put(:terminal_attached, Keyword.fetch!(opts, :terminal_attached)),
       else: builder_options
   end
 
@@ -1077,7 +1123,7 @@ defmodule PtcRunner.ReplFrontend do
              runtime: runtime,
              trace_path: opts[:trace],
              private_terminal: Keyword.get(opts, :private_terminal, false),
-             terminal_attached: AnalysisTerminal.attached?(),
+             terminal_attached: Keyword.fetch!(opts, :terminal_attached),
              input_mode: manifest_input_mode(opts, arguments)
            ) do
       run_workflow_session(session, opts, arguments)

--- a/mix.exs
+++ b/mix.exs
@@ -177,45 +177,22 @@ defmodule PtcRunner.MixProject do
     [
       ptc: &run_ptc/1,
       precommit: [
-        "format --check-formatted",
-        "compile --warnings-as-errors",
-        "xref graph --format cycles --label compile-connected --fail-above 0",
-        "credo --strict",
-        "cmd bash scripts/duplication_gate.sh check",
-        "ptc.validate_spec",
-        "ptc.gen_docs --check",
-        "ptc.conformance_report --check-inventory",
-        "test --warnings-as-errors",
-        "cmd --cd ptc_viewer mix test --color",
-        "cmd --cd ptc_runner_launcher mix precommit",
-        "cmd bash scripts/verify_core_package.sh",
-        "cmd bash scripts/verify_standalone_release.sh"
+        "cmd scripts/ci/core-quality.sh",
+        "cmd scripts/ci/core-tests.sh",
+        "cmd scripts/ci/viewer.sh",
+        "cmd scripts/ci/launcher-package.sh",
+        "cmd scripts/ci/core-release.sh"
       ],
-      # Slower checks kept out of the per-commit loop; run before pushing.
-      # PR CI runs these as individual steps. The upstream audit attests all
-      # exact Java descriptors when Java 11 or newer is available.
-      #
-      # The two staleness checks are also in `precommit`, and are repeated
-      # here on purpose. A generated artifact goes stale from an ordinary edit
-      # to the sources it projects, `AGENTS.md` tells you not to run `precommit`
-      # before an ordinary push because the hook already gates it, and the hook
-      # runs the suite and this alias rather than `precommit`. Without them a
-      # push that touches `lib/` clears every local gate and still fails CI on
-      # an artifact the author never had a chance to regenerate. They cost a few
-      # seconds inside a run that already spends minutes.
+      # Slower static and Dialyzer checks kept out of the per-commit loop.
+      # This diagnostic alias delegates to the same repository-owned scripts
+      # as the pre-push hook and GitHub Actions; it is not a second gate
+      # implementation.
       #
       # `ptc.gen_semantic_revision --check` is deliberately absent from both:
       # it is a release gate, not a per-commit one. See `.gitattributes`.
       prepush: [
-        # Credo is repeated here for the same reason as the staleness checks
-        # below: the hook runs this alias, not `precommit`, so without it a
-        # lint the CI Credo step rejects only surfaces after the push.
-        "credo --strict",
-        "ptc.gen_docs --check",
-        "ptc.conformance_report --check-inventory",
-        "ptc.audit_upstream",
-        "dialyzer",
-        "deps.unlock --check-unused"
+        "cmd scripts/ci/core-static.sh",
+        "cmd scripts/ci/core-dialyzer.sh"
       ],
       coverage: [
         "test --cover"

--- a/scripts/ci/_common.sh
+++ b/scripts/ci/_common.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# Shared process contract for repository-owned deterministic gates.
+# This file is sourced by the executable entry points in this directory.
+
+set -euo pipefail
+
+ci_repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ci_repo_root"
+
+export MIX_ENV=test
+export HEX_SPONSOR=false

--- a/scripts/ci/classify-changes.sh
+++ b/scripts/ci/classify-changes.sh
@@ -97,7 +97,7 @@ while IFS= read -r path || [ -n "$path" ]; do
       ;;
 
     .github/workflows/test.yml|.github/actions/setup-elixir/*|\
-      scripts/classify_changes.sh)
+      scripts/ci/classify-changes.sh)
       select_all
       ;;
 

--- a/scripts/ci/core-dialyzer.sh
+++ b/scripts/ci/core-dialyzer.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$script_dir/_common.sh"
+
+mix dialyzer --format github

--- a/scripts/ci/core-quality.sh
+++ b/scripts/ci/core-quality.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$script_dir/_common.sh"
+
+mix compile --warnings-as-errors
+mix xref graph --format cycles --label compile-connected --fail-above 0
+mix format --check-formatted
+mix credo --strict
+scripts/duplication_gate.sh check
+mix ptc.validate_spec
+mix ptc.gen_docs --check
+mix ptc.conformance_report --check-inventory

--- a/scripts/ci/core-release.sh
+++ b/scripts/ci/core-release.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$script_dir/_common.sh"
+
+scripts/verify_core_package.sh
+scripts/verify_standalone_release.sh

--- a/scripts/ci/core-static.sh
+++ b/scripts/ci/core-static.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$script_dir/_common.sh"
+
+"$script_dir/core-quality.sh"
+mix ptc.audit_upstream
+mix deps.unlock --check-unused

--- a/scripts/ci/core-tests.sh
+++ b/scripts/ci/core-tests.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$script_dir/_common.sh"
+
+# StreamData increases its property run count under CI. Establish that part of
+# the test contract here without changing the environment of non-test gates
+# such as Dialyzer, whose local PLT cache selection depends on CI being unset.
+export CI=1
+
+usage() {
+  echo "usage: core-tests.sh [--schedulers POSITIVE_INTEGER]" >&2
+  exit 64
+}
+
+case "$#" in
+  0)
+    ;;
+
+  2)
+    if [ "$1" != "--schedulers" ] || ! [[ "$2" =~ ^[1-9][0-9]*$ ]]; then
+      usage
+    fi
+    export ERL_FLAGS="+S $2:$2"
+    ;;
+
+  *)
+    usage
+    ;;
+esac
+
+mix compile --warnings-as-errors
+mix test --max-failures 1 --warnings-as-errors

--- a/scripts/ci/docs.sh
+++ b/scripts/ci/docs.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$script_dir/_common.sh"
+
+export MIX_ENV=dev
+
+mix deps.get --check-locked
+mix docs --warnings-as-errors

--- a/scripts/ci/launcher-package.sh
+++ b/scripts/ci/launcher-package.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$script_dir/_common.sh"
+
+cd ptc_runner_launcher || exit 1
+mix clean
+mix precommit

--- a/scripts/ci/launcher.sh
+++ b/scripts/ci/launcher.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$script_dir/_common.sh"
+
+if [ "$#" -gt 1 ]; then
+  echo "usage: launcher.sh [ARTIFACT_DIRECTORY]" >&2
+  exit 64
+fi
+
+artifact_directory="${1:-}"
+cleanup_artifacts=false
+
+if [ -z "$artifact_directory" ]; then
+  artifact_directory="$(mktemp -d "${TMPDIR:-/tmp}/ptc-launcher-ci.XXXXXX")"
+  cleanup_artifacts=true
+fi
+
+cleanup() {
+  if [ "$cleanup_artifacts" = true ]; then
+    rm -rf "$artifact_directory"
+  fi
+}
+trap cleanup EXIT
+
+"$script_dir/launcher-package.sh"
+bash ptc_runner_launcher/scripts/verify_precompiled.sh "$artifact_directory"

--- a/scripts/ci/viewer.sh
+++ b/scripts/ci/viewer.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$script_dir/_common.sh"
+
+cd ptc_viewer || exit 1
+mix compile --warnings-as-errors
+mix test --warnings-as-errors

--- a/test/githooks/pre_push_test.exs
+++ b/test/githooks/pre_push_test.exs
@@ -4,6 +4,7 @@ defmodule PtcRunner.GitHooks.PrePushTest do
   alias PtcRunner.TestSupport.GitEnv
 
   @hook Path.expand("../../.githooks/pre-push", __DIR__)
+  @classifier Path.expand("../../scripts/ci/classify-changes.sh", __DIR__)
   @git_env GitEnv.clear()
 
   test "planning-only changes skip the full gate" do
@@ -37,10 +38,10 @@ defmodule PtcRunner.GitHooks.PrePushTest do
     {output, status} = run_hook(repo, path)
 
     assert status == 0
-    assert output =~ "Launcher checks passed"
+    assert output =~ "launcher validation passed"
 
     assert mix_marker |> File.read!() |> String.split("\n", trim: true) ==
-             ["precommit"]
+             ["ci-gate launcher"]
   end
 
   test "Viewer-only changes do not run the root gate" do
@@ -50,30 +51,40 @@ defmodule PtcRunner.GitHooks.PrePushTest do
     {output, status} = run_hook(repo, path)
 
     assert status == 0
-    assert output =~ "Project: ptc_viewer/"
-    refute output =~ "Project: root"
+    assert output =~ "Viewer validation"
+    refute output =~ "core tests"
 
     assert mix_marker |> File.read!() |> String.split("\n", trim: true) ==
-             ["test --exclude clojure"]
+             ["ci-gate viewer"]
   end
 
   @tag :slow
-  test "full gate runs tests and the canonical prepush alias once" do
+  test "full gate invokes every deterministic root entry point once" do
     %{repo: repo, mix_marker: mix_marker, path: path} =
       git_repo_with_change("lib/example.ex")
 
     {output, status} = run_hook(repo, path)
 
-    assert status == 0
-    assert output =~ ~r/Tests passed in \d+s/
-    assert output =~ ~r/Pre-push checks passed in \d+s/
+    assert status == 0, output
+    assert output =~ ~r/core tests passed in \d+s/
+    assert output =~ ~r/core static analysis passed in \d+s/
+    assert output =~ ~r/core Dialyzer passed in \d+s/
+    assert output =~ ~r/core release verification passed in \d+s/
 
     assert output =~ "Phase timings:"
-    assert output =~ ~r/root \(:ptc_runner\) tests\s+\d+s/
-    assert output =~ ~r/root mix prepush \(incl\. dialyzer\)\s+\d+s/
+    assert output =~ ~r/core tests\s+\d+s/
+    assert output =~ ~r/core Dialyzer\s+\d+s/
 
     assert mix_marker |> File.read!() |> String.split("\n", trim: true) ==
-             ["test --exclude clojure", "prepush"]
+             [
+               "deps.get --check-locked",
+               "docs --warnings-as-errors",
+               "ci-gate core-tests",
+               "ci-gate core-static",
+               "ci-gate core-dialyzer",
+               "ci-gate core-release",
+               "ci-gate viewer"
+             ]
   end
 
   @tag :slow
@@ -87,7 +98,15 @@ defmodule PtcRunner.GitHooks.PrePushTest do
     refute output =~ "Test concurrency"
 
     assert mix_marker |> File.read!() |> String.split("\n", trim: true) ==
-             ["test --exclude clojure", "prepush"]
+             [
+               "deps.get --check-locked",
+               "docs --warnings-as-errors",
+               "ci-gate core-tests",
+               "ci-gate core-static",
+               "ci-gate core-dialyzer",
+               "ci-gate core-release",
+               "ci-gate viewer"
+             ]
   end
 
   @tag :slow
@@ -99,14 +118,17 @@ defmodule PtcRunner.GitHooks.PrePushTest do
 
     assert status == 0
     assert output =~ "Documentation"
-    assert output =~ "Project: root"
+    assert output =~ "core tests"
 
     assert mix_marker |> File.read!() |> String.split("\n", trim: true) ==
              [
                "deps.get --check-locked",
                "docs --warnings-as-errors",
-               "test --exclude clojure",
-               "prepush"
+               "ci-gate core-tests",
+               "ci-gate core-static",
+               "ci-gate core-dialyzer",
+               "ci-gate core-release",
+               "ci-gate viewer"
              ]
   end
 
@@ -117,7 +139,7 @@ defmodule PtcRunner.GitHooks.PrePushTest do
     {output, status} = run_hook(repo, path, [{"MIX_MUTATE_LOCK", "1"}])
 
     assert status != 0
-    assert output =~ "Documentation dependency setup failed"
+    assert output =~ "Documentation dependency setup or build failed"
     refute File.exists?(Path.join(repo, "mix.lock"))
 
     assert mix_marker |> File.read!() |> String.split("\n", trim: true) ==
@@ -142,6 +164,8 @@ defmodule PtcRunner.GitHooks.PrePushTest do
     File.mkdir_p!(bin)
 
     on_exit(fn -> File.rm_rf!(root) end)
+
+    install_hook_fixture!(repo)
 
     fake_mix = Path.join(bin, "mix")
 
@@ -183,7 +207,7 @@ defmodule PtcRunner.GitHooks.PrePushTest do
       env:
         @git_env ++
           [
-            {"HOOK_PATH", @hook},
+            {"HOOK_PATH", Path.join(repo, ".githooks/pre-push")},
             {"HOOK_REFS", refs},
             {"MIX_MARKER",
              Path.join(path |> String.split(":") |> hd() |> Path.dirname(), "mix-called")},
@@ -197,6 +221,35 @@ defmodule PtcRunner.GitHooks.PrePushTest do
     full_path = Path.join(repo, path)
     File.mkdir_p!(Path.dirname(full_path))
     File.write!(full_path, contents)
+  end
+
+  defp install_hook_fixture!(repo) do
+    copy_executable!(@hook, Path.join(repo, ".githooks/pre-push"))
+    copy_executable!(@classifier, Path.join(repo, "scripts/ci/classify-changes.sh"))
+
+    write_executable!(Path.join(repo, "scripts/ci/docs.sh"), """
+    #!/bin/sh
+    mix deps.get --check-locked && mix docs --warnings-as-errors
+    """)
+
+    for gate <- ~w(core-tests core-static core-dialyzer core-release viewer launcher) do
+      write_executable!(Path.join(repo, "scripts/ci/#{gate}.sh"), """
+      #!/bin/sh
+      mix ci-gate #{gate}
+      """)
+    end
+  end
+
+  defp copy_executable!(source, destination) do
+    File.mkdir_p!(Path.dirname(destination))
+    File.cp!(source, destination)
+    File.chmod!(destination, 0o755)
+  end
+
+  defp write_executable!(path, contents) do
+    File.mkdir_p!(Path.dirname(path))
+    File.write!(path, contents)
+    File.chmod!(path, 0o755)
   end
 
   defp git!(repo, args) do

--- a/test/mix/tasks/ptc_repl_test.exs
+++ b/test/mix/tasks/ptc_repl_test.exs
@@ -340,7 +340,9 @@ defmodule PtcRunner.ReplFrontendTest do
           {["--private-terminal", "--private-unattended"], ~r/conflicting_arguments/}
         ] do
       capture_io(fn ->
-        assert_raise Mix.Error, message, fn -> run_repl(missing_resources ++ suffix) end
+        assert_raise Mix.Error, message, fn ->
+          run_repl(missing_resources ++ suffix, terminal_attached: false)
+        end
       end)
     end
   end
@@ -919,7 +921,8 @@ defmodule PtcRunner.ReplFrontendTest do
     assert File.regular?(List.last(records)["trace_path"])
   end
 
-  defp run_repl(args), do: MixCommandAdapter.run_task(["repl" | args]).outcome
+  defp run_repl(args, frontend_opts \\ []),
+    do: MixCommandAdapter.run_task(["repl" | args], frontend_opts).outcome
 
   defp profile_args(source, output_directory) do
     [

--- a/test/ptc_runner/kernel/host_installation_test.exs
+++ b/test/ptc_runner/kernel/host_installation_test.exs
@@ -1146,6 +1146,7 @@ defmodule PtcRunner.Kernel.HostInstallationTest do
       # This test exercises locale propagation, not the default startup
       # deadline. Booting an Elixir source fixture can exceed five seconds
       # while the full CI suite is under load.
+      |> put_in(["install", "workspace", "ceilings"], %{"timeout_ms" => 20_000})
       |> put_in(["install", "workspace", "transport", "start_timeout_ms"], 20_000)
       |> put_in(["install", "workspace", "transport", "inherit_environment"], true)
       |> put_in(["install", "workspace", "tools"], %{
@@ -1153,6 +1154,8 @@ defmodule PtcRunner.Kernel.HostInstallationTest do
       })
 
     host = load_host(dir, config)
+    {:ok, limits} = Limits.new(evaluation_timeout_ms: 20_000)
+    build_context = %{context(dir, :mission) | limits: limits, installed_limits: limits}
 
     assert {:ok, registry} =
              HostInstallation.catalog(host)
@@ -1161,7 +1164,7 @@ defmodule PtcRunner.Kernel.HostInstallationTest do
              end)
 
     assert {:ok, %{capabilities: [capability], close: close}} =
-             ProviderRegistry.build(registry, "workspace", %{}, context(dir, :mission))
+             ProviderRegistry.build(registry, "workspace", %{}, build_context)
 
     on_exit(fn -> close.() end)
 

--- a/test/ptc_runner/kernel/provider_connectivity_test.exs
+++ b/test/ptc_runner/kernel/provider_connectivity_test.exs
@@ -753,7 +753,13 @@ defmodule PtcRunner.Kernel.ProviderConnectivityTest do
     assert diagnostic.phase == :active_preflight
     assert diagnostic.code == :connectivity_timeout
     assert diagnostic.subject == nil
-    assert diagnostic.provider_activity
+
+    # Under full-suite scheduler pressure the operation budget may expire
+    # either immediately before dispatch (`false`) or while the bounded probe
+    # is running (`true`). Both outcomes are the documented cumulative-activity
+    # contract; this test is authoritative for the shared deadline and
+    # subjectless timeout, not for which side wins that race.
+    assert is_boolean(diagnostic.provider_activity)
   end
 
   test "run and connect both refuse a selected OAuth occurrence up front" do

--- a/test/ptc_runner/kernel/run_analysis_profile_test.exs
+++ b/test/ptc_runner/kernel/run_analysis_profile_test.exs
@@ -7,7 +7,6 @@ defmodule PtcRunner.Kernel.PrivateRunAnalysisProfileTest do
   alias PtcRunner.Kernel.AnalysisResources
   alias PtcRunner.Kernel.AnalysisSession
   alias PtcRunner.Kernel.AnalysisSessionBuilder
-  alias PtcRunner.Kernel.AnalysisTerminal
   alias PtcRunner.Kernel.DeterministicJSON
   alias PtcRunner.Kernel.EventSink
   alias PtcRunner.Kernel.InspectionSnapshot
@@ -120,21 +119,27 @@ defmodule PtcRunner.Kernel.PrivateRunAnalysisProfileTest do
                {:directory, "/definitely/missing/private-output"}
              )
 
-    refute AnalysisTerminal.attached?()
-
     assert {:error, :interactive_terminal_required} =
              AnalysisSessionBuilder.start(
                @profile_id,
                resources,
                {:directory, "/definitely/missing/private-output"},
-               private_terminal: true
+               private_terminal: true,
+               terminal_attached: false
+             )
+
+    assert {:error, :invalid_private_run_analysis_source} =
+             AnalysisSessionBuilder.start(
+               @profile_id,
+               resources,
+               {:directory, "/definitely/missing/private-output"},
+               private_terminal: true,
+               terminal_attached: true
              )
   end
 
   test "private_unattended is a second authorized destination, mutually exclusive with the terminal" do
     {:ok, recipe} = AnalysisProfileRegistry.fetch(@profile_id)
-
-    refute AnalysisTerminal.attached?()
 
     base = %{
       output_format: :clojure,

--- a/test/ptc_runner/lisp/java/surface_test.exs
+++ b/test/ptc_runner/lisp/java/surface_test.exs
@@ -794,13 +794,15 @@ defmodule PtcRunner.Lisp.Java.SurfaceTest do
   end
 
   @tag :tmp_dir
-  test "precommit discovers current generated Java audit orphans recursively", %{
+  test "precommit's shared quality gate discovers generated Java audit orphans recursively", %{
     tmp_dir: dir
   } do
     precommit = Mix.Project.config() |> Keyword.fetch!(:aliases) |> Keyword.fetch!(:precommit)
+    quality_gate = File.read!("scripts/ci/core-quality.sh")
 
-    assert "ptc.gen_docs --check" in precommit
-    assert "ptc.conformance_report --check-inventory" in precommit
+    assert "cmd scripts/ci/core-quality.sh" in precommit
+    assert quality_gate =~ "mix ptc.gen_docs --check"
+    assert quality_gate =~ "mix ptc.conformance_report --check-inventory"
 
     current = Path.join(dir, "docs/conformance/current.md")
     orphan = Path.join(dir, "docs/conformance/nested/orphan.md")

--- a/test/scripts/ci_gates_test.exs
+++ b/test/scripts/ci_gates_test.exs
@@ -1,0 +1,154 @@
+defmodule PtcRunner.Scripts.CIGatesTest do
+  use ExUnit.Case, async: true
+
+  alias PtcRunner.TestSupport.GitEnv
+
+  @root Path.expand("../..", __DIR__)
+  @core_tests Path.join(@root, "scripts/ci/core-tests.sh")
+  @core_dialyzer Path.join(@root, "scripts/ci/core-dialyzer.sh")
+  @git_env GitEnv.clear()
+
+  test "core tests establish the CI contract without reducing native scheduler pressure" do
+    %{marker: marker, path: path} = fake_mix()
+
+    {output, status} =
+      System.cmd(@core_tests, [],
+        cd: @root,
+        env:
+          @git_env ++
+            [
+              {"PATH", path},
+              {"MIX_MARKER", marker},
+              {"ERL_FLAGS", "+S 7:7"}
+            ],
+        stderr_to_stdout: true
+      )
+
+    assert status == 0, output
+
+    assert File.read!(marker) |> String.split("\n", trim: true) == [
+             "CI=1 MIX_ENV=test HEX_SPONSOR=false ERL_FLAGS=+S 7:7 :: compile --warnings-as-errors",
+             "CI=1 MIX_ENV=test HEX_SPONSOR=false ERL_FLAGS=+S 7:7 :: test --max-failures 1 --warnings-as-errors"
+           ]
+  end
+
+  test "core tests offer the GitHub four-scheduler CPU shape locally" do
+    %{marker: marker, path: path} = fake_mix()
+
+    {output, status} =
+      System.cmd(@core_tests, ["--schedulers", "4"],
+        cd: @root,
+        env: @git_env ++ [{"PATH", path}, {"MIX_MARKER", marker}],
+        stderr_to_stdout: true
+      )
+
+    assert status == 0, output
+
+    assert File.read!(marker) |> String.split("\n", trim: true) == [
+             "CI=1 MIX_ENV=test HEX_SPONSOR=false ERL_FLAGS=+S 4:4 :: compile --warnings-as-errors",
+             "CI=1 MIX_ENV=test HEX_SPONSOR=false ERL_FLAGS=+S 4:4 :: test --max-failures 1 --warnings-as-errors"
+           ]
+  end
+
+  test "core tests reject malformed scheduler limits before invoking Mix" do
+    %{marker: marker, path: path} = fake_mix()
+
+    {output, status} =
+      System.cmd(@core_tests, ["--schedulers", "many"],
+        cd: @root,
+        env: @git_env ++ [{"PATH", path}, {"MIX_MARKER", marker}],
+        stderr_to_stdout: true
+      )
+
+    assert status == 64
+    assert output =~ "usage: core-tests.sh [--schedulers POSITIVE_INTEGER]"
+    refute File.exists?(marker)
+  end
+
+  test "non-test gates preserve the caller's CI state for local tool caches" do
+    %{marker: marker, path: path} = fake_mix()
+
+    {output, status} =
+      System.cmd(@core_dialyzer, [],
+        cd: @root,
+        env:
+          @git_env ++
+            [{"CI", nil}, {"ERL_FLAGS", nil}, {"PATH", path}, {"MIX_MARKER", marker}],
+        stderr_to_stdout: true
+      )
+
+    assert status == 0, output
+
+    assert File.read!(marker) |> String.trim() ==
+             "CI= MIX_ENV=test HEX_SPONSOR=false ERL_FLAGS= :: dialyzer --format github"
+  end
+
+  test "non-test gates preserve an explicit CI state" do
+    %{marker: marker, path: path} = fake_mix()
+
+    {output, status} =
+      System.cmd(@core_dialyzer, [],
+        cd: @root,
+        env:
+          @git_env ++
+            [{"CI", "true"}, {"ERL_FLAGS", nil}, {"PATH", path}, {"MIX_MARKER", marker}],
+        stderr_to_stdout: true
+      )
+
+    assert status == 0, output
+
+    assert File.read!(marker) |> String.trim() ==
+             "CI=true MIX_ENV=test HEX_SPONSOR=false ERL_FLAGS= :: dialyzer --format github"
+  end
+
+  test "Actions and the pre-push hook delegate deterministic gates to repository scripts" do
+    workflow = File.read!(Path.join(@root, ".github/workflows/test.yml"))
+    setup_action = File.read!(Path.join(@root, ".github/actions/setup-elixir/action.yml"))
+    launcher_release = File.read!(Path.join(@root, ".github/workflows/launcher-release.yml"))
+    hook = File.read!(Path.join(@root, ".githooks/pre-push"))
+    mix_project = File.read!(Path.join(@root, "mix.exs"))
+    launcher = File.read!(Path.join(@root, "scripts/ci/launcher.sh"))
+
+    for entrypoint <- ~w(core-tests core-static core-dialyzer core-release viewer docs launcher) do
+      assert workflow =~ "scripts/ci/#{entrypoint}.sh"
+      assert hook =~ "scripts/ci/#{entrypoint}.sh"
+    end
+
+    refute workflow =~ "run: mix test --max-failures 1 --warnings-as-errors"
+    assert setup_action =~ "mix deps.get --check-locked"
+    assert launcher_release =~ ~s(scripts/ci/launcher.sh "$RUNNER_TEMP/launcher-artifacts")
+    refute launcher_release =~ "run: mix precommit"
+    refute launcher_release =~ "run: bash scripts/verify_precompiled.sh"
+    refute hook =~ "mix test --exclude clojure"
+    refute hook =~ "mix prepush"
+    assert mix_project =~ ~s("cmd scripts/ci/core-tests.sh")
+    assert mix_project =~ ~s("cmd scripts/ci/core-static.sh")
+    assert mix_project =~ ~s("cmd scripts/ci/core-dialyzer.sh")
+    assert launcher =~ ~s(bash ptc_runner_launcher/scripts/verify_precompiled.sh)
+  end
+
+  defp fake_mix do
+    root =
+      Path.join(
+        System.tmp_dir!(),
+        "ptc-ci-gates-#{System.unique_integer([:positive, :monotonic])}"
+      )
+
+    bin = Path.join(root, "bin")
+    marker = Path.join(root, "mix-called")
+    File.mkdir_p!(bin)
+    on_exit(fn -> File.rm_rf!(root) end)
+
+    mix = Path.join(bin, "mix")
+
+    File.write!(mix, """
+    #!/bin/sh
+    printf 'CI=%s MIX_ENV=%s HEX_SPONSOR=%s ERL_FLAGS=%s :: %s\n' \\
+      "$CI" "$MIX_ENV" "$HEX_SPONSOR" "${ERL_FLAGS:-}" "$*" >> "$MIX_MARKER"
+    """)
+
+    File.chmod!(mix, 0o755)
+
+    %{marker: marker, path: bin <> ":" <> System.fetch_env!("PATH")}
+  end
+end

--- a/test/scripts/classify_changes_test.exs
+++ b/test/scripts/classify_changes_test.exs
@@ -1,7 +1,7 @@
 defmodule PtcRunner.Scripts.ClassifyChangesTest do
   use ExUnit.Case, async: true
 
-  @classifier Path.expand("../../scripts/classify_changes.sh", __DIR__)
+  @classifier Path.expand("../../scripts/ci/classify-changes.sh", __DIR__)
 
   test "routes independently testable repository areas" do
     assert classify(["docs/plans/future/note.md"]) == all_false()


### PR DESCRIPTION
## Summary

- centralize deterministic gate commands and environment in `scripts/ci`
- make GitHub Actions, pre-push, Mix aliases, and launcher release validation use the same repository entry points
- enforce `CI=1` property parity while retaining native scheduler stress and offering an explicit four-scheduler mode
- reject stale lockfiles before workflow setup can repair them
- make terminal-sensitive tests deterministic through an injected, validated terminal capability
- harden the load-sensitive MCP launcher timeout contract exposed by the unified full-suite gate

## Context

This is a main-based follow-up to the CI friction observed on #1339. It does not patch or depend on that PR's branch.

## Scope

This PR unifies deterministic core, static, Dialyzer, release, Viewer, documentation, and launcher gates. Ubuntu container parity and the deterministic replay/live-provider split for E2E tests remain focused follow-ups.

## Verification

- `mix precommit`
- `scripts/ci/core-tests.sh --schedulers 4` under an attached pseudo-terminal (6,218 tests)
- complete pre-push replay (all seven selected phases passed)
- `scripts/ci/launcher.sh`
- `scripts/ci/docs.sh`
- ShellCheck and actionlint
- independent Codex review, including follow-up verification of all findings
