### PR TITLE
feat(mcp): unify bounded pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Replaced eager `cap/collect-pages` with resumable `cap/fold-pages`, which
+  reduces pages into bounded caller state, preserves the next cursor at a page
+  bound, and rejects changed snapshots or cursor cycles. The bundled filesystem
+  MCP sample now uses the same signed, query-bound cursor envelope for listing,
+  path search, streaming text search, and exact UTF-8 file chunks. Its 0.2.0
+  disk-backed snapshot can traverse files above the former 1 MiB ceiling without
+  retaining file contents in the Node or BEAM heap.
+
 - Analysis and trace snapshot pagination now treats the caller's item limit as
   an upper bound and returns the largest prefix whose complete encoded and
   retained sizes fit the configured result ceiling. Large private model

--- a/docs/guides/building-agents.md
+++ b/docs/guides/building-agents.md
@@ -219,20 +219,22 @@ Prompt-visible wrappers make supported calls and return contracts clear:
 ```clojure
 (ns my.files "Mission access to the granted file root." {:visibility :prompt})
 
-(defn read-text
-  "Read one UTF-8 file beneath the configured root."
-  {:signature "(path :string) -> :string"}
-  [path]
-  (let [response (tool/workspace.read {"path" path})]
+(defn read-page
+  "Read one bounded UTF-8 page. Pass nil first, then next_cursor."
+  {:signature "(path :string, cursor :string?) -> :any"}
+  [path cursor]
+  (let [arguments (if cursor {"path" path "cursor" cursor} {"path" path})
+        response (tool/workspace.read arguments)]
     (if (= :ok (get response :status))
-      (str (str/join "\n"
-             (map #(get % "text") (get-in response [:value "lines"])))
-           "\n")
+      (get response :value)
       (fail response))))
 ```
 
 The signature validates the public function boundary. The capability still
 enforces its own schema, byte ceiling, timeout, quota, and environment grant.
+Concatenate each page's item `text` exactly, and pass `next_cursor` into the
+next call until it is nil. Do not collect an unbounded file into one evaluation;
+reduce pages into bounded state or resume in a later evaluation.
 
 ## Continue across turns
 
