### PR TITLE
fix(ci): fetch nested project deps in the gates that compile them

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,11 +59,14 @@ how it was verified.
   path dependency (`ptc_runner_launcher/` or `ptc_viewer/`), run a normal
   `mix compile` once. Runtime manifests, host configuration, external inputs,
   and component override descriptors and sources remain live.
-- `mix precommit` — comprehensive local quality gate (format, compile, compile
-  cycles, stable-CLI callers, credo, duplication, spec, generated-artifact
-  staleness, root/Viewer/launcher tests, core-package and standalone release
-  verification); run before every commit. Much broader than the fast,
-  staged-file Git pre-commit hook; takes a few minutes in a fresh worktree.
+- `mix precommit` — comprehensive local quality gate (nested-project dependency
+  preflight, format, compile, compile cycles, stable-CLI callers, credo,
+  duplication, spec, generated-artifact staleness, root/Viewer/launcher tests,
+  core-package and standalone release verification); run before every commit.
+  Much broader than the fast, staged-file Git pre-commit hook; takes a few
+  minutes in a fresh worktree. Every gate fetches the Mix project it compiles,
+  so an unfetched `ptc_viewer/` or `ptc_runner_launcher/` repairs itself
+  instead of failing the run.
 - `scripts/ci/core-tests.sh` — canonical core compile/test gate used by
   `mix precommit`, pre-push, and GitHub Actions. It always sets `CI=1`, so
   StreamData runs the same 300 cases locally and remotely, while retaining all

