### PR TITLE
fix(tutorial): harden executable quickstart coverage

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -84,6 +84,41 @@ GENERATED_DOC_PATTERNS = [
     re.compile(r"^docs/conformance/.*$"),
 ]
 
+REPO_ROOT = os.environ["PTC_PRE_PUSH_REPO_ROOT"]
+EXECUTABLE_GUIDES_PATH = os.path.join(
+    REPO_ROOT, "test", "support", "executable_guides.txt"
+)
+
+def read_executable_doc_paths(path):
+    paths = set()
+
+    with open(path, encoding="utf-8") as registry:
+        for raw_line in registry:
+            line = raw_line.rstrip("\n")
+            entry = line.strip()
+
+            if not entry or entry.startswith("#"):
+                continue
+
+            parts = entry.split("/")
+            if (
+                line != entry
+                or os.path.isabs(entry)
+                or os.path.normpath(entry) != entry
+                or "\\" in entry
+                or any(part in ("", ".", "..") for part in parts)
+            ):
+                raise ValueError(
+                    f"non-canonical executable guide path: {raw_line!r}"
+                )
+
+            paths.add(entry)
+
+    return paths
+
+
+EXECUTABLE_DOC_PATHS = read_executable_doc_paths(EXECUTABLE_GUIDES_PATH)
+
 
 def matches(patterns, path):
     return any(pattern.match(path) for pattern in patterns)
@@ -97,6 +132,7 @@ def is_documentation(path):
     return (
         matches(DOC_PATTERNS, path)
         and not matches(GENERATED_DOC_PATTERNS, path)
+        and path not in EXECUTABLE_DOC_PATHS
     )
 
 
@@ -274,7 +310,8 @@ PYEOF
   trap 'rm -f "$PY_TMP" "$PTC_PRE_PUSH_PATHS_FILE"' EXIT
 
   set +e
-  printf '%s' "$REFS_INPUT" | /usr/bin/env python3 "$PY_TMP"
+  printf '%s' "$REFS_INPUT" |
+    PTC_PRE_PUSH_REPO_ROOT="$HOOK_REPO_ROOT" /usr/bin/env python3 "$PY_TMP"
   SHORT_CIRCUIT_RESULT=$?
   set -e
   rm -f "$PY_TMP"

--- a/docs/guides/documentation-guidelines.md
+++ b/docs/guides/documentation-guidelines.md
@@ -112,11 +112,20 @@ mix ptc run examples/kernel-tutorial/01-orders/ptc.json
 
 Add `requires=ENVIRONMENT_VARIABLE` when the command needs a credential. The
 helper in `test/support/guide_examples.ex` turns each annotation into an ExUnit
-test that runs the literal shell block from the repository root, requires a
-zero exit status and empty standard error, and compares the last standard-output
-line as JSON. Credentialed examples receive the `:scheduled_e2e` tag. Keep
+test after the guide path is added to
+`test/support/executable_guides.txt`. That registry is shared by the test,
+CI classifier, and pre-push hook. The test runs the literal shell block from the
+repository root, requires a zero exit status and empty standard error, and
+compares the last standard-output line as JSON. Credentialed examples receive
+the `:scheduled_e2e` tag.
+`assert=two-turn-agent` additionally points `PTC_ENVELOPE_FILE` at the test's
+owner-only temporary directory and verifies two model calls, two subordinate
+evaluations, and the committed continuation in the command envelope. Keep
 setup, cleanup, secrets, and nondeterministic assertions in the test harness;
-the visible block must remain useful when pasted by a reader.
+the visible block must remain useful when pasted by a reader. Because routing
+comes from the registry rather than current file contents, removing the final
+annotation or deleting a registered guide still runs both documentation and
+core test gates.
 
 ## Style and tone
 

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -45,11 +45,15 @@ declaration forms and how to move off `.env` for a real deployment.
 
 ## 3. Let the model write the program
 
