### PR TITLE
fix(tutorial): make quickstart examples executable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,17 +21,17 @@ OPENROUTER_API_KEY=sk-or-...
 # =============================================================================
 
 # Model for e2e tests. Optional; defaults to
-# openrouter:deepseek/deepseek-v4-flash-0731. Always a full provider-qualified
+# openrouter:deepseek/deepseek-v4-flash. Always a full provider-qualified
 # identifier — there are no short aliases.
 #
 # Known-good alternatives, all cheaper than anthropic/claude-haiku-4.5
-# ($1.00/$5.00 per 1M input/output tokens). Prices checked 2026-08-12; the
-# OpenRouter discounts behind some of them are temporary.
+# ($1.00/$5.00 per 1M input/output tokens). Catalog rates checked 2026-08-14;
+# the OpenRouter discounts behind some of them are temporary.
 #   openrouter:openai/gpt-oss-120b                 $0.03/$0.17
-#   openrouter:deepseek/deepseek-v4-flash-0731     $0.08/$0.25
+#   openrouter:deepseek/deepseek-v4-flash          $0.14/$0.28
 #   openrouter:openai/gpt-5.6-luna                 $0.10/$0.60
 #   openrouter:google/gemini-3.1-flash-lite        $0.25/$1.50
-# PTC_TEST_MODEL=openrouter:deepseek/deepseek-v4-flash-0731
+# PTC_TEST_MODEL=openrouter:deepseek/deepseek-v4-flash
 
 # Stateless MCP 2026-07-28 endpoint used by the direct and model-driven MCP
 # interoperability tests. CI builds the checked-in stateless harness backed by

--- a/docs/agent-library-reference.md
+++ b/docs/agent-library-reference.md
@@ -306,6 +306,8 @@ Successful responses contain `content` and may contain `tool_calls` and
 `tokens`. Normalized tool calls use `id`, `name`, and `args`. Invalid provider
 arguments may include a bounded `args_error` classification. Token usage may
 include `input`, `output`, `cache_creation`, `cache_read`, and `total_cost`.
+When provider pricing is unavailable, `total_cost` is absent; a present zero is
+a measured zero-cost response.
 
 Provider failures remain bounded capability error envelopes so workflow policy
 can decide whether to fail or recover. Credentials, endpoints, sampling,

--- a/docs/development-setup.md
+++ b/docs/development-setup.md
@@ -157,7 +157,8 @@ workflow adds `--include scheduled_e2e` on scheduled and manual runs, but not on
 pull requests. Run those probes directly with:
 
 ```bash
-mix test test/ptc_runner/kernel/tutorial_examples_e2e_test.exs \
+mix test test/quickstart_guide_test.exs \
+  test/ptc_runner/kernel/tutorial_examples_e2e_test.exs \
   --include scheduled_e2e
 ```
 

--- a/docs/guides/documentation-guidelines.md
+++ b/docs/guides/documentation-guidelines.md
@@ -96,6 +96,28 @@ and nondeterministic output.
 An `iex>` block runs only when a test names its module with `doctest/1` or its
 file with `doctest_file/1`.
 
+For a copy/paste CLI example whose final line is deterministic JSON, put this
+hidden annotation immediately before its `console` block and place the expected
+`json` block immediately after it:
+
+````markdown
+<!-- ptc-guide-e2e: id=unique-example-id -->
+```console
+mix ptc run examples/kernel-tutorial/01-orders/ptc.json
+```
+```json
+{"order_count":3}
+```
+````
+
+Add `requires=ENVIRONMENT_VARIABLE` when the command needs a credential. The
+helper in `test/support/guide_examples.ex` turns each annotation into an ExUnit
+test that runs the literal shell block from the repository root, requires a
+zero exit status and empty standard error, and compares the last standard-output
+line as JSON. Credentialed examples receive the `:scheduled_e2e` tag. Keep
+setup, cleanup, secrets, and nondeterministic assertions in the test harness;
+the visible block must remain useful when pasted by a reader.
+
 ## Style and tone
 
 - Write for the API user or maintainer, leading with what the component does.

--- a/docs/guides/host-configuration.md
+++ b/docs/guides/host-configuration.md
@@ -28,7 +28,7 @@ actions happen later during preflight and acquisition.
     "deepseek": {
       "source": "llm",
       "installation_revision": "deepseek-policy-v1",
-      "model": "openrouter:deepseek/deepseek-v4-flash-0731",
+      "model": "openrouter:deepseek/deepseek-v4-flash",
       "credential": "openrouter_key",
       "cache": false
     },