@@ -315,7 +317,7 @@ mix ptc run examples/kernel-tutorial/03-file-agent/ptc.json \
   --host-config examples/kernel-tutorial/ptc-host.json
 ```
 
-The model sees `tutorial.files/read-text`, not the host credential or an
+The model sees `tutorial.files/read-page`, not the host credential or an
 unrestricted filesystem. Add `--trace-dir DIRECTORY` for a sanitized trace,
 then inspect it with the fixed run-analysis profile described in
 [Running and debugging](running-and-debugging.md).

--- a/docs/guides/components-and-preludes.md
+++ b/docs/guides/components-and-preludes.md
@@ -103,6 +103,14 @@ Shipped components use the same dependency rules. For example:
 surface, so fixed profiles pin the complete resolved component list and must
 version public surface changes.
 
+`cap/fold-pages` is the single shipped traversal helper. It reduces page items
+into caller-owned bounded state, stops at `max_pages`, and returns the opaque
+`next_cursor` plus `snapshot_hash` needed to resume in another evaluation.
+Callers must keep the reducer state bounded; collecting every item merely moves
+the source-size heap problem into the accumulator. Cursor-cycle detection covers
+each bounded invocation; the helper deliberately does not retain an unbounded
+history across resumptions.
+
 [Building agents](building-agents.md) covers the `agent.core` loop and the
 `agent.prompt` policy seam these libraries provide.
 

--- a/docs/guides/host-configuration.md
+++ b/docs/guides/host-configuration.md
@@ -34,7 +34,7 @@ actions happen later during preflight and acquisition.
     },
     "workspace": {
       "source": "mcp",
-      "installation_revision": "filesystem-sample-0.1.0",
+      "installation_revision": "filesystem-sample-0.2.0",
       "transport": {
         "type": "stdio",
         "command": "node",

--- a/docs/plans/future/mcp-exact-resources.md
+++ b/docs/plans/future/mcp-exact-resources.md
@@ -19,10 +19,10 @@ application that consumes it.
 
 The 2026-07-29 audit rejected the slice:
 
-- `examples/viewer-demo` reads known files, but the mapped
+- `examples/viewer-demo` reads known files, but the mapped, cursor-paginated
   `read_text_file` tool already supplies every behavior the demo uses.
 - `examples/kernel-tutorial/03-file-agent` reads one known `brief.txt`, and its
-  mapped `read_text_file` tool already supplies the complete application
+  mapped, cursor-paginated `read_text_file` tool supplies the application
   behavior.
 - `examples/kernel-inspection-lab` exercises varied MCP tool/result exchanges;
   it has no resource-native requirement.

--- a/examples/kernel-inspection-lab/support/lab.exs
+++ b/examples/kernel-inspection-lab/support/lab.exs
@@ -205,7 +205,8 @@ defmodule PtcRunner.Examples.KernelInspectionLab do
           }
         },
         timeout_ms: 15_000,
-        max_result_bytes: 64_000
+        max_result_bytes: 64_000,
+        installation_revision: "filesystem-sample-0.2.0"
       )
 
     {:ok, registry} =

--- a/examples/kernel-tutorial/03-file-agent/files.clj
+++ b/examples/kernel-tutorial/03-file-agent/files.clj
@@ -1,10 +1,11 @@
 (ns tutorial.files "Mission-only access to the granted file root." {:visibility :prompt})
 
-(defn read-text
-  "Read one UTF-8 file beneath the configured mission root."
-  {:signature "(path :string) -> :string"}
-  [path]
-  (let [response (tool/workspace.read {"path" path})]
+(defn read-page
+  "Read one bounded page of a UTF-8 file. Pass nil first, then next_cursor."
+  {:signature "(path :string, cursor :string?) -> :any"}
+  [path cursor]
+  (let [arguments (if cursor {"path" path "cursor" cursor} {"path" path})
+        response (tool/workspace.read arguments)]
     (if (= :ok (get response :status))
-      (str (str/join "\n" (map #(get % "text") (get-in response [:value "lines"]))) "\n")
+      (get response :value)
       (fail response))))

--- a/examples/kernel-tutorial/03-file-agent/ptc.json
+++ b/examples/kernel-tutorial/03-file-agent/ptc.json
@@ -17,7 +17,7 @@
   },
   "input": {
     "value": {
-      "task": "Read brief.txt using (tutorial.files/read-text \"brief.txt\"). Return the exact file content as a string."
+      "task": "Read brief.txt with (tutorial.files/read-page \"brief.txt\" nil). Concatenate the text in items, following next_cursor with another read-page call until it is nil. Return the exact file content as a string."
     }
   },
   "providers": {

--- a/examples/kernel-tutorial/ptc-host.json
+++ b/examples/kernel-tutorial/ptc-host.json
@@ -33,7 +33,7 @@
           "effect": "read"
         }
       },
-      "installation_revision": "filesystem-sample-0.1.0",
+      "installation_revision": "filesystem-sample-0.2.0",
       "ceilings": {
         "timeout_ms": 15000,
         "max_catalog_tools": 8,

--- a/examples/mcp/filesystem/README.md
+++ b/examples/mcp/filesystem/README.md
@@ -7,21 +7,26 @@ deploy it.
 
 ## What it does
 
-Captures one host-supplied root into an immutable in-memory snapshot at
-startup, then answers five read-only tools from that snapshot. The filesystem
-is never read again, so a file that changes, appears, or disappears after
-capture cannot alter a result.
+Streams one host-supplied root into an immutable private disk snapshot at
+startup, then answers five read-only tools from that snapshot. File contents
+are not retained or capped in the Node heap. The source filesystem is never
+read again, so later changes cannot alter a result.
 
 | Tool | Returns |
 | --- | --- |
 | `list_directory` | Sorted, paginated entries directly under a relative prefix |
 | `search_files` | Sorted, paginated paths containing a literal substring |
-| `search_text` | Literal matches with path and line evidence |
-| `read_text_file` | A bounded UTF-8 line range with stable line numbers and explicit end-of-file |
+| `search_text` | Paginated literal matches with path and line evidence |
+| `read_text_file` | Paginated exact UTF-8 byte chunks |
 | `snapshot_info` | Content hash and inventory statistics, never the host root |
 
-Every data-bearing result carries the same `snapshot_hash`, so a citation binds
-to the exact bytes queried.
+All four data tools accept optional `cursor` and `limit` arguments and return
+exactly `snapshot_hash`, `items`, and `next_cursor`. Start without a cursor and
+follow the opaque `next_cursor` until it is null. Cursors are bound to the
+snapshot, tool, and query/path arguments; replay in another traversal fails.
+For `read_text_file`, concatenating item `text` reconstructs the file exactly.
+Every page carries the same `snapshot_hash`, so a citation binds to the bytes
+actually queried.
 
 ## Why it freezes
 
@@ -34,9 +39,8 @@ never requires otherwise. This sample freezes for three reasons of its own:
 - **A hashable set of bytes.** A digest can only cover a bounded capture, never
   "the filesystem". Freezing is what makes a content identity possible, not a
   consequence of having one.
-- **No races to defend against.** A capture that is never read twice cannot be
-  raced by a file that changes, appears, or disappears mid-run, so the
-  confinement rules below need no time-of-check logic.
+- **Bounded runtime memory.** Startup and queries use fixed-size buffers; file
+  size consumes private temporary disk rather than Node or BEAM heap.
 
 ## Publishing the content identity
 
@@ -68,7 +72,8 @@ node dist/server.js --root ./workspace --include 'lib/**' --include 'docs/**' --
 `--include` is mandatory and repeatable; the default is **no files**, so a
 server started without it exposes nothing. `--exclude` may only narrow what the
 includes selected. Excluded paths are skipped before any stat or open, so they
-are never inventoried.
+are never inventoried. Optional `--max-file-bytes` and `--max-total-bytes`
+positive-integer limits can reduce the capture budget for a deployment.
 
 ## Confinement
 
@@ -77,12 +82,27 @@ are never inventoried.
 - Symbolic links are skipped, not followed, so a link inside the root cannot
   reach bytes outside it.
 - Non-regular files and files that are not valid UTF-8 are not captured.
-- File count, per-file bytes, aggregate bytes, and directory depth are bounded
-  at startup; results are bounded per page, per match set, and per byte budget.
+- File count, directory depth, visited directories, and visited entries are
+  bounded at startup. Exceeding a bound fails instead of publishing a partial
+  snapshot. File bytes are streamed to private temporary disk. By default the
+  byte ceiling is the available temporary-volume capacity minus a 64 MiB safety
+  reserve; the command-line limits above can lower it. There is no fixed 1 MiB
+  per-file ceiling.
+- Results are fitted against the full decoded MCP result, and text search also
+  has a scan-byte budget. An empty search page can therefore carry a progress
+  cursor when a sparse file requires more scanning.
 - Errors are short actionable text — no stacktraces, no host paths.
 - Nothing is written, no subprocess or network is used, and no Roots, Sampling,
   Logging, MRTR, or Tasks capability is advertised.
 - stdout carries protocol messages only; diagnostics go to stderr.
+
+The selected root must be trusted and quiescent while startup capture runs.
+Portable Node path APIs cannot descriptor-confine every ancestor against a
+privileged actor swapping directories during that short window. The server
+rejects observed symlinks and uses a no-follow final open where supported; it
+does not claim to defend an actively hostile source root. Graceful close and
+catchable signals remove the temporary snapshot. `SIGKILL`, native crash, or
+power loss can leave an operating-system temporary-directory orphan.
 
 ## Building and testing
 

--- a/examples/mcp/filesystem/dist/server.js
+++ b/examples/mcp/filesystem/dist/server.js
@@ -4,6 +4,12 @@ var __export = (target, all) => {
     __defProp(target, name, { get: all[name], enumerable: true });
 };
 
+// src/server.ts
+import { createHash as createHash2, createHmac, randomBytes, timingSafeEqual } from "node:crypto";
+import { closeSync as closeSync2, openSync as openSync2, readSync as readSync2 } from "node:fs";
+import { resolve as resolve2 } from "node:path";
+import { fileURLToPath } from "node:url";
+
 // node_modules/@modelcontextprotocol/server/dist/chunk-Br0eD_fh.mjs
 var __create = Object.create;
 var __defProp2 = Object.defineProperty;
@@ -10001,14 +10007,14 @@ function inputRequiredRoundsExceededMessage(method, maxRounds) {
   return `Multi-round-trip request '${method}' still required input after ${maxRounds} rounds (inputRequired.maxRounds)`;
 }
 function sleep(ms, signal) {
-  return new Promise((resolve2, reject) => {
+  return new Promise((resolve3, reject) => {
     if (signal?.aborted) {
       reject(signal.reason instanceof SdkError ? signal.reason : new SdkError(SdkErrorCode.RequestTimeout, String(signal.reason)));
       return;
     }
     const timer = setTimeout(() => {
       signal?.removeEventListener("abort", onAbort);
-      resolve2();
+      resolve3();
     }, ms);
     const onAbort = () => {
       clearTimeout(timer);
@@ -10802,7 +10808,7 @@ var Protocol = class {
     const flowStartedAt = Date.now();
     let onAbort;
     let cleanupMessageId;
-    return new Promise((resolve2, reject) => {
+    return new Promise((resolve3, reject) => {
       const earlyReject = (error2) => {
         reject(error2);
       };
@@ -10870,7 +10876,7 @@ var Protocol = class {
         }
         if (decoded.kind === "invalid") return reject(decoded.error);
         if (decoded.kind === "input_required") {
-          if (options?.allowInputRequired === true) return resolve2(manualInputRequiredValue(decoded));
+          if (options?.allowInputRequired === true) return resolve3(manualInputRequiredValue(decoded));
           const flow = {
             codec,
             request,
@@ -10882,11 +10888,11 @@ var Protocol = class {
               params
             }, resultSchema, legOptions)
           };
-          return resolve2(this._resolveNonCompleteResult(decoded, flow));
+          return resolve3(this._resolveNonCompleteResult(decoded, flow));
         }
         const result = decoded.result;
         validateStandardSchema(resultSchema, result).then((parseResult) => {
-          if (parseResult.success) resolve2(parseResult.data);
+          if (parseResult.success) resolve3(parseResult.data);
           else reject(new SdkError(SdkErrorCode.InvalidResult, `Invalid result for ${request.method}: ${parseResult.error}`));
         }, reject);
       });
@@ -11621,9 +11627,9 @@ var require_codegen = /* @__PURE__ */ __commonJSMin(((exports) => {
       const rhs = this.rhs === void 0 ? "" : ` = ${this.rhs}`;
       return `${varKind} ${this.name}${rhs};` + _n;
     }
-    optimizeNames(names, constants) {
+    optimizeNames(names, constants2) {
       if (!names[this.name.str]) return;
-      if (this.rhs) this.rhs = optimizeExpr(this.rhs, names, constants);
+      if (this.rhs) this.rhs = optimizeExpr(this.rhs, names, constants2);
       return this;
     }
     get names() {
@@ -11640,9 +11646,9 @@ var require_codegen = /* @__PURE__ */ __commonJSMin(((exports) => {
     render({ _n }) {
       return `${this.lhs} = ${this.rhs};` + _n;
     }
-    optimizeNames(names, constants) {
+    optimizeNames(names, constants2) {
       if (this.lhs instanceof code_1.Name && !names[this.lhs.str] && !this.sideEffects) return;
-      this.rhs = optimizeExpr(this.rhs, names, constants);
+      this.rhs = optimizeExpr(this.rhs, names, constants2);
       return this;
     }
     get names() {
@@ -11701,8 +11707,8 @@ var require_codegen = /* @__PURE__ */ __commonJSMin(((exports) => {
     optimizeNodes() {
       return `${this.code}` ? this : void 0;
     }
-    optimizeNames(names, constants) {
-      this.code = optimizeExpr(this.code, names, constants);
+    optimizeNames(names, constants2) {
+      this.code = optimizeExpr(this.code, names, constants2);
       return this;
     }
     get names() {
@@ -11728,12 +11734,12 @@ var require_codegen = /* @__PURE__ */ __commonJSMin(((exports) => {
       }
       return nodes.length > 0 ? this : void 0;
     }
-    optimizeNames(names, constants) {
+    optimizeNames(names, constants2) {
       const { nodes } = this;
       let i = nodes.length;
       while (i--) {
         const n = nodes[i];
-        if (n.optimizeNames(names, constants)) continue;
+        if (n.optimizeNames(names, constants2)) continue;
         subtractNames(names, n.names);
         nodes.splice(i, 1);
       }
@@ -11780,11 +11786,11 @@ var require_codegen = /* @__PURE__ */ __commonJSMin(((exports) => {
       if (cond === false || !this.nodes.length) return void 0;
       return this;
     }
-    optimizeNames(names, constants) {
+    optimizeNames(names, constants2) {
       var _a3;
-      this.else = (_a3 = this.else) === null || _a3 === void 0 ? void 0 : _a3.optimizeNames(names, constants);
-      if (!(super.optimizeNames(names, constants) || this.else)) return;
-      this.condition = optimizeExpr(this.condition, names, constants);
+      this.else = (_a3 = this.else) === null || _a3 === void 0 ? void 0 : _a3.optimizeNames(names, constants2);
+      if (!(super.optimizeNames(names, constants2) || this.else)) return;
+      this.condition = optimizeExpr(this.condition, names, constants2);
       return this;
     }
     get names() {
@@ -11806,9 +11812,9 @@ var require_codegen = /* @__PURE__ */ __commonJSMin(((exports) => {
     render(opts) {
       return `for(${this.iteration})` + super.render(opts);
     }
-    optimizeNames(names, constants) {
-      if (!super.optimizeNames(names, constants)) return;
-      this.iteration = optimizeExpr(this.iteration, names, constants);
+    optimizeNames(names, constants2) {
+      if (!super.optimizeNames(names, constants2)) return;
+      this.iteration = optimizeExpr(this.iteration, names, constants2);
       return this;
     }
     get names() {
@@ -11843,9 +11849,9 @@ var require_codegen = /* @__PURE__ */ __commonJSMin(((exports) => {
     render(opts) {
       return `for(${this.varKind} ${this.name} ${this.loop} ${this.iterable})` + super.render(opts);
     }
-    optimizeNames(names, constants) {
-      if (!super.optimizeNames(names, constants)) return;
-      this.iterable = optimizeExpr(this.iterable, names, constants);
+    optimizeNames(names, constants2) {
+      if (!super.optimizeNames(names, constants2)) return;
+      this.iterable = optimizeExpr(this.iterable, names, constants2);
       return this;
     }
     get names() {
@@ -11884,11 +11890,11 @@ var require_codegen = /* @__PURE__ */ __commonJSMin(((exports) => {
       (_b = this.finally) === null || _b === void 0 || _b.optimizeNodes();
       return this;
     }
-    optimizeNames(names, constants) {
+    optimizeNames(names, constants2) {
       var _a3, _b;
-      super.optimizeNames(names, constants);
-      (_a3 = this.catch) === null || _a3 === void 0 || _a3.optimizeNames(names, constants);
-      (_b = this.finally) === null || _b === void 0 || _b.optimizeNames(names, constants);
+      super.optimizeNames(names, constants2);
+      (_a3 = this.catch) === null || _a3 === void 0 || _a3.optimizeNames(names, constants2);
+      (_b = this.finally) === null || _b === void 0 || _b.optimizeNames(names, constants2);
       return this;
     }
     get names() {
@@ -12137,7 +12143,7 @@ var require_codegen = /* @__PURE__ */ __commonJSMin(((exports) => {
   function addExprNames(names, from) {
     return from instanceof code_1._CodeOrName ? addNames(names, from.names) : names;
   }
-  function optimizeExpr(expr, names, constants) {
+  function optimizeExpr(expr, names, constants2) {
     if (expr instanceof code_1.Name) return replaceName(expr);
     if (!canOptimize(expr)) return expr;
     return new code_1._Code(expr._items.reduce((items, c) => {
@@ -12147,13 +12153,13 @@ var require_codegen = /* @__PURE__ */ __commonJSMin(((exports) => {
       return items;
     }, []));
     function replaceName(n) {
-      const c = constants[n.str];
+      const c = constants2[n.str];
       if (c === void 0 || names[n.str] !== 1) return n;
       delete names[n.str];
       return c;
     }
     function canOptimize(e) {
-      return e instanceof code_1._Code && e._items.some((c) => c instanceof code_1.Name && names[c.str] === 1 && constants[c.str] !== void 0);
+      return e instanceof code_1._Code && e._items.some((c) => c instanceof code_1.Name && names[c.str] === 1 && constants2[c.str] !== void 0);
     }
   }
   function subtractNames(names, from) {
@@ -13813,7 +13819,7 @@ var require_compile = /* @__PURE__ */ __commonJSMin(((exports) => {
     ref = (0, resolve_1.resolveUrl)(this.opts.uriResolver, baseId, ref);
     const schOrFunc = root.refs[ref];
     if (schOrFunc) return schOrFunc;
-    let _sch = resolve2.call(this, root, ref);
+    let _sch = resolve3.call(this, root, ref);
     if (_sch === void 0) {
       const schema = (_a3 = root.localRefs) === null || _a3 === void 0 ? void 0 : _a3[ref];
       const { schemaId } = this.opts;
@@ -13839,7 +13845,7 @@ var require_compile = /* @__PURE__ */ __commonJSMin(((exports) => {
   function sameSchemaEnv(s1, s2) {
     return s1.schema === s2.schema && s1.root === s2.root && s1.baseId === s2.baseId;
   }
-  function resolve2(root, ref) {
+  function resolve3(root, ref) {
     let sch;
     while (typeof (sch = this.refs[ref]) == "string") ref = sch;
     return sch || this.schemas[ref] || resolveSchema.call(this, root, ref);
@@ -14289,7 +14295,7 @@ var require_fast_uri = /* @__PURE__ */ __commonJSMin(((exports, module) => {
     else if (typeof uri === "object") uri = parse3(serialize(uri, options), options);
     return uri;
   }
-  function resolve2(baseURI, relativeURI, options) {
+  function resolve3(baseURI, relativeURI, options) {
     const schemelessOptions = options ? Object.assign({ scheme: "null" }, options) : { scheme: "null" };
     const resolved = resolveComponent(parse3(baseURI, schemelessOptions), parse3(relativeURI, schemelessOptions), schemelessOptions, true);
     schemelessOptions.skipEscape = true;
@@ -14463,7 +14469,7 @@ var require_fast_uri = /* @__PURE__ */ __commonJSMin(((exports, module) => {
   const fastUri = {
     SCHEMES,
     normalize,
-    resolve: resolve2,
+    resolve: resolve3,
     resolveComponent,
     equal,
     serialize,
@@ -19424,7 +19430,7 @@ var StdioServerTransport = class {
   }
   send(message) {
     if (this._closed) return Promise.reject(/* @__PURE__ */ new Error("StdioServerTransport is closed"));
-    return new Promise((resolve2, reject) => {
+    return new Promise((resolve3, reject) => {
       const json = serializeMessage(message);
       let settled = false;
       const onError = (error2) => {
@@ -19439,14 +19445,14 @@ var StdioServerTransport = class {
         settled = true;
         this._stdout.off("error", onError);
         this._stdout.off("drain", onDrain);
-        resolve2();
+        resolve3();
       };
       this._stdout.once("error", onError);
       if (this._stdout.write(json)) {
         if (settled) return;
         settled = true;
         this._stdout.off("error", onError);
-        resolve2();
+        resolve3();
       } else if (!settled) this._stdout.once("drain", onDrain);
     });
   }
@@ -19500,14 +19506,14 @@ var StdioConnectionChannel = class {
   */
   async whenRequestsAnswered(timeoutMs) {
     if (this._closed || this._pendingRequests.size === 0) return true;
-    return await new Promise((resolve2) => {
+    return await new Promise((resolve3) => {
       const waiter = () => {
         clearTimeout(timer);
-        resolve2(true);
+        resolve3(true);
       };
       const timer = setTimeout(() => {
         this._drainWaiters = this._drainWaiters.filter((pending) => pending !== waiter);
-        resolve2(false);
+        resolve3(false);
       }, timeoutMs);
       this._drainWaiters.push(waiter);
     });
@@ -19848,84 +19854,171 @@ function toError(value) {
 
 // src/snapshot.ts
 import { createHash } from "node:crypto";
-import { lstatSync, readdirSync, readFileSync } from "node:fs";
+import {
+  closeSync,
+  constants,
+  fstatSync,
+  lstatSync,
+  mkdtempSync,
+  openSync,
+  opendirSync,
+  readSync,
+  rmSync,
+  statfsSync,
+  writeSync
+} from "node:fs";
+import { tmpdir } from "node:os";
 import { join, relative, resolve, sep } from "node:path";
 var DEFAULT_LIMITS = {
   maxFiles: 4096,
-  maxFileBytes: 1048576,
-  maxTotalBytes: 33554432,
-  maxDepth: 32
+  maxDepth: 32,
+  maxDirectories: 8192,
+  maxEntries: 1e5,
+  maxFileBytes: Number.MAX_SAFE_INTEGER,
+  maxTotalBytes: Number.MAX_SAFE_INTEGER
 };
+var COPY_BUFFER_BYTES = 65536;
+var TEMP_DISK_RESERVE_BYTES = 64n * 1024n * 1024n;
 var CaptureError = class extends Error {
 };
 function capture(options) {
-  if (options.include.length === 0) {
-    throw new CaptureError("at least one include pattern is required");
-  }
+  if (options.include.length === 0) throw new CaptureError("at least one include pattern is required");
   const limits = { ...DEFAULT_LIMITS, ...options.limits };
+  validateLimits(limits);
   const root = resolve(options.root);
   const rootStat = statOrThrow(root, "root");
-  if (!rootStat.isDirectory()) {
-    throw new CaptureError("root is not a directory");
-  }
+  if (!rootStat.isDirectory()) throw new CaptureError("root is not a directory");
   const include = options.include.map(compileGlob);
   const exclude = (options.exclude ?? []).map(compileGlob);
+  const maxTotalBytes = Math.min(limits.maxTotalBytes, availableSnapshotBytes(tmpdir()));
+  const maxFileBytes = Math.min(limits.maxFileBytes, maxTotalBytes);
+  const snapshotRoot = mkdtempSync(join(tmpdir(), "ptc-runner-filesystem-"));
   const files = /* @__PURE__ */ new Map();
-  const truncated = { files: false, bytes: false, depth: false };
   let totalBytes = 0;
+  let visitedDirectories = 0;
+  let visitedEntries = 0;
+  let cleaned = false;
+  const cleanup = () => {
+    if (cleaned) return;
+    cleaned = true;
+    rmSync(snapshotRoot, { recursive: true, force: true });
+  };
   const walk = (directory, prefix, depth) => {
-    if (depth > limits.maxDepth) {
-      truncated.depth = true;
-      return;
-    }
-    for (const entry of readdirSync(directory).sort()) {
-      if (files.size >= limits.maxFiles) {
-        truncated.files = true;
-        return;
+    if (depth > limits.maxDepth) throw new CaptureError("directory depth limit exceeded");
+    visitedDirectories += 1;
+    if (visitedDirectories > limits.maxDirectories) throw new CaptureError("directory limit exceeded");
+    const entries = opendirSync(directory);
+    try {
+      for (let entry = entries.readSync(); entry !== null; entry = entries.readSync()) {
+        visitedEntries += 1;
+        if (visitedEntries > limits.maxEntries) throw new CaptureError("directory entry limit exceeded");
+        const relativePath = prefix === "" ? entry.name : `${prefix}/${entry.name}`;
+        if (normalizeRelative(relativePath) === null) {
+          throw new CaptureError("path exceeds the supported relative-path contract");
+        }
+        if (matchesAny(relativePath, exclude)) continue;
+        const absolute = join(directory, entry.name);
+        const stat = lstatSync(absolute, { throwIfNoEntry: false });
+        if (!stat || stat.isSymbolicLink()) continue;
+        if (stat.isDirectory()) {
+          walk(absolute, relativePath, depth + 1);
+          continue;
+        }
+        if (!stat.isFile() || !matchesAny(relativePath, include)) continue;
+        if (files.size >= limits.maxFiles) throw new CaptureError("file limit exceeded");
+        const captured = captureFile(
+          absolute,
+          join(snapshotRoot, String(files.size)),
+          Math.min(maxFileBytes, maxTotalBytes - totalBytes)
+        );
+        if (captured === null) continue;
+        files.set(relativePath, captured);
+        totalBytes += captured.bytes;
       }
-      const absolute = join(directory, entry);
-      const relativePath = prefix === "" ? entry : `${prefix}/${entry}`;
-      if (matchesAny(relativePath, exclude)) continue;
-      const stat = lstatSync(absolute, { throwIfNoEntry: false });
-      if (!stat) continue;
-      if (stat.isSymbolicLink()) continue;
-      if (stat.isDirectory()) {
-        walk(absolute, relativePath, depth + 1);
-        continue;
-      }
-      if (!stat.isFile()) continue;
-      if (!matchesAny(relativePath, include)) continue;
-      if (stat.size > limits.maxFileBytes) continue;
-      if (totalBytes + stat.size > limits.maxTotalBytes) {
-        truncated.bytes = true;
-        return;
-      }
-      const raw = readFileSync(absolute);
-      const text = raw.toString("utf8");
-      if (!Buffer.from(text, "utf8").equals(raw)) continue;
-      totalBytes += stat.size;
-      files.set(relativePath, { lines: splitLines(text), bytes: stat.size });
+    } finally {
+      entries.closeSync();
     }
   };
-  walk(root, "", 0);
-  const paths = [...files.keys()].sort();
-  return { paths, files, hash: hashOf(paths, files), totalBytes, truncated };
+  try {
+    walk(root, "", 0);
+    const paths = [...files.keys()].sort();
+    return {
+      paths,
+      files,
+      hash: hashOf(paths, files),
+      totalBytes,
+      truncated: { files: false, depth: false },
+      cleanup
+    };
+  } catch (error2) {
+    cleanup();
+    if (error2 instanceof CaptureError) throw error2;
+    throw new CaptureError("capture failed");
+  }
+}
+function captureFile(sourcePath, snapshotPath, maxBytes) {
+  const noFollow = typeof constants.O_NOFOLLOW === "number" ? constants.O_NOFOLLOW : 0;
+  let source;
+  let target;
+  try {
+    try {
+      source = openSync(sourcePath, constants.O_RDONLY | noFollow);
+      const before = fstatSync(source);
+      if (!before.isFile()) return null;
+      if (before.size > maxBytes) throw new CaptureError("snapshot byte limit exceeded");
+      target = openSync(snapshotPath, constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL, 384);
+      const digest = createHash("sha256");
+      const decoder = new TextDecoder("utf-8", { fatal: true });
+      const buffer = Buffer.allocUnsafe(COPY_BUFFER_BYTES);
+      let bytes = 0;
+      for (let count = readSync(source, buffer, 0, buffer.length, null); count > 0; ) {
+        if (bytes + count > maxBytes) throw new CaptureError("snapshot byte limit exceeded");
+        const chunk = buffer.subarray(0, count);
+        decoder.decode(chunk, { stream: true });
+        digest.update(chunk);
+        writeAll(target, chunk);
+        bytes += count;
+        count = readSync(source, buffer, 0, buffer.length, null);
+      }
+      decoder.decode();
+      const after = fstatSync(source);
+      if (after.size !== before.size || after.mtimeMs !== before.mtimeMs || bytes !== after.size) {
+        throw new CaptureError("source changed during capture");
+      }
+      return { snapshotPath, bytes, contentHash: digest.digest("hex") };
+    } finally {
+      if (target !== void 0) closeSync(target);
+      if (source !== void 0) closeSync(source);
+    }
+  } catch (error2) {
+    rmSync(snapshotPath, { force: true });
+    if (error2 instanceof TypeError) return null;
+    throw error2;
+  }
+}
+function validateLimits(limits) {
+  const positive = [limits.maxFiles, limits.maxDirectories, limits.maxEntries, limits.maxFileBytes, limits.maxTotalBytes];
+  if (positive.some((value) => !Number.isSafeInteger(value) || value < 1) || !Number.isSafeInteger(limits.maxDepth) || limits.maxDepth < 0) {
+    throw new CaptureError("capture limits are not valid");
+  }
+}
+function availableSnapshotBytes(path) {
+  const stat = statfsSync(path, { bigint: true });
+  const available = stat.bavail * stat.bsize;
+  const usable = available > TEMP_DISK_RESERVE_BYTES ? available - TEMP_DISK_RESERVE_BYTES : 0n;
+  return Number(usable > BigInt(Number.MAX_SAFE_INTEGER) ? BigInt(Number.MAX_SAFE_INTEGER) : usable);
+}
+function writeAll(descriptor, bytes) {
+  let offset = 0;
+  while (offset < bytes.length) offset += writeSync(descriptor, bytes, offset, bytes.length - offset);
 }
 function normalizeRelative(value) {
   if (value === "") return "";
-  if (value.includes("\0")) return null;
-  if (value.startsWith("/") || value.includes("\\")) return null;
-  if (value.length > 1024) return null;
-  if (/^[a-zA-Z]:/.test(value)) return null;
+  if (value.includes("\0") || value.startsWith("/") || value.includes("\\")) return null;
+  if (value.length > 1024 || /^[a-zA-Z]:/.test(value)) return null;
   const segments = value.split("/").filter((segment) => segment !== "");
   if (segments.some((segment) => segment === "." || segment === "..")) return null;
   return segments.join("/");
-}
-function splitLines(text) {
-  const normalized = text.replace(/\r\n/g, "\n");
-  const lines = normalized.split("\n");
-  if (lines.length > 1 && lines[lines.length - 1] === "") lines.pop();
-  return lines;
 }
 function hashOf(paths, files) {
   const digest = createHash("sha256");
@@ -19935,7 +20028,7 @@ function hashOf(paths, files) {
     digest.update("\0");
     digest.update(String(file.bytes), "utf8");
     digest.update("\0");
-    digest.update(file.lines.join("\n"), "utf8");
+    digest.update(file.contentHash, "ascii");
     digest.update("\0");
   }
   return `sha256:${digest.digest("hex")}`;
@@ -19959,12 +20052,8 @@ function compileGlob(pattern) {
         if (pattern[index + 1] === "/") {
           index += 1;
           source += "(?:[^/]+/)*";
-        } else {
-          source += ".*";
-        }
-      } else {
-        source += "[^/]*";
-      }
+        } else source += ".*";
+      } else source += "[^/]*";
       continue;
     }
     if (character === "?") {
@@ -19978,11 +20067,23 @@ function compileGlob(pattern) {
 
 // src/server.ts
 var MAX_PAGE = 200;
-var MAX_MATCHES = 500;
-var MAX_READ_LINES = 2e3;
-var MAX_RESULT_BYTES = 262144;
+var MAX_READ_CHUNKS = 8;
+var READ_CHUNK_BYTES = 2048;
+var SEARCH_BUFFER_BYTES = 8192;
+var SEARCH_SCAN_BYTES = 262144;
+var MAX_QUERY_BYTES = 256;
+var MAX_EVIDENCE_BYTES = 1024;
+var MAX_LOGICAL_RESULT_BYTES = 48e3;
 var ToolError = class extends Error {
 };
+var cursorKeys = /* @__PURE__ */ new WeakMap();
+function cursorKey(snapshot) {
+  const existing = cursorKeys.get(snapshot);
+  if (existing) return existing;
+  const created = randomBytes(32);
+  cursorKeys.set(snapshot, created);
+  return created;
+}
 function parseArguments(argv) {
   const parsed = { root: "", include: [], exclude: [] };
   for (let index = 0; index < argv.length; index += 1) {
@@ -19992,33 +20093,70 @@ function parseArguments(argv) {
     if (flag === "--root") parsed.root = value;
     else if (flag === "--include") parsed.include.push(value);
     else if (flag === "--exclude") parsed.exclude.push(value);
+    else if (flag === "--max-file-bytes") parsed.maxFileBytes = positiveIntegerOption(value, flag);
+    else if (flag === "--max-total-bytes") parsed.maxTotalBytes = positiveIntegerOption(value, flag);
     else throw new Error(`unknown option ${flag}`);
     index += 1;
   }
   if (parsed.root === "") throw new Error("--root is required");
   return parsed;
 }
-function encodeCursor(hash, offset) {
-  return Buffer.from(`${hash}:${offset}`, "utf8").toString("base64url");
+function positiveIntegerOption(value, flag) {
+  if (!/^[1-9][0-9]*$/.test(value)) throw new Error(`${flag} must be a positive integer`);
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed)) throw new Error(`${flag} is too large`);
+  return parsed;
 }
-function decodeCursor(hash, cursor) {
-  if (cursor === void 0) return 0;
-  const decoded = Buffer.from(cursor, "base64url").toString("utf8");
-  const separator = decoded.lastIndexOf(":");
-  if (separator === -1) throw new ToolError("cursor is not valid");
-  if (decoded.slice(0, separator) !== hash) {
-    throw new ToolError("cursor was issued for a different snapshot");
+function scopeOf(tool, arguments_) {
+  return createHash2("sha256").update(tool).update("\0").update(JSON.stringify(arguments_)).digest("hex");
+}
+function encodeCursor(snapshot, scope, position) {
+  const payload = Buffer.from(JSON.stringify({ v: 1, h: snapshot.hash, s: scope, p: position }), "utf8").toString(
+    "base64url"
+  );
+  const signature = createHmac("sha256", cursorKey(snapshot)).update(payload, "ascii").digest("base64url");
+  return `${payload}.${signature}`;
+}
+function decodeCursor(snapshot, scope, cursor, validPosition, first) {
+  if (cursor === void 0) return first;
+  if (typeof cursor !== "string" || cursor === "" || cursor.length > 4096) {
+    throw new ToolError("cursor is not valid");
   }
-  const offset = Number(decoded.slice(separator + 1));
-  if (!Number.isSafeInteger(offset) || offset < 0) throw new ToolError("cursor is not valid");
-  return offset;
+  try {
+    const parts = cursor.split(".");
+    if (parts.length !== 2 || parts.some((part) => !/^[A-Za-z0-9_-]+$/.test(part))) {
+      throw new ToolError("cursor is not valid");
+    }
+    const [payload, encodedSignature] = parts;
+    const signature = Buffer.from(encodedSignature, "base64url");
+    const expected = createHmac("sha256", cursorKey(snapshot)).update(payload, "ascii").digest();
+    if (signature.length !== expected.length || !timingSafeEqual(signature, expected)) {
+      throw new ToolError("cursor is not valid");
+    }
+    const decoded = JSON.parse(Buffer.from(payload, "base64url").toString("utf8"));
+    if (decoded.v !== 1 || decoded.h !== snapshot.hash || decoded.s !== scope || !validPosition(decoded.p) || Object.keys(decoded).sort().join(",") !== "h,p,s,v") {
+      throw new ToolError("cursor was issued for a different traversal");
+    }
+    return decoded.p;
+  } catch (error2) {
+    if (error2 instanceof ToolError) throw error2;
+    throw new ToolError("cursor is not valid");
+  }
 }
-function boundedPage(limit) {
-  if (limit === void 0) return MAX_PAGE;
+function offsetPosition(value) {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
+}
+function searchPosition(snapshot, value) {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const position = value;
+  return Object.keys(position).sort().join(",") === "file,line,lineStart,matched,offset" && Number.isSafeInteger(position.file) && position.file >= 0 && position.file < snapshot.paths.length && Number.isSafeInteger(position.offset) && position.offset >= 0 && Number.isSafeInteger(position.lineStart) && position.lineStart >= 0 && position.lineStart <= position.offset && Number.isSafeInteger(position.line) && position.line >= 1 && typeof position.matched === "boolean";
+}
+function boundedPage(limit, maximum = MAX_PAGE) {
+  if (limit === void 0) return maximum;
   if (typeof limit !== "number" || !Number.isSafeInteger(limit) || limit < 1) {
     throw new ToolError("limit must be a positive integer");
   }
-  return Math.min(limit, MAX_PAGE);
+  return Math.min(limit, maximum);
 }
 function requirePath(value, field) {
   if (typeof value !== "string") throw new ToolError(`${field} must be a string`);
@@ -20026,17 +20164,15 @@ function requirePath(value, field) {
   if (normalized === null) throw new ToolError(`${field} is not a relative path inside the snapshot`);
   return normalized;
 }
-function page(snapshot, items, offset, limit) {
-  const slice = items.slice(offset, offset + limit);
-  const next = offset + slice.length;
-  return {
-    snapshot_hash: snapshot.hash,
-    items: slice,
-    next_cursor: next < items.length ? encodeCursor(snapshot.hash, next) : void 0
-  };
+function requireQuery(value) {
+  if (typeof value !== "string" || value === "") throw new ToolError("query must be a non-empty string");
+  const bytes = Buffer.byteLength(value, "utf8");
+  if (bytes > MAX_QUERY_BYTES || value.includes("\n") || value.includes("\r")) {
+    throw new ToolError("query must be one line of at most 256 UTF-8 bytes");
+  }
+  return value;
 }
 var HASH = { type: "string" };
-var CURSOR = { type: "string" };
 function pagedOutput(itemProperties) {
   return {
     type: "object",
@@ -20045,18 +20181,42 @@ function pagedOutput(itemProperties) {
       items: {
         type: "array",
         items: { type: "object", properties: itemProperties, additionalProperties: false }
-      },
-      next_cursor: CURSOR
+      }
     },
+    // PtcRunner's deliberately small frozen schema subset has no nullable
+    // union. The runtime value always includes next_cursor, including null at
+    // completion; descriptions document it while this validator permits it as
+    // the sole forward-compatible extra field.
     required: ["snapshot_hash", "items"],
     additionalProperties: true
   };
 }
+function pageValue(snapshot, scope, start, candidates, finalPosition) {
+  const kept = [...candidates];
+  let next = finalPosition;
+  while (true) {
+    const value = {
+      snapshot_hash: snapshot.hash,
+      items: kept.map((candidate) => candidate.item),
+      next_cursor: next === null ? null : encodeCursor(snapshot, scope, next)
+    };
+    if (logicalResultBytes(value) <= MAX_LOGICAL_RESULT_BYTES) return value;
+    const removed = kept.pop();
+    if (removed === void 0) throw new ToolError("one result item exceeds the result ceiling");
+    next = kept.length === 0 ? start : kept[kept.length - 1].position;
+  }
+}
+function arrayPage(snapshot, scope, items, offset, limit) {
+  if (offset > items.length) throw new ToolError("cursor position is not valid");
+  const end = Math.min(offset + limit, items.length);
+  const candidates = items.slice(offset, end).map((item, index) => ({ item, position: offset + index + 1 }));
+  return pageValue(snapshot, scope, offset, candidates, end < items.length ? end : null);
+}
 function createServer(snapshot) {
   const server = new McpServer(
-    { name: "ptc-runner-filesystem-sample", version: "0.1.0" },
+    { name: "ptc-runner-filesystem-sample", version: "0.2.0" },
     {
-      instructions: "Read-only access to an immutable snapshot captured at startup. Paths are relative; the filesystem is never re-read."
+      instructions: "Read-only access to an immutable disk-backed snapshot captured at startup. Paths are relative; source files are never re-read."
     }
   );
   const readOnly = { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false };
@@ -20065,7 +20225,7 @@ function createServer(snapshot) {
     "list_directory",
     {
       title: "List directory",
-      description: "Sorted, paginated entries directly under a relative prefix of the snapshot.",
+      description: "Sorted entries directly under a relative prefix. Follow next_cursor until null.",
       annotations: readOnly,
       _meta: meta2,
       outputSchema: fromJsonSchema2(
@@ -20073,63 +20233,56 @@ function createServer(snapshot) {
       ),
       inputSchema: fromJsonSchema2({
         type: "object",
-        properties: {
-          path: { type: "string", description: "Relative directory prefix; omit for the root." },
-          cursor: { type: "string" },
-          limit: { type: "integer", minimum: 1, maximum: MAX_PAGE }
-        },
+        properties: { path: { type: "string" }, cursor: { type: "string" }, limit: { type: "integer", minimum: 1 } },
         additionalProperties: false
       })
     },
     async (args) => {
       const prefix = args.path === void 0 ? "" : requirePath(args.path, "path");
-      const scope = prefix === "" ? "" : `${prefix}/`;
+      const traversalScope = scopeOf("list_directory", { path: prefix });
+      const offset = decodeCursor(snapshot, traversalScope, args.cursor, offsetPosition, 0);
+      const pathScope = prefix === "" ? "" : `${prefix}/`;
       const entries = /* @__PURE__ */ new Map();
       for (const path of snapshot.paths) {
-        if (!path.startsWith(scope)) continue;
-        const remainder = path.slice(scope.length);
+        if (!path.startsWith(pathScope)) continue;
+        const remainder = path.slice(pathScope.length);
+        if (remainder === "") continue;
         const separator = remainder.indexOf("/");
         if (separator === -1) entries.set(remainder, "file");
         else entries.set(remainder.slice(0, separator), "directory");
       }
-      const items = [...entries.entries()].sort(([left], [right]) => left < right ? -1 : left > right ? 1 : 0).map(([name, kind]) => ({ name, kind, path: scope + name }));
-      const limit = boundedPage(args.limit);
-      return structured(page(snapshot, items, decodeCursor(snapshot.hash, args.cursor), limit));
+      const items = [...entries.entries()].sort(([left], [right]) => left.localeCompare(right)).map(([name, kind]) => ({ name, kind, path: pathScope + name }));
+      return structured(arrayPage(snapshot, traversalScope, items, offset, boundedPage(args.limit)));
     }
   );
   server.registerTool(
     "search_files",
     {
       title: "Search files",
-      description: "Sorted, paginated snapshot paths matching a literal substring.",
+      description: "Sorted snapshot paths containing a literal substring. Follow next_cursor until null.",
       annotations: readOnly,
       _meta: meta2,
       outputSchema: fromJsonSchema2(pagedOutput({ path: { type: "string" } })),
       inputSchema: fromJsonSchema2({
         type: "object",
-        properties: {
-          query: { type: "string", minLength: 1 },
-          cursor: { type: "string" },
-          limit: { type: "integer", minimum: 1, maximum: MAX_PAGE }
-        },
+        properties: { query: { type: "string", minLength: 1 }, cursor: { type: "string" }, limit: { type: "integer", minimum: 1 } },
         required: ["query"],
         additionalProperties: false
       })
     },
     async (args) => {
-      if (typeof args.query !== "string" || args.query === "") {
-        throw new ToolError("query must be a non-empty string");
-      }
-      const items = snapshot.paths.filter((path) => path.includes(args.query)).map((path) => ({ path }));
-      const limit = boundedPage(args.limit);
-      return structured(page(snapshot, items, decodeCursor(snapshot.hash, args.cursor), limit));
+      const query = requireQuery(args.query);
+      const traversalScope = scopeOf("search_files", { query });
+      const offset = decodeCursor(snapshot, traversalScope, args.cursor, offsetPosition, 0);
+      const items = snapshot.paths.filter((path) => path.includes(query)).map((path) => ({ path }));
+      return structured(arrayPage(snapshot, traversalScope, items, offset, boundedPage(args.limit)));
     }
   );
   server.registerTool(
     "search_text",
     {
       title: "Search text",
-      description: "Literal text search returning path and line evidence.",
+      description: "Streaming literal line search. Empty progress pages may carry next_cursor; follow it until null.",
       annotations: readOnly,
       _meta: meta2,
       outputSchema: fromJsonSchema2(
@@ -20141,66 +20294,44 @@ function createServer(snapshot) {
           query: { type: "string", minLength: 1 },
           path: { type: "string" },
           cursor: { type: "string" },
-          limit: { type: "integer", minimum: 1, maximum: MAX_PAGE }
+          limit: { type: "integer", minimum: 1 }
         },
         required: ["query"],
         additionalProperties: false
       })
     },
     async (args) => {
-      if (typeof args.query !== "string" || args.query === "") {
-        throw new ToolError("query must be a non-empty string");
-      }
-      const scope = args.path === void 0 ? "" : requirePath(args.path, "path");
-      const matches = [];
-      for (const path of snapshot.paths) {
-        if (scope !== "" && path !== scope && !path.startsWith(`${scope}/`)) continue;
-        const file = snapshot.files.get(path);
-        file.lines.forEach((text, offset) => {
-          if (matches.length >= MAX_MATCHES) return;
-          if (!text.includes(args.query)) return;
-          matches.push({ path, line: offset + 1, text: text.slice(0, 1024) });
-        });
-        if (matches.length >= MAX_MATCHES) break;
-      }
-      const limit = boundedPage(args.limit);
-      const result = page(snapshot, matches, decodeCursor(snapshot.hash, args.cursor), limit);
-      return structured({ ...result, match_limit_reached: matches.length >= MAX_MATCHES });
+      const query = requireQuery(args.query);
+      const path = args.path === void 0 ? "" : requirePath(args.path, "path");
+      const traversalScope = scopeOf("search_text", { path, query });
+      const first = { file: 0, offset: 0, lineStart: 0, line: 1, matched: false };
+      const start = decodeCursor(
+        snapshot,
+        traversalScope,
+        args.cursor,
+        (value) => searchPosition(snapshot, value),
+        first
+      );
+      const result = snapshotIO(() => scanText(snapshot, path, query, start, boundedPage(args.limit)));
+      return structured(pageValue(snapshot, traversalScope, start, result.candidates, result.next));
     }
   );
   server.registerTool(
     "read_text_file",
     {
       title: "Read text file",
-      description: "One bounded UTF-8 line range with stable line numbers and explicit end-of-file.",
+      description: "Bounded exact UTF-8 chunks. Concatenate item text and follow next_cursor until null.",
       annotations: readOnly,
       _meta: meta2,
-      outputSchema: fromJsonSchema2({
-        type: "object",
-        properties: {
-          snapshot_hash: HASH,
-          path: { type: "string" },
-          lines: {
-            type: "array",
-            items: {
-              type: "object",
-              properties: { line: { type: "integer" }, text: { type: "string" } },
-              additionalProperties: false
-            }
-          },
-          total_lines: { type: "integer" },
-          end_of_file: { type: "boolean" },
-          truncated: { type: "boolean" }
-        },
-        required: ["snapshot_hash", "path", "lines", "total_lines", "end_of_file", "truncated"],
-        additionalProperties: false
-      }),
+      outputSchema: fromJsonSchema2(
+        pagedOutput({ byte_offset: { type: "integer" }, text: { type: "string" } })
+      ),
       inputSchema: fromJsonSchema2({
         type: "object",
         properties: {
           path: { type: "string", minLength: 1 },
-          start_line: { type: "integer", minimum: 1 },
-          line_count: { type: "integer", minimum: 1, maximum: MAX_READ_LINES }
+          cursor: { type: "string" },
+          limit: { type: "integer", minimum: 1, maximum: MAX_READ_CHUNKS }
         },
         required: ["path"],
         additionalProperties: false
@@ -20210,33 +20341,11 @@ function createServer(snapshot) {
       const path = requirePath(args.path, "path");
       const file = snapshot.files.get(path);
       if (!file) throw new ToolError("path is not part of the snapshot");
-      const start = args.start_line === void 0 ? 1 : Number(args.start_line);
-      if (!Number.isSafeInteger(start) || start < 1) throw new ToolError("start_line must be a positive integer");
-      const requested = args.line_count === void 0 ? MAX_READ_LINES : Number(args.line_count);
-      if (!Number.isSafeInteger(requested) || requested < 1) {
-        throw new ToolError("line_count must be a positive integer");
-      }
-      const count = Math.min(requested, MAX_READ_LINES);
-      const selected = file.lines.slice(start - 1, start - 1 + count);
-      let bytes = 0;
-      let truncated = false;
-      const lines = [];
-      for (const [offset, text] of selected.entries()) {
-        bytes += Buffer.byteLength(text, "utf8") + 1;
-        if (bytes > MAX_RESULT_BYTES) {
-          truncated = true;
-          break;
-        }
-        lines.push({ line: start + offset, text });
-      }
-      return structured({
-        snapshot_hash: snapshot.hash,
-        path,
-        lines,
-        total_lines: file.lines.length,
-        end_of_file: !truncated && start - 1 + selected.length >= file.lines.length,
-        truncated
-      });
+      const traversalScope = scopeOf("read_text_file", { path });
+      const offset = decodeCursor(snapshot, traversalScope, args.cursor, offsetPosition, 0);
+      return structured(
+        snapshotIO(() => readPage(snapshot, file, traversalScope, offset, boundedPage(args.limit, MAX_READ_CHUNKS)))
+      );
     }
   );
   server.registerTool(
@@ -20254,7 +20363,7 @@ function createServer(snapshot) {
           total_bytes: { type: "integer" },
           truncated: {
             type: "object",
-            properties: { files: { type: "boolean" }, bytes: { type: "boolean" }, depth: { type: "boolean" } },
+            properties: { files: { type: "boolean" }, depth: { type: "boolean" } },
             additionalProperties: false
           }
         },
@@ -20263,7 +20372,6 @@ function createServer(snapshot) {
       }),
       inputSchema: fromJsonSchema2({ type: "object", properties: {}, additionalProperties: false })
     },
-    // Deliberately reports no root, no host path, and no absolute location.
     async () => structured({
       snapshot_hash: snapshot.hash,
       file_count: snapshot.paths.length,
@@ -20273,19 +20381,191 @@ function createServer(snapshot) {
   );
   return server;
 }
-function structured(value) {
-  return {
-    content: [{ type: "text", text: JSON.stringify(value) }],
-    structuredContent: value
-  };
+function readPage(snapshot, file, scope, offset, limit) {
+  if (offset > file.bytes) throw new ToolError("cursor position is not valid");
+  const descriptor = openSync2(file.snapshotPath, "r");
+  const candidates = [];
+  let position = offset;
+  try {
+    while (position < file.bytes && candidates.length < limit) {
+      const requested = Math.min(READ_CHUNK_BYTES, file.bytes - position);
+      const buffer = Buffer.allocUnsafe(requested);
+      const count = readSync2(descriptor, buffer, 0, requested, position);
+      if (count <= 0) throw new ToolError("snapshot read failed");
+      const bytes = buffer.subarray(0, count);
+      const safeLength = position + count === file.bytes ? count : validUtf8Prefix(bytes);
+      if (safeLength <= 0) throw new ToolError("snapshot UTF-8 boundary is invalid");
+      const next = position + safeLength;
+      candidates.push({ item: { byte_offset: position, text: bytes.subarray(0, safeLength).toString("utf8") }, position: next });
+      position = next;
+    }
+  } finally {
+    closeSync2(descriptor);
+  }
+  return pageValue(snapshot, scope, offset, candidates, position < file.bytes ? position : null);
 }
-var isEntryPoint = process.argv[1] !== void 0;
+function validUtf8Prefix(bytes) {
+  for (let length = bytes.length; length >= Math.max(bytes.length - 3, 0); length -= 1) {
+    try {
+      new TextDecoder("utf-8", { fatal: true }).decode(bytes.subarray(0, length));
+      return length;
+    } catch {
+    }
+  }
+  return 0;
+}
+function scanText(snapshot, pathScope, query, start, limit) {
+  const queryBytes = Buffer.from(query, "utf8");
+  const failure = kmpFailure(queryBytes);
+  const candidates = [];
+  let position = { ...start };
+  let scanned = 0;
+  while (position.file < snapshot.paths.length && candidates.length < limit && scanned < SEARCH_SCAN_BYTES) {
+    const path = snapshot.paths[position.file];
+    if (pathScope !== "" && path !== pathScope && !path.startsWith(`${pathScope}/`)) {
+      position = nextFile(position.file);
+      continue;
+    }
+    const file = snapshot.files.get(path);
+    if (position.offset > file.bytes || position.lineStart > position.offset) throw new ToolError("cursor position is not valid");
+    const descriptor = openSync2(file.snapshotPath, "r");
+    try {
+      let matchState = restoreMatchState(descriptor, position, queryBytes, failure);
+      const buffer = Buffer.allocUnsafe(Math.min(SEARCH_BUFFER_BYTES, Math.max(file.bytes - position.offset, 1)));
+      while (position.offset < file.bytes && candidates.length < limit && scanned < SEARCH_SCAN_BYTES) {
+        const wanted = Math.min(buffer.length, file.bytes - position.offset, SEARCH_SCAN_BYTES - scanned);
+        const count = readSync2(descriptor, buffer, 0, wanted, position.offset);
+        if (count <= 0) throw new ToolError("snapshot read failed");
+        for (let index = 0; index < count; index += 1) {
+          const byte = buffer[index];
+          position.offset += 1;
+          scanned += 1;
+          if (byte === 10) {
+            if (position.matched) {
+              const item = { path, line: position.line, text: evidence(descriptor, position.lineStart, position.offset - 1) };
+              const resume = { ...position, lineStart: position.offset, line: position.line + 1, matched: false };
+              candidates.push({ item, position: resume });
+            }
+            position.lineStart = position.offset;
+            position.line += 1;
+            position.matched = false;
+            matchState = 0;
+            if (candidates.length >= limit) break;
+            continue;
+          }
+          matchState = kmpStep(queryBytes, failure, matchState, byte);
+          if (matchState === queryBytes.length) {
+            position.matched = true;
+            matchState = failure[matchState - 1] ?? 0;
+          }
+        }
+      }
+      if (position.offset >= file.bytes) {
+        if (position.matched && position.offset > position.lineStart && candidates.length < limit) {
+          const resume = nextFile(position.file);
+          candidates.push({
+            item: { path, line: position.line, text: evidence(descriptor, position.lineStart, position.offset) },
+            position: resume
+          });
+        }
+        position = nextFile(position.file);
+      }
+    } finally {
+      closeSync2(descriptor);
+    }
+  }
+  return { candidates, next: position.file < snapshot.paths.length ? position : null };
+}
+function nextFile(file) {
+  return { file: file + 1, offset: 0, lineStart: 0, line: 1, matched: false };
+}
+function restoreMatchState(descriptor, position, query, failure) {
+  const overlap = Math.min(query.length - 1, position.offset - position.lineStart);
+  if (overlap <= 0) return 0;
+  const bytes = Buffer.allocUnsafe(overlap);
+  const count = readSync2(descriptor, bytes, 0, overlap, position.offset - overlap);
+  if (count !== overlap) throw new ToolError("snapshot read failed");
+  let state = 0;
+  for (const byte of bytes) {
+    state = kmpStep(query, failure, state, byte);
+    if (state === query.length) state = failure[state - 1] ?? 0;
+  }
+  return state;
+}
+function evidence(descriptor, start, end) {
+  const length = Math.min(Math.max(end - start, 0), MAX_EVIDENCE_BYTES);
+  if (length === 0) return "";
+  const bytes = Buffer.allocUnsafe(length);
+  const count = readSync2(descriptor, bytes, 0, length, start);
+  if (count !== length) throw new ToolError("snapshot read failed");
+  const safeLength = end - start <= MAX_EVIDENCE_BYTES ? length : validUtf8Prefix(bytes);
+  return bytes.subarray(0, safeLength).toString("utf8").replace(/\r$/, "");
+}
+function kmpFailure(query) {
+  const failure = Array(query.length).fill(0);
+  for (let index = 1, prefix = 0; index < query.length; index += 1) {
+    while (prefix > 0 && query[index] !== query[prefix]) prefix = failure[prefix - 1];
+    if (query[index] === query[prefix]) prefix += 1;
+    failure[index] = prefix;
+  }
+  return failure;
+}
+function kmpStep(query, failure, state, byte) {
+  while (state > 0 && byte !== query[state]) state = failure[state - 1];
+  if (byte === query[state]) state += 1;
+  return state;
+}
+function structured(value) {
+  return { content: [{ type: "text", text: JSON.stringify(value) }], structuredContent: value };
+}
+function logicalResultBytes(value) {
+  return Buffer.byteLength(JSON.stringify(structured(value)), "utf8");
+}
+function snapshotIO(operation) {
+  try {
+    return operation();
+  } catch (error2) {
+    if (error2 instanceof ToolError) throw error2;
+    throw new ToolError("snapshot backing store is unavailable");
+  }
+}
+var isEntryPoint = process.argv[1] !== void 0 && resolve2(process.argv[1]) === fileURLToPath(import.meta.url);
 if (isEntryPoint) {
+  let snapshot;
+  let transport;
+  let shuttingDown = false;
+  const cleanup = () => snapshot?.cleanup();
+  const shutdown = () => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    if (transport === void 0) {
+      cleanup();
+      process.exit(0);
+    }
+    void Promise.resolve().then(() => transport.close()).finally(() => {
+      cleanup();
+      process.exit(0);
+    });
+  };
+  process.once("SIGINT", shutdown);
+  process.once("SIGTERM", shutdown);
+  process.once("exit", cleanup);
   try {
     const args = parseArguments(process.argv.slice(2));
-    const snapshot = capture({ root: args.root, include: args.include, exclude: args.exclude });
-    serveStdio(() => createServer(snapshot));
+    snapshot = capture({
+      root: args.root,
+      include: args.include,
+      exclude: args.exclude,
+      limits: {
+        ...args.maxFileBytes === void 0 ? {} : { maxFileBytes: args.maxFileBytes },
+        ...args.maxTotalBytes === void 0 ? {} : { maxTotalBytes: args.maxTotalBytes }
+      }
+    });
+    transport = serveStdio(() => createServer(snapshot), {
+      onerror: () => process.stderr.write("filesystem server transport error\n")
+    });
   } catch (error2) {
+    cleanup();
     process.stderr.write(`${error2 instanceof Error ? error2.message : "startup failed"}
 `);
     process.exit(64);

--- a/examples/mcp/filesystem/package-lock.json
+++ b/examples/mcp/filesystem/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "ptc-runner-filesystem-sample",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ptc-runner-filesystem-sample",
-      "version": "0.1.0",
-      "license": "Apache-2.0",
+      "version": "0.2.0",
+      "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/server": "2.0.0-beta.5"
       },

--- a/examples/mcp/filesystem/package.json
+++ b/examples/mcp/filesystem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ptc-runner-filesystem-sample",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "description": "Non-production immutable read-only filesystem MCP server used by PtcRunner tutorials and integration tests.",
   "license": "MIT",

--- a/examples/mcp/filesystem/src/server.ts
+++ b/examples/mcp/filesystem/src/server.ts
@@ -1,76 +1,164 @@
+import { createHash, createHmac, randomBytes, timingSafeEqual } from 'node:crypto'
+import { closeSync, openSync, readSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { McpServer, fromJsonSchema, type JsonSchemaType } from '@modelcontextprotocol/server'
 import { serveStdio } from '@modelcontextprotocol/server/stdio'
 
-import { capture, normalizeRelative, type Snapshot } from './snapshot.js'
+import { capture, normalizeRelative, type Snapshot, type SnapshotFile } from './snapshot.js'
 
 const MAX_PAGE = 200
-const MAX_MATCHES = 500
-const MAX_READ_LINES = 2_000
-const MAX_RESULT_BYTES = 262_144
+const MAX_READ_CHUNKS = 8
+const READ_CHUNK_BYTES = 2_048
+const SEARCH_BUFFER_BYTES = 8_192
+const SEARCH_SCAN_BYTES = 262_144
+const MAX_QUERY_BYTES = 256
+const MAX_EVIDENCE_BYTES = 1_024
+const MAX_LOGICAL_RESULT_BYTES = 48_000
 
 interface Arguments {
   root: string
   include: string[]
   exclude: string[]
+  maxFileBytes?: number
+  maxTotalBytes?: number
+}
+
+type Position = number | SearchPosition
+
+interface SearchPosition {
+  file: number
+  offset: number
+  lineStart: number
+  line: number
+  matched: boolean
+}
+
+interface Candidate<T> {
+  item: T
+  position: Position
 }
 
 /** A bounded, actionable failure. Never carries a stacktrace or a host path. */
 class ToolError extends Error {}
 
+const cursorKeys = new WeakMap<Snapshot, Buffer>()
+
+function cursorKey(snapshot: Snapshot): Buffer {
+  const existing = cursorKeys.get(snapshot)
+  if (existing) return existing
+  const created = randomBytes(32)
+  cursorKeys.set(snapshot, created)
+  return created
+}
+
 function parseArguments(argv: readonly string[]): Arguments {
   const parsed: Arguments = { root: '', include: [], exclude: [] }
-
   for (let index = 0; index < argv.length; index += 1) {
     const flag = argv[index]
     const value = argv[index + 1]
-
     if (value === undefined) throw new Error(`missing value for ${flag}`)
-
     if (flag === '--root') parsed.root = value
     else if (flag === '--include') parsed.include.push(value)
     else if (flag === '--exclude') parsed.exclude.push(value)
+    else if (flag === '--max-file-bytes') parsed.maxFileBytes = positiveIntegerOption(value, flag)
+    else if (flag === '--max-total-bytes') parsed.maxTotalBytes = positiveIntegerOption(value, flag)
     else throw new Error(`unknown option ${flag}`)
-
     index += 1
   }
-
   if (parsed.root === '') throw new Error('--root is required')
   return parsed
 }
 
-/**
- * Encodes a page position.
- *
- * The cursor carries the snapshot hash so a cursor minted against one capture
- * cannot silently resume against another; an opaque token also keeps clients
- * from constructing offsets by hand.
- */
-function encodeCursor(hash: string, offset: number): string {
-  return Buffer.from(`${hash}:${offset}`, 'utf8').toString('base64url')
+function positiveIntegerOption(value: string, flag: string): number {
+  if (!/^[1-9][0-9]*$/.test(value)) throw new Error(`${flag} must be a positive integer`)
+  const parsed = Number(value)
+  if (!Number.isSafeInteger(parsed)) throw new Error(`${flag} is too large`)
+  return parsed
 }
 
-function decodeCursor(hash: string, cursor: string | undefined): number {
-  if (cursor === undefined) return 0
+function scopeOf(tool: string, arguments_: Record<string, unknown>): string {
+  return createHash('sha256').update(tool).update('\0').update(JSON.stringify(arguments_)).digest('hex')
+}
 
-  const decoded = Buffer.from(cursor, 'base64url').toString('utf8')
-  const separator = decoded.lastIndexOf(':')
-  if (separator === -1) throw new ToolError('cursor is not valid')
+function encodeCursor(snapshot: Snapshot, scope: string, position: Position): string {
+  const payload = Buffer.from(JSON.stringify({ v: 1, h: snapshot.hash, s: scope, p: position }), 'utf8').toString(
+    'base64url',
+  )
+  const signature = createHmac('sha256', cursorKey(snapshot)).update(payload, 'ascii').digest('base64url')
+  return `${payload}.${signature}`
+}
 
-  if (decoded.slice(0, separator) !== hash) {
-    throw new ToolError('cursor was issued for a different snapshot')
+function decodeCursor(
+  snapshot: Snapshot,
+  scope: string,
+  cursor: unknown,
+  validPosition: (position: unknown) => position is Position,
+  first: Position,
+): Position {
+  if (cursor === undefined) return first
+  if (typeof cursor !== 'string' || cursor === '' || cursor.length > 4_096) {
+    throw new ToolError('cursor is not valid')
   }
 
-  const offset = Number(decoded.slice(separator + 1))
-  if (!Number.isSafeInteger(offset) || offset < 0) throw new ToolError('cursor is not valid')
-  return offset
+  try {
+    const parts = cursor.split('.')
+    if (parts.length !== 2 || parts.some((part) => !/^[A-Za-z0-9_-]+$/.test(part))) {
+      throw new ToolError('cursor is not valid')
+    }
+    const [payload, encodedSignature] = parts as [string, string]
+    const signature = Buffer.from(encodedSignature, 'base64url')
+    const expected = createHmac('sha256', cursorKey(snapshot)).update(payload, 'ascii').digest()
+    if (signature.length !== expected.length || !timingSafeEqual(signature, expected)) {
+      throw new ToolError('cursor is not valid')
+    }
+
+    const decoded = JSON.parse(Buffer.from(payload, 'base64url').toString('utf8')) as Record<string, unknown>
+    if (
+      decoded.v !== 1 ||
+      decoded.h !== snapshot.hash ||
+      decoded.s !== scope ||
+      !validPosition(decoded.p) ||
+      Object.keys(decoded).sort().join(',') !== 'h,p,s,v'
+    ) {
+      throw new ToolError('cursor was issued for a different traversal')
+    }
+    return decoded.p
+  } catch (error) {
+    if (error instanceof ToolError) throw error
+    throw new ToolError('cursor is not valid')
+  }
 }
 
-function boundedPage(limit: unknown): number {
-  if (limit === undefined) return MAX_PAGE
+function offsetPosition(value: unknown): value is number {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0
+}
+
+function searchPosition(snapshot: Snapshot, value: unknown): value is SearchPosition {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return false
+  const position = value as Record<string, unknown>
+  return (
+    Object.keys(position).sort().join(',') === 'file,line,lineStart,matched,offset' &&
+    Number.isSafeInteger(position.file) &&
+    (position.file as number) >= 0 &&
+    (position.file as number) < snapshot.paths.length &&
+    Number.isSafeInteger(position.offset) &&
+    (position.offset as number) >= 0 &&
+    Number.isSafeInteger(position.lineStart) &&
+    (position.lineStart as number) >= 0 &&
+    (position.lineStart as number) <= (position.offset as number) &&
+    Number.isSafeInteger(position.line) &&
+    (position.line as number) >= 1 &&
+    typeof position.matched === 'boolean'
+  )
+}
+
+function boundedPage(limit: unknown, maximum = MAX_PAGE): number {
+  if (limit === undefined) return maximum
   if (typeof limit !== 'number' || !Number.isSafeInteger(limit) || limit < 1) {
     throw new ToolError('limit must be a positive integer')
   }
-  return Math.min(limit, MAX_PAGE)
+  return Math.min(limit, maximum)
 }
 
 function requirePath(value: unknown, field: string): string {
@@ -80,23 +168,16 @@ function requirePath(value: unknown, field: string): string {
   return normalized
 }
 
-/** Every data-bearing result carries the hash, so a citation binds to the bytes actually queried. */
-function page<T>(snapshot: Snapshot, items: readonly T[], offset: number, limit: number) {
-  const slice = items.slice(offset, offset + limit)
-  const next = offset + slice.length
-
-  return {
-    snapshot_hash: snapshot.hash,
-    items: slice,
-    next_cursor: next < items.length ? encodeCursor(snapshot.hash, next) : undefined,
+function requireQuery(value: unknown): string {
+  if (typeof value !== 'string' || value === '') throw new ToolError('query must be a non-empty string')
+  const bytes = Buffer.byteLength(value, 'utf8')
+  if (bytes > MAX_QUERY_BYTES || value.includes('\n') || value.includes('\r')) {
+    throw new ToolError('query must be one line of at most 256 UTF-8 bytes')
   }
+  return value
 }
 
-
 const HASH = { type: 'string' as const }
-const CURSOR = { type: 'string' as const }
-
-/** Paged results share one envelope so a client learns the shape once. */
 function pagedOutput(itemProperties: Record<string, unknown>): JsonSchemaType {
   return {
     type: 'object',
@@ -106,32 +187,62 @@ function pagedOutput(itemProperties: Record<string, unknown>): JsonSchemaType {
         type: 'array',
         items: { type: 'object', properties: itemProperties, additionalProperties: false },
       },
-      next_cursor: CURSOR,
     },
+    // PtcRunner's deliberately small frozen schema subset has no nullable
+    // union. The runtime value always includes next_cursor, including null at
+    // completion; descriptions document it while this validator permits it as
+    // the sole forward-compatible extra field.
     required: ['snapshot_hash', 'items'],
     additionalProperties: true,
   } as JsonSchemaType
 }
 
+function pageValue<T>(
+  snapshot: Snapshot,
+  scope: string,
+  start: Position,
+  candidates: readonly Candidate<T>[],
+  finalPosition: Position | null,
+) {
+  const kept = [...candidates]
+  let next = finalPosition
+
+  while (true) {
+    const value = {
+      snapshot_hash: snapshot.hash,
+      items: kept.map((candidate) => candidate.item),
+      next_cursor: next === null ? null : encodeCursor(snapshot, scope, next),
+    }
+    if (logicalResultBytes(value) <= MAX_LOGICAL_RESULT_BYTES) return value
+    const removed = kept.pop()
+    if (removed === undefined) throw new ToolError('one result item exceeds the result ceiling')
+    next = kept.length === 0 ? start : kept[kept.length - 1]!.position
+  }
+}
+
+function arrayPage<T>(snapshot: Snapshot, scope: string, items: readonly T[], offset: number, limit: number) {
+  if (offset > items.length) throw new ToolError('cursor position is not valid')
+  const end = Math.min(offset + limit, items.length)
+  const candidates = items.slice(offset, end).map((item, index) => ({ item, position: offset + index + 1 }))
+  return pageValue(snapshot, scope, offset, candidates, end < items.length ? end : null)
+}
+
 export function createServer(snapshot: Snapshot): McpServer {
   const server = new McpServer(
-    { name: 'ptc-runner-filesystem-sample', version: '0.1.0' },
+    { name: 'ptc-runner-filesystem-sample', version: '0.2.0' },
     {
       instructions:
-        'Read-only access to an immutable snapshot captured at startup. Paths are relative; the filesystem is never re-read.',
+        'Read-only access to an immutable disk-backed snapshot captured at startup. Paths are relative; source files are never re-read.',
     },
   )
-
   const readOnly = { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false }
-  // Snapshot contents depend on host include rules, so the catalog is not
-  // provably identical across users and must not be cached publicly.
   const meta = { 'io.modelcontextprotocol/cacheScope': 'private' as const }
 
   server.registerTool(
     'list_directory',
     {
       title: 'List directory',
-      description: 'Sorted, paginated entries directly under a relative prefix of the snapshot.',
+      description: 'Sorted entries directly under a relative prefix. Follow next_cursor until null.',
       annotations: readOnly,
       _meta: meta,
       outputSchema: fromJsonSchema<Record<string, unknown>>(
@@ -139,33 +250,28 @@ export function createServer(snapshot: Snapshot): McpServer {
       ),
       inputSchema: fromJsonSchema<Record<string, unknown>>({
         type: 'object',
-        properties: {
-          path: { type: 'string', description: 'Relative directory prefix; omit for the root.' },
-          cursor: { type: 'string' },
-          limit: { type: 'integer', minimum: 1, maximum: MAX_PAGE },
-        },
+        properties: { path: { type: 'string' }, cursor: { type: 'string' }, limit: { type: 'integer', minimum: 1 } },
         additionalProperties: false,
       }),
     },
     async (args: Record<string, unknown>) => {
       const prefix = args.path === undefined ? '' : requirePath(args.path, 'path')
-      const scope = prefix === '' ? '' : `${prefix}/`
+      const traversalScope = scopeOf('list_directory', { path: prefix })
+      const offset = decodeCursor(snapshot, traversalScope, args.cursor, offsetPosition, 0) as number
+      const pathScope = prefix === '' ? '' : `${prefix}/`
       const entries = new Map<string, 'file' | 'directory'>()
-
       for (const path of snapshot.paths) {
-        if (!path.startsWith(scope)) continue
-        const remainder = path.slice(scope.length)
+        if (!path.startsWith(pathScope)) continue
+        const remainder = path.slice(pathScope.length)
+        if (remainder === '') continue
         const separator = remainder.indexOf('/')
         if (separator === -1) entries.set(remainder, 'file')
         else entries.set(remainder.slice(0, separator), 'directory')
       }
-
       const items = [...entries.entries()]
-        .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
-        .map(([name, kind]) => ({ name, kind, path: scope + name }))
-
-      const limit = boundedPage(args.limit)
-      return structured(page(snapshot, items, decodeCursor(snapshot.hash, args.cursor as string), limit))
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([name, kind]) => ({ name, kind, path: pathScope + name }))
+      return structured(arrayPage(snapshot, traversalScope, items, offset, boundedPage(args.limit)))
     },
   )
 
@@ -173,32 +279,23 @@ export function createServer(snapshot: Snapshot): McpServer {
     'search_files',
     {
       title: 'Search files',
-      description: 'Sorted, paginated snapshot paths matching a literal substring.',
+      description: 'Sorted snapshot paths containing a literal substring. Follow next_cursor until null.',
       annotations: readOnly,
       _meta: meta,
       outputSchema: fromJsonSchema<Record<string, unknown>>(pagedOutput({ path: { type: 'string' } })),
       inputSchema: fromJsonSchema<Record<string, unknown>>({
         type: 'object',
-        properties: {
-          query: { type: 'string', minLength: 1 },
-          cursor: { type: 'string' },
-          limit: { type: 'integer', minimum: 1, maximum: MAX_PAGE },
-        },
+        properties: { query: { type: 'string', minLength: 1 }, cursor: { type: 'string' }, limit: { type: 'integer', minimum: 1 } },
         required: ['query'],
         additionalProperties: false,
       }),
     },
     async (args: Record<string, unknown>) => {
-      if (typeof args.query !== 'string' || args.query === '') {
-        throw new ToolError('query must be a non-empty string')
-      }
-
-      const items = snapshot.paths
-        .filter((path) => path.includes(args.query as string))
-        .map((path) => ({ path }))
-
-      const limit = boundedPage(args.limit)
-      return structured(page(snapshot, items, decodeCursor(snapshot.hash, args.cursor as string), limit))
+      const query = requireQuery(args.query)
+      const traversalScope = scopeOf('search_files', { query })
+      const offset = decodeCursor(snapshot, traversalScope, args.cursor, offsetPosition, 0) as number
+      const items = snapshot.paths.filter((path) => path.includes(query)).map((path) => ({ path }))
+      return structured(arrayPage(snapshot, traversalScope, items, offset, boundedPage(args.limit)))
     },
   )
 
@@ -206,7 +303,7 @@ export function createServer(snapshot: Snapshot): McpServer {
     'search_text',
     {
       title: 'Search text',
-      description: 'Literal text search returning path and line evidence.',
+      description: 'Streaming literal line search. Empty progress pages may carry next_cursor; follow it until null.',
       annotations: readOnly,
       _meta: meta,
       outputSchema: fromJsonSchema<Record<string, unknown>>(
@@ -218,36 +315,26 @@ export function createServer(snapshot: Snapshot): McpServer {
           query: { type: 'string', minLength: 1 },
           path: { type: 'string' },
           cursor: { type: 'string' },
-          limit: { type: 'integer', minimum: 1, maximum: MAX_PAGE },
+          limit: { type: 'integer', minimum: 1 },
         },
         required: ['query'],
         additionalProperties: false,
       }),
     },
     async (args: Record<string, unknown>) => {
-      if (typeof args.query !== 'string' || args.query === '') {
-        throw new ToolError('query must be a non-empty string')
-      }
-
-      const scope = args.path === undefined ? '' : requirePath(args.path, 'path')
-      const matches: Array<{ path: string; line: number; text: string }> = []
-
-      for (const path of snapshot.paths) {
-        if (scope !== '' && path !== scope && !path.startsWith(`${scope}/`)) continue
-        const file = snapshot.files.get(path)!
-
-        file.lines.forEach((text, offset) => {
-          if (matches.length >= MAX_MATCHES) return
-          if (!text.includes(args.query as string)) return
-          matches.push({ path, line: offset + 1, text: text.slice(0, 1_024) })
-        })
-
-        if (matches.length >= MAX_MATCHES) break
-      }
-
-      const limit = boundedPage(args.limit)
-      const result = page(snapshot, matches, decodeCursor(snapshot.hash, args.cursor as string), limit)
-      return structured({ ...result, match_limit_reached: matches.length >= MAX_MATCHES })
+      const query = requireQuery(args.query)
+      const path = args.path === undefined ? '' : requirePath(args.path, 'path')
+      const traversalScope = scopeOf('search_text', { path, query })
+      const first: SearchPosition = { file: 0, offset: 0, lineStart: 0, line: 1, matched: false }
+      const start = decodeCursor(
+        snapshot,
+        traversalScope,
+        args.cursor,
+        (value): value is SearchPosition => searchPosition(snapshot, value),
+        first,
+      ) as SearchPosition
+      const result = snapshotIO(() => scanText(snapshot, path, query, start, boundedPage(args.limit)))
+      return structured(pageValue(snapshot, traversalScope, start, result.candidates, result.next))
     },
   )
 
@@ -255,35 +342,18 @@ export function createServer(snapshot: Snapshot): McpServer {
     'read_text_file',
     {
       title: 'Read text file',
-      description: 'One bounded UTF-8 line range with stable line numbers and explicit end-of-file.',
+      description: 'Bounded exact UTF-8 chunks. Concatenate item text and follow next_cursor until null.',
       annotations: readOnly,
       _meta: meta,
-      outputSchema: fromJsonSchema<Record<string, unknown>>({
-        type: 'object',
-        properties: {
-          snapshot_hash: HASH,
-          path: { type: 'string' },
-          lines: {
-            type: 'array',
-            items: {
-              type: 'object',
-              properties: { line: { type: 'integer' }, text: { type: 'string' } },
-              additionalProperties: false,
-            },
-          },
-          total_lines: { type: 'integer' },
-          end_of_file: { type: 'boolean' },
-          truncated: { type: 'boolean' },
-        },
-        required: ['snapshot_hash', 'path', 'lines', 'total_lines', 'end_of_file', 'truncated'],
-        additionalProperties: false,
-      }),
+      outputSchema: fromJsonSchema<Record<string, unknown>>(
+        pagedOutput({ byte_offset: { type: 'integer' }, text: { type: 'string' } }),
+      ),
       inputSchema: fromJsonSchema<Record<string, unknown>>({
         type: 'object',
         properties: {
           path: { type: 'string', minLength: 1 },
-          start_line: { type: 'integer', minimum: 1 },
-          line_count: { type: 'integer', minimum: 1, maximum: MAX_READ_LINES },
+          cursor: { type: 'string' },
+          limit: { type: 'integer', minimum: 1, maximum: MAX_READ_CHUNKS },
         },
         required: ['path'],
         additionalProperties: false,
@@ -293,41 +363,11 @@ export function createServer(snapshot: Snapshot): McpServer {
       const path = requirePath(args.path, 'path')
       const file = snapshot.files.get(path)
       if (!file) throw new ToolError('path is not part of the snapshot')
-
-      const start = args.start_line === undefined ? 1 : Number(args.start_line)
-      if (!Number.isSafeInteger(start) || start < 1) throw new ToolError('start_line must be a positive integer')
-
-      const requested = args.line_count === undefined ? MAX_READ_LINES : Number(args.line_count)
-      if (!Number.isSafeInteger(requested) || requested < 1) {
-        throw new ToolError('line_count must be a positive integer')
-      }
-
-      const count = Math.min(requested, MAX_READ_LINES)
-      const selected = file.lines.slice(start - 1, start - 1 + count)
-
-      // Trim to the result ceiling rather than returning an oversized payload,
-      // and say so, so a caller can page instead of silently losing content.
-      let bytes = 0
-      let truncated = false
-      const lines: Array<{ line: number; text: string }> = []
-
-      for (const [offset, text] of selected.entries()) {
-        bytes += Buffer.byteLength(text, 'utf8') + 1
-        if (bytes > MAX_RESULT_BYTES) {
-          truncated = true
-          break
-        }
-        lines.push({ line: start + offset, text })
-      }
-
-      return structured({
-        snapshot_hash: snapshot.hash,
-        path,
-        lines,
-        total_lines: file.lines.length,
-        end_of_file: !truncated && start - 1 + selected.length >= file.lines.length,
-        truncated,
-      })
+      const traversalScope = scopeOf('read_text_file', { path })
+      const offset = decodeCursor(snapshot, traversalScope, args.cursor, offsetPosition, 0) as number
+      return structured(
+        snapshotIO(() => readPage(snapshot, file, traversalScope, offset, boundedPage(args.limit, MAX_READ_CHUNKS))),
+      )
     },
   )
 
@@ -346,7 +386,7 @@ export function createServer(snapshot: Snapshot): McpServer {
           total_bytes: { type: 'integer' },
           truncated: {
             type: 'object',
-            properties: { files: { type: 'boolean' }, bytes: { type: 'boolean' }, depth: { type: 'boolean' } },
+            properties: { files: { type: 'boolean' }, depth: { type: 'boolean' } },
             additionalProperties: false,
           },
         },
@@ -355,7 +395,6 @@ export function createServer(snapshot: Snapshot): McpServer {
       }),
       inputSchema: fromJsonSchema<Record<string, unknown>>({ type: 'object', properties: {}, additionalProperties: false }),
     },
-    // Deliberately reports no root, no host path, and no absolute location.
     async () =>
       structured({
         snapshot_hash: snapshot.hash,
@@ -368,22 +407,226 @@ export function createServer(snapshot: Snapshot): McpServer {
   return server
 }
 
+function readPage(snapshot: Snapshot, file: SnapshotFile, scope: string, offset: number, limit: number) {
+  if (offset > file.bytes) throw new ToolError('cursor position is not valid')
+  const descriptor = openSync(file.snapshotPath, 'r')
+  const candidates: Array<Candidate<{ byte_offset: number; text: string }>> = []
+  let position = offset
+  try {
+    while (position < file.bytes && candidates.length < limit) {
+      const requested = Math.min(READ_CHUNK_BYTES, file.bytes - position)
+      const buffer = Buffer.allocUnsafe(requested)
+      const count = readSync(descriptor, buffer, 0, requested, position)
+      if (count <= 0) throw new ToolError('snapshot read failed')
+      const bytes = buffer.subarray(0, count)
+      const safeLength = position + count === file.bytes ? count : validUtf8Prefix(bytes)
+      if (safeLength <= 0) throw new ToolError('snapshot UTF-8 boundary is invalid')
+      const next = position + safeLength
+      candidates.push({ item: { byte_offset: position, text: bytes.subarray(0, safeLength).toString('utf8') }, position: next })
+      position = next
+    }
+  } finally {
+    closeSync(descriptor)
+  }
+  return pageValue(snapshot, scope, offset, candidates, position < file.bytes ? position : null)
+}
+
+function validUtf8Prefix(bytes: Buffer): number {
+  for (let length = bytes.length; length >= Math.max(bytes.length - 3, 0); length -= 1) {
+    try {
+      new TextDecoder('utf-8', { fatal: true }).decode(bytes.subarray(0, length))
+      return length
+    } catch {
+      // At most three trailing bytes can belong to an incomplete UTF-8 scalar.
+    }
+  }
+  return 0
+}
+
+function scanText(snapshot: Snapshot, pathScope: string, query: string, start: SearchPosition, limit: number) {
+  const queryBytes = Buffer.from(query, 'utf8')
+  const failure = kmpFailure(queryBytes)
+  const candidates: Array<Candidate<{ path: string; line: number; text: string }>> = []
+  let position = { ...start }
+  let scanned = 0
+
+  while (position.file < snapshot.paths.length && candidates.length < limit && scanned < SEARCH_SCAN_BYTES) {
+    const path = snapshot.paths[position.file]!
+    if (pathScope !== '' && path !== pathScope && !path.startsWith(`${pathScope}/`)) {
+      position = nextFile(position.file)
+      continue
+    }
+
+    const file = snapshot.files.get(path)!
+    if (position.offset > file.bytes || position.lineStart > position.offset) throw new ToolError('cursor position is not valid')
+    const descriptor = openSync(file.snapshotPath, 'r')
+    try {
+      let matchState = restoreMatchState(descriptor, position, queryBytes, failure)
+      const buffer = Buffer.allocUnsafe(Math.min(SEARCH_BUFFER_BYTES, Math.max(file.bytes - position.offset, 1)))
+
+      while (position.offset < file.bytes && candidates.length < limit && scanned < SEARCH_SCAN_BYTES) {
+        const wanted = Math.min(buffer.length, file.bytes - position.offset, SEARCH_SCAN_BYTES - scanned)
+        const count = readSync(descriptor, buffer, 0, wanted, position.offset)
+        if (count <= 0) throw new ToolError('snapshot read failed')
+
+        for (let index = 0; index < count; index += 1) {
+          const byte = buffer[index]!
+          position.offset += 1
+          scanned += 1
+
+          if (byte === 0x0a) {
+            if (position.matched) {
+              const item = { path, line: position.line, text: evidence(descriptor, position.lineStart, position.offset - 1) }
+              const resume = { ...position, lineStart: position.offset, line: position.line + 1, matched: false }
+              candidates.push({ item, position: resume })
+            }
+            position.lineStart = position.offset
+            position.line += 1
+            position.matched = false
+            matchState = 0
+            if (candidates.length >= limit) break
+            continue
+          }
+
+          matchState = kmpStep(queryBytes, failure, matchState, byte)
+          if (matchState === queryBytes.length) {
+            position.matched = true
+            matchState = failure[matchState - 1] ?? 0
+          }
+        }
+      }
+
+      if (position.offset >= file.bytes) {
+        if (position.matched && position.offset > position.lineStart && candidates.length < limit) {
+          const resume = nextFile(position.file)
+          candidates.push({
+            item: { path, line: position.line, text: evidence(descriptor, position.lineStart, position.offset) },
+            position: resume,
+          })
+        }
+        position = nextFile(position.file)
+      }
+    } finally {
+      closeSync(descriptor)
+    }
+  }
+
+  return { candidates, next: position.file < snapshot.paths.length ? position : null }
+}
+
+function nextFile(file: number): SearchPosition {
+  return { file: file + 1, offset: 0, lineStart: 0, line: 1, matched: false }
+}
+
+function restoreMatchState(
+  descriptor: number,
+  position: SearchPosition,
+  query: Buffer,
+  failure: readonly number[],
+): number {
+  const overlap = Math.min(query.length - 1, position.offset - position.lineStart)
+  if (overlap <= 0) return 0
+  const bytes = Buffer.allocUnsafe(overlap)
+  const count = readSync(descriptor, bytes, 0, overlap, position.offset - overlap)
+  if (count !== overlap) throw new ToolError('snapshot read failed')
+  let state = 0
+  for (const byte of bytes) {
+    state = kmpStep(query, failure, state, byte)
+    if (state === query.length) state = failure[state - 1] ?? 0
+  }
+  return state
+}
+
+function evidence(descriptor: number, start: number, end: number): string {
+  const length = Math.min(Math.max(end - start, 0), MAX_EVIDENCE_BYTES)
+  if (length === 0) return ''
+  const bytes = Buffer.allocUnsafe(length)
+  const count = readSync(descriptor, bytes, 0, length, start)
+  if (count !== length) throw new ToolError('snapshot read failed')
+  const safeLength = end - start <= MAX_EVIDENCE_BYTES ? length : validUtf8Prefix(bytes)
+  return bytes.subarray(0, safeLength).toString('utf8').replace(/\r$/, '')
+}
+
+function kmpFailure(query: Buffer): number[] {
+  const failure = Array<number>(query.length).fill(0)
+  for (let index = 1, prefix = 0; index < query.length; index += 1) {
+    while (prefix > 0 && query[index] !== query[prefix]) prefix = failure[prefix - 1]!
+    if (query[index] === query[prefix]) prefix += 1
+    failure[index] = prefix
+  }
+  return failure
+}
+
+function kmpStep(query: Buffer, failure: readonly number[], state: number, byte: number): number {
+  while (state > 0 && byte !== query[state]) state = failure[state - 1]!
+  if (byte === query[state]) state += 1
+  return state
+}
+
 function structured(value: Record<string, unknown>) {
-  return {
-    content: [{ type: 'text' as const, text: JSON.stringify(value) }],
-    structuredContent: value,
+  return { content: [{ type: 'text' as const, text: JSON.stringify(value) }], structuredContent: value }
+}
+
+function logicalResultBytes(value: Record<string, unknown>): number {
+  return Buffer.byteLength(JSON.stringify(structured(value)), 'utf8')
+}
+
+function snapshotIO<T>(operation: () => T): T {
+  try {
+    return operation()
+  } catch (error) {
+    if (error instanceof ToolError) throw error
+    throw new ToolError('snapshot backing store is unavailable')
   }
 }
 
-const isEntryPoint = process.argv[1] !== undefined
+const isEntryPoint = process.argv[1] !== undefined && resolve(process.argv[1]) === fileURLToPath(import.meta.url)
 
 if (isEntryPoint) {
+  let snapshot: Snapshot | undefined
+  let transport: ReturnType<typeof serveStdio> | undefined
+  let shuttingDown = false
+  const cleanup = (): void => snapshot?.cleanup()
+  const shutdown = (): void => {
+    if (shuttingDown) return
+    shuttingDown = true
+
+    if (transport === undefined) {
+      cleanup()
+      process.exit(0)
+    }
+
+    void Promise.resolve()
+      .then(() => transport!.close())
+      .finally(() => {
+        cleanup()
+        process.exit(0)
+      })
+  }
+
+  // Install protection before capture. A signal received during the
+  // synchronous copy is delivered when control returns to the event loop, at
+  // which point `snapshot` is set and can be removed.
+  process.once('SIGINT', shutdown)
+  process.once('SIGTERM', shutdown)
+  process.once('exit', cleanup)
+
   try {
     const args = parseArguments(process.argv.slice(2))
-    const snapshot = capture({ root: args.root, include: args.include, exclude: args.exclude })
-    serveStdio(() => createServer(snapshot))
+    snapshot = capture({
+      root: args.root,
+      include: args.include,
+      exclude: args.exclude,
+      limits: {
+        ...(args.maxFileBytes === undefined ? {} : { maxFileBytes: args.maxFileBytes }),
+        ...(args.maxTotalBytes === undefined ? {} : { maxTotalBytes: args.maxTotalBytes }),
+      },
+    })
+    transport = serveStdio(() => createServer(snapshot!), {
+      onerror: () => process.stderr.write('filesystem server transport error\n'),
+    })
   } catch (error) {
-    // Startup diagnostics go to stderr: stdout carries protocol messages only.
+    cleanup()
     process.stderr.write(`${error instanceof Error ? error.message : 'startup failed'}\n`)
     process.exit(64)
   }

--- a/examples/mcp/filesystem/src/snapshot.ts
+++ b/examples/mcp/filesystem/src/snapshot.ts
@@ -1,35 +1,37 @@
 import { createHash } from 'node:crypto'
-import { lstatSync, readdirSync, readFileSync } from 'node:fs'
+import {
+  closeSync,
+  constants,
+  fstatSync,
+  lstatSync,
+  mkdtempSync,
+  openSync,
+  opendirSync,
+  readSync,
+  rmSync,
+  statfsSync,
+  writeSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
 import { join, relative, resolve, sep } from 'node:path'
 
-/**
- * An immutable capture of the host-supplied root.
- *
- * Everything the server can ever answer comes from this structure. It is built
- * once, before discovery completes, and no tool reads the filesystem again — so
- * a file that changes, appears, or disappears after capture cannot alter a
- * result, and a path that was excluded was never opened and cannot leak through
- * a later query.
- */
+/** Metadata for one file in the private, disk-backed immutable capture. */
+export interface SnapshotFile {
+  readonly snapshotPath: string
+  readonly bytes: number
+  readonly contentHash: string
+}
+
 export interface Snapshot {
-  /** Relative POSIX paths, lexicographically sorted. Sort order is the pagination order. */
+  /** Relative POSIX paths, lexicographically sorted. */
   readonly paths: readonly string[]
   readonly files: ReadonlyMap<string, SnapshotFile>
-  /** Content hash over the captured set. Safe to publish: derived from relative paths and bytes, never the host root. */
+  /** Derived only from relative paths, byte lengths, and captured content. */
   readonly hash: string
   readonly totalBytes: number
-  readonly truncated: SnapshotTruncation
-}
-
-export interface SnapshotFile {
-  readonly lines: readonly string[]
-  readonly bytes: number
-}
-
-export interface SnapshotTruncation {
-  readonly files: boolean
-  readonly bytes: boolean
-  readonly depth: boolean
+  readonly truncated: { readonly files: false; readonly depth: false }
+  /** Idempotently removes the private snapshot directory. */
+  readonly cleanup: () => void
 }
 
 export interface CaptureOptions {
@@ -41,150 +43,212 @@ export interface CaptureOptions {
 
 export interface Limits {
   readonly maxFiles: number
+  readonly maxDepth: number
+  readonly maxDirectories: number
+  readonly maxEntries: number
   readonly maxFileBytes: number
   readonly maxTotalBytes: number
-  readonly maxDepth: number
 }
 
 export const DEFAULT_LIMITS: Limits = {
   maxFiles: 4_096,
-  maxFileBytes: 1_048_576,
-  maxTotalBytes: 33_554_432,
   maxDepth: 32,
+  maxDirectories: 8_192,
+  maxEntries: 100_000,
+  maxFileBytes: Number.MAX_SAFE_INTEGER,
+  maxTotalBytes: Number.MAX_SAFE_INTEGER,
 }
+
+const COPY_BUFFER_BYTES = 65_536
+const TEMP_DISK_RESERVE_BYTES = 64n * 1_024n * 1_024n
 
 export class CaptureError extends Error {}
 
 /**
- * Captures `root` under the host's include rules.
+ * Streams the selected UTF-8 files into a private immutable disk snapshot.
  *
- * Include patterns are mandatory and the default is no files: a server started
- * without them exposes nothing rather than everything. Excludes may only remove
- * from what the includes selected, so narrowing is always safe and widening is
- * impossible.
+ * File bytes are never retained as a whole in the Node heap. The root must be
+ * trusted and quiescent during this startup capture; portable Node path APIs do
+ * not provide descriptor-confined traversal of every ancestor.
  */
 export function capture(options: CaptureOptions): Snapshot {
-  if (options.include.length === 0) {
-    throw new CaptureError('at least one include pattern is required')
-  }
+  if (options.include.length === 0) throw new CaptureError('at least one include pattern is required')
 
   const limits = { ...DEFAULT_LIMITS, ...options.limits }
+  validateLimits(limits)
   const root = resolve(options.root)
   const rootStat = statOrThrow(root, 'root')
-
-  if (!rootStat.isDirectory()) {
-    throw new CaptureError('root is not a directory')
-  }
+  if (!rootStat.isDirectory()) throw new CaptureError('root is not a directory')
 
   const include = options.include.map(compileGlob)
   const exclude = (options.exclude ?? []).map(compileGlob)
+  const maxTotalBytes = Math.min(limits.maxTotalBytes, availableSnapshotBytes(tmpdir()))
+  const maxFileBytes = Math.min(limits.maxFileBytes, maxTotalBytes)
+  const snapshotRoot = mkdtempSync(join(tmpdir(), 'ptc-runner-filesystem-'))
   const files = new Map<string, SnapshotFile>()
-  const truncated = { files: false, bytes: false, depth: false }
   let totalBytes = 0
+  let visitedDirectories = 0
+  let visitedEntries = 0
+  let cleaned = false
+
+  const cleanup = (): void => {
+    if (cleaned) return
+    cleaned = true
+    rmSync(snapshotRoot, { recursive: true, force: true })
+  }
 
   const walk = (directory: string, prefix: string, depth: number): void => {
-    if (depth > limits.maxDepth) {
-      truncated.depth = true
-      return
-    }
+    if (depth > limits.maxDepth) throw new CaptureError('directory depth limit exceeded')
+    visitedDirectories += 1
+    if (visitedDirectories > limits.maxDirectories) throw new CaptureError('directory limit exceeded')
 
-    // Sorted traversal makes the capture itself deterministic, so the snapshot
-    // hash depends on content rather than on directory iteration order.
-    for (const entry of readdirSync(directory).sort()) {
-      if (files.size >= limits.maxFiles) {
-        truncated.files = true
-        return
+    const entries = opendirSync(directory)
+    try {
+      for (let entry = entries.readSync(); entry !== null; entry = entries.readSync()) {
+        visitedEntries += 1
+        if (visitedEntries > limits.maxEntries) throw new CaptureError('directory entry limit exceeded')
+
+        const relativePath = prefix === '' ? entry.name : `${prefix}/${entry.name}`
+        if (normalizeRelative(relativePath) === null) {
+          throw new CaptureError('path exceeds the supported relative-path contract')
+        }
+        if (matchesAny(relativePath, exclude)) continue
+
+        const absolute = join(directory, entry.name)
+        const stat = lstatSync(absolute, { throwIfNoEntry: false })
+        if (!stat || stat.isSymbolicLink()) continue
+
+        if (stat.isDirectory()) {
+          walk(absolute, relativePath, depth + 1)
+          continue
+        }
+
+        if (!stat.isFile() || !matchesAny(relativePath, include)) continue
+        if (files.size >= limits.maxFiles) throw new CaptureError('file limit exceeded')
+
+        const captured = captureFile(
+          absolute,
+          join(snapshotRoot, String(files.size)),
+          Math.min(maxFileBytes, maxTotalBytes - totalBytes),
+        )
+        if (captured === null) continue
+        files.set(relativePath, captured)
+        totalBytes += captured.bytes
       }
-
-      const absolute = join(directory, entry)
-      const relativePath = prefix === '' ? entry : `${prefix}/${entry}`
-
-      // Excluded paths are skipped before any stat or open, so a secret, a
-      // private result directory, or a dependency tree below the root is never
-      // inventoried merely because it exists.
-      if (matchesAny(relativePath, exclude)) continue
-
-      const stat = lstatSync(absolute, { throwIfNoEntry: false })
-      if (!stat) continue
-
-      // Symlinks are rejected rather than followed: resolving one would let a
-      // link inside the root reach bytes outside it.
-      if (stat.isSymbolicLink()) continue
-
-      if (stat.isDirectory()) {
-        walk(absolute, relativePath, depth + 1)
-        continue
-      }
-
-      if (!stat.isFile()) continue
-      if (!matchesAny(relativePath, include)) continue
-      if (stat.size > limits.maxFileBytes) continue
-
-      if (totalBytes + stat.size > limits.maxTotalBytes) {
-        truncated.bytes = true
-        return
-      }
-
-      const raw = readFileSync(absolute)
-      const text = raw.toString('utf8')
-
-      // Round-trip check: a lossy decode means the bytes were not UTF-8, and a
-      // server promising bounded UTF-8 must not hand back replacement
-      // characters as if they were content.
-      if (!Buffer.from(text, 'utf8').equals(raw)) continue
-
-      totalBytes += stat.size
-      files.set(relativePath, { lines: splitLines(text), bytes: stat.size })
+    } finally {
+      entries.closeSync()
     }
   }
 
-  walk(root, '', 0)
+  try {
+    walk(root, '', 0)
+    const paths = [...files.keys()].sort()
 
-  const paths = [...files.keys()].sort()
-  return { paths, files, hash: hashOf(paths, files), totalBytes, truncated }
+    return {
+      paths,
+      files,
+      hash: hashOf(paths, files),
+      totalBytes,
+      truncated: { files: false, depth: false },
+      cleanup,
+    }
+  } catch (error) {
+    cleanup()
+    if (error instanceof CaptureError) throw error
+    throw new CaptureError('capture failed')
+  }
 }
 
-/**
- * Validates a client-supplied relative path.
- *
- * Rejects absolute paths, NUL bytes, empty, `.` and `..` segments, and Windows
- * separators. Traversal fails here rather than resolving, so no query can name
- * a location outside the captured set.
- */
+function captureFile(sourcePath: string, snapshotPath: string, maxBytes: number): SnapshotFile | null {
+  const noFollow = typeof constants.O_NOFOLLOW === 'number' ? constants.O_NOFOLLOW : 0
+  let source: number | undefined
+  let target: number | undefined
+
+  try {
+    try {
+      source = openSync(sourcePath, constants.O_RDONLY | noFollow)
+      const before = fstatSync(source)
+      if (!before.isFile()) return null
+      if (before.size > maxBytes) throw new CaptureError('snapshot byte limit exceeded')
+
+      target = openSync(snapshotPath, constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL, 0o600)
+      const digest = createHash('sha256')
+      const decoder = new TextDecoder('utf-8', { fatal: true })
+      const buffer = Buffer.allocUnsafe(COPY_BUFFER_BYTES)
+      let bytes = 0
+
+      for (let count = readSync(source, buffer, 0, buffer.length, null); count > 0; ) {
+        if (bytes + count > maxBytes) throw new CaptureError('snapshot byte limit exceeded')
+        const chunk = buffer.subarray(0, count)
+        decoder.decode(chunk, { stream: true })
+        digest.update(chunk)
+        writeAll(target, chunk)
+        bytes += count
+        count = readSync(source, buffer, 0, buffer.length, null)
+      }
+      decoder.decode()
+
+      const after = fstatSync(source)
+      if (after.size !== before.size || after.mtimeMs !== before.mtimeMs || bytes !== after.size) {
+        throw new CaptureError('source changed during capture')
+      }
+
+      return { snapshotPath, bytes, contentHash: digest.digest('hex') }
+    } finally {
+      if (target !== undefined) closeSync(target)
+      if (source !== undefined) closeSync(source)
+    }
+  } catch (error) {
+    rmSync(snapshotPath, { force: true })
+    if (error instanceof TypeError) return null
+    throw error
+  }
+}
+
+function validateLimits(limits: Limits): void {
+  const positive = [limits.maxFiles, limits.maxDirectories, limits.maxEntries, limits.maxFileBytes, limits.maxTotalBytes]
+  if (
+    positive.some((value) => !Number.isSafeInteger(value) || value < 1) ||
+    !Number.isSafeInteger(limits.maxDepth) ||
+    limits.maxDepth < 0
+  ) {
+    throw new CaptureError('capture limits are not valid')
+  }
+}
+
+function availableSnapshotBytes(path: string): number {
+  const stat = statfsSync(path, { bigint: true })
+  const available = stat.bavail * stat.bsize
+  const usable = available > TEMP_DISK_RESERVE_BYTES ? available - TEMP_DISK_RESERVE_BYTES : 0n
+  return Number(usable > BigInt(Number.MAX_SAFE_INTEGER) ? BigInt(Number.MAX_SAFE_INTEGER) : usable)
+}
+
+function writeAll(descriptor: number, bytes: Buffer): void {
+  let offset = 0
+  while (offset < bytes.length) offset += writeSync(descriptor, bytes, offset, bytes.length - offset)
+}
+
 export function normalizeRelative(value: string): string | null {
   if (value === '') return ''
-  if (value.includes('\0')) return null
-  if (value.startsWith('/') || value.includes('\\')) return null
-  if (value.length > 1_024) return null
-  if (/^[a-zA-Z]:/.test(value)) return null
+  if (value.includes('\0') || value.startsWith('/') || value.includes('\\')) return null
+  if (value.length > 1_024 || /^[a-zA-Z]:/.test(value)) return null
 
   const segments = value.split('/').filter((segment) => segment !== '')
   if (segments.some((segment) => segment === '.' || segment === '..')) return null
-
   return segments.join('/')
-}
-
-function splitLines(text: string): string[] {
-  const normalized = text.replace(/\r\n/g, '\n')
-  const lines = normalized.split('\n')
-  // A trailing newline terminates the last line rather than starting an empty one.
-  if (lines.length > 1 && lines[lines.length - 1] === '') lines.pop()
-  return lines
 }
 
 function hashOf(paths: readonly string[], files: ReadonlyMap<string, SnapshotFile>): string {
   const digest = createHash('sha256')
-
   for (const path of paths) {
     const file = files.get(path)!
     digest.update(path, 'utf8')
     digest.update('\0')
     digest.update(String(file.bytes), 'utf8')
     digest.update('\0')
-    digest.update(file.lines.join('\n'), 'utf8')
+    digest.update(file.contentHash, 'ascii')
     digest.update('\0')
   }
-
   return `sha256:${digest.digest('hex')}`
 }
 
@@ -199,46 +263,26 @@ function matchesAny(path: string, patterns: readonly RegExp[]): boolean {
   return patterns.some((pattern) => pattern.test(path))
 }
 
-/**
- * Compiles a bounded glob: `**` spans separators, `*` and `?` do not.
- *
- * Deliberately small. A full glob engine would be a second, less reviewable
- * confinement surface, and the host only needs to select directory subtrees
- * and extensions.
- */
 function compileGlob(pattern: string): RegExp {
   let source = '^'
-
   for (let index = 0; index < pattern.length; index += 1) {
     const character = pattern[index]
-
     if (character === '*') {
       if (pattern[index + 1] === '*') {
         index += 1
-
-        // `**/` spans whole segments so `**/x` matches `x` and `a/b/x`; a
-        // trailing `**` spans the remainder including the final segment, so
-        // `lib/**` matches `lib/a.ex` rather than only directories.
         if (pattern[index + 1] === '/') {
           index += 1
           source += '(?:[^/]+/)*'
-        } else {
-          source += '.*'
-        }
-      } else {
-        source += '[^/]*'
-      }
+        } else source += '.*'
+      } else source += '[^/]*'
       continue
     }
-
     if (character === '?') {
       source += '[^/]'
       continue
     }
-
     source += character.replace(/[.+^${}()|[\]\\]/g, '\\$&')
   }
-
   return new RegExp(`${source}$`)
 }
 

--- a/examples/mcp/filesystem/test/server.test.mjs
+++ b/examples/mcp/filesystem/test/server.test.mjs
@@ -1,7 +1,9 @@
 import assert from 'node:assert/strict'
 import { spawn } from 'node:child_process'
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { dirname, join } from 'node:path'
+import { tmpdir } from 'node:os'
 import test from 'node:test'
 
 const here = dirname(fileURLToPath(import.meta.url))
@@ -9,6 +11,7 @@ const SERVER = join(here, '..', 'dist', 'server.js')
 const FIXTURE = join(here, 'fixture')
 
 const PROTOCOL = '2026-07-28'
+const SNAPSHOT_PREFIX = 'ptc-runner-filesystem-'
 
 /**
  * Drives the built bundle over real stdio, the same way PtcRunner will.
@@ -105,6 +108,54 @@ async function call(server, name, args = {}) {
   return structured(await server.request('tools/call', { name, arguments: args }))
 }
 
+async function collect(server, name, args = {}) {
+  const items = []
+  let cursor
+  let pages = 0
+
+  do {
+    const result = await call(server, name, { ...args, ...(cursor === undefined ? {} : { cursor }) })
+    assert.deepEqual(Object.keys(result).sort(), ['items', 'next_cursor', 'snapshot_hash'])
+    items.push(...result.items)
+    cursor = result.next_cursor ?? undefined
+    pages += 1
+    assert.ok(pages < 10_000, 'cursor traversal must make progress')
+  } while (cursor !== undefined)
+
+  return items
+}
+
+async function withGeneratedServer(files, body) {
+  const root = mkdtempSync(join(tmpdir(), 'ptc-filesystem-test-'))
+  try {
+    for (const [path, contents] of Object.entries(files)) {
+      mkdirSync(dirname(join(root, path)), { recursive: true })
+      writeFileSync(join(root, path), contents)
+    }
+    await withServer(['--root', root, '--include', '**'], (server) => body(server, root))
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+}
+
+function waitForSnapshot(createdBefore) {
+  return new Promise((resolve, reject) => {
+    const deadline = Date.now() + 15_000
+    const timer = setInterval(() => {
+      const created = readdirSync(tmpdir()).find(
+        (name) => name.startsWith(SNAPSHOT_PREFIX) && !createdBefore.has(name),
+      )
+      if (created !== undefined) {
+        clearInterval(timer)
+        resolve(join(tmpdir(), created))
+      } else if (Date.now() >= deadline) {
+        clearInterval(timer)
+        reject(new Error('timed out awaiting private snapshot creation'))
+      }
+    }, 1)
+  })
+}
+
 test('advertises exactly the five read-only tools', async () => {
   await withServer(INCLUDE_LIB, async (server) => {
     const response = await server.request('tools/list')
@@ -165,6 +216,30 @@ test('capture requires at least one include and defaults to nothing', async () =
   assert.match(server.stderr(), /include/i)
 })
 
+test('configured file and total byte ceilings fail closed without snapshot orphans', async () => {
+  for (const { files, args } of [
+    { files: { 'large.txt': '12345' }, args: ['--max-file-bytes', '4'] },
+    { files: { 'one.txt': '123', 'two.txt': '456' }, args: ['--max-total-bytes', '5'] },
+  ]) {
+    const root = mkdtempSync(join(tmpdir(), 'ptc-filesystem-limit-test-'))
+    const createdBefore = new Set(readdirSync(tmpdir()).filter((name) => name.startsWith(SNAPSHOT_PREFIX)))
+    try {
+      for (const [path, contents] of Object.entries(files)) writeFileSync(join(root, path), contents)
+      const server = startServer(['--root', root, '--include', '**', ...args])
+      const code = await new Promise((resolve) => server.child.once('exit', resolve))
+
+      assert.equal(code, 64)
+      assert.match(server.stderr(), /snapshot byte limit exceeded/)
+      const createdAfter = readdirSync(tmpdir()).filter(
+        (name) => name.startsWith(SNAPSHOT_PREFIX) && !createdBefore.has(name),
+      )
+      assert.deepEqual(createdAfter, [], 'failed captures must remove private snapshot bytes')
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  }
+})
+
 test('traversal, absolute paths, and NUL are rejected', async () => {
   await withServer(INCLUDE_LIB, async (server) => {
     for (const path of ['../package.json', '/etc/hostname', 'lib/../../escape', 'lib\u0000.ex']) {
@@ -190,7 +265,7 @@ test('non-UTF-8 files are not captured and UTF-8 is preserved', async () => {
     assert.deepEqual(binary.items, [], 'invalid UTF-8 must not be captured')
 
     const read = await call(server, 'read_text_file', { path: 'lib/utf8.ex' })
-    assert.equal(read.lines[0].text, 'café unicode')
+    assert.equal(read.items.map((item) => item.text).join(''), 'café unicode\n')
   })
 })
 
@@ -209,7 +284,7 @@ test('listings are ordered and paginate through an opaque cursor', async () => {
   })
 })
 
-test('a cursor from another snapshot is refused', async () => {
+test('cursors are bound to the snapshot, tool, and normalized query', async () => {
   let foreign
   await withServer(INCLUDE_LIB, async (server) => {
     foreign = (await call(server, 'search_files', { query: '.ex', limit: 1 })).next_cursor
@@ -222,18 +297,51 @@ test('a cursor from another snapshot is refused', async () => {
     })
     assert.ok(response.result?.isError || response.error, 'a foreign cursor must not resume')
   })
+
+  await withServer(INCLUDE_LIB, async (server) => {
+    const cursor = (await call(server, 'search_files', { query: '.ex', limit: 1 })).next_cursor
+
+    for (const [name, args] of [
+      ['search_files', { query: 'alpha', cursor }],
+      ['read_text_file', { path: 'lib/alpha.ex', cursor }],
+    ]) {
+      const response = await server.request('tools/call', { name, arguments: args })
+      assert.ok(response.result?.isError || response.error, `${name} must reject a cursor from another scope`)
+    }
+
+    const tampered = `${cursor.slice(0, -1)}${cursor.endsWith('a') ? 'b' : 'a'}`
+    const response = await server.request('tools/call', {
+      name: 'search_files',
+      arguments: { query: '.ex', cursor: tampered },
+    })
+    assert.ok(response.result?.isError || response.error, 'a modified cursor must be rejected')
+  })
 })
 
-test('reads are bounded and report end of file', async () => {
+test('read_text_file uses the common cursor envelope', async () => {
   await withServer(INCLUDE_LIB, async (server) => {
-    const whole = await call(server, 'read_text_file', { path: 'lib/alpha.ex' })
-    assert.equal(whole.total_lines, 2)
-    assert.equal(whole.end_of_file, true)
-    assert.deepEqual(whole.lines.map((line) => line.line), [1, 2])
+    const whole = await collect(server, 'read_text_file', { path: 'lib/alpha.ex', limit: 1 })
+    assert.equal(whole.map((item) => item.text).join(''), 'alpha line one\nalpha line two\n')
+    assert.equal(whole[0].byte_offset, 0)
+  })
+})
 
-    const partial = await call(server, 'read_text_file', { path: 'lib/alpha.ex', line_count: 1 })
-    assert.equal(partial.lines.length, 1)
-    assert.equal(partial.end_of_file, false, 'a partial read must not claim end of file')
+test('a file above the former 1 MiB ceiling reconstructs exactly across UTF-8 pages', async () => {
+  const text = `${'x'.repeat(1_100_000)}é${'y'.repeat(100_000)}\n`
+
+  await withGeneratedServer({ 'huge.txt': text }, async (server) => {
+    const chunks = await collect(server, 'read_text_file', { path: 'huge.txt', limit: 2 })
+    assert.ok(chunks.length > 2)
+    assert.equal(chunks.map((item) => item.text).join(''), text)
+  })
+})
+
+test('tool reads stay bound to the startup snapshot after the source changes', async () => {
+  await withGeneratedServer({ 'stable.txt': 'captured\n' }, async (server, root) => {
+    await call(server, 'snapshot_info')
+    writeFileSync(join(root, 'stable.txt'), 'changed\n')
+    const chunks = await collect(server, 'read_text_file', { path: 'stable.txt' })
+    assert.equal(chunks.map((item) => item.text).join(''), 'captured\n')
   })
 })
 
@@ -243,6 +351,47 @@ test('search evidence carries path and line numbers', async () => {
     assert.equal(search.items.length, 1)
     assert.equal(search.items[0].path, 'lib/beta.ex')
     assert.equal(search.items[0].line, 1)
+  })
+})
+
+test('search_text traverses beyond the former 500-match ceiling', async () => {
+  const text = Array.from({ length: 620 }, (_, index) => `needle ${index}\n`).join('')
+
+  await withGeneratedServer({ 'many.txt': text }, async (server) => {
+    const matches = await collect(server, 'search_text', { query: 'needle', limit: 37 })
+    assert.equal(matches.length, 620)
+    assert.deepEqual(matches.map((item) => item.line), Array.from({ length: 620 }, (_, index) => index + 1))
+  })
+})
+
+test('search_text makes cursor progress through a huge sparse line', async () => {
+  const text = `${'a'.repeat(600_000)}needle\n`
+
+  await withGeneratedServer({ 'sparse.txt': text }, async (server) => {
+    const first = await call(server, 'search_text', { query: 'needle', limit: 1 })
+    assert.deepEqual(first.items, [])
+    assert.ok(first.next_cursor, 'a scan budget stop must return a progress cursor')
+
+    const matches = await collect(server, 'search_text', { query: 'needle', limit: 1 })
+    assert.equal(matches.length, 1)
+    assert.equal(matches[0].line, 1)
+  })
+})
+
+test('escape-heavy pages fit below a 64 KiB decoded MCP result ceiling', async () => {
+  const text = `${'\u0001'.repeat(40_000)}\n`
+
+  await withGeneratedServer({ 'controls.txt': text }, async (server) => {
+    let cursor
+    do {
+      const response = await server.request('tools/call', {
+        name: 'read_text_file',
+        arguments: { path: 'controls.txt', limit: 8, ...(cursor === undefined ? {} : { cursor }) },
+      })
+      assert.equal(response.error, undefined)
+      assert.ok(Buffer.byteLength(JSON.stringify(response.result), 'utf8') < 64_000)
+      cursor = response.result.structuredContent.next_cursor ?? undefined
+    } while (cursor !== undefined)
   })
 })
 
@@ -286,6 +435,31 @@ test('errors are bounded text without stacktraces or host paths', async () => {
   })
 })
 
+test('backing-store I/O failures return a fixed message without temporary paths', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'ptc-filesystem-io-test-'))
+  const createdBefore = new Set(readdirSync(tmpdir()).filter((name) => name.startsWith(SNAPSHOT_PREFIX)))
+  writeFileSync(join(root, 'stable.txt'), 'captured\n')
+  const server = startServer(['--root', root, '--include', '**'])
+
+  try {
+    const snapshotPath = await waitForSnapshot(createdBefore)
+    await call(server, 'snapshot_info')
+    rmSync(snapshotPath, { recursive: true, force: true })
+
+    const response = await server.request('tools/call', {
+      name: 'read_text_file',
+      arguments: { path: 'stable.txt' },
+    })
+    const serialized = JSON.stringify(response)
+    assert.match(serialized, /snapshot backing store is unavailable/)
+    assert.equal(serialized.includes(snapshotPath), false)
+    assert.equal(serialized.includes(tmpdir()), false)
+  } finally {
+    await server.close()
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
 test('cancellation leaves the server usable', async () => {
   await withServer(INCLUDE_LIB, async (server) => {
     server.child.stdin.write(
@@ -305,6 +479,25 @@ test('closing stdin terminates the server cleanly', async () => {
   const code = await new Promise((resolve) => server.child.once('exit', resolve))
 
   assert.equal(code, 0, 'end of input must be an ordinary shutdown')
+})
+
+test('SIGTERM during startup removes the private disk snapshot', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'ptc-filesystem-signal-test-'))
+  const createdBefore = new Set(readdirSync(tmpdir()).filter((name) => name.startsWith(SNAPSHOT_PREFIX)))
+  writeFileSync(join(root, 'large.txt'), Buffer.alloc(64 * 1_024 * 1_024, 'x'))
+  const server = startServer(['--root', root, '--include', '**'])
+
+  try {
+    const snapshotPath = await waitForSnapshot(createdBefore)
+    const exited = new Promise((resolve) => server.child.once('exit', (code, signal) => resolve({ code, signal })))
+    server.child.kill('SIGTERM')
+
+    assert.deepEqual(await exited, { code: 0, signal: null })
+    assert.equal(existsSync(snapshotPath), false, 'catchable termination must remove captured bytes')
+  } finally {
+    if (server.child.exitCode === null && server.child.signalCode === null) server.child.kill('SIGKILL')
+    rmSync(root, { recursive: true, force: true })
+  }
 })
 
 test('stdout carries protocol messages only', async () => {

--- a/examples/named-mission-reader-writer/ptc-host.json
+++ b/examples/named-mission-reader-writer/ptc-host.json
@@ -12,7 +12,7 @@
     },
     "reader_workspace": {
       "source": "mcp",
-      "installation_revision": "filesystem-reader-v1",
+      "installation_revision": "filesystem-reader-v2",
       "transport": {
         "type": "stdio",
         "command": "node",

--- a/examples/named-mission-reader-writer/reader.clj
+++ b/examples/named-mission-reader-writer/reader.clj
@@ -1,10 +1,11 @@
 (ns example.reader "Read-only source API." {:visibility :prompt})
 
-(defn read-source
-  "Read one UTF-8 source file from the reader mission's private root."
-  {:signature "(path :string) -> :string"}
-  [path]
-  (let [response (tool/workspace.read {"path" path})]
+(defn read-source-page
+  "Read one bounded source page. Pass nil first, then next_cursor."
+  {:signature "(path :string, cursor :string?) -> :any"}
+  [path cursor]
+  (let [arguments (if cursor {"path" path "cursor" cursor} {"path" path})
+        response (tool/workspace.read arguments)]
     (if (= :ok (get response :status))
-      (str (str/join "\n" (map #(get % "text") (get-in response [:value "lines"]))) "\n")
+      (get response :value)
       (fail response))))

--- a/examples/named-mission-reader-writer/workflow.clj
+++ b/examples/named-mission-reader-writer/workflow.clj
@@ -10,7 +10,8 @@
         destination (get input "destination")
         read-outcome
         (agent.core/run-outcome
-          (str "Read " source " with example.reader/read-source. Return its exact text.")
+          (str "Read " source " with example.reader/read-source-page, passing nil first. "
+               "Concatenate item text and follow next_cursor until nil. Return its exact text.")
           {"mission" "reader" "max_turns" 4})
         text (returned-value read-outcome :reader)
         write-outcome

--- a/examples/viewer-demo/01-recovery.json
+++ b/examples/viewer-demo/01-recovery.json
@@ -17,7 +17,7 @@
   },
   "input": {
     "value": {
-      "task": "First call (demo.files/parse-lines \"notes.txt\") and return its result. If an evaluation fails, recover: read the file with (demo.files/read-text \"notes.txt\") instead and return its exact content as a string.",
+      "task": "First call (demo.files/parse-lines \"notes.txt\") and return its result. If an evaluation fails, recover with (demo.files/read-page \"notes.txt\" nil), concatenate item text, follow next_cursor until nil, and return the exact content as a string.",
       "max_turns": 6
     }
   },

--- a/examples/viewer-demo/README.md
+++ b/examples/viewer-demo/README.md
@@ -29,7 +29,7 @@ sanitized transcripts.
 
 | Journey | Design | Viewer surfaces exercised |
 | --- | --- | --- |
-| `01-recovery` | The task names `demo.files/parse-lines`, which does not exist, then instructs recovery via `demo.files/read-text`. Expect an `:unbound_var` evaluation error, a tool-role correction message, and a successful second turn. | Multi-turn dialogue, error feedback then recovery, source-hash verification, ok status. |
+| `01-recovery` | The task names `demo.files/parse-lines`, which does not exist, then instructs recovery via `demo.files/read-page`. Expect an `:unbound_var` evaluation error, a tool-role correction message, and a successful second turn. | Multi-turn dialogue, error feedback then recovery, source-hash verification, ok status. |
 | `02-bulk` | The task calls `demo.files/sum-values`, which itself reads `index.txt` plus all 30 listed record files (31 `workspace.read` calls, just under the installed per-name quota of 32) and computes a sum the model cannot fabricate (3255). | Long capability lists in the transcript, per-call private payloads, deterministic bulk event volume (~76 events), ok status. |
 | `03-limits` | Same task, but the manifest lowers `mission_capability_calls_per_name` to 6, so `sum-values` exhausts the quota mid-evaluation and the model receives the failure as feedback. | `limit-exceeded` events, error feedback turns, quota-error envelopes in private payloads. |
 | `04-loop-limit` | The task calls `demo.files/spin-forever`, an unbounded `loop`/`recur`, which hits the evaluator's deterministic loop-iteration bound. | Error-outcome runs in the picker, `:loop_limit_exceeded` feedback turns, `explicit_failure` terminal reason. |

--- a/examples/viewer-demo/files.clj
+++ b/examples/viewer-demo/files.clj
@@ -1,17 +1,24 @@
 (ns demo.files "Mission-only access to the granted file root." {:visibility :prompt})
 
-(defn read-text [path]
-  (let [response (tool/workspace.read {"path" path})]
+(defn read-page [path cursor]
+  (let [arguments (if cursor {"path" path "cursor" cursor} {"path" path})
+        response (tool/workspace.read arguments)]
     (if (= :ok (get response :status))
-      (str (str/join "\n" (map #(get % "text") (get-in response [:value "lines"]))) "\n")
+      (get response :value)
       response)))
 
+(defn- small-text [path]
+  (let [page (read-page path nil)]
+    (if (nil? (get page "next_cursor"))
+      (str/join "" (map #(get % "text") (get page "items")))
+      (fail {:status :error :kind :file-too-large :reason :more-pages}))))
+
 (defn- record-value [name]
-  (let [match (re-find #"value (\d+)" (read-text name))]
+  (let [match (re-find #"value (\d+)" (small-text name))]
     (parse-long (second match))))
 
 (defn sum-values []
-  (let [names (filter (fn [line] (not (= line ""))) (split-lines (read-text "index.txt")))]
+  (let [names (filter (fn [line] (not (= line ""))) (split-lines (small-text "index.txt")))]
     (reduce + (map record-value names))))
 
 (defn spin-forever []

--- a/examples/viewer-demo/ptc-host.json
+++ b/examples/viewer-demo/ptc-host.json
@@ -32,7 +32,7 @@
           "effect": "read"
         }
       },
-      "installation_revision": "filesystem-sample-0.1.0",
+      "installation_revision": "filesystem-sample-0.2.0",
       "ceilings": {
         "timeout_ms": 15000,
         "max_catalog_tools": 8,

--- a/lib/ptc_runner/kernel/library.ex
+++ b/lib/ptc_runner/kernel/library.ex
@@ -21,10 +21,11 @@ defmodule PtcRunner.Kernel.Library do
   `cap` is `:discoverable` rather than `:prompt`. Its envelope and pagination
   helpers compose capabilities for other libraries and stay out of the prompt
   inventory; evaluated code still finds them with `(dir "cap")` and reads them
-  with `(doc "cap/collect-pages")`. `unwrap!` fails the program on an error
-  envelope rather than
-  returning it, `with-cursor` adds one opaque cursor to an argument map, and
-  `collect-pages` follows cursors only up to its explicit page bound.
+  with `(doc "cap/fold-pages")`. `unwrap!` fails the program on an error
+  envelope rather than returning it. `fold-pages` is the one traversal helper:
+  it reduces page items into bounded caller state, preserves a resumable cursor
+  at its explicit page bound, and rejects changed snapshots or cursor cycles
+  observed within one invocation without retaining source-sized resume history.
 
   Fetching one component with `component/1` does not expand its dependencies,
   and `PtcRunner.Kernel` refuses to compile an incomplete set. Manifests and

--- a/priv/preludes/kernel/cap.clj
+++ b/priv/preludes/kernel/cap.clj
@@ -16,49 +16,74 @@
     (get response :value)
     (fail response)))
 
-(defn with-cursor
-  "Adds an opaque pagination cursor to a capability argument map.
+(defn- pagination-fail [kind reason]
+  (fail {:status :error :kind kind :reason reason}))
 
-  A nil cursor denotes the first page and removes any existing cursor.
-  Traversal stays explicit in the caller; this helper never follows or
-  interprets a cursor."
-  [arguments cursor]
-  (let [arguments (dissoc arguments "cursor" :cursor)]
-    (if (nil? cursor)
-      arguments
-      (assoc arguments "cursor" cursor))))
+(defn- valid-token? [value]
+  (and (string? value) (not (blank? value))))
 
-(defn- pagination-result [items pages complete? snapshot-hash]
-  (let [result {"items" items "pages" pages "complete?" complete?}]
-    (if (= snapshot-hash :absent)
-      result
-      (assoc result "snapshot_hash" snapshot-hash))))
+(defn- fold-result [value pages complete? next-cursor snapshot-hash]
+  {"value" value
+   "pages" pages
+   "complete?" complete?
+   "next_cursor" next-cursor
+   "snapshot_hash" snapshot-hash})
 
-(defn collect-pages
-  "Collects `items` from cursor-paginated responses up to `max-pages`.
+(defn fold-pages
+  "Reduces cursor-paginated items into bounded caller-owned state.
 
-  `fetch` receives nil for the first page and each opaque `next_cursor`
-  afterward. The result reports how many pages were read and whether the
-  source was exhausted. Snapshot-bound pages preserve their `snapshot_hash`
-  and traversal fails if that identity changes. A page bound that stops
-  traversal returns the collected prefix with `complete?` false; it never
-  presents the prefix as complete."
-  [fetch max-pages]
-  (if (and (integer? max-pages) (pos? max-pages))
-    (loop [cursor nil
-           pages 0
-           items []
-           snapshot-hash :unset]
-      (if (>= pages max-pages)
-        (pagination-result items pages false snapshot-hash)
-        (let [page (fetch cursor)
-              items (into items (get page "items"))
-              next-cursor (get page "next_cursor")
-              page-hash (get page "snapshot_hash" :absent)]
-          (if (or (= snapshot-hash :unset) (= snapshot-hash page-hash))
-            (let [snapshot-hash (if (= snapshot-hash :unset) page-hash snapshot-hash)]
-              (if (nil? next-cursor)
-                (pagination-result items (inc pages) true snapshot-hash)
-                (recur next-cursor (inc pages) items snapshot-hash)))
-            (fail {:status :error :kind :invalid-response :reason :snapshot-changed})))))
-    (fail {:status :error :kind :invalid-request :reason :invalid-max-pages})))
+  `fetch` receives nil for the first page or the opaque cursor supplied in
+  `opts`. `step` receives accumulator then item. Every page must contain
+  `items`, `next_cursor`, and a stable non-empty `snapshot_hash`.
+
+  `opts` requires a positive `max_pages`. Resuming with `cursor` also requires
+  the expected `snapshot_hash`. A page-bound stop returns `complete?` false and
+  preserves `next_cursor`, so another evaluation can continue without retaining
+  prior pages. Keep the accumulator bounded; pagination does not make an
+  unbounded collection safe. Repeated cursors within one invocation fail instead
+  of looping; a resumed invocation does not retain source-sized cursor history."
+  [fetch step initial opts]
+  (let [max-pages (get opts "max_pages")
+        start-cursor (get opts "cursor")
+        expected-hash (get opts "snapshot_hash")]
+    (cond
+      (not (and (integer? max-pages) (pos? max-pages)))
+        (pagination-fail :invalid-request :invalid-max-pages)
+      (and (not (nil? start-cursor)) (not (valid-token? start-cursor)))
+        (pagination-fail :invalid-request :invalid-cursor)
+      (and (not (nil? start-cursor)) (not (valid-token? expected-hash)))
+        (pagination-fail :invalid-request :missing-snapshot-hash)
+      :else
+        (loop [cursor start-cursor
+               pages 0
+               value initial
+               snapshot-hash expected-hash
+               seen (if (nil? start-cursor) {} {start-cursor true})]
+          (let [page (fetch cursor)
+                items (get page "items" :absent)
+                next-cursor (get page "next_cursor" :absent)
+                page-hash (get page "snapshot_hash" :absent)]
+            (cond
+              (not (sequential? items))
+                (pagination-fail :invalid-response :invalid-items)
+              (not (valid-token? page-hash))
+                (pagination-fail :invalid-response :missing-snapshot-hash)
+              (and (not (nil? snapshot-hash)) (not= snapshot-hash page-hash))
+                (pagination-fail :invalid-response :snapshot-changed)
+              (= next-cursor :absent)
+                (pagination-fail :invalid-response :missing-next-cursor)
+              (and (not (nil? next-cursor)) (not (valid-token? next-cursor)))
+                (pagination-fail :invalid-response :invalid-cursor)
+              (and (not (nil? next-cursor)) (contains? seen next-cursor))
+                (pagination-fail :invalid-response :cursor-cycle)
+              :else
+                (let [value (reduce step value items)
+                      pages (inc pages)]
+                  (cond
+                    (nil? next-cursor)
+                      (fold-result value pages true nil page-hash)
+                    (>= pages max-pages)
+                      (fold-result value pages false next-cursor page-hash)
+                    :else
+                      (recur next-cursor pages value page-hash
+                             (assoc seen next-cursor true))))))))))

--- a/test/ptc_runner/kernel/cap_agent_main_test.exs
+++ b/test/ptc_runner/kernel/cap_agent_main_test.exs
@@ -68,82 +68,96 @@ defmodule PtcRunner.Kernel.CapAgentMainTest do
     end
   end
 
-  describe "cap/with-cursor" do
-    test "adds an opaque cursor to a string-keyed argument map" do
-      assert run(~S|(cap/with-cursor {"limit" 100} "abc")|) ==
-               ~S|{"cursor" "abc" "limit" 100}|
-    end
-
-    test "a nil cursor selects the first page and removes a stale cursor" do
-      assert run(~S|(cap/with-cursor {"path" "lib" "limit" 100} nil)|) ==
-               ~S|{"limit" 100 "path" "lib"}|
-
-      assert run(~S|(cap/with-cursor {"cursor" "stale" "limit" 100} nil)|) ==
-               ~S|{"limit" 100}|
-
-      assert run(~S|(cap/with-cursor {:cursor "stale" :limit 100} nil)|) ==
-               ~S|{:limit 100}|
-    end
-
-    test "does not interpret or transform the cursor" do
-      assert run(~S|(cap/with-cursor {} "opaque:page/2?x=1")|) ==
-               ~S|{"cursor" "opaque:page/2?x=1"}|
-    end
-  end
-
-  describe "cap/collect-pages" do
-    test "follows opaque cursors and reports complete traversal" do
+  describe "cap/fold-pages" do
+    test "reduces pages into bounded caller state and reports completion" do
       source = ~S"""
-      (cap/collect-pages
+      (cap/fold-pages
         (fn [cursor]
           (if cursor
-            {"items" [3] "next_cursor" nil}
-            {"items" [1 2] "next_cursor" "page-2"}))
-        2)
+            {"items" [3] "next_cursor" nil "snapshot_hash" "sha256:same"}
+            {"items" [1 2] "next_cursor" "page-2" "snapshot_hash" "sha256:same"}))
+        +
+        0
+        {"max_pages" 2})
       """
 
       assert run(source) ==
-               ~S|{"complete?" true "items" [1 2 3] "pages" 2}|
+               ~S|{"complete?" true "next_cursor" nil "pages" 2 "snapshot_hash" "sha256:same" "value" 6}|
     end
 
-    test "preserves snapshot provenance and rejects a changed snapshot" do
+    test "preserves a resumable cursor and validates the expected snapshot" do
       source = ~S"""
-      (cap/collect-pages
-        (fn [cursor]
-          (if cursor
-            {"items" [2] "next_cursor" nil "snapshot_hash" "sha256:same"}
-            {"items" [1] "next_cursor" "page-2" "snapshot_hash" "sha256:same"}))
-        2)
+      (cap/fold-pages
+        (fn [_] {"items" [1 2] "next_cursor" "page-2" "snapshot_hash" "sha256:same"})
+        +
+        0
+        {"max_pages" 1})
       """
 
       assert run(source) ==
-               ~S|{"complete?" true "items" [1 2] "pages" 2 "snapshot_hash" "sha256:same"}|
+               ~S|{"complete?" false "next_cursor" "page-2" "pages" 1 "snapshot_hash" "sha256:same" "value" 3}|
 
-      changed = ~S"""
-      (cap/collect-pages
+      resumed = ~S"""
+      (cap/fold-pages
         (fn [cursor]
-          (if cursor
-            {"items" [2] "next_cursor" nil "snapshot_hash" "sha256:changed"}
-            {"items" [1] "next_cursor" "page-2" "snapshot_hash" "sha256:first"}))
-        2)
+          {"items" [(if (= cursor "page-2") 3 99)]
+           "next_cursor" nil
+           "snapshot_hash" "sha256:same"})
+        +
+        0
+        {"max_pages" 1 "cursor" "page-2" "snapshot_hash" "sha256:same"})
       """
+
+      assert run(resumed) ==
+               ~S|{"complete?" true "next_cursor" nil "pages" 1 "snapshot_hash" "sha256:same" "value" 3}|
+
+      changed =
+        String.replace(
+          resumed,
+          ~S|"cursor" "page-2" "snapshot_hash" "sha256:same"|,
+          ~S|"cursor" "page-2" "snapshot_hash" "sha256:other"|
+        )
 
       assert run(changed) =~ ":snapshot-changed"
     end
 
-    test "marks a bounded prefix incomplete and rejects an invalid bound" do
-      source = ~S"""
-      (cap/collect-pages
+    test "rejects missing provenance, invalid bounds, and cursor cycles" do
+      assert run(~S|(cap/fold-pages (fn [_] {"items" [] "next_cursor" nil}) + 0 {"max_pages" 1})|) =~
+               ":missing-snapshot-hash"
+
+      assert run(~S|(cap/fold-pages (fn [_] {}) + 0 {"max_pages" 0})|) =~
+               ":invalid-max-pages"
+
+      cycle = ~S"""
+      (cap/fold-pages
         (fn [cursor]
-          {"items" [(if cursor 2 1)] "next_cursor" "more"})
-        1)
+          {"items" []
+           "next_cursor" (if (= cursor "a") "b" "a")
+           "snapshot_hash" "sha256:same"})
+        +
+        0
+        {"max_pages" 4 "cursor" "a" "snapshot_hash" "sha256:same"})
+      """
+
+      assert run(cycle) =~ ":cursor-cycle"
+    end
+
+    test "traverses data larger than the old eager collector with constant accumulator state" do
+      source = ~S"""
+      (cap/fold-pages
+        (fn [cursor]
+          (let [page (if cursor (parse-long cursor) 0)]
+            {"items" (mapv (fn [_] "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx")
+                            (range 500))
+             "next_cursor" (if (< page 99) (str (inc page)) nil)
+             "snapshot_hash" "sha256:large"}))
+        (fn [count _] (inc count))
+        0
+        {"max_pages" 100})
       """
 
       assert run(source) ==
-               ~S|{"complete?" false "items" [1] "pages" 1}|
-
-      assert run(~S|(cap/collect-pages (fn [_] {"items" []}) 0)|) =~
-               ":invalid-max-pages"
+               ~S|{"complete?" true "next_cursor" nil "pages" 100 "snapshot_hash" "sha256:large" "value" 50000}|
     end
   end
 

--- a/test/ptc_runner/kernel/cap_agent_main_test.exs
+++ b/test/ptc_runner/kernel/cap_agent_main_test.exs
@@ -143,12 +143,14 @@ defmodule PtcRunner.Kernel.CapAgentMainTest do
     end
 
     test "traverses data larger than the old eager collector with constant accumulator state" do
-      source = ~S"""
+      payload = String.duplicate("x", 1_100)
+
+      source = """
       (cap/fold-pages
         (fn [cursor]
           (let [page (if cursor (parse-long cursor) 0)]
-            {"items" (mapv (fn [_] "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx")
-                            (range 500))
+            {"items" (mapv (fn [item] (str page ":" item ":" "#{payload}"))
+                            (range 50))
              "next_cursor" (if (< page 99) (str (inc page)) nil)
              "snapshot_hash" "sha256:large"}))
         (fn [count _] (inc count))
@@ -156,8 +158,11 @@ defmodule PtcRunner.Kernel.CapAgentMainTest do
         {"max_pages" 100})
       """
 
-      assert run(source) ==
-               ~S|{"complete?" true "next_cursor" nil "pages" 100 "snapshot_hash" "sha256:large" "value" 50000}|
+      # The 5,000 unique items carry more than 5 MiB in aggregate, but only
+      # one 50-item page and the integer accumulator are live at a time. This
+      # is a heap-safety test, not a deadline test, so tolerate loaded CI hosts.
+      assert run(source, timeout: 30_000) ==
+               ~S|{"complete?" true "next_cursor" nil "pages" 100 "snapshot_hash" "sha256:large" "value" 5000}|
     end
   end
 
@@ -258,20 +263,29 @@ defmodule PtcRunner.Kernel.CapAgentMainTest do
        kernel llm result workflow.event)
   end
 
-  defp run(source) do
+  defp run(source, opts \\ []) do
     {:ok, components} = Library.components(["cap"])
     {:ok, bundle} = Kernel.compile_bundle(components)
 
-    {:ok, result} =
-      Lisp.run_native(source,
-        prelude: bundle.prelude,
-        tools: discovery_tools(),
-        filter_context: false,
-        caller: :kernel
+    run_opts =
+      Keyword.merge(
+        [
+          prelude: bundle.prelude,
+          tools: discovery_tools(),
+          filter_context: false,
+          caller: :kernel
+        ],
+        opts
       )
 
-    {rendered, _truncated} = Lisp.format_value(result.return)
-    rendered
+    case Lisp.run_native(source, run_opts) do
+      {:ok, result} ->
+        {rendered, _truncated} = Lisp.format_value(result.return)
+        rendered
+
+      {:error, result} ->
+        flunk("unexpected evaluator failure: #{inspect(result.fail, limit: 20)}")
+    end
   end
 
   # `cap` declares the discovery tools it wraps, so the bundle only attaches

--- a/test/ptc_runner/kernel/discoverable_reachability_test.exs
+++ b/test/ptc_runner/kernel/discoverable_reachability_test.exs
@@ -61,14 +61,14 @@ defmodule PtcRunner.Kernel.DiscoverableReachabilityTest do
     end
 
     test "documentation for a withheld export is readable" do
-      assert [printed] = run!(~S|(doc "cap/collect-pages")|, cap_bundle()).prints
+      assert [printed] = run!(~S|(doc "cap/fold-pages")|, cap_bundle()).prints
 
-      assert printed =~ "cap/collect-pages"
+      assert printed =~ "cap/fold-pages"
       assert printed =~ "cursor"
     end
 
     test "apropos finds a withheld export by its docstring" do
-      assert "cap/with-cursor" in run!(~S|(apropos "pagination")|, cap_bundle()).return
+      assert "cap/fold-pages" in run!(~S|(apropos "pagination")|, cap_bundle()).return
     end
   end
 

--- a/test/ptc_runner/kernel/filesystem_mcp_e2e_test.exs
+++ b/test/ptc_runner/kernel/filesystem_mcp_e2e_test.exs
@@ -86,7 +86,15 @@ defmodule PtcRunner.Kernel.FilesystemMCPE2ETest do
              matches["items"]
 
     assert read["snapshot_hash"] == snapshot_hash
-    assert read["lines"] == [%{"line" => 2, "text" => "needle"}]
+
+    assert read["items"] == [
+             %{
+               "byte_offset" => 0,
+               "text" => "first\nneedle\nlast\n"
+             }
+           ]
+
+    assert read["next_cursor"] == nil
     refute inspect(values) =~ "TOP-SECRET"
   end
 
@@ -133,8 +141,7 @@ defmodule PtcRunner.Kernel.FilesystemMCPE2ETest do
           listed (tool/workspace.list {"path" "lib"})
           found (tool/workspace.find {"query" "target"})
           matches (tool/workspace.search {"query" "needle"})
-          read (tool/workspace.read
-                 {"path" "lib/nested/target.txt" "start_line" 2 "line_count" 1})]
+          read (tool/workspace.read {"path" "lib/nested/target.txt"})]
       (return
         {"info" info
          "listed" listed
@@ -198,7 +205,7 @@ defmodule PtcRunner.Kernel.FilesystemMCPE2ETest do
             "tool" => "snapshot_info",
             "field" => "snapshot_hash"
           },
-          "installation_revision" => "filesystem-sample-0.1.0",
+          "installation_revision" => "filesystem-sample-0.2.0",
           "ceilings" => %{
             "timeout_ms" => 15_000,
             "max_catalog_tools" => 8,

--- a/test/ptc_runner/kernel/inspection_lab_test.exs
+++ b/test/ptc_runner/kernel/inspection_lab_test.exs
@@ -64,8 +64,8 @@ defmodule PtcRunner.Kernel.InspectionLabTest do
       assert Enum.any?(records, fn record ->
                record["record_type"] == "capability-output" and
                  record["payload"]["name"] == "filesystem.read" and
-                 get_in(record, ["payload", "result", "value", "lines"]) == [
-                   %{"line" => 1, "text" => "fixture-file"}
+                 get_in(record, ["payload", "result", "value", "items"]) == [
+                   %{"byte_offset" => 0, "text" => "fixture-file"}
                  ]
              end)
 


### PR DESCRIPTION
## What
- replace eager cap/collect-pages with resumable bounded cap/fold-pages
- move the shipped filesystem MCP server to one signed cursor envelope for all four data tools
- stream immutable snapshots through private temporary disk with temp-volume and CLI bounds plus lifecycle cleanup

## Why
Eager collection moved source size into the BEAM heap and lost a resumable cursor at the page bound. The sample file server also retained whole files and capped them at 1 MiB.

## Impact
This is a breaking 0.x pagination API and filesystem sample 0.2.0 change. Callers consume snapshot_hash/items/next_cursor and reduce bounded state. No compatibility shim is retained.

## Checks
- mix precommit
- MIX_ENV=dev mix docs --warnings-as-errors
- filesystem server build, typecheck, and tests (26/26)
- pre-push repository gates (root 6,296; Viewer 53; launcher 42; Dialyzer; package and release)

## Review
The plan was reviewed four times and the implementation was reviewed four times. Findings addressed included lifecycle cleanup, disk-capacity ceilings, the per-invocation cycle contract, and sanitized backing-store failures.