### PR TITLE
fix(cli): complete root schema diagnostic paths

### DIFF
--- a/docs/guides/manifests-and-capabilities.md
+++ b/docs/guides/manifests-and-capabilities.md
@@ -6,7 +6,9 @@ path-confined, and inert; it executes no workflow or provider callback.
 
 The checked-in `priv/schemas/ptc-application-manifest.schema.json` is the
 complete structural reference. `PtcRunner.Kernel.Manifest` remains
-authoritative for semantic checks and referenced-file handling.
+authoritative for semantic checks and referenced-file handling. Manifest
+schema diagnostics include a safe JSON Pointer when one is available; a
+missing-required diagnostic points to the absent schema-declared property.
 
 ## Start with one workflow
 
@@ -140,7 +142,8 @@ artifact publication. A mismatch returns `input_contract_failed` or
 safe failure projection identifies a non-root declared path, the command
 envelope and terminal diagnostic include its JSON Pointer. Terminal rendering
 escapes unusual contract-authored property names rather than emitting their
-control bytes.
+control bytes. Missing-required failures name the first missing schema-declared
+property, including when the absent property is at the contract root.
 
 The `agent.main/run` entry also gives a model-authored terminal candidate one
 ordinary correction turn when budget remains. Feedback is schema-derived and

--- a/lib/ptc_runner/kernel/command_contract_authority.ex
+++ b/lib/ptc_runner/kernel/command_contract_authority.ex
@@ -1,11 +1,12 @@
 defmodule PtcRunner.Kernel.CommandContractAuthority do
   @moduledoc """
-  Sealed behavior and branch identity for a classified contract failure.
+  Sealed behavior and path scope for a classified contract failure.
 
   The authority travels with bounded classification evidence, independently of
   any selected diagnostic path. A command source can therefore bind to the
   classifying contract before a path is admitted, preventing a path minted
-  from another contract or tagged-union branch from certifying itself.
+  from another contract or tagged-union branch from certifying itself. Before
+  a tagged-union branch matches, only its shared discriminator is in scope.
   """
 
   alias PtcRunner.Kernel.Attestation

--- a/lib/ptc_runner/kernel/command_path.ex
+++ b/lib/ptc_runner/kernel/command_path.ex
@@ -3,8 +3,9 @@ defmodule PtcRunner.Kernel.CommandPath do
   Schema-authorized diagnostic path.
 
   Paths are minted only after every property or index has been walked through
-  the host/manifest schema or the exact selected branch of one compiled value
-  contract. The attestation prevents a caller-authored segment list from being
+  the host/manifest schema, the exact selected branch of one compiled value
+  contract, or the shared discriminator projection when no tagged-union branch
+  matches. The attestation prevents a caller-authored segment list from being
   substituted at the diagnostic boundary.
   """
 

--- a/lib/ptc_runner/kernel/command_renderer.ex
+++ b/lib/ptc_runner/kernel/command_renderer.ex
@@ -108,11 +108,12 @@ defmodule PtcRunner.Kernel.CommandRenderer do
 
   defp location_suffix(%{
          "phase" => "application",
-         "code" => "schema_violation",
+         "code" => code,
          "source" => %{"kind" => "application"},
          "path" => path
        })
-       when is_binary(path) and path != "",
+       when code in ["schema_violation", "required_property_missing"] and is_binary(path) and
+              path != "",
        do: " at " <> path <> " "
 
   defp location_suffix(%{

--- a/lib/ptc_runner/kernel/execution_input.ex
+++ b/lib/ptc_runner/kernel/execution_input.ex
@@ -7,7 +7,8 @@ defmodule PtcRunner.Kernel.ExecutionInput do
   because it controls later provider and publication policy. A contract
   rejection carries only `ValueContract.classify/2`'s bounded structural
   classification and a sealed authority for its exact contract behavior hash
-  and selected tagged-union branch; the rejected input never enters the error.
+  and selected tagged-union branch, or only the shared discriminator before a
+  branch matches; the rejected input never enters the error.
   """
 
   alias PtcRunner.Kernel.Attestation

