### PR TITLE
fix(analysis): retain interrupted private attempts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -195,6 +195,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Failed private debugger runs now retain validated input-only model and
+  capability attempts as explicitly incomplete evidence. Raw reads expose the
+  complete prefix without inventing terminal data, while reconstructed turns
+  continue to report the interrupted model exchange as missing.
 - A fresh-clone `mix ptc` invocation now performs normal dependency validation
   and compiles fetched dependencies before compiling PtcRunner. Warm root
   commands retain the dependency-check startup optimization after the first

--- a/docs/trace-log-contract.md
+++ b/docs/trace-log-contract.md
@@ -394,6 +394,9 @@ Returns metadata for one source-visible run or a uniform not-found/denied error.
 It does not return all evidence implicitly. Its `collections` catalog names
 each collection, its authority, availability, exact filters, and stable order,
 so a caller can discover the next read without knowing the storage schema.
+The `model_exchanges` and `capability_calls` entries additionally advertise
+`item_completeness_field: "complete?"`; collections without per-item
+completion semantics omit that catalog field.
 
 ### `analysis/read`
 
@@ -408,12 +411,21 @@ also advertise `turns`, `model_exchanges`, `capability_calls`,
 `execution_prints`, and `execution_errors`. Public recipes report those private
 collections as unavailable and reject reads without changing authority.
 
+Every raw `model_exchanges` and `capability_calls` item carries `complete?`.
+Completed items retain their result, output sequence, and output timestamp.
+An interrupted input-only attempt has `complete?: false` and omits those three
+terminal fields. The run metadata counts all admitted attempts and separately
+reports `incomplete_model_exchanges` and `incomplete_capability_calls`, including
+zero on complete runs.
+
 `turns` is the only compiled convenience collection. Each item is one model
 turn with the newly added messages, response, matching generated programs, and
 stable stream/turn identity. It omits the repeated system prompt; exact raw
 model requests remain available through `model_exchanges`. Page-level
 `evidence` reports canonical completeness, missing exchanges, and ambiguity
-separately from pagination.
+separately from pagination. Interrupted model inputs remain raw evidence but
+are excluded from `turns`, so the canonical missing-exchange count records the
+gap instead of a fabricated assistant response.
 
 Generated programs carry `prelude_calls_available?` and a sorted
 `prelude_calls` list of `{ref, component_id}` entries. Exact
@@ -624,11 +636,16 @@ pinning. There may be at most one input and one output for a capability ID, one
 source and one subsequent analysis for an evaluation ID, and one source for an
 environment/component pair.
 A capability output requires an earlier matching input; an input without an
-output is valid only as an interrupted attempt. Private capability name and
-environment must match the canonical `capability-started` event carrying the
-same ID, and canonical capability-start IDs must themselves be unique. Browser
-indexing also refuses to overwrite a prior identity defensively, but server
-validation is authoritative. There may likewise be at most one
+output is valid only as an interrupted attempt. Private queries retain that
+input as `complete?: false` and do not synthesize terminal fields. MCP provider
+exchange projections still require a validated request/response pair; the
+inspection sink retains each pair atomically so interruption cannot leave a
+request without its response. Private
+capability name and environment must match the canonical `capability-started`
+event carrying the same ID, and canonical capability-start IDs must themselves
+be unique. Browser indexing also refuses to overwrite a prior identity
+defensively, but server validation is authoritative. There may likewise be at
+most one
 `execution-prints` and one `execution-error` for a given `evaluation_id`; a run
 with no `println` output and no execution-phase failure emits neither.
 

--- a/lib/ptc_runner/kernel/inspection_query.ex
+++ b/lib/ptc_runner/kernel/inspection_query.ex
@@ -3,10 +3,12 @@ defmodule PtcRunner.Kernel.InspectionQuery do
   Pure, source-bound queries over validated private inspection records.
 
   The compiler performs the joins once, before a snapshot publishes any
-  capability. Capability inputs and outputs are paired by `capability_id`;
-  MCP request and response bodies are paired by `{capability_id, request_id}`.
-  Callers therefore never join private records by timestamp or depend on file
-  order beyond the artifact's validated sequence.
+  capability. Capability inputs and outputs are paired by `capability_id`, and
+  a validated input without an output is retained as an explicitly incomplete
+  interrupted attempt. MCP request and response bodies remain paired by
+  `{capability_id, request_id}`. Callers therefore never join private records
+  by timestamp or depend on file order beyond the artifact's validated
+  sequence.
 
   Every collection uses the same bounded page shape as canonical trace
   queries. Cursors are opaque, bind the immutable source identity, operation,
