### PR TITLE
fix(viewer): correct run list bundle and evaluation metadata

### DIFF
--- a/docs/trace-log-contract.md
+++ b/docs/trace-log-contract.md
@@ -318,7 +318,7 @@ sufficient to select a run without loading its activity:
 - the successful terminal `result_hash` when present, without the result value;
 - workflow/agent name when supplied;
 - model and provider identifiers when recorded by a provider;
-- subordinate-evaluation count;
+- total and subordinate-evaluation counts;
 - workflow and mission capability-call counts;
 - LLM-call summary derived from named `llm-request` events when applicable;
 - error count and duration summary;
@@ -382,8 +382,8 @@ narrowed event set. Workflow and lifecycle events never match a mission filter.
 ### `analysis/runs`
 
 Discovers runs in the granted source. Filters are limited to run/trace ID,
-status, bounded exact-match tags, workflow/agent name, model/provider when
-present, timestamp range, limit, and cursor.
+status, bounded exact-match tags, workflow/agent name, workflow bundle hash,
+model/provider when present, timestamp range, limit, and cursor.
 
 Default ordering is deterministic: newest start timestamp first, with run ID as
 a stable tie-breaker.

--- a/lib/ptc_runner/kernel/run_analysis.ex
+++ b/lib/ptc_runner/kernel/run_analysis.ex
@@ -169,7 +169,7 @@ defmodule PtcRunner.Kernel.RunAnalysis do
     with :ok <-
            validate_keys(
              arguments,
-             ~w(limit cursor status run_id trace_id tags name model provider from to)
+             ~w(limit cursor status run_id trace_id tags name bundle model provider from to)
            ),
          :ok <- validate_limit(arguments) do
       TraceSnapshot.query(analysis.traces, :list_runs, arguments)

--- a/lib/ptc_runner/kernel/run_analysis_capability.ex
+++ b/lib/ptc_runner/kernel/run_analysis_capability.ex
@@ -78,6 +78,7 @@ defmodule PtcRunner.Kernel.RunAnalysisCapability do
       "trace_id" => string_schema(),
       "tags" => %{"type" => "object"},
       "name" => string_schema(),
+      "bundle" => string_schema(),
       "model" => string_schema(),
       "provider" => string_schema(),
       "from" => string_schema(),

--- a/lib/ptc_runner/kernel/trace_log.ex
+++ b/lib/ptc_runner/kernel/trace_log.ex
@@ -748,7 +748,7 @@ defmodule PtcRunner.Kernel.TraceLog do
     with :ok <-
            validate_keys(
              arguments,
-             ~w(limit cursor status run_id trace_id tags name model provider from to)
+             ~w(limit cursor status run_id trace_id tags name bundle model provider from to)
            ),
          :ok <- validate_run_filters(arguments),
          {:ok, page} <- page_options(arguments, source_id, :list_runs) do
@@ -816,7 +816,7 @@ defmodule PtcRunner.Kernel.TraceLog do
     with :ok <-
            validate_keys(
              arguments,
-             ~w(status run_id trace_id tags name model provider from to mission_name)
+             ~w(status run_id trace_id tags name bundle model provider from to mission_name)
            ),
          :ok <- validate_run_filters(arguments),
          :ok <- optional_strings(arguments, ["mission_name"]) do
@@ -2376,7 +2376,8 @@ defmodule PtcRunner.Kernel.TraceLog do
       ~w(mission_prelude mission_inventory_hash mission_inventory_bytes mission_model_context_hash mission_model_context_bytes)
 
     if is_map(data["missions"]) and Enum.all?(singular, &(not Map.has_key?(data, &1))) and
-         not Map.has_key?(data, "mission_name") do
+         not Map.has_key?(data, "mission_name") and
+         valid_workflow_prelude?(data["workflow_prelude"]) do
       :ok
     else
       {:error, :malformed_source}
@@ -2404,6 +2405,28 @@ defmodule PtcRunner.Kernel.TraceLog do
         if Map.has_key?(data, "mission_name"), do: {:error, :malformed_source}, else: :ok
     end
   end
