### PR TITLE
fix(llm): prepare ReqLLM models once

### DIFF
--- a/docs/guides/embedding-in-elixir.md
+++ b/docs/guides/embedding-in-elixir.md
@@ -126,6 +126,13 @@ not a transient model failure. Hosts that configure custom ReqLLM pools also
 own their pool geometry; the CLI uses installed `live_provider_tasks`, not one
 manifest's narrower limit, for its VM-lifetime pool.
 
+An adapter may implement `c:PtcRunner.LLM.prepare_model/1` to resolve its model
+selector once before requester construction. Return an immutable request target
+and its catalog status; do not return processes, ports, credentials, or other
+resources that need cleanup. `PtcRunner.LLM.callback/2` returns
+`{:ok, requester}` only after preparation succeeds, so embedding callers must
+propagate its error tuple before dispatch.
+
 An adapter may implement `c:PtcRunner.LLM.public_model/1` to attest that its exact
 configured target is safe to publish. Missing, altered, invalid, oversized, or
 raising attestations remain private without preventing execution. Treat the

--- a/docs/guides/host-configuration.md
+++ b/docs/guides/host-configuration.md
@@ -130,6 +130,13 @@ This avoids turning a model's full context-window ceiling into an impossible
 output request once the prompt is included. The tutorial keeps the value
 explicit so changing only its model selector retains a bounded request.
 
+The built-in adapter prepares the selected model once before constructing its
+requester. A selector absent from the bundled model catalog remains usable when
+ReqLLM supports its provider, but PtcRunner emits one `model_uncataloged`
+warning for that requester. Catalog metadata such as pricing, limits, token
+estimation, and capability detection may then be incomplete; the warning does
+not mean the provider request itself is known to fail.
+
 The manifest selects only `deepseek`; it cannot change any field above. When
 the adapter attests that the resolved model is safe public identity, provider
 snapshots and model-grouped usage include it. Endpoint-bearing or otherwise

--- a/lib/ptc_runner/kernel/host_installation.ex
+++ b/lib/ptc_runner/kernel/host_installation.ex
@@ -708,7 +708,8 @@ defmodule PtcRunner.Kernel.HostInstallation do
   defp preflight(_host, %{source: :llm} = installation, selection, context, _oauth_runtime) do
     with :ok <- placement(installation, context.destination),
          {:ok, selected} <- llm_selection(installation, selection, context),
-         {:ok, model, adapter} <- preflight_llm(installation.model) do
+         {:ok, model, adapter} <- preflight_llm(installation.model),
+         {:ok, prepared_model} <- prepare_llm_model(model, adapter) do
       public_model = PtcRunner.LLM.attested_public_model(adapter, model)
 
       {:ok,
@@ -719,6 +720,7 @@ defmodule PtcRunner.Kernel.HostInstallation do
             selected,
             context,
             model,
+            prepared_model,
             public_model,
             adapter,
             credentials
@@ -782,6 +784,17 @@ defmodule PtcRunner.Kernel.HostInstallation do
             context
           )
         end}}
+    end
+  end
+
+  # Adapter preparation has a deliberately rich direct-embedding error
+  # vocabulary. An installed provider crosses the Kernel's closed diagnostic
+  # boundary instead, where every invalid or unsupported target is represented
+  # by the existing adapter-unavailable reason.
+  defp prepare_llm_model(model, adapter) do
+    case PtcRunner.LLM.prepare(model, adapter) do
+      {:ok, prepared_model} -> {:ok, prepared_model}
+      {:error, _reason} -> {:error, :invalid_llm_model}
     end
   end
 
@@ -897,12 +910,14 @@ defmodule PtcRunner.Kernel.HostInstallation do
     with :ok <- placement(installation, context.destination),
          {:ok, _selected} <- llm_selection(installation, selection, context),
          {:ok, model, adapter} <- preflight_llm(installation.model),
+         {:ok, prepared_model} <- prepare_llm_model(model, adapter),
          {:ok, credential} <-
            Map.fetch(Map.get(context, :credentials, %{}), installation.credential),
          {:ok, timeout_ms, max_heap_words} <- connectivity_probe_bounds(context) do
       {:ok,
        %{
          model: model,
+         prepared_model: prepared_model,
          adapter: adapter,
          credential: credential,
          params: installation.params,
@@ -955,24 +970,28 @@ defmodule PtcRunner.Kernel.HostInstallation do
         req_http_options: [retry: false, redirect: false, max_retries: 0]
       )
 
-    requester = PtcRunner.LLM.callback(probe.model, options)
+    case PtcRunner.LLM.callback(probe.prepared_model, options) do
+      {:ok, requester} ->
+        result =
+          BoundedWorker.run(
+            fn ->
+              requester.(%{
+                messages: [%{role: :user, content: "Health check."}],
+                cache: false
+              })
+            end,
+            timeout_ms: probe.timeout_ms,
+            max_heap_words: probe.max_heap_words,
+            cancel_with_caller: true
+          )
 
-    result =
-      BoundedWorker.run(
-        fn ->
-          requester.(%{
-            messages: [%{role: :user, content: "Health check."}],
-            cache: false
-          })
-        end,
-        timeout_ms: probe.timeout_ms,
-        max_heap_words: probe.max_heap_words,
-        cancel_with_caller: true
-      )
+        case result do
+          {:ok, {:ok, response}} when is_map(response) -> :ok
+          _failure -> {:error, :llm_connectivity_unavailable}
+        end
 
-    case result do
-      {:ok, {:ok, response}} when is_map(response) -> :ok
-      _failure -> {:error, :llm_connectivity_unavailable}
+      {:error, _reason} ->
+        {:error, :llm_connectivity_unavailable}
     end
   rescue
     _exception -> {:error, :llm_connectivity_unavailable}
@@ -1178,14 +1197,15 @@ defmodule PtcRunner.Kernel.HostInstallation do
          selected,
          context,
          model,
+         prepared_model,
          public_model,
          adapter,
          credentials
        ) do
     with {:ok, credential} <- Map.fetch(credentials, installation.credential),
