### PR TITLE
feat(lisp): make pmap and pcalls callable values

### DIFF
--- a/docs/agent-library-reference.md
+++ b/docs/agent-library-reference.md
@@ -328,3 +328,8 @@ turns.
 
 Set enough `parallel_timeout_ms` headroom for the complete parallel phase. The
 Kernel limit reference, not the agent configuration, defines these ceilings.
+
+Use `pcalls` for a fixed heterogeneous fan-out of zero-arity tasks and `pmap`
+for a runtime-sized homogeneous collection. Both resolve as callable values,
+so a workflow may store them, pass them through a helper, or invoke them with
+`apply`; direct and indirect calls consume the same worker budget and deadline.

--- a/docs/function-reference.md
+++ b/docs/function-reference.md
@@ -303,8 +303,8 @@ See also: [PTC-Lisp Specification](ptc-lisp-specification.md) | [Clojure Conform
 | Function | Signature | Description |
 |----------|-----------|-------------|
 | `juxt` | `(juxt f1 f2 ...)` | Returns a function that applies all functions and returns a vector of results |
-| `pcalls` * | `(pcalls f1 f2 ...)` | Execute thunks in parallel |
-| `pmap` * | `(pmap f coll), (pmap f c1 c2 ...)` | Apply f to each (zipped) item in parallel — Shares map's finite seqable contract: nil -> empty, strings map over graphemes, and multiple collections zip element-wise truncating to the shortest. Runs under bounded parallel limits (per-worker heap, worker budget, shared deadline). |
+| `pcalls` * | `(pcalls f1 f2 ...)` | Execute thunks in parallel — Resolves as a callable value and can be passed to apply, higher-order functions, and function combinators. Direct calls retain the analyzer-optimized CoreAST path. |
+| `pmap` * | `(pmap f coll), (pmap f c1 c2 ...)` | Apply f to each (zipped) item in parallel — Resolves as a callable value and can be passed to apply, higher-order functions, and function combinators. Direct calls retain the analyzer-optimized CoreAST path. Shares map's finite seqable contract: nil -> empty, strings map over graphemes, and multiple collections zip element-wise truncating to the shortest. Runs under bounded parallel limits (per-worker heap, worker budget, shared deadline). |
 
 
 

--- a/docs/ptc-lisp-specification.md
+++ b/docs/ptc-lisp-specification.md
@@ -1739,7 +1739,18 @@ as a `[key value]` pair passed to the predicate. They return a **vector** of
 ;; Closures work - captures outer scope at evaluation time
 (let [factor 10]
   (pmap #(* % factor) [1 2 3]))    ; => [10 20 30]
+
+;; pmap is also a callable value
+(apply pmap [inc [1 2 3]])         ; => [2 3 4]
+((partial pmap inc) [1 2 3])       ; => [2 3 4]
+(map pmap [inc dec] [[1 2] [3 4]]) ; => [[2 3] [2 3]]
 ```
+
+`pmap` resolves in value position like an ordinary function. It may be stored,
+passed to higher-order functions, composed with `partial` or `fnil`, and
+invoked with `apply`. A direct `(pmap ...)` call retains the analyzer-optimized
+path; direct and indirect invocation share the same evaluator, limits,
+effects, and failure semantics.
 
 **pmap semantics:**
 - Order is preserved - results match input order
@@ -1773,7 +1784,17 @@ as a `[key value]` pair passed to the predicate. They return a **vector** of
 
 ;; Simple parallel computations
 (pcalls #(+ 1 1) #(* 2 3) #(- 10 5))    ; => [2 6 5]
+
+;; pcalls is also a variadic callable value
+(apply pcalls [#(+ 1 1) #(* 2 3)])       ; => [2 6]
 ```
+
+`pcalls` may likewise be stored, passed to higher-order functions, composed,
+and invoked with `apply`. It accepts zero thunks, so using `pcalls` itself as a
+`pcalls` thunk is valid; `pmap` is rejected during zero-arity preflight before
+any worker starts. Saved parallel callables resolve evaluator authority and
+limits from the evaluation that invokes them, not the evaluation that stored
+them.
 
 **pcalls semantics:**
 - Order is preserved - results match argument order

--- a/lib/ptc_runner/lisp/analyze.ex
+++ b/lib/ptc_runner/lisp/analyze.ex
@@ -937,8 +937,14 @@ defmodule PtcRunner.Lisp.Analyze do
     end
   end
 
-  defp analyze_pmap(_, _tail?) do
-    {:error, {:invalid_arity, :pmap, "expected (pmap f coll) or (pmap f c1 c2 ...)"}}
+  # A persisted user definition may shadow `pmap` with a different arity. For
+  # arities that cannot use the optimized builtin node, retain an ordinary
+  # call so runtime namespace resolution gets the final say. If no shadow is
+  # present, the builtin value reports the same recoverable arity error.
+  defp analyze_pmap(args, _tail?) do
+    with {:ok, analyzed_args} <- analyze_list(args) do
+      {:ok, {:call, {:var, :pmap}, analyzed_args}}
+    end
   end
 
   # ============================================================
@@ -1188,12 +1194,22 @@ defmodule PtcRunner.Lisp.Analyze do
 
       :error ->
         case qualified_namespace_lookup(ns, key) do
-          {:ok, qualified} -> {:ok, {:var, qualified}}
-          :not_qualified -> prelude_or_clojure_namespace(ns, key, fn -> {:ok, {:var, key}} end)
-          :unknown_member -> namespaced_unknown_member_error(ns, key)
+          {:ok, qualified} ->
+            {:ok, {:var, qualified}}
+
+          :not_qualified ->
+            prelude_or_clojure_namespace(ns, key, fn -> analyze_clojure_value(key) end)
+
+          :unknown_member ->
+            namespaced_unknown_member_error(ns, key)
         end
     end
   end
+
+  defp analyze_clojure_value(key) when key in [:pmap, :pcalls],
+    do: {:ok, {:literal, {:special, key}}}
+
+  defp analyze_clojure_value(key), do: {:ok, {:var, key}}
 
   defp analyze_namespaced_call(ns, func, rest, list, tail?) do
     case PreludeScope.fetch_export(ns, func) do
@@ -1207,7 +1223,7 @@ defmodule PtcRunner.Lisp.Analyze do
 
           :not_qualified ->
             prelude_or_clojure_namespace(ns, func, fn ->
-              dispatch_list_form({:symbol, func}, rest, list, tail?)
+              analyze_clojure_call(func, rest, list, tail?)
             end)
 
           :unknown_member ->
@@ -1215,6 +1231,28 @@ defmodule PtcRunner.Lisp.Analyze do
         end
     end
   end
+
+  # A qualified Clojure builtin is already resolved and must bypass locals and
+  # user namespace definitions. Parallel calls use their callable value path;
+  # qualified pmap keeps strict builtin arity validation at analysis time.
+  defp analyze_clojure_call(:pmap, [function, collection | collections], _list, _tail?) do
+    with {:ok, arguments} <- analyze_list([function, collection | collections]) do
+      {:ok, {:call, {:literal, {:special, :pmap}}, arguments}}
+    end
+  end
+
+  defp analyze_clojure_call(:pmap, _arguments, _list, _tail?) do
+    {:error, {:invalid_arity, :pmap, "expected (pmap f coll) or (pmap f c1 c2 ...)"}}
+  end
+
+  defp analyze_clojure_call(:pcalls, functions, _list, _tail?) do
+    with {:ok, arguments} <- analyze_list(functions) do
+      {:ok, {:call, {:literal, {:special, :pcalls}}, arguments}}
+    end
+  end
+
+  defp analyze_clojure_call(func, rest, list, tail?),
+    do: dispatch_list_form({:symbol, func}, rest, list, tail?)
 
   # ============================================================
   # Helper functions

--- a/lib/ptc_runner/lisp/env.ex
+++ b/lib/ptc_runner/lisp/env.ex
@@ -11,14 +11,16 @@ defmodule PtcRunner.Lisp.Env do
   - `{:multi_arity, name, tuple_of_funs}` - Multiple arities where tuple index = arity - min_arity
   - `{:collect, fun}` - Collects all args into a list and passes to unary function
   - `{:special, name}` - Dispatched by name in `PtcRunner.Lisp.Eval.Apply`
-    because it needs the evaluation context (the print channel, the attached
-    prelude), which a plain function cannot reach. Higher-order use needs a
-    second dispatch path, and which one matters: `println` uses a
-    `Apply.closure_to_fun/3` bridge, while the introspection builtins are
-    dispatched by `PtcRunner.Lisp.Runtime.Callable.call/2` from the argument
-    list. Prefer the latter for anything new — a bridge fixes the arity to the
-    wrapper's and binds the converting context, which drops overloads and lets a
-    converted value carry its converter's authority rather than its caller's.
+    because it needs evaluation context, which a plain function cannot reach.
+    Higher-order use needs a second dispatch path, and which one matters:
+    `println` uses an `Apply.closure_to_fun/3` bridge, while introspection and
+    parallel builtins are dispatched by
+    `PtcRunner.Lisp.Runtime.Callable.call/2` from the argument list. Prefer the
+    latter for anything new — a bridge fixes the arity to the wrapper's and
+    binds the converting context, which drops overloads and lets a converted
+    value carry its converter's authority rather than its caller's. The shared
+    classification and dispatch metadata lives in
+    `PtcRunner.Lisp.SpecialBuiltin`.
   """
 
   alias PtcRunner.Lisp.Env.Builtin

--- a/lib/ptc_runner/lisp/eval.ex
+++ b/lib/ptc_runner/lisp/eval.ex
@@ -597,9 +597,17 @@ defmodule PtcRunner.Lisp.Eval do
   # ============================================================
 
   defp do_eval({:pmap, fn_ast, coll_asts}, %EvalContext{} = eval_ctx) do
-    with {:ok, fn_val, eval_ctx1} <- eval_child(fn_ast, eval_ctx),
-         {:ok, coll_vals, eval_ctx2} <- eval_all(coll_asts, eval_ctx1) do
-      Parallel.eval_pmap(fn_val, coll_vals, eval_ctx2, &do_eval/2)
+    case resolve_user_ns(:pmap, eval_ctx.user_ns, eval_ctx) do
+      {:ok, callable, callable_ctx} ->
+        with {:ok, args, args_ctx} <- eval_all([fn_ast | coll_asts], callable_ctx) do
+          Apply.apply_fun(callable, args, args_ctx, &do_eval/2)
+        end
+
+      :error ->
+        with {:ok, fn_val, eval_ctx1} <- eval_child(fn_ast, eval_ctx),
+             {:ok, coll_vals, eval_ctx2} <- eval_all(coll_asts, eval_ctx1) do
+          Parallel.eval_pmap(fn_val, coll_vals, eval_ctx2, &do_eval/2)
+        end
     end
   end
 
@@ -608,12 +616,20 @@ defmodule PtcRunner.Lisp.Eval do
   # ============================================================
 
   defp do_eval({:pcalls, fn_asts}, %EvalContext{} = eval_ctx) do
-    case eval_all(fn_asts, eval_ctx) do
-      {:ok, fn_vals, eval_ctx2} ->
-        Parallel.eval_pcalls(fn_vals, eval_ctx2, &do_eval/2)
+    case resolve_user_ns(:pcalls, eval_ctx.user_ns, eval_ctx) do
+      {:ok, callable, callable_ctx} ->
+        with {:ok, args, args_ctx} <- eval_all(fn_asts, callable_ctx) do
+          Apply.apply_fun(callable, args, args_ctx, &do_eval/2)
+        end
 
-      {:error, _} = err ->
-        err
+      :error ->
+        case eval_all(fn_asts, eval_ctx) do
+          {:ok, fn_vals, eval_ctx2} ->
+            Parallel.eval_pcalls(fn_vals, eval_ctx2, &do_eval/2)
+
+          {:error, _} = err ->
+            err
+        end
     end
   end
 

--- a/lib/ptc_runner/lisp/eval/apply.ex
+++ b/lib/ptc_runner/lisp/eval/apply.ex
@@ -21,12 +21,14 @@ defmodule PtcRunner.Lisp.Eval.Apply do
   alias PtcRunner.Lisp.Eval.Context, as: EvalContext
   alias PtcRunner.Lisp.Eval.Helpers
   alias PtcRunner.Lisp.Eval.HostContext
+  alias PtcRunner.Lisp.Eval.ParallelCall
   alias PtcRunner.Lisp.Eval.Patterns
   alias PtcRunner.Lisp.Format
   alias PtcRunner.Lisp.Introspection
   alias PtcRunner.Lisp.Java.Callable, as: JavaCallable
   alias PtcRunner.Lisp.Java.Condition, as: JavaCondition
   alias PtcRunner.Lisp.Java.Primitive, as: JavaPrimitive
+  alias PtcRunner.Lisp.Java.Surface, as: JavaSurface
   alias PtcRunner.Lisp.Keyword, as: LispKeyword
   alias PtcRunner.Lisp.Prelude.Contract
   alias PtcRunner.Lisp.PreludeClosure
@@ -34,8 +36,10 @@ defmodule PtcRunner.Lisp.Eval.Apply do
   alias PtcRunner.Lisp.Runtime.Math
   alias PtcRunner.Lisp.Runtime.Predicates
   alias PtcRunner.Lisp.RuntimeCallable
+  alias PtcRunner.Lisp.SpecialBuiltin
 
   @hof_callback_error :__ptc_hof_callback_error__
+  @parallel_specials SpecialBuiltin.names(:parallel)
   alias PtcRunner.Lisp.TypeVocabulary
 
   import PtcRunner.Lisp.Runtime, only: [flex_get: 2, flex_fetch: 2]
@@ -50,6 +54,98 @@ defmodule PtcRunner.Lisp.Eval.Apply do
   def apply_fun(fun_val, args, eval_ctx, do_eval_fn) do
     do_apply_fun(fun_val, args, eval_ctx, do_eval_fn)
   end
+
+  @doc false
+  @spec accepts_arity?(term(), non_neg_integer()) :: boolean()
+  def accepts_arity?(%Builtin{} = builtin, arity),
+    do: accepts_arity?(Builtin.unwrap(builtin), arity)
+
+  def accepts_arity?(%RuntimeCallable{}, _arity), do: true
+
+  def accepts_arity?(%JavaCallable{reference_id: reference_id} = callable, arity) do
+    with true <- JavaCallable.valid?(callable),
+         {:ok, reference} <- JavaSurface.fetch_reference(reference_id) do
+      Enum.any?(reference.overload_ids, fn overload_id ->
+        {:ok, overload} = JavaSurface.fetch_overload(overload_id)
+        receiver_arity = if reference.kind == :instance, do: 1, else: 0
+        overload.arity + receiver_arity == arity
+      end)
+    else
+      _invalid -> false
+    end
+  end
+
+  def accepts_arity?(%LispKeyword{}, arity), do: arity in [1, 2]
+  def accepts_arity?(%MapSet{}, arity), do: arity == 1
+
+  def accepts_arity?(value, arity) when is_map(value) and not is_struct(value),
+    do: arity in [1, 2]
+
+  def accepts_arity?(
+        {:closure, {:variadic, leading, _rest}, _body, _env, _history, _metadata},
+        arity
+      ),
+      do: arity >= length(leading)
+
+  def accepts_arity?({:closure, patterns, _body, _env, _history, _metadata}, arity)
+      when is_list(patterns),
+      do: length(patterns) == arity
+
+  def accepts_arity?({:special, name}, arity) do
+    case SpecialBuiltin.pcalls_thunk(name) do
+      :zero -> arity == 0
+      {:arity, expected} -> arity == expected
+      {:minimum_arity, minimum} -> arity >= minimum
+      :unsupported -> false
+    end
+  end
+
+  def accepts_arity?({:normal, fun}, arity) when is_function(fun),
+    do: function_arity(fun) == arity
+
+  def accepts_arity?({:variadic, fun, _identity}, _arity) when is_function(fun, 2), do: true
+
+  def accepts_arity?({:variadic_nonempty, _name, fun}, arity) when is_function(fun, 2),
+    do: arity > 0
+
+  def accepts_arity?({:collect, fun}, _arity) when is_function(fun, 1), do: true
+
+  def accepts_arity?({:multi_arity, _name, funs}, arity) when is_tuple(funs) do
+    minimum = funs |> elem(0) |> function_arity()
+    arity >= minimum and arity < minimum + tuple_size(funs)
+  end
+
+  def accepts_arity?({:partial_fn, callable, fixed}, arity) when is_list(fixed),
+    do: accepts_arity?(callable, length(fixed) + arity)
+
+  def accepts_arity?({:fnil_fn, callable, _default}, arity),
+    do: accepts_arity?(callable, arity)
+
+  def accepts_arity?({:complement_fn, callable}, arity),
+    do: accepts_arity?(callable, arity)
+
+  def accepts_arity?({:constantly_fn, _value}, _arity), do: true
+
+  def accepts_arity?({:juxt_fn, callables}, arity) when is_list(callables),
+    do: Enum.all?(callables, &accepts_arity?(&1, arity))
+
+  def accepts_arity?({:comp_fn, []}, arity), do: arity == 1
+
+  def accepts_arity?({:comp_fn, callables}, arity) when is_list(callables) do
+    [first | rest] = Enum.reverse(callables)
+    accepts_arity?(first, arity) and Enum.all?(rest, &accepts_arity?(&1, 1))
+  end
+
+  def accepts_arity?({tag, callables}, _arity)
+      when tag in [:every_pred_fn, :some_fn] and is_list(callables),
+      do: true
+
+  def accepts_arity?(value, arity)
+      when is_atom(value) and value not in [nil, true, false],
+      do: arity in [1, 2]
+
+  def accepts_arity?(fun, arity) when is_function(fun), do: function_arity(fun) == arity
+  def accepts_arity?(_callable, _arity), do: false
 
   defp do_apply_fun(
          %Builtin{name: name, binding: {:normal, fun}} = builtin,
@@ -182,6 +278,11 @@ defmodule PtcRunner.Lisp.Eval.Apply do
       _ ->
         {:error, {:arity_error, "apply expects at least 2 arguments, got #{length(args)}"}}
     end
+  end
+
+  defp do_apply_fun({:special, operation}, args, eval_ctx, do_eval_fn)
+       when operation in @parallel_specials do
+    ParallelCall.invoke(operation, args, eval_ctx, do_eval_fn)
   end
 
   # Special builtin: println

--- a/lib/ptc_runner/lisp/eval/helpers.ex
+++ b/lib/ptc_runner/lisp/eval/helpers.ex
@@ -18,6 +18,7 @@ defmodule PtcRunner.Lisp.Eval.Helpers do
   alias PtcRunner.Lisp.Java.Time.LocalDate, as: JavaLocalDate
   alias PtcRunner.Lisp.Java.Util.Date, as: JavaDate
   alias PtcRunner.Lisp.Keyword, as: LispKeyword
+  alias PtcRunner.Lisp.SpecialBuiltin
 
   @stable_parallel_errors [:memory_exceeded, :timeout, :parallel_capacity_exceeded]
   @parallel_run_deadline_message "the run deadline expired during a parallel operation"
@@ -182,9 +183,9 @@ defmodule PtcRunner.Lisp.Eval.Helpers do
   # Surface them as "function" rather than the leaky "unknown".
   def describe_type({tag, _}) when tag in [:normal, :collect], do: "function"
 
-  def describe_type({:special, name})
-      when name in [:dir, :apropos, :doc, :export_meta, :println],
-      do: "function"
+  def describe_type({:special, name}) do
+    if SpecialBuiltin.callable?(name), do: "function", else: "unknown"
+  end
 
   def describe_type({:juxt_fn, fns}) when is_list(fns), do: "function"
   def describe_type({tag, _}) when tag in [:complement_fn, :constantly_fn], do: "function"

--- a/lib/ptc_runner/lisp/eval/parallel.ex
+++ b/lib/ptc_runner/lisp/eval/parallel.ex
@@ -20,6 +20,7 @@ defmodule PtcRunner.Lisp.Eval.Parallel do
   alias PtcRunner.Lisp.Eval.ParallelRunner
   alias PtcRunner.Lisp.Eval.ParallelRunner.Envelope
   alias PtcRunner.Lisp.Keyword, as: LispKeyword
+  alias PtcRunner.Lisp.Runtime.Args
   alias PtcRunner.Lisp.Runtime.Collection.Normalize
   alias PtcRunner.Lisp.UntrustedRenderer
 
@@ -417,43 +418,17 @@ defmodule PtcRunner.Lisp.Eval.Parallel do
     end
   end
 
-  defp pcalls_thunk(
-         {:closure, [], _body, _closure_env, _turn_history, _metadata} = closure,
-         %EvalContext{} = context,
-         do_eval
-       ) do
-    {:ok, fn -> apply_worker_callable(closure, [], context, do_eval) end}
-  end
+  defp pcalls_thunk(value, %EvalContext{} = context, do_eval) do
+    cond do
+      Args.valid_callable?(value) and Apply.accepts_arity?(value, 0) ->
+        {:ok, fn -> apply_worker_callable(value, [], context, do_eval) end}
 
-  defp pcalls_thunk(
-         {:closure, params, _body, _closure_env, _turn_history, _metadata},
-         %EvalContext{},
-         _do_eval
-       ) do
-    {:error, "pcalls requires zero-arity thunks, got function with arity #{length(params)}"}
-  end
+      Args.valid_callable?(value) ->
+        {:error, "pcalls requires zero-arity thunks, got: #{inspect(value)}"}
 
-  defp pcalls_thunk(fun, %EvalContext{}, _do_eval) when is_function(fun, 0), do: {:ok, fun}
-
-  # `dir` is the one introspection builtin with a zero-argument form. It stays a
-  # binding tuple rather than a BEAM function so both its arities survive, so
-  # the plain-function clauses above do not see it.
-  defp pcalls_thunk({:special, :dir} = callable, %EvalContext{} = context, do_eval) do
-    {:ok, fn -> apply_worker_callable(callable, [], context, do_eval) end}
-  end
-
-  defp pcalls_thunk({:special, op}, %EvalContext{}, _do_eval)
-       when op in [:apropos, :doc, :export_meta] do
-    {:error, "pcalls requires zero-arity thunks, got function with arity 1"}
-  end
-
-  defp pcalls_thunk(fun, %EvalContext{}, _do_eval) when is_function(fun) do
-    {:arity, arity} = Function.info(fun, :arity)
-    {:error, "pcalls requires zero-arity thunks, got function with arity #{arity}"}
-  end
-
-  defp pcalls_thunk(value, %EvalContext{}, _do_eval) do
-    {:error, "pcalls requires callable thunks, got: #{inspect(value)}"}
+      true ->
+        {:error, "pcalls requires callable thunks, got: #{inspect(value)}"}
+    end
   end
 
   defp build_pcalls_thunks(values, %EvalContext{} = context, do_eval) do

--- a/lib/ptc_runner/lisp/eval/parallel_call.ex
+++ b/lib/ptc_runner/lisp/eval/parallel_call.ex
@@ -1,0 +1,36 @@
+defmodule PtcRunner.Lisp.Eval.ParallelCall do
+  @moduledoc """
+  Dispatches indirect `pmap` and `pcalls` calls to the parallel evaluator.
+
+  The adapter accepts already-evaluated arguments. Once a special builtin has
+  been selected, it must not be resolved through the user namespace again:
+  saved and namespace-qualified builtin values remain the builtin even when a
+  same-named user definition exists.
+  """
+
+  alias PtcRunner.Lisp.Eval.Context, as: EvalContext
+  alias PtcRunner.Lisp.Eval.Parallel
+
+  @pmap_arity_message "expected (pmap f coll) or (pmap f c1 c2 ...)"
+
+  @type operation :: :pmap | :pcalls
+  @type do_eval ::
+          (term(), EvalContext.t() ->
+             {:ok, term(), EvalContext.t()} | {:error, term()})
+
+  @spec invoke(operation(), [term()], EvalContext.t(), do_eval()) ::
+          {:ok, term(), EvalContext.t()} | {:error, term()}
+  def invoke(:pmap, [function, collection | collections], %EvalContext{} = context, do_eval)
+      when is_function(do_eval, 2) do
+    Parallel.eval_pmap(function, [collection | collections], context, do_eval)
+  end
+
+  def invoke(:pmap, _arguments, %EvalContext{}, do_eval) when is_function(do_eval, 2) do
+    {:error, {:invalid_arity, :pmap, @pmap_arity_message}}
+  end
+
+  def invoke(:pcalls, functions, %EvalContext{} = context, do_eval)
+      when is_list(functions) and is_function(do_eval, 2) do
+    Parallel.eval_pcalls(functions, context, do_eval)
+  end
+end

--- a/lib/ptc_runner/lisp/runtime/args.ex
+++ b/lib/ptc_runner/lisp/runtime/args.ex
@@ -10,6 +10,7 @@ defmodule PtcRunner.Lisp.Runtime.Args do
   alias PtcRunner.Lisp.Java.Callable, as: JavaCallable
   alias PtcRunner.Lisp.Keyword, as: LispKeyword
   alias PtcRunner.Lisp.RuntimeCallable
+  alias PtcRunner.Lisp.SpecialBuiltin
 
   @spec validate!(Builtin.t() | term(), [term()]) :: :ok
   def validate!(callable, args) do
@@ -49,13 +50,7 @@ defmodule PtcRunner.Lisp.Runtime.Args do
 
   def valid_callable?({:partial_fn, _f, fixed}) when is_list(fixed), do: true
   def valid_callable?({:fnil_fn, _f, _default}), do: true
-  # Only specials with higher-order dispatch: the introspection builtins go
-  # through `Runtime.Callable.call/2` and `println` through its
-  # `Apply.closure_to_fun/3` bridge. `apply` has neither, so classifying it
-  # callable would promise a value position it cannot be used in.
-  def valid_callable?({:special, name})
-      when name in [:dir, :apropos, :doc, :export_meta, :println],
-      do: true
+  def valid_callable?({:special, name}), do: SpecialBuiltin.callable?(name)
 
   def valid_callable?(%LispKeyword{}), do: true
   def valid_callable?(x) when is_atom(x) and x not in [nil, true, false], do: true

--- a/lib/ptc_runner/lisp/runtime/builtins.ex
+++ b/lib/ptc_runner/lisp/runtime/builtins.ex
@@ -17,6 +17,8 @@ defmodule PtcRunner.Lisp.Runtime.Builtins do
     [
       {:apply, {:special, :apply}},
       {:println, {:special, :println}},
+      {:pmap, {:special, :pmap}},
+      {:pcalls, {:special, :pcalls}},
       # Prelude introspection. Special because each needs the attached prelude
       # and the run's visibility filter from the evaluation context.
       {:dir, {:special, :dir}},

--- a/lib/ptc_runner/lisp/runtime/callable.ex
+++ b/lib/ptc_runner/lisp/runtime/callable.ex
@@ -20,6 +20,7 @@ defmodule PtcRunner.Lisp.Runtime.Callable do
   alias PtcRunner.Lisp.Eval.Context, as: EvalContext
   alias PtcRunner.Lisp.Eval.Helpers
   alias PtcRunner.Lisp.Eval.HostContext
+  alias PtcRunner.Lisp.Eval.ParallelCall
   alias PtcRunner.Lisp.Introspection
   alias PtcRunner.Lisp.Java.Callable, as: JavaCallable
   alias PtcRunner.Lisp.Java.Condition, as: JavaCondition
@@ -30,6 +31,10 @@ defmodule PtcRunner.Lisp.Runtime.Callable do
   alias PtcRunner.Lisp.Runtime.Math
   alias PtcRunner.Lisp.Runtime.Predicates
   alias PtcRunner.Lisp.RuntimeCallable
+  alias PtcRunner.Lisp.SpecialBuiltin
+
+  @introspection_specials SpecialBuiltin.names(:introspection)
+  @parallel_specials SpecialBuiltin.names(:parallel)
 
   # Guard: true keywords (atoms that aren't nil, true, or false)
   defguardp is_keyword(k) when is_atom(k) and k != nil and k != true and k != false
@@ -62,10 +67,25 @@ defmodule PtcRunner.Lisp.Runtime.Callable do
   # functions. Dispatching from `args` preserves `dir`'s zero- and one-argument
   # forms, and taking the context from `HostContext` resolves visibility
   # against the caller that is running the value, not whoever converted it.
-  def call({:special, op}, args) when op in [:dir, :apropos, :doc, :export_meta] do
+  def call({:special, op}, args) when op in @introspection_specials do
     case HostContext.current() do
       {%EvalContext{} = context, _do_eval} -> introspect(op, args, context)
       nil -> HostContext.error!({:type_error, "#{op} requires an evaluator context", args})
+    end
+  end
+
+  def call({:special, operation}, args) when operation in @parallel_specials do
+    case HostContext.current() do
+      {%EvalContext{} = context, do_eval} ->
+        HostContext.with_materialized_context(context, do_eval, fn materialized_context ->
+          case ParallelCall.invoke(operation, args, materialized_context, do_eval) do
+            {:ok, result, %EvalContext{}} -> result
+            {:error, reason} -> HostContext.error!(reason)
+          end
+        end)
+
+      nil ->
+        HostContext.error!({:type_error, "#{operation} requires an evaluator context", args})
     end
   end
 

--- a/lib/ptc_runner/lisp/runtime/describe.ex
+++ b/lib/ptc_runner/lisp/runtime/describe.ex
@@ -10,6 +10,7 @@ defmodule PtcRunner.Lisp.Runtime.Describe do
   alias PtcRunner.Lisp.Java.Time.LocalDate, as: JavaLocalDate
   alias PtcRunner.Lisp.Java.Util.Date, as: JavaDate
   alias PtcRunner.Lisp.Keyword, as: LispKeyword
+  alias PtcRunner.Lisp.SpecialBuiltin
 
   @default_depth 1
   @max_depth 5
@@ -571,9 +572,9 @@ defmodule PtcRunner.Lisp.Runtime.Describe do
   defp type_name({:closure, _, _, _, _, _}), do: "function"
   defp type_name({tag, _}) when tag in [:normal, :collect], do: "function"
 
-  defp type_name({:special, name})
-       when name in [:dir, :apropos, :doc, :export_meta, :println],
-       do: "function"
+  defp type_name({:special, name}) do
+    if SpecialBuiltin.callable?(name), do: "function", else: "unknown"
+  end
 
   defp type_name({tag, _, _})
        when tag in [:variadic, :variadic_nonempty, :multi_arity, :special],

--- a/lib/ptc_runner/lisp/runtime/predicates.ex
+++ b/lib/ptc_runner/lisp/runtime/predicates.ex
@@ -55,6 +55,9 @@ defmodule PtcRunner.Lisp.Runtime.Predicates do
   alias PtcRunner.Lisp.Keyword, as: LispKeyword
   alias PtcRunner.Lisp.RuntimeCallable
   alias PtcRunner.Lisp.SourceAtoms
+  alias PtcRunner.Lisp.SpecialBuiltin
+
+  @callable_specials SpecialBuiltin.callable_names()
 
   def fnil(f, default) when is_function(f), do: {:fnil_fn, {:normal, f}, default}
 
@@ -80,7 +83,7 @@ defmodule PtcRunner.Lisp.Runtime.Predicates do
 
   # Context-dispatched builtins are callable, so fnil must accept them too.
   def fnil({:special, name} = callable, default)
-      when name in [:dir, :apropos, :doc, :export_meta, :println] do
+      when name in @callable_specials do
     {:fnil_fn, callable, default}
   end
 
@@ -367,7 +370,7 @@ defmodule PtcRunner.Lisp.Runtime.Predicates do
       {tag, fns} when tag in [:comp_fn, :every_pred_fn, :some_fn] and is_list(fns) -> :function
       {:partial_fn, _f, fixed} when is_list(fixed) -> :function
       {:fnil_fn, _f, _default} -> :function
-      {:special, name} when name in [:dir, :apropos, :doc, :export_meta, :println] -> :function
+      {:special, name} -> if(SpecialBuiltin.callable?(name), do: :function, else: :unknown)
       {tag, _, _} when tag in [:variadic, :variadic_nonempty, :multi_arity, :special] -> :function
       _ -> :unknown
     end

--- a/lib/ptc_runner/lisp/special_builtin.ex
+++ b/lib/ptc_runner/lisp/special_builtin.ex
@@ -1,0 +1,51 @@
+defmodule PtcRunner.Lisp.SpecialBuiltin do
+  @moduledoc """
+  Metadata for context-dispatched builtin values.
+
+  A `{:special, name}` binding needs evaluator context and therefore cannot be
+  represented by an ordinary BEAM function. This catalog keeps value
+  callability, higher-order dispatch, and `pcalls` zero-arity preflight in one
+  place without owning any operation's implementation.
+  """
+
+  @metadata %{
+    apply: %{callable?: false, dispatch: :direct, pcalls_thunk: :unsupported},
+    println: %{callable?: true, dispatch: :println_bridge, pcalls_thunk: :zero},
+    dir: %{callable?: true, dispatch: :introspection, pcalls_thunk: :zero},
+    apropos: %{callable?: true, dispatch: :introspection, pcalls_thunk: {:arity, 1}},
+    doc: %{callable?: true, dispatch: :introspection, pcalls_thunk: {:arity, 1}},
+    export_meta: %{callable?: true, dispatch: :introspection, pcalls_thunk: {:arity, 1}},
+    pmap: %{callable?: true, dispatch: :parallel, pcalls_thunk: {:minimum_arity, 2}},
+    pcalls: %{callable?: true, dispatch: :parallel, pcalls_thunk: :zero}
+  }
+
+  @type dispatch :: :direct | :println_bridge | :introspection | :parallel
+  @type pcalls_thunk ::
+          :zero | :unsupported | {:arity, pos_integer()} | {:minimum_arity, pos_integer()}
+
+  @spec callable?(atom()) :: boolean()
+  def callable?(name) when is_atom(name) do
+    case Map.fetch(@metadata, name) do
+      {:ok, metadata} -> metadata.callable?
+      :error -> false
+    end
+  end
+
+  @spec callable_names() :: [atom()]
+  def callable_names do
+    for {name, %{callable?: true}} <- @metadata, do: name
+  end
+
+  @spec names(dispatch()) :: [atom()]
+  def names(dispatch) do
+    for {name, %{dispatch: ^dispatch}} <- @metadata, do: name
+  end
+
+  @spec pcalls_thunk(atom()) :: pcalls_thunk()
+  def pcalls_thunk(name) when is_atom(name) do
+    case Map.fetch(@metadata, name) do
+      {:ok, metadata} -> metadata.pcalls_thunk
+      :error -> :unsupported
+    end
+  end
+end

--- a/priv/functions.exs
+++ b/priv/functions.exs
@@ -4569,15 +4569,17 @@
     %{
       name: "pcalls",
       description: "Execute thunks in parallel",
-      binding: nil,
+      binding: :special,
       category: :core,
-      dispatch: :analyze,
+      dispatch: :env,
       signatures: ["(pcalls f1 f2 ...)"],
       since: nil,
       section: "Functional Tools",
       ptc_extension?: true,
       examples: [],
-      notes: nil,
+      notes:
+        "Resolves as a callable value and can be passed to apply, higher-order functions, " <>
+          "and function combinators. Direct calls retain the analyzer-optimized CoreAST path.",
       see_also: [],
       clojure_var: "pcalls",
       divergences: nil
@@ -4585,16 +4587,18 @@
     %{
       name: "pmap",
       description: "Apply f to each (zipped) item in parallel",
-      binding: nil,
+      binding: :special,
       category: :core,
-      dispatch: :analyze,
+      dispatch: :env,
       signatures: ["(pmap f coll)", "(pmap f c1 c2 ...)"],
       since: nil,
       section: "Functional Tools",
       ptc_extension?: true,
       examples: [],
       notes:
-        "Shares map's finite seqable contract: nil -> empty, strings map over graphemes, " <>
+        "Resolves as a callable value and can be passed to apply, higher-order functions, " <>
+          "and function combinators. Direct calls retain the analyzer-optimized CoreAST path. " <>
+          "Shares map's finite seqable contract: nil -> empty, strings map over graphemes, " <>
           "and multiple collections zip element-wise truncating to the shortest. Runs under " <>
           "bounded parallel limits (per-worker heap, worker budget, shared deadline).",
       see_also: ["map", "pcalls"],

--- a/test/ptc_runner/lisp/callable_parallel_values_test.exs
+++ b/test/ptc_runner/lisp/callable_parallel_values_test.exs
@@ -1,0 +1,248 @@
+defmodule PtcRunner.Lisp.CallableParallelValuesTest do
+  use ExUnit.Case, async: true
+
+  alias PtcRunner.Kernel
+  alias PtcRunner.Kernel.Component
+  alias PtcRunner.Lisp
+  alias PtcRunner.Lisp.Format
+
+  test "apply invokes pmap and pcalls values" do
+    source = ~S"""
+    [(apply pmap [inc [1 2 3]])
+     (apply pcalls [(fn [] 1) (fn [] 2)])]
+    """
+
+    assert {:ok, step} = Lisp.run(source)
+    assert step.return == [[2, 3, 4], [1, 2]]
+    assert Enum.map(step.pmap_calls, & &1.type) == [:pmap, :pcalls]
+  end
+
+  test "parallel values compose through identity, let, partial, and collection HOFs" do
+    source = ~S"""
+    [((identity pmap) inc [1 2])
+     ((partial pmap inc) [3 4])
+     (let [parallel-map pmap] (parallel-map dec [3 4]))
+     (map pmap [inc dec] [[1 2] [3 4]])
+     (map #(apply pmap %) [[inc [1 2]] [dec [3 4]]])]
+    """
+
+    assert {:ok, step} = Lisp.run(source)
+
+    assert step.return == [
+             [2, 3],
+             [4, 5],
+             [2, 3],
+             [[2, 3], [2, 3]],
+             [[2, 3], [2, 3]]
+           ]
+  end
+
+  test "parallel values are functions and fnil accepts them" do
+    source = ~S"""
+    [(fn? pmap)
+     (ifn? pmap)
+     (fn? pcalls)
+     (ifn? pcalls)
+     ((fnil pmap inc) nil [1 2])
+     ((fnil pcalls (fn [] 7)) nil)]
+    """
+
+    assert {:ok, step} = Lisp.run(source)
+    assert step.return == [true, true, true, true, [2, 3], [7]]
+  end
+
+  test "saved parallel callables use a later evaluation context" do
+    assert {:ok, first} =
+             Lisp.run(~S|(do (def parallel-map (partial pmap inc)) (def parallel-calls pcalls))|)
+
+    assert {:partial_fn, {:special, :pmap}, [_increment]} = first.memory["parallel-map"]
+    assert {:special, :pcalls} = first.memory["parallel-calls"]
+
+    source = ~S"""
+    [(parallel-map [1 2])
+     (apply parallel-calls [(fn [] 3) (fn [] 4)])]
+    """
+
+    assert {:ok, second} = Lisp.run(source, memory: first.memory, pmap_max_concurrency: 1)
+    assert second.return == [[2, 3], [3, 4]]
+  end
+
+  test "host-backed collection HOF invocation retains parallel effects exactly once" do
+    tools = %{"touch" => fn arguments -> arguments["x"] end}
+
+    source = ~S"""
+    (first
+      (map pmap
+        [(fn [x] (do (println x) (tool/touch {"x" x})))]
+        [[1 2]]))
+    """
+
+    assert {:ok, step} = Lisp.run(source, tools: tools, pmap_max_concurrency: 1)
+    assert step.return == [1, 2]
+    assert step.prints == ["1", "2"]
+    assert Enum.map(step.tool_calls, & &1.args["x"]) == [1, 2]
+    assert [%{type: :pmap, count: 2, success_count: 2, error_count: 0}] = step.pmap_calls
+  end
+
+  test "host-backed collection HOFs can invoke pcalls values" do
+    source = ~S|(map pcalls [(fn [] 1) (fn [] 2)])|
+
+    assert {:ok, step} = Lisp.run(source, pmap_max_concurrency: 1)
+    assert step.return == [[1], [2]]
+    assert Enum.map(step.pmap_calls, &{&1.type, &1.count}) == [{:pcalls, 1}, {:pcalls, 1}]
+  end
+
+  test "parallel values render and describe as functions without leaking their tuples" do
+    assert {:ok, step} = Lisp.run(~S|[(describe pmap) (describe pcalls) pmap pcalls]|)
+
+    assert [
+             %{type: "function", sample: "#<builtin>"},
+             %{type: "function", sample: "#<builtin>"},
+             %Format.Builtin{} = pmap,
+             %Format.Builtin{} = pcalls
+           ] = step.return
+
+    assert inspect(pmap) == "#<builtin>"
+    assert inspect(pcalls) == "#<builtin>"
+  end
+
+  test "dynamic pmap arity matches the direct analysis error" do
+    assert {:error, step} = Lisp.run(~S|(apply pmap [inc])|)
+    assert step.fail.reason == :invalid_arity
+    assert step.fail.message =~ "expected (pmap f coll)"
+    assert step.pmap_calls == []
+  end
+
+  test "pcalls accepts pcalls and rejects pmap during zero-arity preflight" do
+    assert {:ok, accepted} = Lisp.run(~S|(pcalls pcalls)|)
+    assert accepted.return == [[]]
+    assert Enum.map(accepted.pmap_calls, &{&1.type, &1.count}) == [{:pcalls, 0}, {:pcalls, 1}]
+
+    assert {:error, rejected} = Lisp.run(~S|(pcalls pmap)|)
+    assert rejected.fail.reason == :pcalls_error
+    assert rejected.fail.message =~ "zero-arity"
+    assert rejected.pmap_calls == []
+  end
+
+  test "pcalls accepts tagged callables that can be invoked with zero arguments" do
+    source =
+      ~S|(pcalls (partial pmap inc [1 2]) (partial pcalls) (partial (fn [& xs] :variadic)) (partial :x {:x 4}))|
+
+    assert {:ok, step} = Lisp.run(source)
+    assert step.return == [[2, 3], [], "variadic", 4]
+  end
+
+  test "pcalls accepts a partial runtime callable as a zero-arity thunk" do
+    source = ~S|(pcalls (partial tool/echo {:x 5}))|
+    tools = %{"echo" => fn arguments -> arguments["x"] end}
+
+    assert {:ok, step} = Lisp.run(source, tools: tools)
+    assert step.return == [5]
+    assert Enum.map(step.tool_calls, & &1.name) == ["echo"]
+  end
+
+  test "pcalls accepts zero-arity println and captures its empty print" do
+    assert {:ok, step} = Lisp.run(~S|(pcalls println)|)
+    assert step.return == [nil]
+    assert step.prints == [""]
+  end
+
+  test "local bindings continue to shadow both parallel builtins" do
+    source = ~S"""
+    (let [pmap (fn [x] [:mapped x])
+          pcalls (fn [x] [:called x])]
+      [(pmap 3) (pcalls 4)])
+    """
+
+    assert {:ok, step} = Lisp.run(source)
+    assert step.return == [["mapped", 3], ["called", 4]]
+    assert step.pmap_calls == []
+  end
+
+  test "def bindings shadow direct and indirect parallel calls in the same turn" do
+    source = ~S"""
+    (do
+      (def pmap (fn [f xs] [:mapped (f (first xs))]))
+      (def pcalls (fn [f] [:called (f)]))
+      [(pmap inc [1 2])
+       (apply pmap [inc [2 3]])
+       (pcalls (fn [] 4))
+       (apply pcalls [(fn [] 5)])])
+    """
+
+    assert {:ok, step} = Lisp.run(source)
+    assert step.return == [["mapped", 2], ["mapped", 3], ["called", 4], ["called", 5]]
+    assert step.pmap_calls == []
+  end
+
+  test "persisted def bindings shadow direct parallel calls in later evaluations" do
+    assert {:ok, first} =
+             Lisp.run(~S|(do (def pmap (fn [_ _] :mapped)) (def pcalls (fn [_] :called)))|)
+
+    assert {:ok, second} =
+             Lisp.run(~S|[(pmap inc [1]) (pcalls (fn [] 1))]|, memory: first.memory)
+
+    assert second.return == ["mapped", "called"]
+    assert second.pmap_calls == []
+  end
+
+  test "a differently shaped global pmap binding is resolved before builtin arity" do
+    source = ~S|(do (def pmap (fn [x] [:shadowed x])) (pmap 3))|
+
+    assert {:ok, step} = Lisp.run(source)
+    assert step.return == ["shadowed", 3]
+    assert step.pmap_calls == []
+  end
+
+  test "same-name aliases of qualified parallel values invoke the selected builtins" do
+    source = ~S"""
+    (do
+      (def pmap clojure.core/pmap)
+      (def pcalls clojure.core/pcalls)
+      [(pmap inc [1 2]) (pcalls (fn [] 3))])
+    """
+
+    assert {:ok, step} = Lisp.run(source)
+    assert step.return == [[2, 3], [3]]
+    assert Enum.map(step.pmap_calls, & &1.type) == [:pmap, :pcalls]
+  end
+
+  test "qualified parallel calls bypass same-named global definitions" do
+    source = ~S"""
+    (do
+      (def pmap (fn [_ _] [:shadowed-map]))
+      (def pcalls (fn [_] [:shadowed-calls]))
+      [(clojure.core/pmap inc [1 2])
+       (clojure.core/pcalls (fn [] 3))])
+    """
+
+    assert {:ok, step} = Lisp.run(source)
+    assert step.return == [[2, 3], [3]]
+    assert Enum.map(step.pmap_calls, & &1.type) == [:pmap, :pcalls]
+  end
+
+  test "qualified parallel values bypass same-named local bindings" do
+    source = ~S"""
+    (let [pmap (fn [_ _] [:shadowed-map])
+          pcalls (fn [_] [:shadowed-calls])]
+      [(apply clojure.core/pmap [inc [1 2]])
+       (apply clojure.core/pcalls [(fn [] 3)])])
+    """
+
+    assert {:ok, step} = Lisp.run(source)
+    assert step.return == [[2, 3], [3]]
+    assert Enum.map(step.pmap_calls, & &1.type) == [:pmap, :pcalls]
+  end
+
+  test "component compilation accepts parallel functions in value position" do
+    source = ~S"""
+    (ns parallel.values)
+    (def parallel-map pmap)
+    (def parallel-calls pcalls)
+    (defn map-later [f xs] (apply parallel-map [f xs]))
+    """
+
+    assert {:ok, component} = Component.new(id: "parallel.values", source: source)
+    assert {:ok, _bundle} = Kernel.compile_bundle([component])
+  end
+end

--- a/test/ptc_runner/lisp/integration/parallel_limits_test.exs
+++ b/test/ptc_runner/lisp/integration/parallel_limits_test.exs
@@ -131,6 +131,27 @@ defmodule PtcRunner.Lisp.Integration.ParallelLimitsTest do
     assert step.fail.reason == :parallel_capacity_exceeded
   end
 
+  test "an indirect saved pmap shares the global worker budget" do
+    program = ~S"""
+    (let [parallel-map pmap]
+      (parallel-map
+        (fn [_] (parallel-map inc [1 2]))
+        [0]))
+    """
+
+    assert {:error, step} =
+             Lisp.run(program,
+               max_heap: 200_000,
+               worker_max_heap: 200_000,
+               max_parallel_workers: 1,
+               pmap_max_concurrency: 1,
+               timeout: @timeout
+             )
+
+    assert step.fail.reason == :parallel_capacity_exceeded
+    assert Enum.map(step.pmap_calls, &{&1.type, &1.count}) == [{:pmap, 2}, {:pmap, 1}]
+  end
+
   test "max_parallel_workers of one still permits a single non-nested pmap" do
     assert {:ok, step} =
              Lisp.run("(pmap inc [1 2 3])",
@@ -231,6 +252,21 @@ defmodule PtcRunner.Lisp.Integration.ParallelLimitsTest do
              step.fail.message,
              "the run deadline expired during a parallel operation"
            )
+  end
+
+  test "an apply-invoked pcalls retains the run deadline cap" do
+    tools = %{"park" => fn _ -> receive do: (:never -> :ok), after: (2_000 -> :ok) end}
+
+    assert {:error, step} =
+             Lisp.run("(apply pcalls [(fn [] (tool/park {}))])",
+               tools: tools,
+               timeout: @timeout,
+               pmap_timeout: 60_000,
+               parallel_deadline_cap: System.monotonic_time(:millisecond) + 200
+             )
+
+    assert step.fail.reason == :timeout
+    assert step.fail.message =~ "run deadline expired during a parallel operation"
   end
 
   # The cap must survive both EvalContext reconstructions in Apply: the

--- a/test/ptc_runner/lisp/pmap_test.exs
+++ b/test/ptc_runner/lisp/pmap_test.exs
@@ -27,10 +27,10 @@ defmodule PtcRunner.Lisp.PmapTest do
                Analyze.analyze(raw)
     end
 
-    test "pmap requires at least one collection" do
+    test "pmap with no collection defers arity validation to runtime resolution" do
       raw = {:list, [{:symbol, :pmap}, {:symbol, :inc}]}
-      assert {:error, {:invalid_arity, :pmap, msg}} = Analyze.analyze(raw)
-      assert msg =~ "expected (pmap f coll)"
+
+      assert {:ok, {:call, {:var, :pmap}, [{:var, :inc}]}} = Analyze.analyze(raw)
     end
 
     test "pmap accepts multiple collections" do
@@ -40,8 +40,15 @@ defmodule PtcRunner.Lisp.PmapTest do
                Analyze.analyze(raw)
     end
 
-    test "pmap with no arguments fails" do
+    test "pmap with no arguments defers arity validation to runtime resolution" do
       raw = {:list, [{:symbol, :pmap}]}
+
+      assert {:ok, {:call, {:var, :pmap}, []}} = Analyze.analyze(raw)
+    end
+
+    test "qualified pmap retains strict builtin arity validation" do
+      raw = {:list, [{:ns_symbol, :"clojure.core", :pmap}, {:symbol, :inc}]}
+
       assert {:error, {:invalid_arity, :pmap, msg}} = Analyze.analyze(raw)
       assert msg =~ "expected (pmap f coll)"
     end

--- a/test/ptc_runner/lisp/registry_test.exs
+++ b/test/ptc_runner/lisp/registry_test.exs
@@ -85,6 +85,19 @@ defmodule PtcRunner.Lisp.RegistryTest do
       end
     end
 
+    test "pmap and pcalls are analyzer-optimized env callables" do
+      supported_forms = MapSet.new(Analyze.supported_forms())
+
+      for name <- [:pmap, :pcalls] do
+        entry = Registry.doc(Atom.to_string(name))
+
+        assert entry.dispatch == :env
+        assert entry.binding == :special
+        assert Map.fetch!(Env.initial(), name) == {:special, name}
+        assert MapSet.member?(supported_forms, name)
+      end
+    end
+
     test "every entry has required fields" do
       for entry <- Registry.implemented() do
         assert is_binary(entry.name), "Entry missing name"


### PR DESCRIPTION
## Summary

- expose `pmap` and `pcalls` as first-class callable values while retaining analyzer-optimized direct calls
- route indirect, qualified, and higher-order calls through evaluator-owned parallel semantics, including limits, deadlines, effects, and shadowing
- centralize special-callable metadata and callable arity/preflight handling
- update the language docs and generated function registry, with regression and integration coverage

## Code impact

- 21 files changed
- 660 insertions, 85 deletions
- new special-builtin metadata and parallel-call dispatch modules
- analyzer, evaluator, runtime environment, documentation, and tests updated

## Verification

- focused callable/parallel suites: 97 tests passed
- `MIX_ENV=dev mix docs --warnings-as-errors`
- `mix precommit`: 6,221 root tests, 44 Viewer tests, 40 launcher tests; Credo, duplication, specification, generated artifacts, package, and standalone release checks passed
- full pre-push gate passed
- five independent Codex review invocations; final follow-up reported no remaining actionable findings

Closes #1359