@@ -141,7 +143,9 @@ defmodule PtcRunner.Kernel.InspectionQuery do
 
       counts = %{
         "model_exchanges" => length(model_exchanges),
+        "incomplete_model_exchanges" => incomplete_count(model_exchanges),
         "capability_calls" => length(capability_calls),
+        "incomplete_capability_calls" => incomplete_count(capability_calls),
         "generated_sources" => length(generated_sources),
         "evaluation_analyses" => map_size(evaluation_analyses),
         "effective_preludes" => length(effective_preludes),
@@ -186,18 +190,14 @@ defmodule PtcRunner.Kernel.InspectionQuery do
       |> records_of_type("capability-output")
       |> Map.new(&{&1["correlation"]["capability_id"], &1})
 
-    if Map.keys(inputs) |> MapSet.new() == Map.keys(outputs) |> MapSet.new() do
-      pairs =
-        inputs
-        |> Enum.map(fn {capability_id, input} ->
-          capability_pair(capability_id, input, Map.fetch!(outputs, capability_id))
-        end)
-        |> Enum.sort_by(& &1["input_sequence"])
+    pairs =
+      inputs
+      |> Enum.map(fn {capability_id, input} ->
+        capability_pair(capability_id, input, Map.get(outputs, capability_id))
+      end)
+      |> Enum.sort_by(& &1["input_sequence"])
 
-      {:ok, pairs}
-    else
-      {:error, :incomplete_inspection_correlation}
-    end
+    {:ok, pairs}
   end
 
   defp provider_pairs(records) do
@@ -236,9 +236,23 @@ defmodule PtcRunner.Kernel.InspectionQuery do
     end
   end
 
+  defp capability_pair(capability_id, input, nil) do
+    capability_input(capability_id, input)
+    |> Map.put("complete?", false)
+  end
+
   defp capability_pair(capability_id, input, output) do
+    capability_input(capability_id, input)
+    |> Map.merge(%{
+      "complete?" => true,
+      "output_sequence" => output["sequence"],
+      "output_timestamp" => output["timestamp"],
+      "result" => output["payload"]["result"]
+    })
+  end
+
+  defp capability_input(capability_id, input) do
     input_payload = input["payload"]
-    output_payload = output["payload"]
 
     %{
       "run_id" => input["run_id"],
@@ -248,13 +262,12 @@ defmodule PtcRunner.Kernel.InspectionQuery do
       "mission_name" => input_payload["mission_name"],
       "name" => input_payload["name"],
       "input_sequence" => input["sequence"],
-      "output_sequence" => output["sequence"],
       "input_timestamp" => input["timestamp"],
-      "output_timestamp" => output["timestamp"],
-      "arguments" => input_payload["arguments"],
-      "result" => output_payload["result"]
+      "arguments" => input_payload["arguments"]
     }
   end
+
+  defp incomplete_count(items), do: Enum.count(items, &(&1["complete?"] == false))
 
   defp provider_pair(capability_id, request_id, request, response) do
     request_payload = request["payload"]
@@ -369,7 +382,10 @@ defmodule PtcRunner.Kernel.InspectionQuery do
 
         projection =
           ConversationProjection.compile(
-            Enum.filter(collections.model_exchanges, &(&1["run_id"] == run_id)),
+            Enum.filter(
+              collections.model_exchanges,
+              &(&1["run_id"] == run_id and &1["complete?"])
+            ),
             Enum.filter(collections.generated_sources, &(&1["run_id"] == run_id)),
             Map.get(trace_facts, run_id, %{})
           )

--- a/lib/ptc_runner/kernel/inspection_sink.ex
+++ b/lib/ptc_runner/kernel/inspection_sink.ex
@@ -87,6 +87,22 @@ defmodule PtcRunner.Kernel.InspectionSink do
   def emit(%__MODULE__{} = sink, _record_type, _correlation, _payload),
     do: call(sink, :fail)
 
+  @doc false
+  @spec emit_mcp_exchange(t(), map(), map(), map()) ::
+          :ok | {:error, :inspection_sink_error}
+  def emit_mcp_exchange(
+        %__MODULE__{} = sink,
+        correlation,
+        request_payload,
+        response_payload
+      )
+      when is_map(correlation) and is_map(request_payload) and is_map(response_payload) do
+    call(sink, {:emit_mcp_exchange, correlation, request_payload, response_payload})
+  end
+
+  def emit_mcp_exchange(%__MODULE__{} = sink, _correlation, _request_payload, _response_payload),
+    do: call(sink, :fail)
+
   @spec records(t()) :: {:ok, [map()]} | {:error, :inspection_sink_error}
   @doc "Returns retained records in sequence order while the required sink is healthy."
   def records(%__MODULE__{} = sink), do: call(sink, :records)
@@ -196,6 +212,18 @@ defmodule PtcRunner.Kernel.InspectionSink do
     end
   end
 
+  def handle_call(
+        {token, {:emit_mcp_exchange, correlation, request_payload, response_payload}},
+        _from,
+        %{token: token} = state
+      ) do
+    if state.failed? do
+      {:reply, {:error, :inspection_sink_error}, state}
+    else
+      retain_mcp_exchange(state, correlation, request_payload, response_payload)
+    end
+  end
+
   def handle_call({token, :fail}, _from, %{token: token} = state),
     do: {:reply, {:error, :inspection_sink_error}, %{state | failed?: true}}
 
@@ -225,6 +253,22 @@ defmodule PtcRunner.Kernel.InspectionSink do
   def format_status(_reason, _status), do: [data: [{~c"State", :redacted}]]
 
   defp retain(state, record_type, correlation, payload) do
+    case retain_record(state, record_type, correlation, payload) do
+      {:ok, next} -> {:reply, :ok, next}
+      :error -> {:reply, {:error, :inspection_sink_error}, %{state | failed?: true}}
+    end
+  end
+
+  defp retain_mcp_exchange(state, correlation, request_payload, response_payload) do
+    with {:ok, next} <- retain_record(state, "mcp-request", correlation, request_payload),
+         {:ok, next} <- retain_record(next, "mcp-response", correlation, response_payload) do
+      {:reply, :ok, next}
+    else
+      :error -> {:reply, {:error, :inspection_sink_error}, %{state | failed?: true}}
+    end
+  end
+
+  defp retain_record(state, record_type, correlation, payload) do
     with true <- record_type in record_types(),
          true <- record_type != "run-result" or not state.result?,
          true <- within_record_depth?(correlation, payload),
@@ -240,7 +284,7 @@ defmodule PtcRunner.Kernel.InspectionSink do
          true <- state.encoded_bytes + bytes <= state.max_total_bytes do
       retained_record = RetainedSize.detach_binaries(record)
 
-      {:reply, :ok,
+      {:ok,
        %{
          state
          | sequence: state.sequence + 1,
@@ -249,7 +293,7 @@ defmodule PtcRunner.Kernel.InspectionSink do
            result?: state.result? or record_type == "run-result"
        }}
     else
-      _reason -> {:reply, {:error, :inspection_sink_error}, %{state | failed?: true}}
+      _reason -> :error
     end
   end
 

--- a/lib/ptc_runner/kernel/inspection_snapshot.ex
+++ b/lib/ptc_runner/kernel/inspection_snapshot.ex
@@ -5,9 +5,12 @@ defmodule PtcRunner.Kernel.InspectionSnapshot do
   A snapshot inventories one bounded directory, loads each regular
   `.inspection.jsonl` artifact exactly once through `InspectionArtifact`, and
   validates every artifact against an already captured `TraceSnapshot`.
-  Duplicate runs, orphaned identities, malformed artifacts, incomplete
-  input/output joins, replacement during capture, and aggregate or retained
-  limits fail the entire capture. No partial catalog is published.
+  Duplicate runs, orphaned identities, malformed artifacts, output-only
+  capability joins, incomplete MCP joins, replacement during capture, and
+  aggregate or retained limits fail the entire capture. Validated input-only
+  capability attempts remain available as explicitly incomplete records. MCP
+  request/response pairs are retained atomically so interruption cannot publish
+  only half of an exchange. No partial catalog is published.
 
   The owner process holds only compiled query collections and safe metadata.
   Paths and private records are redacted from process status. Its tokenized

--- a/lib/ptc_runner/kernel/mcp_source.ex
+++ b/lib/ptc_runner/kernel/mcp_source.ex
@@ -1362,10 +1362,12 @@ defmodule PtcRunner.Kernel.MCPSource do
       end)
     end
 
-    case InspectionSink.emit(sink, "mcp-request", correlation, payload.(request)) do
-      :ok -> InspectionSink.emit(sink, "mcp-response", correlation, payload.(response))
-      {:error, :inspection_sink_error} = error -> error
-    end
+    InspectionSink.emit_mcp_exchange(
+      sink,
+      correlation,
+      payload.(request),
+      payload.(response)
+    )
   end
 
   defp capture_exchange(

--- a/lib/ptc_runner/kernel/run_analysis.ex
+++ b/lib/ptc_runner/kernel/run_analysis.ex
@@ -11,7 +11,9 @@ defmodule PtcRunner.Kernel.RunAnalysis do
 
   Public captures expose only canonical `activity`. Private captures add exact
   exchanges, reconstructed turns, generated source with static prelude-call
-  facts, effective prelude source, and workflow execution diagnostics.
+  facts, effective prelude source, and workflow execution diagnostics. The
+  catalog identifies raw collections whose items carry an explicit
+  completeness field.
   """
 
   alias PtcRunner.Kernel.InspectionSnapshot
@@ -45,7 +47,8 @@ defmodule PtcRunner.Kernel.RunAnalysis do
       snapshot: :inspection,
       operation: :model_exchanges,
       filters: ~w(capability_id input_sequence),
-      order: "input_sequence_asc"
+      order: "input_sequence_asc",
+      item_completeness_field: "complete?"
     },
     %{
       name: "capability_calls",
@@ -53,7 +56,8 @@ defmodule PtcRunner.Kernel.RunAnalysis do
       snapshot: :inspection,
       operation: :capability_calls,
       filters: ~w(capability_id mission_name name),
-      order: "input_sequence_asc"
+      order: "input_sequence_asc",
+      item_completeness_field: "complete?"
     },
     %{
       name: "provider_exchanges",
@@ -253,7 +257,15 @@ defmodule PtcRunner.Kernel.RunAnalysis do
         "filters" => collection.filters,
         "order" => collection.order
       }
+      |> put_catalog_option(collection, :item_completeness_field)
     end)
+  end
+
+  defp put_catalog_option(catalog, collection, key) do
+    case Map.fetch(collection, key) do
+      {:ok, value} -> Map.put(catalog, Atom.to_string(key), value)
+      :error -> catalog
+    end
   end
 
   defp inspection_run(nil, _run_id), do: {:ok, %{"available?" => false}}

--- a/test/mix/tasks/ptc_repl_test.exs
+++ b/test/mix/tasks/ptc_repl_test.exs
@@ -452,6 +452,90 @@ defmodule PtcRunner.ReplFrontendTest do
   end
 
   @tag :tmp_dir
+  test "private analysis reads the complete prefix of an interrupted run", %{
+    tmp_dir: directory
+  } do
+    fixture = PrivateInspectionFixture.create_interrupted!(directory, "interrupted-debugger")
+    normal_path = Path.join(fixture.traces, "#{fixture.run_id}.jsonl")
+    private_path = Path.join(fixture.traces, "#{fixture.run_id}.private.jsonl")
+    File.rename!(normal_path, private_path)
+
+    output =
+      capture_io(fn ->
+        run_repl([
+          "--profile",
+          "private-run-analysis-v1",
+          "--resource",
+          "traces=#{fixture.traces}",
+          "--resource",
+          "inspection=#{fixture.inspection}",
+          "--session-trace-dir",
+          fixture.output,
+          "--private-unattended",
+          "--format",
+          "jsonl",
+          "-e",
+          ~s|(analysis/open "#{fixture.run_id}")|,
+          "-e",
+          ~s|(analysis/read "#{fixture.run_id}" {"collection" "model_exchanges"})|,
+          "-e",
+          ~s|(analysis/read "#{fixture.run_id}" {"collection" "capability_calls"})|,
+          "-e",
+          ~s|(analysis/read "#{fixture.run_id}" {"collection" "turns"})|
+        ])
+      end)
+
+    records = decode_jsonl(output)
+
+    assert Enum.map(records, & &1["type"]) == [
+             "session-started",
+             "evaluation",
+             "evaluation",
+             "evaluation",
+             "evaluation",
+             "session-closed"
+           ]
+
+    [opened, model_page, capability_page, turns_page] =
+      records
+      |> Enum.filter(&(&1["type"] == "evaluation"))
+      |> Enum.map(&get_in(&1, ["result", "value"]))
+
+    assert opened["inspection"]["counts"] == %{
+             "capability_calls" => 2,
+             "effective_preludes" => 0,
+             "evaluation_analyses" => 0,
+             "execution_errors" => 0,
+             "execution_prints" => 0,
+             "generated_sources" => 0,
+             "incomplete_capability_calls" => 1,
+             "incomplete_model_exchanges" => 1,
+             "model_exchanges" => 2,
+             "provider_exchanges" => 0
+           }
+
+    assert Enum.map(model_page["items"], & &1["complete?"]) == [true, false]
+    assert Enum.map(capability_page["items"], & &1["complete?"]) == [true, false]
+
+    assert get_in(List.last(model_page["items"]), ["arguments", "messages"]) |> List.last() ==
+             %{"content" => fixture.interrupted_model_secret, "role" => "user"}
+
+    assert get_in(List.last(capability_page["items"]), ["arguments", "path"]) ==
+             fixture.interrupted_tool_secret
+
+    assert turns_page["evidence"]["missing_exchange_count"] == 1
+
+    assert Enum.map(turns_page["items"], & &1["capability_id"]) == [
+             "llm-complete-#{fixture.run_id}"
+           ]
+
+    closed = List.last(records)
+    encoded_trace = File.read!(closed["trace_path"])
+    refute encoded_trace =~ fixture.interrupted_model_secret
+    refute encoded_trace =~ fixture.interrupted_tool_secret
+  end
+
+  @tag :tmp_dir
   test "inspection profile setup explains an unsupported artifact schema", %{
     tmp_dir: directory
   } do

--- a/test/ptc_runner/kernel/inspection_sink_test.exs
+++ b/test/ptc_runner/kernel/inspection_sink_test.exs
@@ -127,7 +127,7 @@ defmodule PtcRunner.Kernel.InspectionSinkTest do
     assert :ok = InspectionSink.stop(sink)
   end
 
-  test "retains paired MCP exchange records" do
+  test "retains an MCP request and response through one atomic sink operation" do
     request = %{
       "jsonrpc" => "2.0",
       "id" => 7,
@@ -146,18 +146,10 @@ defmodule PtcRunner.Kernel.InspectionSinkTest do
     {:ok, sink} = InspectionSink.start(run_id: "run-1", trace_id: "trace-1")
 
     assert :ok =
-             InspectionSink.emit(
+             InspectionSink.emit_mcp_exchange(
                sink,
-               "mcp-request",
                correlation,
-               %{transport: :stdio, body: request}
-             )
-
-    assert :ok =
-             InspectionSink.emit(
-               sink,
-               "mcp-response",
-               correlation,
+               %{transport: :stdio, body: request},
                %{transport: :stdio, body: response}
              )
 

--- a/test/ptc_runner/kernel/inspection_snapshot_test.exs
+++ b/test/ptc_runner/kernel/inspection_snapshot_test.exs
@@ -207,6 +207,7 @@ defmodule PtcRunner.Kernel.InspectionSnapshotTest do
               "items" => [
                 %{
                   "capability_id" => "llm-mcp-run",
+                  "complete?" => true,
                   "input_sequence" => llm_input,
                   "output_sequence" => llm_output,
                   "arguments" => %{"messages" => [%{"content" => "private-mcp-run"}]},
@@ -224,6 +225,7 @@ defmodule PtcRunner.Kernel.InspectionSnapshotTest do
               "items" => [
                 %{
                   "capability_id" => "tool-mcp-run",
+                  "complete?" => true,
                   "arguments" => %{"path" => "private-mcp-run.txt"},
                   "result" => %{"status" => "ok", "value" => %{"text" => "secret-mcp-run"}}
                 }
@@ -365,6 +367,92 @@ defmodule PtcRunner.Kernel.InspectionSnapshotTest do
                "run_id" => "mcp-run",
                "limit" => 1
              })
+  end
+
+  @tag :tmp_dir
+  test "interrupted capability attempts preserve the complete private prefix", %{tmp_dir: root} do
+    fixture = PrivateInspectionFixture.create_interrupted!(root)
+    {:ok, trace_snapshot} = TraceSnapshot.start({:directory, fixture.traces}, owner: self())
+
+    {:ok, snapshot} =
+      InspectionSnapshot.start({:directory, fixture.inspection}, trace_snapshot, owner: self())
+
+    on_exit(fn ->
+      InspectionSnapshot.stop(snapshot)
+      TraceSnapshot.stop(trace_snapshot)
+    end)
+
+    assert {:ok,
+            %{
+              "counts" => %{
+                "model_exchanges" => 2,
+                "incomplete_model_exchanges" => 1,
+                "capability_calls" => 2,
+                "incomplete_capability_calls" => 1
+              }
+            }} = InspectionSnapshot.query(snapshot, :get_run, %{"run_id" => fixture.run_id})
+
+    assert {:ok,
+            %{
+              "items" => [
+                %{
+                  "capability_id" => "llm-complete-" <> _,
+                  "complete?" => true,
+                  "result" => %{"status" => "ok"},
+                  "output_sequence" => output_sequence,
+                  "output_timestamp" => output_timestamp
+                },
+                %{
+                  "capability_id" => "llm-interrupted-" <> _,
+                  "complete?" => false,
+                  "arguments" => %{"messages" => interrupted_messages}
+                } = interrupted_model
+              ]
+            }} =
+             InspectionSnapshot.query(snapshot, :model_exchanges, %{
+               "run_id" => fixture.run_id
+             })
+
+    assert is_integer(output_sequence)
+    assert is_binary(output_timestamp)
+    assert List.last(interrupted_messages)["content"] == fixture.interrupted_model_secret
+    refute Map.has_key?(interrupted_model, "result")
+    refute Map.has_key?(interrupted_model, "output_sequence")
+    refute Map.has_key?(interrupted_model, "output_timestamp")
+
+    assert {:ok,
+            %{
+              "items" => [
+                %{
+                  "capability_id" => "tool-complete-" <> _,
+                  "complete?" => true,
+                  "result" => %{"status" => "ok"}
+                },
+                %{
+                  "capability_id" => "tool-interrupted-" <> _,
+                  "complete?" => false,
+                  "arguments" => %{"path" => interrupted_tool_secret}
+                } = interrupted_tool
+              ]
+            }} =
+             InspectionSnapshot.query(snapshot, :capability_calls, %{
+               "run_id" => fixture.run_id
+             })
+
+    assert interrupted_tool_secret == fixture.interrupted_tool_secret
+    refute Map.has_key?(interrupted_tool, "result")
+    refute Map.has_key?(interrupted_tool, "output_sequence")
+    refute Map.has_key?(interrupted_tool, "output_timestamp")
+
+    assert {:ok,
+            %{
+              "evidence" => %{
+                "canonical_complete?" => true,
+                "complete?" => false,
+                "missing_exchange_count" => 1
+              },
+              "items" => [%{"capability_id" => "llm-complete-" <> _}]
+            }} = InspectionSnapshot.query(snapshot, :turns, %{"run_id" => fixture.run_id})
   end
 
   @tag :tmp_dir
@@ -678,9 +766,9 @@ defmodule PtcRunner.Kernel.InspectionSnapshotTest do
   end
 
   @tag :tmp_dir
-  test "orphan, duplicate, incomplete, malformed, symlink, and replacement captures fail closed",
+  test "orphan, duplicate, malformed, symlink, and replacement captures fail closed",
        %{tmp_dir: root} do
-    for scenario <- [:orphan, :duplicate, :incomplete, :malformed, :symlink, :replacement] do
+    for scenario <- [:orphan, :duplicate, :malformed, :symlink, :replacement] do
       scenario_root = Path.join(root, Atom.to_string(scenario))
       {trace, inspection} = source_directories(scenario_root)
       write_run(trace, inspection, "valid", :basic)
@@ -698,11 +786,6 @@ defmodule PtcRunner.Kernel.InspectionSnapshotTest do
               Path.join(inspection, "duplicate.inspection.jsonl")
             )
 
-            InspectionSnapshot.start({:directory, inspection}, trace_snapshot)
-
-          :incomplete ->
-            File.rm!(Path.join(inspection, "valid.inspection.jsonl"))
-            write_incomplete_inspection(inspection, "valid")
             InspectionSnapshot.start({:directory, inspection}, trace_snapshot)
 
           :malformed ->
@@ -1016,28 +1099,6 @@ defmodule PtcRunner.Kernel.InspectionSnapshotTest do
     {:ok, records} = InspectionSink.records(sink)
     path = Path.join(directory, "#{run_id}.inspection.jsonl")
     :ok = InspectionArtifact.persist(path, records, events)
-    :ok = InspectionSink.stop(sink)
-  end
-
-  defp write_incomplete_inspection(directory, run_id) do
-    {:ok, sink} = InspectionSink.start(run_id: run_id, trace_id: "trace-#{run_id}")
-
-    emit!(sink, "capability-input", %{capability_id: "tool-#{run_id}"}, %{
-      environment: :mission,
-      mission_name: "default",
-      name: "workspace.read",
-      arguments: %{"path" => "private"}
-    })
-
-    {:ok, records} = InspectionSink.records(sink)
-
-    :ok =
-      InspectionArtifact.persist(
-        Path.join(directory, "#{run_id}.inspection.jsonl"),
-        records,
-        canonical_events(run_id)
-      )
-
     :ok = InspectionSink.stop(sink)
   end
 

--- a/test/ptc_runner/kernel/run_analysis_test.exs
+++ b/test/ptc_runner/kernel/run_analysis_test.exs
@@ -50,8 +50,23 @@ defmodule PtcRunner.Kernel.RunAnalysisTest do
 
     assert counts["capability_calls"] == 1
     assert counts["provider_exchanges"] == 1
+    assert counts["incomplete_model_exchanges"] == 0
+    assert counts["incomplete_capability_calls"] == 0
     assert Enum.find(collections, &(&1["name"] == "activity"))["available?"]
     assert Enum.find(collections, &(&1["name"] == "turns"))["available?"]
+
+    assert Enum.find(collections, &(&1["name"] == "model_exchanges"))[
+             "item_completeness_field"
+           ] == "complete?"
+
+    assert Enum.find(collections, &(&1["name"] == "capability_calls"))[
+             "item_completeness_field"
+           ] == "complete?"
+
+    refute Map.has_key?(
+             Enum.find(collections, &(&1["name"] == "turns")),
+             "item_completeness_field"
+           )
 
     capability_id = "tool-#{run_id}"
 

--- a/test/support/private_inspection_fixture.ex
+++ b/test/support/private_inspection_fixture.ex
@@ -18,6 +18,19 @@ defmodule PtcRunner.TestSupport.PrivateInspectionFixture do
     fixture
   end
 
+  def create_interrupted!(root, run_id \\ "interrupted-private-run") do
+    %{traces: traces, inspection: inspection} = fixture = create_directories(root, run_id)
+    events = interrupted_events(run_id)
+
+    File.write!(Path.join(traces, "#{run_id}.jsonl"), encode_jsonl(events))
+    write_interrupted_inspection!(inspection, run_id, events)
+
+    Map.merge(fixture, %{
+      interrupted_model_secret: "INTERRUPTED_MODEL_SECRET_#{run_id}",
+      interrupted_tool_secret: "INTERRUPTED_TOOL_SECRET_#{run_id}"
+    })
+  end
+
   def create_result!(root, value, run_id \\ "private-result-run") do
     %{traces: traces, inspection: inspection} = fixture = create_directories(root, run_id)
     {:ok, result_hash} = ResultIdentity.strict_json_hash(value)
@@ -201,6 +214,115 @@ defmodule PtcRunner.TestSupport.PrivateInspectionFixture do
     :ok = InspectionSink.stop(sink)
   end
 
+  defp write_interrupted_inspection!(directory, run_id, events) do
+    {:ok, sink} = InspectionSink.start(run_id: run_id, trace_id: "trace-#{run_id}")
+
+    emit!(sink, "capability-input", %{capability_id: "llm-complete-#{run_id}"}, %{
+      environment: :workflow,
+      name: "llm-request",
+      arguments: %{
+        "messages" => [%{"content" => "private-prompt-#{run_id}", "role" => "user"}],
+        "system" => "private-system-#{run_id}"
+      }
+    })
+
+    emit!(sink, "capability-output", %{capability_id: "llm-complete-#{run_id}"}, %{
+      environment: :workflow,
+      name: "llm-request",
+      result: %{
+        status: :ok,
+        value: %{"content" => "private-answer-#{run_id}"}
+      }
+    })
+
+    emit!(sink, "capability-input", %{capability_id: "tool-complete-#{run_id}"}, %{
+      environment: :mission,
+      mission_name: "default",
+      name: "workspace.read",
+      arguments: %{"path" => "private-#{run_id}.txt"}
+    })
+
+    emit!(sink, "capability-output", %{capability_id: "tool-complete-#{run_id}"}, %{
+      environment: :mission,
+      mission_name: "default",
+      name: "workspace.read",
+      result: %{status: :ok, value: %{"text" => "private-tool-result-#{run_id}"}}
+    })
+
+    emit!(sink, "capability-input", %{capability_id: "llm-interrupted-#{run_id}"}, %{
+      environment: :workflow,
+      name: "llm-request",
+      arguments: %{
+        "messages" => [
+          %{"content" => "private-prompt-#{run_id}", "role" => "user"},
+          %{"content" => "private-answer-#{run_id}", "role" => "assistant"},
+          %{"content" => "INTERRUPTED_MODEL_SECRET_#{run_id}", "role" => "user"}
+        ],
+        "system" => "private-system-#{run_id}"
+      }
+    })
+
+    emit!(sink, "capability-input", %{capability_id: "tool-interrupted-#{run_id}"}, %{
+      environment: :mission,
+      mission_name: "default",
+      name: "workspace.read",
+      arguments: %{"path" => "INTERRUPTED_TOOL_SECRET_#{run_id}"}
+    })
+
+    {:ok, records} = InspectionSink.records(sink)
+
+    :ok =
+      InspectionArtifact.persist(
+        Path.join(directory, "#{run_id}.inspection.jsonl"),
+        records,
+        events
+      )
+
+    :ok = InspectionSink.stop(sink)
+  end
+
+  defp interrupted_events(run_id) do
+    [
+      event(run_id, 1, "run-started", %{"missions" => %{"default" => %{}}}),
+      event(run_id, 2, "capability-started", %{
+        "capability_id" => "llm-complete-#{run_id}",
+        "environment" => "workflow",
+        "name" => "llm-request"
+      }),
+      event(run_id, 3, "capability-stopped", %{
+        "capability_id" => "llm-complete-#{run_id}",
+        "environment" => "workflow",
+        "name" => "llm-request",
+        "status" => "ok"
+      }),
+      event(run_id, 4, "capability-started", %{
+        "capability_id" => "tool-complete-#{run_id}",
+        "environment" => "mission",
+        "mission_name" => "default",
+        "name" => "workspace.read"
+      }),
+      event(run_id, 5, "capability-stopped", %{
+        "capability_id" => "tool-complete-#{run_id}",
+        "environment" => "mission",
+        "mission_name" => "default",
+        "name" => "workspace.read",
+        "status" => "ok"
+      }),
+      event(run_id, 6, "capability-started", %{
+        "capability_id" => "llm-interrupted-#{run_id}",
+        "environment" => "workflow",
+        "name" => "llm-request"
+      }),
+      event(run_id, 7, "capability-started", %{
+        "capability_id" => "tool-interrupted-#{run_id}",
+        "environment" => "mission",
+        "mission_name" => "default",
+        "name" => "workspace.read"
+      }),
+      event(run_id, 8, "run-stopped", %{"outcome" => "failed"})
+    ]
+  end
+
   def emit_execution_diagnostics!(sink, run_id) do
     emit!(sink, "execution-prints", %{evaluation_id: "workflow-eval-#{run_id}"}, %{
       environment: :workflow,
@@ -247,7 +369,8 @@ defmodule PtcRunner.TestSupport.PrivateInspectionFixture do
       "run_id" => run_id,
       "trace_id" => "trace-#{run_id}",
       "sequence" => sequence,
-      "timestamp" => "2026-07-26T12:00:0#{sequence}Z",
+      "timestamp" =>
+        "2026-07-26T12:00:#{sequence |> Integer.to_string() |> String.pad_leading(2, "0")}Z",
       "type" => type,
       "data" => data
     }


### PR DESCRIPTION
## Summary

- retain validated input-only model and capability attempts as explicit incomplete private evidence
- omit terminal fields and exclude incomplete model exchanges from reconstructed turns
- retain MCP request/response records atomically
- advertise completeness through analysis catalog metadata and counts
- cover the real `private-run-analysis-v1 --private-unattended` path

## Validation

- `mix precommit`
- `MIX_ENV=dev mix docs --warnings-as-errors`
- pre-push parity checks, including 6,197 root tests, static analysis, Dialyzer, release verification, and Viewer tests
- independent implementation review: 3 passes (final pass clean)
- independent plan review: 2 passes (approved)

Closes #1369
Follow-up to #1367