### PR TITLE
fix(cli): report value contract failure paths

### DIFF
--- a/docs/guides/manifests-and-capabilities.md
+++ b/docs/guides/manifests-and-capabilities.md
@@ -136,7 +136,11 @@ The input contract covers manifest input and command-line input overrides. It
 is checked before preflight, credentials, processes, or discovery. The result
 contract is checked after execution and evidence capture, but before stdout or
 artifact publication. A mismatch returns `input_contract_failed` or
-`result_contract_failed`; non-object input returns `input_invalid`.
+`result_contract_failed`; non-object input returns `input_invalid`. When the
+safe failure projection identifies a non-root declared path, the command
+envelope and terminal diagnostic include its JSON Pointer. Terminal rendering
+escapes unusual contract-authored property names rather than emitting their
+control bytes.
 
 The `agent.main/run` entry also gives a model-authored terminal candidate one
 ordinary correction turn when budget remains. Feedback is schema-derived and

--- a/lib/ptc_runner/kernel/command_application_diagnostic.ex
+++ b/lib/ptc_runner/kernel/command_application_diagnostic.ex
@@ -6,6 +6,7 @@ defmodule PtcRunner.Kernel.CommandApplicationDiagnostic do
   alias PtcRunner.Kernel.CommandSource
   alias PtcRunner.Kernel.Manifest
   alias PtcRunner.Kernel.SchemaPath
+  alias PtcRunner.Kernel.ValueContractDiagnostic
 
   @spec project(:validate | :run | :doctor, term()) :: CommandDiagnostic.t()
   def project(_command, reason) do
@@ -13,9 +14,10 @@ defmodule PtcRunner.Kernel.CommandApplicationDiagnostic do
     {code, path_value} = projection(source_role, reason)
 
     source = command_source(source_role, source_name)
+    {source, path_value} = contract_diagnostic_parts(source, reason, path_value)
 
     CommandDiagnostic.new!(:application, code,
-      source: bind_contract_source(source, reason),
+      source: source,
       path: command_path(source_role, path_value)
     )
   end
@@ -83,7 +85,7 @@ defmodule PtcRunner.Kernel.CommandApplicationDiagnostic do
 
   defp projection(role, {:input_contract_failed, classification})
        when role in [:application, :external_input],
-       do: {:input_contract_failed, first_violation_path(classification)}
+       do: {:input_contract_failed, classification}
 
   defp projection(_role, :invalid_contracts), do: {:contract_invalid, nil}
 
@@ -115,15 +117,6 @@ defmodule PtcRunner.Kernel.CommandApplicationDiagnostic do
 
   defp projection(_role, _reason), do: {:schema_violation, nil}
 
-  defp first_violation_path(%{violations: violations}) when is_list(violations) do
-    Enum.find_value(violations, fn
-      %{path: %CommandPath{} = path} -> path
-      _invalid -> nil
-    end)
-  end
-
-  defp first_violation_path(_classification), do: nil
-
   defp command_path(_role, nil), do: nil
   defp command_path(_role, %CommandPath{} = path), do: path
 
@@ -145,11 +138,12 @@ defmodule PtcRunner.Kernel.CommandApplicationDiagnostic do
     path
   end
 
-  defp bind_contract_source(source, {:input_contract_failed, %{contract_authority: authority}})
-       when not is_nil(source) do
-    {:ok, source} = CommandSource.with_contract(source, authority)
-    source
-  end
+  defp contract_diagnostic_parts(
+         source,
+         {:input_contract_failed, classification},
+         classification
+       ),
+       do: ValueContractDiagnostic.diagnostic_parts(source, classification)
 
-  defp bind_contract_source(source, _reason), do: source
+  defp contract_diagnostic_parts(source, _reason, path), do: {source, path}
 end

--- a/lib/ptc_runner/kernel/command_renderer.ex
+++ b/lib/ptc_runner/kernel/command_renderer.ex
@@ -3,13 +3,15 @@ defmodule PtcRunner.Kernel.CommandRenderer do
   Deterministic, privacy-preserving human projection of sealed command outcomes.
 
   Provider failures include the validated provider subject already present in