-<!-- ptc-guide-e2e: id=quickstart-live-agent requires=OPENROUTER_API_KEY -->
+<!-- ptc-guide-e2e: id=quickstart-live-agent requires=OPENROUTER_API_KEY assert=two-turn-agent -->
 ```console
+mkdir -p tmp
+envelope="${PTC_ENVELOPE_FILE:-$(mktemp -d tmp/quickstart.XXXXXX)/command-envelope.json}"
+echo "command envelope: $envelope"
 mix ptc run examples/kernel-tutorial/04-multi-turn-agent/ptc.json \
   --env-file "${PTC_ENV_FILE:-.env}" \
-  --host-config examples/kernel-tutorial/ptc-host.json
+  --host-config examples/kernel-tutorial/ptc-host.json \
+  --envelope "$envelope"
 ```
 
 ```json
@@ -60,7 +64,10 @@ The model was given a task, wrote PTC-Lisp, and the runtime evaluated that
 program in the confined mission environment over two turns.
 
 The `PTC_ENV_FILE` fallback above uses the `.env` you just created. Automation
-may point it at another explicitly named environment file.
+may point it at another explicitly named environment file. Each pasted run
+reserves a fresh public command envelope under the Git-ignored `tmp/` directory
+so you can inspect its usage and continuation summary without replacing an
+earlier run.
 
 [`ptc-host.json`](../../examples/kernel-tutorial/ptc-host.json) is the operator
 document: it maps the `deepseek` alias to a model and binds it to the

--- a/examples/kernel-tutorial/ptc-host.json
+++ b/examples/kernel-tutorial/ptc-host.json
@@ -5,7 +5,7 @@
   "install": {
     "deepseek": {
       "source": "llm",
-      "installation_revision": "tutorial-llm-v2",
+      "installation_revision": "tutorial-llm-v3",
       "model": "openrouter:deepseek/deepseek-v4-flash",
       "credential": "openrouter_key",
       "cache": false

--- a/examples/named-mission-reader-writer/ptc-host.json
+++ b/examples/named-mission-reader-writer/ptc-host.json
@@ -5,8 +5,8 @@
   "install": {
     "agent_model": {
       "source": "llm",
-      "installation_revision": "named-missions-example-v2",
-      "model": "openrouter:deepseek/deepseek-v4-flash-0731",
+      "installation_revision": "named-missions-example-v3",
+      "model": "openrouter:deepseek/deepseek-v4-flash",
       "credential": "openrouter_key",
       "cache": false
     },

--- a/examples/viewer-demo/01-recovery.json
+++ b/examples/viewer-demo/01-recovery.json
@@ -35,7 +35,7 @@
   },
   "labels": {
     "name": "viewer-demo-recovery",
-    "model": "openrouter:deepseek/deepseek-v4-flash-0731",
+    "model": "openrouter:deepseek/deepseek-v4-flash",
     "provider": "openrouter",
     "tags": {
       "mode": "agent"

--- a/examples/viewer-demo/02-bulk.json
+++ b/examples/viewer-demo/02-bulk.json
@@ -35,7 +35,7 @@
   },
   "labels": {
     "name": "viewer-demo-bulk",
-    "model": "openrouter:deepseek/deepseek-v4-flash-0731",
+    "model": "openrouter:deepseek/deepseek-v4-flash",
     "provider": "openrouter",
     "tags": {
       "mode": "agent"

--- a/examples/viewer-demo/03-limits.json
+++ b/examples/viewer-demo/03-limits.json
@@ -39,7 +39,7 @@
   },
   "labels": {
     "name": "viewer-demo-limits",
-    "model": "openrouter:deepseek/deepseek-v4-flash-0731",
+    "model": "openrouter:deepseek/deepseek-v4-flash",
     "provider": "openrouter",
     "tags": {
       "mode": "agent"

--- a/examples/viewer-demo/04-loop-limit.json
+++ b/examples/viewer-demo/04-loop-limit.json
@@ -35,7 +35,7 @@
   },
   "labels": {
     "name": "viewer-demo-loop-limit",
-    "model": "openrouter:deepseek/deepseek-v4-flash-0731",
+    "model": "openrouter:deepseek/deepseek-v4-flash",
     "provider": "openrouter",
     "tags": {
       "mode": "agent"

--- a/examples/viewer-demo/05-memory.json
+++ b/examples/viewer-demo/05-memory.json
@@ -35,7 +35,7 @@
   },
   "labels": {
     "name": "viewer-demo-memory",
-    "model": "openrouter:deepseek/deepseek-v4-flash-0731",
+    "model": "openrouter:deepseek/deepseek-v4-flash",
     "provider": "openrouter",
     "tags": {
       "mode": "agent"

--- a/examples/viewer-demo/ptc-host.json
+++ b/examples/viewer-demo/ptc-host.json
@@ -5,8 +5,8 @@
   "install": {
     "deepseek": {
       "source": "llm",
-      "installation_revision": "viewer-llm-v2",
-      "model": "openrouter:deepseek/deepseek-v4-flash-0731",
+      "installation_revision": "viewer-llm-v3",
+      "model": "openrouter:deepseek/deepseek-v4-flash",
       "credential": "openrouter_key",
       "cache": true
     },

--- a/lib/ptc_runner/llm/req_llm_adapter.ex
+++ b/lib/ptc_runner/llm/req_llm_adapter.ex
@@ -315,14 +315,7 @@ if Code.ensure_loaded?(ReqLLM) do
           done_stream =
             Stream.map([nil], fn _ ->
               usage = ReqLLM.StreamResponse.usage(stream_response) || %{}
-
-              %{
-                done: true,
-                tokens: %{
-                  input: usage[:input_tokens] || 0,
-                  output: usage[:output_tokens] || 0
-                }
-              }
+              build_stream_done_chunk(usage)
             end)
 
           {:ok, Stream.concat(content_stream, done_stream)}
@@ -895,6 +888,11 @@ if Code.ensure_loaded?(ReqLLM) do
         cache_read: cache_read
       }
       |> maybe_put_total_cost(usage)
+    end
+
+    @doc false
+    def build_stream_done_chunk(usage) do
+      %{done: true, tokens: build_tokens_from_req_llm_response(usage, %{})}
     end
 
     defp maybe_put_total_cost(tokens, usage) do

--- a/scripts/ci/classify-changes.sh
+++ b/scripts/ci/classify-changes.sh
@@ -6,6 +6,8 @@
 
 set -euo pipefail
 
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+executable_guides="${PTC_EXECUTABLE_GUIDES_FILE:-$repo_root/test/support/executable_guides.txt}"
 paths_file="${1:-/dev/stdin}"
 
 core=false
@@ -27,9 +29,30 @@ select_all() {
   docs=true
 }
 
+registry_valid=true
+
+if [ ! -f "$executable_guides" ] || ! awk '
+  /^[[:space:]]*$/ || /^[[:space:]]*#/ { next }
+  /^[[:space:]]/ || /[[:space:]]$/ || /^\// || /\\/ || /\/\// || /\/$/ || \
+    /(^|\/)\.(\/|$)/ || /(^|\/)\.\.(\/|$)/ { exit 1 }
+' "$executable_guides"; then
+  registry_valid=false
+fi
+
 while IFS= read -r path || [ -n "$path" ]; do
   [ -n "$path" ] || continue
   saw_path=true
+
+  if [ "$registry_valid" = false ]; then
+    select_all
+    continue
+  fi
+
+  if grep -Fxq -- "$path" "$executable_guides"; then
+    core=true
+    docs=true
+    continue
+  fi
 
   case "$path" in
     docs/plans/*|Plans/*)

--- a/test/githooks/pre_push_test.exs
+++ b/test/githooks/pre_push_test.exs
@@ -5,6 +5,7 @@ defmodule PtcRunner.GitHooks.PrePushTest do
 
   @hook Path.expand("../../.githooks/pre-push", __DIR__)
   @classifier Path.expand("../../scripts/ci/classify-changes.sh", __DIR__)
+  @executable_guides Path.expand("../support/executable_guides.txt", __DIR__)
   @git_env GitEnv.clear()
 
   test "planning-only changes skip the full gate" do
@@ -29,6 +30,81 @@ defmodule PtcRunner.GitHooks.PrePushTest do
 
     assert mix_marker |> File.read!() |> String.split("\n", trim: true) ==
              ["deps.get --check-locked", "docs --warnings-as-errors"]
+  end
+
+  @tag :slow
+  test "annotated quickstart changes run documentation and core gates" do
+    %{repo: repo, mix_marker: mix_marker, path: path} =
+      git_repo_with_change("docs/guides/quickstart.md")
+
+    {output, status} = run_hook(repo, path)
+
+    assert status == 0, output
+    refute output =~ "Documentation-only push"
+    assert output =~ "core tests"
+
+    assert mix_marker |> File.read!() |> String.split("\n", trim: true) ==
+             [
+               "deps.get --check-locked",
+               "docs --warnings-as-errors",
+               "ci-gate core-tests",
+               "ci-gate core-static",
+               "ci-gate core-dialyzer",
+               "ci-gate core-release",
+               "ci-gate viewer"
+             ]
+  end
+
+  @tag :slow
+  test "removing the final annotation still runs documentation and core gates" do
+    %{repo: repo, mix_marker: mix_marker, path: path} =
+      git_repo_with_guide_marker_removed("docs/guides/quickstart.md")
+
+    {output, status} = run_hook(repo, path)
+
+    assert status == 0, output
+    refute output =~ "Documentation-only push"
+    assert output =~ "core tests"
+    assert File.read!(mix_marker) =~ "ci-gate core-tests"
+  end
+
+  @tag :slow
+  test "deleting a registered guide still runs documentation and core gates" do
+    %{repo: repo, mix_marker: mix_marker, path: path} =
+      git_repo_with_deleted_file("docs/guides/quickstart.md")
+
+    {output, status} = run_hook(repo, path)
+
+    assert status == 0, output
+    refute output =~ "Documentation-only push"
+    assert output =~ "core tests"
+    assert File.read!(mix_marker) =~ "ci-gate core-tests"
+  end
+
+  @tag :slow
+  test "non-canonical executable-guide entries fail safe to every gate" do
+    %{repo: repo, mix_marker: mix_marker, path: path} =
+      git_repo_with_changes(
+        ["docs/guides/quickstart.md"],
+        registry: "./docs/guides/quickstart.md\n"
+      )
+
+    {output, status} = run_hook(repo, path)
+
+    assert status == 0, output
+    refute output =~ "Documentation-only push"
+
+    assert mix_marker |> File.read!() |> String.split("\n", trim: true) ==
+             [
+               "deps.get --check-locked",
+               "docs --warnings-as-errors",
+               "ci-gate core-tests",
+               "ci-gate core-static",
+               "ci-gate core-dialyzer",
+               "ci-gate core-release",
+               "ci-gate viewer",
+               "ci-gate launcher"
+             ]
   end
 
   test "launcher-only changes run the launcher gate" do
@@ -150,7 +226,27 @@ defmodule PtcRunner.GitHooks.PrePushTest do
     git_repo_with_changes([changed_path])
   end
 
-  defp git_repo_with_changes(changed_paths) do
+  defp git_repo_with_guide_marker_removed(changed_path) do
+    git_repo_with_mutation(changed_path, fn repo ->
+      write_changed_file!(repo, changed_path, "annotation removed\n")
+    end)
+  end
+
+  defp git_repo_with_deleted_file(changed_path) do
+    git_repo_with_mutation(changed_path, fn repo ->
+      File.rm!(Path.join(repo, changed_path))
+    end)
+  end
+
+  defp git_repo_with_mutation(changed_path, mutate) do
+    fixture = git_repo_with_changes([changed_path], commit_change?: false)
+    mutate.(fixture.repo)
+    git!(fixture.repo, ["add", "-A"])
+    git!(fixture.repo, ["commit", "--quiet", "-m", "change"])
+    fixture
+  end
+
+  defp git_repo_with_changes(changed_paths, opts \\ []) do
     root =
       Path.join(
         System.tmp_dir!(),
@@ -165,7 +261,7 @@ defmodule PtcRunner.GitHooks.PrePushTest do
 
     on_exit(fn -> File.rm_rf!(root) end)
 
-    install_hook_fixture!(repo)
+    install_hook_fixture!(repo, opts)
 
     fake_mix = Path.join(bin, "mix")
 
@@ -185,12 +281,15 @@ defmodule PtcRunner.GitHooks.PrePushTest do
     git!(repo, ["config", "user.name", "Pre-push Test"])
 
     File.write!(Path.join(repo, "mix.exs"), "{:dialyxir, \"~> 1.4\"}\n")
-    Enum.each(changed_paths, &write_changed_file!(repo, &1, "before\n"))
+    Enum.each(changed_paths, &write_changed_file!(repo, &1, fixture_contents(&1, "before")))
     git!(repo, ["add", "."])
     git!(repo, ["commit", "--quiet", "-m", "base"])
-    Enum.each(changed_paths, &write_changed_file!(repo, &1, "after\n"))
-    git!(repo, ["add", "."])
-    git!(repo, ["commit", "--quiet", "-m", "change"])
+
+    if Keyword.get(opts, :commit_change?, true) do
+      Enum.each(changed_paths, &write_changed_file!(repo, &1, fixture_contents(&1, "after")))
+      git!(repo, ["add", "."])
+      git!(repo, ["commit", "--quiet", "-m", "change"])
+    end
 
     %{repo: repo, path: bin <> ":" <> System.fetch_env!("PATH"), mix_marker: mix_marker}
   end
@@ -223,9 +322,22 @@ defmodule PtcRunner.GitHooks.PrePushTest do
     File.write!(full_path, contents)
   end
 
-  defp install_hook_fixture!(repo) do
+  defp fixture_contents("docs/guides/quickstart.md", state),
+    do: "<!-- ptc-guide-e2e: id=fixture -->\n#{state}\n"
+
+  defp fixture_contents(_path, state), do: "#{state}\n"
+
+  defp install_hook_fixture!(repo, opts) do
     copy_executable!(@hook, Path.join(repo, ".githooks/pre-push"))
     copy_executable!(@classifier, Path.join(repo, "scripts/ci/classify-changes.sh"))
+    File.mkdir_p!(Path.join(repo, "test/support"))
+
+    registry = Path.join(repo, "test/support/executable_guides.txt")
+
+    case opts[:registry] do
+      nil -> File.cp!(@executable_guides, registry)
+      contents -> File.write!(registry, contents)
+    end
 
     write_executable!(Path.join(repo, "scripts/ci/docs.sh"), """
     #!/bin/sh

--- a/test/ptc_runner/kernel/tutorial_examples_contract_test.exs
+++ b/test/ptc_runner/kernel/tutorial_examples_contract_test.exs
@@ -3,11 +3,20 @@ defmodule PtcRunner.Kernel.TutorialExamplesContractTest do
 
   @examples Path.expand("../../../examples/kernel-tutorial", __DIR__)
   @host Path.join(@examples, "ptc-host.json")
+  @viewer_examples Path.expand("../../../examples/viewer-demo", __DIR__)
+  @named_missions Path.expand("../../../examples/named-mission-reader-writer", __DIR__)
 
-  test "the shipped tutorial model belongs to ReqLLM's catalog" do
-    model = @host |> decode!() |> get_in(["install", "deepseek", "model"])
+  test "models in shipped runnable examples belong to ReqLLM's catalog" do
+    installations = [
+      {@host, "deepseek"},
+      {Path.join(@viewer_examples, "ptc-host.json"), "deepseek"},
+      {Path.join(@named_missions, "ptc-host.json"), "agent_model"}
+    ]
 
-    assert {:ok, _catalog_model} = ReqLLM.model(model)
+    for {host, alias_name} <- installations do
+      model = host |> decode!() |> get_in(["install", alias_name, "model"])
+      assert {:ok, _catalog_model} = LLMDB.model(model), host
+    end
   end
 
   test "live tutorial labels report the model installed by the host" do
@@ -15,6 +24,19 @@ defmodule PtcRunner.Kernel.TutorialExamplesContractTest do
 
     for example <- ~w(02-deepseek-extract 03-file-agent 04-multi-turn-agent) do
       manifest = decode!(Path.join([@examples, example, "ptc.json"]))
+      assert manifest["labels"]["model"] == model
+    end
+  end
+
+  test "viewer example labels report the model installed by the host" do
+    model =
+      @viewer_examples
+      |> Path.join("ptc-host.json")
+      |> decode!()
+      |> get_in(["install", "deepseek", "model"])
+
+    for journey <- ~w(01-recovery 02-bulk 03-limits 04-loop-limit 05-memory) do
+      manifest = decode!(Path.join(@viewer_examples, "#{journey}.json"))
       assert manifest["labels"]["model"] == model
     end
   end

--- a/test/ptc_runner/llm/req_llm_adapter_test.exs
+++ b/test/ptc_runner/llm/req_llm_adapter_test.exs
@@ -271,6 +271,23 @@ defmodule PtcRunner.LLM.ReqLLMAdapterTest do
     end
   end
 
+  describe "build_stream_done_chunk/1" do
+    test "preserves normalized cost and token usage for streamed responses" do
+      usage = %{input_tokens: 12, output_tokens: 4, total_cost: 0.125}
+
+      assert ReqLLMAdapter.build_stream_done_chunk(usage) == %{
+               done: true,
+               tokens: %{
+                 input: 12,
+                 output: 4,
+                 cache_creation: 0,
+                 cache_read: 0,
+                 total_cost: 0.125
+               }
+             }
+    end
+  end
+
   describe "normalize_tool_calls/1" do
     test "decodes well-formed JSON arguments into a map" do
       tc = ToolCall.new("call_1", "get_weather", ~s({"city":"Paris"}))

--- a/test/quickstart_guide_test.exs
+++ b/test/quickstart_guide_test.exs
@@ -1,21 +1,27 @@
 defmodule PtcRunner.QuickstartGuideTest do
   use ExUnit.Case, async: false
 
+  @moduletag timeout: 180_000
+
   alias PtcRunner.TestSupport.GuideExamples
   alias PtcRunner.TestSupport.LLMSupport
 
   require GuideExamples
 
   setup context do
-    :ok = load_environment()
-
     case context[:requires_env] do
-      nil -> :ok
-      variable -> require_environment(variable)
+      nil ->
+        :ok
+
+      variable ->
+        previous_environment = System.get_env()
+        on_exit(fn -> restore_environment(previous_environment) end)
+        :ok = load_environment()
+        require_environment(variable)
     end
   end
 
-  GuideExamples.test_examples("docs/guides/quickstart.md")
+  GuideExamples.test_registered_examples("test/support/executable_guides.txt")
 
   defp load_environment do
     case System.get_env("PTC_ENV_FILE") do
@@ -25,10 +31,21 @@ defmodule PtcRunner.QuickstartGuideTest do
   end
 
   defp require_environment(variable) do
-    if System.get_env(variable) do
-      :ok
-    else
+    if System.get_env(variable) in [nil, ""] do
       {:skip, "#{variable} is not configured"}
+    else
+      :ok
     end
+  end
+
+  defp restore_environment(previous) do
+    current_names = System.get_env() |> Map.keys() |> MapSet.new()
+    previous_names = previous |> Map.keys() |> MapSet.new()
+
+    current_names
+    |> MapSet.difference(previous_names)
+    |> Enum.each(&System.delete_env/1)
+
+    Enum.each(previous, fn {name, value} -> System.put_env(name, value) end)
   end
 end

--- a/test/scripts/classify_changes_test.exs
+++ b/test/scripts/classify_changes_test.exs
@@ -9,6 +9,11 @@ defmodule PtcRunner.Scripts.ClassifyChangesTest do
     assert classify(["docs/guides/replay.md"]) ==
              all_false() |> Map.put("docs", "true")
 
+    assert classify(["docs/guides/quickstart.md"]) ==
+             all_false()
+             |> Map.put("core", "true")
+             |> Map.put("docs", "true")
+
     assert classify(["ptc_runner_launcher/c_src/launcher.c"]) ==
              all_false() |> Map.put("launcher", "true")
 
@@ -33,7 +38,14 @@ defmodule PtcRunner.Scripts.ClassifyChangesTest do
              Map.new(all_false(), fn {scope, _value} -> {scope, "true"} end)
   end
 
-  defp classify(paths) do
+  test "non-canonical executable-guide entries conservatively select every scope" do
+    for entry <- ["  docs/guides/quickstart.md  ", "./docs/guides/quickstart.md"] do
+      assert classify(["docs/guides/quickstart.md"], registry: entry <> "\n") ==
+               Map.new(all_false(), fn {scope, _value} -> {scope, "true"} end)
+    end
+  end
+
+  defp classify(paths, opts \\ []) do
     path =
       Path.join(
         System.tmp_dir!(),
@@ -43,7 +55,19 @@ defmodule PtcRunner.Scripts.ClassifyChangesTest do
     File.write!(path, Enum.join(paths, "\n") <> "\n")
     on_exit(fn -> File.rm(path) end)
 
-    {output, 0} = System.cmd(@classifier, [path], stderr_to_stdout: true)
+    env =
+      case opts[:registry] do
+        nil ->
+          []
+
+        contents ->
+          registry = path <> "-registry"
+          File.write!(registry, contents)
+          on_exit(fn -> File.rm(registry) end)
+          [{"PTC_EXECUTABLE_GUIDES_FILE", registry}]
+      end
+
+    {output, 0} = System.cmd(@classifier, [path], env: env, stderr_to_stdout: true)
 
     output
     |> String.split("\n", trim: true)

--- a/test/support/executable_guides.txt
+++ b/test/support/executable_guides.txt
@@ -1,0 +1,1 @@
+docs/guides/quickstart.md

--- a/test/support/guide_examples.ex
+++ b/test/support/guide_examples.ex
@@ -3,25 +3,73 @@ defmodule PtcRunner.TestSupport.GuideExamples do
 
   alias __MODULE__, as: GuideExamples
 
-  defstruct [:command, :expected, :id, :line, :requires]
+  defstruct [:assertion, :command, :expected, :id, :line, :requires]
 
   @annotation ~r/<!-- ptc-guide-e2e: (?<options>[^>]+) -->/
   @example ~r/<!-- ptc-guide-e2e: (?<options>[^>]+) -->\s*```console\n(?<command>.*?)\n```\s*```json\n(?<expected>.*?)\n```/s
   @id ~r/^[a-z][a-z0-9-]*$/
   @environment_variable ~r/^[A-Z][A-Z0-9_]*$/
+  @assertions ~w(two-turn-agent)
+  @temporary_directory_attempts 10
 
   @type t :: %__MODULE__{
           command: String.t(),
           expected: term(),
           id: String.t(),
           line: pos_integer(),
-          requires: String.t() | nil
+          requires: String.t() | nil,
+          assertion: String.t() | nil
         }
 
-  defmacro test_examples(path) do
+  defmacro test_registered_examples(registry_path) do
     root = File.cwd!()
-    examples = path |> Path.expand(root) |> parse_file!()
 
+    examples =
+      registry_path
+      |> parse_registry!(root)
+      |> Enum.flat_map(&parse_file!/1)
+
+    if examples == [] do
+      raise ArgumentError, "no ptc-guide-e2e examples registered in #{registry_path}"
+    end
+
+    ids = Enum.map(examples, & &1.id)
+
+    if length(ids) != MapSet.size(MapSet.new(ids)) do
+      raise ArgumentError, "ptc-guide-e2e ids must be unique in #{registry_path}"
+    end
+
+    build_tests(examples, root)
+  end
+
+  @doc false
+  @spec parse_registry!(Path.t(), Path.t()) :: [Path.t()]
+  def parse_registry!(registry_path, root) do
+    registry_path
+    |> Path.expand(root)
+    |> File.read!()
+    |> String.split("\n")
+    |> Enum.with_index(1)
+    |> Enum.reduce([], fn {raw_entry, line}, entries ->
+      entry = String.trim(raw_entry)
+
+      cond do
+        entry == "" or String.starts_with?(entry, "#") ->
+          entries
+
+        raw_entry != entry or not canonical_registry_entry?(entry) ->
+          raise ArgumentError,
+                "executable guide path at #{registry_path}:#{line} must be canonical " <>
+                  "and repository-relative: #{inspect(raw_entry)}"
+
+        true ->
+          [Path.expand(entry, root) | entries]
+      end
+    end)
+    |> Enum.reverse()
+  end
+
+  defp build_tests(examples, root) do
     tests =
       Enum.map(examples, fn example ->
         tag =
@@ -50,6 +98,11 @@ defmodule PtcRunner.TestSupport.GuideExamples do
 
             assert GuideExamples.last_json!(result.stdout) ==
                      unquote(Macro.escape(example.expected))
+
+            assert GuideExamples.verify_assertion(
+                     unquote(Macro.escape(example)),
+                     result.envelope
+                   ) == :ok
           end
         end
       end)
@@ -88,13 +141,11 @@ defmodule PtcRunner.TestSupport.GuideExamples do
   @spec run(t(), Path.t()) :: %{
           status: non_neg_integer(),
           stderr: String.t(),
-          stdout: String.t()
+          stdout: String.t(),
+          envelope: map() | nil
         }
   def run(example, root) do
-    temporary =
-      Path.join(System.tmp_dir!(), "ptc-guide-#{System.unique_integer([:positive, :monotonic])}")
-
-    File.mkdir_p!(temporary)
+    temporary = temporary_directory!()
     File.chmod!(temporary, 0o700)
 
     try do
@@ -120,7 +171,8 @@ defmodule PtcRunner.TestSupport.GuideExamples do
       %{
         status: status,
         stdout: File.read!(stdout_path),
-        stderr: File.read!(stderr_path)
+        stderr: File.read!(stderr_path),
+        envelope: read_envelope(example, temporary)
       }
     after
       File.rm_rf!(temporary)
@@ -135,6 +187,28 @@ defmodule PtcRunner.TestSupport.GuideExamples do
     |> Jason.decode!()
   end
 
+  @spec verify_assertion(t(), map() | nil) :: :ok | {:error, String.t()}
+  def verify_assertion(%{assertion: nil}, nil), do: :ok
+
+  def verify_assertion(%{assertion: "two-turn-agent"}, envelope) do
+    case envelope do
+      %{
+        "status" => "ok",
+        "execution" => %{
+          "usage" => %{
+            "subordinate_evaluations" => 2,
+            "capability_calls" => %{"workflow/llm-request" => 2}
+          },
+          "evaluation_memory" => %{"defined_count" => 1, "history_count" => 1}
+        }
+      } ->
+        :ok
+
+      _unexpected ->
+        {:error, "expected a two-turn agent command envelope, got: #{inspect(envelope)}"}
+    end
+  end
+
   defp build_example!(content, match, path) do
     [{start, _length}, options, command, expected] = match
     options = capture(content, options) |> parse_options!(path)
@@ -142,6 +216,7 @@ defmodule PtcRunner.TestSupport.GuideExamples do
     %__MODULE__{
       id: Map.fetch!(options, "id"),
       requires: Map.get(options, "requires"),
+      assertion: Map.get(options, "assert"),
       command: capture(content, command),
       expected: content |> capture(expected) |> Jason.decode!(),
       line: content |> binary_part(0, start) |> line_number()
@@ -161,10 +236,11 @@ defmodule PtcRunner.TestSupport.GuideExamples do
         end
       end)
 
-    if map_size(parsed) != length(option_list) or Map.keys(parsed) -- ~w(id requires) != [] or
+    if map_size(parsed) != length(option_list) or Map.keys(parsed) -- ~w(assert id requires) != [] or
          not Map.has_key?(parsed, "id") or
          not Regex.match?(@id, parsed["id"]) or
-         not valid_requirement?(parsed["requires"]) do
+         not valid_requirement?(parsed["requires"]) or
+         not valid_assertion?(parsed["assert"]) do
       raise ArgumentError, "invalid ptc-guide-e2e options in #{path}: #{options}"
     end
 
@@ -174,6 +250,18 @@ defmodule PtcRunner.TestSupport.GuideExamples do
   defp valid_requirement?(nil), do: true
   defp valid_requirement?(name), do: Regex.match?(@environment_variable, name)
 
+  defp valid_assertion?(nil), do: true
+  defp valid_assertion?(name), do: name in @assertions
+
+  defp canonical_registry_entry?(entry) do
+    parts = Path.split(entry)
+
+    Path.type(entry) == :relative and
+      entry == Path.join(parts) and
+      not String.contains?(entry, "\\") and
+      Enum.all?(parts, &(&1 not in ["", ".", ".."]))
+  end
+
   defp line_number(prefix) do
     prefix
     |> :binary.matches("\n")
@@ -181,9 +269,13 @@ defmodule PtcRunner.TestSupport.GuideExamples do
     |> Kernel.+(1)
   end
 
-  defp command_environment(%{requires: nil}, _temporary), do: []
+  defp command_environment(example, temporary) do
+    credential_environment(example, temporary) ++ assertion_environment(example, temporary)
+  end
 
-  defp command_environment(%{requires: variable}, temporary) do
+  defp credential_environment(%{requires: nil}, _temporary), do: []
+
+  defp credential_environment(%{requires: variable}, temporary) do
     value = System.fetch_env!(variable)
 
     if String.contains?(value, ["\n", "\r"]) do
@@ -194,5 +286,45 @@ defmodule PtcRunner.TestSupport.GuideExamples do
     File.write!(env_file, "#{variable}=#{value}\n")
     File.chmod!(env_file, 0o600)
     [{"PTC_ENV_FILE", env_file}, {variable, nil}]
+  end
+
+  defp assertion_environment(%{assertion: nil}, _temporary), do: []
+
+  defp assertion_environment(%{assertion: _assertion}, temporary) do
+    [{"PTC_ENVELOPE_FILE", Path.join(temporary, "command-envelope.json")}]
+  end
+
+  defp read_envelope(%{assertion: nil}, _temporary), do: nil
+
+  defp read_envelope(%{assertion: _assertion}, temporary) do
+    path = Path.join(temporary, "command-envelope.json")
+
+    case File.read(path) do
+      {:ok, contents} -> Jason.decode!(contents)
+      {:error, :enoent} -> nil
+      {:error, reason} -> raise File.Error, reason: reason, action: "read file", path: path
+    end
+  end
+
+  defp temporary_directory! do
+    create_temporary_directory!(@temporary_directory_attempts)
+  end
+
+  defp create_temporary_directory!(0) do
+    raise File.Error,
+      reason: :eexist,
+      action: "create exclusive guide-example temporary directory",
+      path: System.tmp_dir!()
+  end
+
+  defp create_temporary_directory!(attempts_left) do
+    suffix = 16 |> :crypto.strong_rand_bytes() |> Base.url_encode64(padding: false)
+    path = Path.join(System.tmp_dir!(), "ptc-guide-#{suffix}")
+
+    case File.mkdir(path) do
+      :ok -> path
+      {:error, :eexist} -> create_temporary_directory!(attempts_left - 1)
+      {:error, reason} -> raise File.Error, reason: reason, action: "create directory", path: path
+    end
   end
 end

--- a/test/support/guide_examples_test.exs
+++ b/test/support/guide_examples_test.exs
@@ -1,0 +1,69 @@
+defmodule PtcRunner.TestSupport.GuideExamplesTest do
+  use ExUnit.Case, async: true
+
+  alias PtcRunner.TestSupport.GuideExamples
+
+  test "returns command diagnostics when an asserted envelope is missing" do
+    example = example("printf 'guide failed\\n' >&2; exit 23")
+
+    result = GuideExamples.run(example, File.cwd!())
+
+    assert result.status == 23
+    assert result.stderr == "guide failed\n"
+    assert result.stdout == ""
+    assert result.envelope == nil
+  end
+
+  test "isolates concurrent guide runs in distinct temporary directories" do
+    example =
+      example("""
+      printf '{"status":"ok","execution":{"usage":{"subordinate_evaluations":2,"capability_calls":{"workflow/llm-request":2}},"evaluation_memory":{"defined_count":1,"history_count":1}},"scratch":"%s"}\\n' "$PTC_ENVELOPE_FILE" > "$PTC_ENVELOPE_FILE"
+      printf '{"ok":true}\\n'
+      """)
+
+    paths =
+      1..32
+      |> Task.async_stream(
+        fn _index -> GuideExamples.run(example, File.cwd!()) end,
+        max_concurrency: 32,
+        ordered: false,
+        timeout: 30_000
+      )
+      |> Enum.map(fn {:ok, result} ->
+        assert result.status == 0
+        assert result.stderr == ""
+        assert GuideExamples.last_json!(result.stdout) == %{"ok" => true}
+        assert GuideExamples.verify_assertion(example, result.envelope) == :ok
+
+        result.envelope
+        |> Map.fetch!("scratch")
+        |> Path.dirname()
+      end)
+
+    assert length(Enum.uniq(paths)) == length(paths)
+  end
+
+  @tag :tmp_dir
+  test "rejects non-canonical executable-guide registry entries", %{tmp_dir: dir} do
+    registry = Path.join(dir, "executable-guides.txt")
+
+    for entry <- ["  docs/guides/quickstart.md  ", "./docs/guides/quickstart.md"] do
+      File.write!(registry, entry <> "\n")
+
+      assert_raise ArgumentError, ~r/must be canonical and repository-relative/, fn ->
+        GuideExamples.parse_registry!(registry, File.cwd!())
+      end
+    end
+  end
+
+  defp example(command) do
+    %GuideExamples{
+      assertion: "two-turn-agent",
+      command: command,
+      expected: %{"ok" => true},
+      id: "test-example",
+      line: 1,
+      requires: nil
+    }
+  end
+end


### PR DESCRIPTION
Follow-up to #1368, which merged while the reviewed branch update was being pushed.

## Summary
- drive executable guide coverage and change routing from one canonical registry
- harden quickstart execution, envelope diagnostics, and scratch-directory isolation
- preserve streamed ReqLLM usage cost and update the named OpenRouter examples
- validate registry paths consistently across Elixir, Python, and shell classifiers

## Validation
- independent Codex review: no remaining actionable findings
- repository pre-push gate: 6,194 core tests, static analysis, Dialyzer, release verification, 44 Viewer tests, and 40 launcher tests
- targeted guide and hook tests: 19 passed, 1 excluded
- ShellCheck and shell syntax checks

Closes #1357