### PR TITLE
perf(lisp): restore eval reduction guardrails

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -55,3 +55,8 @@ jobs:
 
       - name: Run the nightly test suite
         run: mix nightly
+
+      - name: Check evaluator reduction baselines
+        env:
+          MIX_ENV: dev
+        run: mix bench.check --skip-heap

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,10 @@ jobs:
       - uses: ./.github/actions/setup-elixir
       - run: mix precommit
       - run: mix prepush
+      - name: Check evaluator reduction baselines
+        env:
+          MIX_ENV: dev
+        run: mix bench.check --skip-heap
       # Ordinary branches do not regenerate the semantic build projection, so
       # this is the one gate that enforces it. A failure here means the tagged
       # tree ships a build identity that does not describe its own sources:

--- a/bench/README.md
+++ b/bench/README.md
@@ -10,7 +10,7 @@ many concurrent multi-turn sessions).
 
 | Script | What it measures | Tool |
 |---|---|---|
-| `mix bench.check` | Deterministic release gate for sandbox child eval reductions vs committed baseline; also prints the heap table informationally | custom Mix task |
+| `mix bench.check` | Deterministic nightly/release gate for sandbox child eval reductions vs committed baseline; also prints the heap table informationally | custom Mix task |
 | `mix bench.heap` / `heap_baseline.exs` | Heap cost of every embedding unit vs `baselines/heap.json`: idle floor without Mix, `Lisp.run`, `compile_bundle`, `Kernel.run`, concurrency 1..128 | custom Mix task |
 | `lisp_throughput.exs` | Per-program latency: parse / analyze / full run; per-archetype; latency under `parallel:` load | Benchee |
 | `lisp_profile.exs` | Function-level call_time + call_count, aggregated across the per-run sandbox processes | OTP `:tprof` |