-  the public command envelope. Manifest schema violations with a non-root,
-  schema-authorized path include its JSON Pointer. Rendering never derives
-  labels from a rejected value, provider response, credential, or unvalidated
-  path. Component compile failures with a proven byte span render the logical
-  component name and canonical half-open byte range already present in the
-  envelope; rendering does not retain or reopen component source. A replay miss
-  may include only its validated opaque request hash.
+  the public command envelope. Manifest and value-contract failures with a
+  non-root, schema-authorized path include its JSON Pointer. Unusual
+  contract-authored pointers use an escaped quoted representation before they
+  enter a terminal. Rendering never derives labels from a rejected value,
+  provider response, credential, or unvalidated path. Component compile
+  failures with a proven byte span render the logical component name and
+  canonical half-open byte range already present in the envelope; rendering
+  does not retain or reopen component source. A replay miss may include only
+  its validated opaque request hash.
   """
 
   alias PtcRunner.Kernel.CommandOutcome
@@ -121,7 +123,33 @@ defmodule PtcRunner.Kernel.CommandRenderer do
        when is_binary(name) and is_integer(start_byte) and is_integer(end_byte),
        do: " at #{name} bytes [#{start_byte},#{end_byte}) "
 
+  defp location_suffix(%{
+         "phase" => "application",
+         "code" => "input_contract_failed",
+         "source" => %{"kind" => kind},
+         "path" => path
+       })
+       when kind in ["application", "external_input", "input_contract"] and
+              is_binary(path) and path != "",
+       do: " at " <> terminal_contract_path(path) <> " "
+
+  defp location_suffix(%{
+         "phase" => "result_cleanup",
+         "code" => "result_contract_failed",
+         "source" => %{"kind" => "result_contract"},
+         "path" => path
+       })
+       when is_binary(path) and path != "",
+       do: " at " <> terminal_contract_path(path) <> " "
+
   defp location_suffix(_error), do: " "
+
+  defp terminal_contract_path(path) do
+    case path =~ ~r/\A\/[A-Za-z0-9._~\/-]+\z/ do
+      true -> path
+      false -> inspect(path, binaries: :as_strings, limit: :infinity, printable_limit: :infinity)
+    end
+  end
 
   defp subject_prefix(%{
          "kind" => "provider",

--- a/lib/ptc_runner/kernel/command_run_outcome.ex
+++ b/lib/ptc_runner/kernel/command_run_outcome.ex
@@ -12,6 +12,7 @@ defmodule PtcRunner.Kernel.CommandRunOutcome do
   alias PtcRunner.Kernel.PublicationAuthority
   alias PtcRunner.Kernel.Result
   alias PtcRunner.Kernel.RuntimeLimitDiagnostic
+  alias PtcRunner.Kernel.ValueContractDiagnostic
 
   @spec settle(
           term(),
@@ -287,11 +288,11 @@ defmodule PtcRunner.Kernel.CommandRunOutcome do
 
   defp failure_diagnostic(%CommandDiagnostic{} = diagnostic, _provider_activity), do: diagnostic
 
-  defp failure_diagnostic({:error, {:result_contract_failed, _details}}, provider_activity),
-    do: diagnostic(:result_cleanup, :result_contract_failed, provider_activity)
+  defp failure_diagnostic({:error, {:result_contract_failed, details}}, provider_activity),
+    do: result_contract_diagnostic(details, provider_activity)
 
-  defp failure_diagnostic({:result_contract_failed, _details}, provider_activity),
-    do: diagnostic(:result_cleanup, :result_contract_failed, provider_activity)
+  defp failure_diagnostic({:result_contract_failed, details}, provider_activity),
+    do: result_contract_diagnostic(details, provider_activity)
 
   defp failure_diagnostic(%Error{kind: :provider_cleanup_error}, _provider_activity),
     do: diagnostic(:result_cleanup, :provider_cleanup_failed, true)
@@ -380,6 +381,28 @@ defmodule PtcRunner.Kernel.CommandRunOutcome do
 
   defp failure_diagnostic(_reason, provider_activity),
     do: diagnostic(:internal, :internal_error, provider_activity)
+
+  defp result_contract_diagnostic(details, provider_activity) when is_map(details) do
+    source = result_contract_source(details)
+    {source, path} = ValueContractDiagnostic.diagnostic_parts(source, details)
+
+    diagnostic(:result_cleanup, :result_contract_failed, provider_activity,
+      source: source,
+      path: path
+    )
+  end
+
+  defp result_contract_diagnostic(_details, provider_activity),
+    do: diagnostic(:result_cleanup, :result_contract_failed, provider_activity)
+
+  defp result_contract_source(%{contract_source: name}) when is_binary(name) do
+    case CommandSource.new(:result_contract, name) do
+      {:ok, source} -> source
+      {:error, :invalid_command_source} -> nil
+    end
+  end
+
+  defp result_contract_source(_details), do: nil
 
   defp publication_code(:trace), do: :trace_publication_failed
   defp publication_code(:inspection), do: :inspection_publication_failed

--- a/lib/ptc_runner/kernel/execution_input.ex
+++ b/lib/ptc_runner/kernel/execution_input.ex
@@ -11,10 +11,9 @@ defmodule PtcRunner.Kernel.ExecutionInput do
   """
 
   alias PtcRunner.Kernel.Attestation
