### PR TITLE
feat(viewer): inspect private programs and prelude sources

### DIFF
--- a/lib/ptc_runner/kernel/viewer_adapter.ex
+++ b/lib/ptc_runner/kernel/viewer_adapter.ex
@@ -26,7 +26,7 @@ defmodule PtcRunner.Kernel.ViewerAdapter do
          do: TraceLog.query(trace_log, operation, arguments)
   end
 
-  @opaque inspection_grant :: {:inspection_v2, binary(), map(), [map()], binary()}
+  @opaque inspection_grant :: {:inspection_v3, binary(), map()}
 
   @spec pin_inspection(binary(), inspection_trace_source()) ::
           {:ok, inspection_grant()}
@@ -39,8 +39,9 @@ defmodule PtcRunner.Kernel.ViewerAdapter do
          {:ok, %{"trace_id" => ^trace_id}} <-
            trace_query(capture, :get_run, %{"run_id" => run_id}),
          {:ok, trace_page} <- all_turns(capture, run_id),
-         :ok <- InspectionArtifact.validate_correlations(records, trace_page["items"]) do
-      {:ok, {:inspection_v2, run_id, trace_page, records, capture.source_id}}
+         :ok <- InspectionArtifact.validate_correlations(records, trace_page["items"]),
+         {:ok, compiled} <- compile_inspection(records, trace_page, capture.source_id) do
+      {:ok, {:inspection_v3, run_id, compiled}}
     else
       {:error, reason} when reason in [:not_found, :invalid_query] ->
         {:error, :inspection_correlation_missing}
@@ -57,33 +58,43 @@ defmodule PtcRunner.Kernel.ViewerAdapter do
 
   @spec conversation(inspection_grant(), binary()) :: {:ok, map()} | {:error, atom()}
   @doc "Builds a semantic conversation from the pinned, already validated records."
-  def conversation({:inspection_v2, granted_run_id, trace_page, records, trace_source_id}, run_id)
-      when is_binary(granted_run_id) and is_map(trace_page) and is_list(records) and
-             is_binary(trace_source_id) and is_binary(run_id) do
+  def conversation(grant, run_id) do
+    with {:ok, turns} <- inspection_collection(grant, run_id, :turns),
+         result = ConversationProjection.present_page(turns),
+         true <- byte_size(Jason.encode!(result)) <= 1_000_000 do
+      {:ok, result}
+    else
+      false -> {:error, :result_limit_exceeded}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  @spec preludes(inspection_grant(), binary()) :: {:ok, map()} | {:error, atom()}
+  @doc "Returns the pinned run's exact effective prelude sources."
+  def preludes(grant, run_id), do: inspection_collection(grant, run_id, :effective_preludes)
+
+  defp inspection_collection({:inspection_v3, granted_run_id, compiled}, run_id, operation)
+       when is_binary(granted_run_id) and is_map(compiled) and is_binary(run_id) do
     if granted_run_id == run_id do
-      trace_analysis = TraceLog.compile_analysis(trace_page["items"], :private)
-
-      analysis_facts = %{
-        "trace_snapshot_hash" => trace_page["snapshot_hash"],
-        "runs" => trace_analysis.facts_by_run_id
-      }
-
-      with {:ok, compiled} <-
-             InspectionQuery.compile([records], trace_source_id, analysis_facts),
-           {:ok, turns} <- all_inspection(compiled, :turns, run_id),
-           result = ConversationProjection.present_page(turns),
-           true <- byte_size(Jason.encode!(result)) <= 1_000_000 do
-        {:ok, result}
-      else
-        false -> {:error, :result_limit_exceeded}
-        {:error, _reason} = error -> error
-      end
+      all_inspection(compiled, operation, run_id)
     else
       {:error, :inspection_run_mismatch}
     end
   end
 
-  def conversation(_grant, _run_id), do: {:error, :invalid_inspection_query}
+  defp inspection_collection(_grant, _run_id, _operation),
+    do: {:error, :invalid_inspection_query}
+
+  defp compile_inspection(records, trace_page, trace_source_id) do
+    trace_analysis = TraceLog.compile_analysis(trace_page["items"], :private)
+
+    analysis_facts = %{
+      "trace_snapshot_hash" => trace_page["snapshot_hash"],
+      "runs" => trace_analysis.facts_by_run_id
+    }
+
+    InspectionQuery.compile([records], trace_source_id, analysis_facts)
+  end
 
   defp all_inspection(compiled, operation, run_id),
     do: all_inspection(compiled, operation, run_id, nil, [], nil, %{}, 0)

--- a/ptc_viewer/README.md
+++ b/ptc_viewer/README.md
@@ -20,8 +20,10 @@ mix ptc.viewer --trace-dir traces
 
 The root task installs `PtcRunner.Kernel.ViewerAdapter` automatically, starts a
 local server on port 4123, and opens the browser. Use `--port`, `--trace-dir`,
-`--inspection-file`, or `--no-open` to override those defaults. The server
-always binds to loopback.
+`--inspection-file`, `--private-traces`, or `--no-open` to override those
+defaults. The server always binds to loopback. `--private-traces` selects
+owner-only canonical trace files for debugger runs and disables the connected
+public run-analysis REPL; it does not widen that REPL's authority.
 
 The REPL evaluates PTC-Lisp against an immutable capture of the selected trace
 directory. The server fixes the `run-analysis-v1` profile: normal bounded

--- a/ptc_viewer/README.md
+++ b/ptc_viewer/README.md
@@ -49,16 +49,21 @@ and canonical activity, plus one semantic `conversation` result when the Viewer
 was started with an authorized inspection artifact. The URL carries
 `#/run/<run-id>`, so a run view can be bookmarked and reloaded.
 
-The canonical transcript remains sanitized and never joins private records.
-Private model requests and responses appear only in the separate **Model
-conversation** panel produced by `RunAnalysis`; ambiguous exchanges are
-omitted from streams and reported by the semantic result rather than guessed
-into a turn. The browser cannot choose a server path or discover inspection
-files. Startup pins the operator-selected artifact, validates it against the
-captured canonical trace, and retains an immutable grant, so replacing the
-original path cannot change later responses. Symlinks, changed files,
-oversized or malformed records, correlation failures, and mismatched run IDs
-fail closed.
+The canonical transcript keeps canonical events as its execution spine. With
+an authorized inspection artifact, it also shows each evaluation's exact
+generated program from the semantic conversation projection and the feedback
+reconstructed on the following turn. Ambiguous program-to-turn associations
+are not guessed into result blocks. Private model requests and responses also
+appear in the separate **Model conversation** panel produced by `RunAnalysis`;
+ambiguous exchanges are omitted from streams and reported by the semantic
+result rather than guessed into a turn.
+
+The browser cannot choose a server path or discover inspection files. Startup
+pins the operator-selected artifact, validates it against the captured
+canonical trace, and compiles the immutable inspection projection once, so
+replacing the original path cannot change later responses. Symlinks, changed
+files, oversized or malformed records, correlation failures, and mismatched
+run IDs fail closed.
 
 The prelude cards list effective workflow and mission components in frozen
 load order (dependencies before dependants) with the bundle hash. When run
