### PR TITLE
fix(llm): preserve classified provider failures

### DIFF
--- a/docs/agent-library-reference.md
+++ b/docs/agent-library-reference.md
@@ -253,9 +253,11 @@ treating extension keys as invalid. Result-contract diagnostics are capped at
 
 An outer `fail` value is not copied into the public Kernel error or canonical
 trace. Framework failure kinds remain readable; application-defined scalar
-kinds become stable fingerprints. Exact failure values, prompts, provider
-responses, generated source, and capability payloads require an authorized
-private inspection artifact.
+kinds become stable fingerprints. Exact failure values, prompts, generated
+source, and capability payloads require an authorized private inspection
+artifact. Built-in LLM adapters retain only a bounded provider status and
+human-readable reason there; request bodies, raw response bodies, headers, and
+transport causes are not retained as provider-error details.
 
 ## Retry and effect safety
 

--- a/lib/ptc_runner/kernel/llm_capability.ex
+++ b/lib/ptc_runner/kernel/llm_capability.ex
@@ -3,9 +3,10 @@ defmodule PtcRunner.Kernel.LLMCapability do
   Constructs the provider-neutral `llm-request` workflow capability.
 
   The supplied requester owns transport and credential handling. Requests and
-  normalized JSON-like responses are independently bounded. Transport errors
-  become retryable `:unavailable` provider failures; invalid or oversized
-  responses do not cross back into Lisp.
+  normalized JSON-like responses are independently bounded. Requesters may
+  return a classified `PtcRunner.Kernel.ProviderError`; unclassified failures
+  become retryable `:unavailable` errors. Invalid or oversized responses do not
+  cross back into Lisp.
 
   This adapter provides model access, not agent policy. Message construction,
   tool protocols, feedback, retries, and completion remain PTC-Lisp workflow

--- a/lib/ptc_runner/kernel/provider_error.ex
+++ b/lib/ptc_runner/kernel/provider_error.ex
@@ -6,6 +6,9 @@ defmodule PtcRunner.Kernel.ProviderError do
   dispatcher converts it into the uniform Lisp capability error envelope.
   `details` is truncated to 1,024 characters and must not contain credentials,
   BEAM exceptions, stack traces, or other host-private data.
+  Adapters that translate dependency errors must select bounded diagnostic
+  fields explicitly; inspecting an entire error value may retain request
+  bodies, response bodies, headers, causes, or credentials and is forbidden.
 
   `mutation_state: :indeterminate` is orthogonal to the diagnostic `kind`: it
   means a non-successful call may already have changed external state and is

--- a/lib/ptc_runner/llm/req_llm_adapter.ex
+++ b/lib/ptc_runner/llm/req_llm_adapter.ex
@@ -10,6 +10,14 @@ if Code.ensure_loaded?(ReqLLM) do
 
     Requires `{:req_llm, "~> 1.8"}` as a dependency.
 
+    ## Failure classification
+
+    The adapter boundary converts expected provider, HTTP, and transport
+    failures into bounded `PtcRunner.Kernel.ProviderError` values. HTTP status
+    and the dependency's human-readable reason may reach private inspection;
+    request bodies, response bodies, headers, causes, and arbitrary exception
+    inspection do not cross the boundary.
+
     ## Prompt Caching
 
     When `cache: true` is set in the request, prompt caching is enabled for
@@ -25,6 +33,7 @@ if Code.ensure_loaded?(ReqLLM) do
 
     @behaviour PtcRunner.LLM
 
+    alias PtcRunner.Kernel.ProviderError
     alias ReqLLM.Message
     alias ReqLLM.Message.ContentPart
 
@@ -78,31 +87,40 @@ if Code.ensure_loaded?(ReqLLM) do
     end
 
     @impl true
-    @spec call(String.t(), map()) :: {:ok, map()} | {:error, term()}
+    @spec call(String.t(), map()) :: {:ok, map()} | {:error, ProviderError.t()}
     def call(model, %{schema: schema} = req) when is_map(schema) do
       messages = build_messages(req)
 