+
+  defp valid_workflow_prelude?(nil), do: true
+
+  defp valid_workflow_prelude?(prelude) when is_map(prelude) do
+    component_ids = prelude["component_ids"]
+    hash = prelude["hash"]
+    dependency_indices = prelude["dependency_indices"]
+
+    is_list(component_ids) and Enum.all?(component_ids, &(valid_string(&1) == :ok)) and
+      (is_nil(hash) or valid_string(hash) == :ok) and
+      (is_nil(dependency_indices) or valid_dependency_indices?(dependency_indices))
+  end
+
+  defp valid_workflow_prelude?(_prelude), do: false
+
+  defp valid_dependency_indices?(dependency_indices) when is_list(dependency_indices) do
+    Enum.all?(dependency_indices, fn indices ->
+      is_list(indices) and Enum.all?(indices, &(is_integer(&1) and &1 >= 0))
+    end)
+  end
+
+  defp valid_dependency_indices?(_dependency_indices), do: false
 
   defp validate_run_stopped_usage("run-stopped", data) do
     case Map.fetch(data, "usage") do
@@ -2462,6 +2485,7 @@ defmodule PtcRunner.Kernel.TraceLog do
       "name" => Map.get(labels, "name"),
       "model" => Map.get(labels, "model"),
       "provider" => Map.get(labels, "provider"),
+      "evaluations" => evaluation_count(events),
       "subordinate_evaluations" => evaluation_count(events, "mission"),
       "subordinate_source_checks" => subordinate_source_checks(stopped),
       "workflow_capability_calls" => workflow_calls,
