### PR TITLE
fix(test): make optional MCP E2E prerequisites skippable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,9 +85,10 @@ how it was verified.
   unavailable. PR CI runs the same scripts as individual jobs. The test suite uses
   `System.schedulers_online()` concurrent cases; do not reduce that pressure
   to make a failing push pass.
-- `mix test --include e2e` — E2E tests (requires `OPENROUTER_API_KEY`;
-  the MCP tests also require the local server in the
-  [development setup guide](docs/development-setup.md)).
+- `mix test --include e2e` — E2E tests (requires `OPENROUTER_API_KEY`).
+  Optional MCP tests skip unless their endpoint, binary, and token
+  prerequisites are configured as described in the
+  [development setup guide](docs/development-setup.md).
 - `mix nightly` — the `:nightly` tests, excluded from `mix test` by default.
   The `Nightly` workflow runs them daily; run it locally when you touch the
   `mix ptc run` downstream path or the benchmark task. Never add `--trace` (or

--- a/docs/development-setup.md
+++ b/docs/development-setup.md
@@ -147,3 +147,29 @@ PTC_TEST_MCP_OAUTH=1 \
 The scheduled/manual model-driven test uses the same server and additionally
 loads `OPENROUTER_API_KEY` and the optional `PTC_TEST_MODEL` from the root
 checkout's explicitly named `.env` test input.
+
+### Aggregate E2E suite
+
+`mix test --include e2e` runs the live-model tests and every optional MCP test
+whose prerequisites are configured. Missing MCP prerequisites are reported as
+skips, so a checkout configured only with `OPENROUTER_API_KEY` remains a valid
+way to run the model-backed coverage. Once a prerequisite is configured, an
+invalid binary, unreachable endpoint, authentication error, or protocol error
+still fails its test.
+
+The remote MCP tests require `PTC_TEST_MCP_2026_ENDPOINT`. The GitHub MCP test
+requires both:
+
+- `PTC_TEST_GITHUB_MCP_BINARY` — an absolute path to the pinned GitHub MCP
+  Server executable used by CI.
+- `PTC_TEST_GITHUB_TOKEN` — a GitHub token that can read this repository.
+
+With the GitHub MCP prerequisites exported, the repository harness supplies a
+temporary remote endpoint while the aggregate suite runs:
+
+```bash
+export PTC_TEST_GITHUB_MCP_BINARY=/absolute/path/to/github-mcp-server
+export PTC_TEST_GITHUB_TOKEN=replace-with-repository-read-token
+bash test/support/mcp_go_stateless/with_server.sh \
+  mix test --include e2e --trace
+```

--- a/docs/development-setup.md
+++ b/docs/development-setup.md
@@ -164,6 +164,9 @@ requires both:
   Server executable used by CI.
 - `PTC_TEST_GITHUB_TOKEN` — a GitHub token that can read this repository.
 
+The filesystem MCP tests run when a `node` executable is available on `PATH`;
+otherwise they skip with the other unavailable optional integrations.
+
 With the GitHub MCP prerequisites exported, the repository harness supplies a
 temporary remote endpoint while the aggregate suite runs:
 

--- a/test/ptc_runner/kernel/filesystem_mcp_e2e_test.exs
+++ b/test/ptc_runner/kernel/filesystem_mcp_e2e_test.exs
@@ -17,6 +17,11 @@ defmodule PtcRunner.Kernel.FilesystemMCPE2ETest do
   alias PtcRunner.Kernel.HostConfig
   alias PtcRunner.Kernel.HostInstallation
   alias PtcRunner.TestSupport.RunLifecycle
+  alias PtcRunner.TestSupport.TestHelpers
+
+  if reason = TestHelpers.executable_skip_reason(["node"]) do
+    @moduletag skip: reason
+  end
 
   @server Path.expand("../../../examples/mcp/filesystem/dist/server.js", __DIR__)
 

--- a/test/ptc_runner/kernel/github_mcp_e2e_test.exs
+++ b/test/ptc_runner/kernel/github_mcp_e2e_test.exs
@@ -4,16 +4,25 @@ defmodule PtcRunner.Kernel.GitHubMCPE2ETest do
   import ExUnit.CaptureIO
 
   alias Mix.Tasks.Ptc
+  alias PtcRunner.TestSupport.TestHelpers
 
   @moduletag :e2e
   @repository_commit "1f5361d24a72a822633e650a28159058f17c815b"
+
+  if reason =
+       TestHelpers.environment_skip_reason([
+         "PTC_TEST_GITHUB_MCP_BINARY",
+         "PTC_TEST_GITHUB_TOKEN"
+       ]) do
+    @moduletag skip: reason
+  end
 
   @tag :tmp_dir
   test "host JSON checks and calls the pinned GitHub MCP server without leaking credentials", %{
     tmp_dir: dir
   } do
-    binary = required_environment!("PTC_TEST_GITHUB_MCP_BINARY")
-    token = required_environment!("PTC_TEST_GITHUB_TOKEN")
+    binary = System.fetch_env!("PTC_TEST_GITHUB_MCP_BINARY")
+    token = System.fetch_env!("PTC_TEST_GITHUB_TOKEN")
     paths = write_application(dir, binary)
 
     envelope_path = Path.join(dir, "command-envelope.json")
@@ -153,13 +162,6 @@ defmodule PtcRunner.Kernel.GitHubMCPE2ETest do
     File.write!(host_path, Jason.encode!(host))
 
     %{manifest: manifest_path, host: host_path, trace: trace_path}
-  end
-
-  defp required_environment!(name) do
-    case System.fetch_env(name) do
-      {:ok, value} when byte_size(value) > 0 -> value
-      _missing -> flunk("#{name} is required for the GitHub MCP E2E")
-    end
   end
 
   defp refute_server_process(binary) do

--- a/test/ptc_runner/kernel/mcp_remote_agent_e2e_test.exs
+++ b/test/ptc_runner/kernel/mcp_remote_agent_e2e_test.exs
@@ -22,13 +22,17 @@ defmodule PtcRunner.Kernel.MCPRemoteAgentE2ETest do
   alias PtcRunner.Kernel.ProviderRegistry
   alias PtcRunner.TestSupport.LLMSupport
   alias PtcRunner.TestSupport.RunLifecycle
+  alias PtcRunner.TestSupport.TestHelpers
+
+  if reason = TestHelpers.environment_skip_reason(["PTC_TEST_MCP_2026_ENDPOINT"]) do
+    @moduletag skip: reason
+  end
 
   setup_all do
     :ok = LLMSupport.load_dotenv()
     # Host installation admits a provider application through the prepared-run
     # path; a directly registered builder has to start it itself.
-    :ok = LLMSupport.admit_provider_application!()
-    :ok
+    LLMSupport.admit_provider_application!()
   end
 
   @tag :tmp_dir

--- a/test/ptc_runner/kernel/mcp_remote_e2e_test.exs
+++ b/test/ptc_runner/kernel/mcp_remote_e2e_test.exs
@@ -26,6 +26,11 @@ defmodule PtcRunner.Kernel.MCPRemoteE2ETest do
   alias PtcRunner.Kernel.ProviderRegistry
   alias PtcRunner.Kernel.RunConfig
   alias PtcRunner.Kernel.WorkflowEnvironment
+  alias PtcRunner.TestSupport.TestHelpers
+
+  if reason = TestHelpers.environment_skip_reason(["PTC_TEST_MCP_2026_ENDPOINT"]) do
+    @moduletag skip: reason
+  end
 
   test "a live stateless MCP server crosses the bounded Kernel capability boundary" do
     endpoint = System.fetch_env!("PTC_TEST_MCP_2026_ENDPOINT")

--- a/test/ptc_runner/kernel/named_missions_authority_e2e_test.exs
+++ b/test/ptc_runner/kernel/named_missions_authority_e2e_test.exs
@@ -21,6 +21,11 @@ defmodule PtcRunner.Kernel.NamedMissionsAuthorityE2ETest do
   alias PtcRunner.Kernel.HostConfig
   alias PtcRunner.Kernel.HostInstallation
   alias PtcRunner.TestSupport.RunLifecycle
+  alias PtcRunner.TestSupport.TestHelpers
+
+  if reason = TestHelpers.executable_skip_reason(["node"]) do
+    @moduletag skip: reason
+  end
 
   @server Path.expand("../../../examples/mcp/filesystem/dist/server.js", __DIR__)
 

--- a/test/ptc_runner/kernel/tutorial_examples_e2e_test.exs
+++ b/test/ptc_runner/kernel/tutorial_examples_e2e_test.exs
@@ -56,7 +56,7 @@ defmodule PtcRunner.Kernel.TutorialExamplesE2ETest do
     assert result.value == %{"ok" => true, "value" => expected}
     assert result.usage.subordinate_evaluations in 1..4
     assert result.usage.capability_calls.workflow["llm-request"] in 1..4
-    assert result.usage.capability_calls.mission["workspace.read"] == 1
+    assert result.usage.capability_calls.mission["workspace.read"] >= 1
   end
 
   test "the multi-turn tutorial commits a helper before explicit completion" do

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -39,6 +39,19 @@ defmodule PtcRunner.TestSupport.TestHelpers do
   end
 
   @doc """
+  Returns an ExUnit skip reason when optional environment variables are absent.
+
+  Empty values count as absent. Tests still fail normally when a configured
+  prerequisite is invalid or unavailable during execution.
+  """
+  @spec environment_skip_reason([String.t()]) :: String.t() | nil
+  def environment_skip_reason(names) when is_list(names) do
+    names
+    |> Enum.filter(&(System.get_env(&1) in [nil, ""]))
+    |> missing_environment_reason()
+  end
+
+  @doc """
   Stops a process (Agent/GenServer) started in test setup, tolerating the
   teardown race. A `start_link`-ed process dies with the test process, which can
   race `on_exit`: `if Process.alive?(pid), do: GenServer.stop(pid)` is a TOCTOU —
@@ -52,6 +65,11 @@ defmodule PtcRunner.TestSupport.TestHelpers do
   end
 
   def stop_quietly(_), do: :ok
+
+  defp missing_environment_reason([]), do: nil
+
+  defp missing_environment_reason(names),
+    do: "optional E2E prerequisites are not configured: #{Enum.join(names, ", ")}"
 
   @doc """
   A PTC-Lisp entry body that genuinely occupies its worker while a test

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -52,6 +52,19 @@ defmodule PtcRunner.TestSupport.TestHelpers do
   end
 
   @doc """
+  Returns an ExUnit skip reason when optional executables are unavailable.
+
+  Tests still fail normally when a discovered executable cannot start or
+  fails during execution.
+  """
+  @spec executable_skip_reason([String.t()]) :: String.t() | nil
+  def executable_skip_reason(names) when is_list(names) do
+    names
+    |> Enum.filter(&(System.find_executable(&1) == nil))
+    |> missing_executable_reason()
+  end
+
+  @doc """
   Stops a process (Agent/GenServer) started in test setup, tolerating the
   teardown race. A `start_link`-ed process dies with the test process, which can
   race `on_exit`: `if Process.alive?(pid), do: GenServer.stop(pid)` is a TOCTOU —
@@ -70,6 +83,11 @@ defmodule PtcRunner.TestSupport.TestHelpers do
 
   defp missing_environment_reason(names),
     do: "optional E2E prerequisites are not configured: #{Enum.join(names, ", ")}"
+
+  defp missing_executable_reason([]), do: nil
+
+  defp missing_executable_reason(names),
+    do: "optional E2E executables are not available on PATH: #{Enum.join(names, ", ")}"
 
   @doc """
   A PTC-Lisp entry body that genuinely occupies its worker while a test

--- a/test/support/test_helpers_test.exs
+++ b/test/support/test_helpers_test.exs
@@ -1,7 +1,41 @@
 defmodule PtcRunner.TestSupport.TestHelpersTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
-  import PtcRunner.TestSupport.TestHelpers, only: [stop_quietly: 1]
+  import PtcRunner.TestSupport.TestHelpers,
+    only: [environment_skip_reason: 1, stop_quietly: 1]
+
+  describe "environment_skip_reason/1" do
+    setup do
+      names = ["PTC_TEST_HELPER_PRESENT", "PTC_TEST_HELPER_MISSING"]
+      original = Map.new(names, &{&1, System.fetch_env(&1)})
+
+      on_exit(fn ->
+        Enum.each(original, fn
+          {name, {:ok, value}} -> System.put_env(name, value)
+          {name, :error} -> System.delete_env(name)
+        end)
+      end)
+
+      System.put_env("PTC_TEST_HELPER_PRESENT", "configured")
+      System.delete_env("PTC_TEST_HELPER_MISSING")
+      :ok
+    end
+
+    test "continues when every named variable is non-empty" do
+      refute environment_skip_reason(["PTC_TEST_HELPER_PRESENT"])
+    end
+
+    test "returns a descriptive reason for missing and empty variables" do
+      System.put_env("PTC_TEST_HELPER_PRESENT", "")
+
+      assert "optional E2E prerequisites are not configured: " <>
+               "PTC_TEST_HELPER_PRESENT, PTC_TEST_HELPER_MISSING" =
+               environment_skip_reason([
+                 "PTC_TEST_HELPER_PRESENT",
+                 "PTC_TEST_HELPER_MISSING"
+               ])
+    end
+  end
 
   describe "stop_quietly/1" do
     test "stops a live process" do

--- a/test/support/test_helpers_test.exs
+++ b/test/support/test_helpers_test.exs
@@ -2,7 +2,20 @@ defmodule PtcRunner.TestSupport.TestHelpersTest do
   use ExUnit.Case, async: false
 
   import PtcRunner.TestSupport.TestHelpers,
-    only: [environment_skip_reason: 1, stop_quietly: 1]
+    only: [environment_skip_reason: 1, executable_skip_reason: 1, stop_quietly: 1]
+
+  describe "executable_skip_reason/1" do
+    test "continues when every named executable is available" do
+      refute executable_skip_reason(["elixir"])
+    end
+
+    test "returns a descriptive reason for unavailable executables" do
+      missing = "ptc-test-executable-that-does-not-exist"
+      expected = "optional E2E executables are not available on PATH: #{missing}"
+
+      assert executable_skip_reason([missing]) == expected
+    end
+  end
 
   describe "environment_skip_reason/1" do
     setup do


### PR DESCRIPTION
## Summary

- allow the file-agent tutorial to read its granted file more than once while still requiring at least one read and the exact returned content
- mark remote and GitHub MCP E2E tests as skipped when their optional endpoint, binary, or token prerequisites are absent
- keep configured-but-invalid prerequisites fail-closed
- document the aggregate E2E behavior and the GitHub MCP environment variables

## Root cause

The tutorial asserted an exact live-model tool-call count even though rereading is valid behavior. Three optional MCP integration tests fetched environment variables inside their test bodies, turning unavailable local infrastructure into test failures rather than explicit skips.

PR #1349 removed the obsolete repo-analyst portion of #1303. This PR addresses the two remaining failure classes.

## Validation

- missing-prerequisite focused run: 3 skipped, 0 failures
- configured remote MCP test against the repository Go harness: 1 passed
- helper regression tests: 5 passed
- `MIX_ENV=dev mix docs --warnings-as-errors`
- `mix precommit`: 6,156 core tests plus Viewer, launcher, static, duplication, specification, generated-artifact, package, and release gates
- pre-push gate: core tests, static analysis, Dialyzer, documentation, Viewer, launcher, package, and release verification

The live tutorial was not run locally because this worktree has no `OPENROUTER_API_KEY`; the live E2E workflow remains responsible for that configured path.

Closes #1303