--- a/lib/ptc_runner/kernel/value_contract.ex
+++ b/lib/ptc_runner/kernel/value_contract.ex
@@ -727,7 +727,21 @@ defmodule PtcRunner.Kernel.ValueContract do
        when is_list(branches) and is_integer(branch_index) and branch_index >= 0,
        do: Enum.at(branches, branch_index)
 
-  defp selected_path_schema(%{"oneOf" => branches}, nil) when is_list(branches), do: nil
+  defp selected_path_schema(%{"oneOf" => [first | _rest] = branches}, nil) do
+    with {:ok, name} <- shared_discriminator(branches),
+         %{"properties" => properties} <- first,
+         {:ok, discriminator_schema} <- Map.fetch(properties, name) do
+      %{
+        "type" => "object",
+        "properties" => %{name => discriminator_schema},
+        "required" => [name],
+        "additionalProperties" => true
+      }
+    else
+      _invalid -> nil
+    end
+  end
+
   defp selected_path_schema(schema, nil) when is_map(schema), do: schema
   defp selected_path_schema(_schema, _branch_index), do: nil
 

--- a/lib/ptc_runner/kernel/value_contract_classification.ex
+++ b/lib/ptc_runner/kernel/value_contract_classification.ex
@@ -3,9 +3,10 @@ defmodule PtcRunner.Kernel.ValueContractClassification do
   Internal sealed evidence for one value-contract classification.
 
   The public classification map deliberately omits branch indexes and schema
