### PR TITLE
fix(cli): render manifest schema violation paths

### DIFF
--- a/lib/ptc_runner/kernel/command_renderer.ex
+++ b/lib/ptc_runner/kernel/command_renderer.ex
@@ -3,8 +3,10 @@ defmodule PtcRunner.Kernel.CommandRenderer do
   Deterministic, privacy-preserving human projection of sealed command outcomes.
 
   Provider failures include the validated provider subject already present in
-  the public command envelope. Rendering never derives labels from a rejected
-  value, provider response, credential, or path.
+  the public command envelope. Manifest schema violations with a non-root,
+  schema-authorized path include its JSON Pointer. Rendering never derives
+  labels from a rejected value, provider response, credential, or unvalidated
+  path.
   """
 
   alias PtcRunner.Kernel.CommandOutcome
@@ -83,7 +85,8 @@ defmodule PtcRunner.Kernel.CommandRenderer do
     base =
       "error: #{error["phase"]}/#{error["code"]}: " <>
         subject_prefix(error["subject"]) <>
-        "#{error["message"]} " <>
+        error["message"] <>
+        path_suffix(error) <>
         "(run_ref: #{run_ref})"
 
     base <> diagnostic_suffix(error) <> rejection_suffix(rejection) <> "\n"
@@ -97,6 +100,17 @@ defmodule PtcRunner.Kernel.CommandRenderer do
        do: "; export it, pass --env-file PATH, or use a host file credential"
 
   defp diagnostic_suffix(_error), do: ""
+
+  defp path_suffix(%{
+         "phase" => "application",
+         "code" => "schema_violation",
+         "source" => %{"kind" => "application"},
+         "path" => path
+       })
+       when is_binary(path) and path != "",
+       do: " at " <> path <> " "
+
+  defp path_suffix(_error), do: " "
 
   defp subject_prefix(%{
          "kind" => "provider",

--- a/test/ptc_runner/kernel/command_frontend_test.exs
+++ b/test/ptc_runner/kernel/command_frontend_test.exs
@@ -199,6 +199,72 @@ defmodule PtcRunner.Kernel.CommandFrontendTest do
   end
 
   @tag :tmp_dir
+  test "a manifest schema rejection renders its safe document path", %{tmp_dir: dir} do
+    application = write_application(dir)
+    manifest = application |> File.read!() |> Jason.decode!()
+
+    invalid_manifest =
+      put_in(
+        manifest,
+        ["workflow", "components", Access.at(0), "path"],
+        "../shared/main.clj"
+      )
+
+    File.write!(application, Jason.encode!(invalid_manifest))
+
+    presentation =
+      CommandFrontend.execute(["validate", application], :standalone, fn _arguments ->
+        {:ok, CommandRuntime.standalone()}
+      end)
+
+    assert presentation.exit_status == 3
+    assert presentation.outcome.envelope["error"]["path"] == "/workflow/components/0/path"
+
+    assert presentation.stderr ==
+             "error: application/schema_violation: " <>
+               "the application manifest does not satisfy its schema " <>
+               "at /workflow/components/0/path (run_ref: #{presentation.outcome.envelope["run_ref"]})\n"
+
+    refute presentation.stderr =~ "../shared/main.clj"
+  end
+
+  @tag :tmp_dir
+  test "human failures do not render contract-authored control bytes", %{tmp_dir: dir} do
+    application = write_application(dir)
+    manifest = application |> File.read!() |> Jason.decode!()
+    property = "line\n\e[31m"
+
+    input_schema = %{
+      "type" => "object",
+      "properties" => %{property => %{"type" => "integer"}},
+      "required" => [property]
+    }
+
+    invalid_manifest =
+      manifest
+      |> Map.put("contracts", %{"input_schema" => %{"path" => "input.schema.json"}})
+      |> put_in(["input", "value"], %{property => "wrong"})
+
+    File.write!(application, Jason.encode!(invalid_manifest))
+    File.write!(Path.join(dir, "input.schema.json"), Jason.encode!(input_schema))
+
+    presentation =
+      CommandFrontend.execute(["validate", application], :standalone, fn _arguments ->
+        {:ok, CommandRuntime.standalone()}
+      end)
+
+    assert presentation.exit_status == 3
+    assert presentation.outcome.envelope["error"]["path"] == "/" <> property
+
+    assert presentation.stderr ==
+             "error: application/input_contract_failed: " <>
+               "the selected input does not satisfy the input contract " <>
+               "(run_ref: #{presentation.outcome.envelope["run_ref"]})\n"
+
+    refute presentation.stderr =~ property
+  end
+
+  @tag :tmp_dir
   test "an argv rejection does not deliver an envelope or bootstrap", %{tmp_dir: dir} do
     path = Path.join(dir, "must-not-exist.json")
     parent = self()


### PR DESCRIPTION
## Summary

- include the schema-authorized JSON pointer in human-readable application manifest schema violations
- keep rejected values and contract-authored paths out of terminal output
- cover the `..` component-path reproduction and a control-byte property-name regression

## Why

`application/schema_violation` previously rendered one generic sentence, even though the structured diagnostic already carried a safe manifest path. Authors had to bisect manifests to locate mistakes.

## Verification

- `mix precommit`
- `MIX_ENV=dev mix docs --warnings-as-errors`
- repository pre-commit and pre-push hooks
- independent Codex review: no actionable findings after the terminal-injection boundary was tightened

Closes #1355