-  alias PtcRunner.Kernel.CommandContractAuthority
-  alias PtcRunner.Kernel.CommandPath
   alias PtcRunner.Kernel.StrictJSON
   alias PtcRunner.Kernel.ValueContract
+  alias PtcRunner.Kernel.ValueContractDiagnostic
 
   @enforce_keys [:value, :authority]
   defstruct [:value, :authority, :attestation]
@@ -63,12 +62,9 @@ defmodule PtcRunner.Kernel.ExecutionInput do
         :ok
 
       true ->
-        {classification, evidence} = ValueContract.classify_with_evidence(contract, value)
-
-        case CommandContractAuthority.new(evidence) do
-          {:ok, authority} ->
-            {:error,
-             {:input_contract_failed, authorize_violation_paths(classification, authority)}}
+        case ValueContractDiagnostic.classify(contract, value) do
+          {:ok, classification} ->
+            {:error, {:input_contract_failed, classification}}
 
           {:error, :invalid_contract_classification} ->
             {:error, :invalid_input}
@@ -77,23 +73,6 @@ defmodule PtcRunner.Kernel.ExecutionInput do
   end
 
   defp validate_contract(_contract, _value), do: {:error, :invalid_input}
-
-  defp authorize_violation_paths(classification, authority) do
-    classification
-    |> Map.put(:contract_authority, authority)
-    |> Map.update(:violations, [], fn violations ->
-      Enum.flat_map(violations, fn
-        %{segments: segments} = violation ->
-          case CommandPath.contract(authority, segments) do
-            {:ok, path} -> [violation |> Map.delete(:segments) |> Map.put(:path, path)]
-            {:error, :invalid_command_path} -> []
-          end
-
-        _invalid ->
-          []
-      end)
-    end)
-  end
 
   defp payload(input), do: {input.value, input.authority}
 end

--- a/lib/ptc_runner/kernel/execution_outcome.ex
+++ b/lib/ptc_runner/kernel/execution_outcome.ex
@@ -1,6 +1,7 @@
 defmodule PtcRunner.Kernel.ExecutionOutcome do
   @moduledoc """
-  Sealed, path-free evidence captured at the one-shot execution boundary.
+  Sealed, filesystem-path-free evidence captured at the one-shot execution
+  boundary.
 
   The outcome freezes the effective result class, result-contract decision,
   terminal canonical events, and optional private inspection records while the
@@ -12,6 +13,7 @@ defmodule PtcRunner.Kernel.ExecutionOutcome do
   trusted code running in the same VM.
   """
 
+  alias PtcRunner.Kernel.ApplicationSource
   alias PtcRunner.Kernel.Attestation
   alias PtcRunner.Kernel.Error
   alias PtcRunner.Kernel.EventSink
@@ -20,6 +22,7 @@ defmodule PtcRunner.Kernel.ExecutionOutcome do
   alias PtcRunner.Kernel.PublicationAuthority
   alias PtcRunner.Kernel.Result
   alias PtcRunner.Kernel.ValueContract
