### PR TITLE
fix(repl): unwrap return values in output

### DIFF
--- a/docs/guides/kernel-repl.md
+++ b/docs/guides/kernel-repl.md
@@ -30,6 +30,10 @@ mix ptc repl script.clj
 mix ptc repl - < script.clj
 ```
 
+A successful `return` prints its value, including when it is the final form in
+a loaded setup file. The evaluator's internal return control wrapper is never
+part of REPL output.
+
 Use the same strict manifest as `mix ptc run` to attach a frozen workflow
 bundle, workflow capabilities, limits, input, labels, and event policy:
 

--- a/lib/ptc_runner/kernel/runner.ex
+++ b/lib/ptc_runner/kernel/runner.ex
@@ -23,6 +23,7 @@ defmodule PtcRunner.Kernel.Runner do
   alias PtcRunner.Kernel.ToolGrant
   alias PtcRunner.Lisp
   alias PtcRunner.Lisp.Eval.Helpers
+  alias PtcRunner.Lisp.Result, as: LispResult
   alias PtcRunner.Lisp.RetainedSize
 
   # Matches the bound `PtcRunner.Kernel.AnalysisSession` already applies when
@@ -228,7 +229,7 @@ defmodule PtcRunner.Kernel.Runner do
 
       {:ok, step} ->
         with {:ok, value} <-
-               Lisp.project_boundary_value(kernel_return_value(step.return), :kernel_json),
+               Lisp.project_boundary_value(LispResult.unwrap_return(step.return), :kernel_json),
              {:ok, value} <- project_result(value, config.result_projection) do
           if terminal_result_within_limit?(value, config.limits.terminal_result_bytes) do
             value = RetainedSize.detach_binaries(value)
@@ -508,9 +509,6 @@ defmodule PtcRunner.Kernel.Runner do
       do: :ok,
       else: {:error, :entry_source_exceeded}
   end
-
-  defp kernel_return_value({:__ptc_return__, value}), do: value
-  defp kernel_return_value(value), do: value
 
   defp terminal_result_within_limit?(value, limit) do
     case {RetainedSize.bytes_with_cap(value, limit), safe_encoded_size(value)} do

--- a/lib/ptc_runner/lisp/result.ex
+++ b/lib/ptc_runner/lisp/result.ex
@@ -76,6 +76,11 @@ defmodule PtcRunner.Lisp.Result do
     }
   end
 
+  @doc false
+  @spec unwrap_return(term()) :: term()
+  def unwrap_return({:__ptc_return__, value}), do: value
+  def unwrap_return(value), do: value
+
   @spec error(atom(), String.t(), map()) :: t()
   def error(reason, message, memory), do: error(reason, message, memory, %{})
 

--- a/lib/ptc_runner/repl_frontend.ex
+++ b/lib/ptc_runner/repl_frontend.ex
@@ -81,6 +81,7 @@ defmodule PtcRunner.ReplFrontend do
   alias PtcRunner.Kernel.ReplSession
   alias PtcRunner.Lisp.Format
   alias PtcRunner.Lisp.Registry
+  alias PtcRunner.Lisp.Result, as: LispResult
   alias PtcRunner.ReplError
 
   @spec run(CommandArguments.t(), CommandRuntime.t()) :: :ok | {:error, binary()}
@@ -1309,7 +1310,7 @@ defmodule PtcRunner.ReplFrontend do
 
   defp print_step(step) do
     Enum.each(step.prints, &info/1)
-    {formatted, _truncated?} = Format.to_clojure(step.return)
+    {formatted, _truncated?} = Format.to_clojure(LispResult.unwrap_return(step.return))
     info(formatted)
   end
 

--- a/test/mix/tasks/ptc_repl_test.exs
+++ b/test/mix/tasks/ptc_repl_test.exs
@@ -277,6 +277,17 @@ defmodule PtcRunner.ReplFrontendTest do
     assert output =~ "42"
   end
 
+  @tag :tmp_dir
+  test "-l prints a trailing return as its value", %{tmp_dir: directory} do
+    path = Path.join(directory, "setup.clj")
+    File.write!(path, "(def loaded 41)\n(return (+ loaded 1))\n")
+
+    output = capture_io(fn -> run_repl(["-l", path, "-e", "loaded"]) end)
+
+    assert output == "42\nLoaded #{path}\n41\n"
+    refute output =~ "__ptc_return__"
+  end
+
   test "removed upstream and special log options fail closed" do
     assert_raise Mix.Error, ~r/unknown switch; accepted:/, fn ->
       run_repl(["--log-prelude", "-e", "(+ 1 2)"])


### PR DESCRIPTION
## Summary

- print the payload of successful PTC-Lisp `return` results at the REPL boundary
- share the return-unwrapping rule with Kernel execution instead of duplicating it
- add a regression test for a loaded setup file ending in `return`
- document that the internal return wrapper is never part of REPL output

## Root cause

`PtcRunner.ReplFrontend.print_step/1` sent `step.return` directly to the Clojure formatter. Ordinary results are values, but explicit `return` results use the evaluator's internal `{:__ptc_return__, value}` control tuple, so the formatter faithfully exposed that tuple as `[:__ptc_return__ ...]`.

## User impact

A setup file ending in `(return (+ loaded 1))` now prints `42` rather than `[:__ptc_return__ 42]`. The same output boundary also prevents the sentinel from leaking through other direct and manifest REPL evaluations.

## Validation

- `mix test test/mix/tasks/ptc_repl_test.exs` — 37 passed
- `MIX_ENV=dev mix docs --warnings-as-errors`
- `mix precommit` — 6,159 root tests, 44 Viewer tests, 40 launcher tests, static analysis, duplication, conformance, package, and release gates passed
- pre-push hook — root tests, static analysis, Dialyzer, release verification, docs, and Viewer validation passed

Closes #1343