@@ -69,6 +74,13 @@ per-component dependency lists. The complete graph must validate; missing or
 malformed projections fall back to the ordered chips without partially
 rendered edges, reordered IDs, or inferred dependencies. Current canonical
 metadata records only ordered component IDs and the bundle hash.
+
+When inspection capture includes effective prelude sources, component entries
+open the exact captured source. Generated-source records carry statically
+analyzed `prelude_calls`; those facts alone produce the clickable call badges
+that navigate to the matching scoped component. Source highlighting may place
+an anchor on a matching definition, with the component source as the fallback;
+highlighted program text is never parsed to infer that a call occurred.
 
 ```bash
 mix ptc.viewer --trace-dir traces \
@@ -132,6 +144,7 @@ Runs-only UI.
 | `GET /api/kernel/runs/:run_id/turns` | `list_turns` with bounded filters and pagination |
 | `GET /api/kernel/counters` | `counters` |
 | `GET /api/analysis/runs/:run_id/conversation` | Presentation over the bounded `turns` collection |
+| `GET /api/analysis/runs/:run_id/preludes` | Bounded effective prelude sources from the pinned inspection projection |
 | `GET /api/repl` | Bootstrap or refresh the server-owned analysis session |
 | `POST /api/repl/evaluations` | Evaluate one bounded PTC-Lisp form |
 | `POST /api/repl/templates` | Format an inert `analysis/open` or `analysis/read` editor template |

--- a/ptc_viewer/lib/mix/tasks/ptc_viewer.ex
+++ b/ptc_viewer/lib/mix/tasks/ptc_viewer.ex
@@ -12,22 +12,26 @@ defmodule Mix.Tasks.Ptc.Viewer do
           port: :integer,
           trace_dir: :string,
           inspection_file: :string,
+          private_traces: :boolean,
           no_open: :boolean
         ]
       )
 
     Mix.Task.run("app.start")
 
+    private_traces = opts[:private_traces] == true
+
     viewer_opts =
       []
       |> maybe_add(:port, opts[:port])
       |> maybe_add(:trace_dir, opts[:trace_dir])
       |> maybe_add(:inspection_file, opts[:inspection_file])
+      |> maybe_add(:private_traces, private_traces)
       |> maybe_add(:open, if(opts[:no_open], do: false, else: true))
       |> maybe_add(:kernel_trace_adapter, default_kernel_adapter())
       |> maybe_add(:inspection_adapter, inspection_adapter(opts[:inspection_file]))
-      |> maybe_add(:repl_adapter, default_repl_adapter())
-      |> maybe_add(:repl_config, repl_config(opts[:trace_dir]))
+      |> maybe_add(:repl_adapter, if(private_traces, do: nil, else: default_repl_adapter()))
+      |> maybe_add(:repl_config, if(private_traces, do: nil, else: repl_config(opts[:trace_dir])))
 
     case PtcViewer.start(viewer_opts) do
       {:ok, _pid} ->

--- a/ptc_viewer/lib/ptc_viewer/api.ex
+++ b/ptc_viewer/lib/ptc_viewer/api.ex
@@ -6,7 +6,12 @@ defmodule PtcViewer.Api do
   @doc "Delegates a canonical trace query to one explicitly configured host adapter."
   def kernel_query(config, operation, arguments)
       when is_list(config) and operation in @operations and is_map(arguments) do
-    source = {:directory, Keyword.fetch!(config, :trace_dir)}
+    trace_dir = Keyword.fetch!(config, :trace_dir)
+
+    source =
+      if Keyword.get(config, :private_traces, false),
+        do: {:private_directory, trace_dir},
+        else: {:directory, trace_dir}
 
     case Keyword.get(config, :kernel_trace_adapter) do
       nil -> {:error, :unavailable}

--- a/ptc_viewer/lib/ptc_viewer/api.ex
+++ b/ptc_viewer/lib/ptc_viewer/api.ex
@@ -23,17 +23,23 @@ defmodule PtcViewer.Api do
   def kernel_query(_config, _operation, _arguments), do: {:error, :invalid_query}
 
   @doc "Delegates semantic private conversation reconstruction to the configured host adapter."
-  def conversation(config, run_id) when is_list(config) and is_binary(run_id) do
+  def conversation(config, run_id), do: inspection_query(config, :conversation, run_id)
+
+  @doc "Delegates private effective-prelude source retrieval to the configured host adapter."
+  def preludes(config, run_id), do: inspection_query(config, :preludes, run_id)
+
+  defp inspection_query(config, operation, run_id)
+       when is_list(config) and is_binary(run_id) do
     with store when is_pid(store) <- Keyword.get(config, :inspection_store),
          {:ok, source} <- PtcViewer.InspectionStore.fetch(store),
          adapter when not is_nil(adapter) <- Keyword.get(config, :inspection_adapter) do
-      safely_conversation(adapter, source, run_id)
+      safely_inspection(adapter, operation, source, run_id)
     else
       _missing -> {:error, :unavailable}
     end
   end
 
-  def conversation(_config, _run_id), do: {:error, :invalid_inspection_query}
+  defp inspection_query(_config, _operation, _run_id), do: {:error, :invalid_inspection_query}
 
   defp safely_query(adapter, source, operation, arguments) when is_function(adapter, 3) do
     adapter.(source, operation, arguments)
@@ -53,7 +59,8 @@ defmodule PtcViewer.Api do
     _kind, _reason -> {:error, :adapter_failure}
   end
 
-  defp safely_conversation(adapter, source, run_id) when is_function(adapter, 2) do
+  defp safely_inspection(adapter, :conversation, source, run_id)
+       when is_function(adapter, 2) do
     adapter.(source, run_id)
     |> normalize_adapter_result()
   rescue
@@ -62,14 +69,17 @@ defmodule PtcViewer.Api do
     _kind, _reason -> {:error, :adapter_failure}
   end
 
-  defp safely_conversation(adapter, source, run_id) when is_atom(adapter) do
-    apply(adapter, :conversation, [source, run_id])
+  defp safely_inspection(adapter, operation, source, run_id) when is_atom(adapter) do
+    apply(adapter, operation, [source, run_id])
     |> normalize_adapter_result()
   rescue
     _exception -> {:error, :adapter_failure}
   catch
     _kind, _reason -> {:error, :adapter_failure}
   end
+
+  defp safely_inspection(_adapter, _operation, _source, _run_id),
+    do: {:error, :unavailable}
 
   defp normalize_adapter_result({:ok, result}) when is_map(result), do: {:ok, result}
   defp normalize_adapter_result({:error, reason}) when is_atom(reason), do: {:error, reason}

--- a/ptc_viewer/lib/ptc_viewer/router.ex
+++ b/ptc_viewer/lib/ptc_viewer/router.ex
@@ -109,7 +109,11 @@ defmodule PtcViewer.Router do
   end
 
   get "/api/analysis/runs/:run_id/conversation" do
-    send_conversation(conn, run_id)
+    send_analysis(conn, PtcViewer.Api.conversation(viewer_config(conn), run_id))
+  end
+
+  get "/api/analysis/runs/:run_id/preludes" do
+    send_analysis(conn, PtcViewer.Api.preludes(viewer_config(conn), run_id))
   end
 
   match "/api/*path" do
@@ -412,8 +416,8 @@ defmodule PtcViewer.Router do
     end
   end
 
-  defp send_conversation(conn, run_id) do
-    case PtcViewer.Api.conversation(viewer_config(conn), run_id) do
+  defp send_analysis(conn, result) do
+    case result do
       {:ok, result} ->
         send_private_json(conn, result)
 

--- a/ptc_viewer/lib/ptc_viewer/server.ex
+++ b/ptc_viewer/lib/ptc_viewer/server.ex
@@ -25,6 +25,7 @@ defmodule PtcViewer.Server do
     inspection_adapter = Keyword.get(opts, :inspection_adapter)
     repl_adapter = Keyword.get(opts, :repl_adapter)
     repl_config = Keyword.get(opts, :repl_config, %{})
+    private_traces = Keyword.get(opts, :private_traces, false) == true
 
     if is_integer(port) and port in 0..65_535 do
       params = %{
@@ -34,7 +35,8 @@ defmodule PtcViewer.Server do
         inspection_file: inspection_file,
         inspection_adapter: inspection_adapter,
         repl_adapter: repl_adapter,
-        repl_config: repl_config
+        repl_config: repl_config,
+        private_traces: private_traces
       }
 
       case start_resources(params) do
@@ -51,7 +53,11 @@ defmodule PtcViewer.Server do
   end
 
   defp start_resources(params) do
-    case pin_inspection(params.inspection_file, params.inspection_adapter, params.trace_dir) do
+    case pin_inspection(
+           params.inspection_file,
+           params.inspection_adapter,
+           trace_source(params)
+         ) do
       {:ok, inspection_store} -> start_connection(params, inspection_store)
       {:error, reason} -> {:error, reason}
     end
@@ -96,10 +102,8 @@ defmodule PtcViewer.Server do
   defp start_bandit(params, inspection_store, connection, task_supervisor, repl_store) do
     config =
       router_config(
-        params.trace_dir,
-        params.kernel_adapter,
+        params,
         inspection_store,
-        params.inspection_adapter,
         repl_store,
         self()
       )
@@ -227,36 +231,34 @@ defmodule PtcViewer.Server do
     )
   end
 
-  defp router_config(
-         trace_dir,
-         kernel_adapter,
-         inspection_store,
-         inspection_adapter,
-         repl_store,
-         server
-       ) do
+  defp router_config(params, inspection_store, repl_store, server) do
     [
-      trace_dir: trace_dir,
-      kernel_trace_adapter: kernel_adapter,
+      trace_dir: params.trace_dir,
+      private_traces: params.private_traces,
+      kernel_trace_adapter: params.kernel_adapter,
       inspection_store: inspection_store,
-      inspection_adapter: inspection_adapter,
+      inspection_adapter: params.inspection_adapter,
       repl_store: repl_store,
       repl_enabled: not is_nil(repl_store),
       viewer_server: server
     ]
   end
 
-  defp pin_inspection(nil, nil, _trace_dir), do: {:ok, nil}
+  defp trace_source(%{private_traces: true, trace_dir: trace_dir}),
+    do: {:private_directory, trace_dir}
+
+  defp trace_source(%{trace_dir: trace_dir}), do: {:directory, trace_dir}
+
+  defp pin_inspection(nil, nil, _trace_source), do: {:ok, nil}
 
   defp pin_inspection(path, nil, _trace_dir) when is_binary(path),
     do: {:error, :invalid_inspection_config}
 
-  defp pin_inspection(path, adapter, trace_dir) when is_binary(path) and is_atom(adapter) do
-    if Code.ensure_loaded?(adapter) and function_exported?(adapter, :pin_inspection, 2) and
-         function_exported?(adapter, :conversation, 2) do
+  defp pin_inspection(path, adapter, trace_source) when is_binary(path) and is_atom(adapter) do
+    if valid_inspection_adapter?(adapter) do
       with {:ok, source} <-
              adapter
-             |> apply(:pin_inspection, [Path.expand(path), {:directory, trace_dir}])
+             |> apply(:pin_inspection, [Path.expand(path), trace_source])
              |> normalize_pin_result(),
            {:ok, store} <- InspectionStore.start(source) do
         {:ok, store}
@@ -271,6 +273,13 @@ defmodule PtcViewer.Server do
   end
 
   defp pin_inspection(_path, _adapter, _trace_dir), do: {:error, :invalid_inspection_config}
+
+  defp valid_inspection_adapter?(adapter) do
+    Code.ensure_loaded?(adapter) and
+      Enum.all?([:pin_inspection, :conversation, :preludes], fn operation ->
+        function_exported?(adapter, operation, 2)
+      end)
+  end
 
   defp normalize_pin_result({:ok, source}) when not is_nil(source), do: {:ok, source}
   defp normalize_pin_result({:error, reason}) when is_atom(reason), do: {:error, reason}

--- a/ptc_viewer/priv/static/css/styles.css
+++ b/ptc_viewer/priv/static/css/styles.css
@@ -1447,6 +1447,25 @@ button:focus-visible, textarea:focus-visible, summary:focus-visible {
 .kt-call-body { padding: 7px 10px 9px 37px; border-top: 1px solid var(--border); }
 .kt-sanitized-note { margin: 2px 0 8px; color: var(--muted); font-size: 11px; }
 
+.kt-private-source { margin: 2px 0 8px; }
+.kt-private-source > summary { cursor: pointer; font-size: 12px; color: var(--muted); }
+.kt-private-source[open] > summary { margin-bottom: 4px; }
+.kt-private-badge {
+  margin-left: 6px; padding: 1px 6px; border-radius: 8px;
+  background: var(--badge-error-bg, rgba(214, 90, 90, 0.15));
+  color: var(--badge-error-fg, #d65a5a); font-size: 10px;
+  text-transform: uppercase; letter-spacing: 0.04em;
+}
+.kt-prelude-calls { display: flex; align-items: center; flex-wrap: wrap; gap: 5px; margin-top: 6px; }
+.kt-prelude-calls > span:first-child { color: var(--muted); font-size: 10px; }
+.kt-prelude-call {
+  padding: 2px 7px; border: 1px solid var(--border); border-radius: 9px;
+  color: var(--accent); font: 10px 'SF Mono', Consolas, Monaco, monospace; text-decoration: none;
+}
+.kt-prelude-call:hover,
+.kt-prelude-call:focus { background: rgba(86, 156, 214, 0.16); outline: none; }
+.kt-prelude-call-unavailable { color: var(--muted); }
+
 .kt-annotation { margin: 5px 0; border-left: 2px solid var(--keyword); background: var(--bg); }
 .kt-annotation > summary { padding: 6px 9px; cursor: pointer; }
 .kt-annotation > summary span { color: var(--muted); font-size: 10px; }
@@ -1515,6 +1534,28 @@ button:focus-visible, textarea:focus-visible, summary:focus-visible {
   color: var(--fg);
   font-size: 9px;
 }
+.kt-component-source { min-width: 0; }
+.kt-component-source > summary {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 4px;
+  cursor: pointer;
+  list-style-position: outside;
+}
+.kt-component-source > summary:hover code { color: var(--accent); }
+.kt-component-source-label { margin-left: auto; color: var(--accent); font-size: 9px; }
+.kt-component-source-meta { margin: 6px 0 4px; color: var(--muted); font-size: 9px; }
+.kt-component-source .kt-code { max-height: 520px; }
+.kt-component-source-compact {
+  padding: 2px 7px;
+  border-radius: 8px;
+  background: rgba(197, 134, 192, 0.14);
+}
+.kt-component-source-compact > summary { color: var(--keyword); font-size: 10px; }
+.kt-component-source-compact > summary code { color: inherit; }
+.kt-component-source-compact > .kt-code { min-width: min(680px, 80vw); }
+.kt-prelude-definition-active { border-radius: 3px; background: rgba(220, 220, 170, 0.22); }
 
 /* === Private inspection joins (dialogue, program source, payloads) === */
 .kt-private-chip {

--- a/ptc_viewer/priv/static/js/app.js
+++ b/ptc_viewer/priv/static/js/app.js
@@ -254,10 +254,11 @@ async function fetchAllTurns(runId) {
 }
 
 async function loadRun(runId) {
-  const [runResponse, turnsResult, conversationResponse] = await Promise.all([
+  const [runResponse, turnsResult, conversationResponse, preludesResponse] = await Promise.all([
     fetch(`/api/kernel/runs/${encodeURIComponent(runId)}`),
     fetchAllTurns(runId),
-    fetch(`/api/analysis/runs/${encodeURIComponent(runId)}/conversation`)
+    fetch(`/api/analysis/runs/${encodeURIComponent(runId)}/conversation`),
+    fetch(`/api/analysis/runs/${encodeURIComponent(runId)}/preludes`)
   ]);
 
   if (!runResponse.ok || turnsResult.failed) {
@@ -273,11 +274,13 @@ async function loadRun(runId) {
         status: conversationResponse.status,
         reason: await safeBodyText(conversationResponse)
       };
+  const preludes = preludesResponse.ok ? await preludesResponse.json() : null;
   renderRun(
     {
       metadata: await runResponse.json(),
       turns: turnsResult.turns,
-      conversation
+      conversation,
+      preludes
     },
     { fresh: true }
   );
@@ -329,6 +332,7 @@ function renderRun(data, { fresh = false } = {}) {
       renderRun({
         metadata,
         conversation,
+        preludes: data.preludes,
         turns: { ...nextPage, items: [...(turns.items || []), ...(nextPage.items || [])] }
       });
     }

--- a/ptc_viewer/priv/static/js/kernel-transcript.js
+++ b/ptc_viewer/priv/static/js/kernel-transcript.js
@@ -1,8 +1,9 @@
 // Canonical Kernel TraceLog transcript view.
 //
 // This is intentionally a projection of the shared sanitized event vocabulary,
-// not the private evaluator transcript format. Private model conversation is a
-// separate semantic RunAnalysis projection; this renderer never joins records.
+// not the private evaluator transcript format. Authorized conversation and
+// prelude projections may enrich the view, but raw inspection records never
+// reach this renderer.
 //
 // Rendering is Preact. The span derivations below stay pure functions over
 // canonical events so they remain independently testable, and the view is
@@ -12,7 +13,8 @@
 // scroll position survive it, and every interpolated value is escaped by the
 // `html` tag rather than by remembering `escapeHtml` at each site.
 
-import { html, mount, toMarkup } from './preact.js';
+import { html, mount, rawHtml, toMarkup } from './preact.js';
+import { highlightLisp } from './highlight.js';
 
 const SUCCESS = new Set(['ok', 'continued', 'returned', 'completed', 'success']);
 const FAILURE = new Set([
@@ -42,17 +44,55 @@ export function renderKernelTranscriptMarkup(data) {
   return toMarkup(html`<${KernelTranscript} ...${data} />`);
 }
 
-function KernelTranscript({ metadata = {}, turns = {}, options = {} }) {
+function KernelTranscript({
+  metadata = {}, turns = {}, conversation = null, preludes = null, options = {}
+}) {
   const events = [...(turns.items || [])].sort((left, right) => left.sequence - right.sequence);
   const transcript = buildTranscript(events);
   const partial = Boolean(turns.next_cursor);
+  const preludeIndex = buildPreludeIndex(preludes);
+  const privatePrograms = new Map();
+  const privateResults = new Map();
+
+  for (const stream of conversation?.streams || []) {
+    const streamTurns = stream.turns || [];
+
+    streamTurns.forEach((turn, index) => {
+      const generated = turn.generated || [];
+      generated.forEach(program => {
+        if (program?.evaluation_id) privatePrograms.set(program.evaluation_id, program);
+      });
+
+      const feedback = streamTurns[index + 1]?.feedback || [];
+      if (!feedback.length) return;
+
+      generated.forEach(program => {
+        if (!program?.evaluation_id || program['association_ambiguous?']) return;
+
+        const callIds = new Set(
+          (turn.assistant?.tool_calls || [])
+            .filter(call => call?.args?.program === program.source && call?.id)
+            .map(call => call.id)
+        );
+        const matched = feedback.filter(message => callIds.has(message?.tool_call_id));
+        const result = matched.length ? matched : generated.length === 1 ? feedback : [];
+        if (result.length) privateResults.set(program.evaluation_id, result);
+      });
+    });
+  }
+
+  transcript.evaluations.forEach(evaluation => {
+    evaluation.privateProgram = privatePrograms.get(evaluation.id) || null;
+    evaluation.privateResult = privateResults.get(evaluation.id) || null;
+  });
 
   return html`
     <section class="kernel-transcript">
       <${Hero} metadata=${metadata} transcript=${transcript}
                eventCount=${events.length} truncatedPage=${partial} />
       <${Provenance} />