-      case generate_object(model, messages, schema, request_opts(req)) do
+      model
+      |> generate_object(messages, schema, request_opts(req))
+      |> case do
         {:ok, %{object: object, tokens: tokens}} ->
           {:ok, %{content: Jason.encode!(object), tokens: tokens}}
 
-        {:error, reason} ->
-          {:error, reason}
+        error ->
+          normalize_call_result(error)
       end
     end
 
     def call(model, %{tools: tools} = req) when is_list(tools) and tools != [] do
       messages = build_messages(req)
-      generate_with_tools(model, messages, tools, request_opts(req))
+
+      model
+      |> generate_with_tools(messages, tools, request_opts(req))
+      |> normalize_call_result()
     end
 
     def call(model, req) do
       messages = build_messages(req)
-      generate_text(model, messages, request_opts(req))
+
+      model
+      |> generate_text(messages, request_opts(req))
+      |> normalize_call_result()
     end
 
     @impl true
-    @spec stream(String.t(), map()) :: {:ok, Enumerable.t()} | {:error, term()}
+    @spec stream(String.t(), map()) ::
+            {:ok, Enumerable.t()} | {:error, :streaming_not_supported | ProviderError.t()}
     def stream(model, req) do
       case parse_provider(model) do
         {:ollama, _} ->
@@ -321,7 +339,7 @@ if Code.ensure_loaded?(ReqLLM) do
           {:ok, Stream.concat(content_stream, done_stream)}
 
         {:error, reason} ->
-          {:error, reason}
+          provider_failure(reason)
       end
     end
 
@@ -540,6 +558,140 @@ if Code.ensure_loaded?(ReqLLM) do
           {:error, reason}
       end
     end
