### PR TITLE
fix(launcher): retire the server group when the launcher dies, and re-check macOS identity before exec

### DIFF
--- a/ptc_runner_launcher/CHANGELOG.md
+++ b/ptc_runner_launcher/CHANGELOG.md
@@ -13,6 +13,9 @@
 - Added mandatory-checksum precompiled artifacts for ARM64 and x86-64 macOS
   and GNU/Linux, with tested source fallback.
 - Bound protocol-v1 startup to the caller's frozen server-executable SHA-256.
+- Added a lifeline watchdog so a launcher destroyed without running its own
+  teardown — `SIGKILL`, or a host that tears the process down — still retires
+  the server process group instead of leaving it reparented and running.
 - Added tag-only release automation that executes each artifact and assembles
   the verified companion Hex package with signed build provenance.
 - Added a protected publication path that uploads the exact verified package

--- a/ptc_runner_launcher/CHANGELOG.md
+++ b/ptc_runner_launcher/CHANGELOG.md
@@ -13,6 +13,9 @@
 - Added mandatory-checksum precompiled artifacts for ARM64 and x86-64 macOS
   and GNU/Linux, with tested source fallback.
 - Bound protocol-v1 startup to the caller's frozen server-executable SHA-256.
+- Narrowed the macOS path-replacement window to the check-then-exec call pair
+  by re-reading the canonical path immediately before `execve`, instead of
+  leaving the whole identity hash — which scales with the executable — exposed.
 - Added a lifeline watchdog so a launcher destroyed without running its own
   teardown — `SIGKILL`, or a host that tears the process down — still retires
   the server process group instead of leaving it reparented and running.

--- a/ptc_runner_launcher/CHANGELOG.md
+++ b/ptc_runner_launcher/CHANGELOG.md
@@ -13,9 +13,11 @@
 - Added mandatory-checksum precompiled artifacts for ARM64 and x86-64 macOS
   and GNU/Linux, with tested source fallback.
 - Bound protocol-v1 startup to the caller's frozen server-executable SHA-256.
-- Narrowed the macOS path-replacement window to the check-then-exec call pair
-  by re-reading the canonical path immediately before `execve`, instead of
-  leaving the whole identity hash — which scales with the executable — exposed.
+- Narrowed the macOS path-replacement window for a native executable to the
+  check-then-exec call pair by re-reading the canonical path immediately before
+  `execve`, instead of leaving the whole identity hash — which scales with the
+  executable — exposed. An interpreted `#!` target is opened once more by its
+  interpreter, which no launcher check covers.
 - Added a group-resident watchdog so a launcher destroyed without running its
   own teardown — `SIGKILL`, or a host that tears the process down — still
   retires the server process group instead of leaving it reparented and

--- a/ptc_runner_launcher/CHANGELOG.md
+++ b/ptc_runner_launcher/CHANGELOG.md
@@ -16,9 +16,10 @@
 - Narrowed the macOS path-replacement window to the check-then-exec call pair
   by re-reading the canonical path immediately before `execve`, instead of
   leaving the whole identity hash — which scales with the executable — exposed.
-- Added a lifeline watchdog so a launcher destroyed without running its own
-  teardown — `SIGKILL`, or a host that tears the process down — still retires
-  the server process group instead of leaving it reparented and running.
+- Added a group-resident watchdog so a launcher destroyed without running its
+  own teardown — `SIGKILL`, or a host that tears the process down — still
+  retires the server process group instead of leaving it reparented and
+  running.
 - Added tag-only release automation that executes each artifact and assembles
   the verified companion Hex package with signed build provenance.
 - Added a protected publication path that uploads the exact verified package

--- a/ptc_runner_launcher/README.md
+++ b/ptc_runner_launcher/README.md
@@ -36,15 +36,16 @@ atomic no-replace directory publication. It calls
 and fails closed when the primitive is unavailable. Scaffold construction,
 staging ownership, cleanup, and command outcomes remain in the core package.
 
-The watchdog is a second child forked before any other descriptor exists. It
-leaves the launcher's session, holds one end of a private pipe the launcher
-keeps closed-on-exec, and is armed with the server's process-group identifier
-once that group exists. Supervision stands it down as part of reaping the
-leader, because releasing that PID also releases the group identifier its
-signal names; losing the pipe without a stand-down means the launcher died
-holding a live group, and the watchdog retires it. It sends one signal rather
-than escalating, so PID reuse after the launcher's death cannot redirect a
-later signal at an unrelated group.
+The watchdog runs inside the server's own process group, forked by the server
+process after it starts that group and before the identity hash. Membership is
+the point: a process group's lifetime keeps its identifier out of the reuse
+pool, so signalling the caller's own group can only ever reach the group it was
+created for. Nothing holds or transmits a PID, which is what a launcher-side
+observer could not avoid — by the time it noticed the launcher's death, the
+leader could already have been reaped and its number reissued. It keeps only
+the read end of a private pipe whose sole writer is the launcher, and the
+launcher's own escalation retires it with the same `SIGKILL` that ends the
+group.
 
 This is process containment for trusted host-installed MCP servers, not a
 hostile-code sandbox. A trusted child can deliberately leave its process group.

--- a/ptc_runner_launcher/README.md
+++ b/ptc_runner_launcher/README.md
@@ -53,9 +53,13 @@ The trusted operator must not modify executable contents during startup.
 Linux hashes and executes the same held readable descriptor, which prevents a
 path replacement but not an in-place write. macOS cannot exec a descriptor at
 all, so it re-reads the canonical path immediately before `execve` and refuses
-to start unless that path still resolves to the device and inode it hashed.
-The replacement window there is that call pair rather than the length of the
-hash, which scales with the executable.
+to start unless that path still resolves to the device and inode it hashed. For
+a native executable that leaves the interval between the re-read and the
+kernel's own lookup, rather than the length of the hash, which scales with the
+executable. An interpreted `#!` target is weaker still: macOS gives the
+interpreter the script's path rather than a descriptor, so the interpreter opens
+it a second time and no launcher check covers that lookup. A macOS host must
+therefore keep the executable path hierarchy immutable for the whole of startup.
 
 The Elixir API is intentionally small:
 

--- a/ptc_runner_launcher/README.md
+++ b/ptc_runner_launcher/README.md
@@ -50,8 +50,11 @@ This is process containment for trusted host-installed MCP servers, not a
 hostile-code sandbox. A trusted child can deliberately leave its process group.
 The trusted operator must not modify executable contents during startup.
 Linux hashes and executes the same held readable descriptor, which prevents a
-path replacement but not an in-place write. macOS additionally relies on the
-canonical executable path hierarchy remaining immutable through `execve`.
+path replacement but not an in-place write. macOS cannot exec a descriptor at
+all, so it re-reads the canonical path immediately before `execve` and refuses
+to start unless that path still resolves to the device and inode it hashed.
+The replacement window there is that call pair rather than the length of the
+hash, which scales with the executable.
 
 The Elixir API is intentionally small:
 

--- a/ptc_runner_launcher/README.md
+++ b/ptc_runner_launcher/README.md
@@ -9,8 +9,11 @@ host-authorized server with:
   the launcher before spawn;
 - separate stdin, stdout, and bounded stderr streams;
 - acknowledged backpressure;
-- a new process group; and
-- bounded EOF, TERM, and KILL cleanup, including descendant reaping on Linux.
+- a new process group;
+- bounded EOF, TERM, and KILL cleanup, including descendant reaping on Linux;
+  and
+- a lifeline watchdog that retires that group with a single `SIGKILL` when the
+  launcher itself is destroyed before it can run any of that cleanup.
 
 The package restores mandatory-checksum precompiled executables on
 `aarch64-apple-darwin`, `x86_64-apple-darwin`, `aarch64-linux-gnu`, and
@@ -32,6 +35,16 @@ atomic no-replace directory publication. It calls
 `renameat2(RENAME_NOREPLACE)` on Linux and `renamex_np(RENAME_EXCL)` on macOS,
 and fails closed when the primitive is unavailable. Scaffold construction,
 staging ownership, cleanup, and command outcomes remain in the core package.
+
+The watchdog is a second child forked before any other descriptor exists. It
+leaves the launcher's session, holds one end of a private pipe the launcher
+keeps closed-on-exec, and is armed with the server's process-group identifier
+once that group exists. Supervision stands it down as part of reaping the
+leader, because releasing that PID also releases the group identifier its
+signal names; losing the pipe without a stand-down means the launcher died
+holding a live group, and the watchdog retires it. It sends one signal rather
+than escalating, so PID reuse after the launcher's death cannot redirect a
+later signal at an unrelated group.
 
 This is process containment for trusted host-installed MCP servers, not a
 hostile-code sandbox. A trusted child can deliberately leave its process group.

--- a/ptc_runner_launcher/c_src/ptc_runner_launcher.c
+++ b/ptc_runner_launcher/c_src/ptc_runner_launcher.c
@@ -28,6 +28,7 @@
 #define MAX_CONFIG_STRING (128U * 1024U)
 #define IO_CHUNK_BYTES 8192U
 #define MIN_FINAL_KILL_WAIT_MS 1000U
+#define KILL_WAIT_POLL_MS 5
 #define SHA256_BYTES 32U
 #define SHA256_BLOCK_BYTES 64U
 
@@ -905,127 +906,6 @@ static void request_child_subreaper(void) {
 #endif
 }
 
