### PR TITLE
fix(kernel): accept host manifest filenames

### DIFF
--- a/docs/guides/manifests-and-capabilities.md
+++ b/docs/guides/manifests-and-capabilities.md
@@ -119,8 +119,9 @@ example demonstrates distinct read and write grants.
 All manifest references use portable, lowercase logical names and resolve
 beneath the canonical manifest directory. Absolute paths, traversal, devices,
 non-regular files, and symlink escape are rejected. These rules cover files
-the host loads. Model-visible files require a separately installed and selected
-provider such as the
+the host loads. The manifest path itself is selected by the caller and its
+basename does not have to use the logical-name grammar. Model-visible files
+require a separately installed and selected provider such as the
 [filesystem sample](../../examples/mcp/filesystem/README.md).
 
 ## Validate inputs and results

--- a/lib/ptc_runner/kernel/application_source.ex
+++ b/lib/ptc_runner/kernel/application_source.ex
@@ -26,12 +26,10 @@ defmodule PtcRunner.Kernel.ApplicationSource do
   def open_directory(path) when is_binary(path) do
     with {:ok, canonical} <- ConfinedFile.resolve_absolute(Path.expand(path)),
          manifest_name = Path.basename(canonical),
-         true <- valid_name?(manifest_name),
          root = Path.dirname(canonical),
          {:ok, source} <- start({:directory, root}, manifest_name) do
       ensure_manifest(source)
     else
-      false -> {:error, :invalid_logical_name}
       {:error, _reason} = error -> error
     end
   end
@@ -61,7 +59,8 @@ defmodule PtcRunner.Kernel.ApplicationSource do
 
   @spec manifest(t()) :: {:ok, binary()} | {:error, atom()}
   @doc false
-  def manifest(%__MODULE__{} = source), do: read(source, source.manifest_name, 1_000_000)
+  def manifest(%__MODULE__{pid: pid, manifest_name: manifest_name}),
+    do: read_name(pid, manifest_name, 1_000_000)
 
   @spec logical_name(t(), binary()) ::
           {:ok, binary()} | {:error, :outside_application_source | :invalid_logical_name}
@@ -96,9 +95,14 @@ defmodule PtcRunner.Kernel.ApplicationSource do
   @spec resolve_reference(t(), binary(), binary()) ::
           {:ok, binary()} | {:error, :invalid_logical_name}
   @doc false
-  def resolve_reference(%__MODULE__{pid: pid}, document_name, relative_name)
+  def resolve_reference(
+        %__MODULE__{pid: pid, manifest_name: manifest_name},
+        document_name,
+        relative_name
+      )
       when is_binary(document_name) and is_binary(relative_name) do
-    if valid_name?(document_name) and valid_name?(relative_name) do
+    if (document_name == manifest_name or valid_name?(document_name)) and
+         valid_name?(relative_name) do
       Agent.get(pid, fn
         %{mode: {:directory, root}} ->
           directory = Path.expand(Path.dirname(document_name), root)
@@ -150,17 +154,10 @@ defmodule PtcRunner.Kernel.ApplicationSource do
   def read(%__MODULE__{pid: pid}, name, max_bytes)
       when is_binary(name) and is_integer(max_bytes) and max_bytes > 0 do
     if valid_name?(name) do
-      Agent.get_and_update(pid, fn state ->
-        case read_state(state, name, max_bytes) do
-          {:ok, bytes, next} -> {{:ok, bytes}, next}
-          {:error, _reason} = error -> {error, state}
-        end
-      end)
+      read_name(pid, name, max_bytes)
     else
       {:error, :invalid_logical_name}
     end
-  catch
-    :exit, _reason -> {:error, :application_source_closed}
   end
 
   def read(_source, _name, _max_bytes), do: {:error, :invalid_application_source}
@@ -220,7 +217,7 @@ defmodule PtcRunner.Kernel.ApplicationSource do
   end
 
   defp ensure_manifest(source) do
-    case read(source, source.manifest_name, 1_000_000) do
+    case manifest(source) do
       {:ok, _manifest} ->
         {:ok, source}
 
@@ -228,6 +225,17 @@ defmodule PtcRunner.Kernel.ApplicationSource do
         close(source)
         error
     end
+  end
+
+  defp read_name(pid, name, max_bytes) do
+    Agent.get_and_update(pid, fn state ->
+      case read_state(state, name, max_bytes) do
+        {:ok, bytes, next} -> {{:ok, bytes}, next}
+        {:error, _reason} = error -> {error, state}
+      end
+    end)
+  catch
+    :exit, _reason -> {:error, :application_source_closed}
   end
 
   defp read_state(%{closed?: true}, _name, _max_bytes),

--- a/test/ptc_runner/kernel/application_package_test.exs
+++ b/test/ptc_runner/kernel/application_package_test.exs
@@ -94,6 +94,36 @@ defmodule PtcRunner.Kernel.ApplicationPackageTest do
   end
 
   @tag :tmp_dir
+  test "directory manifest filenames are transport paths, not portable logical names", %{
+    tmp_dir: directory
+  } do
+    documents = fixture_documents()
+    baseline_path = write_documents(Path.join(directory, "baseline"), documents)
+
+    assert {:ok, baseline} =
+             ApplicationPackage.request_directory(baseline_path, result_projection: :native)
+
+    for {filename, index} <-
+          Enum.with_index([
+            "_app.json",
+            ".app.json",
+            "-app.json",
+            "Manifest.json",
+            "manifest copy.json"
+          ]) do
+      manifest_path = write_documents(Path.join(directory, "variant-#{index}"), documents)
+      renamed_path = Path.join(Path.dirname(manifest_path), filename)
+      File.rename!(manifest_path, renamed_path)
+
+      assert {:ok, request} =
+               ApplicationPackage.request_directory(renamed_path, result_projection: :native)
+
+      assert package_projection(request.package) == package_projection(baseline.package)
+      assert request.input == baseline.input
+    end
+  end
+
+  @tag :tmp_dir
   test "nested memory manifests resolve references like directory manifests", %{
     tmp_dir: directory
   } do


### PR DESCRIPTION
## Summary
- treat the caller-selected directory manifest basename as a filesystem transport path
- retain portable logical-name validation for all manifest references
- add adapter-parity coverage for leading punctuation, uppercase, and spaces
- document the manifest-path/reference-name distinction

## Root cause
`ApplicationSource.open_directory/1` applied the portable in-package logical-name grammar to the manifest's own host basename. The CLI then projected `:invalid_logical_name` as a missing referenced document, so valid applications failed under ordinary host filenames.

## User impact
Manifests selected by path can now use names such as `_app.json`, `.app.json`, `-app.json`, `Manifest.json`, or `manifest copy.json` without changing package identity or reference semantics.

## Verification
- `mix precommit`
- `MIX_ENV=dev mix docs --warnings-as-errors`
- focused application package, manifest, and confined-file tests (71 passed)
- full pre-push gate, including 6,273 core tests, Dialyzer, release verification, and Viewer tests
- one independent cumulative Codex review: no actionable findings

Closes #1224