@@ -115,7 +115,7 @@ optional request parameters, and request/response ceilings:
 "deepseek": {
   "source": "llm",
   "installation_revision": "deepseek-policy-v1",
-  "model": "openrouter:deepseek/deepseek-v4-flash-0731",
+  "model": "openrouter:deepseek/deepseek-v4-flash",
   "credential": "openrouter_key",
   "cache": false,
   "params": {"temperature": 0.2, "seed": 42, "max_tokens": 4096}

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -14,6 +14,10 @@ covers a machine that has neither.
 git clone https://github.com/andreasronge/ptc_runner
 cd ptc_runner
 mix deps.get
+```
+
+<!-- ptc-guide-e2e: id=quickstart-orders -->
+```console
 mix ptc run examples/kernel-tutorial/01-orders/ptc.json
 ```
 
@@ -22,8 +26,8 @@ mix ptc run examples/kernel-tutorial/01-orders/ptc.json
 ```
 
 That is a PTC-Lisp function reading JSON input. It needs no model, host
-document, or network access. On a fresh clone, the first command performs
-normal dependency validation and compilation; later root commands use the
+document, or network access. On a fresh clone, the first `mix ptc` command
+performs normal dependency validation and compilation; later commands use the
 fast startup path.
 
 ## 2. Supply a model credential
@@ -41,9 +45,10 @@ declaration forms and how to move off `.env` for a real deployment.
 
 ## 3. Let the model write the program
 
+<!-- ptc-guide-e2e: id=quickstart-live-agent requires=OPENROUTER_API_KEY -->
 ```console
 mix ptc run examples/kernel-tutorial/04-multi-turn-agent/ptc.json \
-  --env-file .env \
+  --env-file "${PTC_ENV_FILE:-.env}" \
   --host-config examples/kernel-tutorial/ptc-host.json
 ```
 
@@ -53,6 +58,9 @@ mix ptc run examples/kernel-tutorial/04-multi-turn-agent/ptc.json \
 
 The model was given a task, wrote PTC-Lisp, and the runtime evaluated that
 program in the confined mission environment over two turns.
+
+The `PTC_ENV_FILE` fallback above uses the `.env` you just created. Automation
+may point it at another explicitly named environment file.
 
 [`ptc-host.json`](../../examples/kernel-tutorial/ptc-host.json) is the operator
 document: it maps the `deepseek` alias to a model and binds it to the

--- a/docs/guides/running-and-debugging.md
+++ b/docs/guides/running-and-debugging.md
@@ -342,7 +342,8 @@ Test scripted model responses before a small live-provider boundary. The
 repository's credentialed tutorial check is explicit:
 
 ```console
-mix test test/ptc_runner/kernel/tutorial_examples_e2e_test.exs \
+mix test test/quickstart_guide_test.exs \
+  test/ptc_runner/kernel/tutorial_examples_e2e_test.exs \
   --include scheduled_e2e
 ```
 

--- a/docs/trace-log-contract.md
+++ b/docs/trace-log-contract.md
@@ -422,6 +422,9 @@ Generated programs carry `prelude_calls_available?` and a sorted
 `source_match`; duplicate identical sources are marked ambiguous rather than
 given a fabricated causal identity.
 
+Provider response usage omits `total_cost` when pricing is unavailable. A
+present zero is therefore a measured zero-cost response, not an unknown cost.
+
 For routed `llm-request` calls, `llm_usage` groups stopped events by model alias
 and installation revision. Each row reports total and successful calls, calls
 with valid usage, successful calls missing usage, and sums of the closed

--- a/examples/kernel-tutorial/02-deepseek-extract/ptc.json
+++ b/examples/kernel-tutorial/02-deepseek-extract/ptc.json
@@ -18,7 +18,7 @@
   },
   "labels": {
     "name": "tutorial-deepseek-extract",
-    "model": "openrouter:deepseek/deepseek-v4-flash-0731",
+    "model": "openrouter:deepseek/deepseek-v4-flash",
     "provider": "openrouter",
     "tags": {"mode": "direct"}
   }

