### PR TITLE
fix(mcp): verify cursor signatures by their issued spelling

### DIFF
--- a/examples/mcp/filesystem/README.md
+++ b/examples/mcp/filesystem/README.md
@@ -23,7 +23,8 @@ read again, so later changes cannot alter a result.
 All four data tools accept optional `cursor` and `limit` arguments and return
 exactly `snapshot_hash`, `items`, and `next_cursor`. Start without a cursor and
 follow the opaque `next_cursor` until it is null. Cursors are bound to the
-snapshot, tool, and query/path arguments; replay in another traversal fails.
+snapshot, tool, and query/path arguments, and must be presented exactly as
+issued; replay in another traversal, or any edit to the string, fails.
 For `read_text_file`, concatenating item `text` reconstructs the file exactly.
 Every page carries the same `snapshot_hash`, so a citation binds to the bytes
 actually queried.

--- a/examples/mcp/filesystem/dist/server.js
+++ b/examples/mcp/filesystem/dist/server.js
@@ -20128,8 +20128,11 @@ function decodeCursor(snapshot, scope, cursor, validPosition, first) {
       throw new ToolError("cursor is not valid");
     }
     const [payload, encodedSignature] = parts;
-    const signature = Buffer.from(encodedSignature, "base64url");
-    const expected = createHmac("sha256", cursorKey(snapshot)).update(payload, "ascii").digest();
+    const signature = Buffer.from(encodedSignature, "ascii");
+    const expected = Buffer.from(
+      createHmac("sha256", cursorKey(snapshot)).update(payload, "ascii").digest("base64url"),
+      "ascii"
+    );
     if (signature.length !== expected.length || !timingSafeEqual(signature, expected)) {
       throw new ToolError("cursor is not valid");
     }

--- a/examples/mcp/filesystem/src/server.ts
+++ b/examples/mcp/filesystem/src/server.ts
@@ -107,8 +107,15 @@ function decodeCursor(
       throw new ToolError('cursor is not valid')
     }
     const [payload, encodedSignature] = parts as [string, string]
-    const signature = Buffer.from(encodedSignature, 'base64url')
-    const expected = createHmac('sha256', cursorKey(snapshot)).update(payload, 'ascii').digest()
+    // Compare the encoded signatures, not the decoded bytes. The trailing bits
+    // of a base64url digest are not significant, so several spellings decode to
+    // the same 32 bytes; comparing decoded buffers would admit cursor strings
+    // this server never issued.
+    const signature = Buffer.from(encodedSignature, 'ascii')
+    const expected = Buffer.from(
+      createHmac('sha256', cursorKey(snapshot)).update(payload, 'ascii').digest('base64url'),
+      'ascii',
+    )
     if (signature.length !== expected.length || !timingSafeEqual(signature, expected)) {
       throw new ToolError('cursor is not valid')
     }

--- a/examples/mcp/filesystem/test/server.test.mjs
+++ b/examples/mcp/filesystem/test/server.test.mjs
@@ -138,6 +138,19 @@ async function withGeneratedServer(files, body) {
   }
 }
 
+const BASE64URL = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_'
+
+/** A different string for the same signature bytes, proving the encoding is not canonical. */
+function respell(signature) {
+  const bytes = Buffer.from(signature, 'base64url')
+  const sibling = [...BASE64URL]
+    .map((character) => `${signature.slice(0, -1)}${character}`)
+    .find((candidate) => candidate !== signature && Buffer.from(candidate, 'base64url').equals(bytes))
+
+  assert.ok(sibling, 'the signature must have an alternate spelling for this test to mean anything')
+  return sibling
+}
+
 function waitForSnapshot(createdBefore) {
   return new Promise((resolve, reject) => {
     const deadline = Date.now() + 15_000
@@ -315,6 +328,24 @@ test('cursors are bound to the snapshot, tool, and normalized query', async () =
       arguments: { query: '.ex', cursor: tampered },
     })
     assert.ok(response.result?.isError || response.error, 'a modified cursor must be rejected')
+  })
+})
+
+// The final base64url character of a 32-byte signature carries only four
+// significant bits, so fifteen of its sixteen legal values have a sibling that
+// decodes to the same bytes. A verifier that compares decoded signatures
+// therefore accepts cursor strings it never issued.
+test('a cursor whose signature is re-spelled without changing its bytes is rejected', async () => {
+  await withServer(INCLUDE_LIB, async (server) => {
+    const cursor = (await call(server, 'search_files', { query: '.ex', limit: 1 })).next_cursor
+    const [payload, signature] = cursor.split('.')
+    const sibling = respell(signature)
+
+    const response = await server.request('tools/call', {
+      name: 'search_files',
+      arguments: { query: '.ex', cursor: `${payload}.${sibling}` },
+    })
+    assert.ok(response.result?.isError || response.error, 'only the issued spelling of a cursor may resume')
   })
 })
 


### PR DESCRIPTION
## Why CI is red on `main`

Run [31894503359](https://github.com/andreasronge/ptc_runner/actions/runs/31894503359) failed in **MCP filesystem sample server**:

```
not ok 11 - cursors are bound to the snapshot, tool, and normalized query
  error: 'a modified cursor must be rejected'
  location: examples/mcp/filesystem/test/server.test.mjs:287:1
```

Nothing in the merged PR (#1418, CLI launch config) touches that sample. This is a real, latent server defect that surfaces stochastically.

## Root cause

`decodeCursor` compared the **decoded** HMAC bytes:

```ts
const signature = Buffer.from(encodedSignature, 'base64url')
const expected = createHmac('sha256', cursorKey(snapshot)).update(payload, 'ascii').digest()
```

A 32-byte digest encodes to 43 base64url characters, and the final character carries only **four** significant bits — the trailing two bits are discarded by the decoder. So fifteen of the sixteen legal final characters have a sibling that decodes to the identical 32 bytes.

The test tampers with exactly that character (`cursor.slice(0, -1)` + flip). Whenever the per-snapshot random HMAC key produced a signature ending in `Y`, the tampered string `…a` decoded to the same bytes, verified, and the cursor was accepted — so the assertion failed. That is **1 in 16 runs**, confirmed empirically:

- 20 local runs of the unmodified test on the unmodified server: 1 failure.
- Direct simulation over 20 000 random keys: 6.49 % collision rate (≈ 1/16).

The job passed on the four preceding `main` pushes, which is what a 6 % flake looks like.

## Fix

Compare the **encoded** signatures in constant time, so only the spelling the server issued verifies. This removes the malleability rather than papering over it: the sample now genuinely honours the property its test asserts, and the assertion becomes deterministic.

Also adds a test that fails 100 % of the time against the old server — it re-spells the signature into a different string with identical bytes and requires rejection — and tightens the README's cursor claim to say a cursor must be presented exactly as issued.

## Verification

- `npm run typecheck` — clean
- `npm run build` — `dist/server.js` diff is exactly this change, no other churn
- `npm test` — 27/27, three consecutive runs
- cursor tests, 60 consecutive runs — 0 failures (previously ~1 in 16; 60 clean runs under the old code has ≈2 % probability)
- `mix test test/ptc_runner/kernel/filesystem_mcp_e2e_test.exs --include e2e --warnings-as-errors` — 2 passed

Node 22.14.0 locally (CI pins 22.22.2).