+  alias PtcRunner.Kernel.ValueContractDiagnostic
 
   @enforce_keys [
     :result,
@@ -63,13 +66,22 @@ defmodule PtcRunner.Kernel.ExecutionOutcome do
           EventSink.t(),
           InspectionSink.t() | nil,
           ValueContract.t() | nil,
+          binary() | nil,
           PublicationAuthority.t()
         ) :: {:ok, t()} | {:error, :invalid_execution_outcome}
-  def capture(result, terminal_batch, event_sink, inspection_sink, contract, authority) do
+  def capture(
+        result,
+        terminal_batch,
+        event_sink,
+        inspection_sink,
+        contract,
+        contract_source,
+        authority
+      ) do
     outcome = %__MODULE__{
       result: result,
       result_class: classify(event_sink),
-      result_contract: validate_result(result, contract),
+      result_contract: validate_result(result, contract, contract_source),
       terminal_batch: terminal_batch,
       inspection: capture_inspection(inspection_sink, result, terminal_batch),
       publication_binding: publication_binding(authority),
@@ -166,22 +178,61 @@ defmodule PtcRunner.Kernel.ExecutionOutcome do
 
   defp field(_value, _key), do: nil
 
-  defp validate_result(_result, nil), do: :ok
+  defp validate_result(_result, nil, nil), do: :ok
 
-  defp validate_result({:ok, %Result{value: value}}, %ValueContract{} = contract) do
+  defp validate_result(
+         {:ok, %Result{value: value}},
+         %ValueContract{} = contract,
+         contract_source
+       )
+       when is_nil(contract_source) do
+    validate_result_value(value, contract, contract_source)
+  end
+
+  defp validate_result(
+         {:ok, %Result{value: value}},
+         %ValueContract{} = contract,
+         contract_source
+       )
+       when is_binary(contract_source) do
+    if ApplicationSource.valid_name?(contract_source),
+      do: validate_result_value(value, contract, contract_source),
+      else: :invalid
+  end
+
+  defp validate_result(_result, %ValueContract{}, nil), do: :ok
+
+  defp validate_result(_result, %ValueContract{}, contract_source)
+       when is_binary(contract_source) do
+    if ApplicationSource.valid_name?(contract_source), do: :ok, else: :invalid
+  end
+
+  defp validate_result(_result, _contract, _contract_source), do: :invalid
+
+  defp validate_result_value(value, contract, contract_source) do
     case ValueContract.json_value(value) do
       {:ok, public} ->
-        if ValueContract.valid?(contract, public),
-          do: :ok,
-          else: {:error, {:result_contract_failed, ValueContract.classify(contract, public)}}
+        if ValueContract.valid?(contract, public) do
+          :ok
+        else
+          details =
+            case ValueContractDiagnostic.classify(contract, public) do
+              {:ok, classification} -> classification
+              {:error, :invalid_contract_classification} -> %{value_kind: :unknown}
+            end
+
+          {:error, {:result_contract_failed, with_contract_source(details, contract_source)}}
+        end
 
       {:error, _reason} ->
-        {:error, {:result_contract_failed, %{value_kind: :invalid_json}}}
+        {:error,
+         {:result_contract_failed,
+          with_contract_source(%{value_kind: :invalid_json}, contract_source)}}
     end
   end
 
-  defp validate_result(_result, %ValueContract{}), do: :ok
-  defp validate_result(_result, _contract), do: :invalid
+  defp with_contract_source(details, nil), do: details
+  defp with_contract_source(details, source), do: Map.put(details, :contract_source, source)
 
   defp fields_valid?(outcome) do
     Enum.sort(Map.keys(outcome)) == @field_keys and

--- a/lib/ptc_runner/kernel/run_builder.ex
+++ b/lib/ptc_runner/kernel/run_builder.ex
@@ -862,6 +862,8 @@ defmodule PtcRunner.Kernel.RunBuilder do
            limits: package.limits,
            event_sink: sink,
            result_contract: package.contracts.result,
+           result_contract_source:
+             get_in(package.manifest, ["contracts", "result_schema", "path"]),
            result_projection: request.policy.result_projection,
            inspection_sink: inspection_sink,
            provider_session: providers.provider_session,
@@ -1126,6 +1128,7 @@ defmodule PtcRunner.Kernel.RunBuilder do
           config.event_sink,
           config.inspection_sink,
           config.result_contract,
+          config.result_contract_source,
           authority
         )
       after