@@ -2505,6 +2529,7 @@ defmodule PtcRunner.Kernel.TraceLog do
     Enum.filter(items, fn item ->
       equal_filter?(item, arguments, "status") and equal_filter?(item, arguments, "run_id") and
         equal_filter?(item, arguments, "trace_id") and equal_filter?(item, arguments, "name") and
+        bundle_filter?(item, arguments["bundle"]) and
         equal_filter?(item, arguments, "model") and equal_filter?(item, arguments, "provider") and
         tags_match?(item["tags"], arguments["tags"]) and
         after_or_equal?(item["start_timestamp"], arguments["from"]) and
@@ -2514,6 +2539,11 @@ defmodule PtcRunner.Kernel.TraceLog do
 
   defp equal_filter?(item, arguments, key),
     do: is_nil(arguments[key]) or item[key] == arguments[key]
+
+  defp bundle_filter?(_item, nil), do: true
+
+  defp bundle_filter?(item, bundle),
+    do: get_in(item, ["workflow_prelude", "hash"]) == bundle
 
   defp tags_match?(_tags, nil), do: true
 
@@ -2732,6 +2762,8 @@ defmodule PtcRunner.Kernel.TraceLog do
     Enum.count(events, &(&1["type"] == "capability-started" and event_data(&1, "name") == name))
   end
 
+  defp evaluation_count(events), do: Enum.count(events, &(&1["type"] == "evaluation-started"))
+
   defp evaluation_count(events, environment) do
     Enum.count(events, fn event ->
       event["type"] == "evaluation-started" and
@@ -2897,7 +2929,10 @@ defmodule PtcRunner.Kernel.TraceLog do
 
   defp validate_run_filters(arguments) do
     with :ok <-
-           optional_strings(arguments, ~w(status run_id trace_id name model provider from to)),
+           optional_strings(
+             arguments,
+             ~w(status run_id trace_id name bundle model provider from to)
+           ),
          :ok <- valid_tags(arguments["tags"]),
          :ok <- valid_timestamp(arguments["from"]) do
       valid_timestamp(arguments["to"])

--- a/ptc_viewer/priv/static/js/app.js
+++ b/ptc_viewer/priv/static/js/app.js
@@ -3,6 +3,7 @@ import { renderKernelTranscript } from './kernel-transcript.js';
 import { renderSemanticConversation } from './semantic-conversation.js';
 import { createAnalyzeButton, createReplController, nextTabName, readViewerConfig } from './repl.js';
 import { createRunCatalog } from './run-catalog.js';
+import { commitCurrentLoad } from './current-load.js';
 import { truncate } from './utils.js';
 
 function formatDate(isoString) {
@@ -21,6 +22,7 @@ const state = {
   runs: [],
   page: null,
   catalogGeneration: 0,
+  routeGeneration: 0,
   query: '',
   selectedRunId: null
 };
@@ -97,7 +99,7 @@ function renderRunPicker() {
 function matchesQuery(run, query) {
   if (!query) return true;
   const needle = query.toLowerCase();
-  return [run.run_id, run.name, run.status, run.trace_id]
+  return [run.run_id, run.name, run.status, run.trace_id, run.workflow_prelude?.hash]
     .some(field => typeof field === 'string' && field.toLowerCase().includes(needle));
 }
 
@@ -159,8 +161,10 @@ function RunRow({ run }) {
       </span>
       <span class="file-meta">
         ${run.start_timestamp && html`<span class="modified">${formatDate(run.start_timestamp)}</span>`}
-        <span class="size">${run.subordinate_evaluations || 0} evaluations</span>
-        <span class="file-picker-query" title=${run.name || ''}>${shortenHash(run.name)}</span>
+        <span class="size">${run.evaluations ?? 0} evaluations</span>
+        <span class="file-picker-query" title=${run.workflow_prelude?.hash || ''}>
+          ${shortenHash(run.workflow_prelude?.hash)}
+        </span>
       </span>
     </button>
   `;
@@ -213,17 +217,21 @@ async function applyRoute() {
 
   if (route.runId === state.selectedRunId) return;
   state.selectedRunId = route.runId;
+  state.routeGeneration += 1;
+  const routeGeneration = state.routeGeneration;
 
   if (!route.runId) {
     state.currentRun = null;
-    mount(document.getElementById('view-container'), null);
+    const container = document.getElementById('view-container');
+    renderSemanticConversation(container, null);
+    mount(container, null);
     document.getElementById('breadcrumb').replaceChildren();
     renderRunPicker();
     return;
   }
 
   renderRunPicker();
-  await loadRun(route.runId);
+  await loadRun(route.runId, routeGeneration);
 }
 
 // Bounded page budget for the eager turn fetch. Run-level canonical metrics
@@ -253,7 +261,7 @@ async function fetchAllTurns(runId) {
   return { turns: merged };
 }
 
-async function loadRun(runId) {
+async function loadRun(runId, routeGeneration) {
   const [runResponse, turnsResult, conversationResponse, preludesResponse] = await Promise.all([
     fetch(`/api/kernel/runs/${encodeURIComponent(runId)}`),
     fetchAllTurns(runId),
@@ -261,32 +269,42 @@ async function loadRun(runId) {
     fetch(`/api/analysis/runs/${encodeURIComponent(runId)}/preludes`)
   ]);
 
-  if (!runResponse.ok || turnsResult.failed) {
-    const failed = runResponse.ok ? turnsResult.failed : runResponse;
-    showNotice(`Failed to load run ${runId} (HTTP ${failed.status}: ${await safeBodyText(failed)}).`);
-    return;
-  }
+  await commitCurrentLoad(routeGeneration, {
+    isCurrent: candidate => state.routeGeneration === candidate,
+    load: async () => {
+      if (!runResponse.ok || turnsResult.failed) {
+        const failed = runResponse.ok ? turnsResult.failed : runResponse;
+        return {
+          error: `Failed to load run ${runId} (HTTP ${failed.status}: ${await safeBodyText(failed)}).`
+        };
+      }
 
-  const conversation = conversationResponse.ok
-    ? await conversationResponse.json()
-    : {
-        'available?': false,
-        status: conversationResponse.status,
-        reason: await safeBodyText(conversationResponse)
+      const conversation = conversationResponse.ok
+        ? await conversationResponse.json()
+        : {
+            'available?': false,
+            status: conversationResponse.status,
+            reason: await safeBodyText(conversationResponse)
+          };
+      const preludes = preludesResponse.ok ? await preludesResponse.json() : null;
+
+      return {
+        data: {
+          metadata: await runResponse.json(),
+          turns: turnsResult.turns,
+          conversation,
+          preludes
+        }
       };
-  const preludes = preludesResponse.ok ? await preludesResponse.json() : null;
-  renderRun(
-    {
-      metadata: await runResponse.json(),
-      turns: turnsResult.turns,
-      conversation,
-      preludes
     },
-    { fresh: true }
-  );
+    commit: result => {
+      if (result.error) showNotice(result.error);
+      else renderRun(result.data, { fresh: true, routeGeneration });
+    }
+  });
 }
 
-function renderRun(data, { fresh = false } = {}) {
+function renderRun(data, { fresh = false, routeGeneration = state.routeGeneration } = {}) {
   state.currentRun = data;
   const { metadata, turns, conversation } = data;
   const breadcrumb = document.getElementById('breadcrumb');
@@ -316,24 +334,37 @@ function renderRun(data, { fresh = false } = {}) {
     onLoadMore: async button => {
       button.disabled = true;
       button.textContent = 'Loading…';
-      const response = await fetch(
-        `/api/kernel/runs/${encodeURIComponent(metadata.run_id)}/turns?limit=100&cursor=${encodeURIComponent(turns.next_cursor)}`
-      );
+      await commitCurrentLoad(routeGeneration, {
+        isCurrent: candidate => state.routeGeneration === candidate,
+        load: async () => {
+          const response = await fetch(
+            `/api/kernel/runs/${encodeURIComponent(metadata.run_id)}/turns?limit=100&cursor=${encodeURIComponent(turns.next_cursor)}`
+          );
 
-      if (!response.ok) {
-        button.disabled = false;
-        button.textContent = 'Load more events';
-        return;
-      }
+          if (!response.ok) return { error: true };
+          return { nextPage: await response.json() };
+        },
+        commit: result => {
+          if (result.error) {
+            if (button.isConnected) {
+              button.disabled = false;
+              button.textContent = 'Load more events';
+            }
+            return;
+          }
 
-      const nextPage = await response.json();
-      // Not `fresh`: appending a page diffs into the existing tree, so open
-      // disclosures and the reading position are kept.
-      renderRun({
-        metadata,
-        conversation,
-        preludes: data.preludes,
-        turns: { ...nextPage, items: [...(turns.items || []), ...(nextPage.items || [])] }
+          // Not `fresh`: appending a page diffs into the existing tree, so open
+          // disclosures and the reading position are kept.
+          renderRun({
+            metadata,
+            conversation,
+            preludes: data.preludes,
+            turns: {
+              ...result.nextPage,
+              items: [...(turns.items || []), ...(result.nextPage.items || [])]
+            }
+          }, { routeGeneration });
+        }
       });
     }
   });

--- a/ptc_viewer/priv/static/js/current-load.js
+++ b/ptc_viewer/priv/static/js/current-load.js
@@ -1,0 +1,9 @@
+export async function commitCurrentLoad(token, { isCurrent, load, commit }) {
+  if (!isCurrent(token)) return false;
+
+  const value = await load();
+  if (!isCurrent(token)) return false;
+
+  commit(value);
+  return true;
+}

--- a/ptc_viewer/priv/static/js/kernel-transcript.js
+++ b/ptc_viewer/priv/static/js/kernel-transcript.js
@@ -106,6 +106,7 @@ function KernelTranscript({
 
 function Hero({ metadata, transcript, eventCount, truncatedPage }) {
   const status = metadata.status || (metadata.complete ? 'complete' : 'incomplete');
+  const bundle = metadata.workflow_prelude?.hash;
   // The run ID is the identity a reader recognises and can act on; the bundle
   // hash identifies the workflow, and two runs of one workflow share it. It
   // stays available as a secondary fact rather than as the heading.
@@ -118,7 +119,7 @@ function Hero({ metadata, transcript, eventCount, truncatedPage }) {
     ['Model', abbreviate(metadata.model), metadata.model],
     ['Provider', abbreviate(metadata.provider), metadata.provider],
     ['Source', metadata.source],
-    ['Bundle', abbreviate(metadata.name), metadata.name]
+    ['Bundle', abbreviate(bundle), bundle]
   ].filter(([, value]) => value !== null && value !== undefined && value !== '');
   const errorCount = metadata.error_count ?? transcript.limits.length;
 

--- a/ptc_viewer/priv/static/js/semantic-conversation.js
+++ b/ptc_viewer/priv/static/js/semantic-conversation.js
@@ -1,10 +1,19 @@
 import { html, mount, toMarkup } from './preact.js';
 
 export function renderSemanticConversation(container, conversation) {
-  const host = container.querySelector('.semantic-conversation-wrapper') ||
-    container.appendChild(Object.assign(document.createElement('section'), {
-      className: 'semantic-conversation-wrapper'
-    }));
+  const existingHost = container.querySelector('.semantic-conversation-wrapper');
+
+  if (!conversation) {
+    if (existingHost) {
+      mount(existingHost, null);
+      existingHost.remove();
+    }
+    return;
+  }
+
+  const host = existingHost || container.appendChild(Object.assign(document.createElement('section'), {
+    className: 'semantic-conversation-wrapper'
+  }));
   mount(host, html`<${Conversation} conversation=${conversation} />`);
 }
 

--- a/ptc_viewer/test/kernel_transcript_test.exs
+++ b/ptc_viewer/test/kernel_transcript_test.exs
@@ -111,6 +111,22 @@ defmodule PtcViewer.KernelTranscriptTest do
     refute rendered =~ "ambiguous-result"
   end
 
+  test "labels the workflow prelude hash as the bundle identity", %{tmp_dir: directory} do
+    rendered =
+      render(directory, %{
+        "metadata" => %{
+          "run_id" => "bundle-run",
+          "name" => "sha256:name-fingerprint",
+          "workflow_prelude" => %{"component_ids" => ["kernel"], "hash" => "bundle-hash"}
+        },
+        "turns" => %{"items" => []}
+      })
+
+    assert rendered =~ "Bundle"
+    assert rendered =~ "bundle-hash"
+    refute rendered =~ "sha256:name-fingerprint"
+  end
+
   defp private_program_data(ambiguous?) do
     program = ~S|(runs/diagnose "failed-run")|
 

--- a/ptc_viewer/test/ptc_viewer/router_test.exs
+++ b/ptc_viewer/test/ptc_viewer/router_test.exs
@@ -31,7 +31,7 @@ defmodule PtcViewer.RouterTest do
     router_opts = [trace_dir: trace_dir, kernel_trace_adapter: adapter]
 
     conn =
-      conn(:get, "/api/kernel/runs?limit=2&status=error")
+      conn(:get, "/api/kernel/runs?limit=2&status=error&bundle=sha256%3Abundle")
       |> call_router(router_opts)
 
     assert conn.status == 200
@@ -39,7 +39,11 @@ defmodule PtcViewer.RouterTest do
 
     assert body == %{
              "operation" => "list_runs",
-             "arguments" => %{"limit" => 2, "status" => "error"}
+             "arguments" => %{
+               "limit" => 2,
+               "status" => "error",
+               "bundle" => "sha256:bundle"
+             }
            }
   end
 

--- a/ptc_viewer/test/repl_ui.mjs
+++ b/ptc_viewer/test/repl_ui.mjs
@@ -11,6 +11,7 @@ import {
   templatePayloadMatches
 } from '../priv/static/js/repl.js';
 import { createRunCatalog } from '../priv/static/js/run-catalog.js';
+import { commitCurrentLoad } from '../priv/static/js/current-load.js';
 
 class FakeElement {
   constructor(tag = 'div') {
@@ -156,6 +157,40 @@ const deferred = () => {
 const flush = async () => {
   for (let index = 0; index < 12; index += 1) await Promise.resolve();
 };
+
+let currentLoadGeneration = 1;
+const olderRunBody = deferred();
+const newerRunBody = deferred();
+const committedLoads = [];
+const olderSameRunLoad = commitCurrentLoad(1, {
+  isCurrent: generation => currentLoadGeneration === generation,
+  load: () => olderRunBody.promise,
+  commit: value => committedLoads.push(value)
+});
+currentLoadGeneration = 2;
+const newerSameRunLoad = commitCurrentLoad(2, {
+  isCurrent: generation => currentLoadGeneration === generation,
+  load: () => newerRunBody.promise,
+  commit: value => committedLoads.push(value)
+});
+newerRunBody.resolve({ run_id: 'run-a', snapshot: 'newer' });
+assert.equal(await newerSameRunLoad, true);
+olderRunBody.resolve({ run_id: 'run-a', snapshot: 'older' });
+assert.equal(await olderSameRunLoad, false);
+assert.deepEqual(committedLoads, [{ run_id: 'run-a', snapshot: 'newer' }]);
+
+let continuationGeneration = 1;
+const staleContinuationBody = deferred();
+const continuationRenders = [];
+const staleContinuation = commitCurrentLoad(1, {
+  isCurrent: generation => continuationGeneration === generation,
+  load: () => staleContinuationBody.promise,
+  commit: value => continuationRenders.push(value)
+});
+continuationGeneration = 2;
+staleContinuationBody.resolve({ run_id: 'run-a', page: 2 });
+assert.equal(await staleContinuation, false);
+assert.deepEqual(continuationRenders, []);
 
 // Fresh catalog generations own rendering. Slow older responses and stale
 // load-more controls cannot replace a newer post-persistence catalog, while a
@@ -620,7 +655,16 @@ assert.doesNotMatch(appSource, /dataset\.runId/);
 assert.match(appSource, /onClick=\$\{\(\) => selectRun\(run\.run_id\)\}/);
 assert.match(appSource, /location\.hash = runId \? `#\/run\/\$\{encodeURIComponent\(runId\)\}`/);
 assert.match(appSource, /decodeURIComponent\(match\[1\]\)/);
-assert.match(appSource, /loadRun\(route\.runId\)/);
+assert.match(appSource, /loadRun\(route\.runId, routeGeneration\)/);
 assert.match(appSource, /encodeURIComponent\(runId\)\}`\),/);
+assert.match(appSource, /run\.workflow_prelude\?\.hash/);
+assert.match(appSource, /run\.evaluations \?\? 0/);
+assert.match(appSource, /renderSemanticConversation\(container, null\)/);
+assert.match(appSource, /commitCurrentLoad\(routeGeneration,/);
+const loadMoreSource = appSource.slice(
+  appSource.indexOf('onLoadMore:'),
+  appSource.indexOf('function activateTab')
+);
+assert.match(loadMoreSource, /commitCurrentLoad\(routeGeneration,/);
 
 process.stdout.write('ok');

--- a/test/ptc_runner/kernel/run_analysis_test.exs
+++ b/test/ptc_runner/kernel/run_analysis_test.exs
@@ -40,6 +40,12 @@ defmodule PtcRunner.Kernel.RunAnalysisTest do
 
     assert run_id == fixture.run_id
 
+    assert {:ok, %{"items" => [%{"run_id" => ^run_id}]}} =
+             RunAnalysis.query(analysis, :runs, %{"bundle" => "prelude-hash"})
+
+    assert {:ok, %{"items" => []}} =
+             RunAnalysis.query(analysis, :runs, %{"bundle" => "different-prelude"})
+
     assert {:ok,
             %{
               "run" => %{"run_id" => ^run_id, "complete" => true},
@@ -568,7 +574,9 @@ defmodule PtcRunner.Kernel.RunAnalysisTest do
              "analysis-read"
            ]
 
+    runs = Enum.find(capabilities, &(&1.name == "analysis-runs"))
     read = Enum.find(capabilities, &(&1.name == "analysis-read"))
+    assert runs.input_schema["properties"]["bundle"]["type"] == "string"
     assert read.input_schema["properties"]["limit"]["maximum"] == 100
     assert read.input_schema["properties"]["parent_evaluation_id"]["type"] == "string"
 

--- a/test/ptc_runner/kernel/trace_log_test.exs
+++ b/test/ptc_runner/kernel/trace_log_test.exs
@@ -108,6 +108,75 @@ defmodule PtcRunner.Kernel.TraceLogTest do
   end
 
   @tag :tmp_dir
+  test "run summaries expose total evaluations and filter by workflow bundle", %{
+    tmp_dir: directory
+  } do
+    path = Path.join(directory, "trace.jsonl")
+
+    events = [
+      decoded_event("bundle-a-run", 1, "run-started", %{
+        "labels" => %{"name" => "sha256:same-name"},
+        "workflow_prelude" => %{"component_ids" => ["kernel"], "hash" => "bundle-a"}
+      }),
+      decoded_event("bundle-a-run", 2, "evaluation-started", %{
+        "environment" => "workflow",
+        "evaluation_id" => "workflow-evaluation"
+      }),
+      decoded_event("bundle-a-run", 3, "evaluation-stopped", %{
+        "environment" => "workflow",
+        "evaluation_id" => "workflow-evaluation",
+        "status" => "ok"
+      }),
+      decoded_event("bundle-a-run", 4, "run-stopped", %{"outcome" => "ok"}),
+      decoded_event("bundle-b-run", 1, "run-started", %{
+        "labels" => %{"name" => "sha256:same-name"},
+        "workflow_prelude" => %{"component_ids" => ["kernel"], "hash" => "bundle-b"}
+      }),
+      decoded_event("bundle-b-run", 2, "run-stopped", %{"outcome" => "ok"})
+    ]
+
+    assert :ok = TraceLog.append_jsonl(path, events)
+    assert {:ok, trace_log} = TraceLog.new(source: {:file, path})
+
+    assert {:ok,
+            %{
+              "items" => [
+                %{
+                  "run_id" => "bundle-a-run",
+                  "evaluations" => 1,
+                  "subordinate_evaluations" => 0
+                }
+              ]
+            }} = TraceLog.query(trace_log, :list_runs, %{"bundle" => "bundle-a"})
+
+    assert {:ok, %{"items" => [%{"run_id" => "bundle-b-run"}]}} =
+             TraceLog.query(trace_log, :list_runs, %{"bundle" => "bundle-b"})
+
+    assert {:ok, %{"runs" => 1, "evaluations" => 1}} =
+             TraceLog.query(trace_log, :counters, %{"bundle" => "bundle-a"})
+
+    assert {:error, :invalid_query} =
+             TraceLog.query(trace_log, :list_runs, %{"bundle_hash" => "bundle-a"})
+  end
+
+  @tag :tmp_dir
+  test "canonical validation rejects malformed workflow prelude metadata", %{tmp_dir: directory} do
+    path = Path.join(directory, "malformed-workflow-prelude.jsonl")
+
+    events = [
+      decoded_event("malformed-workflow-prelude", 1, "run-started", %{
+        "workflow_prelude" => "not-a-prelude-projection"
+      })
+    ]
+
+    File.write!(path, Enum.map_join(events, "", &(Jason.encode!(&1) <> "\n")))
+    assert {:ok, trace_log} = TraceLog.new(source: {:file, path})
+
+    assert {:error, :malformed_source} =
+             TraceLog.query(trace_log, :list_runs, %{"bundle" => "bundle-a"})
+  end
+
+  @tag :tmp_dir
   test "canonical JSONL append and reload preserves event order", %{tmp_dir: directory} do
     path = Path.join(directory, "trace.jsonl")
     first = decoded_event("append", 1, "run-started")


### PR DESCRIPTION
## Summary

- expose total evaluation counts in run summaries and use them in the Viewer list
- display and filter by the canonical workflow bundle hash instead of the hashed run label
- clear private conversation content when returning to the run list
- guard initial and continuation run loads with route generations so stale responses cannot replace the selected run
- support bundle filters in analysis and counters, and fail closed on malformed workflow-prelude metadata

## Browser verification

Tested the final build in the real in-app browser with two canonical runs and a correlated private inspection artifact:

- both rows showed `1 evaluations` and their distinct workflow bundle hashes
- a full bundle hash filtered the list to exactly one run
- the detail view showed the same canonical bundle hash
- the private model conversation appeared in detail and its wrapper count returned to zero after `All runs`
- the bundle-scoped runs and counters APIs both selected exactly one run
- no browser console warnings or errors

## Review

Completed the requested maximum of three independent Codex reviews. Findings from all three passes were addressed, including stale response ordering, same-run ABA ordering, stale continuation loads, malformed bundle metadata, and bundle-scoped counters.

## Validation

- `mix precommit` — 6,255 core tests, 52 Viewer tests, 42 launcher tests, plus static/package/release gates
- `MIX_ENV=dev mix docs --warnings-as-errors`
- pre-commit hook
- pre-push hook — documentation, core tests, static analysis, Dialyzer, release verification, and Viewer validation all passed

Closes #1393
Closes #1394