--- a/examples/kernel-tutorial/03-file-agent/ptc.json
+++ b/examples/kernel-tutorial/03-file-agent/ptc.json
@@ -34,7 +34,7 @@
   },
   "labels": {
     "name": "tutorial-deepseek-file-agent",
-    "model": "openrouter:deepseek/deepseek-v4-flash-0731",
+    "model": "openrouter:deepseek/deepseek-v4-flash",
     "provider": "openrouter",
     "tags": {
       "mode": "agent"

--- a/examples/kernel-tutorial/04-multi-turn-agent/ptc.json
+++ b/examples/kernel-tutorial/04-multi-turn-agent/ptc.json
@@ -19,7 +19,7 @@
   },
   "labels": {
     "name": "tutorial-deepseek-multi-turn-agent",
-    "model": "openrouter:deepseek/deepseek-v4-flash-0731",
+    "model": "openrouter:deepseek/deepseek-v4-flash",
     "provider": "openrouter",
     "tags": {"mode": "agent"}
   },

--- a/examples/kernel-tutorial/README.md
+++ b/examples/kernel-tutorial/README.md
@@ -44,8 +44,11 @@ explains its fields.
 Run the live tutorial contracts manually with:
 
 ```bash
-mix test test/ptc_runner/kernel/tutorial_examples_e2e_test.exs --include e2e
+mix test test/quickstart_guide_test.exs \
+  test/ptc_runner/kernel/tutorial_examples_e2e_test.exs \
+  --include scheduled_e2e
 ```
 
-They are tagged `:e2e` and excluded from normal `mix test` and `mix precommit`
-runs.
+The live contracts are tagged `:scheduled_e2e` and excluded from normal
+`mix test` and `mix precommit` runs. The credential-free quickstart command
+still runs in the normal suite.

--- a/examples/kernel-tutorial/ptc-host.json
+++ b/examples/kernel-tutorial/ptc-host.json
@@ -6,7 +6,7 @@
     "deepseek": {
       "source": "llm",
       "installation_revision": "tutorial-llm-v2",
-      "model": "openrouter:deepseek/deepseek-v4-flash-0731",
+      "model": "openrouter:deepseek/deepseek-v4-flash",
       "credential": "openrouter_key",
       "cache": false
     },

--- a/lib/ptc_runner/kernel/host_installation.ex
+++ b/lib/ptc_runner/kernel/host_installation.ex
@@ -1140,7 +1140,7 @@ defmodule PtcRunner.Kernel.HostInstallation do
   end
 
   # A model is a full provider-qualified identifier such as
-  # "openrouter:deepseek/deepseek-v4-flash-0731". Requiring the provider prefix
+  # "openrouter:deepseek/deepseek-v4-flash". Requiring the provider prefix
   # here keeps a mistyped host entry a bounded preflight failure instead of a
   # live provider call that fails after the run clock has started. The adapter
   # remains the authority on whether the provider and model actually exist.

--- a/lib/ptc_runner/llm.ex
+++ b/lib/ptc_runner/llm.ex
@@ -9,6 +9,10 @@ defmodule PtcRunner.LLM do
 
   @type message :: %{role: :system | :user | :assistant | :tool, content: String.t()}
 
+  @typedoc """
+  Provider-reported token usage. `:total_cost` is absent when pricing is
+  unavailable; a present zero is a measured zero-cost response.
+  """
   @type tokens :: %{
           optional(:input) => non_neg_integer(),
           optional(:output) => non_neg_integer(),
@@ -119,7 +123,7 @@ defmodule PtcRunner.LLM do
   Creates a normalized callback for a configured model.
 
   `model` is a full provider-qualified identifier such as
-  `"openrouter:deepseek/deepseek-v4-flash-0731"`. The optional `:adapter`
+  `"openrouter:deepseek/deepseek-v4-flash"`. The optional `:adapter`
   setting selects a transport explicitly; other options are merged into every
   request.
   """

--- a/lib/ptc_runner/llm/req_llm_adapter.ex
+++ b/lib/ptc_runner/llm/req_llm_adapter.ex
@@ -892,9 +892,16 @@ if Code.ensure_loaded?(ReqLLM) do
         input: usage[:input_tokens] || usage["input_tokens"] || 0,
         output: usage[:output_tokens] || usage["output_tokens"] || 0,
         cache_creation: cache_creation,
-        cache_read: cache_read,
-        total_cost: usage[:total_cost] || 0.0
+        cache_read: cache_read
       }
+      |> maybe_put_total_cost(usage)
+    end
+
+    defp maybe_put_total_cost(tokens, usage) do
+      case usage[:total_cost] || usage["total_cost"] do
+        total_cost when is_number(total_cost) -> Map.put(tokens, :total_cost, total_cost)
+        _unknown -> tokens
+      end
     end
 
     defp extract_cache_write_tokens(%{} = meta) do

--- a/test/ptc_runner/kernel/tutorial_examples_contract_test.exs
+++ b/test/ptc_runner/kernel/tutorial_examples_contract_test.exs
@@ -1,0 +1,23 @@
+defmodule PtcRunner.Kernel.TutorialExamplesContractTest do
+  use ExUnit.Case, async: true
+
+  @examples Path.expand("../../../examples/kernel-tutorial", __DIR__)
+  @host Path.join(@examples, "ptc-host.json")
+
+  test "the shipped tutorial model belongs to ReqLLM's catalog" do
+    model = @host |> decode!() |> get_in(["install", "deepseek", "model"])
+
+    assert {:ok, _catalog_model} = ReqLLM.model(model)
+  end
+
+  test "live tutorial labels report the model installed by the host" do
+    model = @host |> decode!() |> get_in(["install", "deepseek", "model"])
+
+    for example <- ~w(02-deepseek-extract 03-file-agent 04-multi-turn-agent) do
+      manifest = decode!(Path.join([@examples, example, "ptc.json"]))
+      assert manifest["labels"]["model"] == model
+    end
+  end
+
+  defp decode!(path), do: path |> File.read!() |> Jason.decode!()
+end

--- a/test/ptc_runner/kernel/tutorial_examples_e2e_test.exs
+++ b/test/ptc_runner/kernel/tutorial_examples_e2e_test.exs
@@ -59,15 +59,6 @@ defmodule PtcRunner.Kernel.TutorialExamplesE2ETest do
     assert result.usage.capability_calls.mission["workspace.read"] >= 1
   end
 
-  test "the multi-turn tutorial commits a helper before explicit completion" do
-    assert {:ok, result} = run("04-multi-turn-agent")
-    assert result.value == %{"ok" => true, "value" => 42}
-    assert result.usage.subordinate_evaluations == 2
-    assert result.usage.capability_calls.workflow["llm-request"] == 2
-    assert result.evaluation_memory.defined_count == 1
-    assert result.evaluation_memory.history_count == 1
-  end
-
   defp run(example) do
     {:ok, host} = HostConfig.load(@host)
 

--- a/test/ptc_runner/llm/req_llm_adapter_test.exs
+++ b/test/ptc_runner/llm/req_llm_adapter_test.exs
@@ -245,8 +245,7 @@ defmodule PtcRunner.LLM.ReqLLMAdapterTest do
                input: 7,
                output: 3,
                cache_read: 2,
-               cache_creation: 0,
-               total_cost: 0.0
+               cache_creation: 0
              }
     end
 
@@ -258,8 +257,7 @@ defmodule PtcRunner.LLM.ReqLLMAdapterTest do
                input: 1,
                output: 0,
                cache_read: 0,
-               cache_creation: 42,
-               total_cost: 0.0
+               cache_creation: 42
              }
     end
 
@@ -268,8 +266,7 @@ defmodule PtcRunner.LLM.ReqLLMAdapterTest do
                input: 0,
                output: 0,
                cache_read: 0,
-               cache_creation: 0,
-               total_cost: 0.0
+               cache_creation: 0
              }
     end
   end

--- a/test/quickstart_guide_test.exs
+++ b/test/quickstart_guide_test.exs
@@ -1,0 +1,34 @@
+defmodule PtcRunner.QuickstartGuideTest do
+  use ExUnit.Case, async: false
+
+  alias PtcRunner.TestSupport.GuideExamples
+  alias PtcRunner.TestSupport.LLMSupport
+
+  require GuideExamples
+
+  setup context do
+    :ok = load_environment()
+
+    case context[:requires_env] do
+      nil -> :ok
+      variable -> require_environment(variable)
+    end
+  end
+
+  GuideExamples.test_examples("docs/guides/quickstart.md")
+
+  defp load_environment do
+    case System.get_env("PTC_ENV_FILE") do
+      nil -> LLMSupport.load_dotenv()
+      path -> PtcRunner.Dotenv.load_file(path)
+    end
+  end
+
+  defp require_environment(variable) do
+    if System.get_env(variable) do
+      :ok
+    else
+      {:skip, "#{variable} is not configured"}
+    end
+  end
+end

--- a/test/support/guide_examples.ex
+++ b/test/support/guide_examples.ex
@@ -1,0 +1,198 @@
+defmodule PtcRunner.TestSupport.GuideExamples do
+  @moduledoc false
+
+  alias __MODULE__, as: GuideExamples
+
+  defstruct [:command, :expected, :id, :line, :requires]
+
+  @annotation ~r/<!-- ptc-guide-e2e: (?<options>[^>]+) -->/
+  @example ~r/<!-- ptc-guide-e2e: (?<options>[^>]+) -->\s*```console\n(?<command>.*?)\n```\s*```json\n(?<expected>.*?)\n```/s
+  @id ~r/^[a-z][a-z0-9-]*$/
+  @environment_variable ~r/^[A-Z][A-Z0-9_]*$/
+
+  @type t :: %__MODULE__{
+          command: String.t(),
+          expected: term(),
+          id: String.t(),
+          line: pos_integer(),
+          requires: String.t() | nil
+        }
+
+  defmacro test_examples(path) do
+    root = File.cwd!()
+    examples = path |> Path.expand(root) |> parse_file!()
+
+    tests =
+      Enum.map(examples, fn example ->
+        tag =
+          if example.requires do
+            quote do
+              @tag :scheduled_e2e
+              @tag requires_env: unquote(example.requires)
+            end
+          end
+
+        quote do
+          unquote(tag)
+
+          test unquote("guide example: #{example.id}") do
+            result =
+              GuideExamples.run(
+                unquote(Macro.escape(example)),
+                unquote(root)
+              )
+
+            assert result.status == 0,
+                   "guide command failed at line #{unquote(example.line)}:\n#{result.stderr}"
+
+            assert result.stderr == "",
+                   "guide command wrote to stderr at line #{unquote(example.line)}:\n#{result.stderr}"
+
+            assert GuideExamples.last_json!(result.stdout) ==
+                     unquote(Macro.escape(example.expected))
+          end
+        end
+      end)
+
+    quote do
+      (unquote_splicing(tests))
+    end
+  end
+
+  @spec parse_file!(Path.t()) :: [t()]
+  def parse_file!(path) do
+    content = File.read!(path)
+    marker_count = @annotation |> Regex.scan(content) |> length()
+    matches = Regex.scan(@example, content, return: :index)
+
+    if marker_count != length(matches) do
+      raise ArgumentError,
+            "every ptc-guide-e2e annotation in #{path} must immediately precede " <>
+              "a console block and its expected JSON block"
+    end
+
+    examples = Enum.map(matches, &build_example!(content, &1, path))
+    ids = Enum.map(examples, & &1.id)
+
+    if examples == [] do
+      raise ArgumentError, "no ptc-guide-e2e examples found in #{path}"
+    end
+
+    if length(ids) != MapSet.size(MapSet.new(ids)) do
+      raise ArgumentError, "ptc-guide-e2e ids must be unique in #{path}"
+    end
+
+    examples
+  end
+
+  @spec run(t(), Path.t()) :: %{
+          status: non_neg_integer(),
+          stderr: String.t(),
+          stdout: String.t()
+        }
+  def run(example, root) do
+    temporary =
+      Path.join(System.tmp_dir!(), "ptc-guide-#{System.unique_integer([:positive, :monotonic])}")
+
+    File.mkdir_p!(temporary)
+    File.chmod!(temporary, 0o700)
+
+    try do
+      stdout_path = Path.join(temporary, "stdout")
+      stderr_path = Path.join(temporary, "stderr")
+      environment = command_environment(example, temporary)
+
+      {_output, status} =
+        System.cmd(
+          System.find_executable("bash") || raise("bash is required for guide examples"),
+          [
+            "-c",
+            ~S(bash -euo pipefail -c "$1" >"$2" 2>"$3"),
+            "ptc-guide-e2e",
+            example.command,
+            stdout_path,
+            stderr_path
+          ],
+          cd: root,
+          env: [{"MIX_ENV", "test"}, {"MIX_QUIET", "1"} | environment]
+        )
+
+      %{
+        status: status,
+        stdout: File.read!(stdout_path),
+        stderr: File.read!(stderr_path)
+      }
+    after
+      File.rm_rf!(temporary)
+    end
+  end
+
+  @spec last_json!(String.t()) :: term()
+  def last_json!(stdout) do
+    stdout
+    |> String.split("\n", trim: true)
+    |> List.last()
+    |> Jason.decode!()
+  end
+
+  defp build_example!(content, match, path) do
+    [{start, _length}, options, command, expected] = match
+    options = capture(content, options) |> parse_options!(path)
+
+    %__MODULE__{
+      id: Map.fetch!(options, "id"),
+      requires: Map.get(options, "requires"),
+      command: capture(content, command),
+      expected: content |> capture(expected) |> Jason.decode!(),
+      line: content |> binary_part(0, start) |> line_number()
+    }
+  end
+
+  defp capture(content, {start, length}), do: binary_part(content, start, length)
+
+  defp parse_options!(options, path) do
+    option_list = String.split(options)
+
+    parsed =
+      Map.new(option_list, fn option ->
+        case String.split(option, "=", parts: 2) do
+          [key, value] when value != "" -> {key, value}
+          _invalid -> raise ArgumentError, "invalid ptc-guide-e2e option in #{path}: #{option}"
+        end
+      end)
+
+    if map_size(parsed) != length(option_list) or Map.keys(parsed) -- ~w(id requires) != [] or
+         not Map.has_key?(parsed, "id") or
+         not Regex.match?(@id, parsed["id"]) or
+         not valid_requirement?(parsed["requires"]) do
+      raise ArgumentError, "invalid ptc-guide-e2e options in #{path}: #{options}"
+    end
+
+    parsed
+  end
+
+  defp valid_requirement?(nil), do: true
+  defp valid_requirement?(name), do: Regex.match?(@environment_variable, name)
+
+  defp line_number(prefix) do
+    prefix
+    |> :binary.matches("\n")
+    |> length()
+    |> Kernel.+(1)
+  end
+
+  defp command_environment(%{requires: nil}, _temporary), do: []
+
+  defp command_environment(%{requires: variable}, temporary) do
+    value = System.fetch_env!(variable)
+
+    if String.contains?(value, ["\n", "\r"]) do
+      raise ArgumentError, "#{variable} cannot contain a newline"
+    end
+
+    env_file = Path.join(temporary, ".env")
+    File.write!(env_file, "#{variable}=#{value}\n")
+    File.chmod!(env_file, 0o600)
+    [{"PTC_ENV_FILE", env_file}, {variable, nil}]
+  end
+end

--- a/test/support/llm_support.ex
+++ b/test/support/llm_support.ex
@@ -13,7 +13,7 @@ defmodule PtcRunner.TestSupport.LLMSupport do
   alias PtcRunner.Kernel.ProviderApplicationGate
   alias PtcRunner.LLM.ReqLLMAdapter
 
-  @default_model "openrouter:deepseek/deepseek-v4-flash-0731"
+  @default_model "openrouter:deepseek/deepseek-v4-flash"
   @timeout 60_000
   @req_opts [retry: :transient, max_retries: 3]
 
@@ -96,7 +96,7 @@ defmodule PtcRunner.TestSupport.LLMSupport do
   Get the current model from PTC_TEST_MODEL env var or return default.
 
   The value is a full provider-qualified identifier, such as
-  `"openrouter:deepseek/deepseek-v4-flash-0731"`.
+  `"openrouter:deepseek/deepseek-v4-flash"`.
   """
   @spec model() :: String.t()
   def model do


### PR DESCRIPTION
## Summary

- pin the tutorial and its live tests to a rolling model present in the locked model catalog
- leave unknown `total_cost` absent instead of reporting a misleading `0.0`
- turn annotated quickstart console examples into literal CLI E2E tests, including the credentialed model example

## Root cause

The tutorial pinned a dated model snapshot that is not present in the locked LLMDB catalog. The response adapter also converted missing provider cost data to zero, and the existing tutorial tests exercised equivalent internals instead of the commands developers copy from the guide.

## User impact

The happy-path tutorial no longer emits the ReqLLM unknown-model warning and stack trace, cost reporting distinguishes unknown from measured zero, and documented commands are continuously checked for successful exit, empty stderr, and expected JSON output.

## Validation

- Live OpenRouter quickstart guide E2E: 2 passed; the agent example returned `{"ok":true,"value":42}` with empty stderr
- Separate live inspection confirmed positive model costs (`0.000071` and `0.000052`)
- `MIX_ENV=dev mix docs --warnings-as-errors`
- `mix precommit`
- tracked pre-push gates: 6,178 core tests, static analysis, Dialyzer, core release, 44 Viewer tests, and 40 launcher tests

Closes #1357