--- a/lib/ptc_runner/kernel/run_config.ex
+++ b/lib/ptc_runner/kernel/run_config.ex
@@ -37,8 +37,10 @@ defmodule PtcRunner.Kernel.RunConfig do
   neither field is visible to Lisp.
 
   `result_contract` is an optional sealed, compiled application contract
-  exposed only through the reserved workflow validator used by `agent.main`. Final
-  publication enforcement remains the responsibility of `RunBuilder`.
+  exposed only through the reserved workflow validator used by `agent.main`.
+  Its optional `result_contract_source` is the portable logical document name
+  used only for an attested result-contract diagnostic. Final publication
+  enforcement remains the responsibility of `RunBuilder`.
 
   `labels` is an optional closed safe-metadata map. Caller-defined identifier
   fields become SHA-256 fingerprints and tags use finite enumerated values
@@ -51,6 +53,7 @@ defmodule PtcRunner.Kernel.RunConfig do
   environments.
   """
 
+  alias PtcRunner.Kernel.ApplicationSource
   alias PtcRunner.Kernel.Deadline
   alias PtcRunner.Kernel.EventSink
   alias PtcRunner.Kernel.FrozenBundle
@@ -88,6 +91,7 @@ defmodule PtcRunner.Kernel.RunConfig do
     :run_deadline,
     :claim_id,
     result_contract: nil,
+    result_contract_source: nil,
     result_projection: :native,
     inspection_sink: nil,
     inspection_sink_owner: nil,
@@ -108,6 +112,7 @@ defmodule PtcRunner.Kernel.RunConfig do
           run_deadline: Deadline.t() | nil,
           claim_id: reference(),
           result_contract: ValueContract.t() | nil,
+          result_contract_source: binary() | nil,
           result_projection: :native | :json,
           inspection_sink: InspectionSink.t() | nil,
           inspection_sink_owner: pid() | nil,
@@ -135,6 +140,7 @@ defmodule PtcRunner.Kernel.RunConfig do
                :limits,
                :event_sink,
                :result_contract,
+               :result_contract_source,
                :result_projection,
                :inspection_sink,
                :provider_session,
@@ -151,6 +157,11 @@ defmodule PtcRunner.Kernel.RunConfig do
          %EventSink{} = sink <- Keyword.get(opts, :event_sink),
          true <- valid_event_sink_contract?(sink, limits),
          true <- result_contract?(Keyword.get(opts, :result_contract)),
+         true <-
+           result_contract_source?(
+             Keyword.get(opts, :result_contract),
+             Keyword.get(opts, :result_contract_source)
+           ),
          true <- result_projection?(Keyword.get(opts, :result_projection, :native)),
          {:ok, event_sink_owner} <- EventSink.owner(sink),
          true <- inspection?(Keyword.get(opts, :inspection_sink)),
@@ -192,6 +203,7 @@ defmodule PtcRunner.Kernel.RunConfig do
          run_deadline: run_deadline,
          claim_id: make_ref(),
          result_contract: Keyword.get(opts, :result_contract),
+         result_contract_source: Keyword.get(opts, :result_contract_source),
          result_projection: Keyword.get(opts, :result_projection, :native),
          inspection_sink: Keyword.get(opts, :inspection_sink),
          inspection_sink_owner: inspection_sink_owner,
@@ -257,6 +269,14 @@ defmodule PtcRunner.Kernel.RunConfig do
   defp result_contract?(nil), do: true
   defp result_contract?(%ValueContract{} = contract), do: ValueContract.sealed?(contract)
   defp result_contract?(_contract), do: false
+
+  defp result_contract_source?(nil, nil), do: true
+  defp result_contract_source?(%ValueContract{}, nil), do: true
+
+  defp result_contract_source?(%ValueContract{}, source),
+    do: ApplicationSource.valid_name?(source)
+
+  defp result_contract_source?(_contract, _source), do: false
 
   defp result_projection?(projection), do: projection in [:native, :json]
 

--- a/lib/ptc_runner/kernel/run_coordinator.ex
+++ b/lib/ptc_runner/kernel/run_coordinator.ex
@@ -10,8 +10,8 @@ defmodule PtcRunner.Kernel.RunCoordinator do
   One-shot execution consumes the prepared run inside an execution-session
   owner. That owner constructs both sinks, keeps responding to caller death
   while a subordinate worker performs provider setup and runs the Kernel, and
-  returns only sealed, path-free execution evidence. Publication remains a
-  separate caller operation.
+  returns only sealed, filesystem-path-free execution evidence. Publication
+  remains a separate caller operation.
   """
 
   alias PtcRunner.Kernel.ApplicationSource