+
+    defp normalize_call_result({:error, reason}), do: provider_failure(reason)
+    defp normalize_call_result(result), do: result
+
+    defp provider_failure(reason), do: {:error, normalize_provider_error(reason)}
+
+    defp normalize_provider_error(%ProviderError{} = error), do: error
+
+    defp normalize_provider_error(%ReqLLM.Error.API.Request{status: status} = error)
+         when is_integer(status) do
+      ProviderError.new(
+        http_error_kind(status),
+        http_error_details(status, error.reason),
+        retryable?: http_retryable?(status, error.retryable)
+      )
+    end
+
+    defp normalize_provider_error(%ReqLLM.Error.API.Request{} = error) do
+      ProviderError.new(
+        transport_error_kind(error.cause),
+        safe_error_details(error.reason, "LLM transport unavailable"),
+        retryable?: transport_retryable?(error.cause, error.retryable)
+      )
+    end
+
+    defp normalize_provider_error(%ReqLLM.Error.API.Response{status: status} = error)
+         when is_integer(status) do
+      ProviderError.new(
+        http_error_kind(status),
+        http_error_details(status, error.reason),
+        retryable?: http_retryable?(status, nil)
+      )
+    end
+
+    defp normalize_provider_error(%ReqLLM.Error.API.Response{} = error) do
+      ProviderError.new(
+        :invalid_result,
+        safe_error_details(error.reason, "LLM provider returned an invalid response")
+      )
+    end
+
+    defp normalize_provider_error(%{status: status} = error) when is_integer(status) do
+      ProviderError.new(
+        http_error_kind(status),
+        direct_http_error_details(status, Map.get(error, :body)),
+        retryable?: http_retryable?(status, nil)
+      )
+    end
+
+    defp normalize_provider_error(%Req.TransportError{reason: reason}) do
+      ProviderError.new(
+        transport_error_kind(reason),
+        transport_error_details(reason),
+        retryable?: retryable_transport_reason?(reason)
+      )
+    end
+
+    defp normalize_provider_error(:structured_output_not_supported),
+      do: ProviderError.new(:invalid_request, "LLM provider does not support structured output")
+
+    defp normalize_provider_error(:tool_calling_not_supported),
+      do: ProviderError.new(:invalid_request, "LLM provider does not support tool calling")
+
+    defp normalize_provider_error(_reason),
+      do: ProviderError.new(:unavailable, "LLM provider unavailable", retryable?: true)
+
+    defp http_error_kind(401), do: :authentication_failed
+    defp http_error_kind(403), do: :denied
+    defp http_error_kind(404), do: :not_found
+    defp http_error_kind(408), do: :timeout
+    defp http_error_kind(429), do: :unavailable
+    defp http_error_kind(status) when status in 400..499, do: :invalid_request
+    defp http_error_kind(status) when status in 500..599, do: :unavailable
+    defp http_error_kind(_status), do: :unavailable
+
+    defp http_retryable?(_status, retryable?) when is_boolean(retryable?), do: retryable?
+    defp http_retryable?(status, _retryable?) when status in [408, 409, 425, 429], do: true
+    defp http_retryable?(status, _retryable?) when status in 500..599, do: true
+    defp http_retryable?(_status, _retryable?), do: false
+
+    defp http_error_details(status, reason) when is_binary(reason),
+      do: safe_error_details("HTTP #{status}: #{reason}", "HTTP #{status}")
+
+    defp http_error_details(status, _reason), do: "HTTP #{status}"
+
+    defp direct_http_error_details(status, body) do
+      case provider_message(body) do
+        message when is_binary(message) -> http_error_details(status, message)
+        _missing -> "HTTP #{status}"
+      end
+    end
+
+    defp provider_message(%{"error" => %{"message" => message}}) when is_binary(message),
+      do: message
+
+    defp provider_message(%{"error" => message}) when is_binary(message), do: message
+    defp provider_message(%{"message" => message}) when is_binary(message), do: message
+    defp provider_message(_body), do: nil
+
+    defp safe_error_details(details, fallback) when is_binary(details) do
+      if String.valid?(details) and details != "", do: details, else: fallback
+    end
+
+    defp safe_error_details(_details, fallback), do: fallback
+
+    defp transport_error_kind(%Req.TransportError{reason: reason}),
+      do: transport_error_kind(reason)
+
+    defp transport_error_kind(%Finch.TransportError{reason: reason}),
+      do: transport_error_kind(reason)
+
+    defp transport_error_kind(%Mint.TransportError{reason: reason}),
+      do: transport_error_kind(reason)
+
+    defp transport_error_kind(:timeout), do: :timeout
+    defp transport_error_kind(_reason), do: :transport_error
+
+    defp transport_retryable?(_cause, retryable?) when is_boolean(retryable?), do: retryable?
+
+    defp transport_retryable?(cause, _retryable?),
+      do: cause |> transport_reason() |> retryable_transport_reason?()
+
+    defp transport_reason(%Req.TransportError{reason: reason}), do: reason
+    defp transport_reason(%Finch.TransportError{reason: reason}), do: reason
+    defp transport_reason(%Mint.TransportError{reason: reason}), do: reason
+    defp transport_reason(_cause), do: nil
+
+    defp retryable_transport_reason?(reason),
+      do: reason in [:closed, :timeout, :econnrefused, :pool_not_available]
+
+    defp transport_error_details(reason) when is_atom(reason),
+      do: "LLM transport error: #{reason}"
+
+    defp transport_error_details(_reason), do: "LLM transport unavailable"
 
     @doc false
     def normalize_tool_calls(raw_tool_calls) do

--- a/test/ptc_runner/llm/req_llm_adapter_test.exs
+++ b/test/ptc_runner/llm/req_llm_adapter_test.exs
@@ -1,9 +1,33 @@
 defmodule PtcRunner.LLM.ReqLLMAdapterTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
+  alias PtcRunner.Kernel.Dispatcher
+  alias PtcRunner.Kernel.InspectionSink
+  alias PtcRunner.Kernel.Limits
+  alias PtcRunner.Kernel.LLMCapability
+  alias PtcRunner.Kernel.ProviderError
+  alias PtcRunner.Kernel.ProviderRegistry
+  alias PtcRunner.Kernel.RunState
+  alias PtcRunner.Kernel.WorkflowEnvironment
   alias PtcRunner.LLM.ReqLLMAdapter
