### PR TITLE
fix(cli): make transcript walkthrough executable

### DIFF
--- a/docs/guides/kernel-repl.md
+++ b/docs/guides/kernel-repl.md
@@ -216,15 +216,18 @@ available in the raw `model_exchanges` collection.
 For one complete conversation, use the simpler one-shot command:
 
 ```console
+mkdir -p tmp/tutorial-transcript
 ptc transcript RUN_ID \
   --traces tmp/tutorial-traces \
   --inspection tmp/tutorial-inspection \
   --private-unattended \
-  --private-output tmp/transcript.private.json
+  --private-output tmp/tutorial-transcript/conversation.private.json
 ```
 
 The destination is reserved at owner-only mode before capture. Incomplete or
-ambiguous evidence fails without publication.
+ambiguous evidence fails without publication. The trace, inspection, and
+output directories must be pairwise physically separate: none may equal or
+contain another.
 
 ### Private analysis without a terminal
 

--- a/docs/guides/running-and-debugging.md
+++ b/docs/guides/running-and-debugging.md
@@ -305,18 +305,20 @@ creates a correlated pair without a live model.
 For one transcript, avoid a REPL:
 
 ```console
+mkdir -p tmp/transcript
 ptc transcript RUN_ID \
   --traces tmp/traces \
   --inspection tmp/inspection \
   --private-unattended \
-  --private-output tmp/transcript.private.json
+  --private-output tmp/transcript/conversation.private.json
 ```
 
 The command reserves an owner-only destination before capture. Trace,
-inspection, and output directories must be physically separate. Ambiguous,
-incomplete, changed, unsupported, or oversized evidence fails without a
-partial output. `PtcRunner.TranscriptFrontend` defines the exact one-shot
-contract.
+inspection, and output directories must be pairwise physically separate: no
+directory may equal, contain, or be contained by either of the others.
+Ambiguous, incomplete, changed, unsupported, or oversized evidence fails
+without a partial output. `PtcRunner.TranscriptFrontend` defines the exact
+one-shot contract.
 
 Use `private-run-analysis-v1` when you need several correlated questions or
 custom PTC-Lisp analysis. Its results can include exact messages, generated

