### PR TITLE
fix(e2e): restore named mission bundle compilation

### DIFF
--- a/test/ptc_runner/kernel/named_missions_e2e_test.exs
+++ b/test/ptc_runner/kernel/named_missions_e2e_test.exs
@@ -8,7 +8,6 @@ defmodule PtcRunner.Kernel.NamedMissionsE2ETest do
   """
   use ExUnit.Case, async: false
 
-  @moduletag :e2e
   @moduletag timeout: 180_000
 
   alias PtcRunner.Kernel
@@ -65,17 +64,26 @@ defmodule PtcRunner.Kernel.NamedMissionsE2ETest do
          "review-api" (kernel/mission-model-context "review")})))
   """
 
-  setup_all do
-    :ok = LLMSupport.load_dotenv()
-    :ok = LLMSupport.admit_provider_application!()
+  setup context do
+    if context[:e2e] do
+      :ok = LLMSupport.load_dotenv()
+      :ok = LLMSupport.admit_provider_application!()
 
-    if System.get_env("OPENROUTER_API_KEY") do
-      :ok
+      if System.get_env("OPENROUTER_API_KEY") do
+        :ok
+      else
+        {:skip, "OPENROUTER_API_KEY is not configured"}
+      end
     else
-      {:skip, "OPENROUTER_API_KEY is not configured"}
+      :ok
     end
   end
 
+  test "the shipped named-mission workflow bundle compiles without live credentials" do
+    assert {:ok, _bundle} = shipped_loop_bundle()
+  end
+
+  @tag :e2e
   test "the shipped agent.core loop drives two isolated spaces via its cfg" do
     {:ok, limits} =
       Limits.new(
@@ -89,15 +97,7 @@ defmodule PtcRunner.Kernel.NamedMissionsE2ETest do
     {:ok, %{capabilities: [llm_capability], close: close}} = build_live_llm(limits)
     if close, do: on_exit(close)
 
-    {:ok, shipped} =
-      Component.new(
-        id: "spike.shipped",
-        source: @shipped_loop_source,
-        dependencies: ["agent.core"]
-      )
-
-    {:ok, components} = Library.resolve_components([shipped, {:library, "agent.core"}])
-    {:ok, bundle} = Kernel.compile_bundle(components)
+    {:ok, bundle} = shipped_loop_bundle()
 
     {:ok, workflow} = WorkflowEnvironment.new(bundle: bundle, capabilities: [llm_capability])
     {:ok, default_mission} = MissionEnvironment.new([])
@@ -141,6 +141,7 @@ defmodule PtcRunner.Kernel.NamedMissionsE2ETest do
     refute "default" in spaces
   end
 
+  @tag :e2e
   test "live agents under pcalls: where the parallel boundary actually is" do
     {:ok, limits} =
       Limits.new(
@@ -213,6 +214,19 @@ defmodule PtcRunner.Kernel.NamedMissionsE2ETest do
     {:ok, component} = Component.new(id: id, source: source)
     {:ok, bundle} = Kernel.compile_bundle([component])
     bundle
+  end
+
+  defp shipped_loop_bundle do
+    with {:ok, shipped} <-
+           Component.new(
+             id: "spike.shipped",
+             source: @shipped_loop_source,
+             dependencies: ["agent.core", "kernel"]
+           ),
+         {:ok, components} <-
+           Library.resolve_components([shipped, {:library, "agent.core"}]) do
+      Kernel.compile_bundle(components)
+    end
   end
 
   # ex_dna:disable-for-next-line — mirrors the established live DeepSeek provider fixture


### PR DESCRIPTION
## Summary

- declare the shipped `kernel` prelude as a direct dependency of the named-missions workflow fixture
- reuse one bundle builder between the live assertion and a new credential-free compile regression
- keep only the provider-backed executions tagged `:e2e`, so normal CI catches fixture compilation regressions

## Root cause

PR #1365 replaced the model-sensitive hand-written loop with `agent.core`, but the updated workflow continued to call `kernel/eval-source` and `kernel/mission-model-context` without declaring `kernel` as a direct component dependency. The entire live test therefore failed during bundle compilation before contacting a model, while normal CI excluded the module under its module-level `:e2e` tag.

## Impact

The named-missions E2E reaches the production agent loop again, and the ordinary credential-free suite now compiles the exact shared workflow fixture so missing dependencies fail in PR CI.

## Verification

- focused named-mission suite: 7 passed, 2 live tests excluded
- Qwen `qwen3.7-flash`: 3/3 focused live runs passed
- Gemini `gemini-3.1-flash-lite`: 3/3 focused live runs passed
- complete named-missions live file under Gemini: 3 passed
- one independent Codex review: no actionable findings
- `mix precommit`: passed, including 6,247 root tests, 44 Viewer tests, 40 launcher tests, static checks, packaging, and release verification
- pre-push gates: passed, including docs, core tests, static analysis, Dialyzer, release, and Viewer validation

Closes #1358