+  alias PtcRunner.TestSupport.TestHelpers
   alias ReqLLM.Message
   alias ReqLLM.ToolCall
+
+  @openrouter_model "openrouter:anthropic/claude-haiku-4.5"
+
+  setup_all do
+    initially_started = Application.started_applications() |> MapSet.new(&elem(&1, 0))
+    {:ok, started} = Application.ensure_all_started(:req_llm)
+    :ok = ReqLLMAdapter.ensure_ready()
+
+    on_exit(fn ->
+      started
+      |> Enum.reverse()
+      |> Enum.reject(&MapSet.member?(initially_started, &1))
+      |> Enum.each(&Application.stop/1)
+    end)
+  end
 
   describe "generate_object/4" do
     test "returns structured_output_not_supported for ollama" do
@@ -44,6 +68,57 @@ defmodule PtcRunner.LLM.ReqLLMAdapterTest do
   end
 
   describe "call/2" do
+    test "classifies a permanent ReqLLM HTTP failure and retains its provider message" do
+      provider_message = "Grok 4 Fast is deprecated. xAI recommends switching to Grok 4.3"
+
+      assert {:error,
+              %ProviderError{
+                kind: :not_found,
+                details: details,
+                retryable?: false
+              }} =
+               call_http_failure(404, provider_message)
+
+      assert details =~ "HTTP 404"
+      assert details =~ provider_message
+      refute details =~ "private prompt sentinel"
+    end
+
+    test "derives retryability from the HTTP status when ReqLLM does not classify it" do
+      cases = [
+        {400, :invalid_request, false},
+        {401, :authentication_failed, false},
+        {403, :denied, false},
+        {408, :timeout, true},
+        {409, :invalid_request, true},
+        {425, :invalid_request, true},
+        {429, :unavailable, true},
+        {503, :unavailable, true}
+      ]
+
+      for {status, kind, retryable?} <- cases do
+        assert {:error,
+                %ProviderError{
+                  kind: ^kind,
+                  details: details,
+                  retryable?: ^retryable?
+                }} = call_http_failure(status, "provider failure #{status}")
+
+        assert details =~ "HTTP #{status}"
+        assert details =~ "provider failure #{status}"
+      end
+    end
+
+    test "classifies a wrapped ReqLLM transport timeout as retryable" do
+      plug = fn conn -> Req.Test.transport_error(conn, :timeout) end
+
+      assert {:error,
+              %ProviderError{
+                kind: :timeout,
+                retryable?: true
+              }} = ReqLLMAdapter.call(@openrouter_model, request(plug))
+    end
+
     test "routes schema mode to generate_object for ollama" do
       req = %{
         system: "You are helpful",
@@ -51,7 +126,12 @@ defmodule PtcRunner.LLM.ReqLLMAdapterTest do
         schema: %{"type" => "object", "properties" => %{"a" => %{"type" => "string"}}}
       }
 
-      assert {:error, :structured_output_not_supported} = ReqLLMAdapter.call("ollama:test", req)
+      assert {:error,
+              %ProviderError{
+                kind: :invalid_request,
+                details: "LLM provider does not support structured output",
+                retryable?: false
+              }} = ReqLLMAdapter.call("ollama:test", req)
     end
 
     test "routes text mode to generate_text" do
@@ -61,8 +141,66 @@ defmodule PtcRunner.LLM.ReqLLMAdapterTest do
         cache: false
       }
 