-      <${Reference} metadata=${metadata} transcript=${transcript} options=${options} />
+      <${Reference} metadata=${metadata} transcript=${transcript}
+                    preludeIndex=${preludeIndex} options=${options} />
       ${turns.next_cursor && html`
         <button class="btn kernel-load-more" type="button"
                 onClick=${event => options.onLoadMore?.(event.currentTarget)}>
@@ -120,12 +160,12 @@ function Provenance() {
 // Supporting canonical evidence stays one click away instead of expanding a
 // small run to several screens of prelude chips and raw event JSON.
 
-function Reference({ metadata, transcript, options }) {
+function Reference({ metadata, transcript, preludeIndex, options }) {
   return html`
     <section class="kt-reference" aria-label="Run reference">
       <${Disclosure} className="kt-reference-panel" summary="Environment"
                      hint="Preludes, mission inventory and connector fingerprints">
-        <${Preludes} metadata=${metadata} />
+        <${Preludes} metadata=${metadata} preludeIndex=${preludeIndex} />
         <${Fingerprints} metadata=${metadata} />
       <//>
       <${Disclosure} className="kt-reference-panel" summary="Execution transcript"
@@ -140,7 +180,7 @@ function Reference({ metadata, transcript, options }) {
                     onClick=${() => options.onExpandAll?.(false)}>Collapse all</button>
           </div>
         </div>
-        <${Execution} transcript=${transcript} />
+        <${Execution} transcript=${transcript} preludeIndex=${preludeIndex} />
         <${LooseEvents} events=${transcript.looseEvents} />
       <//>
     </section>
@@ -159,7 +199,7 @@ function Disclosure({ className, summary, hint, open = false, children }) {
   `;
 }
 
-function Preludes({ metadata }) {
+function Preludes({ metadata, preludeIndex }) {
   const entries = [
     ['Workflow prelude', 'workflow', null, metadata.workflow_prelude],
     ...missionEntries(metadata).map(([name, mission]) =>
@@ -169,22 +209,32 @@ function Preludes({ metadata }) {
   return html`
     <div class="kt-preludes">
       ${entries.map(([title, environment, mission, prelude]) => html`
-        <${PreludeCard} key=${mission || environment} title=${title} prelude=${prelude} />`)}
+        <${PreludeCard} key=${mission || environment} title=${title} prelude=${prelude}
+                        environment=${environment} mission=${mission}
+                        preludeIndex=${preludeIndex} />`)}
     </div>
   `;
 }
 
-function PreludeCard({ title, prelude }) {
+function PreludeCard({ title, prelude, environment, mission, preludeIndex }) {
   const ids = Array.isArray(prelude?.component_ids) ? prelude.component_ids : [];
   const components = dependencyGraph(prelude);
+  const hasPrivateSources = ids.some(id =>
+    preludeIndex.byComponent.has(scopeComponentKey(environment, mission, id))
+  );
 
   return html`
     <article class="kt-prelude-card">
       <div class="kt-card-label">
         ${title}
         ${ids.length > 0 && html`<span class="kt-card-count">${ids.length} component${ids.length === 1 ? '' : 's'}</span>`}
+        ${hasPrivateSources && html`<span class="kt-private-badge">private evidence</span>`}
       </div>
-      ${components ? html`<${ComponentRows} components=${components} />` : html`<${ComponentChips} ids=${ids} />`}
+      ${components
+        ? html`<${ComponentRows} components=${components} environment=${environment}
+                                mission=${mission} preludeIndex=${preludeIndex} />`
+        : html`<${ComponentChips} ids=${ids} environment=${environment}
+                                mission=${mission} preludeIndex=${preludeIndex} />`}
       ${ids.length > 1 && html`<div class="kt-prelude-order-note">Load order — dependencies before dependants.</div>`}
       <div class="kt-hash" title=${String(prelude?.hash || '')}>${shorten(prelude?.hash) || 'No bundle hash'}</div>
     </article>
@@ -220,17 +270,20 @@ function dependencyGraph(prelude) {
   return components;
 }
 
-function ComponentChips({ ids }) {
+function ComponentChips({ ids, environment, mission, preludeIndex }) {
   return html`
     <div class="kt-component-list">
       ${ids.length
-        ? ids.map((id, index) => html`<span key=${id}><em class="kt-component-order">${index + 1}</em>${String(id)}</span>`)
+        ? ids.map((id, index) => html`
+            <${ComponentSource} key=${id} component=${{ id, dependencies: [] }} position=${index}
+                                environment=${environment} mission=${mission}
+                                preludeIndex=${preludeIndex} compact=${true} />`)
         : html`<em>No components</em>`}
     </div>
   `;
 }
 
-function ComponentRows({ components }) {
+function ComponentRows({ components, environment, mission, preludeIndex }) {
   const dependants = new Map();
   for (const component of components) {
     for (const dependency of component.dependencies) {
@@ -242,15 +295,43 @@ function ComponentRows({ components }) {
     <ol class="kt-component-rows">
       ${components.map(component => html`
         <li key=${component.id}>
-          <code>${component.id}</code>
-          ${dependants.has(component.id) && html`
-            <span class="kt-component-used-by" title="Direct dependants">↳ used by ${dependants.get(component.id)}</span>`}
-          ${component.dependencies.length > 0 && html`
-            <span class="kt-component-deps">needs ${component.dependencies.map(dependency =>
-              html`<span key=${dependency}>${dependency}</span>`)}</span>`}
+          <${ComponentSource} component=${component} dependants=${dependants.get(component.id)}
+                              environment=${environment} mission=${mission}
+                              preludeIndex=${preludeIndex} />
         </li>
       `)}
     </ol>
+  `;
+}
+
+function ComponentSource({
+  component, position, dependants, environment, mission, preludeIndex, compact = false
+}) {
+  const source = preludeIndex.byComponent.get(scopeComponentKey(environment, mission, component.id));
+  const label = html`
+    ${compact && html`<em class="kt-component-order">${position + 1}</em>`}
+    <code>${component.id}</code>
+    ${dependants && html`
+      <span class="kt-component-used-by" title="Direct dependants">↳ used by ${dependants}</span>`}
+    ${component.dependencies.length > 0 && html`
+      <span class="kt-component-deps">needs ${component.dependencies.map(dependency =>
+        html`<span key=${dependency}>${dependency}</span>`)}</span>`}
+  `;
+
+  if (!source) return compact ? html`<span>${label}</span>` : label;
+
+  return html`
+    <details class=${compact ? 'kt-component-source kt-component-source-compact' : 'kt-component-source'}
+             id=${source.domId}>
+      <summary>
+        ${label}
+        <span class="kt-component-source-label">source</span>
+      </summary>
+      <div class="kt-component-source-meta">
+        ${source.source_bytes ?? '?'} bytes · ${shorten(source.source_hash) || 'no source hash'}
+      </div>
+      ${rawHtml('pre', 'kt-code kt-code-lisp', highlightPreludeSource(source))}
+    </details>
   `;
 }
 
@@ -307,7 +388,7 @@ function missionEntries(metadata) {
 
 // --- Execution transcript -------------------------------------------------
 
-function Execution({ transcript }) {
+function Execution({ transcript, preludeIndex }) {
   if (!transcript.evaluations.length) {
     return html`<div class="kt-empty">No evaluation events were recorded for this run.</div>`;
   }
@@ -315,12 +396,13 @@ function Execution({ transcript }) {
   return html`
     <div class="kt-execution">
       ${transcript.evaluations.map(evaluation => html`
-        <${Evaluation} key=${evaluation.id} evaluation=${evaluation} />`)}
+        <${Evaluation} key=${evaluation.id} evaluation=${evaluation}
+                       preludeIndex=${preludeIndex} />`)}
     </div>
   `;
 }
 
-function Evaluation({ evaluation }) {
+function Evaluation({ evaluation, preludeIndex }) {
   const environment = environmentOf(evaluation) || 'unknown';
   const missionName = missionNameOf(evaluation);
   const status = statusOf(evaluation);
@@ -342,7 +424,7 @@ function Evaluation({ evaluation }) {
         </span>
       </summary>
       <div class="kt-evaluation-body">
-        <${EvaluationSource} evaluation=${evaluation} />
+        <${EvaluationSource} evaluation=${evaluation} preludeIndex=${preludeIndex} />
         <${Capabilities} capabilities=${evaluation.capabilities} />
         <${Annotations} annotations=${evaluation.annotations} />
         <${Limits} limits=${evaluation.limits} />
@@ -355,13 +437,70 @@ function Evaluation({ evaluation }) {
   `;
 }
 
-function EvaluationSource({ evaluation }) {
+function EvaluationSource({ evaluation, preludeIndex }) {
   const canonicalHash = evaluation.start?.data?.source_hash;
-  return canonicalHash
-    ? html`<p class="kt-sanitized-note">${
-        `Program source is omitted from the canonical trace (source_hash ${shorten(canonicalHash)}, ` +
-        `${evaluation.start?.data?.source_bytes ?? '?'} bytes).`}</p>`
+  const program = evaluation.privateProgram;
+
+  const sourceBlock = program?.source != null
+    ? html`
+      <details class="kt-private-source" open=${environmentOf(evaluation) === 'workflow'}>
+        <summary>
+          Program source
+          <span class="kt-private-badge">private evidence</span>
+        </summary>
+        ${rawHtml('pre', 'kt-code kt-code-lisp', highlightLisp(program.source))}
+        <${PreludeCalls} program=${program} evaluation=${evaluation}
+                         preludeIndex=${preludeIndex} />
+      </details>
+    `
+    : canonicalHash
+      ? html`<p class="kt-sanitized-note">${
+          `Program source is omitted from the canonical trace (source_hash ${shorten(canonicalHash)}, ` +
+          `${evaluation.start?.data?.source_bytes ?? '?'} bytes).`}</p>`
+      : null;
+
+  const resultBlock = evaluation.privateResult?.length
+    ? html`
+      <details class="kt-private-source">
+        <summary>
+          Execution result
+          <span class="kt-private-badge">private evidence</span>
+        </summary>
+        ${evaluation.privateResult.map((message, index) => html`
+          <pre class="kt-code" key=${message?.tool_call_id || index}>${message?.content ?? json(message)}</pre>`)}
+      </details>
+    `
     : null;
+
+  return html`${sourceBlock}${resultBlock}`;
+}
+
+function PreludeCalls({ program, evaluation, preludeIndex }) {
+  const calls = Array.isArray(program.prelude_calls) ? program.prelude_calls : [];
+  if (!calls.length) return null;
+
+  const environment = program.environment || environmentOf(evaluation);
+  const mission = program.mission_name || missionNameOf(evaluation);
+
+  return html`
+    <div class="kt-prelude-calls" aria-label="Captured prelude calls">
+      <span>Prelude calls</span>
+      ${calls.map((call, index) => {
+        const item = preludeIndex.byComponent.get(
+          scopeComponentKey(environment, mission, call?.component_id)
+        );
+        const target = item ? preludeCallTarget(item, call?.ref) : null;
+        const label = call?.ref || call?.component_id || 'unknown';
+
+        return target
+          ? html`<a class="kt-prelude-call" key=${`${label}-${index}`} href=${`#${target}`}
+                    data-prelude-target=${target} onClick=${revealPreludeSource}
+                    title=${`Open ${label} in ${call.component_id}`}>${label}</a>`
+          : html`<span class="kt-prelude-call kt-prelude-call-unavailable"
+                       key=${`${label}-${index}`}>${label}</span>`;
+      })}
+    </div>
+  `;
 }
 
 function Capabilities({ capabilities }) {
@@ -471,6 +610,83 @@ function Tags({ tags }) {
       ${entries.map(([key, value]) => html`<span key=${key}>${key}: ${String(value)}</span>`)}
     </div>
   `;
+}
+
+// --- Private prelude source navigation -----------------------------------
+
+function buildPreludeIndex(preludes) {
+  const byComponent = new Map();
+
+  (preludes?.items || []).forEach((record, index) => {
+    if (!record || typeof record.source !== 'string') return;
+
+    const item = {
+      ...record,
+      definitions: definitionNames(record.source),
+      domId: `kt-prelude-${record.sequence ?? 'unknown'}-${index}`
+    };
+    const key = scopeComponentKey(record.environment, record.mission_name, record.component_id);
+    if (!byComponent.has(key)) byComponent.set(key, item);
+  });
+
+  return { byComponent };
+}
+
+function definitionNames(source) {
+  const names = new Set();
+  const pattern = /\(defn-?\s+([^\s()[\]{}]+)/g;
+  let match;
+  while ((match = pattern.exec(String(source))) !== null) names.add(match[1]);
+  return names;
+}
+
+function scopeComponentKey(environment, mission, component) {
+  return `${JSON.stringify([environment || '', mission || ''])}\u0000${component || ''}`;
+}
+
+function functionDomId(item, name) {
+  const encoded = Array.from(String(name), character => character.codePointAt(0).toString(16)).join('-');
+  return `${item.domId}-function-${encoded}`;
+}
+
+function preludeCallTarget(item, ref) {
+  const name = String(ref || '').split('/').at(-1);
+  return name && item.definitions.has(name) ? functionDomId(item, name) : item.domId;
+}
+
+function highlightPreludeSource(item) {
+  return highlightLisp(item.source).replace(
+    /(<span class="hljs-keyword">defn-?<\/span>\s+)<span class="hljs-title">([^<]+)<\/span>/g,
+    (markup, prefix, encodedName) => {
+      const name = decodeHighlightedText(encodedName);
+      if (!item.definitions.has(name)) return markup;
+      return `${prefix}<span class="hljs-title kt-prelude-definition" id="${functionDomId(item, name)}">${encodedName}</span>`;
+    }
+  );
+}
+
+function decodeHighlightedText(value) {
+  return String(value)
+    .replaceAll('&lt;', '<')
+    .replaceAll('&gt;', '>')
+    .replaceAll('&quot;', '"')
+    .replaceAll('&#x27;', "'")
+    .replaceAll('&amp;', '&');
+}
+
+function revealPreludeSource(event) {
+  const targetId = event.currentTarget?.dataset?.preludeTarget;
+  const target = targetId ? document.getElementById(targetId) : null;
+  if (!target) return;
+
+  event.preventDefault();
+  for (let node = target; node; node = node.parentElement) {
+    if (node.tagName === 'DETAILS') node.open = true;
+  }
+  document.querySelectorAll('.kt-prelude-definition-active')
+    .forEach(definition => definition.classList.remove('kt-prelude-definition-active'));
+  target.classList.add('kt-prelude-definition-active');
+  target.scrollIntoView({ block: 'center', behavior: 'smooth' });
 }
 
 // --- Canonical span derivation --------------------------------------------

--- a/ptc_viewer/test/kernel_transcript_test.exs
+++ b/ptc_viewer/test/kernel_transcript_test.exs
@@ -1,0 +1,193 @@
+defmodule PtcViewer.KernelTranscriptTest do
+  use ExUnit.Case, async: true
+
+  @moduletag :tmp_dir
+
+  test "renders conversation programs, following results, and captured prelude call links", %{
+    tmp_dir: directory
+  } do
+    program = ~S|(do (runs/diagnose "failed-run") (other/uncaptured))|
+
+    data = %{
+      "metadata" => %{
+        "run_id" => "debugger-run",
+        "missions" => %{
+          "default" => %{
+            "prelude" => %{
+              "component_ids" => ["runs"],
+              "dependency_indices" => [[]],
+              "hash" => "mission-hash"
+            }
+          }
+        }
+      },
+      "turns" => %{
+        "items" => [
+          event(1, "evaluation-started", %{
+            "evaluation_id" => "mission-evaluation-1",
+            "environment" => "mission",
+            "mission_name" => "default",
+            "program_kind" => "ptc-lisp"
+          }),
+          event(2, "evaluation-stopped", %{
+            "evaluation_id" => "mission-evaluation-1",
+            "environment" => "mission",
+            "mission_name" => "default",
+            "status" => "ok"
+          })
+        ]
+      },
+      "conversation" => %{
+        "streams" => [
+          %{
+            "stream_id" => "stream-1",
+            "turns" => [
+              %{
+                "assistant" => %{
+                  "tool_calls" => [
+                    %{"id" => "call-1", "args" => %{"program" => program}}
+                  ]
+                },
+                "feedback" => [],
+                "generated" => [
+                  %{
+                    "evaluation_id" => "mission-evaluation-1",
+                    "environment" => "mission",
+                    "mission_name" => "default",
+                    "source" => program,
+                    "association_ambiguous?" => false,
+                    "prelude_calls" => [
+                      %{"component_id" => "runs", "ref" => "runs/diagnose"}
+                    ]
+                  }
+                ]
+              },
+              %{
+                "feedback" => [
+                  %{"role" => "tool", "tool_call_id" => "call-1", "content" => "diagnosis"}
+                ],
+                "generated" => []
+              }
+            ]
+          }
+        ]
+      },
+      "preludes" => %{
+        "items" => [
+          prelude(20, "mission", "default", ~S|(ns runs) (defn diagnose [] "mission")|)
+        ]
+      }
+    }
+
+    rendered = render(directory, data)
+
+    assert rendered =~ "Program source"
+    assert rendered =~ "Execution result"
+    assert rendered =~ "diagnosis"
+    assert rendered =~ "other/uncaptured"
+    assert rendered =~ ~s(class="kt-prelude-call")
+    assert rendered =~ ~s(>runs/diagnose</a>)
+    assert rendered =~ ~s(href="#kt-prelude-20-0-function-64-69-61-67-6e-6f-73-65")
+    refute rendered =~ ~s(>other/uncaptured</a>)
+  end
+
+  test "keeps captured calls unlinked without authorized prelude source", %{tmp_dir: directory} do
+    data = private_program_data(false)
+    rendered = render(directory, data)
+
+    assert rendered =~ "runs/diagnose"
+    assert rendered =~ "kt-prelude-call-unavailable"
+    refute rendered =~ ~s(class="kt-prelude-call" href=)
+  end
+
+  test "does not guess a result for an ambiguous generated-source association", %{
+    tmp_dir: directory
+  } do
+    data = private_program_data(true)
+    rendered = render(directory, data)
+
+    assert rendered =~ "Program source"
+    refute rendered =~ "Execution result"
+    refute rendered =~ "ambiguous-result"
+  end
+
+  defp private_program_data(ambiguous?) do
+    program = ~S|(runs/diagnose "failed-run")|
+
+    %{
+      "metadata" => %{},
+      "turns" => %{
+        "items" => [
+          event(1, "evaluation-started", %{
+            "evaluation_id" => "evaluation-1",
+            "environment" => "workflow"
+          })
+        ]
+      },
+      "conversation" => %{
+        "streams" => [
+          %{
+            "turns" => [
+              %{
+                "assistant" => %{
+                  "tool_calls" => [%{"id" => "call-1", "args" => %{"program" => program}}]
+                },
+                "generated" => [
+                  %{
+                    "evaluation_id" => "evaluation-1",
+                    "environment" => "workflow",
+                    "source" => program,
+                    "association_ambiguous?" => ambiguous?,
+                    "prelude_calls" => [%{"component_id" => "runs", "ref" => "runs/diagnose"}]
+                  }
+                ]
+              },
+              %{
+                "feedback" => [
+                  %{
+                    "role" => "tool",
+                    "tool_call_id" => "call-1",
+                    "content" => "ambiguous-result"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    }
+  end
+
+  defp prelude(sequence, environment, mission_name, source) do
+    %{
+      "sequence" => sequence,
+      "component_id" => "runs",
+      "environment" => environment,
+      "mission_name" => mission_name,
+      "source" => source,
+      "source_hash" => "sha256:#{sequence}",
+      "source_bytes" => byte_size(source)
+    }
+  end
+
+  defp event(sequence, type, data) do
+    %{
+      "schema_version" => 2,
+      "run_id" => "debugger-run",
+      "trace_id" => "debugger-trace",
+      "sequence" => sequence,
+      "timestamp" => "2026-08-13T12:00:0#{sequence}Z",
+      "type" => type,
+      "data" => data
+    }
+  end
+
+  defp render(directory, data) do
+    input = Path.join(directory, "kernel-transcript.json")
+    File.write!(input, Jason.encode!(data))
+
+    script = Path.expand("render_kernel_transcript.mjs", __DIR__)
+    assert {rendered, 0} = System.cmd("node", [script, input], stderr_to_stdout: true)
+    rendered
+  end
+end

--- a/ptc_viewer/test/ptc_viewer/api_test.exs
+++ b/ptc_viewer/test/ptc_viewer/api_test.exs
@@ -76,6 +76,23 @@ defmodule PtcViewer.ApiTest do
     assert {:error, :unavailable} = PtcViewer.Api.conversation([], "run-1")
   end
 
+  test "preludes delegates the pinned inspection grant", %{trace_dir: trace_dir} do
+    source = {:pinned, "run.inspection.jsonl"}
+    {:ok, store} = PtcViewer.InspectionStore.start(source)
+    on_exit(fn -> if Process.alive?(store), do: PtcViewer.InspectionStore.stop(store) end)
+
+    config = [
+      trace_dir: trace_dir,
+      inspection_store: store,
+      inspection_adapter: PtcViewer.PinningInspectionTestAdapter
+    ]
+
+    assert {:ok, %{"source" => actual_source, "run_id" => "run-1", "items" => []}} =
+             PtcViewer.Api.preludes(config, "run-1")
+
+    assert actual_source == inspect(source)
+  end
+
   test "start rejects an adapter that does not implement the query contract" do
     assert {:error, :invalid_kernel_trace_adapter} =
              PtcViewer.start(kernel_trace_adapter: String, open: false)

--- a/ptc_viewer/test/ptc_viewer/api_test.exs
+++ b/ptc_viewer/test/ptc_viewer/api_test.exs
@@ -30,6 +30,26 @@ defmodule PtcViewer.ApiTest do
              PtcViewer.Api.kernel_query(config, :list_runs, %{})
   end
 
+  test "kernel_query delegates the explicitly selected private directory", %{trace_dir: trace_dir} do
+    parent = self()
+
+    adapter = fn source, operation, arguments ->
+      send(parent, {:query, source, operation, arguments})
+      {:ok, %{"items" => []}}
+    end
+
+    config = [
+      trace_dir: trace_dir,
+      private_traces: true,
+      kernel_trace_adapter: adapter
+    ]
+
+    assert {:ok, %{"items" => []}} =
+             PtcViewer.Api.kernel_query(config, :list_runs, %{})
+
+    assert_receive {:query, {:private_directory, ^trace_dir}, :list_runs, %{}}
+  end
+
   test "conversation delegates only the exact configured file and run", %{trace_dir: trace_dir} do
     parent = self()
     source = {:pinned, "run.inspection.jsonl"}

--- a/ptc_viewer/test/ptc_viewer/router_test.exs
+++ b/ptc_viewer/test/ptc_viewer/router_test.exs
@@ -199,5 +199,27 @@ defmodule PtcViewer.RouterTest do
     end)
   end
 
+  test "prelude route delegates only the pinned inspection grant", %{trace_dir: trace_dir} do
+    source = {:pinned, "fixed.inspection.jsonl"}
+    {:ok, store} = PtcViewer.InspectionStore.start(source)
+    on_exit(fn -> if Process.alive?(store), do: PtcViewer.InspectionStore.stop(store) end)
+
+    response =
+      conn(:get, "/api/analysis/runs/run-1/preludes")
+      |> call_router(
+        trace_dir: trace_dir,
+        inspection_store: store,
+        inspection_adapter: PtcViewer.PinningInspectionTestAdapter
+      )
+
+    assert response.status == 200
+
+    assert Jason.decode!(response.resp_body) == %{
+             "source" => inspect(source),
+             "run_id" => "run-1",
+             "items" => []
+           }
+  end
+
   defp call_router(conn, opts), do: PtcViewer.Router.call(conn, PtcViewer.Router.init(opts))
 end

--- a/ptc_viewer/test/ptc_viewer/server_test.exs
+++ b/ptc_viewer/test/ptc_viewer/server_test.exs
@@ -1,7 +1,7 @@
 defmodule PtcViewer.ServerTest do
   use ExUnit.Case, async: false
 
-  alias PtcViewer.{TestInspectionAdapter, TestReplAdapter}
+  alias PtcViewer.{PinningInspectionTestAdapter, TestInspectionAdapter, TestReplAdapter}
 
   test "inspection startup preserves an unsupported schema version error" do
     assert {:error,
@@ -32,6 +32,23 @@ defmodule PtcViewer.ServerTest do
 
     assert {:error, :invalid_repl_adapter} =
              PtcViewer.start(port: 0, repl_adapter: String, repl_config: %{}, open: false)
+  end
+
+  @tag :tmp_dir
+  test "private trace mode pins inspection against the private directory", %{tmp_dir: trace_dir} do
+    {:ok, viewer} =
+      PtcViewer.start(
+        port: 0,
+        trace_dir: trace_dir,
+        private_traces: true,
+        inspection_file: "run.inspection.jsonl",
+        inspection_adapter: PinningInspectionTestAdapter,
+        open: false
+      )
+
+    store = :sys.get_state(viewer).inspection_store
+    assert {:ok, {:private_directory, ^trace_dir}} = PtcViewer.InspectionStore.fetch(store)
+    assert :ok = PtcViewer.stop(viewer)
   end
 
   test "lifecycle owner exposes the bound listener and performs orderly REPL shutdown" do

--- a/ptc_viewer/test/render_kernel_transcript.mjs
+++ b/ptc_viewer/test/render_kernel_transcript.mjs
@@ -1,0 +1,7 @@
+import fs from 'node:fs';
+import { renderKernelTranscriptMarkup } from '../priv/static/js/kernel-transcript.js';
+
+const [inputPath] = process.argv.slice(2);
+if (!inputPath) throw new Error('usage: node render_kernel_transcript.mjs INPUT');
+
+process.stdout.write(renderKernelTranscriptMarkup(JSON.parse(fs.readFileSync(inputPath, 'utf8'))));

--- a/ptc_viewer/test/support/inspection_test_adapter.ex
+++ b/ptc_viewer/test/support/inspection_test_adapter.ex
@@ -7,4 +7,17 @@ defmodule PtcViewer.TestInspectionAdapter do
   end
 
   def conversation(_source, _run_id), do: {:error, :not_called}
+  def preludes(_source, _run_id), do: {:error, :not_called}
+end
+
+defmodule PtcViewer.PinningInspectionTestAdapter do
+  @moduledoc false
+
+  def pin_inspection(_path, trace_source), do: {:ok, trace_source}
+
+  def conversation(source, run_id),
+    do: {:ok, %{"source" => inspect(source), "run_id" => run_id, "streams" => []}}
+
+  def preludes(source, run_id),
+    do: {:ok, %{"source" => inspect(source), "run_id" => run_id, "items" => []}}
 end

--- a/test/ptc_runner/kernel/viewer_adapter_test.exs
+++ b/test/ptc_runner/kernel/viewer_adapter_test.exs
@@ -22,6 +22,12 @@ defmodule PtcRunner.Kernel.ViewerAdapterTest do
     assert {:ok, page} = RunAnalysis.collect(analysis, fixture.run_id, "turns", 1_000)
     expected = ConversationProjection.present_page(page)
 
+    assert {:ok, expected_preludes} =
+             InspectionSnapshot.query(inspection, :effective_preludes, %{
+               "run_id" => fixture.run_id,
+               "limit" => 1_000
+             })
+
     inspection_path =
       fixture.inspection
       |> Path.join("*.inspection.jsonl")
@@ -33,6 +39,8 @@ defmodule PtcRunner.Kernel.ViewerAdapterTest do
 
     assert {:ok, actual} = ViewerAdapter.conversation(grant, fixture.run_id)
     assert actual == expected
+    assert {:ok, ^expected_preludes} = ViewerAdapter.preludes(grant, fixture.run_id)
+    assert {:error, :inspection_run_mismatch} = ViewerAdapter.preludes(grant, "another-run")
   end
 
   @tag :tmp_dir


### PR DESCRIPTION
# Summary

- let the Viewer discover private canonical debugger traces with `--private-traces`, while keeping its public REPL disabled for that authority
- render generated PTC-Lisp programs and their following execution feedback from the existing conversation projection
- expose one pinned private prelude-source projection and navigate captured `prelude_calls` to their authorized component definitions

# Design

This deliberately does not carry forward the spike's separate `/sources` endpoint. Programs and results come from `conversation.streams[].turns[]`, and clickable calls come only from captured static `prelude_calls` facts. Prelude source is the sole additional private Viewer endpoint. The root adapter validates and compiles the pinned inspection artifact once at Viewer startup.

# Verification

- `mix precommit` — 6,253 root checks, 51 Viewer tests, 40 launcher tests, package and standalone release verification
- pre-push repository gate — ExDoc, core tests, static analysis, Dialyzer, release verification, and Viewer validation all passed
- real-browser QA against a fresh private capture at desktop and 390×844 viewports
  - private run discovery and REPL suppression
  - program source and following execution-result disclosures
  - captured call navigation opens the prelude disclosures, highlights the definition, preserves the run route, and scrolls it into view
  - no horizontal overflow or browser console warnings/errors
