### PR TITLE
test(mcp-oauth): synchronize manager monitor

### DIFF
--- a/test/ptc_runner/kernel/mcp_oauth/store_memory_test.exs
+++ b/test/ptc_runner/kernel/mcp_oauth/store_memory_test.exs
@@ -111,6 +111,12 @@ defmodule PtcRunner.Kernel.MCPOAuth.StoreMemoryTest do
     store_reference = Process.monitor(memory.pid)
     manager_reference = Process.monitor(manager)
 
+    # A monitor request is asynchronous. This process sends both it and the
+    # following process-info request to the manager, so the reply proves the
+    # monitor arrived before the store can be told to kill the manager.
+    assert {:monitored_by, monitoring_processes} = Process.info(manager, :monitored_by)
+    assert self() in monitoring_processes
+
     Process.exit(owner, :kill)
 
     assert_receive {:DOWN, ^store_reference, :process, _store, :normal}, 5_000


### PR DESCRIPTION
## Summary

- wait until the test process's manager monitor is installed before triggering owner shutdown
- retain the strict `:killed` exit-reason assertion instead of accepting the racy `:noproc` outcome
- document why the process-info request acts as an ordering barrier

## Root cause

`Process.monitor/1` sends an asynchronous monitor signal. The test process sent that signal while the OAuth store later sent the manager's kill signal. Because those signals had different senders, Erlang did not order them; under load, the kill could arrive first and the test monitor would report `:noproc` even though cleanup succeeded.

The subsequent `Process.info(manager, :monitored_by)` request comes from the same test process and targets the same manager. Its reply proves the earlier monitor signal has been processed before owner shutdown is triggered.

## Impact

This is a test-only synchronization fix. Production runtime behavior is unchanged.

## Validation

- exact test with CI seed and four-scheduler shape
- full `store_memory_test.exs`: 29 passed
- exact test repeated 10,000 times without failure
- `mix precommit`: 6,158 core tests plus Viewer, launcher, package, and release checks
- tracked pre-push hook: documentation, 6,158 core tests, static analysis, Dialyzer, release verification, and Viewer validation