-      # Will fail with connection error for ollama, confirming routing to generate_text
-      assert {:error, _} = ReqLLMAdapter.call("ollama:test", req)
+      # A contained connection failure confirms routing to generate_text and
+      # classification at the adapter boundary.
+      assert {:error, %ProviderError{}} = ReqLLMAdapter.call("ollama:test", req)
+    end
+  end
+
+  describe "private inspection" do
+    test "records the classified provider message instead of the generic fallback" do
+      provider_message = "Grok 4 Fast is deprecated. xAI recommends switching to Grok 4.3"
+
+      plug = fn conn ->
+        conn
+        |> Plug.Conn.put_status(404)
+        |> Req.Test.json(%{"error" => %{"message" => provider_message, "code" => 404}})
+      end
+
+      requester = fn request ->
+        request
+        |> ProviderRegistry.adapter_request()
+        |> Map.merge(provider_options(plug))
+        |> then(&ReqLLMAdapter.call(@openrouter_model, &1))
+      end
+
+      {:ok, capability} = LLMCapability.new(requester: requester)
+      {:ok, environment} = WorkflowEnvironment.new(capabilities: [capability])
+      {:ok, state} = RunState.start(Limits.defaults())
+
+      {:ok, inspection_sink} =
+        InspectionSink.start(run_id: "llm-provider-error", trace_id: "llm-provider-error-trace")
+
+      assert %{
+               status: :error,
+               kind: :provider_error,
+               reason: :not_found,
+               details: details,
+               retryable?: false
+             } =
+               Dispatcher.dispatch(
+                 state,
+                 :workflow,
+                 environment,
+                 capability.name,
+                 %{
+                   "messages" => [
+                     %{"role" => "user", "content" => "private prompt sentinel"}
+                   ]
+                 },
+                 TestHelpers.dispatch_context(state, :workflow, 1_000),
+                 nil,
+                 inspection_sink
+               )
+
+      assert details =~ provider_message
+      assert {:ok, records} = InspectionSink.records(inspection_sink)
+
+      assert Enum.any?(records, fn record ->
+               record["record_type"] == "capability-output" and
+                 get_in(record, ["payload", "result", "details"]) == details and
+                 get_in(record, ["payload", "result", "retryable?"]) == false
+             end)
     end
   end
 
@@ -385,5 +523,32 @@ defmodule PtcRunner.LLM.ReqLLMAdapterTest do
                arguments: ~s|{"program":"(return 42)"}|
              }
     end
+  end
+
+  defp call_http_failure(status, message) do
+    plug = fn conn ->
+      conn
+      |> Plug.Conn.put_status(status)
+      |> Req.Test.json(%{"error" => %{"message" => message, "code" => status}})
+    end
+
+    ReqLLMAdapter.call(@openrouter_model, request(plug))
+  end
+
+  defp request(plug) do
+    Map.put(
+      provider_options(plug),
+      :messages,
+      [%{role: :user, content: "private prompt sentinel"}]
+    )
+  end
+
+  defp provider_options(plug) do
+    %{
+      api_key: "test-openrouter-key",
+      max_retries: 0,
+      max_tokens: 10,
+      req_http_options: [plug: plug, retry: false]
+    }
   end
 end


### PR DESCRIPTION
## Summary

- classify ReqLLM HTTP and transport failures into bounded `ProviderError` values at the adapter boundary
- preserve provider status and human-readable reason for private inspection without retaining request bodies, raw response bodies, headers, or causes
- derive retryability from ReqLLM's explicit classification or HTTP/transport semantics
- document the diagnostic boundary and add network-free ReqLLM integration coverage

## Root cause

`ReqLLMAdapter` returned `%ReqLLM.Error.API.Request{}` unchanged. `LLMCapability` only passes through `%ProviderError{}`, so every live ReqLLM failure fell into the generic `unavailable` / `retryable?: true` fallback.

Permanent 4xx failures—including deprecated models—are now non-retryable and diagnosable in private inspection. Transient statuses remain retryable.

The separate model-token-limit problem from the original issue remains tracked in #1404.

## Verification

- `mix test test/ptc_runner/llm/req_llm_adapter_test.exs --seed 638260`
- `MIX_ENV=dev mix docs --warnings-as-errors`
- `mix precommit`
- repository pre-push gate: 6,293 core tests, Credo, duplication, spec/conformance, Dialyzer, Viewer, packaging, and standalone release verification

Fixes #1327