### PR TITLE
fix(cli): compile dependencies on first mix ptc run

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,9 +49,11 @@ how it was verified.
 
 ## Commands
 
-- `mix ptc ...` — the root-project command path skips dependency validation for fast
-  startup while still compiling changed root sources and shipped preludes.
-  This optimization is root-only; downstream projects retain Mix's normal
+- `mix ptc ...` — after the root application has compiled successfully once,
+  the root-project command path skips dependency validation for fast startup
+  while still compiling changed root sources and shipped preludes. A fresh
+  build performs Mix's normal dependency validation and compilation. This
+  optimization is root-only; downstream projects always retain Mix's normal
   dependency validation.
   After changing `mix.exs`, `mix.lock`, dependency sources, or either local
   path dependency (`ptc_runner_launcher/` or `ptc_viewer/`), run a normal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -190,6 +190,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A fresh-clone `mix ptc` invocation now performs normal dependency validation
+  and compiles fetched dependencies before compiling PtcRunner. Warm root
+  commands retain the dependency-check startup optimization after the first
+  successful application build.
 - Command envelope publication no longer suppresses the normal terminal
   rendering. Help, version, and init now use readable code-owned projections,
   while workflow result values retain deterministic JSON rendering.

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -22,8 +22,10 @@ mix ptc run examples/kernel-tutorial/01-orders/ptc.json
 ```
 
 That is a PTC-Lisp function reading JSON input. No model, no host document, no
-network. The first run compiles the dependencies and the project, which took
-about 90 seconds from a fresh clone; later runs start in a few seconds.
+network. On a fresh clone, the first `mix ptc` run performs Mix's normal
+dependency validation and compiles the dependencies and project, which took
+about 90 seconds. Once that build succeeds, later root-project commands skip
+dependency validation and start in a few seconds.
 
 ## 2. Supply a model credential
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,9 +1,11 @@
 defmodule PtcRunner.MixProject do
   use Mix.Project
 
+  @app :ptc_runner
+
   def project do
     [
-      app: :ptc_runner,
+      app: @app,
       version: "0.13.0",
       elixir: "~> 1.15",
       start_permanent: Mix.env() == :prod,
@@ -225,8 +227,20 @@ defmodule PtcRunner.MixProject do
   end
 
   defp run_ptc(args) do
-    Mix.Task.run(ptc_prepare_task(args), ["--no-deps-check"])
+    Mix.Task.run(ptc_prepare_task(args), ptc_prepare_args(Mix.Project.app_path()))
     Mix.Task.run("ptc", args)
+  end
+
+  @doc false
+  @spec ptc_prepare_args(binary()) :: [binary()]
+  def ptc_prepare_args(app_path) when is_binary(app_path) do
+    # The app compiler runs after the language compilers, so this artifact is
+    # an O(1) signal that the initial dependency-aware build completed. Calling
+    # Mix.Dep.cached/0 here would restore much of the warm-start cost this path
+    # deliberately avoids.
+    app_file = Path.join([app_path, "ebin", Atom.to_string(@app) <> ".app"])
+
+    if File.regular?(app_file), do: ["--no-deps-check"], else: []
   end
 
   # These raw forms are only preparation hints; the shared parser remains the

--- a/test/mix/tasks/ptc_test.exs
+++ b/test/mix/tasks/ptc_test.exs
@@ -11,13 +11,61 @@ defmodule Mix.Tasks.PtcTest do
   alias PtcRunner.MixCommandAdapter
   alias PtcRunner.MixCommandRuntime
 
+  @root Path.expand("../../..", __DIR__)
+
   test "only the root project bootstrap skips dependency checks" do
     assert MixCommandRuntime.app_config_args(PtcRunner.MixProject) == ["--no-deps-check"]
     assert MixCommandRuntime.app_config_args(Downstream.MixProject) == []
     assert MixCommandRuntime.app_config_args(nil) == []
   end
 
-  @root Path.expand("../../..", __DIR__)
+  @tag :tmp_dir
+  test "root command validates dependencies until the application has been built", %{
+    tmp_dir: directory
+  } do
+    app_path = Path.join(directory, "ptc_runner")
+    app_file = Path.join([app_path, "ebin", "ptc_runner.app"])
+
+    assert PtcRunner.MixProject.ptc_prepare_args(app_path) == []
+
+    File.mkdir_p!(Path.dirname(app_file))
+    assert PtcRunner.MixProject.ptc_prepare_args(app_path) == []
+
+    File.write!(app_file, "built")
+    assert PtcRunner.MixProject.ptc_prepare_args(app_path) == ["--no-deps-check"]
+  end
+
+  # Seed everything except one dependency so this exercises the real alias
+  # without rebuilding the entire dependency tree. The old unconditional
+  # --no-deps-check path leaves the omitted dependency uncompiled.
+  @tag :slow
+  test "a cold root command compiles dependencies before running" do
+    build_path =
+      Path.join(@root, "_build/ptc-cold-start-#{System.unique_integer([:positive, :monotonic])}")
+
+    on_exit(fn -> File.rm_rf!(build_path) end)
+    seed_incomplete_build(build_path)
+
+    {output, status} =
+      System.cmd(System.find_executable("mix"), ["ptc", "--version"],
+        cd: @root,
+        env: [
+          {"MIX_BUILD_PATH", build_path},
+          {"MIX_ENV", "test"},
+          {"MIX_QUIET", "1"}
+        ],
+        stderr_to_stdout: true
+      )
+
+    assert status == 0, output
+    assert output =~ Mix.Project.config()[:version]
+
+    assert File.regular?(
+             Path.join([build_path, "lib", "nimble_parsec", "ebin", "nimble_parsec.app"])
+           )
+
+    assert File.regular?(Path.join([build_path, "lib", "ptc_runner", "ebin", "ptc_runner.app"]))
+  end
 
   @tag :tmp_dir
   test "renders a normal run value as deterministic compact JSON", %{tmp_dir: dir} do
@@ -239,6 +287,26 @@ defmodule Mix.Tasks.PtcTest do
 
     message = failed_message(args)
     assert %{"readiness" => "failed", "checks" => ^checks} = Jason.decode!(message)
+  end
+
+  defp seed_incomplete_build(build_path) do
+    source_lib_path = Path.join(Mix.Project.build_path(), "lib")
+    build_lib_path = Path.join(build_path, "lib")
+    File.mkdir_p!(build_lib_path)
+
+    source_lib_path
+    |> File.ls!()
+    |> Enum.reject(&(&1 in ["nimble_parsec", "ptc_runner"]))
+    |> Enum.each(fn dependency ->
+      File.ln_s!(
+        Path.join(source_lib_path, dependency),
+        Path.join(build_lib_path, dependency)
+      )
+    end)
+
+    runner_path = Path.join(build_lib_path, "ptc_runner")
+    File.cp_r!(Path.join(source_lib_path, "ptc_runner"), runner_path)
+    File.rm!(Path.join([runner_path, "ebin", "ptc_runner.app"]))
   end
 
   defp run_output(args) do


### PR DESCRIPTION
Fixes #1341

## Summary

- restore Mix dependency validation when the root application has not been built
- retain the warm root-command fast path after the `.app` artifact exists
- document cold- and warm-start behavior in the quickstart, contributor guidance, and changelog

## Root cause

The root `mix ptc` alias unconditionally passed `--no-deps-check`. On a fresh clone after `mix deps.get`, Mix therefore attempted to compile PtcRunner against fetched but uncompiled dependencies.

## Verification

- `mix test test/mix/tasks/ptc_test.exs --max-failures 1 --warnings-as-errors`
- isolated cold quickstart run
- `mix precommit`
- `MIX_ENV=dev mix docs --warnings-as-errors`
- independent Codex review
- repository pre-push hook (tests, static analysis, Dialyzer, release, Viewer, and launcher)