-         requester =
+         {:ok, requester} <-
            PtcRunner.LLM.callback(
-             model,
+             prepared_model,
              [
                adapter: adapter,
                cache: installation.cache,

--- a/lib/ptc_runner/llm.ex
+++ b/lib/ptc_runner/llm.ex
@@ -33,6 +33,7 @@ defmodule PtcRunner.LLM do
         }
 
   @type chunk :: %{delta: String.t()} | %{done: true, tokens: tokens()}
+  @type catalog_status :: :cataloged | :uncataloged | :unavailable
 
   @doc """
   Make an LLM call.
@@ -46,7 +47,7 @@ defmodule PtcRunner.LLM do
 
   Returns `{:ok, response}` or `{:error, reason}`.
   """
-  @callback call(model :: String.t(), request :: map()) :: {:ok, map()} | {:error, term()}
+  @callback call(model :: term(), request :: map()) :: {:ok, map()} | {:error, term()}
 
   @doc """
   Stream an LLM response.
@@ -55,8 +56,18 @@ defmodule PtcRunner.LLM do
   - `%{delta: "text"}` for content chunks
   - `%{done: true, tokens: %{...}}` for the final chunk
   """
-  @callback stream(model :: String.t(), request :: map()) ::
+  @callback stream(model :: term(), request :: map()) ::
               {:ok, Enumerable.t()} | {:error, term()}
+
+  @doc """
+  Prepares an adapter-owned request target and reports its catalog status.
+
+  Optional. Adapters without an external model catalog may omit this callback;
+  PtcRunner then passes the original selector to requests and records the status
+  as `:unavailable`.
+  """
+  @callback prepare_model(model :: String.t()) ::
+              {:ok, target :: term(), catalog_status()} | {:error, term()}
 
   @doc """
   Preload adapter-owned model metadata into a shared, process-independent store
@@ -96,7 +107,15 @@ defmodule PtcRunner.LLM do
   """
   @callback public_model(model :: String.t()) :: {:ok, String.t()} | :private
 
-  @optional_callbacks [stream: 2, ensure_ready: 0, provider_application: 1, public_model: 1]
+  @optional_callbacks [
+    stream: 2,
+    prepare_model: 1,
+    ensure_ready: 0,
+    provider_application: 1,
+    public_model: 1
+  ]
+
+  alias PtcRunner.LLM.PreparedModel
 
   @doc false
   @spec attested_public_model(module(), String.t()) :: String.t() | nil
@@ -120,38 +139,113 @@ defmodule PtcRunner.LLM do
   def attested_public_model(_adapter, _model), do: nil
 
   @doc """
-  Creates a normalized callback for a configured model.
+  Resolves a configured selector into an immutable adapter-owned request target.
 
-  `model` is a full provider-qualified identifier such as
-  `"openrouter:deepseek/deepseek-v4-flash"`. The optional `:adapter`
-  setting selects a transport explicitly; other options are merged into every
-  request.
+  Preparation runs adapter warmup and model resolution once. It returns a typed
+  error immediately when either operation cannot produce a valid prepared value.
   """
-  @spec callback(String.t(), keyword()) :: (map() -> {:ok, map()} | {:error, term()})
+  @spec prepare(String.t(), module()) :: {:ok, PreparedModel.t()} | {:error, term()}
+  def prepare(model, adapter \\ adapter!())
+
+  def prepare(model, adapter) when is_binary(model) and is_atom(adapter) do
+    if Code.ensure_loaded?(adapter) do
+      if function_exported?(adapter, :ensure_ready, 0), do: adapter.ensure_ready()
+
+      result =
+        if function_exported?(adapter, :prepare_model, 1),
+          do: adapter.prepare_model(model),
+          else: {:ok, model, :unavailable}
+
+      case result do
+        {:ok, target, status} -> PreparedModel.new(adapter, model, target, status)
+        {:error, _reason} = error -> error
+        _invalid -> {:error, :invalid_model_preparation}
+      end
+    else
+      {:error, :invalid_model_preparation}
+    end
+  rescue
+    _exception -> {:error, :invalid_model_preparation}
+  catch
+    _kind, _reason -> {:error, :invalid_model_preparation}
+  end
+
+  def prepare(_model, _adapter), do: {:error, :invalid_model_preparation}
+
+  @doc """
+  Creates a normalized requester for a configured or prepared model.
+
+  A selector is prepared once while this function constructs the requester. A
+  prepared value is bound directly. The optional `:adapter` setting selects a
+  transport explicitly; other options are merged into every request.
+
+  Returns `{:ok, requester}` or an error before any request can run. An
+  uncataloged selector emits one concise warning while the requester is built.
+  """
+  @spec callback(String.t() | PreparedModel.t(), keyword()) ::
+          {:ok, (map() -> {:ok, map()} | {:error, term()})} | {:error, term()}
   def callback(model, opts \\ []) do
     {adapter_override, opts} = Keyword.pop(opts, :adapter)
-    adapter = adapter_override || adapter!()
-    # Provider-application admission normally warms this before the run clock.
-    # Keep the idempotent call here for direct embedding paths that construct a
-    # capability without that gate.
-    if function_exported?(adapter, :ensure_ready, 0), do: adapter.ensure_ready()
-    merged_opts = Map.new(opts)
 
-    fn req ->
-      {stream_fn, clean_req} = Map.pop(req, :stream)
-      final_req = if merged_opts == %{}, do: clean_req, else: Map.merge(clean_req, merged_opts)
+    with {:ok, prepared} <- prepared_model(model, adapter_override),
+         :ok <- warn_catalog_status(prepared) do
+      merged_opts = Map.new(opts)
 
-      if stream_fn && function_exported?(adapter, :stream, 2) do
-        case adapter.stream(model, final_req) do
-          {:ok, stream} -> consume_stream(stream, stream_fn)
-          {:error, :streaming_not_supported} -> adapter.call(model, final_req)
-          error -> error
-        end
-      else
-        adapter.call(model, final_req)
-      end
+      {:ok,
+       fn req ->
+         {stream_fn, clean_req} = Map.pop(req, :stream)
+         final_req = if merged_opts == %{}, do: clean_req, else: Map.merge(clean_req, merged_opts)
+
+         if stream_fn && function_exported?(prepared.adapter, :stream, 2) do
+           case prepared.adapter.stream(prepared.target, final_req) do
+             {:ok, stream} ->
+               consume_stream(stream, stream_fn)
+
+             {:error, :streaming_not_supported} ->
+               prepared.adapter.call(prepared.target, final_req)
+
+             error ->
+               error
+           end
+         else
+           prepared.adapter.call(prepared.target, final_req)
+         end
+       end}
     end
   end
+
+  defp prepared_model(%PreparedModel{} = prepared, nil) do
+    if PreparedModel.valid?(prepared),
+      do: {:ok, prepared},
+      else: {:error, :invalid_prepared_model}
+  end
+
+  defp prepared_model(%PreparedModel{adapter: adapter} = prepared, adapter) do
+    if PreparedModel.valid?(prepared),
+      do: {:ok, prepared},
+      else: {:error, :invalid_prepared_model}
+  end
+
+  defp prepared_model(%PreparedModel{}, _different_adapter),
+    do: {:error, :invalid_prepared_model}
+
+  defp prepared_model(model, adapter_override) when is_binary(model),
+    do: prepare(model, adapter_override || adapter!())
+
+  defp prepared_model(_model, _adapter), do: {:error, :invalid_prepared_model}
+
+  defp warn_catalog_status(%PreparedModel{catalog_status: :uncataloged} = prepared) do
+    public_model = attested_public_model(prepared.adapter, prepared.selector)
+    identity = if public_model, do: " #{inspect(public_model)}", else: ""
+
+    IO.warn(
+      "model_uncataloged: configured model#{identity} is not an exact catalog entry; " <>
+        "pricing, limits, token estimation, and capability detection may be incomplete",
+      []
+    )
+  end
+
+  defp warn_catalog_status(%PreparedModel{}), do: :ok
 
   defp consume_stream(stream, on_chunk) do
     {content, tokens} =
@@ -184,7 +278,7 @@ defmodule PtcRunner.LLM do
   """
   @spec call(String.t(), map()) :: {:ok, map()} | {:error, term()}
   def call(model, request) do
-    adapter!().call(model, request)
+    with {:ok, requester} <- callback(model), do: requester.(request)
   end
 
   @doc """

--- a/lib/ptc_runner/llm/prepared_model.ex
+++ b/lib/ptc_runner/llm/prepared_model.ex
@@ -1,0 +1,53 @@
+defmodule PtcRunner.LLM.PreparedModel do
+  @moduledoc """
+  Immutable result of preparing a configured LLM selector.
+
+  The value binds the adapter, original selector, adapter-owned request target,
+  and catalog status. Hosts may pass it to `PtcRunner.LLM.callback/2` to avoid
+  repeating adapter preparation; the target remains opaque to the host.
+  """
+
+  @statuses [:cataloged, :uncataloged, :unavailable]
+
+  @enforce_keys [:adapter, :selector, :target, :catalog_status]
+  defstruct @enforce_keys
+
+  @type catalog_status :: :cataloged | :uncataloged | :unavailable
+  @type t :: %__MODULE__{
+          adapter: module(),
+          selector: String.t(),
+          target: term(),
+          catalog_status: catalog_status()
+        }
+
+  @spec new(module(), String.t(), term(), catalog_status()) ::
+          {:ok, t()} | {:error, :invalid_prepared_model}
+  def new(adapter, selector, target, catalog_status)
+      when is_atom(adapter) and is_binary(selector) and catalog_status in @statuses do
+    if byte_size(selector) in 1..256 and String.valid?(selector) do
+      {:ok,
+       %__MODULE__{
+         adapter: adapter,
+         selector: selector,
+         target: target,
+         catalog_status: catalog_status
+       }}
+    else
+      {:error, :invalid_prepared_model}
+    end
+  end
+
+  def new(_adapter, _selector, _target, _catalog_status),
+    do: {:error, :invalid_prepared_model}
+
+  @spec valid?(term()) :: boolean()
+  def valid?(%__MODULE__{} = prepared) do
+    Enum.sort(Map.keys(prepared)) ==
+      Enum.sort([:__struct__, :adapter, :selector, :target, :catalog_status]) and
+      is_atom(prepared.adapter) and is_binary(prepared.selector) and
+      byte_size(prepared.selector) in 1..256 and String.valid?(prepared.selector) and
+      prepared.catalog_status in @statuses
+  end
+
+  def valid?(_prepared), do: false
+end

--- a/lib/ptc_runner/llm/req_llm_adapter.ex
+++ b/lib/ptc_runner/llm/req_llm_adapter.ex
@@ -34,6 +34,7 @@ if Code.ensure_loaded?(ReqLLM) do
     @behaviour PtcRunner.LLM
 
     alias PtcRunner.Kernel.ProviderError
+    alias PtcRunner.LLM.ReqLLMPreparedModel
     alias ReqLLM.Message
     alias ReqLLM.Message.ContentPart
 
@@ -55,6 +56,11 @@ if Code.ensure_loaded?(ReqLLM) do
     ]
     @req_llm_stream_generation_options @req_llm_generation_options -- [:tool_choice]
     @token_limit_options [:max_tokens, :max_completion_tokens, :max_output_tokens]