-  material. This value carries the exact contract behavior and selected path
-  schema separately so diagnostic authority can remain branch-specific without
-  widening model-facing feedback.
+  material. This value carries the exact contract behavior and path schema
+  separately so diagnostic authority can remain branch-specific after a union
+  match, or limited to the shared discriminator before a branch matches,
+  without widening model-facing feedback.
   """
 
   alias PtcRunner.Kernel.Attestation

--- a/lib/ptc_runner/kernel/value_contract_diagnostic.ex
+++ b/lib/ptc_runner/kernel/value_contract_diagnostic.ex
@@ -32,7 +32,7 @@ defmodule PtcRunner.Kernel.ValueContractDiagnostic do
         %{contract_authority: authority} = classification
       ) do
     case CommandSource.with_contract(source, authority) do
-      {:ok, bound_source} -> {bound_source, first_violation_path(classification)}
+      {:ok, bound_source} -> {bound_source, first_violation_path(classification, authority)}
       {:error, :invalid_command_source} -> {source, nil}
     end
   end
@@ -55,12 +55,25 @@ defmodule PtcRunner.Kernel.ValueContractDiagnostic do
     end)
   end
 
-  defp first_violation_path(%{violations: violations}) when is_list(violations) do
-    Enum.find_value(violations, fn
-      %{path: %CommandPath{} = path} -> path
-      _invalid -> nil
-    end)
+  defp first_violation_path(%{violations: violations}, authority) when is_list(violations) do
+    paths = Enum.flat_map(violations, &violation_paths(&1, authority))
+
+    Enum.find(paths, &(&1.segments != [])) || List.first(paths)
   end
 
-  defp first_violation_path(_classification), do: nil
+  defp first_violation_path(_classification, _authority), do: nil
+
+  defp violation_paths(
+         %{path: %CommandPath{} = parent, missing_required: [name | _rest]},
+         authority
+       )
+       when is_binary(name) do
+    case CommandPath.contract(authority, parent.segments ++ [{:property, name}]) do
+      {:ok, missing_path} -> [missing_path]
+      {:error, :invalid_command_path} -> [parent]
+    end
+  end
+
+  defp violation_paths(%{path: %CommandPath{} = path}, _authority), do: [path]
+  defp violation_paths(_violation, _authority), do: []
 end

--- a/test/mix/tasks/ptc_test.exs
+++ b/test/mix/tasks/ptc_test.exs
@@ -107,6 +107,84 @@ defmodule Mix.Tasks.PtcTest do
   end
 
   @tag :tmp_dir
+  test "root command names a missing manifest property", %{tmp_dir: dir} do
+    manifest_path = write_manifest(dir, %{"value" => 1})
+
+    invalid_manifest =
+      manifest_path
+      |> File.read!()
+      |> Jason.decode!()
+      |> update_in(["workflow"], &Map.delete(&1, "entry"))
+
+    File.write!(manifest_path, Jason.encode!(invalid_manifest))
+
+    message = failed_message(["validate", manifest_path])
+
+    assert message =~
+             "application/required_property_missing: " <>
+               "the application manifest is missing a required property at /workflow/entry"
+  end
+
+  @tag :tmp_dir
+  test "root command names input and result contract failure paths", %{tmp_dir: dir} do
+    manifest_path = write_manifest(dir, %{})
+    File.write!(Path.join(dir, "main.clj"), ~S|(ns main) (defn run [input] (return input))|)
+
+    schema = %{
+      "type" => "object",
+      "properties" => %{"answer" => %{"type" => "integer"}},
+      "required" => ["answer"]
+    }
+
+    File.write!(Path.join(dir, "contract.schema.json"), Jason.encode!(schema))
+    manifest = manifest_path |> File.read!() |> Jason.decode!()
+
+    for {role, value, command, code} <- [
+          {"input_schema", %{"answer" => "wrong"}, "validate", "input_contract_failed"},
+          {"result_schema", %{"answer" => "wrong", "extra" => 1}, "run",
+           "result_contract_failed"},
+          {"input_schema", %{}, "validate", "input_contract_failed"},
+          {"result_schema", %{}, "run", "result_contract_failed"}
+        ] do
+      contract_manifest =
+        manifest
+        |> Map.put("contracts", %{role => %{"path" => "contract.schema.json"}})
+        |> put_in(["input", "value"], value)
+
+      File.write!(manifest_path, Jason.encode!(contract_manifest))
+
+      message = failed_message([command, manifest_path])
+      assert message =~ "#{code}:"
+      assert message =~ " at /answer", "#{role} with #{inspect(value)} rendered: #{message}"
+    end
+
+    tagged_union = %{
+      "oneOf" => [
+        contract_branch("left", "left_value"),
+        contract_branch("right", "right_value")
+      ]
+    }
+
+    File.write!(Path.join(dir, "contract.schema.json"), Jason.encode!(tagged_union))
+
+    for {role, command, code} <- [
+          {"input_schema", "validate", "input_contract_failed"},
+          {"result_schema", "run", "result_contract_failed"}
+        ] do
+      contract_manifest =
+        manifest
+        |> Map.put("contracts", %{role => %{"path" => "contract.schema.json"}})
+        |> put_in(["input", "value"], %{})
+
+      File.write!(manifest_path, Jason.encode!(contract_manifest))
+
+      message = failed_message([command, manifest_path])
+      assert message =~ "#{code}:"
+      assert message =~ " at /kind"
+    end
+  end
+
+  @tag :tmp_dir
   test "an invalid inspection destination states the required filename suffix", %{tmp_dir: dir} do
     manifest_path = write_manifest(dir, %{"value" => 1})
     invalid_inspection = Path.join(dir, "run.jsonl")
@@ -430,6 +508,17 @@ defmodule Mix.Tasks.PtcTest do
     )
 
     path
+  end
+
+  defp contract_branch(kind, value_name) do
+    %{
+      "type" => "object",
+      "properties" => %{
+        "kind" => %{"type" => "string", "const" => kind},
+        value_name => %{"type" => "integer"}
+      },
+      "required" => ["kind", value_name]
+    }
   end
 
   defp write_provider_application(dir, missing_env) do

--- a/test/ptc_runner/kernel/value_contract_test.exs
+++ b/test/ptc_runner/kernel/value_contract_test.exs
@@ -3,8 +3,10 @@ defmodule PtcRunner.Kernel.ValueContractTest do
 
   alias PtcRunner.Kernel.CommandContractAuthority
   alias PtcRunner.Kernel.CommandPath
+  alias PtcRunner.Kernel.CommandSource
   alias PtcRunner.Kernel.ExecutionInput
   alias PtcRunner.Kernel.ValueContract
+  alias PtcRunner.Kernel.ValueContractDiagnostic
 
   test "compiles and validates an ordinary bounded object contract" do
     schema = %{
@@ -433,6 +435,60 @@ defmodule PtcRunner.Kernel.ValueContractTest do
              CommandPath.contract(classification.contract_authority, [
                {:property, "candidate"}
              ])
+  end
+
+  test "command diagnostics prefer declared leaves and name missing properties" do
+    assert {:ok, contract} =
+             ValueContract.compile(%{
+               "type" => "object",
+               "properties" => %{"answer" => %{"type" => "integer"}},
+               "required" => ["answer"]
+             })
+
+    {:ok, source} = CommandSource.new(:result_contract, "result.schema.json")
+
+    for value <- [%{"answer" => "wrong", "extra" => 1}, %{}] do
+      assert {:ok, classification} = ValueContractDiagnostic.classify(contract, value)
+
+      assert {_bound_source, %CommandPath{} = path} =
+               ValueContractDiagnostic.diagnostic_parts(source, classification)
+
+      assert CommandPath.to_pointer(path) == "/answer"
+    end
+
+    assert {:ok, missing} = ValueContractDiagnostic.classify(contract, %{})
+
+    assert Enum.any?(missing.violations, fn
+             %{missing_required: ["answer"], path: path} -> CommandPath.to_pointer(path) == ""
+             _other -> false
+           end)
+
+    assert {:ok, union_contract} = ValueContract.compile(decision_schema())
+    assert {:ok, union_classification} = ValueContractDiagnostic.classify(union_contract, %{})
+
+    assert {_bound_source, %CommandPath{} = discriminator_path} =
+             ValueContractDiagnostic.diagnostic_parts(source, union_classification)
+
+    assert CommandPath.to_pointer(discriminator_path) == "/decision"
+
+    assert {:error, :invalid_command_path} =
+             CommandPath.contract(union_classification.contract_authority, [
+               {:property, "reason"}
+             ])
+
+    assert {:ok, unmatched} =
+             ValueContractDiagnostic.classify(union_contract, %{
+               "decision" => "unknown",
+               "reason" => "still declared in one branch"
+             })
+
+    refute Enum.any?(unmatched.violations, &Map.has_key?(&1, :allowed_keys))
+    refute Enum.any?(unmatched.violations, &Map.has_key?(&1, :undeclared_key_count))
+
+    assert {_bound_source, %CommandPath{} = unmatched_path} =
+             ValueContractDiagnostic.diagnostic_parts(source, unmatched)
+
+    assert CommandPath.to_pointer(unmatched_path) == "/decision"
   end
 
   test "nested object diagnostics retain the selected branch's attested path" do


### PR DESCRIPTION
## Summary

- prefer schema-declared non-root violations so root-project result contracts report `/answer` even when a root-only violation appears first
- name missing required properties across manifest, input-contract, and result-contract diagnostics
- authorize unmatched tagged-union diagnostics only through their shared discriminator path
- render and document manifest missing-property pointers

## Root cause

Command diagnostics selected the first contract violation even when it carried only the contract root. Missing-required classifications also retained the parent object path because the absent child has no instance pointer, while manifest rendering omitted paths for `required_property_missing`.

The fix selects a schema-authorized leaf where available and derives absent-property paths only when the exact contract authority attests them. Before a tagged-union branch matches, that authority is limited to the shared discriminator.

## Validation

- `mix precommit`: 6256 root tests, 51 Viewer tests, 42 launcher tests, static/spec/generated/package/release gates
- pre-push parity checks: root suite, Credo, duplication, spec, Dialyzer, release verification, and Viewer suite all passed
- `MIX_ENV=dev mix docs --warnings-as-errors`
- real browser: loaded a deterministic trace, filtered/opened the run detail, exercised REPL `(analysis/runs {})`, and observed no console warnings or errors
- three independent Codex reviews: incremental, focused follow-up, and final cumulative; the final pass found no actionable issues

Closes #1374

Completes the recorded residual from #1355.