### PR TITLE
perf(hooks): overlap the deterministic pre-push gates

### DIFF
--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -11,6 +11,18 @@ before the longer test and Dialyzer stages. Plan-only changes skip the
 expensive gate. Unknown paths select every gate, and
 `FORCE_FULL_PRE_PUSH=1` explicitly forces the complete gate.
 
+After the test suite, the deterministic gates run as concurrent lanes, because
+they own disjoint build trees: core static analysis followed by Dialyzer
+(`_build/test`), release verification (`_build/prod`), and the Viewer
+(`ptc_viewer/_build/test`). Each lane's output is buffered and replayed under
+its own heading once it finishes, so a concurrent run reads like a serial one
+and every lane is reported even when an earlier one fails.
+
+The test suite and the launcher gate deliberately do not share the machine.
+Both own load-sensitive assertions, and a gate that flakes costs more than a
+gate that is slow. Set `PTC_PRE_PUSH_SERIAL=1` to run every gate serially when
+diagnosing a failure or pushing from a machine too small to overlap them.
+
 For an ordinary push, run `git push` and let the hook execute the complete gate
 once. "Complete" excludes `:nightly` tests, which cost tens of seconds each and
 run in the `Nightly` workflow instead; everything else runs. Run `mix prepush` directly only to diagnose that portion of the gate or

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -486,24 +486,30 @@ wait_lanes() {
     label="${LANE_LABELS[$i]}"
     log="${LANE_LOGS[$i]}"
 
-    if wait "$pid"; then
-      secs="$(cat "$log.secs" 2>/dev/null || echo '?')"
-      echo ""
-      echo "📦 $label"
-      cat "$log"
+    local lane_status=0
+    wait "$pid" || lane_status=$?
+
+    # Reaped: drop the PID before replaying output, which can take long enough
+    # for the system to hand that number to an unrelated process. An interrupt
+    # arriving mid-replay must not make cleanup signal a stranger.
+    LANE_PIDS[i]=""
+
+    secs="$(cat "$log.secs" 2>/dev/null || echo '?')"
+    echo ""
+    echo "📦 $label"
+    cat "$log"
+
+    if [ "$lane_status" -eq 0 ]; then
       echo "  ✅ $label passed in ${secs}s"
       record_phase "$label" "$secs"
     else
-      secs="$(cat "$log.secs" 2>/dev/null || echo '?')"
-      echo ""
-      echo "📦 $label"
-      cat "$log"
       echo "  ❌ $label failed after ${secs}s"
       record_phase "$label (failed)" "$secs"
       failures=$((failures + 1))
     fi
 
     rm -f "$log" "$log.secs"
+    LANE_LOGS[i]=""
   done
 
   LANE_PIDS=()
@@ -519,25 +525,44 @@ wait_lanes() {
 # to report to. Descend first so nothing is orphaned on the way down.
 kill_lane_tree() {
   local pid="$1"
+  local signal="$2"
   local child
 
   for child in $(pgrep -P "$pid" 2>/dev/null); do
-    kill_lane_tree "$child"
+    kill_lane_tree "$child" "$signal"
   done
 
-  kill "$pid" 2>/dev/null || true
+  kill "-$signal" "$pid" 2>/dev/null || true
 }
 
 # A lane outlives the shell that started it, so an interrupted push must take
-# its lanes and their logs with it.
+# its lanes and their logs with it. Entries are blanked as `wait_lanes` reaps
+# them, and a blank entry is skipped: signalling a reaped PID would be
+# signalling whatever the system has since given that number to.
 cleanup_lanes() {
   local entry
+  local signalled=false
 
   for entry in ${LANE_PIDS[@]+"${LANE_PIDS[@]}"}; do
-    kill_lane_tree "$entry"
+    [ -n "$entry" ] || continue
+    kill_lane_tree "$entry" TERM
+    signalled=true
   done
 
+  if [ "$signalled" = true ]; then
+    # A gate that forks while the walk is in progress, or that is slow to
+    # honor TERM, survives the first pass. Settle once and take down what is
+    # left. This is an abort path: bounded and blunt beats thorough.
+    sleep 1
+
+    for entry in ${LANE_PIDS[@]+"${LANE_PIDS[@]}"}; do
+      [ -n "$entry" ] || continue
+      kill_lane_tree "$entry" KILL
+    done
+  fi
+
   for entry in ${LANE_LOGS[@]+"${LANE_LOGS[@]}"}; do
+    [ -n "$entry" ] || continue
     rm -f "$entry" "$entry.secs"
   done
 

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -513,6 +513,42 @@ wait_lanes() {
   return "$failures"
 }
 
+# Signalling the lane subshell is not enough: the gate it launched is a
+# grandchild, and killing only the parent reparents a release build or a
+# Dialyzer run to init, where it keeps consuming the machine with nothing left
+# to report to. Descend first so nothing is orphaned on the way down.
+kill_lane_tree() {
+  local pid="$1"
+  local child
+
+  for child in $(pgrep -P "$pid" 2>/dev/null); do
+    kill_lane_tree "$child"
+  done
+
+  kill "$pid" 2>/dev/null || true
+}
+
+# A lane outlives the shell that started it, so an interrupted push must take
+# its lanes and their logs with it.
+cleanup_lanes() {
+  local entry
+
+  for entry in ${LANE_PIDS[@]+"${LANE_PIDS[@]}"}; do
+    kill_lane_tree "$entry"
+  done
+
+  for entry in ${LANE_LOGS[@]+"${LANE_LOGS[@]}"}; do
+    rm -f "$entry" "$entry.secs"
+  done
+
+  LANE_PIDS=()
+  LANE_LOGS=()
+}
+
+trap 'cleanup_lanes; rm -f "${PTC_PRE_PUSH_PATHS_FILE:-}"' EXIT
+trap 'cleanup_lanes; exit 130' INT
+trap 'cleanup_lanes; exit 143' TERM
+
 # Both stages compile into `_build/test`, so they share Mix's build lock and
 # gain nothing from being separate lanes.
 core_static_and_dialyzer() {

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -411,18 +411,162 @@ run_gate() {
   record_phase "$label" "$gate_secs"
 }
 
+# ----------------------------------------------------------------------
+# Lanes: the deterministic gates overlap, the test suite never does.
+#
+# The suite is the longest stage and roughly four fifths of it is
+# `async: false` -- legitimately so, because those modules call `File.cd`,
+# `Application.put_env`, and `System.put_env`, which are VM-global. It
+# therefore holds a single core for minutes while the rest of the machine
+# idles, which is what makes the gate look like a chain of half-empty
+# stages. It still runs alone: this repository's timing-sensitive tests
+# fail under unrelated background load, and a gate that flakes costs more
+# than a gate that is slow.
+#
+# What does overlap is the deterministic tail, whose stages own disjoint
+# build trees and have no shared mutable state:
+#
+#   lane A   core-static -> core-Dialyzer   _build/test  (shared: serial)
+#   lane B   core-release                   _build/prod
+#   lane C   Viewer                         ptc_viewer/_build/test
+#
+# Documentation keeps its head start above: it owns `_build/dev` and is
+# the only stage that writes the root `deps/`, so finishing it first also
+# keeps `mix deps.get` off the lanes.
+#
+# The launcher gate stays serial on purpose. Its port-teardown assertions
+# are load-sensitive (`:DOWN` can outrun `Port.info/1` releasing the port),
+# a failure mode this repository has already had to chase down on a loaded
+# CI runner.
+#
+# Lane output is buffered and replayed in lane order, so a concurrent run
+# reads like a serial one. PTC_PRE_PUSH_SERIAL=1 restores serial execution
+# for diagnosis or for a machine too small to share.
+# ----------------------------------------------------------------------
+
+LANE_PIDS=()
+LANE_LABELS=()
+LANE_LOGS=()
+
+start_lane() {
+  local label="$1"
+  shift
+  local log
+  log="$(mktemp -t pre-push-lane.XXXXXX)"
+
+  (
+    # Inherited errexit would abort the subshell on the gate's own failure,
+    # losing both the exit status and the duration this lane is reporting.
+    set +e
+    lane_start=$SECONDS
+    "$@" > "$log" 2>&1
+    lane_rc=$?
+    echo $((SECONDS - lane_start)) > "$log.secs"
+    exit $lane_rc
+  ) &
+
+  LANE_PIDS+=("$!")
+  LANE_LABELS+=("$label")
+  LANE_LOGS+=("$log")
+  echo "  ⏳ $label started"
+}
+
+# Waits for every started lane, replays each lane's output under its own
+# heading, and returns the number that failed. Every lane is awaited even
+# after one fails: they are already running, and reporting all of them
+# beats surfacing one failure per push cycle.
+wait_lanes() {
+  local failures=0
+  local i pid label log secs
+
+  [ "${#LANE_PIDS[@]}" -gt 0 ] || return 0
+
+  for i in "${!LANE_PIDS[@]}"; do
+    pid="${LANE_PIDS[$i]}"
+    label="${LANE_LABELS[$i]}"
+    log="${LANE_LOGS[$i]}"
+
+    if wait "$pid"; then
+      secs="$(cat "$log.secs" 2>/dev/null || echo '?')"
+      echo ""
+      echo "📦 $label"
+      cat "$log"
+      echo "  ✅ $label passed in ${secs}s"
+      record_phase "$label" "$secs"
+    else
+      secs="$(cat "$log.secs" 2>/dev/null || echo '?')"
+      echo ""
+      echo "📦 $label"
+      cat "$log"
+      echo "  ❌ $label failed after ${secs}s"
+      record_phase "$label (failed)" "$secs"
+      failures=$((failures + 1))
+    fi
+
+    rm -f "$log" "$log.secs"
+  done
+
+  LANE_PIDS=()
+  LANE_LABELS=()
+  LANE_LOGS=()
+
+  return "$failures"
+}
+
+# Both stages compile into `_build/test`, so they share Mix's build lock and
+# gain nothing from being separate lanes.
+core_static_and_dialyzer() {
+  "$HOOK_REPO_ROOT/scripts/ci/core-static.sh" &&
+    "$HOOK_REPO_ROOT/scripts/ci/core-dialyzer.sh"
+}
+
+run_core_gates=false
 if [ "$core" = true ] || [ "$mcp_http" = true ] ||
    [ "$mcp_filesystem" = true ] || [ "$java" = true ]; then
-  run_gate "core tests" "$HOOK_REPO_ROOT/scripts/ci/core-tests.sh"
-  run_gate "core static analysis" "$HOOK_REPO_ROOT/scripts/ci/core-static.sh"
-  run_gate "core Dialyzer" "$HOOK_REPO_ROOT/scripts/ci/core-dialyzer.sh"
-  run_gate "core release verification" "$HOOK_REPO_ROOT/scripts/ci/core-release.sh"
+  run_core_gates=true
 fi
 
 # Root trace and inspection contracts are consumed by the Viewer, so retain
 # Viewer coverage for core changes as well as Viewer-owned changes.
+run_viewer_gate=false
 if [ "$viewer" = true ] || [ "$core" = true ]; then
-  run_gate "Viewer validation" "$HOOK_REPO_ROOT/scripts/ci/viewer.sh"
+  run_viewer_gate=true
+fi
+
+if [ "$run_core_gates" = true ]; then
+  run_gate "core tests" "$HOOK_REPO_ROOT/scripts/ci/core-tests.sh"
+fi
+
+if [ -n "${PTC_PRE_PUSH_SERIAL:-}" ]; then
+  if [ "$run_core_gates" = true ]; then
+    run_gate "core static analysis" "$HOOK_REPO_ROOT/scripts/ci/core-static.sh"
+    run_gate "core Dialyzer" "$HOOK_REPO_ROOT/scripts/ci/core-dialyzer.sh"
+    run_gate "core release verification" "$HOOK_REPO_ROOT/scripts/ci/core-release.sh"
+  fi
+
+  if [ "$run_viewer_gate" = true ]; then
+    run_gate "Viewer validation" "$HOOK_REPO_ROOT/scripts/ci/viewer.sh"
+  fi
+elif [ "$run_core_gates" = true ] || [ "$run_viewer_gate" = true ]; then
+  echo ""
+  echo "📦 Deterministic gates (concurrent lanes)"
+
+  if [ "$run_core_gates" = true ]; then
+    start_lane "core static analysis + Dialyzer" core_static_and_dialyzer
+    start_lane "core release verification" \
+      "$HOOK_REPO_ROOT/scripts/ci/core-release.sh"
+  fi
+
+  if [ "$run_viewer_gate" = true ]; then
+    start_lane "Viewer validation" "$HOOK_REPO_ROOT/scripts/ci/viewer.sh"
+  fi
+
+  if ! wait_lanes; then
+    echo ""
+    echo "❌ A deterministic gate failed. Re-run it on its own, or set"
+    echo "   PTC_PRE_PUSH_SERIAL=1 to run every gate serially."
+    exit 1
+  fi
 fi
 
 if [ "$launcher" = true ]; then

--- a/test/githooks/pre_push_test.exs
+++ b/test/githooks/pre_push_test.exs
@@ -353,7 +353,13 @@ defmodule PtcRunner.GitHooks.PrePushTest do
             {"HOOK_REFS", refs},
             {"MIX_MARKER",
              Path.join(path |> String.split(":") |> hd() |> Path.dirname(), "mix-called")},
-            {"PATH", path}
+            {"PATH", path},
+            # The gate that runs these tests may itself have been invoked with
+            # PTC_PRE_PUSH_SERIAL set. Without clearing it, the ambient value
+            # decides whether the hook under test runs lanes or not, and the
+            # lane assertions quietly test serial execution instead. Cases that
+            # want a mode set it through extra_env, which wins by coming last.
+            {"PTC_PRE_PUSH_SERIAL", nil}
           ] ++ extra_env,
       stderr_to_stdout: true
     )

--- a/test/githooks/pre_push_test.exs
+++ b/test/githooks/pre_push_test.exs
@@ -181,6 +181,44 @@ defmodule PtcRunner.GitHooks.PrePushTest do
   end
 
   @tag :slow
+  test "a failing static analysis skips Dialyzer in its own lane" do
+    %{repo: repo, mix_marker: mix_marker, path: path} =
+      git_repo_with_change("lib/example.ex")
+
+    {output, status} = run_hook(repo, path, [{"MIX_FAIL_GATE", "core-static"}])
+
+    refute status == 0
+    assert output =~ "core static analysis + Dialyzer failed"
+
+    invocations = mix_marker |> File.read!() |> String.split("\n", trim: true)
+
+    # Dialyzer consumes what static analysis just compiled, so the lane chains
+    # them with `&&` and a failed static stage must not spend time on Dialyzer.
+    assert "ci-gate core-static" in invocations
+    refute "ci-gate core-dialyzer" in invocations
+
+    # The sibling lanes are independent and still run to completion.
+    assert "ci-gate core-release" in invocations
+    assert "ci-gate viewer" in invocations
+  end
+
+  @tag :slow
+  test "a failing Dialyzer fails the push after static analysis passed" do
+    %{repo: repo, mix_marker: mix_marker, path: path} =
+      git_repo_with_change("lib/example.ex")
+
+    {output, status} = run_hook(repo, path, [{"MIX_FAIL_GATE", "core-dialyzer"}])
+
+    refute status == 0
+    assert output =~ "core static analysis + Dialyzer failed"
+
+    invocations = mix_marker |> File.read!() |> String.split("\n", trim: true)
+
+    assert "ci-gate core-static" in invocations
+    assert "ci-gate core-dialyzer" in invocations
+  end
+
+  @tag :slow
   test "the removed concurrency environment variable cannot throttle the full gate" do
     %{repo: repo, mix_marker: mix_marker, path: path} =
       git_repo_with_change("lib/example.ex")

--- a/test/githooks/pre_push_test.exs
+++ b/test/githooks/pre_push_test.exs
@@ -43,16 +43,7 @@ defmodule PtcRunner.GitHooks.PrePushTest do
     refute output =~ "Documentation-only push"
     assert output =~ "core tests"
 
-    assert mix_marker |> File.read!() |> String.split("\n", trim: true) ==
-             [
-               "deps.get --check-locked",
-               "docs --warnings-as-errors",
-               "ci-gate core-tests",
-               "ci-gate core-static",
-               "ci-gate core-dialyzer",
-               "ci-gate core-release",
-               "ci-gate viewer"
-             ]
+    assert_core_gate_invocations(mix_marker)
   end
 
   @tag :slow
@@ -94,17 +85,11 @@ defmodule PtcRunner.GitHooks.PrePushTest do
     assert status == 0, output
     refute output =~ "Documentation-only push"
 
-    assert mix_marker |> File.read!() |> String.split("\n", trim: true) ==
-             [
-               "deps.get --check-locked",
-               "docs --warnings-as-errors",
-               "ci-gate core-tests",
-               "ci-gate core-static",
-               "ci-gate core-dialyzer",
-               "ci-gate core-release",
-               "ci-gate viewer",
-               "ci-gate launcher"
-             ]
+    invocations = assert_core_gate_invocations(mix_marker, ["ci-gate launcher"])
+
+    # The launcher gate owns load-sensitive port-teardown assertions, so it
+    # never shares the machine with a lane.
+    assert List.last(invocations) == "ci-gate launcher"
   end
 
   test "launcher-only changes run the launcher gate" do
@@ -143,13 +128,24 @@ defmodule PtcRunner.GitHooks.PrePushTest do
 
     assert status == 0, output
     assert output =~ ~r/core tests passed in \d+s/
-    assert output =~ ~r/core static analysis passed in \d+s/
-    assert output =~ ~r/core Dialyzer passed in \d+s/
+    assert output =~ ~r/core static analysis \+ Dialyzer passed in \d+s/
     assert output =~ ~r/core release verification passed in \d+s/
 
     assert output =~ "Phase timings:"
     assert output =~ ~r/core tests\s+\d+s/
-    assert output =~ ~r/core Dialyzer\s+\d+s/
+    assert output =~ ~r/core static analysis \+ Dialyzer\s+\d+s/
+
+    assert_core_gate_invocations(mix_marker)
+  end
+
+  @tag :slow
+  test "serial mode runs every gate in the documented order" do
+    %{repo: repo, mix_marker: mix_marker, path: path} =
+      git_repo_with_change("lib/example.ex")
+
+    {output, status} = run_hook(repo, path, [{"PTC_PRE_PUSH_SERIAL", "1"}])
+
+    assert status == 0, output
 
     assert mix_marker |> File.read!() |> String.split("\n", trim: true) ==
              [
@@ -164,6 +160,27 @@ defmodule PtcRunner.GitHooks.PrePushTest do
   end
 
   @tag :slow
+  test "a failing lane fails the push and still reports its siblings" do
+    %{repo: repo, mix_marker: mix_marker, path: path} =
+      git_repo_with_change("lib/example.ex")
+
+    {output, status} =
+      run_hook(repo, path, [{"MIX_FAIL_GATE", "core-release"}])
+
+    refute status == 0
+
+    assert output =~ "core release verification failed"
+    assert output =~ "PTC_PRE_PUSH_SERIAL=1"
+
+    # Every lane is awaited and reported even once one of them has failed,
+    # so a push surfaces all of its broken gates in a single cycle.
+    assert output =~ ~r/core static analysis \+ Dialyzer passed in \d+s/
+    assert output =~ ~r/Viewer validation passed in \d+s/
+
+    assert "ci-gate viewer" in (mix_marker |> File.read!() |> String.split("\n", trim: true))
+  end
+
+  @tag :slow
   test "the removed concurrency environment variable cannot throttle the full gate" do
     %{repo: repo, mix_marker: mix_marker, path: path} =
       git_repo_with_change("lib/example.ex")
@@ -173,16 +190,7 @@ defmodule PtcRunner.GitHooks.PrePushTest do
     assert status == 0
     refute output =~ "Test concurrency"
 
-    assert mix_marker |> File.read!() |> String.split("\n", trim: true) ==
-             [
-               "deps.get --check-locked",
-               "docs --warnings-as-errors",
-               "ci-gate core-tests",
-               "ci-gate core-static",
-               "ci-gate core-dialyzer",
-               "ci-gate core-release",
-               "ci-gate viewer"
-             ]
+    assert_core_gate_invocations(mix_marker)
   end
 
   @tag :slow
@@ -196,16 +204,7 @@ defmodule PtcRunner.GitHooks.PrePushTest do
     assert output =~ "Documentation"
     assert output =~ "core tests"
 
-    assert mix_marker |> File.read!() |> String.split("\n", trim: true) ==
-             [
-               "deps.get --check-locked",
-               "docs --warnings-as-errors",
-               "ci-gate core-tests",
-               "ci-gate core-static",
-               "ci-gate core-dialyzer",
-               "ci-gate core-release",
-               "ci-gate viewer"
-             ]
+    assert_core_gate_invocations(mix_marker)
   end
 
   test "documentation dependency setup rejects an uncommitted lockfile repair" do
@@ -220,6 +219,47 @@ defmodule PtcRunner.GitHooks.PrePushTest do
 
     assert mix_marker |> File.read!() |> String.split("\n", trim: true) ==
              ["deps.get --check-locked"]
+  end
+
+  @core_gate_invocations [
+    "deps.get --check-locked",
+    "docs --warnings-as-errors",
+    "ci-gate core-tests",
+    "ci-gate core-static",
+    "ci-gate core-dialyzer",
+    "ci-gate core-release",
+    "ci-gate viewer"
+  ]
+
+  # The deterministic gates run as concurrent lanes, so the recorded sequence
+  # is asserted as a multiset plus the orderings the design actually
+  # guarantees. Pinning a total order here would only re-record whichever
+  # interleaving the machine happened to produce.
+  defp assert_core_gate_invocations(mix_marker, extra_gates \\ []) do
+    invocations = mix_marker |> File.read!() |> String.split("\n", trim: true)
+
+    assert Enum.sort(invocations) == Enum.sort(@core_gate_invocations ++ extra_gates),
+           "unexpected gate invocations: #{inspect(invocations)}"
+
+    assert_runs_before(invocations, "deps.get --check-locked", "docs --warnings-as-errors")
+    assert_runs_before(invocations, "docs --warnings-as-errors", "ci-gate core-tests")
+
+    # The suite owns the machine: no lane starts until it has finished.
+    for lane <- ["ci-gate core-static", "ci-gate core-release", "ci-gate viewer"] do
+      assert_runs_before(invocations, "ci-gate core-tests", lane)
+    end
+
+    # Static analysis and Dialyzer compile into the same `_build/test`, so
+    # they share one lane and keep their relative order.
+    assert_runs_before(invocations, "ci-gate core-static", "ci-gate core-dialyzer")
+
+    invocations
+  end
+
+  defp assert_runs_before(invocations, earlier, later) do
+    assert Enum.find_index(invocations, &(&1 == earlier)) <
+             Enum.find_index(invocations, &(&1 == later)),
+           "expected #{earlier} before #{later}, got: #{inspect(invocations)}"
   end
 
   defp git_repo_with_change(changed_path) do
@@ -269,6 +309,9 @@ defmodule PtcRunner.GitHooks.PrePushTest do
     #!/bin/sh
     printf '%s\n' "$*" >> "$MIX_MARKER"
     if [ "${MIX_MUTATE_LOCK:-}" = "1" ] && [ "$*" = "deps.get --check-locked" ]; then
+      exit 1
+    fi
+    if [ -n "${MIX_FAIL_GATE:-}" ] && [ "$*" = "ci-gate ${MIX_FAIL_GATE}" ]; then
       exit 1
     fi
     exit 0


### PR DESCRIPTION
## Why the push gate is slow

The gate is a chain of six stages, none of which fills the machine. Measured
end to end, one change accounts for most of the shape.

### The stage map

`.githooks/pre-push` classifies the pushed and dirty paths, then runs, strictly
in order:

| stage | entry point | `MIX_ENV` | build tree |
| --- | --- | --- | --- |
| documentation | `scripts/ci/docs.sh` | `dev` | `_build/dev` |
| core tests | `scripts/ci/core-tests.sh` | `test` | `_build/test` |
| core static | `scripts/ci/core-static.sh` | `test` | `_build/test` |
| core Dialyzer | `scripts/ci/core-dialyzer.sh` | `test` | `_build/test` |
| core release | `scripts/ci/core-release.sh` | `prod` | `_build/prod` |
| Viewer | `scripts/ci/viewer.sh` | `test` | `ptc_viewer/_build/test` |
| launcher | `scripts/ci/launcher.sh` | `test` | `ptc_runner_launcher/` |

GitHub Actions runs the same scripts as separate parallel jobs, so only the
local hook pays the serial cost.

### Where the time goes

Warm, standalone, on this machine (macOS 26.3.1, M1 Pro, **10 cores**, Elixir
1.20.2/OTP 29). The reporter's baseline is a **4-core Linux** box; both are
shown because the core count changes the ratios.

| gate | local warm | reporter's Linux |
| --- | --- | --- |
| documentation | 10.9s | 8.0s |
| **core tests** | **178.1s** | *(was still running)* |
| core static | 54.4s | 87.8s |
| core Dialyzer | 12.0s | 19.1s |
| core release | 84.7s | 46.2s |
| Viewer | 6.3s | 3.7s |

**The suite is the largest stage, and four fifths of it is serialized:**

```
Finished in 170.9 seconds (31.8s async, 139.0s sync)
6253 passed (122 doctests, 5 properties), 367 excluded
```

139 of 171 seconds run one test at a time on a single core. That is the
"partly-idle stages" shape: 58 of 300 test files are `async: false` (19% of the
files, 81% of the time), and the cost concentrates hard — the top 4 modules are
50% of the sync time, the top 10 are 80%:

| module | sync time |
| --- | --- |
| `CommandEngineTest` | 22.6s |
| `MCPStdioTransportTest` | 21.8s |
| `MCPSourceTest` | 16.4s |
| `Mix.Tasks.PtcTest` | 12.7s |
| `ProviderActiveSessionTest` | 10.8s |

**Those markers are earned, not cargo-culted.** `CommandEngineTest` calls
`File.cd` 11 times and `Application.put_env` 7 times; `ProviderActiveSessionTest`
calls `Application.put_env` 19 times; `MCPSourceTest` carries a comment
explaining that its short request deadlines break when it shares the scheduler.
`File.cd`, `Application.put_env`, and `System.put_env` are VM-global. The
serialization inside the suite is real work, not an oversight.

Secondary finding, for the record: inside `core-static`, `scripts/duplication_gate.sh`
is 21.0s of the 54.4s, and 16.0s of that is `mix ex_dna` running at ~113% CPU —
effectively single-threaded. `core-static` also pays ~10 separate BEAM boots at
1.2–1.4s each, and two of its `mix compile` invocations are no-ops by the time
they run.

## The change

Run the deterministic tail as concurrent lanes. They own disjoint build trees
and share no mutable state:

```
lane A   core-static -> core-Dialyzer   _build/test   (shared tree: serial)
lane B   core-release                   _build/prod
lane C   Viewer                         ptc_viewer/_build/test
```

Documentation keeps its head start: it owns `_build/dev` and is the only stage
that writes the root `deps/`, so finishing it first also keeps `mix deps.get`
off the lanes.

**The test suite and the launcher gate keep the machine to themselves.** Both
own load-sensitive assertions, and a gate that flakes costs more than a gate
that is slow.

Lane output is buffered and replayed under its own heading, so a concurrent run
reads like a serial one, and every lane is awaited and reported even when one
fails — a push surfaces all its broken gates in one cycle. `PTC_PRE_PUSH_SERIAL=1`
restores serial execution.

No gate script, flag, or environment variable changed, so CI — which already
runs these as separate jobs and never invokes the hook — is unaffected.

## Result

Full hook, same commit, back to back on the same warm worktree:

| phase | serial | lanes |
| --- | --- | --- |
| documentation | 17s | 11s |
| core tests | 203s | 208s |
| core static (+ Dialyzer) | 57s + 11s | **70s** (lane A) |
| core release | 59s | **68s** (lane B) |
| Viewer | 6s | **5s** (lane C) |
| launcher | 43s | 44s |
| **deterministic tail** | **133s** | **70s** |
| **total** | **401.0s** | **338.0s** |

**−63s, −15.7% overall; the deterministic tail is 47% faster.** The suite's
203s→208s drift is run-to-run variance and slightly understates the win. A
final run of the reviewed code came in at 347.3s: the tail lands in a 70–80s
band across runs, against 133s serial.

## Verification

- Lane machinery unit-tested for concurrency (3×3s lanes complete in 3s),
  single-lane failure, multi-lane failure, and the empty case.
- Mutating `wait_lanes` to `return 0` makes the failing-lane test fail, so it
  detects a false green.
- Interrupting a real hook run mid-lane leaves 0 orphaned processes and 0
  leaked temp files — measured before the fix (3 orphans) and after (0) — while
  an unrelated sentinel process started before the run is still alive
  afterwards, so the sweep does not reach outside its own lanes.
- Full hook run serially and concurrently, both green, on the same commit.
- `bash -n` and `shellcheck` clean.
- `test/githooks/pre_push_test.exs`: 16/16, with and without an ambient
  `PTC_PRE_PUSH_SERIAL`.

The test changes replace an exact total order — which lanes make
nondeterministic — with the invariants the design actually guarantees: every
gate runs exactly once, documentation precedes the suite, the suite precedes
every lane, and `core-static` precedes `core-Dialyzer` inside its lane. Two
cases were added that the old assertion could not express: serial mode still
runs the documented order, and a failing lane fails the push while its siblings
are still reported.

Two defects surfaced during verification and are fixed here:

- `run_hook/3` passed the ambient environment through, so running the gate
  itself with `PTC_PRE_PUSH_SERIAL=1` silently forced every hook invocation
  under test into serial mode, and the lane assertions quietly tested serial
  execution instead.
- Interrupting a push killed only the lane subshell. The gate it launched is a
  grandchild, so a release build or Dialyzer run was reparented to init and
  kept consuming the machine. Lane teardown now walks the process tree
  depth-first, wired to `EXIT`/`INT`/`TERM`.

Two independent review rounds raised four findings, all addressed: the
teardown gap, the missing composite-lane failure coverage, a PID-reuse window
(reaped lane PIDs were held until the last lane finished, so an interrupt
during output replay could signal a recycled number), and a single-pass
`TERM`-only sweep (now settles once and follows with `KILL`, guarded so a
successful push pays nothing). Neither round found a failure-swallowing path.

**Known gap:** the interrupt path is verified out of band, not by a committed
test. An in-repo version would have to spawn background processes, signal
them, and poll for their death inside the very suite this PR is speeding up —
a load-sensitive test of a best-effort abort path, which is the trade this
repository has repeatedly decided against. Happy to add it if you disagree.

## Alternatives rejected

**Overlap the suite with the other gates** — the largest theoretical win, since
the suite leaves ~3 cores idle for 139s. Rejected: this repository's
timing-sensitive tests fail under unrelated background load, and its own
`AGENTS.md` says to fix such tests rather than reduce pressure. Deliberately
adding a concurrent `prod` release build during the suite manufactures exactly
that load.

**Convert `async: false` modules to `async: true`** — rejected on the evidence
above; the top modules mutate VM-global state.

**Move slow tests to `:nightly`** — rejected by the repository's own rule.
`:nightly` removes a test from every PR gate, and excluding `:slow` globally
once dropped ten correctness tests to save 14.2s. The suite is 6253 real tests.

**Add the launcher gate to a lane** — rejected: its port-teardown assertions
have a recorded flake that reproduces specifically under CPU load (`:DOWN`
outrunning `Port.info/1`).

**Collapse `core-static`'s ~10 `mix` invocations into one `mix do` chain, and
drop `duplication_gate.sh`'s redundant `mix compile`** — not rejected,
deferred. Worth roughly 10–14s, and the pre-commit hook already uses this
pattern. It is a separate mechanism and belongs in its own change.


---

https://claude.ai/code/session_01QH17Uzuoa31vrMhMyBXG3u