+    # ReqLLM 1.19 gives these providers richer uncataloged fallbacks than its
+    # documented generic inline form. Keep only the dispatch list here and let
+    # ReqLLM's public string resolver construct each target. Generic providers
+    # use the documented inline form so the dependency warning never escapes.
+    @req_llm_special_fallback_providers [:github_copilot, :minimax, :mistral, :openai_codex]
 
     # --- Behaviour Callbacks ---
 
@@ -100,7 +106,21 @@ if Code.ensure_loaded?(ReqLLM) do
     end
 
     @impl true
-    @spec call(String.t(), map()) :: {:ok, map()} | {:error, ProviderError.t()}
+    @spec prepare_model(String.t()) ::
+            {:ok, String.t() | ReqLLMPreparedModel.t(), PtcRunner.LLM.catalog_status()}
+            | {:error, term()}
+    def prepare_model(model) when is_binary(model) do
+      case parse_provider(model) do
+        {:req_llm, selector} -> prepare_req_llm_model(selector)
+        _direct_http -> {:ok, model, :unavailable}
+      end
+    end
+
+    def prepare_model(_model), do: {:error, :invalid_model}
+
+    @impl true
+    @spec call(String.t() | ReqLLMPreparedModel.t(), map()) ::
+            {:ok, map()} | {:error, ProviderError.t()}
     def call(model, %{schema: schema} = req) when is_map(schema) do
       messages = build_messages(req)
 
@@ -132,8 +152,10 @@ if Code.ensure_loaded?(ReqLLM) do
     end
 
     @impl true
-    @spec stream(String.t(), map()) ::
+    @spec stream(String.t() | ReqLLMPreparedModel.t(), map()) ::
             {:ok, Enumerable.t()} | {:error, :streaming_not_supported | ProviderError.t()}
+    def stream(%ReqLLMPreparedModel{} = model, req), do: stream_req_llm(model, req)
+
     def stream(model, req) do
       case parse_provider(model) do
         {:ollama, _} ->
@@ -143,7 +165,8 @@ if Code.ensure_loaded?(ReqLLM) do
           {:error, :streaming_not_supported}
 
         {:req_llm, model_id} ->
-          stream_req_llm(model_id, req)
+          with {:ok, prepared, _status} <- prepare_req_llm_model(model_id),
+               do: stream_req_llm(prepared, req)
       end
     end
 
@@ -159,9 +182,14 @@ if Code.ensure_loaded?(ReqLLM) do
     - `:max_tokens` - Output budget. ReqLLM-backed models default to at most
       #{@default_max_tokens}, bounded by cataloged output and context limits.
     """
-    @spec generate_text(String.t(), [map()], keyword()) ::
+    @spec generate_text(String.t() | ReqLLMPreparedModel.t(), [map()], keyword()) ::
             {:ok, PtcRunner.LLM.response()} | {:error, term()}
-    def generate_text(model, messages, opts \\ []) do
+    def generate_text(model, messages, opts \\ [])
+
+    def generate_text(%ReqLLMPreparedModel{} = model, messages, opts),
+      do: call_req_llm(model, messages, opts)
+
+    def generate_text(model, messages, opts) do
       case parse_provider(model) do
         {:ollama, model_name} ->
           call_ollama(model_name, messages, opts)
@@ -170,7 +198,8 @@ if Code.ensure_loaded?(ReqLLM) do
           call_openai_compat(base_url, model_name, messages, opts)
 
         {:req_llm, model_id} ->
-          call_req_llm(model_id, messages, opts)
+          with {:ok, prepared, _status} <- prepare_req_llm_model(model_id),
+               do: call_req_llm(prepared, messages, opts)
       end
     end
 
@@ -191,9 +220,14 @@ if Code.ensure_loaded?(ReqLLM) do
     Only supported for ReqLLM providers. Local providers return
     `{:error, :structured_output_not_supported}`.
     """