--- a/examples/kernel-inspection-lab/README.md
+++ b/examples/kernel-inspection-lab/README.md
@@ -30,6 +30,10 @@ directory:
 mix run examples/kernel-inspection-lab/run.exs /tmp/ptc-inspection-lab
 ```
 
+Each journey writes canonical artifacts under `traces/` and private artifacts
+under `inspection/`. Those sibling directories can be passed directly to
+`ptc transcript`; create a third sibling directory for `--private-output`.
+
 Inspection artifacts contain full model requests/responses, generated source,
 and capability payloads. They are not sanitized traces and should not be
 shared as such.

--- a/examples/kernel-inspection-lab/run.exs
+++ b/examples/kernel-inspection-lab/run.exs
@@ -30,5 +30,6 @@ end)
 IO.puts("Open one artifact with:")
 
 IO.puts(
-  "  mix ptc.viewer --trace-dir #{output}/direct --inspection-file #{output}/direct/run.inspection.jsonl"
+  "  mix ptc.viewer --trace-dir #{output}/direct/traces " <>
+    "--inspection-file #{output}/direct/inspection/run.inspection.jsonl"
 )

--- a/examples/kernel-inspection-lab/support/lab.exs
+++ b/examples/kernel-inspection-lab/support/lab.exs
@@ -37,8 +37,10 @@ defmodule PtcRunner.Examples.KernelInspectionLab do
   defp run_journey(output_dir, endpoint, name, program, wrapper?) do
     directory = Path.join(output_dir, name)
     :ok = File.mkdir(directory)
+    traces = Path.join(directory, "traces")
+    inspection = Path.join(directory, "inspection")
     files = Path.join(directory, "files")
-    :ok = File.mkdir(files)
+    Enum.each([traces, inspection, files], &File.mkdir!/1)
     :ok = File.write(Path.join(files, "value.txt"), "fixture-file")
     :ok = File.write(Path.join(directory, "workflow.clj"), workflow_source())
 
@@ -52,8 +54,8 @@ defmodule PtcRunner.Examples.KernelInspectionLab do
 
     manifest = manifest(name, mission_components, wrapper?)
     manifest_path = Path.join(directory, "ptc.json")
-    trace_path = Path.join(directory, "run.jsonl")
-    inspection_path = Path.join(directory, "run.inspection.jsonl")
+    trace_path = Path.join(traces, "run.jsonl")
+    inspection_path = Path.join(inspection, "run.inspection.jsonl")
     :ok = File.write(manifest_path, Jason.encode!(manifest))
     registry = registry(endpoint, program, wrapper?, directory)
 

--- a/lib/ptc_runner/kernel/command_arguments.ex
+++ b/lib/ptc_runner/kernel/command_arguments.ex
@@ -4,8 +4,9 @@ defmodule PtcRunner.Kernel.CommandArguments do
 
   Acquisition paths remain confined to this command-boundary value and are
   consumed before `RunCoordinator`. Artifact destinations are captured against
-  the invocation working directory after parsing and move only into the sealed
-  phase-6 command continuation.
+  the invocation working directory after parsing. `run` destinations move into
+  the sealed phase-6 command continuation; one-shot `repl` and `transcript`
+  destinations remain on the arguments passed to their dedicated frontends.
   """
 
   @enforce_keys [

--- a/lib/ptc_runner/kernel/command_engine.ex
+++ b/lib/ptc_runner/kernel/command_engine.ex
@@ -64,7 +64,8 @@ defmodule PtcRunner.Kernel.CommandEngine do
           {:error,
            arguments_outcome(entry.arguments, entry.run_ref, :arguments, :invalid_arguments)}
 
-        {:ok, %CommandEntry{arguments: %{command: :repl}} = entry} ->
+        {:ok, %CommandEntry{arguments: %{command: command}} = entry}
+        when command in [:repl, :transcript] ->
           {:error, outcome(:unknown, entry.run_ref, :arguments, :invalid_command)}
 
         {:ok, %CommandEntry{} = entry} ->
@@ -99,11 +100,12 @@ defmodule PtcRunner.Kernel.CommandEngine do
     do: dispatch_entry_context(entry, runtime, true)
 
   defp dispatch_entry_context(
-         %CommandEntry{arguments: %CommandArguments{command: :repl}} = entry,
+         %CommandEntry{arguments: %CommandArguments{command: command}} = entry,
          _runtime,
          _presentation?
-       ),
-       do: with_rejection(one_shot_repl_failure(entry.run_ref, :invalid_command))
+       )
+       when command in [:repl, :transcript],
+       do: with_rejection(one_shot_failure(entry.run_ref, :invalid_command))
 
   defp dispatch_entry_context(
          %CommandEntry{arguments: %CommandArguments{} = arguments, rejection: nil} = entry,
@@ -144,17 +146,19 @@ defmodule PtcRunner.Kernel.CommandEngine do
   @doc false
   @spec entry_failure(CommandEntry.t()) :: {:error, CommandOutcome.t()}
   def entry_failure(
-        %CommandEntry{rejection: %CommandRejection{command: :repl} = rejection} = entry
-      ),
-      do: one_shot_repl_failure(entry.run_ref, rejection.code)
+        %CommandEntry{rejection: %CommandRejection{command: command} = rejection} = entry
+      )
+      when command in [:repl, :transcript],
+      do: one_shot_failure(entry.run_ref, rejection.code)
 
   def entry_failure(%CommandEntry{rejection: %CommandRejection{} = rejection} = entry),
     do: {:error, outcome(rejection.command, entry.run_ref, :arguments, rejection.code)}
 
   @doc false
   @spec startup_failure(CommandEntry.t()) :: {:error, CommandOutcome.t()}
-  def startup_failure(%CommandEntry{arguments: %CommandArguments{command: :repl}} = entry),
-    do: one_shot_repl_failure(entry.run_ref, :invalid_command)
+  def startup_failure(%CommandEntry{arguments: %CommandArguments{command: command}} = entry)
+      when command in [:repl, :transcript],
+      do: one_shot_failure(entry.run_ref, :invalid_command)
 
   def startup_failure(%CommandEntry{
         arguments: %CommandArguments{} = arguments,
@@ -184,8 +188,8 @@ defmodule PtcRunner.Kernel.CommandEngine do
 
   defp prepare_with_ref(argv, run_ref, runtime) do
     case CommandParser.parse(argv) do
-      {:ok, %CommandArguments{command: :repl}} ->
-        one_shot_repl_failure(run_ref, :invalid_command)
+      {:ok, %CommandArguments{command: command}} when command in [:repl, :transcript] ->
+        one_shot_failure(run_ref, :invalid_command)
 
       {:ok, %CommandArguments{frontend_options: []} = arguments} ->
         prepare_arguments_safely(
@@ -198,8 +202,9 @@ defmodule PtcRunner.Kernel.CommandEngine do
       {:ok, %CommandArguments{} = arguments} ->
         {:error, arguments_outcome(arguments, run_ref, :arguments, :invalid_arguments)}
 
-      {:error, %CommandRejection{command: :repl} = rejection} ->
-        one_shot_repl_failure(run_ref, rejection.code)
+      {:error, %CommandRejection{command: command} = rejection}
+      when command in [:repl, :transcript] ->
+        one_shot_failure(run_ref, rejection.code)
 
       {:error, %CommandRejection{} = rejection} ->
         {:error, outcome(rejection.command, run_ref, :arguments, rejection.code)}
@@ -210,10 +215,10 @@ defmodule PtcRunner.Kernel.CommandEngine do
     _kind, _reason -> {:error, outcome(:unknown, run_ref, :internal, :internal_error)}
   end
 
-  defp one_shot_repl_failure(run_ref, :invalid_command),
+  defp one_shot_failure(run_ref, :invalid_command),
     do: {:error, outcome(:unknown, run_ref, :arguments, :invalid_command)}
 
-  defp one_shot_repl_failure(run_ref, _rejection_code),
+  defp one_shot_failure(run_ref, _rejection_code),
     do: {:error, outcome(:unknown, run_ref, :arguments, :invalid_arguments)}
 
   defp prepare_arguments_safely(%CommandArguments{} = arguments, run_ref, destinations, runtime) do

--- a/lib/ptc_runner/kernel/command_entry.ex
+++ b/lib/ptc_runner/kernel/command_entry.ex
@@ -4,7 +4,9 @@ defmodule PtcRunner.Kernel.CommandEntry do
 
   Entry generates the command reference, parses exactly once, and validates an
   envelope destination against every derivable artifact target before startup.
-  A rejected entry retains no caller-owned destination or unknown switch text.
+  One-shot result destinations are anchored into both parsed option views before
+  their frontends receive them. A rejected entry retains no caller-owned
+  destination or unknown switch text.
   """
 
   alias PtcRunner.Kernel.CommandArguments
@@ -77,9 +79,12 @@ defmodule PtcRunner.Kernel.CommandEntry do
   defp finish(arguments, run_ref, frontend) do
     destinations = CommandDestination.capture(arguments.options)
 
-    case anchor_entry_paths(arguments) do
-      {:ok, arguments} ->
-        finish(arguments, destinations, run_ref, frontend)
+    with {:ok, arguments} <- anchor_entry_paths(arguments),
+         {:ok, arguments} <- anchor_one_shot_destinations(arguments, destinations, frontend) do
+      finish(arguments, destinations, run_ref, frontend)
+    else
+      {:error, %CommandRejection{} = rejection} ->
+        {:error, rejected(run_ref, frontend, rejection)}
 
       _invalid ->
         {:error,
@@ -89,6 +94,43 @@ defmodule PtcRunner.Kernel.CommandEntry do
            CommandRejection.generic(arguments.command, :invalid_arguments)
          )}
     end
+  end
+
+  defp anchor_one_shot_destinations(
+         %CommandArguments{command: command, options: options, ordered_options: ordered} =
+           arguments,
+         {destinations, failures},
+         frontend
+       )
+       when command in [:repl, :transcript] do
+    keys = one_shot_destination_keys(command)
+
+    case Enum.find(keys, &(&1 in failures)) do
+      nil ->
+        anchored = Map.take(destinations, keys)
+
+        {:ok,
+         %{
+           arguments
+           | options: Map.merge(options, anchored),
+             ordered_options: replace_ordered_destinations(ordered, anchored)
+         }}
+
+      key ->
+        {:error, CommandRejection.invalid_destination(command, key, frontend)}
+    end
+  end
+
+  defp anchor_one_shot_destinations(%CommandArguments{} = arguments, _destinations, _frontend),
+    do: {:ok, arguments}
+
+  defp one_shot_destination_keys(:transcript), do: [:private_output]
+  defp one_shot_destination_keys(:repl), do: [:output, :private_output]
+
+  defp replace_ordered_destinations(ordered, destinations) do
+    Enum.reduce(destinations, ordered, fn {key, path}, options ->
+      Keyword.replace!(options, key, path)
+    end)
   end
 
   defp anchor_entry_paths(arguments) do

--- a/lib/ptc_runner/kernel/command_frontend.ex
+++ b/lib/ptc_runner/kernel/command_frontend.ex
@@ -33,7 +33,8 @@ defmodule PtcRunner.Kernel.CommandFrontend do
     present(entry, outcome, entry.rejection)
   end
 
-  def present_entry(%CommandEntry{arguments: %{command: :repl}} = entry, _bootstrap) do
+  def present_entry(%CommandEntry{arguments: %{command: command}} = entry, _bootstrap)
+      when command in [:repl, :transcript] do
     {:error, outcome} = CommandEngine.dispatch_entry(entry, CommandRuntime.standalone())
     present(entry, outcome, nil)
   end

--- a/lib/ptc_runner/kernel/command_rejection.ex
+++ b/lib/ptc_runner/kernel/command_rejection.ex
@@ -68,17 +68,19 @@ defmodule PtcRunner.Kernel.CommandRejection do
 
   @spec invalid_destination(
           CommandDeclaration.command(),
-          :envelope,
+          atom(),
           CommandDeclaration.frontend()
         ) :: t()
-  def invalid_destination(command, :envelope, frontend)
-      when command in [:validate, :run, :doctor, :models, :init] do
+  def invalid_destination(command, destination, frontend)
+      when (destination == :envelope and command in [:validate, :run, :doctor, :models, :init]) or
+             (command == :transcript and destination == :private_output) or
+             (command == :repl and destination in [:output, :private_output]) do
     %__MODULE__{
       command: command,
       code: :invalid_arguments,
       kind: :invalid_destination,
       accepted: [],
-      destination: CommandDeclaration.option_switch!(command, frontend, :envelope),
+      destination: CommandDeclaration.option_switch!(command, frontend, destination),
       conflicts: []
     }
   end

--- a/lib/ptc_runner/kernel/command_renderer.ex
+++ b/lib/ptc_runner/kernel/command_renderer.ex
@@ -191,6 +191,14 @@ defmodule PtcRunner.Kernel.CommandRenderer do
   defp rejection_suffix(%CommandRejection{kind: :init_destination_collision}),
     do: "; --envelope must be outside the init directory"
 
+  defp rejection_suffix(%CommandRejection{
+         command: :transcript,
+         code: :invalid_arguments,
+         kind: :generic
+       }),
+       do:
+         "; required: RUN_ID, --traces, --inspection, --private-unattended, and --private-output"
+
   defp rejection_suffix(_rejection), do: ""
 
   defp help_text(%{"usage" => usage, "options" => options, "notices" => notices}) do

--- a/lib/ptc_runner/transcript_frontend.ex
+++ b/lib/ptc_runner/transcript_frontend.ex
@@ -49,8 +49,8 @@ defmodule PtcRunner.TranscriptFrontend do
           result = capture_and_publish(handle, run_id, traces, inspection, capture_opts)
           finalize_handle(handle, result)
 
-        {:error, _reason} ->
-          {:error, :destination_unavailable, "private transcript destination unavailable"}
+        {:error, reason} ->
+          destination_error(reason)
       end
     else
       {:error, :invalid_arguments, "invalid transcript command"}
@@ -67,13 +67,12 @@ defmodule PtcRunner.TranscriptFrontend do
   defp capture_and_publish(handle, run_id, traces, inspection, capture_opts) do
     resources = %{"traces" => traces, "inspection" => inspection}
 
-    case validate_separation(handle, traces, inspection) do
+    case validate_sources_and_separation(handle, traces, inspection) do
       :ok ->
         capture_source(handle, run_id, resources, capture_opts)
 
-      {:error, _reason} ->
-        {:error, :source_separation_failed,
-         "private transcript sources and destination must be separate"}
+      {:error, _code, _message} = error ->
+        error
     end
   end
 
@@ -104,7 +103,8 @@ defmodule PtcRunner.TranscriptFrontend do
               {:error, :incomplete_evidence, "transcript evidence is incomplete or ambiguous"}
 
             {:error, :not_found} ->
-              {:error, :run_not_found, "analysis run not found"}
+              {:error, :run_not_found,
+               "RUN_ID was not found in the correlated --traces and --inspection sources"}
 
             {:error, :source_changed} ->
               {:error, :source_changed, "analysis source changed during capture"}
@@ -132,8 +132,17 @@ defmodule PtcRunner.TranscriptFrontend do
       {:error, :source_changed} ->
         {:error, :source_changed, "analysis source changed during capture"}
 
+      {:error, :empty_traces_resource} ->
+        {:error, :source_unavailable,
+         "--traces must contain at least one canonical trace artifact"}
+
+      {:error, :empty_inspection_resource} ->
+        {:error, :source_unavailable,
+         "--inspection must contain at least one correlated inspection artifact"}
+
       {:error, _reason} ->
-        {:error, :source_unavailable, "private transcript source unavailable"}
+        {:error, :source_unavailable,
+         "--traces or --inspection could not be captured as private transcript sources"}
     end
   end
 
@@ -150,17 +159,79 @@ defmodule PtcRunner.TranscriptFrontend do
 
   defp valid_capture_opts?(_opts), do: false
 
-  defp validate_separation(handle, traces, inspection) do
-    with {:ok, trace} <- AnalysisDirectory.resolve(traces),
-         {:ok, private} <- AnalysisDirectory.resolve(inspection),
+  defp validate_sources_and_separation(handle, traces, inspection) do
+    with {:ok, trace} <- resolve_source(traces, :traces),
+         {:ok, private} <- resolve_source(inspection, :inspection),
          {:ok, output} <-
-           handle |> PublicationHandle.path() |> Path.dirname() |> AnalysisDirectory.resolve(),
-         true <- AnalysisDirectory.pairwise_separate?([trace, private, output]) do
-      :ok
-    else
-      _ -> {:error, :invalid_directory_separation}
+           handle
+           |> PublicationHandle.path()
+           |> Path.dirname()
+           |> resolve_output_directory() do
+      validate_separation(trace, private, output)
     end
   end
+
+  defp resolve_source(directory, :traces) do
+    case AnalysisDirectory.resolve(directory) do
+      {:ok, resolved} ->
+        {:ok, resolved}
+
+      {:error, _reason} ->
+        {:error, :source_unavailable, "--traces must name an existing directory"}
+    end
+  end
+
+  defp resolve_source(directory, :inspection) do
+    case AnalysisDirectory.resolve(directory) do
+      {:ok, resolved} ->
+        {:ok, resolved}
+
+      {:error, _reason} ->
+        {:error, :source_unavailable, "--inspection must name an existing directory"}
+    end
+  end
+
+  defp resolve_output_directory(directory) do
+    case AnalysisDirectory.resolve(directory) do
+      {:ok, resolved} ->
+        {:ok, resolved}
+
+      {:error, _reason} ->
+        {:error, :destination_unavailable,
+         "the parent directory for --private-output is unavailable"}
+    end
+  end
+
+  defp validate_separation(trace, private, output) do
+    cond do
+      not AnalysisDirectory.pairwise_separate?([trace, private]) ->
+        separation_error("--traces", "--inspection")
+
+      not AnalysisDirectory.pairwise_separate?([trace, output]) ->
+        separation_error("--traces", "--private-output")
+
+      not AnalysisDirectory.pairwise_separate?([private, output]) ->
+        separation_error("--inspection", "--private-output")
+
+      true ->
+        :ok
+    end
+  end
+
+  defp separation_error(first, second) do
+    {:error, :source_separation_failed,
+     "directories for #{first} and #{second} must be physically separate; " <>
+       "neither may contain the other"}
+  end
+
+  defp destination_error(:destination_exists),
+    do: {:error, :destination_exists, "--private-output already exists; choose a new file"}
+
+  defp destination_error(:invalid_destination),
+    do: {:error, :destination_unavailable, "--private-output must name a valid new file"}
+
+  defp destination_error(_reason),
+    do: {:error, :destination_unavailable, "--private-output destination is unavailable"}
 
   defp finalize_handle(handle, :ok) do
     :ok = PublicationHandle.release(handle)

--- a/test/mix/tasks/ptc_repl_test.exs
+++ b/test/mix/tasks/ptc_repl_test.exs
@@ -642,6 +642,9 @@ defmodule PtcRunner.ReplFrontendTest do
     Enum.each([source, traces, results], &File.mkdir!/1)
     seed_trace(source, "seed")
     output = Path.join(results, "overview.json")
+    relative_output = Path.relative_to(output, File.cwd!())
+
+    assert Path.type(relative_output) == :relative
 
     capture_io(fn ->
       run_repl([
@@ -652,7 +655,7 @@ defmodule PtcRunner.ReplFrontendTest do
         "--session-trace-dir",
         traces,
         "--output",
-        output,
+        relative_output,
         "-e",
         ~s|(analysis/open "seed")|
       ])

--- a/test/mix/tasks/ptc_transcript_test.exs
+++ b/test/mix/tasks/ptc_transcript_test.exs
@@ -15,6 +15,9 @@ defmodule Mix.Tasks.PtcTranscriptTest do
     output_directory = Path.join(root, "transcript")
     File.mkdir!(output_directory)
     output = Path.join(output_directory, "transcript.private.json")
+    relative_output = Path.relative_to(output, File.cwd!())
+
+    assert Path.type(relative_output) == :relative
 
     presentation =
       MixCommandAdapter.execute([
@@ -26,7 +29,7 @@ defmodule Mix.Tasks.PtcTranscriptTest do
         fixture.inspection,
         "--private-unattended",
         "--private-output",
-        output
+        relative_output
       ])
 
     assert presentation.exit_status == 0
@@ -55,6 +58,101 @@ defmodule Mix.Tasks.PtcTranscriptTest do
     assert prompt == "private-prompt-#{run_id}"
     assert answer == "private-answer-#{run_id}"
     assert File.stat!(output).mode |> Bitwise.band(0o777) == 0o600
+  end
+
+  @tag :tmp_dir
+  test "destination failures identify --private-output without echoing its path", %{tmp_dir: root} do
+    fixture = PrivateInspectionFixture.create!(root)
+    output = Path.join(fixture.output, "occupied.private.json")
+    File.write!(output, "original")
+
+    presentation = MixCommandAdapter.execute(transcript_argv(fixture, output))
+
+    assert presentation.exit_status == 1
+    assert presentation.stderr =~ "transcript/destination_exists"
+    assert presentation.stderr =~ "--private-output"
+    assert presentation.stderr =~ "already exists"
+    refute presentation.stderr =~ output
+    assert File.read!(output) == "original"
+  end
+
+  @tag :tmp_dir
+  test "physical source and output collisions identify the conflicting switches", %{tmp_dir: root} do
+    fixture = PrivateInspectionFixture.create!(root)
+    alias_root = Path.join(root, "root-alias")
+    File.ln_s!(root, alias_root)
+    aliased_traces = Path.join(alias_root, "traces")
+
+    cases = [
+      {fixture.traces, fixture.traces, Path.join(fixture.output, "same-source.json"),
+       ["--traces", "--inspection"]},
+      {fixture.traces, fixture.inspection, Path.join(root, "ancestor-output.json"),
+       ["--traces", "--private-output"]},
+      {fixture.traces, aliased_traces, Path.join(fixture.output, "aliased-source.json"),
+       ["--traces", "--inspection"]}
+    ]
+
+    for {traces, inspection, output, switches} <- cases do
+      presentation =
+        MixCommandAdapter.execute(
+          transcript_argv(fixture, output, traces: traces, inspection: inspection)
+        )
+
+      assert presentation.exit_status == 1
+      assert presentation.stderr =~ "transcript/source_separation_failed"
+      assert presentation.stderr =~ "physically separate"
+      Enum.each(switches, &assert(presentation.stderr =~ &1))
+      refute presentation.stderr =~ root
+      refute File.exists?(output)
+    end
+  end
+
+  @tag :tmp_dir
+  test "unavailable and swapped sources identify the declared source switch", %{tmp_dir: root} do
+    fixture = PrivateInspectionFixture.create!(root)
+
+    cases = [
+      {Path.join(root, "missing-traces"), fixture.inspection, "--traces", "existing"},
+      {fixture.inspection, fixture.traces, "--traces", "canonical trace"}
+    ]
+
+    for {traces, inspection, switch, cause} <- cases do
+      output = Path.join(fixture.output, "source-#{System.unique_integer([:positive])}.json")
+
+      presentation =
+        MixCommandAdapter.execute(
+          transcript_argv(fixture, output, traces: traces, inspection: inspection)
+        )
+
+      assert presentation.exit_status == 1
+      assert presentation.stderr =~ "transcript/source_unavailable"
+      assert presentation.stderr =~ switch
+      assert presentation.stderr =~ cause
+      refute presentation.stderr =~ root
+      refute File.exists?(output)
+    end
+  end
+
+  @tag :tmp_dir
+  test "an unknown RUN_ID identifies the selector and correlated source switches", %{
+    tmp_dir: root
+  } do
+    fixture = PrivateInspectionFixture.create!(root)
+    output = Path.join(fixture.output, "unknown-run.json")
+
+    presentation =
+      MixCommandAdapter.execute(
+        transcript_argv(fixture, output, run_id: "caller-private-unknown-run")
+      )
+
+    assert presentation.exit_status == 1
+    assert presentation.stderr =~ "transcript/run_not_found"
+    assert presentation.stderr =~ "RUN_ID"
+    assert presentation.stderr =~ "--traces"
+    assert presentation.stderr =~ "--inspection"
+    refute presentation.stderr =~ "caller-private-unknown-run"
+    refute presentation.stderr =~ root
+    refute File.exists?(output)
   end
 
   @tag :tmp_dir
@@ -149,29 +247,57 @@ defmodule Mix.Tasks.PtcTranscriptTest do
     refute File.exists?(output)
   end
 
-  test "the unattended accident guard and private destination are mandatory" do
+  test "every missing required argument reports the complete transcript command shape" do
+    complete = [
+      "transcript",
+      "caller-run",
+      "--traces",
+      "caller-traces",
+      "--inspection",
+      "caller-inspection",
+      "--private-unattended",
+      "--private-output",
+      "caller-output.json"
+    ]
+
     for argv <- [
-          [
-            "transcript",
-            "run",
-            "--traces",
-            "traces",
-            "--inspection",
-            "inspection",
-            "--private-output",
-            "out.json"
-          ],
-          [
-            "transcript",
-            "run",
-            "--traces",
-            "traces",
-            "--inspection",
-            "inspection",
-            "--private-unattended"
-          ]
+          List.delete_at(complete, 1),
+          without_option(complete, "--traces"),
+          without_option(complete, "--inspection"),
+          List.delete(complete, "--private-unattended"),
+          without_option(complete, "--private-output")
         ] do
-      assert %{exit_status: 2} = MixCommandAdapter.execute(argv)
+      presentation = MixCommandAdapter.execute(argv)
+
+      assert presentation.exit_status == 2
+      assert presentation.stderr =~ "RUN_ID"
+      assert presentation.stderr =~ "--traces"
+      assert presentation.stderr =~ "--inspection"
+      assert presentation.stderr =~ "--private-unattended"
+      assert presentation.stderr =~ "--private-output"
+      refute presentation.stderr =~ "caller-run"
+      refute presentation.stderr =~ "caller-traces"
+      refute presentation.stderr =~ "caller-inspection"
+      refute presentation.stderr =~ "caller-output.json"
     end
+  end
+
+  defp transcript_argv(fixture, output, overrides \\ []) do
+    [
+      "transcript",
+      Keyword.get(overrides, :run_id, fixture.run_id),
+      "--traces",
+      Keyword.get(overrides, :traces, fixture.traces),
+      "--inspection",
+      Keyword.get(overrides, :inspection, fixture.inspection),
+      "--private-unattended",
+      "--private-output",
+      output
+    ]
+  end
+
+  defp without_option(argv, switch) do
+    index = Enum.find_index(argv, &(&1 == switch))
+    argv |> List.delete_at(index) |> List.delete_at(index)
   end
 end

--- a/test/ptc_runner/kernel/command_engine_test.exs
+++ b/test/ptc_runner/kernel/command_engine_test.exs
@@ -148,11 +148,23 @@ defmodule PtcRunner.Kernel.CommandEngineTest do
     end
   end
 
-  test "the one-shot engine APIs reject accepted and malformed repl requests as sealed outcomes" do
+  test "the one-shot engine APIs reject accepted and malformed requests as sealed outcomes" do
     for {argv, code} <- [
           {["repl"], "invalid_command"},
           {["repl", "--caller-secret", "value"], "invalid_arguments"},
-          {["repl", "-e", "expr", "script.clj"], "invalid_arguments"}
+          {["repl", "-e", "expr", "script.clj"], "invalid_arguments"},
+          {[
+             "transcript",
+             "run-1",
+             "--traces",
+             "traces",
+             "--inspection",
+             "inspection",
+             "--private-unattended",
+             "--private-output",
+             "transcript.json"
+           ], "invalid_command"},
+          {["transcript", "run-1"], "invalid_arguments"}
         ],
         operation <- [&CommandEngine.prepare/1, &CommandEngine.dispatch/1] do
       assert {:error, %CommandOutcome{} = outcome} = operation.(argv)

--- a/test/ptc_runner/kernel/command_frontend_test.exs
+++ b/test/ptc_runner/kernel/command_frontend_test.exs
@@ -125,6 +125,38 @@ defmodule PtcRunner.Kernel.CommandFrontendTest do
     refute_received :unexpected_bootstrap
   end
 
+  test "the one-shot frontend rejects transcript without invoking bootstrap" do
+    parent = self()
+
+    presentation =
+      CommandFrontend.execute(
+        [
+          "transcript",
+          "run-1",
+          "--traces",
+          "traces",
+          "--inspection",
+          "inspection",
+          "--private-unattended",
+          "--private-output",
+          "transcript.json"
+        ],
+        :standalone,
+        fn _arguments ->
+          send(parent, :unexpected_bootstrap)
+          {:ok, CommandRuntime.standalone()}
+        end
+      )
+
+    assert presentation.exit_status == 2
+    assert presentation.outcome.command_mode == :unknown
+
+    assert %{"code" => "invalid_command", "phase" => "arguments"} =
+             presentation.outcome.envelope["error"]
+
+    refute_received :unexpected_bootstrap
+  end
+
   @tag :tmp_dir
   test "a recoverable startup failure publishes one schema-valid envelope", %{tmp_dir: dir} do
     path = Path.join(dir, "command-envelope.json")

--- a/test/ptc_runner/kernel/inspection_lab_test.exs
+++ b/test/ptc_runner/kernel/inspection_lab_test.exs
@@ -11,6 +11,7 @@ defmodule PtcRunner.Kernel.InspectionLabTest do
   alias PtcRunner.Examples.KernelInspectionLab
   alias PtcRunner.Kernel.InspectionArtifact
   alias PtcRunner.Kernel.ViewerAdapter
+  alias PtcRunner.MixCommandAdapter
 
   @tag :tmp_dir
   @tag :slow
@@ -23,6 +24,8 @@ defmodule PtcRunner.Kernel.InspectionLabTest do
     assert wrapper.name == "wrapper"
 
     for journey <- [direct, wrapper] do
+      assert Path.basename(Path.dirname(journey.trace)) == "traces"
+      assert Path.basename(Path.dirname(journey.inspection)) == "inspection"
       assert {:ok, records} = InspectionArtifact.load(journey.inspection)
       assert File.read!(journey.trace) =~ "mcp-2026-07-28"
 
@@ -161,6 +164,32 @@ defmodule PtcRunner.Kernel.InspectionLabTest do
       refute turns.resp_body =~ "fixture-text"
       refute turns.resp_body =~ "fixture-file"
       PtcViewer.InspectionStore.stop(inspection_store)
+
+      journey_directory = journey.trace |> Path.dirname() |> Path.dirname()
+      transcript_directory = Path.join(journey_directory, "transcript")
+      File.mkdir!(transcript_directory)
+      transcript = Path.join(transcript_directory, "conversation.private.json")
+
+      presentation =
+        MixCommandAdapter.execute([
+          "transcript",
+          journey.run_id,
+          "--traces",
+          Path.dirname(journey.trace),
+          "--inspection",
+          Path.dirname(journey.inspection),
+          "--private-unattended",
+          "--private-output",
+          transcript
+        ])
+
+      assert presentation.exit_status == 0
+
+      assert %{"run_id" => run_id, "conversation" => %{"complete?" => true}} =
+               transcript |> File.read!() |> Jason.decode!()
+
+      assert run_id == journey.run_id
+      assert File.stat!(transcript).mode |> Bitwise.band(0o777) == 0o600
     end
 
     direct_request = model_request(direct.inspection)


### PR DESCRIPTION
## Summary

- anchor one-shot `repl` and `transcript` output paths at command entry so relative destinations behave like `mix ptc run --output`
- preserve private-safe transcript failure causes and name the responsible argument or switch in every documented failure mode
- split the inspection lab's trace, inspection, and transcript artifacts into physically separate sibling directories and make both guides directly executable
- add integration coverage from the lab run through transcript publication, plus direct-engine, path-separation, required-argument, and privacy regressions

## Root cause

`repl` and `transcript` bypassed the anchored destination view used by run publication, while transcript capture collapsed specific closed failures into generic messages. The walkthroughs also placed the transcript output in an ancestor of both source directories, violating the physical pairwise-separation invariant.

## Verification

- `mix precommit`
- `MIX_ENV=dev mix docs --warnings-as-errors`
- pre-push repository gates in serial mode: 6,308 core tests, static analysis, Dialyzer, release verification, Viewer validation, and launcher validation
- independent plan review once; implementation reviewed three times with the final follow-up clean

Closes #1406
