### PR TITLE
feat(analysis): link workflow and mission evaluations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added canonical parent-evaluation edges for workflow-launched mission
+  evaluations. Private generated-source and turn projections preserve the edge,
+  and `activity`, `generated_sources`, and `turns` accept exact
+  `parent_evaluation_id` filters so debuggers can navigate from a workflow error
+  to its child programs without comparing unrelated snapshot sequences.
+
 - Replaced the split log/inspection analysis vocabularies with the three-operation
   `analysis/runs`, `analysis/open`, and `analysis/read` navigation API shared by
   PTC-Lisp, the Viewer, Elixir embedders, and the one-shot `ptc transcript`

--- a/docs/guides/kernel-repl.md
+++ b/docs/guides/kernel-repl.md
@@ -165,6 +165,23 @@ adding smart diagnosis APIs:
 (analysis/read run-id {"collection" "execution_errors"})
 ```
 
+An execution error carries the workflow `evaluation_id`. Follow its exact
+children without comparing collection-local sequence numbers:
+
+```clojure
+(def error (first (get (analysis/read run-id {"collection" "execution_errors"})
+                       "items")))
+(def workflow-evaluation-id (get error "evaluation_id"))
+(analysis/read run-id {"collection" "generated_sources"
+                       "parent_evaluation_id" workflow-evaluation-id})
+(analysis/read run-id {"collection" "turns"
+                       "parent_evaluation_id" workflow-evaluation-id})
+```
+
+`parent_evaluation_id` proves that the workflow evaluation launched the
+subordinate evaluation. It does not claim that every child caused the eventual
+workflow error.
+
 Results may include exact model messages, generated programs, effective
 component source, capability payloads, prints, failure details, and terminal
 values. `turns` reconstructs cumulative model requests once when the immutable

--- a/docs/trace-log-contract.md
+++ b/docs/trace-log-contract.md
@@ -548,6 +548,12 @@ workflow evaluation ID can select its child programs and turns without
 comparing canonical and inspection sequence numbers. The edge proves nesting,
 not that a particular child caused the workflow error.
 
+Canonical loading validates the edge before exposing it: the parent must be a
+preceding, still-open workflow evaluation in the same run, only a mission
+evaluation may name it, and a matching child stop must repeat the same parent.
+Orphaned, cyclic, wrong-environment, or contradictory edges make the source
+malformed rather than becoming navigation evidence.
+
 Optional sensitive development capture uses a separate private inspection
 record stream, not a canonical event. Every `.inspection.jsonl` line is one
 JSON object with this exact envelope:

--- a/docs/trace-log-contract.md
+++ b/docs/trace-log-contract.md
@@ -528,6 +528,9 @@ file/directory sources and Viewer discovery reject or omit that suffix.
 
 Sanitized subordinate `evaluation-started` data adds:
 
+- `parent_evaluation_id` — the enclosing workflow evaluation ID when the
+  subordinate evaluation was launched through the workflow's `kernel-eval`
+  route; the matching `evaluation-stopped` event repeats this ID;
 - `source_hash` — lower-case SHA-256 hex over the exact UTF-8 source bytes passed
   to `Lisp.run_native/2`;
 - `source_bytes` — `byte_size(source)` over those same bytes; and
@@ -537,6 +540,13 @@ Sanitized subordinate `evaluation-started` data adds:
 It must not contain exact source. The `activity` collection returns canonical event
 data, so embedding source in a supposedly private event would collapse source
 authorization into the ordinary activity query.
+
+Private `generated_sources` copy `parent_evaluation_id` only from that
+canonical start event, and reconstructed `turns` can be filtered by either the
+child `evaluation_id` or its `parent_evaluation_id`. Thus an execution error's
+workflow evaluation ID can select its child programs and turns without
+comparing canonical and inspection sequence numbers. The edge proves nesting,
+not that a particular child caused the workflow error.
 
 Optional sensitive development capture uses a separate private inspection
 record stream, not a canonical event. Every `.inspection.jsonl` line is one

--- a/lib/ptc_runner/kernel/evaluation.ex
+++ b/lib/ptc_runner/kernel/evaluation.ex
@@ -72,6 +72,11 @@ defmodule PtcRunner.Kernel.Evaluation do
       |> Keyword.get(:admission, :fail_fast)
       |> validate_admission!()
 
+    parent_evaluation_id =
+      opts
+      |> Keyword.get(:parent_evaluation_id)
+      |> validate_parent_evaluation_id!()
+
     result =
       evaluate_detailed(
         state,
@@ -84,7 +89,8 @@ defmodule PtcRunner.Kernel.Evaluation do
           started_ms,
           Keyword.get(opts, :after_started_hook),
           projection_boundary,
-          Keyword.fetch(opts, :params)
+          Keyword.fetch(opts, :params),
+          parent_evaluation_id
         },
         mission_name
       )
@@ -175,7 +181,14 @@ defmodule PtcRunner.Kernel.Evaluation do
          timeout_ms,
          {memory, history, lease},
          capture,
-         {evaluation_id, started_ms, after_started_hook, projection_boundary, params},
+         {
+           evaluation_id,
+           started_ms,
+           after_started_hook,
+           projection_boundary,
+           params,
+           parent_evaluation_id
+         },
          mission_name
        ) do
     limits = RunState.limits(state)
@@ -188,14 +201,22 @@ defmodule PtcRunner.Kernel.Evaluation do
     source_bytes = byte_size(source)
 
     with :ok <-
-           Events.emit(state, capture.event_sink, "evaluation-started", %{
-             evaluation_id: evaluation_id,
-             environment: :mission,
-             mission_name: mission_name,
-             program_kind: :"ptc-lisp",
-             source_hash: source_hash,
-             source_bytes: source_bytes
-           }),
+           Events.emit(
+             state,
+             capture.event_sink,
+             "evaluation-started",
+             put_parent_evaluation_id(
+               %{
+                 evaluation_id: evaluation_id,
+                 environment: :mission,
+                 mission_name: mission_name,
+                 program_kind: :"ptc-lisp",
+                 source_hash: source_hash,
+                 source_bytes: source_bytes
+               },
+               parent_evaluation_id
+             )
+           ),
          :ok <-
            inspection_source(
              capture.inspection_sink,
@@ -222,14 +243,22 @@ defmodule PtcRunner.Kernel.Evaluation do
       duration_ms = Events.duration_ms(started_ms)
 
       _ =
-        Events.emit(state, capture.event_sink, "evaluation-stopped", %{
-          evaluation_id: evaluation_id,
-          environment: :mission,
-          mission_name: mission_name,
-          status: result.outcome,
-          continuation: RunState.evaluation_memory_summary(state),
-          duration_ms: duration_ms
-        })
+        Events.emit(
+          state,
+          capture.event_sink,
+          "evaluation-stopped",
+          put_parent_evaluation_id(
+            %{
+              evaluation_id: evaluation_id,
+              environment: :mission,
+              mission_name: mission_name,
+              status: result.outcome,
+              continuation: RunState.evaluation_memory_summary(state),
+              duration_ms: duration_ms
+            },
+            parent_evaluation_id
+          )
+        )
 
       Map.put(result, :duration_ms, duration_ms)
     else
@@ -277,6 +306,26 @@ defmodule PtcRunner.Kernel.Evaluation do
     raise ArgumentError,
           "invalid admission mode #{inspect(admission)}; expected :fail_fast or :block"
   end
+
+  defp validate_parent_evaluation_id!(nil), do: nil
+
+  defp validate_parent_evaluation_id!(parent_evaluation_id)
+       when is_binary(parent_evaluation_id) and byte_size(parent_evaluation_id) in 1..256 do
+    if String.valid?(parent_evaluation_id) do
+      parent_evaluation_id
+    else
+      raise ArgumentError, "invalid parent evaluation ID"
+    end
+  end
+
+  defp validate_parent_evaluation_id!(_parent_evaluation_id) do
+    raise ArgumentError, "invalid parent evaluation ID"
+  end
+
+  defp put_parent_evaluation_id(data, nil), do: data
+
+  defp put_parent_evaluation_id(data, parent_evaluation_id),
+    do: Map.put(data, :parent_evaluation_id, parent_evaluation_id)
 
   defp execute_with_lease(
          state,

--- a/lib/ptc_runner/kernel/inspection_query.ex
+++ b/lib/ptc_runner/kernel/inspection_query.ex
@@ -29,6 +29,9 @@ defmodule PtcRunner.Kernel.InspectionQuery do
   repeated component and capability names remain unambiguous.
   V6 adds one singular, non-paginated terminal `result` projection per run and
   joins static prelude-call analysis to generated source by `evaluation_id`.
+  Generated source and reconstructed turns copy the canonical
+  `parent_evaluation_id` edge rather than inferring one from snapshot-local
+  sequence numbers.
   """
 
   alias PtcRunner.Kernel.ConversationProjection
@@ -364,11 +367,16 @@ defmodule PtcRunner.Kernel.InspectionQuery do
 
   defp merge_artifacts(compiled, %{"runs" => trace_facts} = trace_analysis)
        when is_map(trace_facts) do
+    generated_sources =
+      compiled
+      |> merge_collection(:generated_sources)
+      |> Enum.map(&attach_parent_evaluation_id(&1, trace_facts))
+
     collections = %{
       list_runs: compiled |> Enum.map(& &1.run) |> Enum.sort_by(& &1["run_id"]),
       model_exchanges: merge_collection(compiled, :model_exchanges),
       capability_calls: merge_collection(compiled, :capability_calls),
-      generated_sources: merge_collection(compiled, :generated_sources),
+      generated_sources: generated_sources,
       effective_preludes: merge_collection(compiled, :effective_preludes),
       provider_exchanges: merge_collection(compiled, :provider_exchanges),
       execution_prints: merge_collection(compiled, :execution_prints),
@@ -405,6 +413,15 @@ defmodule PtcRunner.Kernel.InspectionQuery do
   end
 
   defp merge_artifacts(_compiled, _trace_analysis), do: {:error, :invalid_inspection_snapshot}
+
+  defp attach_parent_evaluation_id(source, trace_facts) do
+    parent_evaluation_id =
+      get_in(trace_facts, [source["run_id"], "parent_evaluation_ids", source["evaluation_id"]])
+
+    if is_binary(parent_evaluation_id),
+      do: Map.put(source, "parent_evaluation_id", parent_evaluation_id),
+      else: source
+  end
 
   defp merge_collection(compiled, operation) do
     compiled
@@ -452,7 +469,8 @@ defmodule PtcRunner.Kernel.InspectionQuery do
     do: {:error, :invalid_query}
 
   defp execute(collections, source_id, :turns, %{"run_id" => run_id} = arguments, max_bytes) do
-    allowed = ~w(run_id limit cursor stream_id capability_id prelude_call prelude_component)
+    allowed =
+      ~w(run_id limit cursor stream_id capability_id evaluation_id parent_evaluation_id prelude_call prelude_component)
 
     with :ok <- validate_keys(arguments, allowed),
          true <- valid_string?(run_id),
@@ -548,7 +566,7 @@ defmodule PtcRunner.Kernel.InspectionQuery do
   defp collection_filters(:provider_exchanges), do: ~w(capability_id mission_name request_id)
 
   defp collection_filters(:generated_sources),
-    do: ~w(evaluation_id mission_name prelude_call prelude_component)
+    do: ~w(evaluation_id parent_evaluation_id mission_name prelude_call prelude_component)
 
   defp collection_filters(:effective_preludes),
     do: ~w(component_id environment mission_name)
@@ -572,12 +590,19 @@ defmodule PtcRunner.Kernel.InspectionQuery do
   defp collection_match?(:turns, item, arguments) do
     equal_filter?(item, arguments, "stream_id") and
       equal_filter?(item, arguments, "capability_id") and
+      generated_equal_match?(item, arguments["evaluation_id"], "evaluation_id") and
+      generated_equal_match?(
+        item,
+        arguments["parent_evaluation_id"],
+        "parent_evaluation_id"
+      ) and
       generated_call_match?(item, arguments["prelude_call"], "ref") and
       generated_call_match?(item, arguments["prelude_component"], "component_id")
   end
 
   defp collection_match?(:generated_sources, item, arguments) do
     equal_filter?(item, arguments, "evaluation_id") and
+      equal_filter?(item, arguments, "parent_evaluation_id") and
       equal_filter?(item, arguments, "mission_name") and
       call_match?(item, arguments["prelude_call"], "ref") and
       call_match?(item, arguments["prelude_component"], "component_id")
@@ -595,6 +620,14 @@ defmodule PtcRunner.Kernel.InspectionQuery do
     item
     |> Map.get("generated", [])
     |> Enum.any?(&call_match?(&1, expected, key))
+  end
+
+  defp generated_equal_match?(_item, nil, _key), do: true
+
+  defp generated_equal_match?(item, expected, key) do
+    item
+    |> Map.get("generated", [])
+    |> Enum.any?(&(&1[key] == expected))
   end
 
   defp call_match?(_item, nil, _key), do: true

--- a/lib/ptc_runner/kernel/inspection_query.ex
+++ b/lib/ptc_runner/kernel/inspection_query.ex
@@ -590,14 +590,7 @@ defmodule PtcRunner.Kernel.InspectionQuery do
   defp collection_match?(:turns, item, arguments) do
     equal_filter?(item, arguments, "stream_id") and
       equal_filter?(item, arguments, "capability_id") and
-      generated_equal_match?(item, arguments["evaluation_id"], "evaluation_id") and
-      generated_equal_match?(
-        item,
-        arguments["parent_evaluation_id"],
-        "parent_evaluation_id"
-      ) and
-      generated_call_match?(item, arguments["prelude_call"], "ref") and
-      generated_call_match?(item, arguments["prelude_component"], "component_id")
+      generated_source_match?(item, arguments)
   end
 
   defp collection_match?(:generated_sources, item, arguments) do
@@ -614,20 +607,21 @@ defmodule PtcRunner.Kernel.InspectionQuery do
     |> Enum.all?(fn {key, value} -> is_nil(value) or item[key] == value end)
   end
 
-  defp generated_call_match?(_item, nil, _key), do: true
+  defp generated_source_match?(item, arguments) do
+    filters = ~w(evaluation_id parent_evaluation_id prelude_call prelude_component)
 
-  defp generated_call_match?(item, expected, key) do
-    item
-    |> Map.get("generated", [])
-    |> Enum.any?(&call_match?(&1, expected, key))
-  end
-
-  defp generated_equal_match?(_item, nil, _key), do: true
-
-  defp generated_equal_match?(item, expected, key) do
-    item
-    |> Map.get("generated", [])
-    |> Enum.any?(&(&1[key] == expected))
+    if Enum.all?(filters, &is_nil(arguments[&1])) do
+      true
+    else
+      item
+      |> Map.get("generated", [])
+      |> Enum.any?(fn source ->
+        equal_filter?(source, arguments, "evaluation_id") and
+          equal_filter?(source, arguments, "parent_evaluation_id") and
+          call_match?(source, arguments["prelude_call"], "ref") and
+          call_match?(source, arguments["prelude_component"], "component_id")
+      end)
+    end
   end
 
   defp call_match?(_item, nil, _key), do: true

--- a/lib/ptc_runner/kernel/run_analysis.ex
+++ b/lib/ptc_runner/kernel/run_analysis.ex
@@ -30,7 +30,7 @@ defmodule PtcRunner.Kernel.RunAnalysis do
       authority: :public,
       snapshot: :traces,
       operation: :list_turns,
-      filters: ~w(status evaluation_id capability mission_name),
+      filters: ~w(status evaluation_id parent_evaluation_id capability mission_name),
       order: "sequence_asc"
     },
     %{
@@ -38,7 +38,8 @@ defmodule PtcRunner.Kernel.RunAnalysis do
       authority: :private,
       snapshot: :inspection,
       operation: :turns,
-      filters: ~w(stream_id capability_id prelude_call prelude_component),
+      filters:
+        ~w(stream_id capability_id evaluation_id parent_evaluation_id prelude_call prelude_component),
       order: "stream_turn_asc"
     },
     %{
@@ -72,7 +73,7 @@ defmodule PtcRunner.Kernel.RunAnalysis do
       authority: :private,
       snapshot: :inspection,
       operation: :generated_sources,
-      filters: ~w(evaluation_id mission_name prelude_call prelude_component),
+      filters: ~w(evaluation_id parent_evaluation_id mission_name prelude_call prelude_component),
       order: "sequence_asc"
     },
     %{

--- a/lib/ptc_runner/kernel/runner.ex
+++ b/lib/ptc_runner/kernel/runner.ex
@@ -200,7 +200,7 @@ defmodule PtcRunner.Kernel.Runner do
   defp execute_workflow(entry_source, config, state, timeout_ms, deadline_ms, evaluation_id) do
     opts = [
       context: config.input,
-      tools: workflow_tools(config, state, deadline_ms),
+      tools: workflow_tools(config, state, deadline_ms, evaluation_id),
       prelude: bundle_prelude(config.workflow_environment),
       timeout: timeout_ms,
       compile_timeout: timeout_ms,
@@ -430,7 +430,7 @@ defmodule PtcRunner.Kernel.Runner do
         {name, Map.fetch!(mission.inventory, field)}
       end)
 
-  defp workflow_tools(config, state, validation_deadline_ms) do
+  defp workflow_tools(config, state, validation_deadline_ms, evaluation_id) do
     state
     |> ToolGrant.capability_callbacks(
       :workflow,
@@ -458,7 +458,8 @@ defmodule PtcRunner.Kernel.Runner do
           config.limits,
           config.event_sink,
           config.inspection_sink,
-          admission: :block
+          admission: :block,
+          parent_evaluation_id: evaluation_id
         )
       )
     )

--- a/lib/ptc_runner/kernel/runtime_tools.ex
+++ b/lib/ptc_runner/kernel/runtime_tools.ex
@@ -116,7 +116,8 @@ defmodule PtcRunner.Kernel.RuntimeTools do
   @doc """
   Builds the workflow-only subordinate-evaluation callback.
 
-  `opts` accepts `admission: :block | :fail_fast` (default `:fail_fast`).
+  `opts` accepts `admission: :block | :fail_fast` (default `:fail_fast`) and an
+  optional `parent_evaluation_id` for the enclosing workflow evaluation.
   The Runner's workflow route blocks, so concurrent agent loops queue behind
   the single evaluation lease instead of failing. The REPL keeps fail-fast:
   a REPL expression evaluates under the session's own lease, so a blocking
@@ -124,7 +125,10 @@ defmodule PtcRunner.Kernel.RuntimeTools do
   """
   def kernel_eval(state, missions, limits, event_sink, inspection_sink \\ nil, opts \\ [])
       when is_map(missions) and not is_struct(missions) do
-    admission = Keyword.get(opts, :admission, :fail_fast)
+    evaluation_opts = [
+      admission: Keyword.get(opts, :admission, :fail_fast),
+      parent_evaluation_id: Keyword.get(opts, :parent_evaluation_id)
+    ]
 
     fn arguments ->
       case take_mission(arguments, missions) do
@@ -136,7 +140,7 @@ defmodule PtcRunner.Kernel.RuntimeTools do
             limits,
             event_sink,
             inspection_sink,
-            admission
+            evaluation_opts
           )
 
         :error ->
@@ -202,13 +206,21 @@ defmodule PtcRunner.Kernel.RuntimeTools do
          limits,
          event_sink,
          inspection_sink,
-         admission
+         evaluation_opts
        ) do
     case arguments do
       %{"kind" => kind, "source" => source} = arguments
       when is_binary(source) and map_size(arguments) == 2 ->
         if keyword_name(kind) == "source" do
-          evaluate_source(state, target, source, limits, event_sink, inspection_sink, admission)
+          evaluate_source(
+            state,
+            target,
+            source,
+            limits,
+            event_sink,
+            inspection_sink,
+            evaluation_opts
+          )
         else
           invalid_kernel_eval_request(state)
         end
@@ -224,7 +236,7 @@ defmodule PtcRunner.Kernel.RuntimeTools do
             limits,
             event_sink,
             inspection_sink,
-            admission
+            evaluation_opts
           )
         else
           invalid_kernel_eval_request(state)
@@ -233,7 +245,15 @@ defmodule PtcRunner.Kernel.RuntimeTools do
       %{"kind" => kind, "program" => %Program{source: source}} = arguments
       when map_size(arguments) == 2 ->
         if keyword_name(kind) == "embedded" do
-          evaluate_source(state, target, source, limits, event_sink, inspection_sink, admission)
+          evaluate_source(
+            state,
+            target,
+            source,
+            limits,
+            event_sink,
+            inspection_sink,
+            evaluation_opts
+          )
         else
           invalid_kernel_eval_request(state)
         end
@@ -249,7 +269,7 @@ defmodule PtcRunner.Kernel.RuntimeTools do
             limits,
             event_sink,
             inspection_sink,
-            admission
+            evaluation_opts
           )
         else
           invalid_kernel_eval_request(state)
@@ -361,7 +381,7 @@ defmodule PtcRunner.Kernel.RuntimeTools do
          limits,
          event_sink,
          inspection_sink,
-         admission
+         evaluation_opts
        ) do
     %{
       status: :ok,
@@ -374,7 +394,7 @@ defmodule PtcRunner.Kernel.RuntimeTools do
           limits.evaluation_timeout_ms,
           event_sink,
           inspection_sink,
-          admission: admission
+          evaluation_opts
         )
     }
   end
@@ -387,7 +407,7 @@ defmodule PtcRunner.Kernel.RuntimeTools do
          limits,
          event_sink,
          inspection_sink,
-         admission
+         evaluation_opts
        ) do
     case normalize_params(params, limits.capability_argument_bytes) do
       {:ok, params} ->
@@ -402,8 +422,7 @@ defmodule PtcRunner.Kernel.RuntimeTools do
               limits.evaluation_timeout_ms,
               event_sink,
               inspection_sink,
-              params: params,
-              admission: admission
+              Keyword.put(evaluation_opts, :params, params)
             )
         }
 

--- a/lib/ptc_runner/kernel/trace_log.ex
+++ b/lib/ptc_runner/kernel/trace_log.ex
@@ -2175,7 +2175,8 @@ defmodule PtcRunner.Kernel.TraceLog do
       sequences: %{},
       run_traces: %{},
       trace_runs: %{},
-      run_lifecycles: %{}
+      run_lifecycles: %{},
+      evaluation_lifecycles: %{}
     }
 
     Enum.reduce_while(events, {:ok, initial}, fn event, {:ok, state} ->
@@ -2187,14 +2188,17 @@ defmodule PtcRunner.Kernel.TraceLog do
            true <- sequence > previous,
            :ok <- same_identity(state, run_id, trace_id),
            {:ok, run_lifecycles} <-
-             advance_run_lifecycle(state.run_lifecycles, run_id, event["type"]) do
+             advance_run_lifecycle(state.run_lifecycles, run_id, event["type"]),
+           {:ok, evaluation_lifecycles} <-
+             advance_evaluation_lifecycle(state.evaluation_lifecycles, run_id, event) do
         {:cont,
          {:ok,
           %{
             sequences: Map.put(state.sequences, trace_id, sequence),
             run_traces: Map.put(state.run_traces, run_id, trace_id),
             trace_runs: Map.put(state.trace_runs, trace_id, run_id),
-            run_lifecycles: run_lifecycles
+            run_lifecycles: run_lifecycles,
+            evaluation_lifecycles: evaluation_lifecycles
           }}}
       else
         {:error, reason} -> {:halt, {:error, reason}}
@@ -2228,6 +2232,92 @@ defmodule PtcRunner.Kernel.TraceLog do
         {:error, :malformed_source}
     end
   end
+
+  defp advance_evaluation_lifecycle(evaluations, run_id, %{
+         "type" => "evaluation-started",
+         "data" => data
+       }) do
+    evaluation_id = data["evaluation_id"]
+    environment = stringify(data["environment"])
+    parent_evaluation_id = data["parent_evaluation_id"]
+    key = {run_id, evaluation_id}
+
+    with :ok <- valid_event_id(evaluation_id),
+         false <- Map.has_key?(evaluations, key),
+         :ok <-
+           validate_parent_evaluation(
+             evaluations,
+             run_id,
+             environment,
+             parent_evaluation_id
+           ) do
+      {:ok,
+       Map.put(evaluations, key, %{
+         environment: environment,
+         parent_evaluation_id: parent_evaluation_id,
+         lifecycle: :open
+       })}
+    else
+      _invalid -> {:error, :malformed_source}
+    end
+  end
+
+  defp advance_evaluation_lifecycle(evaluations, run_id, %{
+         "type" => "evaluation-stopped",
+         "data" => data
+       }) do
+    evaluation_id = data["evaluation_id"]
+    environment = stringify(data["environment"])
+    parent_evaluation_id = data["parent_evaluation_id"]
+    key = {run_id, evaluation_id}
+
+    with :ok <- valid_event_id(evaluation_id),
+         %{lifecycle: :open} = started <- Map.get(evaluations, key),
+         true <- started.environment == environment,
+         true <- started.parent_evaluation_id == parent_evaluation_id do
+      {:ok, put_in(evaluations, [key, :lifecycle], :stopped)}
+    else
+      nil when is_nil(parent_evaluation_id) -> {:ok, evaluations}
+      _invalid -> {:error, :malformed_source}
+    end
+  end
+
+  defp advance_evaluation_lifecycle(evaluations, _run_id, %{"data" => data}) do
+    if Map.has_key?(data, "parent_evaluation_id"),
+      do: {:error, :malformed_source},
+      else: {:ok, evaluations}
+  end
+
+  defp validate_parent_evaluation(_evaluations, _run_id, _environment, nil), do: :ok
+
+  defp validate_parent_evaluation(
+         evaluations,
+         run_id,
+         "mission",
+         parent_evaluation_id
+       ) do
+    with :ok <- valid_event_id(parent_evaluation_id),
+         %{environment: "workflow", lifecycle: :open, parent_evaluation_id: nil} <-
+           Map.get(evaluations, {run_id, parent_evaluation_id}) do
+      :ok
+    else
+      _invalid -> {:error, :malformed_source}
+    end
+  end
+
+  defp validate_parent_evaluation(
+         _evaluations,
+         _run_id,
+         _environment,
+         _parent_evaluation_id
+       ),
+       do: {:error, :malformed_source}
+
+  defp valid_event_id(value)
+       when is_binary(value) and byte_size(value) in 1..256,
+       do: if(String.valid?(value), do: :ok, else: {:error, :malformed_source})
+
+  defp valid_event_id(_value), do: {:error, :malformed_source}
 
   defp same_identity(state, run_id, trace_id) do
     with existing_trace when existing_trace in [nil, trace_id] <-

--- a/lib/ptc_runner/kernel/trace_log.ex
+++ b/lib/ptc_runner/kernel/trace_log.ex
@@ -196,9 +196,20 @@ defmodule PtcRunner.Kernel.TraceLog do
           |> Enum.uniq()
           |> Enum.sort()
 
+        parent_evaluation_ids =
+          run_events
+          |> Enum.filter(&(&1["type"] == "evaluation-started"))
+          |> Map.new(fn event ->
+            {event_data(event, "evaluation_id"), event_data(event, "parent_evaluation_id")}
+          end)
+          |> Map.reject(fn {evaluation_id, parent_evaluation_id} ->
+            not is_binary(evaluation_id) or not is_binary(parent_evaluation_id)
+          end)
+
         {run_id,
          %{
            "expected_model_exchange_ids" => expected_model_exchanges,
+           "parent_evaluation_ids" => parent_evaluation_ids,
            "terminal?" => Enum.any?(run_events, &(&1["type"] == "run-stopped")),
            "events_dropped?" => Enum.any?(run_events, &(&1["type"] == "events-dropped"))
          }}
@@ -782,7 +793,7 @@ defmodule PtcRunner.Kernel.TraceLog do
     with :ok <-
            validate_keys(
              arguments,
-             ~w(run_id limit cursor status evaluation_id capability mission_name)
+             ~w(run_id limit cursor status evaluation_id parent_evaluation_id capability mission_name)
            ),
          :ok <- valid_string(run_id),
          :ok <- validate_turn_filters(arguments),
@@ -2445,6 +2456,8 @@ defmodule PtcRunner.Kernel.TraceLog do
     (is_nil(arguments["status"]) or status == arguments["status"]) and
       (is_nil(arguments["evaluation_id"]) or
          event_data(event, "evaluation_id") == arguments["evaluation_id"]) and
+      (is_nil(arguments["parent_evaluation_id"]) or
+         event_data(event, "parent_evaluation_id") == arguments["parent_evaluation_id"]) and
       (is_nil(arguments["capability"]) or event_data(event, "name") == arguments["capability"]) and
       mission_matches?(event, arguments["mission_name"])
   end
@@ -2802,7 +2815,11 @@ defmodule PtcRunner.Kernel.TraceLog do
   end
 
   defp validate_turn_filters(arguments),
-    do: optional_strings(arguments, ~w(status evaluation_id capability mission_name))
+    do:
+      optional_strings(
+        arguments,
+        ~w(status evaluation_id parent_evaluation_id capability mission_name)
+      )
 
   defp evaluations_by_mission(events) do
     events

--- a/test/ptc_runner/kernel/inspection_snapshot_test.exs
+++ b/test/ptc_runner/kernel/inspection_snapshot_test.exs
@@ -155,6 +155,65 @@ defmodule PtcRunner.Kernel.InspectionSnapshotTest do
            ]
   end
 
+  test "turn filters must match the same generated source" do
+    run_id = "conjunctive-turn-filters"
+    trace_id = "trace-conjunctive-turn-filters"
+    first_source = "(return 1)"
+    second_source = "(return 2)"
+
+    records = [
+      inspection_record(run_id, trace_id, 1, "capability-input", %{"capability_id" => "llm"}, %{
+        "environment" => "workflow",
+        "name" => "llm-request",
+        "arguments" => %{"messages" => [%{"role" => "user", "content" => "run both"}]}
+      }),
+      inspection_record(run_id, trace_id, 2, "capability-output", %{"capability_id" => "llm"}, %{
+        "environment" => "workflow",
+        "name" => "llm-request",
+        "result" => %{
+          "status" => "ok",
+          "value" => %{
+            "tool_calls" => [
+              %{"args" => %{"program" => first_source}},
+              %{"args" => %{"program" => second_source}}
+            ]
+          }
+        }
+      }),
+      evaluation_source_record(run_id, trace_id, 3, "evaluation-1", first_source),
+      evaluation_source_record(run_id, trace_id, 4, "evaluation-2", second_source)
+    ]
+
+    assert {:ok, %{source_id: source_id, collections: collections}} =
+             InspectionQuery.compile([records], "trace-source", %{
+               "trace_snapshot_hash" => "trace-source",
+               "runs" => %{
+                 run_id => %{
+                   "terminal?" => true,
+                   "events_dropped?" => false,
+                   "expected_model_exchange_ids" => ["llm"],
+                   "parent_evaluation_ids" => %{
+                     "evaluation-1" => "workflow-1",
+                     "evaluation-2" => "workflow-2"
+                   }
+                 }
+               }
+             })
+
+    assert {:ok, %{"items" => []}} =
+             InspectionQuery.query(
+               collections,
+               source_id,
+               :turns,
+               %{
+                 "run_id" => run_id,
+                 "evaluation_id" => "evaluation-1",
+                 "parent_evaluation_id" => "workflow-2"
+               },
+               100_000
+             )
+  end
+
   @tag :tmp_dir
   test "multiple artifacts expose paired deterministic private queries", %{tmp_dir: root} do
     {trace, inspection} = source_directories(root)
@@ -1104,6 +1163,37 @@ defmodule PtcRunner.Kernel.InspectionSnapshotTest do
 
   defp emit!(sink, type, correlation, payload),
     do: :ok = InspectionSink.emit(sink, type, correlation, payload)
+
+  defp evaluation_source_record(run_id, trace_id, sequence, evaluation_id, source) do
+    inspection_record(
+      run_id,
+      trace_id,
+      sequence,
+      "evaluation-source",
+      %{"evaluation_id" => evaluation_id},
+      %{
+        "environment" => "mission",
+        "mission_name" => "default",
+        "program_kind" => "ptc-lisp",
+        "source" => source,
+        "source_hash" => Base.encode16(:crypto.hash(:sha256, source), case: :lower),
+        "source_bytes" => byte_size(source)
+      }
+    )
+  end
+
+  defp inspection_record(run_id, trace_id, sequence, record_type, correlation, payload) do
+    %{
+      "schema_version" => 6,
+      "run_id" => run_id,
+      "trace_id" => trace_id,
+      "sequence" => sequence,
+      "timestamp" => "2026-08-14T12:00:0#{sequence}Z",
+      "record_type" => record_type,
+      "correlation" => correlation,
+      "payload" => payload
+    }
+  end
 
   # ex_dna:disable-for-next-line — Keep the compared snapshot-local trace readable here.
   defp canonical_events(run_id) do

--- a/test/ptc_runner/kernel/named_missions_continuation_test.exs
+++ b/test/ptc_runner/kernel/named_missions_continuation_test.exs
@@ -167,13 +167,23 @@ defmodule PtcRunner.Kernel.NamedMissionsContinuationTest do
 
     assert {:ok, _result} = Kernel.run(source, config)
 
-    missions =
+    evaluation_events =
       sink
       |> EventSink.events()
       |> Enum.filter(&(&1.type == "evaluation-started"))
-      |> Enum.map(&get_in(&1.data, [:mission_name]))
+
+    missions = Enum.map(evaluation_events, &get_in(&1.data, [:mission_name]))
 
     assert "review" in missions
+
+    workflow_evaluation_id =
+      evaluation_events
+      |> Enum.find(&(&1.data.environment == :workflow))
+      |> get_in([Access.key!(:data), Access.key!(:evaluation_id)])
+
+    mission_events = Enum.filter(evaluation_events, &(&1.data.environment == :mission))
+    assert mission_events != []
+    assert Enum.all?(mission_events, &(&1.data.parent_evaluation_id == workflow_evaluation_id))
   end
 
   test "evaluation preflight limits carry the requested mission" do

--- a/test/ptc_runner/kernel/run_analysis_test.exs
+++ b/test/ptc_runner/kernel/run_analysis_test.exs
@@ -140,6 +140,84 @@ defmodule PtcRunner.Kernel.RunAnalysisTest do
              })
   end
 
+  @tag :tmp_dir
+  test "follows a workflow error to its child source and producing turn", %{tmp_dir: root} do
+    fixture = PrivateInspectionFixture.create!(root, "failure-navigation")
+    {:ok, trace} = TraceSnapshot.start({:private_authorized_directory, fixture.traces})
+    {:ok, inspection} = InspectionSnapshot.start({:directory, fixture.inspection}, trace)
+    on_exit(fn -> InspectionSnapshot.stop(inspection) end)
+    on_exit(fn -> TraceSnapshot.stop(trace) end)
+    assert {:ok, analysis} = RunAnalysis.new(trace, inspection)
+
+    assert {:ok, %{"collections" => collections}} =
+             RunAnalysis.query(analysis, :open, %{"run_id" => fixture.run_id})
+
+    assert "parent_evaluation_id" in Enum.find(collections, &(&1["name"] == "activity"))[
+             "filters"
+           ]
+
+    assert "evaluation_id" in Enum.find(collections, &(&1["name"] == "turns"))["filters"]
+
+    assert "parent_evaluation_id" in Enum.find(collections, &(&1["name"] == "turns"))["filters"]
+
+    assert {:ok, %{"items" => [%{"evaluation_id" => workflow_evaluation_id}]}} =
+             RunAnalysis.query(analysis, :read, %{
+               "run_id" => fixture.run_id,
+               "collection" => "execution_errors"
+             })
+
+    assert {:ok, %{"items" => child_activity}} =
+             RunAnalysis.query(analysis, :read, %{
+               "run_id" => fixture.run_id,
+               "collection" => "activity",
+               "parent_evaluation_id" => workflow_evaluation_id
+             })
+
+    child_evaluation_ids =
+      child_activity
+      |> Enum.map(&get_in(&1, ["data", "evaluation_id"]))
+      |> Enum.uniq()
+
+    assert child_evaluation_ids == ["eval-#{fixture.run_id}"]
+    [child_evaluation_id] = child_evaluation_ids
+
+    assert {:ok,
+            %{
+              "items" => [
+                %{
+                  "evaluation_id" => ^child_evaluation_id,
+                  "parent_evaluation_id" => ^workflow_evaluation_id,
+                  "source" => "(return 42)"
+                }
+              ]
+            }} =
+             RunAnalysis.query(analysis, :read, %{
+               "run_id" => fixture.run_id,
+               "collection" => "generated_sources",
+               "parent_evaluation_id" => workflow_evaluation_id
+             })
+
+    assert {:ok,
+            %{
+              "items" => [
+                %{
+                  "generated" => [
+                    %{
+                      "evaluation_id" => ^child_evaluation_id,
+                      "parent_evaluation_id" => ^workflow_evaluation_id
+                    }
+                  ]
+                }
+              ]
+            }} =
+             RunAnalysis.query(analysis, :read, %{
+               "run_id" => fixture.run_id,
+               "collection" => "turns",
+               "evaluation_id" => child_evaluation_id,
+               "parent_evaluation_id" => workflow_evaluation_id
+             })
+  end
+
   test "conversation streams choose the unique longest complete prefix" do
     user = %{"role" => "user", "content" => "start"}
     assistant_1 = %{"role" => "assistant", "content" => nil, "tool_calls" => [%{"id" => "1"}]}
@@ -492,6 +570,7 @@ defmodule PtcRunner.Kernel.RunAnalysisTest do
 
     read = Enum.find(capabilities, &(&1.name == "analysis-read"))
     assert read.input_schema["properties"]["limit"]["maximum"] == 100
+    assert read.input_schema["properties"]["parent_evaluation_id"]["type"] == "string"
 
     assert {:ok, %{"items" => [_]}} =
              read.callback.(%{"run_id" => fixture.run_id, "collection" => "turns"})

--- a/test/ptc_runner/kernel/trace_log_test.exs
+++ b/test/ptc_runner/kernel/trace_log_test.exs
@@ -746,6 +746,71 @@ defmodule PtcRunner.Kernel.TraceLogTest do
     end
   end
 
+  @tag :tmp_dir
+  test "current validation rejects unproven parent evaluation edges", %{tmp_dir: directory} do
+    query = fn events, name ->
+      path = Path.join(directory, "parent-edge-#{name}.jsonl")
+      File.write!(path, Enum.map_join(events, "", &(Jason.encode!(&1) <> "\n")))
+      {:ok, log} = TraceLog.new(source: {:file, path})
+      TraceLog.query(log, :list_runs, %{})
+    end
+
+    valid = [
+      decoded_event("parent-edge", 1, "run-started", %{"missions" => %{}}),
+      decoded_event("parent-edge", 2, "evaluation-started", %{
+        "environment" => "workflow",
+        "evaluation_id" => "workflow-eval"
+      }),
+      decoded_event("parent-edge", 3, "evaluation-started", %{
+        "environment" => "mission",
+        "mission_name" => "reader",
+        "evaluation_id" => "mission-eval",
+        "parent_evaluation_id" => "workflow-eval"
+      }),
+      decoded_event("parent-edge", 4, "evaluation-stopped", %{
+        "environment" => "mission",
+        "mission_name" => "reader",
+        "evaluation_id" => "mission-eval",
+        "parent_evaluation_id" => "workflow-eval",
+        "status" => "ok"
+      }),
+      decoded_event("parent-edge", 5, "evaluation-stopped", %{
+        "environment" => "workflow",
+        "evaluation_id" => "workflow-eval",
+        "status" => "ok"
+      }),
+      decoded_event("parent-edge", 6, "run-stopped", %{"outcome" => "ok"})
+    ]
+
+    assert {:ok, _result} = query.(valid, "valid")
+
+    orphaned =
+      put_in(valid, [Access.at(2), "data", "parent_evaluation_id"], "missing-eval")
+
+    wrong_parent_environment =
+      put_in(valid, [Access.at(1), "data", "environment"], "mission")
+      |> put_in([Access.at(1), "data", "mission_name"], "reader")
+
+    parent_on_workflow =
+      put_in(valid, [Access.at(1), "data", "parent_evaluation_id"], "workflow-eval")
+
+    mismatched_stop =
+      put_in(valid, [Access.at(3), "data", "parent_evaluation_id"], "other-eval")
+
+    missing_stop_parent =
+      update_in(valid, [Access.at(3), "data"], &Map.delete(&1, "parent_evaluation_id"))
+
+    for {label, events} <- [
+          orphaned: orphaned,
+          wrong_parent_environment: wrong_parent_environment,
+          parent_on_workflow: parent_on_workflow,
+          mismatched_stop: mismatched_stop,
+          missing_stop_parent: missing_stop_parent
+        ] do
+      assert {:error, :malformed_source} = query.(events, "invalid-#{label}")
+    end
+  end
+
   test "mission filters narrow counters by explicit identity" do
     events = [
       decoded_event("mission-filter", 1, "run-started", %{"missions" => %{}}),

--- a/test/support/private_inspection_fixture.ex
+++ b/test/support/private_inspection_fixture.ex
@@ -103,6 +103,7 @@ defmodule PtcRunner.TestSupport.PrivateInspectionFixture do
       workflow_evaluation_event(run_id, 4),
       event(run_id, 5, "evaluation-started", %{
         "evaluation_id" => "eval-#{run_id}",
+        "parent_evaluation_id" => "workflow-eval-#{run_id}",
         "environment" => "mission",
         "mission_name" => "default",
         "program_kind" => "ptc-lisp",
@@ -111,6 +112,7 @@ defmodule PtcRunner.TestSupport.PrivateInspectionFixture do
       }),
       event(run_id, 6, "evaluation-stopped", %{
         "evaluation_id" => "eval-#{run_id}",
+        "parent_evaluation_id" => "workflow-eval-#{run_id}",
         "environment" => "mission",
         "mission_name" => "default",
         "status" => "ok"


### PR DESCRIPTION
## Summary

- emit the enclosing workflow evaluation ID on mission evaluation start/stop events
- preserve the edge in generated-source and reconstructed-turn projections
- add exact parent filters for activity, generated sources, and turns
- keep combined turn filters scoped to one generated-source record
- reject orphaned, cyclic, wrong-environment, and contradictory parent edges during canonical trace loading
- document the navigation contract and its causality limits

## Why

This lets private run analysis navigate from a workflow evaluation error to the mission programs launched inside that evaluation without comparing unrelated snapshot-local sequence numbers. The edge proves nesting; it does not claim every child caused the eventual workflow error.

This is a focused parent-edge/navigation increment for issue #1367, not a claim that the entire issue is complete.

## Verification

- `mix precommit`
- documentation warnings gate
- targeted trace, inspection snapshot, run analysis, and named mission suites
- repository pre-push gate: 6,249 core tests, Viewer tests, Credo, duplication, spec/generated artifacts, Dialyzer, and release verification
- three independent review passes; all actionable findings addressed and final follow-up approved

Refs #1367