-    @spec generate_object(String.t(), [map()], map(), keyword()) ::
+    @spec generate_object(String.t() | ReqLLMPreparedModel.t(), [map()], map(), keyword()) ::
             {:ok, map()} | {:error, term()}
-    def generate_object(model, messages, schema, opts \\ []) do
+    def generate_object(model, messages, schema, opts \\ [])
+
+    def generate_object(%ReqLLMPreparedModel{} = model, messages, schema, opts),
+      do: call_req_llm_object(model, messages, schema, opts)
+
+    def generate_object(model, messages, schema, opts) do
       case parse_provider(model) do
         {:ollama, _model_name} ->
           {:error, :structured_output_not_supported}
@@ -202,7 +236,8 @@ if Code.ensure_loaded?(ReqLLM) do
           {:error, :structured_output_not_supported}
 
         {:req_llm, model_id} ->
-          call_req_llm_object(model_id, messages, schema, opts)
+          with {:ok, prepared, _status} <- prepare_req_llm_model(model_id),
+               do: call_req_llm_object(prepared, messages, schema, opts)
       end
     end
 
@@ -223,9 +258,14 @@ if Code.ensure_loaded?(ReqLLM) do
     Passes tools to the LLM provider. If the LLM returns tool calls,
     they are included in the response as `tool_calls`.
     """
-    @spec generate_with_tools(String.t(), [map()], [map()], keyword()) ::
+    @spec generate_with_tools(String.t() | ReqLLMPreparedModel.t(), [map()], [map()], keyword()) ::
             {:ok, map()} | {:error, term()}
-    def generate_with_tools(model, messages, tools, opts \\ []) do
+    def generate_with_tools(model, messages, tools, opts \\ [])
+
+    def generate_with_tools(%ReqLLMPreparedModel{} = model, messages, tools, opts),
+      do: call_req_llm_with_tools(model, messages, tools, opts)
+
+    def generate_with_tools(model, messages, tools, opts) do
       case parse_provider(model) do
         {:ollama, _model_name} ->
           {:error, :tool_calling_not_supported}
@@ -234,7 +274,8 @@ if Code.ensure_loaded?(ReqLLM) do
           {:error, :tool_calling_not_supported}
 
         {:req_llm, model_id} ->
-          call_req_llm_with_tools(model_id, messages, tools, opts)
+          with {:ok, prepared, _status} <- prepare_req_llm_model(model_id),
+               do: call_req_llm_with_tools(prepared, messages, tools, opts)
       end
     end
 
@@ -305,10 +346,8 @@ if Code.ensure_loaded?(ReqLLM) do
 
     # --- Streaming ---
 
-    defp stream_req_llm(model_id, req) do
-      model_id = maybe_resolve_inference_profile(model_id)
+    defp stream_req_llm(%ReqLLMPreparedModel{selector: model_id, model: req_llm_model}, req) do
       messages = build_messages(req)
-      req_llm_model = resolve_req_llm_model(model_id)
       cache_enabled = req[:cache] || false
 
       {messages, extra_opts} = apply_caching(model_id, messages, cache_enabled)
@@ -451,9 +490,7 @@ if Code.ensure_loaded?(ReqLLM) do
       end
     end
 
-    defp call_req_llm(model, messages, opts) do
-      model = maybe_resolve_inference_profile(model)
-      req_llm_model = resolve_req_llm_model(model)
+    defp call_req_llm(%ReqLLMPreparedModel{selector: model, model: req_llm_model}, messages, opts) do
       timeout = Keyword.get(opts, :receive_timeout, @default_timeout)
       http_opts = Keyword.get(opts, :req_http_options, [])
       cache_enabled = Keyword.get(opts, :cache, false)
@@ -481,9 +518,12 @@ if Code.ensure_loaded?(ReqLLM) do
       end
     end
 
-    defp call_req_llm_object(model, messages, schema, opts) do
-      model = maybe_resolve_inference_profile(model)
-      req_llm_model = resolve_req_llm_model(model)
+    defp call_req_llm_object(
+           %ReqLLMPreparedModel{selector: model, model: req_llm_model},
+           messages,
+           schema,
+           opts
+         ) do
       timeout = Keyword.get(opts, :receive_timeout, @default_timeout)
       http_opts = Keyword.get(opts, :req_http_options, [])
       cache_enabled = Keyword.get(opts, :cache, false)
@@ -510,9 +550,12 @@ if Code.ensure_loaded?(ReqLLM) do
       end
     end
 
-    defp call_req_llm_with_tools(model, messages, tools, opts) do
-      model = maybe_resolve_inference_profile(model)
-      req_llm_model = resolve_req_llm_model(model)
+    defp call_req_llm_with_tools(
+           %ReqLLMPreparedModel{selector: model, model: req_llm_model},
+           messages,
+           tools,
+           opts
+         ) do
       timeout = Keyword.get(opts, :receive_timeout, @default_timeout)
       http_opts = Keyword.get(opts, :req_http_options, [])
       cache_enabled = Keyword.get(opts, :cache, false)
@@ -880,34 +923,7 @@ if Code.ensure_loaded?(ReqLLM) do
 
     # --- Inference Profiles ---
 
-    @bedrock_inference_prefixes ["us.", "eu.", "ap.", "ca.", "global."]
     @bedrock_inference_required_families ["amazon."]
-
-    @doc false
-    def maybe_resolve_inference_profile("amazon_bedrock:" <> model_id = full) do
-      cond do
-        String.starts_with?(model_id, @bedrock_inference_prefixes) ->
-          [_region, base_id] = String.split(model_id, ".", parts: 2)
-
-          case ReqLLM.model("amazon_bedrock:#{base_id}") do
-            {:ok, model} -> %{model | provider_model_id: model_id}
-            {:error, _} -> full
-          end
-
-        Enum.any?(@bedrock_inference_required_families, &String.starts_with?(model_id, &1)) ->
-          region_prefix = bedrock_region_prefix()
-
-          case ReqLLM.model("amazon_bedrock:#{model_id}") do
-            {:ok, model} -> %{model | provider_model_id: "#{region_prefix}.#{model_id}"}
-            {:error, _} -> full
-          end
-
-        true ->
-          full
-      end
-    end
-
-    def maybe_resolve_inference_profile(model), do: model
 
     defp bedrock_region_prefix do
       region =
@@ -1060,13 +1076,66 @@ if Code.ensure_loaded?(ReqLLM) do
       :erlang.external_size(request_payload) + @request_token_headroom
     end
 
-    defp resolve_req_llm_model(%LLMDB.Model{} = model), do: model
+    defp prepare_req_llm_model(selector) do
+      {effective_selector, provider_model_id} = inference_profile_resolution(selector)
+      catalog_status = catalog_status(effective_selector)
 
-    defp resolve_req_llm_model(model) do
-      case ReqLLM.model(model) do
-        {:ok, %LLMDB.Model{} = resolved} -> resolved
-        _error -> model
+      case resolve_req_llm_model(effective_selector, catalog_status) do
+        {:ok, %LLMDB.Model{} = model} ->
+          model =
+            if provider_model_id,
+              do: %{model | provider_model_id: provider_model_id},
+              else: model
+
+          {:ok, %ReqLLMPreparedModel{selector: selector, model: model}, catalog_status}
+
+        {:error, _reason} = error ->
+          error
       end
+    end
+
+    defp inference_profile_resolution("amazon_bedrock:" <> model_id = selector) do
+      if Enum.any?(@bedrock_inference_required_families, &String.starts_with?(model_id, &1)),
+        do: {selector, "#{bedrock_region_prefix()}.#{model_id}"},
+        else: {selector, nil}
+    end
+
+    defp inference_profile_resolution(selector), do: {selector, nil}
+
+    defp catalog_status(selector) do
+      case LLMDB.model(selector) do
+        {:ok, %LLMDB.Model{}} -> :cataloged
+        _missing -> :uncataloged
+      end
+    end
+
+    defp resolve_req_llm_model(selector, :cataloged), do: ReqLLM.model(selector)
+
+    defp resolve_req_llm_model(selector, :uncataloged) do
+      with {:ok, provider, model_id} <- split_req_llm_selector(selector),
+           {:ok, _provider_module} <- ReqLLM.provider(provider) do
+        if provider in @req_llm_special_fallback_providers,
+          do: ReqLLM.model(selector),
+          else: ReqLLM.model(%{provider: provider, id: model_id})
+      end
+    end
+
+    defp split_req_llm_selector(selector) do
+      case String.split(selector, ":", parts: 2) do
+        [provider_name, model_id] when model_id != "" ->
+          {:ok, provider_atom(provider_name), model_id}
+
+        _invalid ->
+          {:error, :invalid_model}
+      end
+    rescue
+      ArgumentError -> {:error, :invalid_model}
+    end
+
+    defp provider_atom(provider_name) do
+      provider_name
+      |> String.replace("-", "_")
+      |> String.to_existing_atom()
     end
 
     defp token_limit_present?(opts, model) do

--- a/lib/ptc_runner/llm/req_llm_prepared_model.ex
+++ b/lib/ptc_runner/llm/req_llm_prepared_model.ex
@@ -1,0 +1,19 @@
+if Code.ensure_loaded?(LLMDB.Model) do
+  defmodule PtcRunner.LLM.ReqLLMPreparedModel do
+    @moduledoc """
+    Prepared request target owned by `PtcRunner.LLM.ReqLLMAdapter`.
+
+    Callers normally use configured selector strings. This value is exposed so
+    the adapter's public types remain complete; its fields are an implementation
+    detail and should be treated as opaque.
+    """
+
+    @enforce_keys [:selector, :model]
+    defstruct @enforce_keys
+
+    @type t :: %__MODULE__{
+            selector: String.t(),
+            model: LLMDB.Model.t()
+          }
+  end
+end

--- a/test/ptc_runner/kernel/host_installation_test.exs
+++ b/test/ptc_runner/kernel/host_installation_test.exs
@@ -1,6 +1,27 @@
 defmodule PtcRunner.Kernel.HostInstallationTest do
   use ExUnit.Case, async: false
 
+  defmodule PreparingHostLLMAdapter do
+    @behaviour PtcRunner.LLM
+
+    @impl true
+    def prepare_model(model) do
+      send(Application.fetch_env!(:ptc_runner, :host_preparing_llm_owner), {:prepared, model})
+      {:ok, {:prepared, model}, :uncataloged}
+    end
+
+    @impl true
+    def call({:prepared, model}, request) do
+      send(Application.fetch_env!(:ptc_runner, :host_preparing_llm_owner), {
+        :prepared_request,
+        model,
+        request
+      })
+
+      {:ok, %{content: "ok", tokens: %{}}}
+    end
+  end
+
   @stdio_fixture Path.expand("../../support/mcp_stdio_fixture.exs", __DIR__)
 
   import PtcRunner.TestSupport.Eventually, only: [assert_eventually: 1]
@@ -23,6 +44,7 @@ defmodule PtcRunner.Kernel.HostInstallationTest do
   alias PtcRunner.Kernel.ProviderSnapshot
   alias PtcRunner.Kernel.RunBuilder
   alias PtcRunner.Kernel.SelectionRules
+  alias PtcRunner.TestSupport.LLMSupport
   alias PtcRunner.TestSupport.RunLifecycle
 
   @tag :tmp_dir
@@ -767,6 +789,33 @@ defmodule PtcRunner.Kernel.HostInstallationTest do
   end
 
   @tag :tmp_dir
+  test "normalizes an unsupported ReqLLM provider for active host diagnostics", %{tmp_dir: dir} do
+    LLMSupport.admit_provider_application!()
+
+    host =
+      load_host(dir, %{
+        "credentials" => %{"key" => %{"literal" => "not-read"}},
+        "install" => %{
+          "live" => %{
+            "source" => "llm",
+            "installation_revision" => "live-v1",
+            "model" => "logger:future-model",
+            "credential" => "key"
+          }
+        }
+      })
+
+    assert {:ok, catalog} = HostInstallation.catalog(host)
+    assert {:ok, registry} = HostInstallation.runtime_registry(host, catalog)
+
+    assert {:ok, prepared} =
+             ProviderRegistry.prepare(registry, "live", %{}, context(dir, :workflow))
+
+    assert {:error, :invalid_llm_model} = ProviderRegistry.preflight(prepared)
+    assert :ok = ProviderRegistry.close(registry)
+  end
+
+  @tag :tmp_dir
   test "audited local preflight matches missing LLM adapters and stdio runtime files", %{
     tmp_dir: dir
   } do
@@ -1002,6 +1051,64 @@ defmodule PtcRunner.Kernel.HostInstallationTest do
     assert private_built.snapshot["acquisition"] == %{"source" => "llm"}
     refute Map.has_key?(private_built.snapshot["acquisition"], "resolved_model")
     assert :error = ProviderSnapshot.llm_identity(private_built.snapshot)
+  end
+
+  @tag :tmp_dir
+  test "a live LLM requester binds one prepared target across turns", %{tmp_dir: dir} do
+    previous_adapter = Application.get_env(:ptc_runner, :llm_adapter)
+    previous_owner = Application.get_env(:ptc_runner, :host_preparing_llm_owner)
+    Application.put_env(:ptc_runner, :llm_adapter, PreparingHostLLMAdapter)
+    Application.put_env(:ptc_runner, :host_preparing_llm_owner, self())
+
+    on_exit(fn ->
+      restore_env(:llm_adapter, previous_adapter)
+      restore_env(:host_preparing_llm_owner, previous_owner)
+    end)
+
+    host =
+      load_host(dir, %{
+        "credentials" => %{"key" => %{"literal" => "test-secret"}},
+        "install" => %{
+          "live" => %{
+            "source" => "llm",
+            "installation_revision" => "live-v1",
+            "model" => "provider:future-model",
+            "credential" => "key"
+          }
+        }
+      })
+
+    assert {:ok, catalog} = HostInstallation.catalog(host)
+    assert {:ok, registry} = HostInstallation.runtime_registry(host, catalog)
+
+    assert {:ok, prepared} =
+             ProviderRegistry.prepare(registry, "live", %{}, context(dir, :workflow))
+
+    assert {:ok, preflighted} = ProviderRegistry.preflight(prepared)
+    assert_receive {:prepared, "provider:future-model"}
+    refute_receive {:prepared, _model}
+    assert {:ok, credentials} = ProviderRegistry.resolve_credentials(registry, ["key"])
+
+    warning =
+      ExUnit.CaptureIO.capture_io(:stderr, fn ->
+        assert {:ok, built} = ProviderRegistry.acquire(preflighted, credentials)
+        assert [%{callback: requester}] = built.capabilities
+
+        for content <- ["first", "second"] do
+          assert {:ok, %{"content" => "ok"}} =
+                   requester.(%{
+                     "messages" => [%{"role" => "user", "content" => content}]
+                   })
+        end
+      end)
+
+    assert length(Regex.scan(~r/model_uncataloged/, warning)) == 1
+    refute warning =~ "provider:future-model"
+    refute warning =~ "ReqLLM"
+    refute_receive {:prepared, _model}
+    assert_receive {:prepared_request, "provider:future-model", _request}
+    assert_receive {:prepared_request, "provider:future-model", _request}
+    assert :ok = InstallationCatalog.close(catalog)
   end
 
   @tag :tmp_dir

--- a/test/ptc_runner/kernel/mcp_remote_agent_e2e_test.exs
+++ b/test/ptc_runner/kernel/mcp_remote_agent_e2e_test.exs
@@ -205,10 +205,11 @@ defmodule PtcRunner.Kernel.MCPRemoteAgentE2ETest do
          preflight: fn ->
            {:ok,
             fn %{} ->
-              requester =
-                PtcRunner.LLM.callback(model, api_key: System.get_env("OPENROUTER_API_KEY"))
-
-              with {:ok, capability} <-
+              with {:ok, requester} <-
+                     PtcRunner.LLM.callback(model,
+                       api_key: System.get_env("OPENROUTER_API_KEY")
+                     ),
+                   {:ok, capability} <-
                      LLMCapability.new(
                        requester: fn request ->
                          request

--- a/test/ptc_runner/llm/req_llm_adapter_request_test.exs
+++ b/test/ptc_runner/llm/req_llm_adapter_request_test.exs
@@ -82,27 +82,130 @@ defmodule PtcRunner.LLM.ReqLLMAdapterRequestTest do
     assert max_tokens in 1..4_094
   end
 
-  test "resolves an uncataloged model only once per request", %{test: test} do
-    expect_request(test, "vendor/new-model")
+  test "one requester prepares an uncataloged model once and owns its warning", %{test: test} do
+    stub_requests(test, "vendor/new-model")
 
     warnings =
       capture_io(:stderr, fn ->
-        assert {:ok, %{content: "ok"}} =
-                 ReqLLMAdapter.generate_text(
-                   "openrouter:vendor/new-model",
-                   [%{role: :user, content: "hi"}],
-                   api_key: "test",
-                   req_http_options: [plug: {Req.Test, test}]
+        {:ok, requester} =
+          PtcRunner.LLM.callback("openrouter:vendor/new-model",
+            adapter: ReqLLMAdapter,
+            api_key: "test",
+            req_http_options: [plug: {Req.Test, test}]
+          )
+
+        for content <- ["first", "second"] do
+          assert {:ok, %{content: "ok"}} =
+                   requester.(%{messages: [%{role: :user, content: content}]})
+        end
+      end)
+
+    assert length(Regex.scan(~r/model_uncataloged/, warnings)) == 1
+    refute warnings =~ "Using unverified model"
+    refute warnings =~ "ReqLLM.model"
+    refute warnings =~ "req_llm.ex"
+
+    assert_receive {:request_body, %{"model" => "vendor/new-model"}}
+    assert_receive {:request_body, %{"model" => "vendor/new-model"}}
+  end
+
+  test "a cataloged model does not emit a catalog warning" do
+    warnings =
+      capture_io(:stderr, fn ->
+        assert {:ok, _requester} =
+                 PtcRunner.LLM.callback("openrouter:google/gemma-2-27b-it",
+                   adapter: ReqLLMAdapter
                  )
       end)
 
-    assert length(Regex.scan(~r/Using unverified model:/, warnings)) == 1
+    refute warnings =~ "model_uncataloged"
+  end
+
+  test "direct HTTP routes report that catalog status is unavailable" do
+    for selector <- ["ollama:local-model", "openai-compat:https://example.com/v1|deployment"] do
+      assert {:ok, %{catalog_status: :unavailable, selector: ^selector, target: ^selector}} =
+               PtcRunner.LLM.prepare(selector, ReqLLMAdapter)
+    end
+  end
+
+  test "special uncataloged fallbacks preserve ReqLLM's public resolver fields" do
+    selectors = [
+      "openai_codex:future-chat-1408",
+      "github_copilot:future-chat-1408",
+      "mistral:future-chat-1408",
+      "minimax:future-chat-1408"
+    ]
+
+    for selector <- selectors do
+      assert {:ok, expected} = ReqLLM.model(selector)
+
+      assert {:ok,
+              %{
+                catalog_status: :uncataloged,
+                target: %{model: actual, selector: ^selector}
+              }} = PtcRunner.LLM.prepare(selector, ReqLLMAdapter)
+
+      fields = [:provider, :id, :model, :provider_model_id, :capabilities, :limits, :extra]
+      assert Map.take(actual, fields) == Map.take(expected, fields)
+    end
+  end
+
+  test "Bedrock preparation preserves and supplies inference-profile prefixes" do
+    set_bedrock_region("eu-west-1")
+
+    prefixed = "amazon_bedrock:eu.amazon.nova-pro-v1:0"
+
+    assert {:ok, %{catalog_status: :cataloged, target: %{model: prefixed_model}}} =
+             PtcRunner.LLM.prepare(prefixed, ReqLLMAdapter)
+
+    assert prefixed_model.provider_model_id == "eu.amazon.nova-pro-v1:0"
+
+    unprefixed = "amazon_bedrock:amazon.nova-pro-v1:0"
+
+    assert {:ok, %{catalog_status: :cataloged, target: %{model: unprefixed_model}}} =
+             PtcRunner.LLM.prepare(unprefixed, ReqLLMAdapter)
+
+    assert unprefixed_model.provider_model_id == "eu.amazon.nova-pro-v1:0"
+  end
+
+  test "an uncataloged Bedrock model emits only the PtcRunner warning" do
+    set_bedrock_region("eu-west-1")
+    selector = "amazon_bedrock:amazon.future-1408-v1:0"
+
+    warning =
+      capture_io(:stderr, fn ->
+        assert {:ok, _requester} = PtcRunner.LLM.callback(selector, adapter: ReqLLMAdapter)
+      end)
+
+    assert length(Regex.scan(~r/model_uncataloged/, warning)) == 1
+    refute warning =~ "Using unverified model"
+    refute warning =~ "ReqLLM.model"
+
+    assert {:ok, %{target: %{model: model}}} = PtcRunner.LLM.prepare(selector, ReqLLMAdapter)
+    assert model.provider_model_id == "eu.amazon.future-1408-v1:0"
+  end
+
+  test "an invalid provider fails preparation without dependency warning frames" do
+    warnings =
+      capture_io(:stderr, fn ->
+        assert {:error, :invalid_model} =
+                 PtcRunner.LLM.callback("provider1408:future-model", adapter: ReqLLMAdapter)
+      end)
+
+    refute warnings =~ "ReqLLM"
+    refute warnings =~ "req_llm.ex"
   end
 
   defp expect_request(test, response_model) do
-    test_pid = self()
+    Req.Test.expect(test, request_handler(self(), response_model))
+  end
 
-    Req.Test.expect(test, fn conn ->
+  defp stub_requests(test, response_model) do
+    Req.Test.stub(test, request_handler(self(), response_model))
+  end
+
+  defp request_handler(test_pid, response_model) do
+    fn conn ->
       {:ok, body, conn} = Plug.Conn.read_body(conn)
       send(test_pid, {:request_body, Jason.decode!(body)})
 
@@ -118,6 +221,28 @@ defmodule PtcRunner.LLM.ReqLLMAdapterRequestTest do
         ],
         "usage" => %{"prompt_tokens" => 1, "completion_tokens" => 1, "total_tokens" => 2}
       })
+    end
+  end
+
+  defp set_bedrock_region(region) do
+    previous_system_region = System.get_env("AWS_REGION")
+    previous_configured_region = Application.fetch_env(:ptc_runner, :bedrock_region)
+
+    on_exit(fn ->
+      if previous_system_region,
+        do: System.put_env("AWS_REGION", previous_system_region),
+        else: System.delete_env("AWS_REGION")
+
+      case previous_configured_region do
+        {:ok, configured_region} ->
+          Application.put_env(:ptc_runner, :bedrock_region, configured_region)
+
+        :error ->
+          Application.delete_env(:ptc_runner, :bedrock_region)
+      end
     end)
+
+    System.delete_env("AWS_REGION")
+    Application.put_env(:ptc_runner, :bedrock_region, region)
   end
 end

--- a/test/ptc_runner/llm/req_llm_adapter_test.exs
+++ b/test/ptc_runner/llm/req_llm_adapter_test.exs
@@ -340,23 +340,6 @@ defmodule PtcRunner.LLM.ReqLLMAdapterTest do
     end
   end
 
-  describe "maybe_resolve_inference_profile/1" do
-    test "passes through non-bedrock model strings unchanged" do
-      assert ReqLLMAdapter.maybe_resolve_inference_profile("openrouter:anthropic/claude") ==
-               "openrouter:anthropic/claude"
-
-      assert ReqLLMAdapter.maybe_resolve_inference_profile("anthropic:claude-3-5-sonnet") ==
-               "anthropic:claude-3-5-sonnet"
-    end
-
-    test "passes through bedrock models with no inference-prefix and no required family" do
-      # Not "us./eu./ap./ca./global." and not the "amazon." family -> the
-      # passthrough `true` branch returns the full string unchanged (no registry hit).
-      full = "amazon_bedrock:anthropic.claude-3-haiku"
-      assert ReqLLMAdapter.maybe_resolve_inference_profile(full) == full
-    end
-  end
-
   describe "build_tokens_from_req_llm_response/2" do
     test "reads atom-keyed usage including cache read/creation and cost" do
       usage = %{

--- a/test/ptc_runner/llm_test.exs
+++ b/test/ptc_runner/llm_test.exs
@@ -52,6 +52,61 @@ defmodule PtcRunner.LLMTest do
     def public_model(model), do: {:ok, model}
   end
 
+  defmodule PreparingAdapter do
+    @behaviour PtcRunner.LLM
+
+    @impl true
+    def prepare_model(model) do
+      send(self(), {:prepared_model, model})
+      {:ok, {:prepared, model}, :unavailable}
+    end
+
+    @impl true
+    def call({:prepared, model}, request) do
+      send(self(), {:called_prepared_model, model, request})
+      {:ok, %{content: "prepared", tokens: %{}}}
+    end
+
+    @impl true
+    def stream({:prepared, model}, request) do
+      send(self(), {:streamed_prepared_model, model, request})
+      {:error, :streaming_not_supported}
+    end
+  end
+
+  defmodule FailingPreparationAdapter do
+    @behaviour PtcRunner.LLM
+
+    @impl true
+    def prepare_model(_model), do: {:error, :model_unavailable}
+
+    @impl true
+    def call(_model, _request), do: raise("a failed preparation must not reach call/2")
+  end
+
+  defmodule UncatalogedPublicAdapter do
+    @behaviour PtcRunner.LLM
+
+    @impl true
+    def prepare_model(model), do: {:ok, model, :uncataloged}
+
+    @impl true
+    def call(_model, _request), do: {:ok, %{content: "", tokens: %{}}}
+
+    @impl true
+    def public_model(model), do: {:ok, model}
+  end
+
+  defmodule UncatalogedPrivateAdapter do
+    @behaviour PtcRunner.LLM
+
+    @impl true
+    def prepare_model(model), do: {:ok, model, :uncataloged}
+
+    @impl true
+    def call(_model, _request), do: {:ok, %{content: "", tokens: %{}}}
+  end
+
   defmodule MismatchingPublicModelAdapter do
     @behaviour PtcRunner.LLM
 
@@ -88,20 +143,93 @@ defmodule PtcRunner.LLMTest do
   describe "callback/2 adapter warmup" do
     test "invokes the adapter's ensure_ready/0 at build time, before the request runs" do
       Process.delete({ReadyProbe, :called})
-      closure = PtcRunner.LLM.callback("ollama:test-model", adapter: ReadyProbe)
+      {:ok, closure} = PtcRunner.LLM.callback("ollama:test-model", adapter: ReadyProbe)
       assert is_function(closure, 1)
       assert Process.get({ReadyProbe, :called}) == true
     end
 
     test "is a no-op for adapters that do not implement ensure_ready/0" do
       # MockAdapter (installed by setup) defines no ensure_ready/0.
-      assert is_function(PtcRunner.LLM.callback("ollama:test-model"), 1)
+      assert {:ok, callback} = PtcRunner.LLM.callback("ollama:test-model")
+      assert is_function(callback, 1)
     end
   end
 
   describe "callback/2" do
+    test "prepares a model once when the requester is constructed" do
+      {:ok, callback} =
+        PtcRunner.LLM.callback("provider:model",
+          adapter: PreparingAdapter,
+          temperature: 0.25
+        )
+
+      assert_receive {:prepared_model, "provider:model"}
+      refute_receive {:prepared_model, _model}
+
+      assert {:ok, %{content: "prepared"}} =
+               callback.(%{system: "test", messages: []})
+
+      assert_receive {:called_prepared_model, "provider:model",
+                      %{system: "test", messages: [], temperature: 0.25}}
+
+      assert {:ok, %{content: "prepared"}} =
+               callback.(%{system: "again", messages: []})
+
+      refute_receive {:prepared_model, _model}
+      assert_receive {:called_prepared_model, "provider:model", %{system: "again"}}
+    end
+
+    test "uses the prepared target when streaming falls back to call/2" do
+      {:ok, callback} = PtcRunner.LLM.callback("provider:model", adapter: PreparingAdapter)
+
+      assert {:ok, %{content: "prepared"}} =
+               callback.(%{system: "fallback", messages: [], stream: fn _chunk -> :ok end})
+
+      assert_receive {:prepared_model, "provider:model"}
+      assert_receive {:streamed_prepared_model, "provider:model", %{system: "fallback"}}
+      assert_receive {:called_prepared_model, "provider:model", %{system: "fallback"}}
+      refute_receive {:prepared_model, _model}
+    end
+
+    test "returns preparation failures before constructing a requester" do
+      assert {:error, :model_unavailable} =
+               PtcRunner.LLM.callback("provider:model", adapter: FailingPreparationAdapter)
+    end
+
+    test "emits an uncataloged warning once without publishing unattested selectors" do
+      public_warning =
+        ExUnit.CaptureIO.capture_io(:stderr, fn ->
+          assert {:ok, _requester} =
+                   PtcRunner.LLM.callback("provider:public", adapter: UncatalogedPublicAdapter)
+        end)
+
+      private_warning =
+        ExUnit.CaptureIO.capture_io(:stderr, fn ->
+          assert {:ok, _requester} =
+                   PtcRunner.LLM.callback("provider:private", adapter: UncatalogedPrivateAdapter)
+        end)
+
+      assert public_warning =~ "model_uncataloged"
+      assert public_warning =~ "provider:public"
+      assert private_warning =~ "model_uncataloged"
+      refute private_warning =~ "provider:private"
+    end
+
+    test "escapes control characters in an attested selector" do
+      selector = "provider:public\nwarning: forged"
+
+      warning =
+        ExUnit.CaptureIO.capture_io(:stderr, fn ->
+          assert {:ok, _requester} =
+                   PtcRunner.LLM.callback(selector, adapter: UncatalogedPublicAdapter)
+        end)
+
+      assert warning =~ inspect(selector)
+      refute warning =~ "public\nwarning: forged"
+    end
+
     test "returns a function that calls the adapter" do
-      callback = PtcRunner.LLM.callback("ollama:test-model")
+      {:ok, callback} = PtcRunner.LLM.callback("ollama:test-model")
       assert is_function(callback, 1)
 
       {:ok, resp} = callback.(%{system: "test", messages: []})
@@ -110,7 +238,7 @@ defmodule PtcRunner.LLMTest do
     end
 
     test "merges opts into request" do
-      callback = PtcRunner.LLM.callback("ollama:test-model", cache: true)
+      {:ok, callback} = PtcRunner.LLM.callback("ollama:test-model", cache: true)
       assert is_function(callback, 1)
 
       {:ok, resp} = callback.(%{system: "with cache", messages: []})
@@ -118,7 +246,7 @@ defmodule PtcRunner.LLMTest do
     end
 
     test "streams when request has :stream key and adapter supports streaming" do
-      callback = PtcRunner.LLM.callback("ollama:test-model")
+      {:ok, callback} = PtcRunner.LLM.callback("ollama:test-model")
       chunks = :ets.new(:chunks, [:ordered_set, :public])
 
       on_chunk = fn %{delta: text} ->
@@ -144,7 +272,7 @@ defmodule PtcRunner.LLMTest do
 
       Application.put_env(:ptc_runner, :llm_adapter, NoStreamAdapter2)
 
-      callback = PtcRunner.LLM.callback("ollama:test-model")
+      {:ok, callback} = PtcRunner.LLM.callback("ollama:test-model")
       chunk_called = :atomics.new(1, [])
 
       on_chunk = fn _chunk ->
@@ -159,7 +287,7 @@ defmodule PtcRunner.LLMTest do
     end
 
     test "stream key is stripped before passing to adapter" do
-      callback = PtcRunner.LLM.callback("ollama:test-model")
+      {:ok, callback} = PtcRunner.LLM.callback("ollama:test-model")
       # Without stream key, it hits call/2 with system: "test"
       {:ok, resp} = callback.(%{system: "test", messages: [], stream: fn _ -> :ok end})
       # Stream was used, so we get the streamed content
@@ -205,6 +333,17 @@ defmodule PtcRunner.LLMTest do
     test "delegates to adapter" do
       {:ok, resp} = PtcRunner.LLM.call("ollama:test-model", %{system: "hello", messages: []})
       assert resp.content == "mock response for: hello"
+    end
+
+    test "prepares before delegating" do
+      Application.put_env(:ptc_runner, :llm_adapter, PreparingAdapter)
+
+      assert {:ok, %{content: "prepared"}} =
+               PtcRunner.LLM.call("provider:model", %{system: "hello", messages: []})
+
+      assert_receive {:prepared_model, "provider:model"}
+      assert_receive {:called_prepared_model, "provider:model", %{system: "hello"}}
+      refute_receive {:prepared_model, _model}
     end
   end
 


### PR DESCRIPTION
## Summary

- prepare ReqLLM model selectors once during provider preflight/requester construction
- bind the prepared model into text, object, tool, and streaming paths
- replace ReqLLM's repeated stack-bearing warning with one stackless `model_uncataloged` warning owned by PtcRunner
- preserve special-provider and Bedrock fallback behavior and document embedding/host contracts

Closes #1408

## Verification

- `mix precommit`
- `MIX_ENV=dev mix docs --warnings-as-errors`
- pre-push repository hooks
- plan reviewed once; implementation reviewed three times, with all findings addressed