--- a/lib/ptc_runner/kernel/value_contract_diagnostic.ex
+++ b/lib/ptc_runner/kernel/value_contract_diagnostic.ex
@@ -1,0 +1,66 @@
+defmodule PtcRunner.Kernel.ValueContractDiagnostic do
+  @moduledoc false
+
+  alias PtcRunner.Kernel.CommandContractAuthority
+  alias PtcRunner.Kernel.CommandPath
+  alias PtcRunner.Kernel.CommandSource
+  alias PtcRunner.Kernel.ValueContract
+
+  @spec classify(ValueContract.t(), term()) ::
+          {:ok, map()} | {:error, :invalid_contract_classification}
+  def classify(%ValueContract{} = contract, value) do
+    {classification, evidence} = ValueContract.classify_with_evidence(contract, value)
+
+    case CommandContractAuthority.new(evidence) do
+      {:ok, authority} ->
+        {:ok,
+         classification
+         |> Map.put(:contract_authority, authority)
+         |> authorize_violation_paths(authority)}
+
+      {:error, :invalid_contract_classification} = error ->
+        error
+    end
+  end
+
+  def classify(_contract, _value), do: {:error, :invalid_contract_classification}
+
+  @spec diagnostic_parts(CommandSource.t() | nil, map()) ::
+          {CommandSource.t() | nil, CommandPath.t() | nil}
+  def diagnostic_parts(
+        %CommandSource{} = source,
+        %{contract_authority: authority} = classification
+      ) do
+    case CommandSource.with_contract(source, authority) do
+      {:ok, bound_source} -> {bound_source, first_violation_path(classification)}
+      {:error, :invalid_command_source} -> {source, nil}
+    end
+  end
+
+  def diagnostic_parts(%CommandSource{} = source, _classification), do: {source, nil}
+  def diagnostic_parts(nil, _classification), do: {nil, nil}
+
+  defp authorize_violation_paths(classification, authority) do
+    Map.update(classification, :violations, [], fn violations ->
+      Enum.flat_map(violations, fn
+        %{segments: segments} = violation ->
+          case CommandPath.contract(authority, segments) do
+            {:ok, path} -> [violation |> Map.delete(:segments) |> Map.put(:path, path)]
+            {:error, :invalid_command_path} -> []
+          end
+
+        _invalid ->
+          []
+      end)
+    end)
+  end
+
+  defp first_violation_path(%{violations: violations}) when is_list(violations) do
+    Enum.find_value(violations, fn
+      %{path: %CommandPath{} = path} -> path
+      _invalid -> nil
+    end)
+  end
+
+  defp first_violation_path(_classification), do: nil
+end

--- a/test/ptc_runner/kernel/command_frontend_test.exs
+++ b/test/ptc_runner/kernel/command_frontend_test.exs
@@ -229,6 +229,84 @@ defmodule PtcRunner.Kernel.CommandFrontendTest do
   end
 
   @tag :tmp_dir
