### PR TITLE
docs(lisp): explain function reference extension marker

### DIFF
--- a/docs/function-reference.md
+++ b/docs/function-reference.md
@@ -6,6 +6,8 @@
 
 332 functions and special forms.
 
+`*` marks PtcRunner extensions without a `clojure.core` equivalent.
+
 See also: [PTC-Lisp Specification](ptc-lisp-specification.md) | [Clojure Conformance Gaps](clojure-conformance-gaps.md) | [Namespace Coverage](conformance/index.md)
 
 ## Table of Contents

--- a/lib/mix/tasks/ptc.gen_docs.ex
+++ b/lib/mix/tasks/ptc.gen_docs.ex
@@ -251,6 +251,8 @@ defmodule Mix.Tasks.Ptc.GenDocs do
 
     #{length(entries)} functions and special forms.
 
+    `*` marks PtcRunner extensions without a `clojure.core` equivalent.
+
     See also: [PTC-Lisp Specification](ptc-lisp-specification.md) | [Clojure Conformance Gaps](clojure-conformance-gaps.md) | [Namespace Coverage](conformance/index.md)
 
     ## Table of Contents

--- a/test/mix/tasks/ptc_gen_docs_test.exs
+++ b/test/mix/tasks/ptc_gen_docs_test.exs
@@ -3,6 +3,13 @@ defmodule Mix.Tasks.Ptc.GenDocsTest do
 
   alias Mix.Tasks.Ptc.GenDocs
 
+  test "generated function reference explains the PtcRunner extension marker" do
+    reference = File.read!("docs/function-reference.md")
+
+    assert reference =~ ~r/`[^`]+` \*/
+    assert reference =~ "`*` marks PtcRunner extensions without a `clojure.core` equivalent."
+  end
+
   @tag :tmp_dir
   test "generated schema inventory reports missing and orphaned PTC schemas", %{tmp_dir: dir} do
     schema_dir = Path.join(dir, "priv/schemas")


### PR DESCRIPTION
## Summary

- define the function-reference `*` marker in one short sentence
- keep the explanation in the documentation generator
- add regression coverage for marked entries and their legend

## Why

The generated reference marked 26 PtcRunner extensions without explaining the marker, making it easy to confuse them with special forms.

## Validation

- `mix test test/mix/tasks/ptc_gen_docs_test.exs`
- `mix ptc.gen_docs --check`
- `MIX_ENV=dev mix docs --warnings-as-errors`
- `mix precommit`
- repository pre-push checks

Closes #1360