--- a/docs/development-setup.md
+++ b/docs/development-setup.md
@@ -17,14 +17,28 @@ mix deps.get
 mix compile
 ```
 
+The nested projects are listed because `mix test` inside `ptc_viewer/` or
+`ptc_runner_launcher/` needs them; no gate depends on your having run them.
+`mix precommit` opens with `scripts/ci/preflight.sh`, which fetches both, and
+each gate fetches the project it compiles — running
+`mix deps.get --check-locked`, the command GitHub runs once per job.
+
 ## Worktree seeding
 
 `scripts/worktree.sh new` seeds a fresh worktree with the main checkout's
 `deps/`, `_build/`, and `priv/plts/` (root, Viewer, and launcher) so the
 commands above become incremental instead of cold. It prints one line per
 artifact saying whether it was seeded or why not — copy skipped, source not
-built, or already present — and skips seeding entirely when `mise.toml` or any
-lockfile differs from the main checkout's copy.
+built, already present, or pinned by a file that differs from the main
+checkout's copy.
+
+That last key is per artifact, not per seed: every artifact is pinned by
+`mise.toml`, and each project's artifacts additionally by that project's own
+lockfile. A branch that bumps the root `mix.lock` therefore keeps seeding
+`ptc_viewer/` and `ptc_runner_launcher/` — projects it never touched — while a
+diverged `ptc_viewer/mix.lock` skips only the Viewer's two artifacts. The root
+lockfile covers the nested projects' Hex dependencies as well, because Mix
+converges a path dependency's requirements into the parent lock.
 
 For build staleness the seed is never an authority: Mix revalidates `deps/`
 and `_build/` against `mix.lock` and source digests, and dialyxir revalidates

--- a/mix.exs
+++ b/mix.exs
@@ -178,7 +178,13 @@ defmodule PtcRunner.MixProject do
   defp aliases do
     [
       ptc: &run_ptc/1,
+      # The nested-project fetch leads: the Viewer and launcher gates run after
+      # the root suite, so without it a worktree that never fetched them learns
+      # so several minutes in. Each gate still fetches its own project -- this
+      # only moves the discovery to the front. GitHub gets the same fetch from
+      # the setup action, per job.
       precommit: [
+        "cmd scripts/ci/preflight.sh",
         "cmd scripts/ci/core-quality.sh",
         "cmd scripts/ci/core-tests.sh",
         "cmd scripts/ci/viewer.sh",

--- a/ptc_viewer/.gitignore
+++ b/ptc_viewer/.gitignore
@@ -1,3 +1,8 @@
 /_build/
 /deps
 *.beam
+
+# ExUnit's `tmp_dir` tag writes here. Untracked output makes the Viewer gate
+# dirty its own worktree, which `scripts/worktree.sh gc` then reads as
+# unsaved work and refuses to reclaim.
+/tmp/

--- a/scripts/ci/_common.sh
+++ b/scripts/ci/_common.sh
@@ -10,3 +10,17 @@ cd "$ci_repo_root"
 
 export MIX_ENV=test
 export HEX_SPONSOR=false
+
+# A gate fetches what it is about to compile.
+#
+# `ptc_viewer` and `ptc_runner_launcher` are separate Mix projects: the root's
+# `deps/` says nothing about whether theirs were ever fetched. GitHub supplies
+# each from the setup action's `project-directory`
+# (.github/actions/setup-elixir), so a gate that assumes them is green in CI
+# and fails only locally -- in a fresh worktree, after the multi-minute suites
+# that run ahead of it. `--check-locked` is the flag CI uses: an unfetched
+# project is repaired, a lockfile that diverged from its `mix.exs` fails here
+# exactly as it would there. About a second per project once warm.
+ci_fetch_deps() {
+  (cd "$ci_repo_root/$1" && mix deps.get --check-locked)
+}

--- a/scripts/ci/launcher-package.sh
+++ b/scripts/ci/launcher-package.sh
@@ -4,6 +4,12 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck disable=SC1091
 source "$script_dir/_common.sh"
 
+# The launcher's own `precommit` alias fetches, but with a bare `deps.get`:
+# a lockfile that diverged from its `mix.exs` is silently rewritten there and
+# rejected by CI's `--check-locked`. Establish the locked fetch here so this
+# gate answers the same way in both places, however it was entered.
+ci_fetch_deps ptc_runner_launcher
+
 cd ptc_runner_launcher || exit 1
 mix clean
 mix precommit

--- a/scripts/ci/preflight.sh
+++ b/scripts/ci/preflight.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$script_dir/_common.sh"
+
+# Fail-fast admission for the local gate.
+#
+# Every gate already fetches the project it compiles, so this changes no
+# outcome -- only when you learn it. `mix precommit` runs the root suite for
+# minutes before it reaches the Viewer and the launcher, and a worktree that
+# never fetched them, or a branch whose nested lockfile diverged from its
+# `mix.exs`, should cost seconds to discover rather than a finished suite.
+#
+# The root project is deliberately absent: the gate that runs next opens with
+# `mix compile`, which reports the root's own dependency state before anything
+# long-running starts. GitHub does not run this script -- there each job gets
+# the same fetch from the setup action, and each job is already independent.
+ci_fetch_deps ptc_viewer
+ci_fetch_deps ptc_runner_launcher

--- a/scripts/ci/viewer.sh
+++ b/scripts/ci/viewer.sh
@@ -4,6 +4,8 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck disable=SC1091
 source "$script_dir/_common.sh"
 
+ci_fetch_deps ptc_viewer
+
 cd ptc_viewer || exit 1
 mix compile --warnings-as-errors
 mix test --warnings-as-errors

--- a/scripts/worktree.sh
+++ b/scripts/worktree.sh
@@ -157,7 +157,34 @@ issue_state() {
 # is ever shared, so concurrent gates cannot race.
 # ----------------------------------------------------------------------
 
-SEED_KEY_FILES=(mise.toml mix.lock ptc_viewer/mix.lock ptc_runner_launcher/mix.lock)
+# Each artifact is keyed by the files that actually pin it: the toolchain,
+# which every compiled tree shares, plus its own project's lockfile. Keying
+# them together instead would make any root dependency bump -- the common case
+# for a branch -- also skip `ptc_viewer/deps` and the launcher's, projects the
+# branch never touched, sending their gates to the network for a cold fetch.
+# The root's lockfile covers the nested projects' *hex* dependencies too: Mix
+# converges a path dependency's requirements into the parent lock.
+seed_key_files() {
+  case "$1" in
+    ptc_viewer/*) printf '%s\n' mise.toml ptc_viewer/mix.lock ;;
+    ptc_runner_launcher/*) printf '%s\n' mise.toml ptc_runner_launcher/mix.lock ;;
+    *) printf '%s\n' mise.toml mix.lock ;;
+  esac
+}
+
+# The first key file that differs between the two checkouts, empty if none do.
+# The trailing `return 0` is load-bearing under `set -e`: the caller assigns
+# this in a command substitution, so "no divergence" must not read as failure.
+seed_key_divergence() {
+  local src="$1" dst="$2" artifact="$3" file
+  while IFS= read -r file; do
+    if ! cmp -s "$src/$file" "$dst/$file"; then
+      printf '%s' "$file"
+      return 0
+    fi
+  done < <(seed_key_files "$artifact")
+  return 0
+}
 
 # deps/_build make `mix deps.get` and `mix compile` incremental in all three
 # Mix projects; priv/plts carries the writable project PLT so dialyxir
@@ -196,14 +223,7 @@ clone_tree() {
 }
 
 seed_worktree() {
-  local src="$1" dst="$2" file artifact staging tmp seeded=0 start=$SECONDS
-
-  for file in "${SEED_KEY_FILES[@]}"; do
-    if ! cmp -s "$src/$file" "$dst/$file"; then
-      echo "🌱 Seed skipped: $file differs from the main checkout's copy"
-      return 0
-    fi
-  done
+  local src="$1" dst="$2" diverged artifact staging tmp seeded=0 start=$SECONDS
 
   # Stage each copy and promote it with an atomic same-volume rename, so an
   # interrupted seed can never leave a partial tree that a later run skips as
@@ -215,7 +235,10 @@ seed_worktree() {
 
   for artifact in "${SEED_ARTIFACTS[@]}"; do
     tmp="$staging/${artifact//\//__}"
-    if [ -L "$src/$artifact" ]; then
+    diverged="$(seed_key_divergence "$src" "$dst" "$artifact")"
+    if [ -n "$diverged" ]; then
+      echo "   ⏭️  $artifact — $diverged differs from the main checkout's copy"
+    elif [ -L "$src/$artifact" ]; then
       echo "   ⏭️  $artifact — main checkout's copy is a symlink"
     elif [ ! -d "$src/$artifact" ]; then
       echo "   ⏭️  $artifact — not built in the main checkout"

--- a/test/scripts/ci_gates_test.exs
+++ b/test/scripts/ci_gates_test.exs
@@ -8,6 +8,7 @@ defmodule PtcRunner.Scripts.CIGatesTest do
   @core_dialyzer Path.join(@root, "scripts/ci/core-dialyzer.sh")
   @preflight Path.join(@root, "scripts/ci/preflight.sh")
   @viewer Path.join(@root, "scripts/ci/viewer.sh")
+  @launcher_package Path.join(@root, "scripts/ci/launcher-package.sh")
   @git_env GitEnv.clear()
 
   test "core tests establish the CI contract without reducing native scheduler pressure" do
@@ -83,6 +84,24 @@ defmodule PtcRunner.Scripts.CIGatesTest do
              "CI= MIX_ENV=test HEX_SPONSOR=false ERL_FLAGS= PWD=ptc_viewer :: deps.get --check-locked",
              "CI= MIX_ENV=test HEX_SPONSOR=false ERL_FLAGS= PWD=ptc_viewer :: compile --warnings-as-errors",
              "CI= MIX_ENV=test HEX_SPONSOR=false ERL_FLAGS= PWD=ptc_viewer :: test --warnings-as-errors"
+           ]
+  end
+
+  # The launcher project's own `precommit` alias fetches with a bare
+  # `deps.get`, which repairs a diverged lockfile instead of rejecting it. The
+  # gate establishes the locked fetch first, so entering it directly -- from
+  # the pre-push hook, say -- answers the way CI does.
+  test "the launcher gate fetches with the locked check before the project's own alias" do
+    %{marker: marker} = fake = fake_mix()
+
+    {output, status} = run_gate(@launcher_package, fake, env: [{"CI", nil}, {"ERL_FLAGS", nil}])
+
+    assert status == 0, output
+
+    assert File.read!(marker) |> String.split("\n", trim: true) == [
+             "CI= MIX_ENV=test HEX_SPONSOR=false ERL_FLAGS= PWD=ptc_runner_launcher :: deps.get --check-locked",
+             "CI= MIX_ENV=test HEX_SPONSOR=false ERL_FLAGS= PWD=ptc_runner_launcher :: clean",
+             "CI= MIX_ENV=test HEX_SPONSOR=false ERL_FLAGS= PWD=ptc_runner_launcher :: precommit"
            ]
   end
 

--- a/test/scripts/ci_gates_test.exs
+++ b/test/scripts/ci_gates_test.exs
@@ -6,59 +6,40 @@ defmodule PtcRunner.Scripts.CIGatesTest do
   @root Path.expand("../..", __DIR__)
   @core_tests Path.join(@root, "scripts/ci/core-tests.sh")
   @core_dialyzer Path.join(@root, "scripts/ci/core-dialyzer.sh")
+  @preflight Path.join(@root, "scripts/ci/preflight.sh")
+  @viewer Path.join(@root, "scripts/ci/viewer.sh")
   @git_env GitEnv.clear()
 
   test "core tests establish the CI contract without reducing native scheduler pressure" do
-    %{marker: marker, path: path} = fake_mix()
+    %{marker: marker} = fake = fake_mix()
 
-    {output, status} =
-      System.cmd(@core_tests, [],
-        cd: @root,
-        env:
-          @git_env ++
-            [
-              {"PATH", path},
-              {"MIX_MARKER", marker},
-              {"ERL_FLAGS", "+S 7:7"}
-            ],
-        stderr_to_stdout: true
-      )
+    {output, status} = run_gate(@core_tests, fake, env: [{"ERL_FLAGS", "+S 7:7"}])
 
     assert status == 0, output
 
     assert File.read!(marker) |> String.split("\n", trim: true) == [
-             "CI=1 MIX_ENV=test HEX_SPONSOR=false ERL_FLAGS=+S 7:7 :: compile --warnings-as-errors",
-             "CI=1 MIX_ENV=test HEX_SPONSOR=false ERL_FLAGS=+S 7:7 :: test --max-failures 1 --warnings-as-errors"
+             "CI=1 MIX_ENV=test HEX_SPONSOR=false ERL_FLAGS=+S 7:7 PWD=. :: compile --warnings-as-errors",
+             "CI=1 MIX_ENV=test HEX_SPONSOR=false ERL_FLAGS=+S 7:7 PWD=. :: test --max-failures 1 --warnings-as-errors"
            ]
   end
 
   test "core tests offer the GitHub four-scheduler CPU shape locally" do
-    %{marker: marker, path: path} = fake_mix()
+    %{marker: marker} = fake = fake_mix()
 
-    {output, status} =
-      System.cmd(@core_tests, ["--schedulers", "4"],
-        cd: @root,
-        env: @git_env ++ [{"PATH", path}, {"MIX_MARKER", marker}],
-        stderr_to_stdout: true
-      )
+    {output, status} = run_gate(@core_tests, fake, args: ["--schedulers", "4"])
 
     assert status == 0, output
 
     assert File.read!(marker) |> String.split("\n", trim: true) == [
-             "CI=1 MIX_ENV=test HEX_SPONSOR=false ERL_FLAGS=+S 4:4 :: compile --warnings-as-errors",
-             "CI=1 MIX_ENV=test HEX_SPONSOR=false ERL_FLAGS=+S 4:4 :: test --max-failures 1 --warnings-as-errors"
+             "CI=1 MIX_ENV=test HEX_SPONSOR=false ERL_FLAGS=+S 4:4 PWD=. :: compile --warnings-as-errors",
+             "CI=1 MIX_ENV=test HEX_SPONSOR=false ERL_FLAGS=+S 4:4 PWD=. :: test --max-failures 1 --warnings-as-errors"
            ]
   end
 
   test "core tests reject malformed scheduler limits before invoking Mix" do
-    %{marker: marker, path: path} = fake_mix()
+    %{marker: marker} = fake = fake_mix()
 
-    {output, status} =
-      System.cmd(@core_tests, ["--schedulers", "many"],
-        cd: @root,
-        env: @git_env ++ [{"PATH", path}, {"MIX_MARKER", marker}],
-        stderr_to_stdout: true
-      )
+    {output, status} = run_gate(@core_tests, fake, args: ["--schedulers", "many"])
 
     assert status == 64
     assert output =~ "usage: core-tests.sh [--schedulers POSITIVE_INTEGER]"
@@ -66,39 +47,59 @@ defmodule PtcRunner.Scripts.CIGatesTest do
   end
 
   test "non-test gates preserve the caller's CI state for local tool caches" do
-    %{marker: marker, path: path} = fake_mix()
+    %{marker: marker} = fake = fake_mix()
 
-    {output, status} =
-      System.cmd(@core_dialyzer, [],
-        cd: @root,
-        env:
-          @git_env ++
-            [{"CI", nil}, {"ERL_FLAGS", nil}, {"PATH", path}, {"MIX_MARKER", marker}],
-        stderr_to_stdout: true
-      )
+    {output, status} = run_gate(@core_dialyzer, fake, env: [{"CI", nil}, {"ERL_FLAGS", nil}])
 
     assert status == 0, output
 
     assert File.read!(marker) |> String.trim() ==
-             "CI= MIX_ENV=test HEX_SPONSOR=false ERL_FLAGS= :: dialyzer --format github"
+             "CI= MIX_ENV=test HEX_SPONSOR=false ERL_FLAGS= PWD=. :: dialyzer --format github"
   end
 
   test "non-test gates preserve an explicit CI state" do
-    %{marker: marker, path: path} = fake_mix()
+    %{marker: marker} = fake = fake_mix()
 
-    {output, status} =
-      System.cmd(@core_dialyzer, [],
-        cd: @root,
-        env:
-          @git_env ++
-            [{"CI", "true"}, {"ERL_FLAGS", nil}, {"PATH", path}, {"MIX_MARKER", marker}],
-        stderr_to_stdout: true
-      )
+    {output, status} = run_gate(@core_dialyzer, fake, env: [{"CI", "true"}, {"ERL_FLAGS", nil}])
 
     assert status == 0, output
 
     assert File.read!(marker) |> String.trim() ==
-             "CI=true MIX_ENV=test HEX_SPONSOR=false ERL_FLAGS= :: dialyzer --format github"
+             "CI=true MIX_ENV=test HEX_SPONSOR=false ERL_FLAGS= PWD=. :: dialyzer --format github"
+  end
+
+  # CI supplies each nested project's dependencies from the setup action's
+  # `project-directory`, so a gate that assumes them is green there and fails
+  # only locally -- in a fresh worktree, after the multi-minute suites that run
+  # ahead of it. Every gate fetches what it is about to compile instead.
+  test "the Viewer gate fetches the Viewer's own dependencies before compiling it" do
+    %{marker: marker} = fake = fake_mix()
+
+    {output, status} = run_gate(@viewer, fake, env: [{"CI", nil}, {"ERL_FLAGS", nil}])
+
+    assert status == 0, output
+
+    assert File.read!(marker) |> String.split("\n", trim: true) == [
+             "CI= MIX_ENV=test HEX_SPONSOR=false ERL_FLAGS= PWD=ptc_viewer :: deps.get --check-locked",
+             "CI= MIX_ENV=test HEX_SPONSOR=false ERL_FLAGS= PWD=ptc_viewer :: compile --warnings-as-errors",
+             "CI= MIX_ENV=test HEX_SPONSOR=false ERL_FLAGS= PWD=ptc_viewer :: test --warnings-as-errors"
+           ]
+  end
+
+  # The fetch itself costs about a second warm. Paying it up front is what
+  # matters: an unfetched or diverged nested project is then a seconds-long
+  # failure rather than one that lands after the root suite has finished.
+  test "the preflight fetches every nested project before the long gates run" do
+    %{marker: marker} = fake = fake_mix()
+
+    {output, status} = run_gate(@preflight, fake, env: [{"CI", nil}, {"ERL_FLAGS", nil}])
+
+    assert status == 0, output
+
+    assert File.read!(marker) |> String.split("\n", trim: true) == [
+             "CI= MIX_ENV=test HEX_SPONSOR=false ERL_FLAGS= PWD=ptc_viewer :: deps.get --check-locked",
+             "CI= MIX_ENV=test HEX_SPONSOR=false ERL_FLAGS= PWD=ptc_runner_launcher :: deps.get --check-locked"
+           ]
   end
 
   test "Actions and the pre-push hook delegate deterministic gates to repository scripts" do
@@ -124,7 +125,20 @@ defmodule PtcRunner.Scripts.CIGatesTest do
     assert mix_project =~ ~s("cmd scripts/ci/core-tests.sh")
     assert mix_project =~ ~s("cmd scripts/ci/core-static.sh")
     assert mix_project =~ ~s("cmd scripts/ci/core-dialyzer.sh")
+    assert mix_project =~ ~r/precommit: \[\n\s*"cmd scripts\/ci\/preflight\.sh",/
     assert launcher =~ ~s(bash ptc_runner_launcher/scripts/verify_precompiled.sh)
+  end
+
+  # Every gate is exercised the same way: the repository root as the working
+  # directory, a cleared git environment, and a fake `mix` first on PATH that
+  # records what it was asked to do. `:env` entries are appended, so a test can
+  # override anything this sets.
+  defp run_gate(script, %{marker: marker, path: path}, opts) do
+    System.cmd(script, Keyword.get(opts, :args, []),
+      cd: @root,
+      env: @git_env ++ [{"PATH", path}, {"MIX_MARKER", marker}] ++ Keyword.get(opts, :env, []),
+      stderr_to_stdout: true
+    )
   end
 
   defp fake_mix do
@@ -141,10 +155,16 @@ defmodule PtcRunner.Scripts.CIGatesTest do
 
     mix = Path.join(bin, "mix")
 
+    # The recorded working directory is part of the contract, not decoration:
+    # a nested project's dependencies are only fetched if Mix was invoked
+    # inside that project.
     File.write!(mix, """
     #!/bin/sh
-    printf 'CI=%s MIX_ENV=%s HEX_SPONSOR=%s ERL_FLAGS=%s :: %s\n' \\
-      "$CI" "$MIX_ENV" "$HEX_SPONSOR" "${ERL_FLAGS:-}" "$*" >> "$MIX_MARKER"
+    repo_root='#{@root}'
+    rel="${PWD#$repo_root}"
+    rel="${rel#/}"
+    printf 'CI=%s MIX_ENV=%s HEX_SPONSOR=%s ERL_FLAGS=%s PWD=%s :: %s\n' \\
+      "$CI" "$MIX_ENV" "$HEX_SPONSOR" "${ERL_FLAGS:-}" "${rel:-.}" "$*" >> "$MIX_MARKER"
     """)
 
     File.chmod!(mix, 0o755)

--- a/test/scripts/worktree_seed_test.exs
+++ b/test/scripts/worktree_seed_test.exs
@@ -106,16 +106,52 @@ defmodule PtcRunner.Scripts.WorktreeSeedTest do
     assert File.lstat!(Path.join(worktree, "deps")).type == :symlink
   end
 
-  test "skips seeding entirely when a lockfile differs" do
+  # Each project's artifacts are pinned by that project's own lockfile. A
+  # branch that bumps the root lock leaves `ptc_viewer/deps` identical, and
+  # skipping it too costs a cold fetch in a project the branch never touched.
+  test "a diverged lockfile skips only the artifacts that lockfile pins" do
     %{main: main, worktree: worktree} = repo_with_worktree()
 
     write!(main, "deps/jason/mix.exs", "jason\n")
+    write!(main, "ptc_viewer/deps/plug/mix.exs", "plug\n")
     write!(worktree, "mix.lock", "diverged\n")
 
     {output, 0} = seed(main, worktree)
 
-    assert output =~ "Seed skipped: mix.lock differs"
+    assert output =~ "deps — mix.lock differs from the main checkout's copy"
     refute File.exists?(Path.join(worktree, "deps"))
+    assert File.read!(Path.join(worktree, "ptc_viewer/deps/plug/mix.exs")) == "plug\n"
+  end
+
+  test "a diverged nested lockfile leaves the root's artifacts seedable" do
+    %{main: main, worktree: worktree} = repo_with_worktree()
+
+    write!(main, "deps/jason/mix.exs", "jason\n")
+    write!(main, "ptc_viewer/deps/plug/mix.exs", "plug\n")
+    write!(worktree, "ptc_viewer/mix.lock", "diverged\n")
+
+    {output, 0} = seed(main, worktree)
+
+    assert output =~ "ptc_viewer/deps — ptc_viewer/mix.lock differs from the main checkout's copy"
+    refute File.exists?(Path.join(worktree, "ptc_viewer/deps"))
+    assert File.read!(Path.join(worktree, "deps/jason/mix.exs")) == "jason\n"
+  end
+
+  # The toolchain pin is the one key every artifact shares: a different Erlang
+  # or Elixir invalidates every compiled tree at once.
+  test "a diverged toolchain pin skips every artifact" do
+    %{main: main, worktree: worktree} = repo_with_worktree()
+
+    write!(main, "deps/jason/mix.exs", "jason\n")
+    write!(main, "ptc_viewer/deps/plug/mix.exs", "plug\n")
+    write!(worktree, "mise.toml", "diverged\n")
+
+    {output, 0} = seed(main, worktree)
+
+    assert output =~ ~r/Seeded 0 artifact\(s\)/
+    assert output =~ "deps — mise.toml differs from the main checkout's copy"
+    refute File.exists?(Path.join(worktree, "deps"))
+    refute File.exists?(Path.join(worktree, "ptc_viewer/deps"))
   end
 
   test "leaves artifacts that are already present untouched" do


### PR DESCRIPTION
## The surprise

A fresh worktree ran the root gate to completion — all ~6,200 tests — and then
stopped at the Viewer gate because `ptc_viewer/deps` had never been fetched.
No source failure; several minutes lost to a ~1.5s omission.

`scripts/ci/viewer.sh` was the one gate script that did not own its dependency
precondition:

```bash
cd ptc_viewer || exit 1
mix compile --warnings-as-errors
mix test --warnings-as-errors
```

Three separate things supplied that precondition, and none of them was the
script:

- **CI** — `.github/workflows/test.yml` sets up the Viewer job with
  `project-directory: ptc_viewer`, and the setup action runs
  `mix deps.get --check-locked`. CI never saw the failure.
- **A main checkout** — the manual step in `docs/development-setup.md`, run
  once, long ago.
- **A seeded worktree** — `scripts/worktree.sh` copies `ptc_viewer/deps` from
  the main checkout, when seeding is not skipped and the worktree was created
  through that script at all.

## Changes

1. **`ci_fetch_deps` in `scripts/ci/_common.sh`, used by `viewer.sh`.** One
   policy, stated once — the same `mix deps.get --check-locked` CI runs. A gate
   fetches what it is about to compile.
2. **`scripts/ci/preflight.sh`, first in `mix precommit`.** Fetches both nested
   projects up front, so an unfetched or diverged project is a seconds-long
   failure rather than one that lands after the root suite. The root project is
   deliberately absent — the next gate opens with `mix compile`.
3. **Per-artifact seed keys in `scripts/worktree.sh`.** Seeding was
   all-or-nothing: any of `mise.toml`, `mix.lock`, `ptc_viewer/mix.lock`, or
   `ptc_runner_launcher/mix.lock` differing skipped *every* artifact. A branch
   that only bumps the root lock therefore lost Viewer seeding too. Each
   artifact is now keyed by the toolchain plus its own project's lockfile.
4. **The launcher gate fetches with the locked check** (from Codex review, see
   below). `scripts/ci/launcher-package.sh` fetched only through the launcher
   project's own `precommit` alias, a bare `Mix.Task.run("deps.get")` — so a
   lockfile that diverged from its `mix.exs` was repaired locally and rejected
   by CI. That is the same asymmetry, on the path `scripts/ci/launcher.sh` and
   the pre-push hook take.
5. **`ptc_viewer/.gitignore` covers `/tmp/`.** Four Viewer test files use the
   `tmp_dir` tag, so running the Viewer gate left its own worktree dirty — and
   `scripts/worktree.sh gc` counts untracked entries as unsaved work, so such a
   worktree could never be reclaimed. Root and launcher already ignored it.

## Cost

Installing them is not the expensive part:

| step | time |
|---|---|
| `preflight.sh`, both nested projects, warm | 2.0s |
| `mix deps.get --check-locked` in `ptc_viewer`, warm | 1.5s |
| all 10 Viewer deps + project compiled from zero | 8.2s |

## Verification

- **The actual repro**: with `ptc_viewer/{deps,_build}` deleted, the gate that
  used to abort now recovers on its own in **13.1s**, 44 Viewer tests passing.
- Tests were written first and observed failing (6 failures across the two
  script suites), then made to pass — including that a nested fetch happens
  *in* the nested project, which the fake `mix` now records.
- `mix precommit` green end to end: 6201 root, 44 Viewer, 40 launcher.
  `scripts/ci/launcher-package.sh` re-run green after change 4.
- `scripts/ci/viewer.sh` leaves `git status` clean after change 5.
- shellcheck clean; duplication gate at baseline.

## Review

`codex review` (independent, gpt-5.6-sol): **no [P1]**, one [P2] — the launcher
gate's unlocked fetch, applied here as change 4. It confirmed the per-artifact
seed mapping, bash 3.2 parsing, and ShellCheck.