@@ -20,6 +20,7 @@ many concurrent multi-turn sessions).
 
 ```bash
 mix bench.check                             # gates reductions, reports heap
+mix bench.check --write-baseline --reason "accepted cause"
 mix bench.heap                              # gates heap
 mix run bench/heap_baseline.exs             # reports heap; --write re-records
 mix run bench/lisp_throughput.exs
@@ -41,6 +42,21 @@ path; the scripts re-add them so `:tprof` / `:msacc` load.
   wall-clock timings stay informational: hosted runner timing noise is too large
   for a gate, and a single per-call `memory_bytes` sample cannot separate a leak
   from one-shot warmup.
+- Its matrix covers raw/no-prelude evaluation, public prelude calls,
+  strict-transitive prelude calls, and private-tool prelude calls. Keep those
+  policy rows separate: optimizing the default path must not erase the cost or
+  correctness signal for the stricter paths.
+- The reductions baseline records full runtime provenance and refuses to compare
+  when the Mix environment, Elixir, OTP, ERTS, emulator flavor, or word size
+  differs. Architecture and scheduler details remain diagnostic because
+  reductions are measured in the isolated eval child rather than as a whole-VM
+  resource figure. The committed baseline and automated checks use `MIX_ENV=dev`.
+  Regenerate it on an intentional BEAM-shape upgrade rather than treating the
+  resulting delta as a code regression.
+- Re-record `baselines/lisp_eval.json` only with `--reason`; the task requires
+  and stores that written cause for every accepted change. The Nightly workflow
+  catches drift daily and the Release Gate blocks a release whose reductions
+  exceed the committed allowance.
 - `mix bench.heap` is the gating heap entry point; `mix bench.check` prints the
   same table without failing on it. Byte metrics on a per-commit path invite the
   reflexive re-baseline that is how a gate stops meaning anything, so the split

--- a/bench/baselines/lisp_eval.json
+++ b/bench/baselines/lisp_eval.json
@@ -1,45 +1,93 @@
 {
-  "elixir": "1.19.3",
-  "otp": "28",
+  "provenance": {
+    "architecture": "aarch64-apple-darwin25.4.0",
+    "dirty_cpu_schedulers": 10,
+    "elixir": "1.20.2",
+    "emu_flavor": "jit",
+    "erts": "17.0.3",
+    "logical_processors": 10,
+    "mix_env": "dev",
+    "otp": "29",
+    "schedulers_online": 10,
+    "wordsize_bytes": 8
+  },
+  "reason": "Accept Elixir 1.20/OTP 29 and evaluator correctness work since 7ed8da82; #1396 bisect attributes the July steps, while #1100 removes redundant default-path origin bookkeeping and closure atomics.",
   "samples": 7,
   "scenarios": [
     {
       "duration_ms": 0,
-      "eval_reductions": 779,
-      "memory_bytes": 6928,
+      "eval_reductions": 1171,
+      "identity_sha256": "5555fffb741af2046245fdbfd4171749e422488537b9bd65c702de40d5a128c8",
+      "memory_bytes": 16800,
       "name": "arithmetic",
+      "policy": "raw",
       "program": "(+ 1 (* 2 3) (- 10 4) (* (+ 1 1) 5))"
     },
     {
       "duration_ms": 0,
-      "eval_reductions": 10543,
-      "memory_bytes": 19072,
+      "eval_reductions": 14825,
+      "identity_sha256": "7c6038fc1e4ba74991214320615f6789403272d8757e8b38ada7e7896d459310",
+      "memory_bytes": 30048,
       "name": "collection_hofs",
+      "policy": "raw",
       "program": "(reduce + 0 (map (fn [x] (* x x)) (filter odd? (range 0 40))))"
     },
     {
       "duration_ms": 0,
-      "eval_reductions": 925,
-      "memory_bytes": 21608,
+      "eval_reductions": 1372,
+      "identity_sha256": "ba9d615a5afeb695414c392c3f2141c31b577e10ced169a9fdc839ac4b6bca45",
+      "memory_bytes": 26528,
       "name": "map_string",
+      "policy": "raw",
       "program": "(let [m {:a \"alpha\" :b \"beta\" :c \"gamma\"}] (clojure.string/join \",\" (map clojure.string/upper-case [(:a m) (:b m) (:c m)])))"
     },
     {
       "duration_ms": 0,
-      "eval_reductions": 3308,
-      "memory_bytes": 13872,
+      "eval_reductions": 4264,
+      "identity_sha256": "438a6ea13e91f58a1bac37bb21f4c88f5b26da3852590df093ae3a15a262dd14",
+      "memory_bytes": 21736,
       "name": "closure_apply",
+      "policy": "raw",
       "program": "(let [mk (fn [x] (fn [y] (+ x y)))] (reduce + 0 (map (mk 10) [1 2 3 4 5])))"
     },
     {
       "duration_ms": 0,
-      "eval_reductions": 2528,
-      "memory_bytes": 10736,
+      "eval_reductions": 3393,
+      "identity_sha256": "6745c6ef4c93e3d8b0072da4e9aa1fea7be08c1edd6c6727f6cf3335df493b0e",
+      "memory_bytes": 34504,
       "name": "context_filter",
+      "policy": "raw",
       "program": "(->> data/orders (filter #(> (:total %) 20)) (map :total) (reduce + 0))"
+    },
+    {
+      "duration_ms": 0,
+      "eval_reductions": 25049,
+      "identity_sha256": "b1b3d54bf09a7ef6fbea3070af6be35835bd613e43762c0c3ee43c6c976af633",
+      "memory_bytes": 68280,
+      "name": "public_prelude",
+      "policy": "public_prelude",
+      "program": "(reduce + 0 (map bench/square (range 0 40)))"
+    },
+    {
+      "duration_ms": 0,
+      "eval_reductions": 25143,
+      "identity_sha256": "625f62c516deadd3ddb92ff030f95e26e41d03baa46d929a4a31f65bbbf6bbd9",
+      "memory_bytes": 55824,
+      "name": "strict_transitive_prelude",
+      "policy": "strict_transitive_prelude",
+      "program": "(reduce + 0 (map bench/square (range 0 40)))"
+    },
+    {
+      "duration_ms": 0,
+      "eval_reductions": 5136,
+      "identity_sha256": "d0d984f00158e56490cdc81634c2671c8de756cef52c2fc1927d512b3172de9d",
+      "memory_bytes": 34528,
+      "name": "private_tool_prelude",
+      "policy": "private_tool_prelude",
+      "program": "(reduce + 0 (map bench/private-value [1 2 3 4 5]))"
     }
   ],
   "threshold": 1.07,
-  "version": 1,
+  "version": 2,
   "warmup": 20
 }

--- a/lib/mix/tasks/bench.check.ex
+++ b/lib/mix/tasks/bench.check.ex
@@ -4,10 +4,16 @@ defmodule Mix.Tasks.Bench.Check do
   Checks deterministic PTC-Lisp eval metrics against a committed baseline.
 
       mix bench.check
-      mix bench.check --write-baseline
+      mix bench.check --write-baseline --reason "accepted cause"
       mix bench.check --skip-heap
 
   This task gates `eval_reductions` collected from the sandbox child process.
+  Its scenario matrix covers the raw evaluator and the public-prelude,
+  strict-transitive, and private-tool authority paths. Before measuring, the
+  task requires the baseline's Mix environment, Elixir, OTP, ERTS, emulator
+  flavor, and word size to match the current runtime; reduction counts from a
+  different BEAM execution shape are not a valid comparison.
+
   Child `memory_bytes` and wall-clock duration are reported as informational
   metrics: runner timing noise is too large for a gate, and a single per-call
   `memory_bytes` sample cannot separate a leak from one-shot warmup. Repeated
@@ -27,42 +33,88 @@ defmodule Mix.Tasks.Bench.Check do
   alias Mix.Tasks.Bench.Heap
   alias PtcRunner.Bench.Baseline
   alias PtcRunner.Lisp
+  alias PtcRunner.Lisp.Prelude.Compiler
 
   @default_baseline Path.join(["bench", "baselines", "lisp_eval.json"])
   @default_threshold 1.07
   @default_samples 7
   @default_warmup 20
+  @runtime_provenance_fields ~w(mix_env elixir otp erts emu_flavor wordsize_bytes)
+
+  @public_prelude """
+  (ns bench "Benchmark helpers." {:visibility :prompt})
+  (defn square "Squares a number." [x] (* x x))
+  """
+
+  @private_tool_prelude """
+  (ns bench "Benchmark private-tool helpers." {:visibility :prompt})
+  (defn private-value "Reads a value through a private tool." [x]
+    (tool/private_echo {:value x}))
+  """
 
   @scenarios [
     %{
       name: "arithmetic",
-      program: "(+ 1 (* 2 3) (- 10 4) (* (+ 1 1) 5))"
+      program: "(+ 1 (* 2 3) (- 10 4) (* (+ 1 1) 5))",
+      config: %{opts: []}
     },
     %{
       name: "collection_hofs",
-      program: "(reduce + 0 (map (fn [x] (* x x)) (filter odd? (range 0 40))))"
+      program: "(reduce + 0 (map (fn [x] (* x x)) (filter odd? (range 0 40))))",
+      config: %{opts: []}
     },
     %{
       name: "map_string",
       program:
-        ~S|(let [m {:a "alpha" :b "beta" :c "gamma"}] (clojure.string/join "," (map clojure.string/upper-case [(:a m) (:b m) (:c m)])))|
+        ~S|(let [m {:a "alpha" :b "beta" :c "gamma"}] (clojure.string/join "," (map clojure.string/upper-case [(:a m) (:b m) (:c m)])))|,
+      config: %{opts: []}
     },
     %{
       name: "closure_apply",
-      program: "(let [mk (fn [x] (fn [y] (+ x y)))] (reduce + 0 (map (mk 10) [1 2 3 4 5])))"
+      program: "(let [mk (fn [x] (fn [y] (+ x y)))] (reduce + 0 (map (mk 10) [1 2 3 4 5])))",
+      config: %{opts: []}
     },
     %{
       name: "context_filter",
       program: "(->> data/orders (filter #(> (:total %) 20)) (map :total) (reduce + 0))",
-      opts: [
-        context: %{
-          "orders" => [
-            %{"id" => 1, "total" => 10},
-            %{"id" => 2, "total" => 25},
-            %{"id" => 3, "total" => 40}
-          ]
+      config: %{
+        opts: [
+          context: %{
+            "orders" => [
+              %{"id" => 1, "total" => 10},
+              %{"id" => 2, "total" => 25},
+              %{"id" => 3, "total" => 40}
+            ]
+          }
+        ]
+      }
+    },
+    %{
+      name: "public_prelude",
+      program: "(reduce + 0 (map bench/square (range 0 40)))",
+      policy: :public_prelude,
+      config: %{prelude_source: @public_prelude}
+    },
+    %{
+      name: "strict_transitive_prelude",
+      program: "(reduce + 0 (map bench/square (range 0 40)))",
+      policy: :strict_transitive_prelude,
+      config: %{
+        prelude_source: @public_prelude,
+        strict_transitive_calls: true,
+        direct_namespaces: ["bench"]
+      }
+    },
+    %{
+      name: "private_tool_prelude",
+      program: "(reduce + 0 (map bench/private-value [1 2 3 4 5]))",
+      policy: :private_tool_prelude,
+      config: %{
+        prelude_source: @private_tool_prelude,
+        tools: %{
+          "private_echo" => %{implementation: :return_value_argument, visibility: :private}
         }
-      ]
+      }
     }
   ]
 
@@ -75,6 +127,15 @@ defmodule Mix.Tasks.Bench.Check do
     threshold = opts[:threshold]
     samples = opts[:samples]
     warmup = opts[:warmup]
+    reason = opts[:reason]
+
+    baseline =
+      unless opts[:write_baseline] do
+        baseline_path
+        |> Baseline.read!()
+        |> validate_provenance!()
+        |> validate_scenario_identity!()
+      end
 
     results = measure_all(samples, warmup)
 
@@ -83,9 +144,9 @@ defmodule Mix.Tasks.Bench.Check do
     unless opts[:skip_heap], do: Heap.report()
 
     if opts[:write_baseline] do
-      write_baseline!(baseline_path, threshold, samples, warmup, results)
+      write_baseline!(baseline_path, threshold, samples, warmup, reason, results)
     else
-      check_baseline!(baseline_path, threshold, results)
+      check_baseline!(baseline, threshold, results)
     end
   end
 
@@ -97,6 +158,7 @@ defmodule Mix.Tasks.Bench.Check do
           threshold: :float,
           samples: :integer,
           warmup: :integer,
+          reason: :string,
           write_baseline: :boolean,
           skip_heap: :boolean
         ],
@@ -112,6 +174,7 @@ defmodule Mix.Tasks.Bench.Check do
       threshold: Keyword.get(opts, :threshold, @default_threshold),
       samples: Keyword.get(opts, :samples, @default_samples),
       warmup: Keyword.get(opts, :warmup, @default_warmup),
+      reason: Keyword.get(opts, :reason),
       write_baseline: Keyword.get(opts, :write_baseline, false),
       skip_heap: Keyword.get(opts, :skip_heap, false)
     ]
@@ -122,6 +185,8 @@ defmodule Mix.Tasks.Bench.Check do
     threshold = opts[:threshold]
     samples = opts[:samples]
     warmup = opts[:warmup]
+    reason = opts[:reason]
+    write_baseline? = opts[:write_baseline]
 
     cond do
       not is_float(threshold) or threshold < 1.0 ->
@@ -133,6 +198,12 @@ defmodule Mix.Tasks.Bench.Check do
       not is_integer(warmup) or warmup < 0 ->
         Mix.raise("--warmup must be a non-negative integer")
 
+      write_baseline? and (not is_binary(reason) or String.trim(reason) == "") ->
+        Mix.raise("--write-baseline requires a non-empty --reason")
+
+      not write_baseline? and not is_nil(reason) ->
+        Mix.raise("--reason may only be used with --write-baseline")
+
       true ->
         opts
     end
@@ -141,7 +212,9 @@ defmodule Mix.Tasks.Bench.Check do
   defp measure_all(samples, warmup) do
     Mix.shell().info("==> measuring PTC-Lisp eval performance")
 
-    Enum.map(@scenarios, fn scenario ->
+    @scenarios
+    |> prepare_scenarios!()
+    |> Enum.map(fn scenario ->
       warmup!(scenario, warmup)
 
       measurements =
@@ -151,13 +224,75 @@ defmodule Mix.Tasks.Bench.Check do
 
       %{
         name: scenario.name,
+        policy: Map.get(scenario, :policy, :raw),
         program: scenario.program,
+        identity_sha256: scenario_identity_sha256(scenario),
         samples: samples,
         eval_reductions: Baseline.median(Enum.map(measurements, & &1.eval_reductions)),
         memory_bytes: Enum.max(Enum.map(measurements, & &1.memory_bytes)),
         duration_ms: Baseline.median(Enum.map(measurements, & &1.duration_ms))
       }
     end)
+  end
+
+  defp prepare_scenarios!(scenarios) do
+    preludes =
+      scenarios
+      |> Enum.flat_map(fn scenario ->
+        case scenario.config do
+          %{prelude_source: source} -> [source]
+          _config -> []
+        end
+      end)
+      |> Enum.uniq()
+      |> Map.new(&{&1, compile_prelude!(&1)})
+
+    Enum.map(scenarios, fn scenario ->
+      Map.put(scenario, :opts, scenario_opts(scenario.config, preludes))
+    end)
+  end
+
+  defp scenario_opts(%{opts: opts}, _preludes), do: opts
+
+  defp scenario_opts(%{prelude_source: source} = config, preludes) do
+    opts = [prelude: Map.fetch!(preludes, source)]
+
+    opts =
+      if config[:strict_transitive_calls] do
+        Keyword.merge(opts,
+          strict_transitive_calls: true,
+          direct_namespaces: Map.fetch!(config, :direct_namespaces)
+        )
+      else
+        opts
+      end
+
+    case config[:tools] do
+      nil -> opts
+      tools -> Keyword.put(opts, :tools, prepare_tools!(tools))
+    end
+  end
+
+  defp prepare_tools!(tools) do
+    Map.new(tools, fn
+      {name, %{implementation: :return_value_argument, visibility: visibility}} ->
+        {name, {fn args -> args["value"] end, visibility: visibility}}
+    end)
+  end
+
+  defp scenario_identity_sha256(scenario) do
+    scenario
+    |> Map.take([:name, :program, :policy, :config])
+    |> :erlang.term_to_binary([:deterministic])
+    |> then(&:crypto.hash(:sha256, &1))
+    |> Base.encode16(case: :lower)
+  end
+
+  defp compile_prelude!(source) do
+    case Compiler.compile(source) do
+      {:ok, prelude} -> prelude
+      {:error, error} -> Mix.raise("benchmark prelude failed to compile: #{error.message}")
+    end
   end
 
   defp warmup!(_scenario, 0), do: :ok
@@ -181,25 +316,71 @@ defmodule Mix.Tasks.Bench.Check do
     end
   end
 
-  defp write_baseline!(path, threshold, samples, warmup, results) do
+  defp write_baseline!(path, threshold, samples, warmup, reason, results) do
     Baseline.write!(path, %{
-      "version" => 1,
+      "version" => 2,
       "threshold" => threshold,
       "samples" => samples,
       "warmup" => warmup,
-      # This baseline keeps its original `elixir`/`otp` keys rather than moving
-      # to the richer `provenance` block `bench.heap` writes. Reformatting it
-      # would mean rewriting the committed reduction numbers, and those are only
-      # ever bumped with a written cause.
-      "elixir" => System.version(),
-      "otp" => System.otp_release(),
+      "reason" => String.trim(reason),
+      "provenance" => Baseline.provenance() |> Map.delete("commit"),
       "scenarios" => Enum.map(results, &encode_result/1)
     })
   end
 
-  defp check_baseline!(path, threshold, results) do
-    baseline = Baseline.read!(path)
+  defp validate_provenance!(baseline) do
+    recorded = baseline["provenance"]
+    current = Baseline.provenance()
+
+    unless baseline["version"] == 2 and is_binary(baseline["reason"]) and
+             String.trim(baseline["reason"]) != "" do
+      Mix.raise(
+        "benchmark baseline has no written acceptance reason; " <>
+          "regenerate it with mix bench.check --write-baseline --reason \"accepted cause\""
+      )
+    end
+
+    unless is_map(recorded) do
+      Mix.raise(
+        "benchmark baseline has no runtime provenance; " <>
+          "regenerate it with mix bench.check --write-baseline"
+      )
+    end
+
+    mismatches =
+      Enum.flat_map(@runtime_provenance_fields, fn field ->
+        expected = recorded[field]
+        actual = current[field]
+
+        if expected == actual do
+          []
+        else
+          ["#{field}: baseline #{inspect(expected)}, current #{inspect(actual)}"]
+        end
+      end)
+
+    if mismatches != [] do
+      Mix.raise(
+        "benchmark baseline runtime does not match the current toolchain:\n" <>
+          Enum.join(mismatches, "\n")
+      )
+    end
+
+    baseline
+  end
+
+  defp check_baseline!(baseline, threshold, results) do
     baseline_by_name = Map.new(baseline["scenarios"], &{&1["name"], &1})
+
+    expected_names = baseline_by_name |> Map.keys() |> Enum.sort()
+    actual_names = results |> Enum.map(& &1.name) |> Enum.sort()
+
+    if expected_names != actual_names do
+      Mix.raise(
+        "benchmark scenario set differs from the baseline; " <>
+          "expected #{inspect(expected_names)}, got #{inspect(actual_names)}"
+      )
+    end
 
     failures =
       results
@@ -215,6 +396,33 @@ defmodule Mix.Tasks.Bench.Check do
     end
 
     Mix.shell().info("Performance check passed.")
+  end
+
+  defp validate_scenario_identity!(baseline) do
+    recorded =
+      Enum.map(
+        baseline["scenarios"] || [],
+        &Map.take(&1, ~w(name policy program identity_sha256))
+      )
+
+    current =
+      Enum.map(@scenarios, fn scenario ->
+        %{
+          "name" => scenario.name,
+          "policy" => scenario |> Map.get(:policy, :raw) |> Atom.to_string(),
+          "program" => scenario.program,
+          "identity_sha256" => scenario_identity_sha256(scenario)
+        }
+      end)
+
+    if Enum.sort_by(recorded, & &1["name"]) != Enum.sort_by(current, & &1["name"]) do
+      Mix.raise(
+        "benchmark scenario definitions differ from the baseline; " <>
+          "regenerate it only after reviewing the program and policy changes"
+      )
+    end
+
+    baseline
   end
 
   defp check_result(result, expected, threshold) do
@@ -233,14 +441,15 @@ defmodule Mix.Tasks.Bench.Check do
 
   defp print_results(results, baseline_by_name, threshold) do
     Mix.shell().info("")
-    Mix.shell().info("| Scenario | Eval reductions | Memory bytes | Duration ms |")
-    Mix.shell().info("|---|---:|---:|---:|")
+    Mix.shell().info("| Scenario | Policy | Eval reductions | Memory bytes | Duration ms |")
+    Mix.shell().info("|---|---|---:|---:|---:|")
 
     Enum.each(results, fn result ->
       baseline = Map.fetch!(baseline_by_name, result.name)
 
       Mix.shell().info(
-        "| #{result.name} | #{format_metric(result.eval_reductions, baseline["eval_reductions"], threshold)} | " <>
+        "| #{result.name} | #{result.policy} | " <>
+          "#{format_metric(result.eval_reductions, baseline["eval_reductions"], threshold)} | " <>
           "#{format_informational(result.memory_bytes, baseline["memory_bytes"])} | #{result.duration_ms} |"
       )
     end)
@@ -258,7 +467,9 @@ defmodule Mix.Tasks.Bench.Check do
   defp encode_result(result) do
     %{
       "name" => result.name,
+      "policy" => Atom.to_string(result.policy),
       "program" => result.program,
+      "identity_sha256" => result.identity_sha256,
       "eval_reductions" => result.eval_reductions,
       "memory_bytes" => result.memory_bytes,
       "duration_ms" => result.duration_ms

--- a/lib/ptc_runner/bench/baseline.ex
+++ b/lib/ptc_runner/bench/baseline.ex
@@ -2,11 +2,11 @@ defmodule PtcRunner.Bench.Baseline do
   @moduledoc false
   # Shared baseline-file plumbing for the `mix bench.*` tasks.
   #
-  # A committed benchmark number is only readable next to the machine that
-  # produced it: heap and reduction figures do not carry across OTP releases,
-  # architectures, scheduler counts, or emulator flavors. Every baseline this
-  # module writes therefore records its own provenance, and every task that
-  # reads one gets the same accessors rather than its own copy.
+  # Benchmark portability is metric-specific. Whole-VM heap figures depend on
+  # the host architecture and scheduler shape. Child-process reductions are
+  # stable across hosts only for the same Elixir/OTP/ERTS, emulator flavor, and
+  # word size. Every baseline records full provenance so each owning task can
+  # validate the fields relevant to its metric and report the rest.
 
   @doc "Reads a committed baseline, raising a `Mix.raise` on a missing file."
   @spec read!(Path.t()) :: map()
@@ -34,14 +34,14 @@ defmodule PtcRunner.Bench.Baseline do
   @doc """
   Captures the environment a baseline was measured in.
 
-  None of these are portable, so a baseline that omits them cannot be checked
-  against anything: an OTP bump, a different word size, or a different
-  scheduler count moves the numbers on their own.
+  Portability depends on the metric. An owning task must validate the fields
+  that affect its comparison and may retain the others for diagnostics.
   """
   @spec provenance() :: map()
   def provenance do
     %{
       "commit" => commit(),
+      "mix_env" => Mix.env() |> Atom.to_string(),
       "elixir" => System.version(),
       "otp" => System.otp_release(),
       "erts" => to_string(:erlang.system_info(:version)),

--- a/lib/ptc_runner/lisp.ex
+++ b/lib/ptc_runner/lisp.ex
@@ -837,6 +837,9 @@ defmodule PtcRunner.Lisp do
            }}
         end)
 
+      private_tool_authority? =
+        Enum.any?(normalized_tools, fn {_name, tool} -> Tool.private?(tool) end)
+
       opts =
         Map.merge(params, %{
           normalized_tools: normalized_tools,
@@ -844,7 +847,8 @@ defmodule PtcRunner.Lisp do
           parsed_signature: parsed_signature,
           signature_str: signature_str,
           tool_failure_token: tool_failure_token,
-          tools_meta: tools_meta
+          tools_meta: tools_meta,
+          private_tool_authority?: private_tool_authority?
         })
 
       execute_program(source, opts)
@@ -1183,6 +1187,7 @@ defmodule PtcRunner.Lisp do
       turn_history_mode: turn_history_mode,
       strict_data: strict_data,
       strict_transitive_calls: strict_transitive_calls,
+      private_tool_authority?: private_tool_authority?,
       direct_namespaces: direct_namespaces,
       transitive_namespace_requirers: transitive_namespace_requirers,
       prelude_export_mask: prelude_export_mask
@@ -1216,6 +1221,7 @@ defmodule PtcRunner.Lisp do
         max_tool_call_result_bytes: max_tool_call_result_bytes,
         strict_data: strict_data,
         strict_transitive_calls: strict_transitive_calls,
+        private_tool_authority?: private_tool_authority?,
         direct_namespaces: direct_namespaces,
         transitive_namespace_requirers: transitive_namespace_requirers,
         prelude_export_mask: prelude_export_mask,

--- a/lib/ptc_runner/lisp/eval/apply.ex
+++ b/lib/ptc_runner/lisp/eval/apply.ex
@@ -1048,12 +1048,10 @@ defmodule PtcRunner.Lisp.Eval.Apply do
       end
 
     eval_ctx =
-      EvalContext.new(
-        eval_context.ctx,
+      EvalContext.new_child(
+        eval_context,
         closure_user_ns,
         new_env,
-        eval_context.tool_exec,
-        eval_context.turn_history,
         max_print_length: eval_context.max_print_length,
         pmap_timeout: eval_context.pmap_timeout,
         parallel_deadline_cap: eval_context.parallel_deadline_cap,
@@ -1078,7 +1076,6 @@ defmodule PtcRunner.Lisp.Eval.Apply do
           # nested pmap/pcalls inside this closure inherits it.
           pmap_deadline: eval_context.pmap_deadline
       }
-      |> EvalContext.inherit_prelude(eval_context)
       |> maybe_push_prelude_origin(metadata, eval_context)
       |> Capture.materialize_context()
 
@@ -1387,6 +1384,18 @@ defmodule PtcRunner.Lisp.Eval.Apply do
 
   defp maybe_push_prelude_origin(
          %EvalContext{} = context,
+         _metadata,
+         %EvalContext{
+           prelude: nil,
+           strict_transitive_calls: false,
+           private_tool_authority?: false
+         }
+       ) do
+    context
+  end
+
+  defp maybe_push_prelude_origin(
+         %EvalContext{} = context,
          %{
            prelude_ref: ref,
            prelude_ns: ns,
@@ -1477,7 +1486,7 @@ defmodule PtcRunner.Lisp.Eval.Apply do
          {:closure, _closure_patterns, body, closure_env, _closure_turn_history, meta} = closure,
          binding_patterns,
          args,
-         %EvalContext{ctx: ctx, user_ns: user_ns, tool_exec: tool_exec} = caller_ctx,
+         %EvalContext{user_ns: user_ns} = caller_ctx,
          do_eval_fn
        ) do
     case bind_args(binding_patterns, args) do
@@ -1497,9 +1506,7 @@ defmodule PtcRunner.Lisp.Eval.Apply do
         # isolation, mirroring the direct `(crm/export ...)` call path).
         {closure_user_ns, restore_user_ns} = prelude_run_scope(meta, user_ns, caller_ctx)
 
-        closure_ctx =
-          EvalContext.new(ctx, closure_user_ns, new_env, tool_exec, caller_ctx.turn_history)
-          |> EvalContext.inherit_prelude(caller_ctx)
+        closure_ctx = EvalContext.new_child(caller_ctx, closure_user_ns, new_env)
 
         # Carry accumulated state from caller so tool_calls/cache aren't lost across closure calls.
         # `locals` is rebuilt from the closure's lexical capture + this invocation's

--- a/lib/ptc_runner/lisp/eval/context.ex
+++ b/lib/ptc_runner/lisp/eval/context.ex
@@ -37,6 +37,7 @@ defmodule PtcRunner.Lisp.Eval.Context do
 
   alias PtcRunner.Lisp.Eval.Capture
   alias PtcRunner.Lisp.Eval.Effects
+  alias PtcRunner.Lisp.Eval.RunResources
   alias PtcRunner.Lisp.RetainedSize
 
   @default_print_length 2000
@@ -110,6 +111,9 @@ defmodule PtcRunner.Lisp.Eval.Context do
     # were directly attached. Prelude-internal calls remain allowed because the
     # compiler already validated their declared namespace deps.
     strict_transitive_calls: false,
+    # Whether any tool in this run is private. Raw/no-prelude runs use this
+    # once-computed flag to avoid authority bookkeeping on every closure.
+    private_tool_authority?: false,
     direct_namespaces: MapSet.new(),
     transitive_namespace_requirers: %{},
     prelude_export_mask: nil,
@@ -204,6 +208,7 @@ defmodule PtcRunner.Lisp.Eval.Context do
           tools_meta: %{String.t() => %{optional(atom()) => term()}},
           strict_data: boolean(),
           strict_transitive_calls: boolean(),
+          private_tool_authority?: boolean(),
           direct_namespaces: MapSet.t(String.t()),
           transitive_namespace_requirers: %{String.t() => [String.t()]},
           prelude_export_mask: %{String.t() => MapSet.t(String.t())} | nil,
@@ -266,7 +271,7 @@ defmodule PtcRunner.Lisp.Eval.Context do
       prelude_caller_user_ns_stack: Keyword.get(opts, :prelude_caller_user_ns_stack, []),
       turn_history: turn_history,
       max_tool_calls: Keyword.get(opts, :max_tool_calls),
-      tool_call_budget: Keyword.get_lazy(opts, :tool_call_budget, fn -> :atomics.new(1, []) end),
+      tool_call_budget: Keyword.get_lazy(opts, :tool_call_budget, &RunResources.new_counter/0),
       max_tool_call_result_bytes:
         Keyword.get(opts, :max_tool_call_result_bytes, @default_tool_call_result_bytes),
       max_print_length: Keyword.get(opts, :max_print_length, @default_print_length),
@@ -277,11 +282,12 @@ defmodule PtcRunner.Lisp.Eval.Context do
       max_heap: Keyword.get(opts, :max_heap),
       worker_max_heap: Keyword.get(opts, :worker_max_heap, Keyword.get(opts, :max_heap)),
       parallel_budget: Keyword.get(opts, :parallel_budget),
-      tool_activity: Keyword.get_lazy(opts, :tool_activity, fn -> :atomics.new(1, []) end),
+      tool_activity: Keyword.get_lazy(opts, :tool_activity, &RunResources.new_counter/0),
       effects: Effects.empty(),
       tools_meta: Keyword.get(opts, :tools_meta, %{}),
       strict_data: Keyword.get(opts, :strict_data, false),
       strict_transitive_calls: Keyword.get(opts, :strict_transitive_calls, false),
+      private_tool_authority?: Keyword.get(opts, :private_tool_authority?, false),
       direct_namespaces: namespace_set(Keyword.get(opts, :direct_namespaces, [])),
       transitive_namespace_requirers:
         normalize_namespace_requirers(Keyword.get(opts, :transitive_namespace_requirers, %{})),
@@ -289,6 +295,20 @@ defmodule PtcRunner.Lisp.Eval.Context do
       prelude_exports: prelude_exports(Keyword.get(opts, :prelude)),
       prelude: prelude_artifact(Keyword.get(opts, :prelude))
     }
+  end
+
+  @doc false
+  @spec new_child(t(), map(), map(), keyword()) :: t()
+  def new_child(%__MODULE__{} = parent, user_ns, env, opts \\ []) do
+    opts =
+      [
+        tool_call_budget: parent.tool_call_budget,
+        tool_activity: parent.tool_activity
+      ] ++ opts
+
+    parent.ctx
+    |> new(user_ns, env, parent.tool_exec, parent.turn_history, opts)
+    |> inherit_prelude(parent)
   end
 
   @doc false
@@ -563,6 +583,7 @@ defmodule PtcRunner.Lisp.Eval.Context do
       | prelude_exports: source.prelude_exports,
         prelude: source.prelude,
         strict_transitive_calls: source.strict_transitive_calls,
+        private_tool_authority?: source.private_tool_authority?,
         direct_namespaces: source.direct_namespaces,
         transitive_namespace_requirers: source.transitive_namespace_requirers,
         prelude_export_mask: source.prelude_export_mask,

--- a/lib/ptc_runner/lisp/eval/run_resources.ex
+++ b/lib/ptc_runner/lisp/eval/run_resources.ex
@@ -1,0 +1,7 @@
+defmodule PtcRunner.Lisp.Eval.RunResources do
+  @moduledoc false
+
+  @doc false
+  @spec new_counter() :: :atomics.atomics_ref()
+  def new_counter, do: :atomics.new(1, [])
+end

--- a/test/mix/tasks/bench_check_test.exs
+++ b/test/mix/tasks/bench_check_test.exs
@@ -1,14 +1,8 @@
 defmodule Mix.Tasks.Bench.CheckTest do
   use ExUnit.Case, async: false
 
-  # `:nightly` because both tests execute the real benchmark task rather than a
-  # stub: even at `--samples 1 --warmup 0` the module cost 25.5 s of the CI
-  # suite's 177.8 s serial floor, second only to the downstream-consumer build.
-  # A benchmark's per-commit signal is a trend, not a verdict, so the `Nightly`
-  # workflow is the right home for it.
-  @moduletag :nightly
-
   alias Mix.Tasks.Bench.Check
+  alias PtcRunner.Bench.Baseline
 
   setup do
     old_shell = Mix.shell()
@@ -22,6 +16,9 @@ defmodule Mix.Tasks.Bench.CheckTest do
     :ok
   end
 
+  @tag :nightly
+  # This test executes the real matrix twice; the cheap option/provenance tests
+  # below remain in the per-commit suite.
   test "writes and checks a temporary baseline" do
     baseline =
       Path.join(System.tmp_dir!(), "ptc-runner-bench-check-#{System.unique_integer()}.json")
@@ -29,6 +26,8 @@ defmodule Mix.Tasks.Bench.CheckTest do
     try do
       Check.run([
         "--write-baseline",
+        "--reason",
+        "test baseline",
         "--baseline",
         baseline,
         "--samples",
@@ -61,6 +60,64 @@ defmodule Mix.Tasks.Bench.CheckTest do
 
     assert_raise Mix.Error, ~r/missing baseline/, fn ->
       Check.run(["--baseline", baseline, "--samples", "1", "--warmup", "0"])
+    end
+  end
+
+  test "requires a written reason when replacing the baseline" do
+    assert_raise Mix.Error, ~r/requires a non-empty --reason/, fn ->
+      Check.run(["--write-baseline", "--samples", "1", "--warmup", "0"])
+    end
+  end
+
+  test "rejects a baseline from another runtime before measuring" do
+    baseline =
+      Path.join(System.tmp_dir!(), "ptc-runner-bench-provenance-#{System.unique_integer()}.json")
+
+    try do
+      provenance = Map.put(Baseline.provenance(), "erts", "mismatched")
+
+      Baseline.write!(baseline, %{
+        "version" => 2,
+        "reason" => "test mismatch",
+        "provenance" => provenance,
+        "scenarios" => []
+      })
+
+      assert_raise Mix.Error, ~r/baseline runtime does not match.*erts:/s, fn ->
+        Check.run(["--baseline", baseline, "--samples", "1", "--warmup", "0"])
+      end
+    after
+      File.rm(baseline)
+    end
+  end
+
+  test "rejects a baseline whose scenario configuration digest changed before measuring" do
+    baseline =
+      Path.join(System.tmp_dir!(), "ptc-runner-bench-policy-#{System.unique_integer()}.json")
+
+    try do
+      committed = Baseline.read!(Path.join(["bench", "baselines", "lisp_eval.json"]))
+
+      scenarios =
+        Enum.map(committed["scenarios"], fn
+          %{"name" => "strict_transitive_prelude"} = scenario ->
+            Map.put(scenario, "identity_sha256", String.duplicate("0", 64))
+
+          scenario ->
+            scenario
+        end)
+
+      Baseline.write!(baseline, %{
+        committed
+        | "provenance" => Baseline.provenance(),
+          "scenarios" => scenarios
+      })
+
+      assert_raise Mix.Error, ~r/scenario definitions differ/, fn ->
+        Check.run(["--baseline", baseline, "--samples", "1", "--warmup", "0"])
+      end
+    after
+      File.rm(baseline)
     end
   end
 end

--- a/test/ptc_runner/lisp/eval/context_test.exs
+++ b/test/ptc_runner/lisp/eval/context_test.exs
@@ -11,6 +11,24 @@ defmodule PtcRunner.Lisp.Eval.ContextTest do
     refute Map.has_key?(Map.from_struct(ctx), :trace_context)
   end
 
+  test "child contexts reuse the run-owned atomic resources" do
+    parent =
+      Context.new(%{}, %{}, %{}, fn _, _, _ -> nil end, [],
+        prelude: nil,
+        strict_transitive_calls: true,
+        private_tool_authority?: true
+      )
+
+    child = Context.new_child(parent, %{"scope" => "child"}, %{"x" => 1})
+
+    assert child.tool_call_budget === parent.tool_call_budget
+    assert child.tool_activity === parent.tool_activity
+    assert child.strict_transitive_calls === parent.strict_transitive_calls
+    assert child.private_tool_authority? === parent.private_tool_authority?
+    assert child.user_ns == %{"scope" => "child"}
+    assert child.env == %{"x" => 1}
+  end
+
   describe "append_tool_call/2" do
     test "accumulates tool calls in reverse order" do
       ctx = Context.new(%{}, %{}, %{}, fn _, _ -> nil end, [])

--- a/test/ptc_runner/lisp/eval/run_resource_test.exs
+++ b/test/ptc_runner/lisp/eval/run_resource_test.exs
@@ -1,0 +1,39 @@
+defmodule PtcRunner.Lisp.Eval.RunResourceTest do
+  use ExUnit.Case, async: false
+
+  alias PtcRunner.Lisp
+  alias PtcRunner.Lisp.Eval.RunResources
+
+  test "closure contexts do not allocate throwaway run resources" do
+    :erlang.trace_pattern({RunResources, :new_counter, 0}, true, [:local])
+    :erlang.trace(self(), true, [:call, :set_on_spawn])
+
+    on_exit(fn ->
+      :erlang.trace(self(), false, [:all])
+      :erlang.trace_pattern({RunResources, :new_counter, 0}, false, [:local])
+    end)
+
+    assert {:ok, _step} =
+             Lisp.run(
+               "(let [mk (fn [x] (fn [y] (+ x y)))] " <>
+                 "(reduce + 0 (map (mk 10) [1 2 3 4 5])))"
+             )
+
+    delivered = :erlang.trace_delivered(:all)
+    assert_receive {:trace_delivered, :all, ^delivered}, 5_000
+
+    # One budget counter and one activity counter belong to the sandbox owner.
+    # Before child contexts received those references at construction time,
+    # every closure call allocated two more and immediately overwrote them.
+    assert count_allocations(0) == 2
+  end
+
+  defp count_allocations(count) do
+    receive do
+      {:trace, _pid, :call, {RunResources, :new_counter, []}} ->
+        count_allocations(count + 1)
+    after
+      0 -> count
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- make the ordinary no-prelude/no-strict/no-private-tool evaluator path skip per-closure origin bookkeeping while keeping every authority-sensitive path fail-closed
- construct closure child contexts with the run-owned tool-budget/activity atomics instead of allocating and immediately discarding two counters per closure call
- expand `mix bench.check` to cover raw, public-prelude, strict-transitive, and private-tool policies, with full scenario digests, BEAM-shape provenance, and a required written rebaseline reason
- run the reduction gate from Nightly and the Release Gate

## Investigation

A same-toolchain historical bisect for #1396 found the broad reduction increase began with strict-transitive tracking (`737c55ae`) and rose again when inner evaluations acquired prelude state (`c166eb97`); repairs through `7ed8da82` removed most of the second step. That makes `7ed8da82` the prior rebaseline point, not the primary cause.

The #1100 runtime optimization is intentionally narrow. It does not skip recursive prelude-authority stripping, and public preludes, strict-transitive mode, or any private tool keep origin bookkeeping.

## Verification

- `mix precommit`
  - 6,279 root tests passed; Viewer 52; launcher 42
  - Credo clean, new duplication 0, Dialyzer clean
  - specification, generated-artifact, package, and standalone-release gates passed
- `MIX_ENV=dev mix docs --warnings-as-errors`
- `mix bench.check --skip-heap` (repeat check passed)
- pre-push CI-shaped hook passed on commit `7a37e2a5`
- 3 independent review passes (the requested maximum); final follow-up had no actionable findings

## Review/base note

`main` advanced afterward via #1402, touching unrelated agent turn-limit paths. This draft preserves the exact reviewed commit instead of rebasing after the review cap; GitHub CI will validate the current merge result.

Refs #1100
Refs #1396