+  test "an input contract rejection renders its safe declared path", %{tmp_dir: dir} do
+    application = write_application(dir)
+    manifest = application |> File.read!() |> Jason.decode!()
+
+    input_schema = %{
+      "type" => "object",
+      "properties" => %{"answer" => %{"type" => "integer"}},
+      "required" => ["answer"]
+    }
+
+    invalid_manifest =
+      manifest
+      |> Map.put("contracts", %{"input_schema" => %{"path" => "input.schema.json"}})
+      |> put_in(["input", "value", "answer"], "wrong")
+
+    File.write!(application, Jason.encode!(invalid_manifest))
+    File.write!(Path.join(dir, "input.schema.json"), Jason.encode!(input_schema))
+
+    presentation =
+      CommandFrontend.execute(["validate", application], :standalone, fn _arguments ->
+        {:ok, CommandRuntime.standalone()}
+      end)
+
+    assert presentation.exit_status == 3
+    assert presentation.outcome.envelope["error"]["path"] == "/answer"
+
+    assert presentation.stderr ==
+             "error: application/input_contract_failed: " <>
+               "the selected input does not satisfy the input contract " <>
+               "at /answer (run_ref: #{presentation.outcome.envelope["run_ref"]})\n"
+  end
+
+  @tag :tmp_dir
+  test "a result contract rejection retains and renders its safe declared path", %{tmp_dir: dir} do
+    application = write_application(dir)
+    manifest = application |> File.read!() |> Jason.decode!()
+
+    result_schema = %{
+      "type" => "object",
+      "properties" => %{"answer" => %{"type" => "integer"}},
+      "required" => ["answer"]
+    }
+
+    File.write!(
+      Path.join(dir, "main.clj"),
+      ~S|(ns main) (defn run [_] (return {"answer" "wrong"}))|
+    )
+
+    File.write!(
+      application,
+      manifest
+      |> Map.put("contracts", %{"result_schema" => %{"path" => "result.schema.json"}})
+      |> Jason.encode!()
+    )
+
+    File.write!(Path.join(dir, "result.schema.json"), Jason.encode!(result_schema))
+
+    presentation =
+      CommandFrontend.execute(["run", application], :standalone, fn _arguments ->
+        {:ok, CommandRuntime.standalone()}
+      end)
+
+    assert presentation.exit_status == 7
+
+    assert presentation.outcome.envelope["error"]["source"] == %{
+             "kind" => "result_contract",
+             "name" => "result.schema.json"
+           }
+
+    assert presentation.outcome.envelope["error"]["path"] == "/answer"
+
+    assert presentation.stderr ==
+             "error: result_cleanup/result_contract_failed: " <>
+               "the workflow result does not satisfy its contract " <>
+               "at /answer (run_ref: #{presentation.outcome.envelope["run_ref"]})\n"
+  end
+
+  @tag :tmp_dir
   test "human failures do not render contract-authored control bytes", %{tmp_dir: dir} do
     application = write_application(dir)
     manifest = application |> File.read!() |> Jason.decode!()
@@ -259,6 +337,7 @@ defmodule PtcRunner.Kernel.CommandFrontendTest do
     assert presentation.stderr ==
              "error: application/input_contract_failed: " <>
                "the selected input does not satisfy the input contract " <>
+               ~S|at "/line\n\e[31m" | <>
                "(run_ref: #{presentation.outcome.envelope["run_ref"]})\n"
 
     refute presentation.stderr =~ property

--- a/test/ptc_runner/kernel/execution_outcome_test.exs
+++ b/test/ptc_runner/kernel/execution_outcome_test.exs
@@ -1,6 +1,7 @@
 defmodule PtcRunner.Kernel.ExecutionOutcomeTest do
   use ExUnit.Case, async: true
 
+  alias PtcRunner.Kernel.CommandPath
   alias PtcRunner.Kernel.DeterministicJSON
   alias PtcRunner.Kernel.Error
   alias PtcRunner.Kernel.EventSink
@@ -26,7 +27,7 @@ defmodule PtcRunner.Kernel.ExecutionOutcomeTest do
       {:ok, sink} = EventSink.start(policy, limits)
 
       assert {:ok, outcome} =
-               ExecutionOutcome.capture(result(), {:ok, []}, sink, nil, nil, authority)
+               ExecutionOutcome.capture(result(), {:ok, []}, sink, nil, nil, nil, authority)
 
       assert ExecutionOutcome.valid?(outcome)
       assert open!(outcome, authority).result_class == policy
@@ -44,6 +45,7 @@ defmodule PtcRunner.Kernel.ExecutionOutcomeTest do
                error_result(),
                {:error, :event_sink_error},
                sink,
+               nil,
                nil,
                nil,
                authority
@@ -65,6 +67,7 @@ defmodule PtcRunner.Kernel.ExecutionOutcomeTest do
                sink,
                nil,
                nil,
+               nil,
                authority
              )
 