-/*
- * Lifeline watchdog.
- *
- * Every launcher teardown path retires the server process group, but a
- * launcher destroyed without running any of its own code -- SIGKILL, or a host
- * that tears the process down -- runs none of them. Closing the server's stdin
- * is then the only backstop, and a server that never reads stdin never
- * observes it, so the group is reparented and survives.
- *
- * The watchdog is a second child forked before any other descriptor exists. It
- * holds the read end of a private lifeline pipe whose write end only the
- * launcher retains, and leaves the launcher's session so a signal aimed at the
- * launcher's own group cannot take it along. Losing that write end without an
- * explicit stand-down means the launcher died while its group was still live.
- *
- * It then sends exactly one round of signals. Once the launcher is gone the
- * leader is reparented and reaped, releasing its PID, and the PID is also the
- * group identifier -- so a TERM-then-KILL escalation could point its second
- * signal at an unrelated group that reused the number. A single SIGKILL keeps
- * that exposure to the interval between the launcher's death and this wake-up.
- * The direct kill covers the window before the leader reaches `setsid`, where
- * no group of its own exists yet; `terminate_starting_child` pairs them for
- * the same reason.
- */
-static int lifeline_watchdog(int lifeline_fd) {
-  struct sigaction ignored;
-  uint8_t identifier[4];
-  uint8_t stand_down;
-  pid_t process_group;
-  ssize_t count;
-
-  (void)setsid();
-  (void)close(STDIN_FILENO);
-  (void)close(STDOUT_FILENO);
-  (void)close(STDERR_FILENO);
-
-  memset(&ignored, 0, sizeof(ignored));
-  ignored.sa_handler = SIG_IGN;
-  (void)sigemptyset(&ignored.sa_mask);
-  (void)sigaction(SIGTERM, &ignored, NULL);
-  (void)sigaction(SIGINT, &ignored, NULL);
-  (void)sigaction(SIGHUP, &ignored, NULL);
-
-  if (!read_exact(lifeline_fd, identifier, sizeof(identifier))) {
-    return 0;
-  }
-
-  process_group = (pid_t)read_u32_be(identifier);
-
-  do {
-    count = read(lifeline_fd, &stand_down, sizeof(stand_down));
-  } while (count < 0 && errno == EINTR);
-
-  if (count > 0) {
-    return 0;
-  }
-
-  signal_process_group(process_group, SIGKILL);
-  (void)kill(process_group, SIGKILL);
-  return 0;
-}
-
-static bool start_lifeline_watchdog(int *lifeline_fd) {
-  int lifeline[2] = {-1, -1};
-  pid_t watchdog_pid;
-
-  if (!make_pipe(lifeline)) {
-    return false;
-  }
-
-  /*
-   * The server inherits the write end across `fork` and must not carry it past
-   * `execve`: a lifeline the server itself holds open never reports the
-   * launcher's death.
-   */
-  if (!close_on_exec(lifeline[1])) {
-    close_if_open(&lifeline[0]);
-    close_if_open(&lifeline[1]);
-    return false;
-  }
-
-  watchdog_pid = fork();
-  if (watchdog_pid < 0) {
-    close_if_open(&lifeline[0]);
-    close_if_open(&lifeline[1]);
-    return false;
-  }
-
-  if (watchdog_pid == 0) {
-    (void)close(lifeline[1]);
-    _exit(lifeline_watchdog(lifeline[0]));
-  }
-
-  (void)close(lifeline[0]);
-  *lifeline_fd = lifeline[1];
-  return true;
-}
-
-static void arm_lifeline(int lifeline_fd, pid_t process_group) {
-  uint8_t identifier[4];
-
-  write_u32_be(identifier, (uint32_t)process_group);
-  (void)write_exact(lifeline_fd, identifier, sizeof(identifier));
-}
-
-/*
- * The watchdog's group-directed SIGKILL is only sound while the leader's PID is
- * still pinned by an uncollected status, so standing the watchdog down belongs
- * to releasing that PID rather than to exiting. Every caller has already
- * SIGKILLed the group and reaps immediately afterwards.
- */
-static void disarm_lifeline(int *lifeline_fd) {
-  static const uint8_t stand_down = 1U;
-
-  if (*lifeline_fd >= 0) {
-    (void)write_exact(*lifeline_fd, &stand_down, sizeof(stand_down));
-    (void)close(*lifeline_fd);
-    *lifeline_fd = -1;
-  }
-}
-
 static void queue_compact(struct byte_queue *queue) {
   if (queue->offset > 0 && queue->length > 0) {
     memmove(queue->bytes, queue->bytes + queue->offset, queue->length);
@@ -1212,6 +1092,117 @@ static bool emit_stderr(const uint8_t *bytes, size_t length,
   return true;
 }
 
+/*
+ * Group watchdog.
+ *
+ * Every launcher teardown path retires the target's process group, but a
+ * launcher destroyed without running any of its own code -- SIGKILL, or a host
+ * that tears the process down -- runs none of them. Closing the target's stdin
+ * is then the only backstop, and a target that never reads stdin never observes
+ * it, so the group is reparented and survives.
+ *
+ * This runs in a process the target forks off inside its own brand-new group,
+ * and that membership is the whole design. A process group's lifetime keeps its
+ * identifier -- which is also the leader's PID -- out of the reuse pool, so
+ * `kill(0, ...)` from inside the group can only ever reach the group it was
+ * created for. Nothing here holds, transmits, or trusts a PID, which is what
+ * makes a launcher-side observer unsafe: by the time such an observer noticed
+ * the death, the leader could already have been reaped and its number reissued.
+ *
+ * The launcher holds the lifeline's only writer for its whole life. Losing it
+ * means the launcher is gone. Its ordinary teardown SIGKILLs this group before
+ * it collects the leader, so the same signal retires this process and no
+ * stand-down handshake is needed.
+ */
+static int group_watchdog(int lifeline_fd, pid_t leader_pid) {
+  struct sigaction ignored;
+  uint8_t unexpected;
+  ssize_t count;
+
+  /*
+   * The launcher's graceful escalation aims SIGTERM at this group first; the
+   * watchdog has to outlive that and stay until the SIGKILL that ends it.
+   */
+  memset(&ignored, 0, sizeof(ignored));
+  ignored.sa_handler = SIG_IGN;
+  (void)sigemptyset(&ignored.sa_mask);
+  (void)sigaction(SIGTERM, &ignored, NULL);
+  (void)sigaction(SIGINT, &ignored, NULL);
+  (void)sigaction(SIGHUP, &ignored, NULL);
+
+  do {
+    count = read(lifeline_fd, &unexpected, sizeof(unexpected));
+  } while (count > 0 || (count < 0 && errno == EINTR));
+
+  /*
+   * Tripwire, not a race check: the group identifier equals the leader's PID
+   * only because this process was forked after the leader's `setsid`. Moving
+   * that fork earlier would silently aim `kill(0, ...)` at the launcher's own
+   * group -- and therefore at the BEAM -- so refuse instead.
+   */
+  if (getpgrp() == leader_pid) {
+    (void)kill(0, SIGKILL);
+  }
+
+  return 0;
+}
+
+/*
+ * Forked before the identity hash so that a launcher dying at any point from
+ * here on is observed, and before any executable descriptor exists so that
+ * there is nothing of the target's to leak. It keeps only the lifeline reader:
+ * holding the target's streams would defer their EOF, and holding the exec
+ * status pipe would stall the launcher's startup wait. The target waits for
+ * those closes rather than assuming them, so it never execs while a second
+ * writer is still open.
+ */
+static bool start_group_watchdog(const int lifeline[2],
+                                 const int child_stdin[2],
+                                 const int child_stdout[2],
+                                 const int child_stderr[2],
+                                 const int exec_status[2]) {
+  pid_t leader_pid = getpid();
+  int ready[2] = {-1, -1};
+  pid_t watchdog_pid;
+  uint8_t unexpected;
+
+  if (!make_pipe(ready)) {
+    return false;
+  }
+
+  watchdog_pid = fork();
+  if (watchdog_pid < 0) {
+    int fork_errno = errno;
+
+    (void)close(ready[0]);
+    (void)close(ready[1]);
+    errno = fork_errno;
+    return false;
+  }
+
+  if (watchdog_pid == 0) {
+    (void)close(ready[0]);
+    (void)close(STDIN_FILENO);
+    (void)close(STDOUT_FILENO);
+    (void)close(STDERR_FILENO);
+    (void)close(child_stdin[0]);
+    (void)close(child_stdout[1]);
+    (void)close(child_stderr[1]);
+    (void)close(exec_status[1]);
+    (void)close(ready[1]);
+    _exit(group_watchdog(lifeline[0], leader_pid));
+  }
+
+  (void)close(ready[1]);
+
+  while (read(ready[0], &unexpected, sizeof(unexpected)) < 0 &&
+         errno == EINTR) {
+  }
+
+  (void)close(ready[0]);
+  return true;
+}
+
 #if !defined(__linux__)
 /*
  * Descriptor exec is unavailable on macOS -- `fexecve` is undeclared and
@@ -1234,7 +1225,8 @@ static bool executable_identity_unchanged(const struct launcher_config *config) 
 
 static int child_main(struct launcher_config *config,
                       const int child_stdin[2], const int child_stdout[2],
-                      const int child_stderr[2], const int exec_status[2]) {
+                      const int child_stderr[2], const int exec_status[2],
+                      const int lifeline[2]) {
   struct sigaction default_action;
   int exec_errno;
 
@@ -1242,12 +1234,19 @@ static int child_main(struct launcher_config *config,
   (void)close(child_stdout[0]);
   (void)close(child_stderr[0]);
   (void)close(exec_status[0]);
+  /*
+   * Closed before anything that can block: a lifeline writer held here would
+   * hide the launcher's death for the whole identity hash.
+   */
+  (void)close(lifeline[1]);
 
   memset(&default_action, 0, sizeof(default_action));
   default_action.sa_handler = SIG_DFL;
   (void)sigemptyset(&default_action.sa_mask);
 
   if (sigaction(SIGPIPE, &default_action, NULL) != 0 || setsid() < 0 ||
+      !start_group_watchdog(lifeline, child_stdin, child_stdout, child_stderr,
+                            exec_status) ||
       !resolve_config_paths(config) || fchdir(config->cwd_fd) != 0 ||
       dup2(child_stdin[0], STDIN_FILENO) < 0 ||
       dup2(child_stdout[1], STDOUT_FILENO) < 0 ||
@@ -1262,6 +1261,7 @@ static int child_main(struct launcher_config *config,
   (void)close(child_stdout[1]);
   (void)close(child_stderr[1]);
   (void)close(config->cwd_fd);
+  (void)close(lifeline[0]);
 
 #if defined(__linux__)
   fexecve(config->executable_fd, config->argv, config->envp);
@@ -1340,12 +1340,11 @@ static enum startup_result await_child_start(int exec_status_fd,
   }
 }
 
-static void terminate_starting_child(pid_t child_pid, int *lifeline_fd) {
+static void terminate_starting_child(pid_t child_pid) {
   int64_t deadline = monotonic_ms() + 1000LL;
 
   signal_process_group(child_pid, SIGKILL);
   (void)kill(child_pid, SIGKILL);
-  disarm_lifeline(lifeline_fd);
 
   for (;;) {
     pid_t waited = waitpid(child_pid, NULL, WNOHANG);
@@ -1382,8 +1381,7 @@ static int finish_supervision(enum finish_reason reason, bool child_reaped,
 }
 
 static int supervise(const struct launcher_config *config, pid_t child_pid,
-                     int *lifeline_fd, int child_stdin, int child_stdout,
-                     int child_stderr) {
+                     int child_stdin, int child_stdout, int child_stderr) {
   uint8_t input[MAX_FRAME_BYTES + 4U];
   size_t input_length = 0;
   struct byte_queue pending = {
@@ -1403,12 +1401,12 @@ static int supervise(const struct launcher_config *config, pid_t child_pid,
 
   if (!nonblocking(STDIN_FILENO) || !nonblocking(child_stdin) ||
       !nonblocking(child_stdout) || !nonblocking(child_stderr)) {
-    terminate_starting_child(child_pid, lifeline_fd);
+    terminate_starting_child(child_pid);
     return 70;
   }
 
   if (!emit_frame('R', NULL, 0)) {
-    terminate_starting_child(child_pid, lifeline_fd);
+    terminate_starting_child(child_pid);
     return 70;
   }
 
@@ -1464,7 +1462,6 @@ static int supervise(const struct launcher_config *config, pid_t child_pid,
       close_if_open(&child_stdout);
       close_if_open(&child_stderr);
       if (!child_reaped) {
-        disarm_lifeline(lifeline_fd);
         child_reaped = reap_child(child_pid, &child_status);
       }
       return finish_supervision(FINISH_TERMINATION_TIMEOUT, child_reaped,
@@ -1472,13 +1469,12 @@ static int supervise(const struct launcher_config *config, pid_t child_pid,
     }
 
     /*
-     * SIGKILL above is the final process-group signal. Only now may the leader
-     * be reaped and its numeric PID released, and the lifeline watchdog stands
-     * down with it because its own signal names the same number. Subsequent
-     * loops merely observe whether any same-group descendants remain.
+     * SIGKILL above is the final process-group signal, and it also retires the
+     * group's lifeline watchdog. Only now may the leader be reaped and its
+     * numeric PID released. Subsequent loops merely observe whether any
+     * same-group descendants remain.
      */
     if (phase == PHASE_KILL_WAIT && child_exited && !child_reaped) {
-      disarm_lifeline(lifeline_fd);
       child_reaped = reap_child(child_pid, &child_status);
     }
 
@@ -1502,6 +1498,16 @@ static int supervise(const struct launcher_config *config, pid_t child_pid,
         stdout_eof && stderr_eof) {
       return finish_supervision(finish_reason, child_reaped, child_status,
                                 stderr_truncated);
+    }
+
+    /*
+     * Draining is the only thing left to observe here, and every member's exit
+     * is collected out of band -- by init for descendants the launcher never
+     * parented, including the target's own watchdog. Keeping the ordinary
+     * cadence would charge a full tick of it to each shutdown.
+     */
+    if (phase == PHASE_KILL_WAIT) {
+      poll_timeout = KILL_WAIT_POLL_MS;
     }
 
     if (phase != PHASE_RUNNING && deadline > 0) {
@@ -1673,7 +1679,7 @@ int main(int argc, char **argv) {
   int child_stdout[2] = {-1, -1};
   int child_stderr[2] = {-1, -1};
   int exec_status[2] = {-1, -1};
-  int lifeline_fd = -1;
+  int lifeline[2] = {-1, -1};
   pid_t child_pid;
   struct sigaction action;
   enum startup_result startup;
@@ -1697,16 +1703,6 @@ int main(int argc, char **argv) {
   (void)signal(SIGPIPE, SIG_IGN);
   request_child_subreaper();
 
-  /*
-   * Started before every other descriptor so no launcher death after this
-   * point can leave a started server without an observer, and so the watchdog
-   * inherits nothing it would have to close beyond the standard streams.
-   */
-  if (!start_lifeline_watchdog(&lifeline_fd)) {
-    (void)emit_frame('F', NULL, 0);
-    return 70;
-  }
-
   if (!load_bootstrap(&config)) {
     (void)emit_frame('F', NULL, 0);
     return 64;
@@ -1726,7 +1722,8 @@ int main(int argc, char **argv) {
 
   if (!make_pipe(child_stdin) || !make_pipe(child_stdout) ||
       !make_pipe(child_stderr) || !make_pipe(exec_status) ||
-      !close_on_exec(exec_status[1])) {
+      !make_pipe(lifeline) || !close_on_exec(exec_status[1]) ||
+      !close_on_exec(lifeline[0]) || !close_on_exec(lifeline[1])) {
     (void)emit_frame('F', NULL, 0);
     free_config(&config);
     return 70;
@@ -1741,6 +1738,8 @@ int main(int argc, char **argv) {
     close_if_open(&child_stderr[1]);
     close_if_open(&exec_status[0]);
     close_if_open(&exec_status[1]);
+    close_if_open(&lifeline[0]);
+    close_if_open(&lifeline[1]);
     free_config(&config);
     return 69;
   }
@@ -1755,21 +1754,20 @@ int main(int argc, char **argv) {
   if (child_pid == 0) {
     int child_result =
         child_main(&config, child_stdin, child_stdout, child_stderr,
-                   exec_status);
+                   exec_status, lifeline);
     _exit(child_result);
   }
-
-  /*
-   * The child becomes its own group leader in `setsid`, so before that call
-   * the identifier still names the launcher's group; the watchdog kills the
-   * PID directly as well to cover the gap.
-   */
-  arm_lifeline(lifeline_fd, child_pid);
 
   close_if_open(&child_stdin[0]);
   close_if_open(&child_stdout[1]);
   close_if_open(&child_stderr[1]);
   close_if_open(&exec_status[1]);
+  /*
+   * The launcher keeps the only writer for its whole life: the group
+   * watchdog treats losing it as the launcher's death, and process exit
+   * closes it however the launcher ends.
+   */
+  close_if_open(&lifeline[0]);
 
   startup = await_child_start(exec_status[0], config.start_timeout_ms);
   if (startup != STARTUP_READY) {
@@ -1777,7 +1775,7 @@ int main(int argc, char **argv) {
     close_if_open(&child_stdin[1]);
     close_if_open(&child_stdout[0]);
     close_if_open(&child_stderr[0]);
-    terminate_starting_child(child_pid, &lifeline_fd);
+    terminate_starting_child(child_pid);
     if (startup != STARTUP_OWNER_EOF) {
       (void)emit_frame('F', NULL, 0);
     }
@@ -1786,14 +1784,8 @@ int main(int argc, char **argv) {
   }
 
   close_if_open(&exec_status[0]);
-  /*
-   * Supervision stands the watchdog down as part of reaping the leader, and
-   * every path that returns from here has done so. An exit that somehow left
-   * it armed is the safe direction: the watchdog then retires a group the
-   * launcher never confirmed dead.
-   */
-  result = supervise(&config, child_pid, &lifeline_fd, child_stdin[1],
-                     child_stdout[0], child_stderr[0]);
+  result = supervise(&config, child_pid, child_stdin[1], child_stdout[0],
+                     child_stderr[0]);
   free_config(&config);
   return result;
 }

--- a/ptc_runner_launcher/c_src/ptc_runner_launcher.c
+++ b/ptc_runner_launcher/c_src/ptc_runner_launcher.c
@@ -66,6 +66,8 @@ struct launcher_config {
   char *cwd;
   int executable_fd;
   int cwd_fd;
+  dev_t executable_device;
+  ino_t executable_inode;
   uint8_t executable_sha256[SHA256_BYTES];
   char **argv;
   size_t argc;
@@ -726,6 +728,8 @@ static bool resolve_config_paths(struct launcher_config *config) {
       fstat(config->cwd_fd, &cwd_stat) == 0 && S_ISDIR(cwd_stat.st_mode) &&
       sha256_fd(readable_executable_fd, executable_sha256) &&
       memcmp(executable_sha256, config->executable_sha256, SHA256_BYTES) == 0) {
+    config->executable_device = executable_stat.st_dev;
+    config->executable_inode = executable_stat.st_ino;
     valid = true;
   }
 
@@ -1208,6 +1212,26 @@ static bool emit_stderr(const uint8_t *bytes, size_t length,
   return true;
 }
 
+#if !defined(__linux__)
+/*
+ * Descriptor exec is unavailable on macOS -- `fexecve` is undeclared and
+ * execing `/dev/fd/N` fails with ENOTSUP for O_EXEC and EACCES for O_RDONLY --
+ * so the identity that is hashed and the identity that is executed can only be
+ * connected through the path. Re-reading the path here narrows the replacement
+ * window from "the whole hash", which a rename against a 64 MiB target wins by
+ * three hundred milliseconds, to this call pair. The hashed descriptor is
+ * still open, so the inode number it reports cannot have been recycled by a
+ * different file underneath the comparison.
+ */
+static bool executable_identity_unchanged(const struct launcher_config *config) {
+  struct stat current;
+
+  return stat(config->executable, &current) == 0 && S_ISREG(current.st_mode) &&
+         current.st_dev == config->executable_device &&
+         current.st_ino == config->executable_inode;
+}
+#endif
+
 static int child_main(struct launcher_config *config,
                       const int child_stdin[2], const int child_stdout[2],
                       const int child_stderr[2], const int exec_status[2]) {
@@ -1260,8 +1284,12 @@ static int child_main(struct launcher_config *config,
     }
   }
 #else
-  execve(config->executable, config->argv, config->envp);
-  exec_errno = errno;
+  if (executable_identity_unchanged(config)) {
+    execve(config->executable, config->argv, config->envp);
+    exec_errno = errno;
+  } else {
+    exec_errno = EPERM;
+  }
 #endif
   (void)write_exact(exec_status[1], (const uint8_t *)&exec_errno,
                     sizeof(exec_errno));

--- a/ptc_runner_launcher/c_src/ptc_runner_launcher.c
+++ b/ptc_runner_launcher/c_src/ptc_runner_launcher.c
@@ -901,6 +901,127 @@ static void request_child_subreaper(void) {
 #endif
 }
 
+/*
+ * Lifeline watchdog.
+ *
+ * Every launcher teardown path retires the server process group, but a
+ * launcher destroyed without running any of its own code -- SIGKILL, or a host
+ * that tears the process down -- runs none of them. Closing the server's stdin
+ * is then the only backstop, and a server that never reads stdin never
+ * observes it, so the group is reparented and survives.
+ *
+ * The watchdog is a second child forked before any other descriptor exists. It
+ * holds the read end of a private lifeline pipe whose write end only the
+ * launcher retains, and leaves the launcher's session so a signal aimed at the
+ * launcher's own group cannot take it along. Losing that write end without an
+ * explicit stand-down means the launcher died while its group was still live.
+ *
+ * It then sends exactly one round of signals. Once the launcher is gone the
+ * leader is reparented and reaped, releasing its PID, and the PID is also the
+ * group identifier -- so a TERM-then-KILL escalation could point its second
+ * signal at an unrelated group that reused the number. A single SIGKILL keeps
+ * that exposure to the interval between the launcher's death and this wake-up.
+ * The direct kill covers the window before the leader reaches `setsid`, where
+ * no group of its own exists yet; `terminate_starting_child` pairs them for
+ * the same reason.
+ */
+static int lifeline_watchdog(int lifeline_fd) {
+  struct sigaction ignored;
+  uint8_t identifier[4];
+  uint8_t stand_down;
+  pid_t process_group;
+  ssize_t count;
+
+  (void)setsid();
+  (void)close(STDIN_FILENO);
+  (void)close(STDOUT_FILENO);
+  (void)close(STDERR_FILENO);
+
+  memset(&ignored, 0, sizeof(ignored));
+  ignored.sa_handler = SIG_IGN;
+  (void)sigemptyset(&ignored.sa_mask);
+  (void)sigaction(SIGTERM, &ignored, NULL);
+  (void)sigaction(SIGINT, &ignored, NULL);
+  (void)sigaction(SIGHUP, &ignored, NULL);
+
+  if (!read_exact(lifeline_fd, identifier, sizeof(identifier))) {
+    return 0;
+  }
+
+  process_group = (pid_t)read_u32_be(identifier);
+
+  do {
+    count = read(lifeline_fd, &stand_down, sizeof(stand_down));
+  } while (count < 0 && errno == EINTR);
+
+  if (count > 0) {
+    return 0;
+  }
+
+  signal_process_group(process_group, SIGKILL);
+  (void)kill(process_group, SIGKILL);
+  return 0;
+}
+
+static bool start_lifeline_watchdog(int *lifeline_fd) {
+  int lifeline[2] = {-1, -1};
+  pid_t watchdog_pid;
+
+  if (!make_pipe(lifeline)) {
+    return false;
+  }
+
+  /*
+   * The server inherits the write end across `fork` and must not carry it past
+   * `execve`: a lifeline the server itself holds open never reports the
+   * launcher's death.
+   */
+  if (!close_on_exec(lifeline[1])) {
+    close_if_open(&lifeline[0]);
+    close_if_open(&lifeline[1]);
+    return false;
+  }
+
+  watchdog_pid = fork();
+  if (watchdog_pid < 0) {
+    close_if_open(&lifeline[0]);
+    close_if_open(&lifeline[1]);
+    return false;
+  }
+
+  if (watchdog_pid == 0) {
+    (void)close(lifeline[1]);
+    _exit(lifeline_watchdog(lifeline[0]));
+  }
+
+  (void)close(lifeline[0]);
+  *lifeline_fd = lifeline[1];
+  return true;
+}
+
+static void arm_lifeline(int lifeline_fd, pid_t process_group) {
+  uint8_t identifier[4];
+
+  write_u32_be(identifier, (uint32_t)process_group);
+  (void)write_exact(lifeline_fd, identifier, sizeof(identifier));
+}
+
+/*
+ * The watchdog's group-directed SIGKILL is only sound while the leader's PID is
+ * still pinned by an uncollected status, so standing the watchdog down belongs
+ * to releasing that PID rather than to exiting. Every caller has already
+ * SIGKILLed the group and reaps immediately afterwards.
+ */
+static void disarm_lifeline(int *lifeline_fd) {
+  static const uint8_t stand_down = 1U;
+
+  if (*lifeline_fd >= 0) {
+    (void)write_exact(*lifeline_fd, &stand_down, sizeof(stand_down));
+    (void)close(*lifeline_fd);
+    *lifeline_fd = -1;
+  }
+}
+
 static void queue_compact(struct byte_queue *queue) {
   if (queue->offset > 0 && queue->length > 0) {
     memmove(queue->bytes, queue->bytes + queue->offset, queue->length);
@@ -1191,11 +1312,12 @@ static enum startup_result await_child_start(int exec_status_fd,
   }
 }
 
-static void terminate_starting_child(pid_t child_pid) {
+static void terminate_starting_child(pid_t child_pid, int *lifeline_fd) {
   int64_t deadline = monotonic_ms() + 1000LL;
 
   signal_process_group(child_pid, SIGKILL);
   (void)kill(child_pid, SIGKILL);
+  disarm_lifeline(lifeline_fd);
 
   for (;;) {
     pid_t waited = waitpid(child_pid, NULL, WNOHANG);
@@ -1232,7 +1354,8 @@ static int finish_supervision(enum finish_reason reason, bool child_reaped,
 }
 
 static int supervise(const struct launcher_config *config, pid_t child_pid,
-                     int child_stdin, int child_stdout, int child_stderr) {
+                     int *lifeline_fd, int child_stdin, int child_stdout,
+                     int child_stderr) {
   uint8_t input[MAX_FRAME_BYTES + 4U];
   size_t input_length = 0;
   struct byte_queue pending = {
@@ -1252,12 +1375,12 @@ static int supervise(const struct launcher_config *config, pid_t child_pid,
 
   if (!nonblocking(STDIN_FILENO) || !nonblocking(child_stdin) ||
       !nonblocking(child_stdout) || !nonblocking(child_stderr)) {
-    terminate_starting_child(child_pid);
+    terminate_starting_child(child_pid, lifeline_fd);
     return 70;
   }
 
   if (!emit_frame('R', NULL, 0)) {
-    terminate_starting_child(child_pid);
+    terminate_starting_child(child_pid, lifeline_fd);
     return 70;
   }
 
@@ -1313,6 +1436,7 @@ static int supervise(const struct launcher_config *config, pid_t child_pid,
       close_if_open(&child_stdout);
       close_if_open(&child_stderr);
       if (!child_reaped) {
+        disarm_lifeline(lifeline_fd);
         child_reaped = reap_child(child_pid, &child_status);
       }
       return finish_supervision(FINISH_TERMINATION_TIMEOUT, child_reaped,
@@ -1321,10 +1445,12 @@ static int supervise(const struct launcher_config *config, pid_t child_pid,
 
     /*
      * SIGKILL above is the final process-group signal. Only now may the leader
-     * be reaped and its numeric PID released. Subsequent loops merely observe
-     * whether any same-group descendants remain.
+     * be reaped and its numeric PID released, and the lifeline watchdog stands
+     * down with it because its own signal names the same number. Subsequent
+     * loops merely observe whether any same-group descendants remain.
      */
     if (phase == PHASE_KILL_WAIT && child_exited && !child_reaped) {
+      disarm_lifeline(lifeline_fd);
       child_reaped = reap_child(child_pid, &child_status);
     }
 
@@ -1519,6 +1645,7 @@ int main(int argc, char **argv) {
   int child_stdout[2] = {-1, -1};
   int child_stderr[2] = {-1, -1};
   int exec_status[2] = {-1, -1};
+  int lifeline_fd = -1;
   pid_t child_pid;
   struct sigaction action;
   enum startup_result startup;
@@ -1541,6 +1668,16 @@ int main(int argc, char **argv) {
   (void)sigaction(SIGHUP, &action, NULL);
   (void)signal(SIGPIPE, SIG_IGN);
   request_child_subreaper();
+
+  /*
+   * Started before every other descriptor so no launcher death after this
+   * point can leave a started server without an observer, and so the watchdog
+   * inherits nothing it would have to close beyond the standard streams.
+   */
+  if (!start_lifeline_watchdog(&lifeline_fd)) {
+    (void)emit_frame('F', NULL, 0);
+    return 70;
+  }
 
   if (!load_bootstrap(&config)) {
     (void)emit_frame('F', NULL, 0);
@@ -1594,6 +1731,13 @@ int main(int argc, char **argv) {
     _exit(child_result);
   }
 
+  /*
+   * The child becomes its own group leader in `setsid`, so before that call
+   * the identifier still names the launcher's group; the watchdog kills the
+   * PID directly as well to cover the gap.
+   */
+  arm_lifeline(lifeline_fd, child_pid);
+
   close_if_open(&child_stdin[0]);
   close_if_open(&child_stdout[1]);
   close_if_open(&child_stderr[1]);
@@ -1605,7 +1749,7 @@ int main(int argc, char **argv) {
     close_if_open(&child_stdin[1]);
     close_if_open(&child_stdout[0]);
     close_if_open(&child_stderr[0]);
-    terminate_starting_child(child_pid);
+    terminate_starting_child(child_pid, &lifeline_fd);
     if (startup != STARTUP_OWNER_EOF) {
       (void)emit_frame('F', NULL, 0);
     }
@@ -1614,8 +1758,14 @@ int main(int argc, char **argv) {
   }
 
   close_if_open(&exec_status[0]);
-  result = supervise(&config, child_pid, child_stdin[1], child_stdout[0],
-                     child_stderr[0]);
+  /*
+   * Supervision stands the watchdog down as part of reaping the leader, and
+   * every path that returns from here has done so. An exit that somehow left
+   * it armed is the safe direction: the watchdog then retires a group the
+   * launcher never confirmed dead.
+   */
+  result = supervise(&config, child_pid, &lifeline_fd, child_stdin[1],
+                     child_stdout[0], child_stderr[0]);
   free_config(&config);
   return result;
 }

--- a/ptc_runner_launcher/test/fixtures/mcp_stdio_launcher_fixture.sh
+++ b/ptc_runner_launcher/test/fixtures/mcp_stdio_launcher_fixture.sh
@@ -102,6 +102,7 @@ case "$1" in
     ) &
 
     descendant="$!"
+    printf 'leader=%s\n' "$$"
     printf 'descendant=%s\n' "$descendant"
     trap '' TERM
 

--- a/ptc_runner_launcher/test/ptc_runner_launcher/conformance_test.exs
+++ b/ptc_runner_launcher/test/ptc_runner_launcher/conformance_test.exs
@@ -9,11 +9,17 @@ defmodule PtcRunnerLauncher.ConformanceTest do
   # The identity hash is the only interval long enough to race a rename into, so
   # the target has to be large enough that hashing it is still in progress when
   # the swap lands: 64 MiB takes roughly a third of a second, and the rename
-  # fires 40 ms in. A rename that lands too early only makes the case vacuous --
-  # the launcher then hashes the impostor and refuses on identity -- so a slow
-  # host cannot turn this red.
+  # fires 40 ms in.
+  #
+  # The two ways to miss that interval are distinguishable rather than silent. A
+  # rename landing before the launcher opens the target makes it hash the small
+  # impostor and refuse within milliseconds, which the elapsed-time floor
+  # rejects; one landing after the exec runs the authorized target, which the
+  # output assertion accepts as the rename simply losing. Neither can report a
+  # pass for the window itself.
   @race_target_mebibytes 64
   @race_rename_delay_ms 40
+  @race_minimum_hash_ms 100
 
   setup_all do
     compiler = System.find_executable("cc") || flunk("C compiler is unavailable")
@@ -527,10 +533,10 @@ defmodule PtcRunnerLauncher.ConformanceTest do
     %{leader: leader, descendant: descendant} = tree_pids(launcher)
 
     # Nothing else reaps this group once its launcher is gone, so a regression
-    # here must not leak a `sleep` loop into the rest of the run.
-    on_exit(fn ->
-      System.cmd(kill_executable(), ["-9", "-#{leader}"], stderr_to_stdout: true)
-    end)
+    # here must not leak a `sleep` loop into the rest of the run. The leader's
+    # PID is also the group identifier and is released the moment it is reaped,
+    # so confirm this is still our fixture before aiming a group kill at it.
+    on_exit(fn -> kill_fixture_group(leader) end)
 
     assert os_process_running?(leader)
     assert os_process_running?(descendant)
@@ -584,6 +590,8 @@ defmodule PtcRunnerLauncher.ConformanceTest do
         :file.rename(impostor, authorized)
       end)
 
+    started_at = System.monotonic_time(:millisecond)
+
     result =
       MCPStdioLauncher.open(
         executable: authorized,
@@ -595,11 +603,15 @@ defmodule PtcRunnerLauncher.ConformanceTest do
         start_timeout_ms: 30_000
       )
 
+    elapsed = System.monotonic_time(:millisecond) - started_at
     assert :ok = Task.await(racer, 5_000)
 
     case result do
       {:error, reason} ->
         assert reason == :mcp_stdio_spawn_failed
+        # Only a full pass over the authorized target takes this long, so the
+        # refusal cannot have come from hashing the impostor instead.
+        assert elapsed >= @race_minimum_hash_ms
 
       {:ok, launcher} ->
         output = collect_until(launcher, &(&1.stdout =~ ~r/-EXECUTED\n/))
@@ -1004,6 +1016,17 @@ defmodule PtcRunnerLauncher.ConformanceTest do
     state = String.trim(output)
 
     status == 0 and state != "" and not String.starts_with?(state, "Z")
+  end
+
+  defp kill_fixture_group(leader) do
+    {command, status} =
+      System.cmd(ps_executable(), ["-o", "command=", "-p", Integer.to_string(leader)],
+        stderr_to_stdout: true
+      )
+
+    if status == 0 and command =~ @fixture do
+      System.cmd(kill_executable(), ["-9", "-#{leader}"], stderr_to_stdout: true)
+    end
   end
 
   defp kill_executable do

--- a/ptc_runner_launcher/test/ptc_runner_launcher/conformance_test.exs
+++ b/ptc_runner_launcher/test/ptc_runner_launcher/conformance_test.exs
@@ -512,6 +512,29 @@ defmodule PtcRunnerLauncher.ConformanceTest do
   end
 
   @tag :tmp_dir
+  test "a forcibly killed launcher still retires its server group", %{tmp_dir: dir} do
+    marker = Path.join(dir, "orphan-term-observed")
+    launcher = open_launcher(["tree", marker], grace_ms: 100)
+    %{leader: leader, descendant: descendant} = tree_pids(launcher)
+
+    # Nothing else reaps this group once its launcher is gone, so a regression
+    # here must not leak a `sleep` loop into the rest of the run.
+    on_exit(fn ->
+      System.cmd(kill_executable(), ["-9", "-#{leader}"], stderr_to_stdout: true)
+    end)
+
+    assert os_process_running?(leader)
+    assert os_process_running?(descendant)
+
+    {:os_pid, launcher_pid} = Port.info(launcher.port, :os_pid)
+    assert {_output, 0} = System.cmd(kill_executable(), ["-9", Integer.to_string(launcher_pid)])
+    assert_eventually(fn -> not os_process_running?(launcher_pid) end, 2_000)
+
+    assert_eventually(fn -> not os_process_running?(leader) end, 5_000)
+    assert_eventually(fn -> not os_process_running?(descendant) end, 5_000)
+  end
+
+  @tag :tmp_dir
   test "close terminates an npx-shaped wrapper and its nested leaf", %{tmp_dir: dir} do
     marker = Path.join(dir, "nested-term-observed")
     launcher = open_launcher(["deep-tree", marker], grace_ms: 1_000)
@@ -837,6 +860,19 @@ defmodule PtcRunnerLauncher.ConformanceTest do
     String.to_integer(pid)
   end
 
+  defp tree_pids(launcher) do
+    output =
+      collect_until(
+        launcher,
+        &(&1.stdout =~ ~r/leader=\d+\n/ and &1.stdout =~ ~r/descendant=\d+\n/)
+      )
+
+    [leader] = Regex.run(~r/leader=(\d+)/, output.stdout, capture: :all_but_first)
+    [descendant] = Regex.run(~r/descendant=(\d+)/, output.stdout, capture: :all_but_first)
+
+    %{leader: String.to_integer(leader), descendant: String.to_integer(descendant)}
+  end
+
   defp next_finished(launcher, timeout_ms) do
     deadline = System.monotonic_time(:millisecond) + timeout_ms
     do_next_finished(launcher, deadline)
@@ -884,8 +920,26 @@ defmodule PtcRunnerLauncher.ConformanceTest do
     status == 0
   end
 
+  # `kill -0` also succeeds for an un-reaped zombie, and nothing reaps the
+  # server group once its launcher has been destroyed, so liveness after a
+  # forced launcher kill has to be read from the process state instead.
+  defp os_process_running?(pid) do
+    {output, status} =
+      System.cmd(ps_executable(), ["-o", "state=", "-p", Integer.to_string(pid)],
+        stderr_to_stdout: true
+      )
+
+    state = String.trim(output)
+
+    status == 0 and state != "" and not String.starts_with?(state, "Z")
+  end
+
   defp kill_executable do
     System.find_executable("kill") || flunk("POSIX kill is unavailable")
+  end
+
+  defp ps_executable do
+    System.find_executable("ps") || flunk("POSIX ps is unavailable")
   end
 
   defp mailbox_messages do

--- a/ptc_runner_launcher/test/ptc_runner_launcher/conformance_test.exs
+++ b/ptc_runner_launcher/test/ptc_runner_launcher/conformance_test.exs
@@ -875,12 +875,15 @@ defmodule PtcRunnerLauncher.ConformanceTest do
 
   defp held_descriptor_exec?, do: :os.type() == {:unix, :linux}
 
-  # The launcher forks the process that opens and hashes the target only after
-  # its bootstrap arrives, so a second process still running the launcher image
-  # means the descriptor under test is already open.
+  # Three live processes running the launcher image are the launcher, the
+  # process it forked to open and hash the target, and that process's own
+  # watchdog. The watchdog fork is the last thing to happen before the target is
+  # opened, so the count clears only microseconds ahead of the descriptor under
+  # test; anything longer than that would have to be a scheduling stall, which
+  # can only cost this case coverage, never turn it red.
   defp await_launcher_fork do
     {:ok, binary} = PtcRunnerLauncher.executable_path()
-    assert_eventually(fn -> launcher_image_count(binary) >= 2 end, 10_000)
+    assert_eventually(fn -> launcher_image_count(binary) >= 3 end, 10_000)
   end
 
   defp launcher_image_count(binary) do

--- a/ptc_runner_launcher/test/ptc_runner_launcher/conformance_test.exs
+++ b/ptc_runner_launcher/test/ptc_runner_launcher/conformance_test.exs
@@ -6,20 +6,18 @@ defmodule PtcRunnerLauncher.ConformanceTest do
   @fixture Path.expand("../fixtures/mcp_stdio_launcher_fixture.sh", __DIR__)
   @native_fixture Path.expand("../fixtures/mcp_stdio_native_fixture.c", __DIR__)
 
-  # The identity hash is the only interval long enough to race a rename into, so
-  # the target has to be large enough that hashing it is still in progress when
-  # the swap lands: 64 MiB takes roughly a third of a second, and the rename
-  # fires 40 ms in.
+  # The identity hash is the only interval long enough to swap an executable
+  # into, so the raced target is large enough that hashing it is still running
+  # when the replacement lands: 64 MiB takes roughly a third of a second.
   #
-  # The two ways to miss that interval are distinguishable rather than silent. A
-  # rename landing before the launcher opens the target makes it hash the small
-  # impostor and refuse within milliseconds, which the elapsed-time floor
-  # rejects; one landing after the exec runs the authorized target, which the
-  # output assertion accepts as the rename simply losing. Neither can report a
-  # pass for the window itself.
+  # Missing that interval is detected rather than silent, and a miss is retried
+  # instead of asserted away. The launcher is refused either way, so the proof
+  # that it was hashing the authorized target rather than the impostor is how
+  # much hashing remained after the swap: a launcher that had opened the
+  # impostor instead settles within milliseconds of it.
   @race_target_mebibytes 64
-  @race_rename_delay_ms 40
   @race_minimum_hash_ms 100
+  @race_attempts 3
 
   setup_all do
     compiler = System.find_executable("cc") || flunk("C compiler is unavailable")
@@ -575,50 +573,21 @@ defmodule PtcRunnerLauncher.ConformanceTest do
   @tag :tmp_dir
   @tag :slow
   test "a replacement landing during the identity hash never reaches exec", %{tmp_dir: dir} do
+    payload = Path.join(dir, "payload")
     authorized = Path.join(dir, "server")
-    impostor = Path.join(dir, "impostor")
-
-    frozen = write_padded_script(authorized, "AUTHORIZED-EXECUTED", @race_target_mebibytes)
-    _impostor_digest = write_padded_script(impostor, "IMPOSTOR-EXECUTED", 0)
     on_exit(fn -> File.rm_rf(dir) end)
 
-    racer =
-      Task.async(fn ->
-        # Deliberate scaffolding rather than a wait: the window under test is
-        # defined by wall-clock position inside the launcher's hash.
-        Process.sleep(@race_rename_delay_ms)
-        :file.rename(impostor, authorized)
+    frozen = write_padded_script(payload, "AUTHORIZED-EXECUTED", @race_target_mebibytes)
+
+    exercised? =
+      Enum.reduce_while(1..@race_attempts, false, fn _attempt, false ->
+        case race_identity_swap(dir, payload, authorized, frozen) do
+          :exercised -> {:halt, true}
+          :missed -> {:cont, false}
+        end
       end)
 
-    started_at = System.monotonic_time(:millisecond)
-
-    result =
-      MCPStdioLauncher.open(
-        executable: authorized,
-        executable_sha256: frozen,
-        cwd: dir,
-        args: [],
-        env: %{},
-        inherit_environment: false,
-        start_timeout_ms: 30_000
-      )
-
-    elapsed = System.monotonic_time(:millisecond) - started_at
-    assert :ok = Task.await(racer, 5_000)
-
-    case result do
-      {:error, reason} ->
-        assert reason == :mcp_stdio_spawn_failed
-        # Only a full pass over the authorized target takes this long, so the
-        # refusal cannot have come from hashing the impostor instead.
-        assert elapsed >= @race_minimum_hash_ms
-
-      {:ok, launcher} ->
-        output = collect_until(launcher, &(&1.stdout =~ ~r/-EXECUTED\n/))
-        assert output.stdout =~ "AUTHORIZED-EXECUTED"
-        refute output.stdout =~ "IMPOSTOR-EXECUTED"
-        assert {:ok, %{reason: :close}} = MCPStdioLauncher.close(launcher, 2_000)
-    end
+    assert exercised?, "the replacement never landed inside the identity window"
   end
 
   @tag :tmp_dir
@@ -842,6 +811,84 @@ defmodule PtcRunnerLauncher.ConformanceTest do
       )
 
     launcher
+  end
+
+  # Replaces the authorized executable with an impostor while the launcher is
+  # hashing it, and reports whether the swap landed inside that window. The
+  # replacement is released only once the launcher has forked the process that
+  # opens and hashes the target, so it cannot fire before that descriptor
+  # exists; re-linking the payload leaves each retry to cost a link rather than
+  # another pass over 64 MiB.
+  defp race_identity_swap(dir, payload, authorized, frozen) do
+    impostor = Path.join(dir, "impostor")
+
+    File.rm(authorized)
+    File.ln!(payload, authorized)
+    write_padded_script(impostor, "IMPOSTOR-EXECUTED", 0)
+
+    racer =
+      Task.async(fn ->
+        await_launcher_fork()
+        :ok = :file.rename(impostor, authorized)
+        System.monotonic_time(:millisecond)
+      end)
+
+    result =
+      MCPStdioLauncher.open(
+        executable: authorized,
+        executable_sha256: frozen,
+        cwd: dir,
+        args: [],
+        env: %{},
+        inherit_environment: false,
+        start_timeout_ms: 30_000
+      )
+
+    settled_at = System.monotonic_time(:millisecond)
+    renamed_at = Task.await(racer, 30_000)
+
+    classify_identity_swap(result, settled_at - renamed_at)
+  end
+
+  # Linux hashes and executes one held descriptor, so a swap inside the window
+  # cannot reach it and the authorized target runs; a refusal there means the
+  # launcher had already opened the impostor. macOS executes a path and must
+  # refuse, and only a refusal with a full hash still outstanding proves the
+  # swap landed after the authorized descriptor was open.
+  defp classify_identity_swap({:ok, launcher}, _outstanding_hash_ms) do
+    output = collect_until(launcher, &(&1.stdout =~ ~r/-EXECUTED\n/))
+    assert {:ok, %{reason: :close}} = MCPStdioLauncher.close(launcher, 2_000)
+
+    refute output.stdout =~ "IMPOSTOR-EXECUTED"
+    assert output.stdout =~ "AUTHORIZED-EXECUTED"
+
+    if held_descriptor_exec?(), do: :exercised, else: :missed
+  end
+
+  defp classify_identity_swap({:error, reason}, outstanding_hash_ms) do
+    assert reason == :mcp_stdio_spawn_failed
+
+    if not held_descriptor_exec?() and outstanding_hash_ms >= @race_minimum_hash_ms,
+      do: :exercised,
+      else: :missed
+  end
+
+  defp held_descriptor_exec?, do: :os.type() == {:unix, :linux}
+
+  # The launcher forks the process that opens and hashes the target only after
+  # its bootstrap arrives, so a second process still running the launcher image
+  # means the descriptor under test is already open.
+  defp await_launcher_fork do
+    {:ok, binary} = PtcRunnerLauncher.executable_path()
+    assert_eventually(fn -> launcher_image_count(binary) >= 2 end, 10_000)
+  end
+
+  defp launcher_image_count(binary) do
+    {output, 0} = System.cmd(ps_executable(), ["-eo", "command="])
+
+    output
+    |> String.split("\n", trim: true)
+    |> Enum.count(&String.starts_with?(&1, binary))
   end
 
   # Returns the SHA-256 of what was written, hashed as it goes: reading a target

--- a/ptc_runner_launcher/test/ptc_runner_launcher/conformance_test.exs
+++ b/ptc_runner_launcher/test/ptc_runner_launcher/conformance_test.exs
@@ -6,6 +6,15 @@ defmodule PtcRunnerLauncher.ConformanceTest do
   @fixture Path.expand("../fixtures/mcp_stdio_launcher_fixture.sh", __DIR__)
   @native_fixture Path.expand("../fixtures/mcp_stdio_native_fixture.c", __DIR__)
 
+  # The identity hash is the only interval long enough to race a rename into, so
+  # the target has to be large enough that hashing it is still in progress when
+  # the swap lands: 64 MiB takes roughly a third of a second, and the rename
+  # fires 40 ms in. A rename that lands too early only makes the case vacuous --
+  # the launcher then hashes the impostor and refuses on identity -- so a slow
+  # host cannot turn this red.
+  @race_target_mebibytes 64
+  @race_rename_delay_ms 40
+
   setup_all do
     compiler = System.find_executable("cc") || flunk("C compiler is unavailable")
 
@@ -558,6 +567,49 @@ defmodule PtcRunnerLauncher.ConformanceTest do
   end
 
   @tag :tmp_dir
+  @tag :slow
+  test "a replacement landing during the identity hash never reaches exec", %{tmp_dir: dir} do
+    authorized = Path.join(dir, "server")
+    impostor = Path.join(dir, "impostor")
+
+    frozen = write_padded_script(authorized, "AUTHORIZED-EXECUTED", @race_target_mebibytes)
+    _impostor_digest = write_padded_script(impostor, "IMPOSTOR-EXECUTED", 0)
+    on_exit(fn -> File.rm_rf(dir) end)
+
+    racer =
+      Task.async(fn ->
+        # Deliberate scaffolding rather than a wait: the window under test is
+        # defined by wall-clock position inside the launcher's hash.
+        Process.sleep(@race_rename_delay_ms)
+        :file.rename(impostor, authorized)
+      end)
+
+    result =
+      MCPStdioLauncher.open(
+        executable: authorized,
+        executable_sha256: frozen,
+        cwd: dir,
+        args: [],
+        env: %{},
+        inherit_environment: false,
+        start_timeout_ms: 30_000
+      )
+
+    assert :ok = Task.await(racer, 5_000)
+
+    case result do
+      {:error, reason} ->
+        assert reason == :mcp_stdio_spawn_failed
+
+      {:ok, launcher} ->
+        output = collect_until(launcher, &(&1.stdout =~ ~r/-EXECUTED\n/))
+        assert output.stdout =~ "AUTHORIZED-EXECUTED"
+        refute output.stdout =~ "IMPOSTOR-EXECUTED"
+        assert {:ok, %{reason: :close}} = MCPStdioLauncher.close(launcher, 2_000)
+    end
+  end
+
+  @tag :tmp_dir
   test "matches SHA-256 padding-boundary known answers", %{tmp_dir: dir} do
     prefix = "#!/bin/sh\nread _ || true\nexit 0\n#"
 
@@ -778,6 +830,26 @@ defmodule PtcRunnerLauncher.ConformanceTest do
       )
 
     launcher
+  end
+
+  # Returns the SHA-256 of what was written, hashed as it goes: reading a target
+  # this size back just to freeze its identity would cost more than the launch
+  # under test.
+  defp write_padded_script(path, marker, mebibytes) do
+    header = "#!/bin/sh\nprintf '#{marker}\\n'\nexit 0\n#"
+    padding = :binary.copy("x", 1024 * 1024)
+
+    digest =
+      File.open!(path, [:write, :binary], fn handle ->
+        Enum.reduce([header | List.duplicate(padding, mebibytes)], :crypto.hash_init(:sha256), fn
+          chunk, context ->
+            IO.binwrite(handle, chunk)
+            :crypto.hash_update(context, chunk)
+        end)
+      end)
+
+    File.chmod!(path, 0o700)
+    :crypto.hash_final(digest)
   end
 
   defp executable_sha256(executable) do

--- a/ptc_runner_launcher/test/ptc_runner_launcher/conformance_test.exs
+++ b/ptc_runner_launcher/test/ptc_runner_launcher/conformance_test.exs
@@ -8,16 +8,23 @@ defmodule PtcRunnerLauncher.ConformanceTest do
 
   # The identity hash is the only interval long enough to swap an executable
   # into, so the raced target is large enough that hashing it is still running
-  # when the replacement lands: 64 MiB takes roughly a third of a second.
+  # when the replacement lands: 64 MiB takes a third of a second here, and the
+  # swap fires 80 ms in.
   #
-  # Missing that interval is detected rather than silent, and a miss is retried
-  # instead of asserted away. The launcher is refused either way, so the proof
-  # that it was hashing the authorized target rather than the impostor is how
-  # much hashing remained after the swap: a launcher that had opened the
-  # impostor instead settles within milliseconds of it.
+  # The delay is deliberately biased early. Landing before the target is opened
+  # only costs the case its coverage -- the launcher hashes the impostor and
+  # refuses on identity. Landing after `execve` would be worse than useless on
+  # macOS, because an interpreted target is reopened by its interpreter through
+  # a path no launcher check covers, and the case would then go red over a
+  # documented limitation rather than a regression. Startup alone rules out
+  # reaching `execve` within 80 ms of a 64 MiB target.
+  #
+  # This is a probe rather than a gate: nothing here can tell coverage from a
+  # miss, and making it deterministic would mean a synchronization point inside
+  # a binary whose job is deciding what may execute. What it cannot do is pass
+  # while the impostor runs.
   @race_target_mebibytes 64
-  @race_minimum_hash_ms 100
-  @race_attempts 3
+  @race_swap_delay_ms 80
 
   setup_all do
     compiler = System.find_executable("cc") || flunk("C compiler is unavailable")
@@ -573,21 +580,49 @@ defmodule PtcRunnerLauncher.ConformanceTest do
   @tag :tmp_dir
   @tag :slow
   test "a replacement landing during the identity hash never reaches exec", %{tmp_dir: dir} do
-    payload = Path.join(dir, "payload")
     authorized = Path.join(dir, "server")
+    impostor = Path.join(dir, "impostor")
     on_exit(fn -> File.rm_rf(dir) end)
 
-    frozen = write_padded_script(payload, "AUTHORIZED-EXECUTED", @race_target_mebibytes)
+    frozen = write_padded_script(authorized, "AUTHORIZED-EXECUTED", @race_target_mebibytes)
+    write_padded_script(impostor, "IMPOSTOR-EXECUTED", 0)
 
-    exercised? =
-      Enum.reduce_while(1..@race_attempts, false, fn _attempt, false ->
-        case race_identity_swap(dir, payload, authorized, frozen) do
-          :exercised -> {:halt, true}
-          :missed -> {:cont, false}
-        end
+    racer =
+      Task.async(fn ->
+        # Deliberate scaffolding, not a wait for a result: the interval under
+        # test is defined by wall-clock position inside the launcher's hash and
+        # the launcher publishes nothing to synchronize on.
+        Process.sleep(@race_swap_delay_ms)
+        :file.rename(impostor, authorized)
       end)
 
-    assert exercised?, "the replacement never landed inside the identity window"
+    result =
+      MCPStdioLauncher.open(
+        executable: authorized,
+        executable_sha256: frozen,
+        cwd: dir,
+        args: [],
+        env: %{},
+        inherit_environment: false,
+        start_timeout_ms: 30_000
+      )
+
+    assert :ok = Task.await(racer, 30_000)
+
+    # Refused on macOS, where the path is what gets executed; on Linux the held
+    # descriptor still carries the authorized target through. Either is a safe
+    # outcome, and the impostor running is the only unsafe one.
+    case result do
+      {:error, reason} ->
+        assert reason == :mcp_stdio_spawn_failed
+
+      {:ok, launcher} ->
+        output = collect_until(launcher, &(&1.stdout =~ ~r/-EXECUTED\n/))
+        assert {:ok, %{reason: :close}} = MCPStdioLauncher.close(launcher, 5_000)
+
+        refute output.stdout =~ "IMPOSTOR-EXECUTED"
+        assert output.stdout =~ "AUTHORIZED-EXECUTED"
+    end
   end
 
   @tag :tmp_dir
@@ -813,92 +848,13 @@ defmodule PtcRunnerLauncher.ConformanceTest do
     launcher
   end
 
-  # Replaces the authorized executable with an impostor while the launcher is
-  # hashing it, and reports whether the swap landed inside that window. The
-  # replacement is released only once the launcher has forked the process that
-  # opens and hashes the target, so it cannot fire before that descriptor
-  # exists; re-linking the payload leaves each retry to cost a link rather than
-  # another pass over 64 MiB.
-  defp race_identity_swap(dir, payload, authorized, frozen) do
-    impostor = Path.join(dir, "impostor")
-
-    File.rm(authorized)
-    File.ln!(payload, authorized)
-    write_padded_script(impostor, "IMPOSTOR-EXECUTED", 0)
-
-    racer =
-      Task.async(fn ->
-        await_launcher_fork()
-        :ok = :file.rename(impostor, authorized)
-        System.monotonic_time(:millisecond)
-      end)
-
-    result =
-      MCPStdioLauncher.open(
-        executable: authorized,
-        executable_sha256: frozen,
-        cwd: dir,
-        args: [],
-        env: %{},
-        inherit_environment: false,
-        start_timeout_ms: 30_000
-      )
-
-    settled_at = System.monotonic_time(:millisecond)
-    renamed_at = Task.await(racer, 30_000)
-
-    classify_identity_swap(result, settled_at - renamed_at)
-  end
-
-  # Linux hashes and executes one held descriptor, so a swap inside the window
-  # cannot reach it and the authorized target runs; a refusal there means the
-  # launcher had already opened the impostor. macOS executes a path and must
-  # refuse, and only a refusal with a full hash still outstanding proves the
-  # swap landed after the authorized descriptor was open.
-  defp classify_identity_swap({:ok, launcher}, _outstanding_hash_ms) do
-    output = collect_until(launcher, &(&1.stdout =~ ~r/-EXECUTED\n/))
-    assert {:ok, %{reason: :close}} = MCPStdioLauncher.close(launcher, 2_000)
-
-    refute output.stdout =~ "IMPOSTOR-EXECUTED"
-    assert output.stdout =~ "AUTHORIZED-EXECUTED"
-
-    if held_descriptor_exec?(), do: :exercised, else: :missed
-  end
-
-  defp classify_identity_swap({:error, reason}, outstanding_hash_ms) do
-    assert reason == :mcp_stdio_spawn_failed
-
-    if not held_descriptor_exec?() and outstanding_hash_ms >= @race_minimum_hash_ms,
-      do: :exercised,
-      else: :missed
-  end
-
-  defp held_descriptor_exec?, do: :os.type() == {:unix, :linux}
-
-  # Three live processes running the launcher image are the launcher, the
-  # process it forked to open and hash the target, and that process's own
-  # watchdog. The watchdog fork is the last thing to happen before the target is
-  # opened, so the count clears only microseconds ahead of the descriptor under
-  # test; anything longer than that would have to be a scheduling stall, which
-  # can only cost this case coverage, never turn it red.
-  defp await_launcher_fork do
-    {:ok, binary} = PtcRunnerLauncher.executable_path()
-    assert_eventually(fn -> launcher_image_count(binary) >= 3 end, 10_000)
-  end
-
-  defp launcher_image_count(binary) do
-    {output, 0} = System.cmd(ps_executable(), ["-eo", "command="])
-
-    output
-    |> String.split("\n", trim: true)
-    |> Enum.count(&String.starts_with?(&1, binary))
-  end
-
   # Returns the SHA-256 of what was written, hashed as it goes: reading a target
   # this size back just to freeze its identity would cost more than the launch
   # under test.
   defp write_padded_script(path, marker, mebibytes) do
-    header = "#!/bin/sh\nprintf '#{marker}\\n'\nexit 0\n#"
+    # Waits for stdin EOF rather than exiting on its own, so closing the
+    # launcher finishes as a close instead of racing a server exit.
+    header = "#!/bin/sh\nprintf '#{marker}\\n'\nread _ || true\nexit 0\n#"
     padding = :binary.copy("x", 1024 * 1024)
 
     digest =

--- a/ptc_runner_launcher/test/support/launcher_port.ex
+++ b/ptc_runner_launcher/test/support/launcher_port.ex
@@ -30,6 +30,11 @@ defmodule PtcRunnerLauncher.TestSupport.LauncherPort do
   process group. `close/1` drains but deliberately discards output emitted
   after shutdown begins; request output must be consumed before closing.
   Losing the owning BEAM process closes the Port and triggers the same cleanup.
+  A launcher that is destroyed outright instead runs none of it, so a lifeline
+  watchdog forked before the target retires the group with a single `SIGKILL`
+  once the launcher stops holding its end of a private pipe. Supervision stands
+  that watchdog down as part of reaping the leader, whose PID is also the group
+  identifier the watchdog would name.
   POSIX process groups contain descendants that remain in the launched group;
   a deliberately trusted child can escape with `setpgid` or `setsid`. A killed
   group is only observably empty once every member has been reaped, so the

--- a/ptc_runner_launcher/test/support/launcher_port.ex
+++ b/ptc_runner_launcher/test/support/launcher_port.ex
@@ -31,11 +31,12 @@ defmodule PtcRunnerLauncher.TestSupport.LauncherPort do
   process group. `close/1` drains but deliberately discards output emitted
   after shutdown begins; request output must be consumed before closing.
   Losing the owning BEAM process closes the Port and triggers the same cleanup.
-  A launcher that is destroyed outright instead runs none of it, so a lifeline
-  watchdog forked before the target retires the group with a single `SIGKILL`
-  once the launcher stops holding its end of a private pipe. Supervision stands
-  that watchdog down as part of reaping the leader, whose PID is also the group
-  identifier the watchdog would name.
+  A launcher that is destroyed outright instead runs none of it, so the target
+  forks a watchdog inside its own new process group; that watchdog retires the
+  group with a single `SIGKILL` once the launcher stops holding its end of a
+  private pipe. Signalling from inside the group avoids naming a PID that the
+  launcher's death would have released. The launcher's own escalation ends the
+  watchdog with the same signal that ends the group.
   POSIX process groups contain descendants that remain in the launched group;
   a deliberately trusted child can escape with `setpgid` or `setsid`. A killed
   group is only observably empty once every member has been reaped, so the

--- a/ptc_runner_launcher/test/support/launcher_port.ex
+++ b/ptc_runner_launcher/test/support/launcher_port.ex
@@ -13,8 +13,11 @@ defmodule PtcRunnerLauncher.TestSupport.LauncherPort do
   descriptor for the same file, re-reads the canonical path immediately before
   `execve`, and refuses to start unless it still resolves to the device and
   inode that were hashed. The trusted operator must not modify executable
-  contents during startup on either platform. Linux script interpreters
-  intentionally inherit the held
+  contents during startup on either platform, and a macOS operator must also
+  leave the executable path hierarchy alone: an interpreted `#!` target is
+  handed to its interpreter as a path, which opens it a second time outside any
+  launcher check. Linux script interpreters instead intentionally inherit the
+  held
   executable descriptor because the kernel uses it for the interpreter
   handoff; native executables do not.
 
@@ -52,7 +55,8 @@ defmodule PtcRunnerLauncher.TestSupport.LauncherPort do
   hierarchy during startup on either platform. Linux executes the held object
   after it is opened; macOS executes a path, so the exposed interval there is
   the identity re-check that immediately precedes `execve` rather than the
-  identity hash, whose cost scales with the executable.
+  identity hash, whose cost scales with the executable — plus, for an
+  interpreted target, the interpreter's own second lookup of that path.
 
   This module is deliberately test-only. It exercises the packet protocol
   consumed by the core transport without making that transport part of the

--- a/ptc_runner_launcher/test/support/launcher_port.ex
+++ b/ptc_runner_launcher/test/support/launcher_port.ex
@@ -10,10 +10,11 @@ defmodule PtcRunnerLauncher.TestSupport.LauncherPort do
   canonical executable, hashes it, and confirms that identity. It then starts
   a new session/process group with only the supplied environment. Linux hashes
   and executes the same held readable descriptor. macOS hashes a readable
-  descriptor for the same file and executes the canonical host-installed path.
-  The trusted operator must not modify executable contents during startup on
-  either platform; macOS additionally requires its installation hierarchy to
-  remain immutable. Linux script interpreters intentionally inherit the held
+  descriptor for the same file, re-reads the canonical path immediately before
+  `execve`, and refuses to start unless it still resolves to the device and
+  inode that were hashed. The trusted operator must not modify executable
+  contents during startup on either platform. Linux script interpreters
+  intentionally inherit the held
   executable descriptor because the kernel uses it for the interpreter
   handoff; native executables do not.
 
@@ -48,8 +49,9 @@ defmodule PtcRunnerLauncher.TestSupport.LauncherPort do
   Canonicalization and descriptor opening are separate POSIX operations.
   Operators must not mutate executable contents or the working-directory path
   hierarchy during startup on either platform. Linux executes the held object
-  after it is opened; macOS executes the canonical path and therefore also
-  requires its executable path hierarchy to stay immutable.
+  after it is opened; macOS executes a path, so the exposed interval there is
+  the identity re-check that immediately precedes `execve` rather than the
+  identity hash, whose cost scales with the executable.
 
   This module is deliberately test-only. It exercises the packet protocol
   consumed by the core transport without making that transport part of the


### PR DESCRIPTION
Closes #1141 (items 1 and 2). Items 3–5 remain open and are untouched.

## Item 2 — the server group survives launcher death

A launcher killed without running any of its own code — `SIGKILL`, or a host
that tears the process down — ran none of its EOF/TERM/KILL teardown. Closing
the server's stdin was the only backstop, and a server that never reads stdin
never saw it, so the group stayed alive, reparented.

`PR_SET_PDEATHSIG` was the fix the issue suggested, but it is Linux-only and
Linux clears it on `fork`, so it would have covered the server leader and none
of its descendants. Instead the target forks a watchdog **inside the process
group it has just created**, before the identity hash. The launcher holds the
only writer of a private pipe; losing it means the launcher is gone, and the
watchdog retires the group with a single `kill(0, SIGKILL)`.

Group membership is the point. A process group's lifetime keeps its identifier —
which is also the leader's PID — out of the reuse pool, so signalling from
inside can only ever reach the group it was created for. No PID is held,
transmitted, or trusted. That is what a launcher-side observer could not
achieve: by the time it noticed the death, the leader could already have been
reaped and its number reissued. A `getpgrp` tripwire refuses to signal if a
future edit ever moves that fork ahead of `setsid`.

The target waits for the watchdog to release every descriptor it inherited
before it execs, so it never starts while a second writer holds the exec-status
pipe.

Because the group now contains one member the launcher never parented, kill-wait
drains at a 5 ms cadence instead of the ordinary 100 ms tick. Without that,
every shutdown paid a full extra tick — close latency medians over 30 launches:
104 ms on `main`, 206 ms group-resident, 110 ms with the finer cadence. Startup
is unchanged within noise.

## Item 1 — macOS execs a path rather than the hashed descriptor

The comment thread recorded this as fixed. It is not. The device/inode
comparison runs *before* the SHA-256 pass rather than before `execve`, so the
whole hash — whose cost scales with the executable — is still inside the
replacement window. A probe against a 64 MiB authorized target, renaming an
impostor over the canonical path 40 ms after launch, executed the impostor with
about 300 ms to spare.

The hashed descriptor's device and inode are now recorded, and the child re-reads
the canonical path immediately before `execve`, refusing with `EPERM` unless it
still resolves to that object. The held descriptor keeps the inode number from
being recycled underneath the comparison. The same probe is now refused.

**Known limit, newly documented and newly reproduced:** that bounds a *native*
executable. macOS hands an interpreted `#!` target to its interpreter as a path
rather than a descriptor — the interpreter's `$0` is the script's own path, not
`/dev/fd/N` as it is under Linux `fexecve` — so the interpreter opens it a second
time and no launcher check covers that lookup. Shrinking the raced target until
the swap lands past `execve` executes the impostor *with this fix in place*,
which is that second lookup, observed. A macOS host must keep the executable path
hierarchy immutable for the whole of startup; the README, changelog, and protocol
reference now say so.

## Tests

Two new conformance cases, both verified red before the fix and green after:

- `kill -9` on the launcher, asserting the leader and its same-group descendant
  stop *running* — `kill -0` succeeds for an un-reaped zombie, and nothing reaps
  this group once its launcher is gone, so liveness is read from process state.
- A rename raced against the identity hash, asserting the impostor never
  executes. Red three times over against a build with the pre-exec re-check
  removed; green four times with it.

The swap fires 80 ms in, biased early on purpose. Measured against the unfixed
build, 40 ms is a coin flip against launcher startup while 60 ms and up catch the
impostor every time, and the hash still has ~250 ms to run at 80 ms. Landing
early only costs the case its coverage; landing after `execve` would make it red
over the documented interpreter limitation rather than a regression.

That leaves a probe, not a gate, and its comment says so: nothing in it
distinguishes coverage from a miss. Review pushed twice for determinism here;
the only way to get it is a synchronization point inside a binary whose job is
deciding what may execute, which I judged not worth the trade.

## Verification

`mix precommit` green (6246 root, 44 Viewer, 42 launcher). CI green on all four
launcher platforms, including both Linux targets — the watchdog carries no
platform conditionals, but only CI exercises them.

Three rounds of independent Codex review. The first two raised P1s on watchdog
identity and the arming window, which drove the group-resident redesign; the
third found no P1s and two P2s, both addressed — the interpreter's second lookup
is now documented and reproduced, and the race case no longer depends on process
sampling.