### PR TITLE
fix(analysis): preserve debugger turn streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -195,6 +195,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Reconstructed model conversations now treat blank tool-call narration and
+  the agent loop's carried-forward `nil` as the same absent content. Private
+  debugger traversals therefore retain their stream-local turn numbering while
+  preserving exact raw model exchanges.
 - Failed private debugger runs now retain validated input-only model and
   capability attempts as explicitly incomplete evidence. Raw reads expose the
   complete prefix without inventing terminal data, while reconstructed turns

--- a/docs/trace-log-contract.md
+++ b/docs/trace-log-contract.md
@@ -420,8 +420,12 @@ zero on complete runs.
 
 `turns` is the only compiled convenience collection. Each item is one model
 turn with the newly added messages, response, matching generated programs, and
-stable stream/turn identity. It omits the repeated system prompt; exact raw
-model requests remain available through `model_exchanges`. Page-level
+stable stream/turn identity. Turn numbers start at one independently within
+each reconstructed stream; `{stream_id, turn}` is the identity, while
+`request_sequence` only orders records inside the inspection snapshot. It must
+not be compared with canonical activity sequence numbers. The collection omits
+the repeated system prompt; exact raw model requests remain available through
+`model_exchanges`. Page-level
 `evidence` reports canonical completeness, missing exchanges, and ambiguity
 separately from pagination. Interrupted model inputs remain raw evidence but
 are excluded from `turns`, so the canonical missing-exchange count records the

--- a/lib/ptc_runner/kernel/conversation_projection.ex
+++ b/lib/ptc_runner/kernel/conversation_projection.ex
@@ -1,6 +1,8 @@
 defmodule PtcRunner.Kernel.ConversationProjection do
   @moduledoc false
 
+  alias PtcRunner.Lisp.Runtime.String, as: RuntimeString
+
   @spec compile([map()], [map()], map()) :: map()
   def compile(exchanges, programs, trace_facts)
       when is_list(exchanges) and is_list(programs) and is_map(trace_facts) do
@@ -219,10 +221,35 @@ defmodule PtcRunner.Kernel.ConversationProjection do
 
   defp ensure_assistant_content(message, _value), do: message
 
-  defp prefix?(prefix, messages) when length(prefix) < length(messages),
-    do: Enum.take(messages, length(prefix)) == prefix
+  defp prefix?(prefix, messages) when length(prefix) < length(messages) do
+    messages
+    |> Enum.take(length(prefix))
+    |> Enum.zip(prefix)
+    |> Enum.all?(fn {message, expected} ->
+      comparable_message(message) == comparable_message(expected)
+    end)
+  end
 
   defp prefix?(_prefix, _messages), do: false
+
+  # The agent loop carries blank tool-call narration forward as nil. Compare
+  # that known provider/agent representation difference without rewriting the
+  # raw request or response retained in the projection.
+  defp comparable_message(%{"role" => "assistant", "tool_calls" => [_ | _]} = message) do
+    case Map.get(message, "content") do
+      nil -> Map.put(message, "content", nil)
+      content when is_binary(content) -> normalize_blank_content(message, content)
+      _other -> message
+    end
+  end
+
+  defp comparable_message(message), do: message
+
+  defp normalize_blank_content(message, content) do
+    if RuntimeString.blank?(content),
+      do: Map.put(message, "content", nil),
+      else: message
+  end
 
   defp add_ambiguous(exchange, reason, state) do
     entry = %{

--- a/test/ptc_runner/kernel/run_analysis_test.exs
+++ b/test/ptc_runner/kernel/run_analysis_test.exs
@@ -166,6 +166,55 @@ defmodule PtcRunner.Kernel.RunAnalysisTest do
     assert Enum.at(turns, 2)["feedback"] == [feedback_2]
   end
 
+  test "conversation streams equate absent tool-call narration across captures" do
+    user = %{"role" => "user", "content" => "start"}
+    call = %{"id" => "1", "name" => "run_ptc_lisp", "args" => %{"program" => "42"}}
+    carried = %{"role" => "assistant", "content" => nil, "tool_calls" => [call]}
+    feedback = %{"role" => "tool", "tool_call_id" => "1", "content" => "42"}
+
+    for content_fields <- [%{"content" => ""}, %{"content" => " \n\t"}, %{}] do
+      captured =
+        %{"role" => "assistant", "tool_calls" => [call]}
+        |> Map.merge(content_fields)
+
+      exchanges = [
+        exchange(1, [user], captured),
+        exchange(3, [user, carried, feedback], %{"role" => "assistant", "content" => "done"})
+      ]
+
+      assert %{"ambiguous?" => false, "streams" => [%{"turns" => turns}]} =
+               ConversationProjection.streams(exchanges)
+
+      assert Enum.map(turns, & &1["turn"]) == [1, 2]
+      assert hd(turns)["assistant"] == captured
+    end
+  end
+
+  test "conversation stream matching keeps other message content exact" do
+    user = %{"role" => "user", "content" => "start"}
+    call = %{"id" => "1", "name" => "run_ptc_lisp", "args" => %{"program" => "42"}}
+    feedback = %{"role" => "tool", "tool_call_id" => "1", "content" => "42"}
+
+    narrated = %{"role" => "assistant", "content" => "I will inspect.", "tool_calls" => [call]}
+    narration_dropped = %{"role" => "assistant", "content" => nil, "tool_calls" => [call]}
+
+    assert %{"streams" => [%{"turns" => [_]}, %{"turns" => [_]}]} =
+             ConversationProjection.streams([
+               exchange(1, [user], narrated),
+               exchange(3, [user, narration_dropped, feedback], narrated)
+             ])
+
+    blank_user = %{"role" => "user", "content" => ""}
+    nil_user = %{"role" => "user", "content" => nil}
+    assistant = %{"role" => "assistant", "content" => nil, "tool_calls" => [call]}
+
+    assert %{"streams" => [%{"turns" => [_]}, %{"turns" => [_]}]} =
+             ConversationProjection.streams([
+               exchange(1, [blank_user], assistant),
+               exchange(3, [nil_user, assistant, feedback], assistant)
+             ])
+  end
+
   test "conversation streams preserve equal maximal forks as ambiguous" do
     user = %{"role" => "user", "content" => "same"}
     assistant = %{"role" => "assistant", "content" => "same answer"}


### PR DESCRIPTION
## Summary

- normalize absent, empty, and whitespace-only assistant narration when matching tool-call conversation prefixes
- preserve the original captured messages in projected output and keep all other content comparisons exact
- document that `turn` is one-based and local to a reconstructed `stream_id`
- add regression coverage for the reported repeated-`turn: 1` traversal

## Root cause

ReqLLM can capture an assistant tool-call response with `content: ""`, while the next request carries that same message as `content: null`. Conversation reconstruction used exact map equality, so every request failed to match its predecessor and started a new stream at turn 1.

The fix canonicalizes only the `content` field of assistant messages containing tool calls, and only for prefix comparison. Missing, null, empty, and whitespace-only content compare as absent. Raw inspection evidence remains unchanged.

## Verification

- `mix test test/ptc_runner/kernel/run_analysis_test.exs` — 15 passed
- `MIX_ENV=dev mix docs --warnings-as-errors` — passed
- `mix precommit` — passed
- pre-push gate — 6,203 core tests passed; static analysis, Dialyzer, release verification, documentation, and Viewer validation passed
- two plan review passes completed
- independent cumulative implementation review approved with no actionable findings

Residual risk: the regression fixture models captured exchanges synthetically rather than replaying an end-to-end private inspection artifact.

Fixes #1379