@@ -81,7 +84,7 @@ defmodule PtcRunner.Kernel.ExecutionOutcomeTest do
       InspectionSink.start(run_id: "outcome-inspection", trace_id: "outcome-inspection")
 
     assert {:ok, outcome} =
-             ExecutionOutcome.capture(result(), {:ok, []}, sink, inspection, nil, authority)
+             ExecutionOutcome.capture(result(), {:ok, []}, sink, inspection, nil, nil, authority)
 
     assert open!(outcome, authority).inspection == {:ok, []}
     assert :ok = InspectionSink.stop(inspection)
@@ -117,6 +120,7 @@ defmodule PtcRunner.Kernel.ExecutionOutcomeTest do
                terminal_batch,
                sink,
                inspection,
+               nil,
                nil,
                authority
              )
@@ -157,6 +161,7 @@ defmodule PtcRunner.Kernel.ExecutionOutcomeTest do
                sink,
                inspection,
                nil,
+               nil,
                authority
              )
 
@@ -183,6 +188,7 @@ defmodule PtcRunner.Kernel.ExecutionOutcomeTest do
                sink,
                nil,
                contract,
+               "result.schema.json",
                authority
              )
 
@@ -195,13 +201,42 @@ defmodule PtcRunner.Kernel.ExecutionOutcomeTest do
                sink,
                nil,
                contract,
+               "result.schema.json",
                authority
              )
 
     assert {:error, {:result_contract_failed, details}} =
              open!(rejected, authority).result_contract
 
-    assert is_map(details)
+    assert details.contract_source == "result.schema.json"
+    assert [%{kind: :type, path: path}] = details.violations
+    assert CommandPath.to_pointer(path) == "/answer"
+    assert :ok = EventSink.stop(sink)
+  end
+
+  test "rejects a non-portable result-contract source", %{
+    limits: limits,
+    authority: authority
+  } do
+    {:ok, sink} = EventSink.start(:normal, limits)
+
+    {:ok, contract} =
+      ValueContract.compile(%{
+        "type" => "object",
+        "properties" => %{"answer" => %{"type" => "integer"}}
+      })
+
+    assert {:error, :invalid_execution_outcome} =
+             ExecutionOutcome.capture(
+               result(),
+               {:ok, []},
+               sink,
+               nil,
+               contract,
+               "../private/result.schema.json",
+               authority
+             )
+
     assert :ok = EventSink.stop(sink)
   end
 
@@ -213,6 +248,7 @@ defmodule PtcRunner.Kernel.ExecutionOutcomeTest do
                result(),
                {:ok, [%{sequence: 1}]},
                sink,
+               nil,
                nil,
                nil,
                authority
@@ -242,6 +278,7 @@ defmodule PtcRunner.Kernel.ExecutionOutcomeTest do
                result(),
                {:ok, [%{sequence: 1}]},
                sink,
+               nil,
                nil,
                nil,
                authority


### PR DESCRIPTION
## Summary

- preserve schema-authorized violation paths for both input and result contracts
- retain the result contract's logical manifest source name through execution outcome capture
- render ordinary pointers directly and escape unusual/control-bearing pointers before terminal output
- share the attested classification logic between input and result diagnostics
- document the public envelope/terminal behavior and add end-to-end regressions

## Root cause

Input-contract classification already carried an authorized path into the public command envelope, but the terminal renderer did not display it. Result-contract cleanup discarded the classification details entirely, and the execution outcome did not retain the logical result-schema source needed to bind an authorized path to a public diagnostic.

## Impact and boundaries

Contract failures now identify locations such as `/answer` in both the stable command envelope and terminal message. Unusual contract-authored names are quoted and escaped, so control bytes never reach the terminal. Rejected values, undeclared properties, filesystem paths, trace payloads, and private inspection records remain excluded.

## Verification

- independent cumulative Codex review against `origin/main`: no actionable findings
- `mix precommit`
  - 6,249 root tests
  - 44 Viewer tests
  - 40 launcher tests
  - compile, Credo, duplication, specification, generated-artifact, package, and release gates
- pre-push CI-equivalent checks
  - 6,249 root tests
  - static analysis and Dialyzer
  - ExDoc, release verification, and 44 Viewer tests

Closes #1374