### PR TITLE
Debugging substrate: navigate a failed run from another PTC run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ ptc_runner-*.tar
 
 # Local artifacts produced by the runnable tutorial project files.
 examples/kernel-tutorial/*/.ptc/
+examples/debug-a-failed-run/*/.ptc/
 
 # Temporary commit message files from tooling.
 .commit_msg.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Private inspection now retains an authenticated `result_contract_failed`
+  diagnostic instead of destroying it. The retained runtime details carry
+  internal contract-authority and command-path structs, which are not JSON
+  inspection values; emitting them poisoned the inspection sink and replaced
+  the real outcome with `inspection_sink_error`, so the run most in need of
+  debugging lost its own evidence. Only the inspection copy is projected — the
+  attestation is dropped and each already-authorized path is rendered as a JSON
+  Pointer — while the runtime error keeps its authenticated structs unchanged.
+
 - Replaced eager `cap/collect-pages` with resumable `cap/fold-pages`, which
   reduces pages into bounded caller state, preserves the next cursor at a page
   bound, and rejects changed snapshots or cursor cycles. The bundled filesystem

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added occurrence-qualified `dependency_prelude_source` relationships to
+  effective prelude sources, so a debugger can walk a frozen dependency closure
+  instead of guessing which copy of a shared component a call reached. A
+  component ID alone is not an occurrence identity, so every edge repeats its
+  environment and mission name. The edges are derived only from a prelude graph
+  that satisfies the complete positional contract — indices aligned with unique
+  component IDs, each row unique, ascending, and strictly earlier than its own
+  position — and any other graph yields one honest `incomplete` relation.
+
+- Generated entries embedded in `turns` now carry the same `relationships` list
+  as the matching `generated_sources` item. A generic walker that starts from a
+  turn no longer needs an extra exact read by `evaluation_id` merely to obtain
+  followable links.
+
 - Added typed, followable run-analysis relationships from workflow boundary
   errors to directly proven child producers, generated source, producing turns,
   and referenced prelude source. Each relation supplies an exact target

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   effective prelude sources, so a debugger can walk a frozen dependency closure
   instead of guessing which copy of a shared component a call reached. A
   component ID alone is not an occurrence identity, so every edge repeats its
-  environment and mission name. The edges are derived only from a prelude graph
+  environment and, for a mission occurrence, its mission name. The edges are
+  derived only from a prelude graph
   that satisfies the complete positional contract — indices aligned with unique
   component IDs, each row unique, ascending, and strictly earlier than its own
   position — and any other graph yields one honest `incomplete` relation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added the shipped `debug.nav` component: `runs`, `open`, `read`, and a safe
+  `follow` over one immutable run-evidence capture. `follow` takes a typed
+  relationship exactly as an evidence item published it, refuses an unavailable
+  or filterless one, and returns the relationship beside the unchanged native
+  page envelope so cursors, completeness, and relationship state survive the
+  hop. It adds no host authority and no diagnosis policy.
+
+- Added the [Debug a failed run](docs/guides/debugging-a-failed-run.md) guide
+  and its credential-free `examples/debug-a-failed-run` pair, in which one
+  ordinary PTC run navigates another run's captured failure from the boundary
+  error through generated source and referenced prelude source to the frozen
+  dependency closure.
+
 - Added occurrence-qualified `dependency_prelude_source` relationships to
   effective prelude sources, so a debugger can walk a frozen dependency closure
   instead of guessing which copy of a shared component a call reached. A

--- a/README.md
+++ b/README.md
@@ -207,7 +207,9 @@ Read these in order. Each one owns its topic and links onward.
    aliases, credentials, data classes, and outer policy.
 7. [Running and debugging](docs/guides/running-and-debugging.md) — the
    commands, results, traces, private inspection, and development Viewer.
-8. [Evaluate changes with replay](docs/guides/evaluating-with-replay.md) — hold
+8. [Debug a failed run](docs/guides/debugging-a-failed-run.md) — navigate one
+   immutable failed capture from another PTC run, through typed evidence links.
+9. [Evaluate changes with replay](docs/guides/evaluating-with-replay.md) — hold
    model responses fixed while testing candidate component source.
 
 ### Going further

--- a/docs/guides/debugging-a-failed-run.md
+++ b/docs/guides/debugging-a-failed-run.md
@@ -1,0 +1,335 @@
+# Debug a failed run with another PTC run
+
+A failed run leaves an immutable capture. A second, ordinary PTC run can
+navigate that capture: the boundary failure, the programs the run generated,
+their results, the prelude source those programs reached, and that source's
+frozen dependencies.
+
+The substrate is structural. It exposes evidence and typed links; it never
+selects a suspect or proposes a repair. Reaching a conclusion — or deciding the
+evidence is insufficient — stays with the caller, whether that caller is a
+deterministic walk or a model.
+
+## What the evidence path looks like
+
+```text
+failed immutable run
+  -> runs / open / read / follow
+  -> generated source and result
+  -> referenced prelude source
+  -> dependency prelude source
+  -> supported diagnosis, or insufficient evidence
+```
+
+Each arrow is a typed relationship carried on the evidence item itself, so a
+walker never has to guess a filter or reconstruct an identity by hand.
+
+## Capture the evidence a debugger can read
+
+Two artifacts matter, and they carry different authority.
+
+A **canonical trace** is bounded operational evidence: run and evaluation
+lifecycle, capability names and outcomes, counts, and a sanitized failure
+taxonomy. It contains no prompts, model responses, capability payloads, or
+generated source. A workflow's own `fail` value never reaches it; an
+unrecognized `kind` is retained only as a one-way fingerprint.
+
+A **private inspection artifact** is an explicit `0600` host development
+authority. It adds the frozen component sources, the exact generated programs,
+capability arguments and results, model exchanges, prints, and detailed
+failures. Read it only through an authorized private sink, and never publish it
+alongside a normal trace.
+
+A project document captures both:
+
+```json
+"artifacts": {"root": "target/.ptc", "trace": true, "inspection": true, "result": true, "envelope": true}
+```
+
+The equivalent low-level form is `--trace-dir` plus `--inspect`. See
+[Running and debugging](running-and-debugging.md) for every switch and
+[Project configuration](project-configuration.md) for the artifact layout.
+
+Inspection requires a trace, because every private record is validated against
+the canonical run it claims to describe.
+
+## Give the debugger bounded navigation authority
+
+The debugger is an ordinary application. Its host document installs the failed
+run's two directories as snapshot providers:
+
+```json
+{
+  "install": {
+    "failed-run-traces": {
+      "source": "ptc_private_trace_snapshot",
+      "installation_revision": "failed-run-traces-v1",
+      "directory": "target/.ptc/traces"
+    },
+    "debug.nav": {
+      "source": "ptc_inspection_snapshot",
+      "installation_revision": "failed-run-inspection-v1",
+      "directory": "target/.ptc/inspection"
+    }
+  }
+}
+```
+
+Use `ptc_private_trace_snapshot` when the captured run wrote a
+`.private.jsonl` trace, and `ptc_trace_snapshot` for an ordinary one. Either
+way the inspection selection fixes the debugger's data class to
+`private_inspection`, so no normal vendor connector can run beside it.
+
+The manifest selects both into one mission and installs the `debug.nav`
+prelude:
+
+```json
+"missions": {
+  "evidence": {
+    "components": [
+      {"id": "evidence.walk", "path": "evidence.walk.clj", "dependencies": ["debug.nav"]},
+      {"library": "debug.nav"}
+    ],
+    "providers": ["debug.nav", "failed-run-traces"]
+  }
+},
+"providers": {
+  "mission": [
+    {"name": "debug.nav"},
+    {"name": "failed-run-traces", "config": {"expose": false}}
+  ]
+}
+```
+
+`{"expose": false}` keeps the trace selection as the inspection source's
+dependency without creating a second navigation namespace.
+
+A snapshot provider names its operations `<alias>.runs`, `<alias>.open`, and
+`<alias>.read`, and the shipped prelude binds that conventional alias, so the
+inspection selection must be called `debug.nav`. The alternative shipped
+surface, `analysis`, binds the stable `analysis-runs`/`analysis-open`/
+`analysis-read` names a REPL profile grants; install one or the other, never
+both.
+
+## Navigate with debug.nav
+
+`debug.nav` is a thin policy layer over the snapshot provider. It adds no host
+authority and no diagnosis policy:
+
+| Call | Purpose |
+| --- | --- |
+| `(debug.nav/runs options)` | list captured runs, filtered by status, name, tags, or id |
+| `(debug.nav/open run-id)` | discover a run's collections, filters, identifiers, and completeness fields |
+| `(debug.nav/read run-id options)` | read one bounded native page from a named collection |
+| `(debug.nav/follow run-id relationship options)` | follow one typed relationship |
+
+`follow` takes a relationship exactly as an evidence item published it and
+reads its declared target collection and filters. It returns the original
+relationship beside the unchanged page envelope, so cursors, `omitted_count`,
+`snapshot_hash`, truncation, and the relationship's own state all survive the
+hop. Caller options may contain only `limit` and `cursor`; a relationship that
+is `unavailable` or carries null filters is refused rather than guessed at.
+
+Start from the failure:
+
+```clojure
+(let [run (first (get (debug.nav/runs {"status" "error" "limit" 1}) "items"))
+      run-id (get run "run_id")
+      error (first (get (debug.nav/read run-id {"collection" "execution_errors"}) "items"))]
+  {"terminal_reason" (get run "terminal_reason")
+   "relationships" (map #(get % "rel") (get error "relationships"))})
+```
+
+## Follow the typed links
+
+Relationships are declared with a semantics that is deliberately narrower than
+their name:
+
+| Relation | Semantics | Reaches |
+| --- | --- | --- |
+| `boundary_failure` | causation | the failing activity record |
+| `child_evaluations` | nesting | evaluations parented by the failing one |
+| `direct_boundary_producer` | causation | the child evaluation that produced the boundary value |
+| `generated_source` | association | that evaluation's generated program |
+| `producing_turn` | association | the model turn that emitted a program |
+| `referenced_prelude_source` | association | a component a program actually called |
+| `dependency_prelude_source` | dependency | a component's frozen direct dependencies |
+
+`causation` requires proof: a workflow boundary failure, or a direct-return
+origin marker plus exact equality with the retained child result. A parent edge
+alone is never promoted to causation. When a run fails by calling `fail`
+directly, no direct producer is proven, and that relation honestly reports
+`incomplete` instead of pointing at the most likely child.
+
+Generated entries embedded in `turns` carry the same relationships as their
+`generated_sources` item, so a walker that starts from a model turn can follow
+evidence without a second exact read.
+
+From a generated program, one hop reaches the component it called, and each
+further hop reaches that component's frozen dependencies:
+
+```clojure
+(let [referenced (first
+                   (filter #(= (get % "rel") "referenced_prelude_source")
+                           (get generated "relationships")))
+      entry (first (get (get (debug.nav/follow run-id referenced {}) "page") "items"))]
+  (get entry "source"))
+```
+
+A component ID alone is not an occurrence identity: the same component can be
+frozen into the workflow environment and into several missions with different
+dependency edges. Every dependency filter therefore repeats its `environment`
+and, for a mission occurrence, its `mission_name`. The edges come only from a
+frozen prelude graph that satisfies its complete positional contract, so a
+malformed or absent graph produces one `incomplete` relation rather than a
+guessed edge.
+
+## Read the evidence state honestly
+
+Every relationship carries one of four states, and a walker that ignores them
+will report confident nonsense:
+
+| State | Meaning |
+| --- | --- |
+| `complete` | the host proved this edge; the filters are exact |
+| `incomplete` | evidence was truncated or the canonical run is not terminal |
+| `ambiguous` | several candidates match; each is offered as its own exact filter |
+| `unavailable` | a complete search proved there is no such target |
+
+`unavailable` is a finding, not a gap: it means the evidence exists and
+contains no match. `incomplete` means the capture cannot answer. Never follow
+a relationship whose filters are null.
+
+Pages carry their own completeness separately from relationship state:
+`next_cursor`, `omitted_count`, `truncated`, and `snapshot_hash`. Turn pages
+add an `evidence` block reporting canonical completeness, missing model
+exchanges, and ambiguity counts.
+
+A diagnosis is supported when every edge it rests on is `complete` and the
+pages it read were not truncated. Otherwise the honest report is insufficient
+evidence, naming which edge was missing.
+
+## Run the credential-free example
+
+The checked-in example needs no credential or network access. `target/` prices
+an order through `orders` → `pricing.tax` → `pricing.rule`; the rule adds 2
+while the captured call requires 20, so the run fails. `pricing.discount` is an
+unused decoy.
+
+Capture the failed run. It exits nonzero by design:
+
+```console
+mix ptc run examples/debug-a-failed-run/target.ptc-project.json
+```
+
+Then navigate that capture:
+
+```console
+mix ptc run examples/debug-a-failed-run/debugger.ptc-project.json
+```
+
+The debugger is a private run, so read its value from the project's result
+directory rather than stdout:
+
+```console
+cat examples/debug-a-failed-run/debugger/.ptc/results/*.private.json
+```
+
+It reports the boundary failure, the exact generated program including the
+required total, and the frozen dependency closure with each component's source:
+
+```json
+{
+  "boundary_kind": "workflow_failed",
+  "dependency_closure": ["orders", "pricing.tax", "pricing.rule"],
+  "evidence_states": ["complete", "incomplete", "unavailable"],
+  "generated_source": "(let [quote (orders/place data/params)] (if (= (get quote \"total\") 120) quote (fail {:kind \"order-total-mismatch\"})))",
+  "terminal_reason": "explicit_failure"
+}
+```
+
+The decoy never appears, because the walk follows frozen dependency edges
+rather than the manifest's component list. `evidence_states` includes
+`incomplete` because this run failed by calling `fail`, so no direct boundary
+producer was proven — a fact the report keeps rather than hides.
+
+The generated program requires 120, the reached rule adds 2, and the closure
+contains exactly one component that decides the added amount. That is a
+supported diagnosis. Confirming it is a separate step: edit
+`target/pricing.rule.clj`, remove the stale capture, and rerun the target.
+
+## Let a model do the walking
+
+The same mission works for an agent. Keep `debug.nav` as the mission's only
+domain authority and let the shipped agent loop drive it:
+
+```json
+"workflow": {
+  "components": [{"library": "agent.main"}],
+  "entry": "agent.main/run"
+},
+"missions": {
+  "evidence": {
+    "components": [{"library": "debug.nav"}],
+    "providers": ["debug.nav", "failed-run-traces"]
+  }
+},
+"providers": {
+  "workflow": [{"name": "deepseek"}],
+  "mission": [{"name": "debug.nav"}, {"name": "failed-run-traces", "config": {"expose": false}}]
+}
+```
+
+Supply the task and turn budget through input, and require a result contract
+with an explicit decision so an abstention is a first-class answer rather than
+an empty diagnosis slot:
+
+```json
+"input": {
+  "value": {
+    "task": "Explain why the captured failed run did not produce its required value. Cite the exact evidence you read. If the evidence does not identify one faulty component, say so and name what is missing.",
+    "agent": {"max_turns": 8}
+  }
+},
+"contracts": {"result_schema": {"path": "report.schema.json"}}
+```
+
+Two limits are worth knowing before trusting such a run.
+
+A model that can still call evidence tools may keep verifying instead of
+concluding, even when the decisive comparison is already in its context.
+Budget for that, and treat an exhausted turn limit as an unfinished
+investigation rather than an absent cause.
+
+A contract-valid report is not a correct one. A forced diagnosis slot invites
+an invented explanation. Where the claim is mechanically testable, test it:
+run the proposed change against host-owned cases before believing it. The
+model may diagnose and author; whether a change is accepted stays with the
+host.
+
+## Scope and limits
+
+This substrate is structural navigation, not automatic debugging:
+
+- it reports evidence and typed links, and never selects a diagnosis;
+- the walk follows dependency edges only — not callers, data flow, or
+  capability side effects;
+- it assumes a captured failure with retained generated source; a run that
+  produced no program leaves nothing to walk;
+- host validation, not a model report, decides whether a repair is accepted.
+
+The one shape it demonstrably covers is a complete single-call failure whose
+relevant source lies inside the called component's dependency closure.
+Discovery outside that closure, and repair of nonlocal or weakly specified
+defects, are not established.
+
+## Next steps
+
+- [Kernel REPL](kernel-repl.md) covers `private-run-analysis-v1` for
+  interactive or unattended investigation of the same capture.
+- [TraceLog contract](../trace-log-contract.md) defines every collection,
+  filter, relationship, and completeness field.
+- [Running and debugging](running-and-debugging.md) documents artifacts,
+  diagnostics, and the transcript command.
+- [Components and preludes](components-and-preludes.md) explains component
+  identity, dependencies, and the shipped libraries.

--- a/docs/guides/debugging-a-failed-run.md
+++ b/docs/guides/debugging-a-failed-run.md
@@ -192,13 +192,27 @@ will report confident nonsense:
 | State | Meaning |
 | --- | --- |
 | `complete` | the host proved this edge; the filters are exact |
-| `incomplete` | evidence was truncated or the canonical run is not terminal |
-| `ambiguous` | several candidates match; each is offered as its own exact filter |
+| `incomplete` | the capture cannot answer, so no claim is made |
+| `ambiguous` | more than one item matches |
 | `unavailable` | a complete search proved there is no such target |
 
-`unavailable` is a finding, not a gap: it means the evidence exists and
-contains no match. `incomplete` means the capture cannot answer. Never follow
-a relationship whose filters are null.
+`incomplete` is the honest catch-all for "not established": a non-terminal or
+truncated canonical run, producer evidence that was cut off, an absent or
+malformed frozen prelude graph, or a program whose prelude-call analysis was
+never captured. It does not distinguish those causes, and a null-filtered
+`incomplete` relation cannot be followed at all.
+
+`unavailable` is a finding rather than a gap: the evidence exists and contains
+no match.
+
+`ambiguous` means different things by relation. Ambiguous boundary-producer
+candidates are emitted as several separate relations, each with its own exact
+filter, rather than one unbounded scan. An ambiguous prelude or turn
+association is a single relation whose one filter matches more than one item;
+following it returns them all, and choosing between them is the caller's
+problem.
+
+Never follow a relationship whose filters are null.
 
 Pages carry their own completeness separately from relationship state:
 `next_cursor`, `omitted_count`, `truncated`, and `snapshot_hash`. Turn pages
@@ -212,9 +226,9 @@ evidence, naming which edge was missing.
 ## Run the credential-free example
 
 The checked-in example needs no credential or network access. `target/` prices
-an order through `orders` → `pricing.tax` → `pricing.rule`; the rule adds 2
-while the captured call requires 20, so the run fails. `pricing.discount` is an
-unused decoy.
+an order through `orders` → `pricing.tax`, which branches to `pricing.base` and
+`pricing.rule`. The rule adds 2 while the captured call requires 20, so the run
+fails. `pricing.discount` is an unused decoy.
 
 Capture the failed run. It exits nonzero by design:
 
@@ -241,7 +255,8 @@ required total, and the frozen dependency closure with each component's source:
 ```json
 {
   "boundary_kind": "workflow_failed",
-  "dependency_closure": ["orders", "pricing.tax", "pricing.rule"],
+  "closure_complete": true,
+  "dependency_closure": ["orders", "pricing.tax", "pricing.base", "pricing.rule"],
   "evidence_states": ["complete", "incomplete", "unavailable"],
   "generated_source": "(let [quote (orders/place data/params)] (if (= (get quote \"total\") 120) quote (fail {:kind \"order-total-mismatch\"})))",
   "terminal_reason": "explicit_failure"
@@ -249,9 +264,15 @@ required total, and the frozen dependency closure with each component's source:
 ```
 
 The decoy never appears, because the walk follows frozen dependency edges
-rather than the manifest's component list. `evidence_states` includes
-`incomplete` because this run failed by calling `fail`, so no direct boundary
-producer was proven — a fact the report keeps rather than hides.
+rather than the manifest's component list. Both branches under `pricing.tax`
+do appear: a walk that followed one edge per component would silently drop the
+other, and might drop the defective one.
+
+Two fields keep the report honest about its own coverage. `closure_complete` is
+false whenever the walk stopped at an edge the host could not prove or hit its
+own bound, so a partial closure is never mistaken for the whole one.
+`evidence_states` includes `incomplete` here because this run failed by calling
+`fail`, so no direct boundary producer was proven.
 
 The generated program requires 120, the reached rule adds 2, and the closure
 contains exactly one component that decides the added amount. That is a

--- a/docs/guides/debugging-a-failed-run.md
+++ b/docs/guides/debugging-a-failed-run.md
@@ -262,10 +262,11 @@ supported diagnosis. Confirming it is a separate step: edit
 
 The same mission works for an agent. `debugger-agent/` in the example replaces
 the deterministic walk with the shipped agent loop over the same authority. It
-is the one part of the example that needs a credential:
+is the one part of the example that needs a credential, named on the command
+line so no environment file has to live inside the example directory:
 
 ```console
-mix ptc run examples/debug-a-failed-run/debugger-agent.ptc-project.json
+mix ptc run examples/debug-a-failed-run/debugger-agent.ptc-project.json --env-file .env
 ```
 
 Keep `debug.nav` as the mission's only domain authority and select a model into
@@ -327,12 +328,14 @@ and returned a report missing a single required field. The bounded contract
 feedback named exactly that field; the model resumed exploring instead of
 correcting. Stating the contract's fields in the task removed the problem.
 
-**Correct evidence does not make a correct diagnosis.** The final live run
-returned a contract-valid `diagnosed` report whose five evidence lines were all
-accurate and all genuinely read — and whose conclusion was wrong. It blamed the
-component that never calls the unused decoy, rather than the rule that adds the
-wrong amount. Nothing in the substrate could have prevented that, because the
-substrate deliberately does not choose a diagnosis.
+**Correct evidence does not make a correct diagnosis.** Two live runs of the
+identical configuration reached the same complete evidence and answered
+differently: one returned `insufficient-evidence`, the other a confident
+`diagnosed` report whose five evidence lines were all accurate and genuinely
+read, and whose conclusion was wrong — it blamed the component that never calls
+the unused decoy rather than the rule that adds the wrong amount. Nothing in
+the substrate could have prevented that, because the substrate deliberately
+does not choose a diagnosis. Treat a single sample as one opinion.
 
 That last point is the reason this layer stops where it does. Where a claim is
 mechanically testable, test it: apply the proposed change and run it against

--- a/docs/guides/debugging-a-failed-run.md
+++ b/docs/guides/debugging-a-failed-run.md
@@ -258,7 +258,7 @@ required total, and the frozen dependency closure with each component's source:
   "closure_complete": true,
   "dependency_closure": ["orders", "pricing.tax", "pricing.base", "pricing.rule"],
   "evidence_states": ["complete", "incomplete", "unavailable"],
-  "generated_source": "(let [quote (orders/place data/params)] (if (= (get quote \"total\") 120) quote (fail {:kind \"order-total-mismatch\"})))",
+  "generated_source": "(let [quote (orders/place {\"subtotal\" 100})] (if (= (get quote \"total\") 120) quote (fail {:kind \"order-total-mismatch\"})))",
   "terminal_reason": "explicit_failure"
 }
 ```
@@ -274,10 +274,22 @@ own bound, so a partial closure is never mistaken for the whole one.
 `evidence_states` includes `incomplete` here because this run failed by calling
 `fail`, so no direct boundary producer was proven.
 
-The generated program requires 120, the reached rule adds 2, and the closure
-contains exactly one component that decides the added amount. That is a
-supported diagnosis. Confirming it is a separate step: edit
-`target/pricing.rule.clj`, remove the stale capture, and rerun the target.
+The generated program is what makes this diagnosis supported rather than
+plausible. It carries both values the check ran on — subtotal 100 and required
+total 120 — so the reached sources settle the question: `pricing.base` returns
+the subtotal unchanged and `pricing.rule` adds 2, and no other component in the
+closure decides the amount.
+
+This is worth noticing, because the same example with `data/params` in the
+generated program instead of the literal order is genuinely insufficient
+evidence. The capture would still show the check and the whole source chain,
+but not the value checked, and a wrong input would then be indistinguishable
+from a wrong component. A live model given that earlier capture correctly
+refused to name a component for exactly this reason. What a run generates is
+what a later run can prove.
+
+Confirming the diagnosis is a separate step: edit `target/pricing.rule.clj`,
+remove the stale capture, and rerun the target.
 
 ## Let a model do the walking
 
@@ -349,16 +361,24 @@ and returned a report missing a single required field. The bounded contract
 feedback named exactly that field; the model resumed exploring instead of
 correcting. Stating the contract's fields in the task removed the problem.
 
-**Correct evidence does not make a correct diagnosis.** Two live runs of the
-identical configuration reached the same complete evidence and answered
-differently: one returned `insufficient-evidence`, the other a confident
-`diagnosed` report whose five evidence lines were all accurate and genuinely
-read, and whose conclusion was wrong — it blamed the component that never calls
-the unused decoy rather than the rule that adds the wrong amount. Nothing in
-the substrate could have prevented that, because the substrate deliberately
-does not choose a diagnosis. Treat a single sample as one opinion.
+**What the run generated decides what the debugger can prove.** Against the
+current capture, whose generated program carries both the order and the
+required total, the live model traced the branching chain and correctly named
+`pricing.rule`, citing that `pricing.base` returns the subtotal unchanged while
+the rule adds 2. Against an earlier capture whose program referenced
+`data/params` instead of the literal order, the same configuration correctly
+returned `insufficient-evidence`, reasoning that without the input value a
+wrong input and a wrong component are indistinguishable. Both answers were
+right about their own evidence.
 
-That last point is the reason this layer stops where it does. Where a claim is
+**A contract-valid report is still not a correct one.** A third run returned a
+confident `diagnosed` report whose evidence lines were all accurate and
+genuinely read, and whose conclusion was wrong — it blamed the component that
+never calls the unused decoy. Nothing in the substrate could have prevented
+that, because the substrate deliberately does not choose a diagnosis. Treat a
+single sample as one opinion.
+
+That is the reason this layer stops where it does. Where a claim is
 mechanically testable, test it: apply the proposed change and run it against
 host-owned cases before believing it. The model may diagnose and author;
 whether a change is accepted stays with the host.

--- a/docs/guides/debugging-a-failed-run.md
+++ b/docs/guides/debugging-a-failed-run.md
@@ -260,14 +260,19 @@ supported diagnosis. Confirming it is a separate step: edit
 
 ## Let a model do the walking
 
-The same mission works for an agent. Keep `debug.nav` as the mission's only
-domain authority and let the shipped agent loop drive it:
+The same mission works for an agent. `debugger-agent/` in the example replaces
+the deterministic walk with the shipped agent loop over the same authority. It
+is the one part of the example that needs a credential:
+
+```console
+mix ptc run examples/debug-a-failed-run/debugger-agent.ptc-project.json
+```
+
+Keep `debug.nav` as the mission's only domain authority and select a model into
+the workflow:
 
 ```json
-"workflow": {
-  "components": [{"library": "agent.main"}],
-  "entry": "agent.main/run"
-},
+"workflow": {"components": [{"library": "agent.main"}], "entry": "agent.main/run"},
 "missions": {
   "evidence": {
     "components": [{"library": "debug.nav"}],
@@ -280,32 +285,59 @@ domain authority and let the shipped agent loop drive it:
 }
 ```
 
-Supply the task and turn budget through input, and require a result contract
-with an explicit decision so an abstention is a first-class answer rather than
-an empty diagnosis slot:
+Selecting an inspection snapshot fixes the run's class to `private_inspection`,
+so the model installation must declare
+`"accepts_data": ["normal", "private_inspection"]`. That declaration is the
+operator deciding to send captured private evidence — generated source, frozen
+component source, failure detail — to a model vendor. Make it deliberately.
+
+Name the mission that holds the evidence, and require a result contract with an
+explicit decision so an abstention is a first-class answer rather than an empty
+diagnosis slot:
 
 ```json
-"input": {
-  "value": {
-    "task": "Explain why the captured failed run did not produce its required value. Cite the exact evidence you read. If the evidence does not identify one faulty component, say so and name what is missing.",
-    "agent": {"max_turns": 8}
-  }
-},
+"input": {"value": {"task": "...", "agent": {"max_turns": 14, "mission": "evidence"}}},
 "contracts": {"result_schema": {"path": "report.schema.json"}}
 ```
 
-Two limits are worth knowing before trusting such a run.
+The agent loop runs inside one workflow evaluation, so `workflow_timeout_ms`
+must cover every model turn, not one call. Its installed default of 30 s ends a
+multi-turn investigation mid-flight; the example raises the host ceiling and
+the manifest together.
 
-A model that can still call evidence tools may keep verifying instead of
-concluding, even when the decisive comparison is already in its context.
-Budget for that, and treat an exhausted turn limit as an unfinished
-investigation rather than an absent cause.
+### What to expect
 
-A contract-valid report is not a correct one. A forced diagnosis slot invites
-an invented explanation. Where the claim is mechanically testable, test it:
-run the proposed change against host-owned cases before believing it. The
-model may diagnose and author; whether a change is accepted stays with the
-host.
+Four limits showed up repeatedly while this example was built against a live
+model, and all four are worth designing around.
+
+**Traversal beats budget.** Told only to "read the boundary error", the model
+looped on the public `activity` collection for eight turns and never reached
+`execution_errors`. Naming the collections and the intended order — API
+vocabulary, not answer hints — moved it onto the typed relationships
+immediately. Generic navigation authority does not imply a generic traversal
+plan.
+
+**Available tools postpone conclusions.** With the evidence chain fully read by
+turn 7, the model spent its remaining turns re-reading unrelated collections.
+An explicit stopping rule in the task fixed it. Treat an exhausted turn limit
+as an unfinished investigation, not an absent cause.
+
+**Report shape is a separate failure mode.** One run reached the right evidence
+and returned a report missing a single required field. The bounded contract
+feedback named exactly that field; the model resumed exploring instead of
+correcting. Stating the contract's fields in the task removed the problem.
+
+**Correct evidence does not make a correct diagnosis.** The final live run
+returned a contract-valid `diagnosed` report whose five evidence lines were all
+accurate and all genuinely read — and whose conclusion was wrong. It blamed the
+component that never calls the unused decoy, rather than the rule that adds the
+wrong amount. Nothing in the substrate could have prevented that, because the
+substrate deliberately does not choose a diagnosis.
+
+That last point is the reason this layer stops where it does. Where a claim is
+mechanically testable, test it: apply the proposed change and run it against
+host-owned cases before believing it. The model may diagnose and author;
+whether a change is accepted stays with the host.
 
 ## Scope and limits
 

--- a/docs/guides/debugging-a-failed-run.md
+++ b/docs/guides/debugging-a-failed-run.md
@@ -193,7 +193,7 @@ will report confident nonsense:
 | --- | --- |
 | `complete` | the host proved this edge; the filters are exact |
 | `incomplete` | the capture cannot answer, so no claim is made |
-| `ambiguous` | more than one item matches |
+| `ambiguous` | the target is not uniquely determined; see below |
 | `unavailable` | a complete search proved there is no such target |
 
 `incomplete` is the honest catch-all for "not established": a non-terminal or

--- a/docs/guides/running-and-debugging.md
+++ b/docs/guides/running-and-debugging.md
@@ -295,6 +295,10 @@ source, effective components, capability payloads, prints, diagnostics, and
 terminal values. The attached-terminal and unattended switches are accident
 guards, not access control; treat every downstream sink as private.
 
+To walk the same capture from an ordinary application rather than a session,
+[Debug a failed run](debugging-a-failed-run.md) installs it as a snapshot
+provider and follows typed evidence links with the shipped `debug.nav` prelude.
+
 ## Browse with the development Viewer
 
 From a source checkout:

--- a/docs/trace-log-contract.md
+++ b/docs/trace-log-contract.md
@@ -454,8 +454,8 @@ Generated programs carry `prelude_calls_available?` and a sorted
 `source_match`; duplicate identical sources are marked ambiguous rather than
 given a fabricated causal identity.
 
-Private execution errors and generated programs may carry a `relationships`
-list. Each relationship has this closed shape:
+Private execution errors, generated programs, and effective prelude sources may
+carry a `relationships` list. Each relationship has this closed shape:
 
 ```json
 {
@@ -468,8 +468,8 @@ list. Each relationship has this closed shape:
 ```
 
 The closed relation IDs are `boundary_failure`, `child_evaluations`,
-`direct_boundary_producer`, `generated_source`, `producing_turn`, and
-`referenced_prelude_source`.
+`dependency_prelude_source`, `direct_boundary_producer`, `generated_source`,
+`producing_turn`, and `referenced_prelude_source`.
 `target_collection` and non-null `filters` are the exact options to add to the
 same run's next `analysis/read`; callers must not follow a null filter. State is
 one of `complete`, `incomplete`, `ambiguous`, or `unavailable`. Ambiguous
@@ -490,6 +490,24 @@ generated-source/turn source match. A source match can be ambiguous; a parent
 edge alone is never promoted to causation. Truncated producer evidence is
 `incomplete`, a complete search with no match is `unavailable`, and no relation
 compares canonical and inspection sequence values.
+
+`dependency` is reserved for the frozen prelude graph. Each effective prelude
+source carries one `dependency_prelude_source` relation per direct dependency
+recorded at run start. A component ID alone is not an occurrence identity — the
+same component can be frozen into the workflow environment and into several
+missions with different dependency edges — so every filter set repeats the
+owning `environment` and, for a mission occurrence, its `mission_name`. The
+edges are read only from a graph that satisfies the complete positional
+contract: `dependency_indices` aligned with unique `component_ids`, and each
+entry holding unique ascending indices strictly earlier than its own position.
+A graph that is absent, or that violates any part of that contract, yields one
+`incomplete` relation with null filters rather than a guessed edge. A component
+with no dependencies yields an empty list, which is a different claim from
+`incomplete`.
+
+Generated entries embedded in `turns` carry the same `relationships` list as
+the matching `generated_sources` item, so a walker that starts from a turn can
+follow evidence without an extra exact read to obtain the links.
 
 Provider response usage omits `total_cost` when pricing is unavailable. A
 present zero is therefore a measured zero-cost response, not an unknown cost.

--- a/examples/debug-a-failed-run/README.md
+++ b/examples/debug-a-failed-run/README.md
@@ -4,9 +4,10 @@ This credential-free pair shows one PTC application navigating another
 application's immutable failed run. No model, network access, or credential is
 involved: both runs are deterministic.
 
-`target/` prices an order through a three-component mission. `pricing.rule`
-adds 2 while the captured call requires the subtotal plus 20, so the run fails.
-`pricing.discount` is an unused decoy: nothing in the failing call reaches it.
+`target/` prices an order through `orders` → `pricing.tax`, which branches to
+`pricing.base` and `pricing.rule`. The rule adds 2 while the captured call
+requires the subtotal plus 20, so the run fails. `pricing.discount` is an
+unused decoy: nothing in the failing call reaches it.
 
 `debugger/` installs the target's frozen trace and inspection directories as
 snapshot providers and walks the evidence with the shipped `debug.nav` prelude.
@@ -35,9 +36,10 @@ cat examples/debug-a-failed-run/debugger/.ptc/results/*.private.json
 ```
 
 It reports the boundary failure, the exact generated program including the
-required total, the frozen dependency closure `orders` → `pricing.tax` →
-`pricing.rule`, and the source of each. The decoy never appears, because the
-walk follows frozen dependency edges rather than the manifest component list.
+required total, the complete frozen dependency closure, and the source of each.
+The decoy never appears, because the walk follows frozen dependency edges
+rather than the manifest component list, and `closure_complete` says whether
+the walk saw the whole closure or stopped early.
 
 ## Check the diagnosis
 

--- a/examples/debug-a-failed-run/README.md
+++ b/examples/debug-a-failed-run/README.md
@@ -1,0 +1,70 @@
+# Debug a failed run with another PTC run
+
+This credential-free pair shows one PTC application navigating another
+application's immutable failed run. No model, network access, or credential is
+involved: both runs are deterministic.
+
+`target/` prices an order through a three-component mission. `pricing.rule`
+adds 2 while the captured call requires the subtotal plus 20, so the run fails.
+`pricing.discount` is an unused decoy: nothing in the failing call reaches it.
+
+`debugger/` installs the target's frozen trace and inspection directories as
+snapshot providers and walks the evidence with the shipped `debug.nav` prelude.
+It reports what the evidence shows and how completely the host proved each
+edge. It never names a suspect.
+
+## Run it
+
+Capture the failed run first. It exits nonzero by design:
+
+```console
+mix ptc run examples/debug-a-failed-run/target.ptc-project.json
+```
+
+Then navigate that capture:
+
+```console
+mix ptc run examples/debug-a-failed-run/debugger.ptc-project.json
+```
+
+The debugger is a private run, so its value goes to
+`examples/debug-a-failed-run/debugger/.ptc/results/` rather than stdout:
+
+```console
+cat examples/debug-a-failed-run/debugger/.ptc/results/*.private.json
+```
+
+It reports the boundary failure, the exact generated program including the
+required total, the frozen dependency closure `orders` → `pricing.tax` →
+`pricing.rule`, and the source of each. The decoy never appears, because the
+walk follows frozen dependency edges rather than the manifest component list.
+
+## Check the diagnosis
+
+The evidence supports one change: `pricing.rule/apply-standard` adds 2 where
+the captured call requires 20. Edit `target/pricing.rule.clj`, remove the stale
+capture, and rerun the target to see it pass:
+
+```console
+rm -rf examples/debug-a-failed-run/target/.ptc
+mix ptc run examples/debug-a-failed-run/target.ptc-project.json
+```
+
+## What each file does
+
+| Path | Role |
+| --- | --- |
+| `target/ptc.json` | the failing application and its `pricing` mission |
+| `target.ptc-project.json` | captures trace, inspection, result, and envelope under `target/.ptc` |
+| `ptc-host.json` | installs the target's capture as `failed-run-traces` and `debug.nav` |
+| `debugger/ptc.json` | selects `debug.nav` and the snapshot providers into the `evidence` mission |
+| `debugger/evidence.walk.clj` | the bounded walk over runs, errors, generated source, and prelude source |
+
+The inspection snapshot provider must be selected under the alias `debug.nav`,
+because the shipped prelude binds `<alias>.runs`, `<alias>.open`, and
+`<alias>.read`.
+
+Inspection artifacts hold generated source, capability payloads, and frozen
+component sources. They are not sanitized traces and should not be shared as
+such. The complete walkthrough is in
+[Debug a failed run](../../docs/guides/debugging-a-failed-run.md).

--- a/examples/debug-a-failed-run/README.md
+++ b/examples/debug-a-failed-run/README.md
@@ -69,11 +69,12 @@ Selecting the inspection snapshot fixes the run's class to
 `"accepts_data": ["normal", "private_inspection"]`. That is an operator
 decision to send captured private evidence to a model vendor.
 
-Two live runs of this configuration reached the same complete evidence and
-answered differently: one abstained, the other confidently blamed `orders` for
-not calling the unused decoy rather than the rule that adds the wrong amount.
-That is the point of the decoy, and the reason this layer reports evidence
-instead of choosing a diagnosis.
+A verified live run traced the branching chain and correctly named
+`pricing.rule`. Earlier runs, against a capture whose generated program did not
+carry the order values, correctly abstained instead — and one run was
+confidently wrong, blaming `orders` for not calling the unused decoy. That is
+the point of the decoy, and the reason this layer reports evidence rather than
+choosing a diagnosis.
 
 ## What each file does
 

--- a/examples/debug-a-failed-run/README.md
+++ b/examples/debug-a-failed-run/README.md
@@ -50,6 +50,28 @@ rm -rf examples/debug-a-failed-run/target/.ptc
 mix ptc run examples/debug-a-failed-run/target.ptc-project.json
 ```
 
+## Optional: let a model walk it
+
+`debugger-agent/` runs the shipped agent loop over the same authority. It is
+the one part of this example that needs a credential, so create `.env` beside
+this README with `OPENROUTER_API_KEY=...` first:
+
+```console
+mix ptc run examples/debug-a-failed-run/debugger-agent.ptc-project.json
+cat examples/debug-a-failed-run/debugger-agent/.ptc/results/*.private.json
+```
+
+Selecting the inspection snapshot fixes the run's class to
+`private_inspection`, so the model installation declares
+`"accepts_data": ["normal", "private_inspection"]`. That is an operator
+decision to send captured private evidence to a model vendor.
+
+A verified live run reached the whole chain and returned a contract-valid
+report whose evidence lines were accurate — and whose conclusion blamed
+`orders` for not calling the unused decoy rather than the rule that adds the
+wrong amount. That is the point of the decoy, and the reason this layer reports
+evidence instead of choosing a diagnosis.
+
 ## What each file does
 
 | Path | Role |
@@ -59,6 +81,7 @@ mix ptc run examples/debug-a-failed-run/target.ptc-project.json
 | `ptc-host.json` | installs the target's capture as `failed-run-traces` and `debug.nav` |
 | `debugger/ptc.json` | selects `debug.nav` and the snapshot providers into the `evidence` mission |
 | `debugger/evidence.walk.clj` | the bounded walk over runs, errors, generated source, and prelude source |
+| `debugger-agent/ptc.json` | the optional live-model variant over the same mission authority |
 
 The inspection snapshot provider must be selected under the alias `debug.nav`,
 because the shipped prelude binds `<alias>.runs`, `<alias>.open`, and

--- a/examples/debug-a-failed-run/README.md
+++ b/examples/debug-a-failed-run/README.md
@@ -53,11 +53,12 @@ mix ptc run examples/debug-a-failed-run/target.ptc-project.json
 ## Optional: let a model walk it
 
 `debugger-agent/` runs the shipped agent loop over the same authority. It is
-the one part of this example that needs a credential, so create `.env` beside
-this README with `OPENROUTER_API_KEY=...` first:
+the one part of this example that needs a credential. Name the environment file
+on the command line rather than placing one in this directory, which ships
+inside the published package:
 
 ```console
-mix ptc run examples/debug-a-failed-run/debugger-agent.ptc-project.json
+mix ptc run examples/debug-a-failed-run/debugger-agent.ptc-project.json --env-file .env
 cat examples/debug-a-failed-run/debugger-agent/.ptc/results/*.private.json
 ```
 
@@ -66,11 +67,11 @@ Selecting the inspection snapshot fixes the run's class to
 `"accepts_data": ["normal", "private_inspection"]`. That is an operator
 decision to send captured private evidence to a model vendor.
 
-A verified live run reached the whole chain and returned a contract-valid
-report whose evidence lines were accurate — and whose conclusion blamed
-`orders` for not calling the unused decoy rather than the rule that adds the
-wrong amount. That is the point of the decoy, and the reason this layer reports
-evidence instead of choosing a diagnosis.
+Two live runs of this configuration reached the same complete evidence and
+answered differently: one abstained, the other confidently blamed `orders` for
+not calling the unused decoy rather than the rule that adds the wrong amount.
+That is the point of the decoy, and the reason this layer reports evidence
+instead of choosing a diagnosis.
 
 ## What each file does
 

--- a/examples/debug-a-failed-run/debugger-agent.ptc-project.json
+++ b/examples/debug-a-failed-run/debugger-agent.ptc-project.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://ptc-runner.dev/schemas/ptc-project-config.schema.json",
+  "kind": "ptc-project",
+  "version": 1,
+  "application": {
+    "path": "debugger-agent/ptc.json"
+  },
+  "host": {
+    "path": "ptc-host.json",
+    "env_file": {"path": ".env"}
+  },
+  "artifacts": {
+    "root": "debugger-agent/.ptc",
+    "trace": true,
+    "inspection": true,
+    "result": true,
+    "envelope": true
+  },
+  "viewer": {
+    "port": 4125,
+    "open": true,
+    "repl": true,
+    "private": true
+  }
+}

--- a/examples/debug-a-failed-run/debugger-agent.ptc-project.json
+++ b/examples/debug-a-failed-run/debugger-agent.ptc-project.json
@@ -6,8 +6,7 @@
     "path": "debugger-agent/ptc.json"
   },
   "host": {
-    "path": "ptc-host.json",
-    "env_file": {"path": ".env"}
+    "path": "ptc-host.json"
   },
   "artifacts": {
     "root": "debugger-agent/.ptc",

--- a/examples/debug-a-failed-run/debugger-agent/ptc.json
+++ b/examples/debug-a-failed-run/debugger-agent/ptc.json
@@ -1,0 +1,39 @@
+{
+  "version": 1,
+  "workflow": {
+    "components": [{"library": "agent.main"}],
+    "entry": "agent.main/run"
+  },
+  "missions": {
+    "evidence": {
+      "components": [{"library": "debug.nav"}],
+      "providers": ["debug.nav", "failed-run-traces"]
+    }
+  },
+  "contracts": {
+    "result_schema": {"path": "report.schema.json"}
+  },
+  "input": {
+    "value": {
+      "task": "A captured run failed. Determine why it did not produce the value it was required to produce, using only evidence you actually read.\nWork in this order: list runs and select the failed one; open it; read its execution_errors collection; read its generated_sources collection to obtain the exact program the run generated; then use debug.nav/follow on the typed relationships those items carry to reach the prelude source the program called, and keep following dependency relationships until an item has none.\nFollow a relationship object exactly as you received it, and only when its state is \"complete\". Do not invent filters, and do not pass a run id where an evaluation id is expected.\nStopping rule: as soon as you have read a source with no further complete dependency relationship, make the very next program your final report. Do not gather more evidence after that point.\nThe report is an object with exactly these fields: \"decision\", \"cause\" (a string), \"evidence\" (an array of strings), and \"component_id\" only when you name one. Use decision \"diagnosed\" with the responsible component_id only when the source you read identifies one; otherwise use decision \"insufficient-evidence\" and let \"cause\" name what is missing.",
+      "agent": {"max_turns": 14, "mission": "evidence"}
+    }
+  },
+  "providers": {
+    "workflow": [{"name": "deepseek"}],
+    "mission": [
+      {"name": "debug.nav"},
+      {"name": "failed-run-traces", "config": {"expose": false}}
+    ]
+  },
+  "limits": {
+    "run_duration_ms": 600000,
+    "workflow_timeout_ms": 540000,
+    "evaluation_timeout_ms": 480000
+  },
+  "events": {"policy": "private"},
+  "labels": {
+    "name": "debug-a-failed-run-agent",
+    "tags": {"mode": "agent"}
+  }
+}

--- a/examples/debug-a-failed-run/debugger-agent/report.schema.json
+++ b/examples/debug-a-failed-run/debugger-agent/report.schema.json
@@ -1,0 +1,16 @@
+{
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["decision", "cause", "evidence"],
+  "properties": {
+    "decision": {"type": "string", "enum": ["diagnosed", "insufficient-evidence"]},
+    "cause": {"type": "string", "minLength": 1, "maxLength": 2000},
+    "component_id": {"type": "string", "minLength": 1, "maxLength": 128},
+    "evidence": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 20,
+      "items": {"type": "string", "minLength": 1, "maxLength": 500}
+    }
+  }
+}

--- a/examples/debug-a-failed-run/debugger.ptc-project.json
+++ b/examples/debug-a-failed-run/debugger.ptc-project.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://ptc-runner.dev/schemas/ptc-project-config.schema.json",
+  "kind": "ptc-project",
+  "version": 1,
+  "application": {
+    "path": "debugger/ptc.json"
+  },
+  "host": {
+    "path": "ptc-host.json"
+  },
+  "artifacts": {
+    "root": "debugger/.ptc",
+    "trace": true,
+    "inspection": false,
+    "result": true,
+    "envelope": true
+  },
+  "viewer": {
+    "port": 4124,
+    "open": true,
+    "repl": true,
+    "private": true
+  }
+}

--- a/examples/debug-a-failed-run/debugger/evidence.walk.clj
+++ b/examples/debug-a-failed-run/debugger/evidence.walk.clj
@@ -1,0 +1,59 @@
+(ns evidence.walk
+  "Collect the evidence a diagnosis would have to rest on, and nothing more."
+  {:visibility :prompt})
+
+(defn- first-item [page] (first (get page "items")))
+
+(defn- relation [item rel]
+  (first (filter #(= (get % "rel") rel) (get item "relationships"))))
+
+(defn- complete? [relationship]
+  (and (map? relationship) (= (get relationship "state") "complete")))
+
+(defn- hop [run-id relationship]
+  (first-item (get (debug.nav/follow run-id relationship {}) "page")))
+
+;; Walk the frozen dependency edges the failing call actually reached. The
+;; walk is bounded, stops at the first edge the host did not prove complete,
+;; and never widens to components outside that closure.
+(defn- dependency-closure [run-id entry]
+  (reduce
+    (fn [chain _step]
+      (let [dependency (relation (last chain) "dependency_prelude_source")]
+        (if (complete? dependency)
+          (conj chain (hop run-id dependency))
+          chain)))
+    [entry]
+    (range 8)))
+
+(defn- states [items]
+  (sort (distinct (mapcat #(map (fn [r] (get r "state")) (get % "relationships")) items))))
+
+(defn collect
+  "Return the failed run's boundary error, generated program, and reached source."
+  {:signature "(options :map) -> :map"}
+  [options]
+  (let [run (first-item (debug.nav/runs {"status" "error" "limit" (get options "limit")}))
+        run-id (get run "run_id")
+        error (first-item (debug.nav/read run-id {"collection" "execution_errors"}))
+        children (get (debug.nav/follow run-id (relation error "child_evaluations") {}) "page")
+        generated (first-item
+                    (debug.nav/read
+                      run-id
+                      {"collection" "generated_sources"
+                       "parent_evaluation_id" (get error "evaluation_id")}))
+        entry (hop run-id (relation generated "referenced_prelude_source"))
+        chain (dependency-closure run-id entry)]
+    {"run_id" run-id
+     "terminal_reason" (get run "terminal_reason")
+     "boundary_kind" (get error "kind")
+     "nested_evaluations" (count (get children "items"))
+     "generated_source" (get generated "source")
+     "dependency_closure" (map #(get % "component_id") chain)
+     "reached_sources" (map #(get % "source") chain)
+     ;; Report how well the host proved every edge on the path, so a caller can
+     ;; tell a supported diagnosis from an incomplete or ambiguous picture
+     ;; instead of assuming the walk saw everything.
+     "evidence_states" (states (concat [error generated] chain))
+     ;; Nothing here selects a suspect. That judgement belongs to the caller.
+     "diagnosis" nil}))

--- a/examples/debug-a-failed-run/debugger/evidence.walk.clj
+++ b/examples/debug-a-failed-run/debugger/evidence.walk.clj
@@ -17,36 +17,62 @@
 
 (defn- dependency-edges [item] (relations item "dependency_prelude_source"))
 
+(defn- edge-component [relationship] (get (get relationship "filters") "component_id"))
+
+;; Two components in one round can name the same dependency, so drop an edge
+;; already recorded and an edge repeated inside this round. Deduplicating the
+;; edges rather than the fetched items also saves the redundant capability
+;; call.
+(defn- new-edges [seen edges]
+  (reduce
+    (fn [kept edge]
+      (let [id (edge-component edge)]
+        (if (or (some #(= % id) seen) (some #(= (edge-component %) id) kept))
+          kept
+          (conj kept edge))))
+    []
+    edges))
+
 ;; Walk every frozen dependency edge the failing call reached, breadth first.
 ;; A frozen graph orders dependencies before dependants, so it cannot cycle,
-;; but deduplicate by component anyway and keep explicit bounds. The walk
-;; reports whether it saw the whole closure: an edge the host did not prove
-;; complete, or either bound, makes the result partial rather than silently
-;; short.
+;; but deduplicate by component anyway and keep explicit bounds. Any edge the
+;; host did not prove complete, and any followed edge that returned no item,
+;; makes the result partial rather than silently short.
 (defn- expand [run-id state]
-  (let [frontier (get state "frontier")
-        edges (mapcat dependency-edges frontier)
+  (let [seen (get state "seen")
+        edges (mapcat dependency-edges (get state "frontier"))
         followable (filter complete? edges)
-        seen (get state "seen")
-        found (map #(hop run-id %) followable)
-        fresh (remove #(some (fn [id] (= id (get % "component_id"))) seen) found)]
-    {"chain" (concat (get state "chain") fresh)
-     "seen" (concat seen (map #(get % "component_id") fresh))
-     "frontier" fresh
-     "complete?" (and (get state "complete?") (= (count edges) (count followable)))}))
+        available (new-edges seen followable)
+        ;; Apply the component bound to this round's edges, not merely before
+        ;; it: one high-degree frontier could otherwise follow far more than
+        ;; the bound before anything notices.
+        wanted (take (max 0 (- 64 (count seen))) available)
+        found (remove nil? (map #(hop run-id %) wanted))]
+    {"chain" (concat (get state "chain") found)
+     ;; Record every attempted component, so a failed hop is not retried.
+     "seen" (concat seen (map edge-component wanted))
+     "frontier" found
+     "complete?" (and (get state "complete?")
+                      (= (count edges) (count followable))
+                      (= (count wanted) (count available))
+                      (= (count found) (count wanted)))}))
 
-(defn- closure [run-id entry]
-  (reduce
-    (fn [state _round]
-      (cond
-        (empty? (get state "frontier")) state
-        (>= (count (get state "seen")) 64) (assoc state "complete?" false)
-        :else (expand run-id state)))
-    {"chain" [entry]
-     "seen" [(get entry "component_id")]
-     "frontier" [entry]
-     "complete?" true}
-    (range 16)))
+;; A round that finds nothing new empties the frontier, so a frontier that
+;; survives every round means the walk ran out of rounds with edges still
+;; unchecked.
+(defn- closure [run-id roots complete?]
+  (let [walked (reduce
+                 (fn [state _round]
+                   (if (empty? (get state "frontier"))
+                     state
+                     (expand run-id state)))
+                 {"chain" roots
+                  "seen" (map #(get % "component_id") roots)
+                  "frontier" roots
+                  "complete?" complete?}
+                 (range 16))]
+    (assoc walked "complete?"
+           (and (get walked "complete?") (empty? (get walked "frontier"))))))
 
 (defn- states [items]
   (sort (distinct (mapcat #(map (fn [r] (get r "state")) (get % "relationships")) items))))
@@ -64,8 +90,16 @@
                       run-id
                       {"collection" "generated_sources"
                        "parent_evaluation_id" (get error "evaluation_id")}))
-        entry (hop run-id (relation generated "referenced_prelude_source"))
-        walk (closure run-id entry)
+        ;; A program may call several components. Seed the walk from every one
+        ;; the host proved, and let an unproven or empty reference make the
+        ;; whole closure partial rather than quietly narrowing it to the first.
+        referenced (relations generated "referenced_prelude_source")
+        proven (new-edges [] (filter complete? referenced))
+        roots (remove nil? (map #(hop run-id %) proven))
+        walk (closure
+               run-id
+               roots
+               (and (= (count referenced) (count proven)) (= (count roots) (count proven))))
         chain (get walk "chain")]
     {"run_id" run-id
      "terminal_reason" (get run "terminal_reason")

--- a/examples/debug-a-failed-run/debugger/evidence.walk.clj
+++ b/examples/debug-a-failed-run/debugger/evidence.walk.clj
@@ -4,8 +4,10 @@
 
 (defn- first-item [page] (first (get page "items")))
 
-(defn- relation [item rel]
-  (first (filter #(= (get % "rel") rel) (get item "relationships"))))
+(defn- relations [item rel]
+  (filter #(= (get % "rel") rel) (get item "relationships")))
+
+(defn- relation [item rel] (first (relations item rel)))
 
 (defn- complete? [relationship]
   (and (map? relationship) (= (get relationship "state") "complete")))
@@ -13,18 +15,38 @@
 (defn- hop [run-id relationship]
   (first-item (get (debug.nav/follow run-id relationship {}) "page")))
 
-;; Walk the frozen dependency edges the failing call actually reached. The
-;; walk is bounded, stops at the first edge the host did not prove complete,
-;; and never widens to components outside that closure.
-(defn- dependency-closure [run-id entry]
+(defn- dependency-edges [item] (relations item "dependency_prelude_source"))
+
+;; Walk every frozen dependency edge the failing call reached, breadth first.
+;; A frozen graph orders dependencies before dependants, so it cannot cycle,
+;; but deduplicate by component anyway and keep explicit bounds. The walk
+;; reports whether it saw the whole closure: an edge the host did not prove
+;; complete, or either bound, makes the result partial rather than silently
+;; short.
+(defn- expand [run-id state]
+  (let [frontier (get state "frontier")
+        edges (mapcat dependency-edges frontier)
+        followable (filter complete? edges)
+        seen (get state "seen")
+        found (map #(hop run-id %) followable)
+        fresh (remove #(some (fn [id] (= id (get % "component_id"))) seen) found)]
+    {"chain" (concat (get state "chain") fresh)
+     "seen" (concat seen (map #(get % "component_id") fresh))
+     "frontier" fresh
+     "complete?" (and (get state "complete?") (= (count edges) (count followable)))}))
+
+(defn- closure [run-id entry]
   (reduce
-    (fn [chain _step]
-      (let [dependency (relation (last chain) "dependency_prelude_source")]
-        (if (complete? dependency)
-          (conj chain (hop run-id dependency))
-          chain)))
-    [entry]
-    (range 8)))
+    (fn [state _round]
+      (cond
+        (empty? (get state "frontier")) state
+        (>= (count (get state "seen")) 64) (assoc state "complete?" false)
+        :else (expand run-id state)))
+    {"chain" [entry]
+     "seen" [(get entry "component_id")]
+     "frontier" [entry]
+     "complete?" true}
+    (range 16)))
 
 (defn- states [items]
   (sort (distinct (mapcat #(map (fn [r] (get r "state")) (get % "relationships")) items))))
@@ -43,7 +65,8 @@
                       {"collection" "generated_sources"
                        "parent_evaluation_id" (get error "evaluation_id")}))
         entry (hop run-id (relation generated "referenced_prelude_source"))
-        chain (dependency-closure run-id entry)]
+        walk (closure run-id entry)
+        chain (get walk "chain")]
     {"run_id" run-id
      "terminal_reason" (get run "terminal_reason")
      "boundary_kind" (get error "kind")
@@ -51,6 +74,10 @@
      "generated_source" (get generated "source")
      "dependency_closure" (map #(get % "component_id") chain)
      "reached_sources" (map #(get % "source") chain)
+     ;; False means the walk stopped early: an edge the host could not prove,
+     ;; or a bound. A diagnosis must not treat a partial closure as the whole
+     ;; one.
+     "closure_complete" (get walk "complete?")
      ;; Report how well the host proved every edge on the path, so a caller can
      ;; tell a supported diagnosis from an incomplete or ambiguous picture
      ;; instead of assuming the walk saw everything.

--- a/examples/debug-a-failed-run/debugger/evidence.walk.clj
+++ b/examples/debug-a-failed-run/debugger/evidence.walk.clj
@@ -33,43 +33,49 @@
     []
     edges))
 
-;; Walk every frozen dependency edge the failing call reached, breadth first.
-;; A frozen graph orders dependencies before dependants, so it cannot cycle,
-;; but deduplicate by component anyway and keep explicit bounds. Any edge the
-;; host did not prove complete, and any followed edge that returned no item,
-;; makes the result partial rather than silently short.
-(defn- expand [run-id state]
-  (let [seen (get state "seen")
-        edges (mapcat dependency-edges (get state "frontier"))
-        followable (filter complete? edges)
-        available (new-edges seen followable)
-        ;; Apply the component bound to this round's edges, not merely before
-        ;; it: one high-degree frontier could otherwise follow far more than
-        ;; the bound before anything notices.
+;; The single place that turns edges into items, so the 64-component bound and
+;; the deduplication apply to the roots exactly as they apply to every later
+;; round. Withholding an edge, or following one that returns no item, makes the
+;; walk partial rather than silently short.
+(defn- follow-edges [run-id seen edges]
+  (let [available (new-edges seen edges)
         wanted (take (max 0 (- 64 (count seen))) available)
         found (remove nil? (map #(hop run-id %) wanted))]
-    {"chain" (concat (get state "chain") found)
+    {"found" found
      ;; Record every attempted component, so a failed hop is not retried.
      "seen" (concat seen (map edge-component wanted))
-     "frontier" found
+     "complete?" (and (= (count wanted) (count available))
+                      (= (count found) (count wanted)))}))
+
+;; Walk every frozen dependency edge the failing call reached, breadth first.
+;; A frozen graph orders dependencies before dependants, so it cannot cycle,
+;; but deduplicate by component anyway. An edge the host did not prove complete
+;; also makes the result partial.
+(defn- expand [run-id state]
+  (let [edges (mapcat dependency-edges (get state "frontier"))
+        followable (filter complete? edges)
+        round (follow-edges run-id (get state "seen") followable)]
+    {"chain" (concat (get state "chain") (get round "found"))
+     "seen" (get round "seen")
+     "frontier" (get round "found")
      "complete?" (and (get state "complete?")
                       (= (count edges) (count followable))
-                      (= (count wanted) (count available))
-                      (= (count found) (count wanted)))}))
+                      (get round "complete?"))}))
 
 ;; A round that finds nothing new empties the frontier, so a frontier that
 ;; survives every round means the walk ran out of rounds with edges still
 ;; unchecked.
-(defn- closure [run-id roots complete?]
-  (let [walked (reduce
+(defn- closure [run-id seeded]
+  (let [roots (get seeded "found")
+        walked (reduce
                  (fn [state _round]
                    (if (empty? (get state "frontier"))
                      state
                      (expand run-id state)))
                  {"chain" roots
-                  "seen" (map #(get % "component_id") roots)
+                  "seen" (get seeded "seen")
                   "frontier" roots
-                  "complete?" complete?}
+                  "complete?" (get seeded "complete?")}
                  (range 16))]
     (assoc walked "complete?"
            (and (get walked "complete?") (empty? (get walked "frontier"))))))
@@ -91,15 +97,17 @@
                       {"collection" "generated_sources"
                        "parent_evaluation_id" (get error "evaluation_id")}))
         ;; A program may call several components. Seed the walk from every one
-        ;; the host proved, and let an unproven or empty reference make the
-        ;; whole closure partial rather than quietly narrowing it to the first.
+        ;; the host proved, through the same bounded follow every later round
+        ;; uses, and let an unproven reference make the closure partial rather
+        ;; than quietly narrowing it to the first.
         referenced (relations generated "referenced_prelude_source")
-        proven (new-edges [] (filter complete? referenced))
-        roots (remove nil? (map #(hop run-id %) proven))
+        followable (filter complete? referenced)
+        seeded (follow-edges run-id [] followable)
         walk (closure
                run-id
-               roots
-               (and (= (count referenced) (count proven)) (= (count roots) (count proven))))
+               (assoc seeded "complete?"
+                      (and (get seeded "complete?")
+                           (= (count referenced) (count followable)))))
         chain (get walk "chain")]
     {"run_id" run-id
      "terminal_reason" (get run "terminal_reason")

--- a/examples/debug-a-failed-run/debugger/main.clj
+++ b/examples/debug-a-failed-run/debugger/main.clj
@@ -1,0 +1,10 @@
+(ns main "Deterministic evidence-collection entry." {:visibility :prompt})
+
+(defn run
+  "Collect immutable evidence about the most recent failed run."
+  {:signature "(input :map) -> :map"}
+  [input]
+  (return
+    (get
+      (kernel/eval-source-with "evidence" "(evidence.walk/collect data/params)" input)
+      "value")))

--- a/examples/debug-a-failed-run/debugger/ptc.json
+++ b/examples/debug-a-failed-run/debugger/ptc.json
@@ -1,0 +1,30 @@
+{
+  "version": 1,
+  "workflow": {
+    "components": [
+      {"id": "main", "path": "main.clj", "dependencies": ["kernel"]},
+      {"library": "kernel"}
+    ],
+    "entry": "main/run"
+  },
+  "missions": {
+    "evidence": {
+      "components": [
+        {"id": "evidence.walk", "path": "evidence.walk.clj", "dependencies": ["debug.nav"]},
+        {"library": "debug.nav"}
+      ],
+      "providers": ["debug.nav", "failed-run-traces"]
+    }
+  },
+  "input": {"value": {"limit": 1}},
+  "providers": {
+    "mission": [
+      {"name": "debug.nav"},
+      {"name": "failed-run-traces", "config": {"expose": false}}
+    ]
+  },
+  "labels": {
+    "name": "debug-a-failed-run-debugger",
+    "tags": {"mode": "deterministic"}
+  }
+}

--- a/examples/debug-a-failed-run/ptc-host.json
+++ b/examples/debug-a-failed-run/ptc-host.json
@@ -1,4 +1,7 @@
 {
+  "credentials": {
+    "openrouter_key": {"env": "OPENROUTER_API_KEY"}
+  },
   "install": {
     "failed-run-traces": {
       "source": "ptc_private_trace_snapshot",
@@ -9,6 +12,20 @@
       "source": "ptc_inspection_snapshot",
       "installation_revision": "failed-run-inspection-v1",
       "directory": "target/.ptc/inspection"
+    },
+    "deepseek": {
+      "source": "llm",
+      "installation_revision": "debug-agent-v1",
+      "model": "openrouter:deepseek/deepseek-v4-flash",
+      "credential": "openrouter_key",
+      "cache": false,
+      "params": {"temperature": 0, "max_tokens": 4096},
+      "accepts_data": ["normal", "private_inspection"]
     }
+  },
+  "limits": {
+    "run_duration_ms": 600000,
+    "workflow_timeout_ms": 540000,
+    "evaluation_timeout_ms": 480000
   }
 }

--- a/examples/debug-a-failed-run/ptc-host.json
+++ b/examples/debug-a-failed-run/ptc-host.json
@@ -1,0 +1,14 @@
+{
+  "install": {
+    "failed-run-traces": {
+      "source": "ptc_private_trace_snapshot",
+      "installation_revision": "failed-run-traces-v1",
+      "directory": "target/.ptc/traces"
+    },
+    "debug.nav": {
+      "source": "ptc_inspection_snapshot",
+      "installation_revision": "failed-run-inspection-v1",
+      "directory": "target/.ptc/inspection"
+    }
+  }
+}

--- a/examples/debug-a-failed-run/target.ptc-project.json
+++ b/examples/debug-a-failed-run/target.ptc-project.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://ptc-runner.dev/schemas/ptc-project-config.schema.json",
+  "kind": "ptc-project",
+  "version": 1,
+  "application": {
+    "path": "target/ptc.json"
+  },
+  "artifacts": {
+    "root": "target/.ptc",
+    "trace": true,
+    "inspection": true,
+    "result": true,
+    "envelope": true
+  },
+  "viewer": {
+    "port": 4123,
+    "open": true,
+    "repl": true,
+    "private": true
+  }
+}

--- a/examples/debug-a-failed-run/target/main.clj
+++ b/examples/debug-a-failed-run/target/main.clj
@@ -1,0 +1,21 @@
+(ns main "Deterministic order-total entry." {:visibility :prompt})
+
+;; The caller's requirement is part of the program the mission evaluates, so
+;; the frozen evidence records what the failing call was actually asked to do.
+(defn- check-source [required]
+  (str "(let [quote (orders/place data/params)]"
+       " (if (= (get quote \"total\") " required ")"
+       " quote"
+       " (fail {:kind \"order-total-mismatch\"})))"))
+
+(defn run
+  "Price one order against the total its caller requires."
+  {:signature "(input :map) -> :map"}
+  [input]
+  (let [required (get input "required_total")
+        outcome (kernel/eval-source-with "pricing" (check-source required) input)
+        quote (get outcome "value")]
+    (if (= (get quote "total") required)
+      (return quote)
+      ;; Only a one-way fingerprint of this kind reaches the canonical trace.
+      (fail {:kind "order-total-mismatch"}))))

--- a/examples/debug-a-failed-run/target/main.clj
+++ b/examples/debug-a-failed-run/target/main.clj
@@ -1,9 +1,12 @@
 (ns main "Deterministic order-total entry." {:visibility :prompt})
 
-;; The caller's requirement is part of the program the mission evaluates, so
-;; the frozen evidence records what the failing call was actually asked to do.
-(defn- check-source [required]
-  (str "(let [quote (orders/place data/params)]"
+;; Both the order and the caller's requirement are part of the program the
+;; mission evaluates, so the frozen evidence records exactly what the failing
+;; call was asked to do. A capture that referenced `data/params` instead would
+;; retain the check but not the values it ran on, which is not enough to
+;; distinguish a wrong input from a wrong component.
+(defn- check-source [subtotal required]
+  (str "(let [quote (orders/place {\"subtotal\" " subtotal "})]"
        " (if (= (get quote \"total\") " required ")"
        " quote"
        " (fail {:kind \"order-total-mismatch\"})))"))
@@ -13,7 +16,9 @@
   {:signature "(input :map) -> :map"}
   [input]
   (let [required (get input "required_total")
-        outcome (kernel/eval-source-with "pricing" (check-source required) input)
+        outcome (kernel/eval-source
+                  "pricing"
+                  (check-source (get input "subtotal") required))
         quote (get outcome "value")]
     (if (= (get quote "total") required)
       (return quote)

--- a/examples/debug-a-failed-run/target/orders.clj
+++ b/examples/debug-a-failed-run/target/orders.clj
@@ -1,0 +1,7 @@
+(ns orders "Order pricing API." {:visibility :prompt})
+
+(defn place
+  "Return the payable total for one order."
+  {:signature "(order :map) -> :map"}
+  [order]
+  {"total" (pricing.tax/add-standard (get order "subtotal"))})

--- a/examples/debug-a-failed-run/target/pricing.base.clj
+++ b/examples/debug-a-failed-run/target/pricing.base.clj
@@ -1,0 +1,7 @@
+(ns pricing.base "The amount the standard rule applies to." {:visibility :prompt})
+
+(defn amount
+  "Return the amount the standard charge applies to."
+  {:signature "(subtotal :int) -> :int"}
+  [subtotal]
+  subtotal)

--- a/examples/debug-a-failed-run/target/pricing.discount.clj
+++ b/examples/debug-a-failed-run/target/pricing.discount.clj
@@ -1,0 +1,7 @@
+(ns pricing.discount "An unused promotional helper." {:visibility :prompt})
+
+(defn preview
+  "Preview a promotional price. Nothing in the failing call reaches this."
+  {:signature "(subtotal :int) -> :int"}
+  [subtotal]
+  (- subtotal 5))

--- a/examples/debug-a-failed-run/target/pricing.rule.clj
+++ b/examples/debug-a-failed-run/target/pricing.rule.clj
@@ -1,0 +1,7 @@
+(ns pricing.rule "The standard pricing rule." {:visibility :prompt})
+
+(defn apply-standard
+  "Add the standard charge to a subtotal."
+  {:signature "(subtotal :int) -> :int"}
+  [subtotal]
+  (+ subtotal 2))

--- a/examples/debug-a-failed-run/target/pricing.tax.clj
+++ b/examples/debug-a-failed-run/target/pricing.tax.clj
@@ -1,0 +1,7 @@
+(ns pricing.tax "Standard tax application." {:visibility :prompt})
+
+(defn add-standard
+  "Apply the standard rule to a subtotal."
+  {:signature "(subtotal :int) -> :int"}
+  [subtotal]
+  (pricing.rule/apply-standard subtotal))

--- a/examples/debug-a-failed-run/target/pricing.tax.clj
+++ b/examples/debug-a-failed-run/target/pricing.tax.clj
@@ -1,7 +1,9 @@
 (ns pricing.tax "Standard tax application." {:visibility :prompt})
 
+;; Two dependencies, so the closure branches here. A walk that follows only
+;; the first edge would silently drop one of them.
 (defn add-standard
   "Apply the standard rule to a subtotal."
   {:signature "(subtotal :int) -> :int"}
   [subtotal]
-  (pricing.rule/apply-standard subtotal))
+  (pricing.rule/apply-standard (pricing.base/amount subtotal)))

--- a/examples/debug-a-failed-run/target/ptc.json
+++ b/examples/debug-a-failed-run/target/ptc.json
@@ -11,7 +11,12 @@
     "pricing": {
       "components": [
         {"id": "orders", "path": "orders.clj", "dependencies": ["pricing.tax"]},
-        {"id": "pricing.tax", "path": "pricing.tax.clj", "dependencies": ["pricing.rule"]},
+        {
+          "id": "pricing.tax",
+          "path": "pricing.tax.clj",
+          "dependencies": ["pricing.base", "pricing.rule"]
+        },
+        {"id": "pricing.base", "path": "pricing.base.clj"},
         {"id": "pricing.rule", "path": "pricing.rule.clj"},
         {"id": "pricing.discount", "path": "pricing.discount.clj"}
       ]

--- a/examples/debug-a-failed-run/target/ptc.json
+++ b/examples/debug-a-failed-run/target/ptc.json
@@ -1,0 +1,26 @@
+{
+  "version": 1,
+  "workflow": {
+    "components": [
+      {"id": "main", "path": "main.clj", "dependencies": ["kernel"]},
+      {"library": "kernel"}
+    ],
+    "entry": "main/run"
+  },
+  "missions": {
+    "pricing": {
+      "components": [
+        {"id": "orders", "path": "orders.clj", "dependencies": ["pricing.tax"]},
+        {"id": "pricing.tax", "path": "pricing.tax.clj", "dependencies": ["pricing.rule"]},
+        {"id": "pricing.rule", "path": "pricing.rule.clj"},
+        {"id": "pricing.discount", "path": "pricing.discount.clj"}
+      ]
+    }
+  },
+  "input": {"value": {"subtotal": 100, "required_total": 120}},
+  "events": {"policy": "private"},
+  "labels": {
+    "name": "debug-a-failed-run-target",
+    "tags": {"mode": "deterministic"}
+  }
+}

--- a/lib/ptc_runner/kernel/library.ex
+++ b/lib/ptc_runner/kernel/library.ex
@@ -4,7 +4,7 @@ defmodule PtcRunner.Kernel.Library do
 
   Available component IDs are `kernel`, `runtime`, `cap`, `workflow.event`,
   `llm`, `agent.native`, `agent.core`, `agent.feedback`, `agent.retry`,
-  `agent.prompt`, `agent.main`, `result`, and `analysis`.
+  `agent.prompt`, `agent.main`, `result`, `analysis`, and `debug.nav`.
 
   `agent.main` is a generic entry wrapper: a manifest names `agent.main/run`
   and supplies `task` and `agent` through input, instead of every application
@@ -17,6 +17,20 @@ defmodule PtcRunner.Kernel.Library do
   `agent.core/run-value` is the composable variant: it returns the same
   model-authored value to its PTC-Lisp caller without terminating the outer
   workflow, allowing an evaluator to judge the answer before returning.
+
+  `analysis` and `debug.nav` are the two navigation surfaces over one immutable
+  run-evidence capture, and a mission installs one or the other. `analysis`
+  binds the stable `analysis-runs`/`analysis-open`/`analysis-read` capability
+  names a REPL analysis profile grants. `debug.nav` adds `follow` and binds a
+  manifest-installed snapshot provider, which names its operations
+  `<alias>.runs`/`<alias>.open`/`<alias>.read`; the mission must therefore
+  select its correlated inspection snapshot provider under the conventional
+  alias `debug.nav`. `follow` takes one typed relationship from an evidence
+  item and reads its exact target collection and filters, refusing an
+  unavailable or filterless relationship and any caller filter beyond `limit`
+  and `cursor`. It adds no host authority and no diagnosis policy: it returns
+  the original relationship beside the unchanged native page envelope, so
+  cursors, completeness, and relationship state survive the hop.
 
   `cap` is `:discoverable` rather than `:prompt`. Its envelope and pagination
   helpers compose capabilities for other libraries and stay out of the prompt
@@ -53,6 +67,7 @@ defmodule PtcRunner.Kernel.Library do
   @agent_retry_path Path.expand("../../../priv/preludes/kernel/agent.retry.clj", __DIR__)
   @result_path Path.expand("../../../priv/preludes/kernel/result.clj", __DIR__)
   @analysis_path Path.expand("../../../priv/preludes/kernel/analysis.clj", __DIR__)
+  @debug_nav_path Path.expand("../../../priv/preludes/kernel/debug.nav.clj", __DIR__)
   @external_resource @kernel_path
   @external_resource @runtime_path
   @external_resource @cap_path
@@ -66,6 +81,7 @@ defmodule PtcRunner.Kernel.Library do
   @external_resource @agent_retry_path
   @external_resource @result_path
   @external_resource @analysis_path
+  @external_resource @debug_nav_path
   @sources %{
     "kernel" => File.read!(@kernel_path),
     "runtime" => File.read!(@runtime_path),
@@ -79,10 +95,12 @@ defmodule PtcRunner.Kernel.Library do
     "agent.feedback" => File.read!(@agent_feedback_path),
     "agent.retry" => File.read!(@agent_retry_path),
     "result" => File.read!(@result_path),
-    "analysis" => File.read!(@analysis_path)
+    "analysis" => File.read!(@analysis_path),
+    "debug.nav" => File.read!(@debug_nav_path)
   }
   @dependencies %{
     "analysis" => ["cap"],
+    "debug.nav" => ["cap"],
     "agent.prompt" => ["kernel"],
     "agent.core" => [
       "agent.feedback",

--- a/lib/ptc_runner/kernel/llm_usage_summary.ex
+++ b/lib/ptc_runner/kernel/llm_usage_summary.ex
@@ -257,9 +257,21 @@ defmodule PtcRunner.Kernel.LLMUsageSummary do
   defp normalize_timestamp(event), do: event
 
   defp field(map, key) when is_map(map),
-    do: Map.get(map, key) || Map.get(map, String.to_existing_atom(key))
+    do: Map.get(map, key) || Map.get(map, existing_atom(key))
 
   defp field(_value, _key), do: nil
+
+  # Events arrive with either string or atom keys, so a string lookup falls
+  # back to the atom form. `String.to_existing_atom/1` raises when nothing has
+  # created that atom yet, which depends on which modules the VM happens to
+  # have loaded — so this crashed or not purely on test and load ordering. An
+  # atom that does not exist cannot be a key in the map either, so the honest
+  # answer is that the field is absent.
+  defp existing_atom(key) do
+    String.to_existing_atom(key)
+  rescue
+    ArgumentError -> nil
+  end
 
   defp field(map, outer, inner), do: map |> field(outer) |> field(inner)
 

--- a/lib/ptc_runner/kernel/result_contract_diagnostic.ex
+++ b/lib/ptc_runner/kernel/result_contract_diagnostic.ex
@@ -58,6 +58,25 @@ defmodule PtcRunner.Kernel.ResultContractDiagnostic do
 
   def retain_details(_details), do: :error
 
+  # The retained runtime details deliberately carry `CommandContractAuthority`
+  # and `CommandPath` structs: they are what makes the diagnostic
+  # authenticated at the error boundary. Neither is a JSON inspection value,
+  # so publishing them verbatim poisons the sink and replaces the real
+  # `result_contract_failed` outcome with `inspection_sink_error` — losing
+  # exactly the evidence a failed run needs. Project only the inspection copy:
+  # drop the internal attestation and render each already-authorized path as a
+  # JSON Pointer. The runtime error keeps its structs unchanged.
+  @doc false
+  @spec inspection_details(term()) :: {:ok, map()} | :error
+  def inspection_details(details) do
+    with {:ok, retained} <- retain_details(details) do
+      {:ok,
+       retained
+       |> Map.delete(:contract_authority)
+       |> Map.put(:violations, Enum.map(retained.violations, &inspection_violation/1))}
+    end
+  end
+
   @doc false
   @spec message(term(), term()) :: {:ok, binary()} | :error
   def message(turns, constraint) when turns in 1..128 and constraint in @constraints,
@@ -109,6 +128,14 @@ defmodule PtcRunner.Kernel.ResultContractDiagnostic do
   end
 
   defp retain_violations(_violations, _constraint, _authority), do: :error
+
+  # `retain_violations/3` already proved the path valid, so `to_pointer/1`
+  # cannot raise here.
+  defp inspection_violation(%{kind: kind, path: %CommandPath{} = path} = violation) do
+    violation
+    |> Map.take([:missing_required])
+    |> Map.merge(%{kind: kind, path: CommandPath.to_pointer(path)})
+  end
 
   defp valid_contract_source?(nil), do: true
 

--- a/lib/ptc_runner/kernel/run_analysis_relationships.ex
+++ b/lib/ptc_runner/kernel/run_analysis_relationships.ex
@@ -12,23 +12,25 @@ defmodule PtcRunner.Kernel.RunAnalysisRelationships do
         {run_id, projection.evidence}
       end)
 
-    preludes_by_run = Enum.group_by(collections.effective_preludes, & &1["run_id"])
     sources_by_run = Enum.group_by(collections.generated_sources, & &1["run_id"])
+
+    # Both prelude relation builders answer the same question — how many
+    # captured preludes match one exact occurrence — so index it once instead
+    # of rescanning the run's preludes per edge. A large accepted capture can
+    # hold every component of a workflow and sixteen missions.
+    occurrences = Enum.frequencies_by(collections.effective_preludes, &occurrence_key/1)
+    graphs = indexed_graphs(collections.effective_preludes, trace_facts)
 
     effective_preludes =
       Enum.map(collections.effective_preludes, fn prelude ->
-        Map.put(
-          prelude,
-          "relationships",
-          dependency_relations(prelude, trace_facts, preludes_by_run)
-        )
+        Map.put(prelude, "relationships", dependency_relations(prelude, graphs, occurrences))
       end)
 
     generated_sources =
       Enum.map(collections.generated_sources, fn source ->
         relationships =
           [producing_turn_relation(source, turns_by_run, turn_evidence_by_run)] ++
-            prelude_relations(source, preludes_by_run)
+            prelude_relations(source, occurrences)
 
         Map.put(source, "relationships", relationships)
       end)
@@ -105,20 +107,19 @@ defmodule PtcRunner.Kernel.RunAnalysisRelationships do
   # its own dependency edges. Qualify every dependency edge with the
   # occurrence that owns it, and refuse to guess when the frozen positional
   # graph does not hold.
-  defp dependency_relations(prelude, trace_facts, preludes_by_run) do
-    with {:ok, graph} <- prelude_graph(prelude, trace_facts),
-         {:ok, component_ids, dependency_indices} <- validated_graph(graph),
-         index when is_integer(index) <-
-           Enum.find_index(component_ids, &(&1 == prelude["component_id"])) do
-      dependency_indices
-      |> Enum.at(index)
+  defp dependency_relations(prelude, graphs, occurrences) do
+    with {:ok, component_ids, positions, dependency_rows} <-
+           Map.get(graphs, graph_key(prelude), :error),
+         {:ok, index} <- Map.fetch(positions, prelude["component_id"]) do
+      dependency_rows
+      |> elem(index)
       |> Enum.map(fn dependency_index ->
-        filters = prelude_filters(prelude, Enum.at(component_ids, dependency_index))
+        dependency_id = elem(component_ids, dependency_index)
+        filters = prelude_filters(prelude, dependency_id)
 
         state =
-          preludes_by_run
-          |> Map.get(prelude["run_id"], [])
-          |> Enum.count(&prelude_matches?(&1, filters))
+          occurrences
+          |> Map.get(occurrence_key(prelude, dependency_id), 0)
           |> relation_state()
 
         relation("dependency_prelude_source", "dependency", "prelude_sources", filters, state)
@@ -137,17 +138,45 @@ defmodule PtcRunner.Kernel.RunAnalysisRelationships do
     end
   end
 
-  defp prelude_graph(%{"run_id" => run_id, "environment" => "workflow"}, trace_facts),
+  # One graph per environment occurrence, validated and indexed once. Tuples
+  # and a position map keep every later lookup constant-time.
+  defp indexed_graphs(preludes, trace_facts) do
+    preludes
+    |> Enum.map(&graph_key/1)
+    |> Enum.uniq()
+    |> Map.new(fn key -> {key, key |> prelude_graph(trace_facts) |> indexed_graph()} end)
+  end
+
+  defp indexed_graph({:ok, graph}) do
+    case validated_graph(graph) do
+      {:ok, component_ids, dependency_indices} ->
+        positions = component_ids |> Enum.with_index() |> Map.new()
+
+        {:ok, List.to_tuple(component_ids), positions, List.to_tuple(dependency_indices)}
+
+      :error ->
+        :error
+    end
+  end
+
+  defp indexed_graph(:error), do: :error
+
+  defp graph_key(prelude),
+    do: {prelude["run_id"], prelude["environment"], prelude["mission_name"]}
+
+  defp occurrence_key(prelude), do: occurrence_key(prelude, prelude["component_id"])
+
+  defp occurrence_key(item, component_id),
+    do: {item["run_id"], item["environment"], item["mission_name"], component_id}
+
+  defp prelude_graph({run_id, "workflow", nil}, trace_facts),
     do: fetch_graph(get_in(trace_facts, [run_id, "workflow_prelude"]))
 
-  defp prelude_graph(
-         %{"run_id" => run_id, "environment" => "mission", "mission_name" => mission_name},
-         trace_facts
-       )
+  defp prelude_graph({run_id, "mission", mission_name}, trace_facts)
        when is_binary(mission_name),
        do: fetch_graph(get_in(trace_facts, [run_id, "missions", mission_name, "prelude"]))
 
-  defp prelude_graph(_prelude, _trace_facts), do: :error
+  defp prelude_graph(_key, _trace_facts), do: :error
 
   defp fetch_graph(graph) when is_map(graph), do: {:ok, graph}
   defp fetch_graph(_graph), do: :error
@@ -185,12 +214,6 @@ defmodule PtcRunner.Kernel.RunAnalysisRelationships do
   defp prelude_filters(prelude, component_id) do
     %{"component_id" => component_id, "environment" => prelude["environment"]}
     |> maybe_put("mission_name", prelude["mission_name"])
-  end
-
-  defp prelude_matches?(prelude, filters) do
-    prelude["component_id"] == filters["component_id"] and
-      prelude["environment"] == filters["environment"] and
-      prelude["mission_name"] == filters["mission_name"]
   end
 
   defp relation_state(0), do: "unavailable"
@@ -482,41 +505,29 @@ defmodule PtcRunner.Kernel.RunAnalysisRelationships do
 
   defp ambiguous_turn_match?(_matches, _evaluation_id), do: true
 
-  defp prelude_relations(%{"prelude_calls_available?" => false}, _preludes_by_run) do
+  defp prelude_relations(%{"prelude_calls_available?" => false}, _occurrences) do
     [relation("referenced_prelude_source", "association", "prelude_sources", nil, "incomplete")]
   end
 
-  defp prelude_relations(source, preludes_by_run) do
+  defp prelude_relations(source, occurrences) do
     source
     |> Map.get("prelude_calls", [])
     |> Enum.map(& &1["component_id"])
     |> Enum.uniq()
     |> Enum.sort()
     |> Enum.map(fn component_id ->
-      filters =
-        %{
-          "component_id" => component_id,
-          "environment" => source["environment"]
-        }
-        |> maybe_put("mission_name", source["mission_name"])
-
-      matches =
-        preludes_by_run
-        |> Map.get(source["run_id"], [])
-        |> Enum.count(fn prelude ->
-          prelude["component_id"] == component_id and
-            prelude["environment"] == source["environment"] and
-            prelude["mission_name"] == source["mission_name"]
-        end)
-
       state =
-        case matches do
-          0 -> "unavailable"
-          1 -> "complete"
-          _many -> "ambiguous"
-        end
+        occurrences
+        |> Map.get(occurrence_key(source, component_id), 0)
+        |> relation_state()
 
-      relation("referenced_prelude_source", "association", "prelude_sources", filters, state)
+      relation(
+        "referenced_prelude_source",
+        "association",
+        "prelude_sources",
+        prelude_filters(source, component_id),
+        state
+      )
     end)
   end
 

--- a/lib/ptc_runner/kernel/run_analysis_relationships.ex
+++ b/lib/ptc_runner/kernel/run_analysis_relationships.ex
@@ -15,6 +15,15 @@ defmodule PtcRunner.Kernel.RunAnalysisRelationships do
     preludes_by_run = Enum.group_by(collections.effective_preludes, & &1["run_id"])
     sources_by_run = Enum.group_by(collections.generated_sources, & &1["run_id"])
 
+    effective_preludes =
+      Enum.map(collections.effective_preludes, fn prelude ->
+        Map.put(
+          prelude,
+          "relationships",
+          dependency_relations(prelude, trace_facts, preludes_by_run)
+        )
+      end)
+
     generated_sources =
       Enum.map(collections.generated_sources, fn source ->
         relationships =
@@ -33,8 +42,160 @@ defmodule PtcRunner.Kernel.RunAnalysisRelationships do
         Map.put(error, "relationships", error_relations(error, facts, sources))
       end)
 
-    %{collections | generated_sources: generated_sources, execution_errors: execution_errors}
+    generated_relationships = relationships_by_generated_key(generated_sources)
+
+    %{
+      collections
+      | effective_preludes: effective_preludes,
+        generated_sources: generated_sources,
+        execution_errors: execution_errors,
+        turns: mirror_generated_relationships(collections.turns, generated_relationships),
+        turns_by_run_id:
+          Map.new(collections.turns_by_run_id, fn {run_id, projection} ->
+            {run_id,
+             Map.replace_lazy(
+               projection,
+               :items,
+               &mirror_generated_relationships(&1, generated_relationships)
+             )}
+          end)
+    }
   end
+
+  # A turn embeds the same generated-source items the `generated_sources`
+  # collection publishes, but `ConversationProjection` builds them before this
+  # module runs, so they used to carry identity without the relationship
+  # objects. A generic walker then needed an extra exact read by
+  # `evaluation_id` just to obtain followable links. Mirror the already
+  # computed relationships onto the embedded copies instead of recomputing
+  # them: one projection, one implementation, and `producing_turn` on an
+  # embedded entry resolves back to the turn that carries it.
+  defp mirror_generated_relationships(turns, generated_relationships) do
+    Enum.map(turns, fn turn ->
+      Map.replace_lazy(turn, "generated", fn generated ->
+        Enum.map(generated, &mirror_generated_entry(&1, generated_relationships))
+      end)
+    end)
+  end
+
+  defp mirror_generated_entry(entry, generated_relationships) do
+    case Map.fetch(generated_relationships, generated_key(entry)) do
+      {:ok, relations} -> Map.put(entry, "relationships", relations)
+      :error -> entry
+    end
+  end
+
+  # `{run_id, sequence}` is the private-inspection identity of one retained
+  # evaluation-source record. A repeated key can only come from malformed
+  # input, so drop it rather than attach another item's links.
+  defp relationships_by_generated_key(generated_sources) do
+    generated_sources
+    |> Enum.group_by(&generated_key/1, & &1["relationships"])
+    |> Enum.flat_map(fn
+      {key, [relations]} -> [{key, relations}]
+      {_key, _ambiguous} -> []
+    end)
+    |> Map.new()
+  end
+
+  defp generated_key(item), do: {item["run_id"], item["sequence"]}
+
+  # A component ID is not an occurrence identity: the same component can be
+  # frozen into the workflow environment and into several missions, each with
+  # its own dependency edges. Qualify every dependency edge with the
+  # occurrence that owns it, and refuse to guess when the frozen positional
+  # graph does not hold.
+  defp dependency_relations(prelude, trace_facts, preludes_by_run) do
+    with {:ok, graph} <- prelude_graph(prelude, trace_facts),
+         {:ok, component_ids, dependency_indices} <- validated_graph(graph),
+         index when is_integer(index) <-
+           Enum.find_index(component_ids, &(&1 == prelude["component_id"])) do
+      dependency_indices
+      |> Enum.at(index)
+      |> Enum.map(fn dependency_index ->
+        filters = prelude_filters(prelude, Enum.at(component_ids, dependency_index))
+
+        state =
+          preludes_by_run
+          |> Map.get(prelude["run_id"], [])
+          |> Enum.count(&prelude_matches?(&1, filters))
+          |> relation_state()
+
+        relation("dependency_prelude_source", "dependency", "prelude_sources", filters, state)
+      end)
+    else
+      _unknown ->
+        [
+          relation(
+            "dependency_prelude_source",
+            "dependency",
+            "prelude_sources",
+            nil,
+            "incomplete"
+          )
+        ]
+    end
+  end
+
+  defp prelude_graph(%{"run_id" => run_id, "environment" => "workflow"}, trace_facts),
+    do: fetch_graph(get_in(trace_facts, [run_id, "workflow_prelude"]))
+
+  defp prelude_graph(
+         %{"run_id" => run_id, "environment" => "mission", "mission_name" => mission_name},
+         trace_facts
+       )
+       when is_binary(mission_name),
+       do: fetch_graph(get_in(trace_facts, [run_id, "missions", mission_name, "prelude"]))
+
+  defp prelude_graph(_prelude, _trace_facts), do: :error
+
+  defp fetch_graph(graph) when is_map(graph), do: {:ok, graph}
+  defp fetch_graph(_graph), do: :error
+
+  # The trace-log schema only requires `dependency_indices` to be lists of
+  # non-negative integers, but the frozen-bundle contract is stronger: the
+  # outer list is positionally aligned with `component_ids`, and each entry
+  # holds unique ascending indices strictly earlier than its own position.
+  # Reading a graph that violates any of that would silently attribute one
+  # component's dependencies to another, so validate the whole contract before
+  # relying on any single row.
+  defp validated_graph(%{"component_ids" => component_ids} = graph)
+       when is_list(component_ids) do
+    dependency_indices = graph["dependency_indices"]
+
+    valid? =
+      Enum.all?(component_ids, &(is_binary(&1) and &1 != "")) and
+        component_ids == Enum.uniq(component_ids) and
+        is_list(dependency_indices) and
+        length(dependency_indices) == length(component_ids) and
+        dependency_indices |> Enum.with_index() |> Enum.all?(&valid_dependency_row?/1)
+
+    if valid?, do: {:ok, component_ids, dependency_indices}, else: :error
+  end
+
+  defp validated_graph(_graph), do: :error
+
+  defp valid_dependency_row?({indices, position}) when is_list(indices) do
+    Enum.all?(indices, &(is_integer(&1) and &1 >= 0 and &1 < position)) and
+      indices == Enum.sort(indices) and indices == Enum.uniq(indices)
+  end
+
+  defp valid_dependency_row?(_row), do: false
+
+  defp prelude_filters(prelude, component_id) do
+    %{"component_id" => component_id, "environment" => prelude["environment"]}
+    |> maybe_put("mission_name", prelude["mission_name"])
+  end
+
+  defp prelude_matches?(prelude, filters) do
+    prelude["component_id"] == filters["component_id"] and
+      prelude["environment"] == filters["environment"] and
+      prelude["mission_name"] == filters["mission_name"]
+  end
+
+  defp relation_state(0), do: "unavailable"
+  defp relation_state(1), do: "complete"
+  defp relation_state(_many), do: "ambiguous"
 
   defp error_relations(error, trace_facts, generated_sources) do
     workflow_evaluation_id = error["evaluation_id"]

--- a/lib/ptc_runner/kernel/runner.ex
+++ b/lib/ptc_runner/kernel/runner.ex
@@ -450,9 +450,30 @@ defmodule PtcRunner.Kernel.Runner do
       sink,
       "execution-error",
       %{evaluation_id: evaluation_id},
-      %{environment: :workflow, kind: kind, reason: reason, details: details}
+      %{
+        environment: :workflow,
+        kind: kind,
+        reason: reason,
+        details: inspection_error_details(reason, details)
+      }
     )
   end
+
+  # `capture_execution_failure/6` merges the private `boundary_producer` fact
+  # into the same details map the authenticated result-contract diagnostic
+  # owns, so split them before projecting: only the contract half holds
+  # structs the sink cannot serialize.
+  defp inspection_error_details(:result_contract_failed, details) do
+    boundary = Map.take(details, [:boundary_producer])
+    contract = Map.drop(details, [:boundary_producer])
+
+    case ResultContractDiagnostic.inspection_details(contract) do
+      {:ok, projected} -> Map.merge(projected, boundary)
+      :error -> boundary
+    end
+  end
+
+  defp inspection_error_details(_reason, details), do: details
 
   defp project_result(value, :native), do: {:ok, value}
 

--- a/lib/ptc_runner/kernel/trace_log.ex
+++ b/lib/ptc_runner/kernel/trace_log.ex
@@ -210,11 +210,14 @@ defmodule PtcRunner.Kernel.TraceLog do
   @spec compile_analysis([map()], :sanitized | :private | map()) :: map()
   def compile_analysis(events, source_kind) when is_list(events) do
     summaries = runs(events, source_kind)
+    summaries_by_id = Map.new(summaries, &{&1["run_id"], &1})
 
     facts =
       events
       |> Enum.group_by(& &1["run_id"])
       |> Map.new(fn {run_id, run_events} ->
+        summary = Map.fetch!(summaries_by_id, run_id)
+
         expected_model_exchanges =
           run_events
           |> Enum.filter(fn event ->
@@ -252,6 +255,8 @@ defmodule PtcRunner.Kernel.TraceLog do
            "expected_model_exchange_ids" => expected_model_exchanges,
            "evaluation_statuses" => evaluation_statuses,
            "parent_evaluation_ids" => parent_evaluation_ids,
+           "workflow_prelude" => summary["workflow_prelude"],
+           "missions" => summary["missions"],
            "terminal?" => Enum.any?(run_events, &(&1["type"] == "run-stopped")),
            "events_dropped?" => Enum.any?(run_events, &(&1["type"] == "events-dropped"))
          }}
@@ -259,7 +264,7 @@ defmodule PtcRunner.Kernel.TraceLog do
 
     %{
       runs: summaries,
-      runs_by_id: Map.new(summaries, &{&1["run_id"], &1}),
+      runs_by_id: summaries_by_id,
       facts_by_run_id: facts
     }
   end

--- a/mix.exs
+++ b/mix.exs
@@ -409,6 +409,7 @@ defmodule PtcRunner.MixProject do
           "docs/guides/building-agents.md",
           "docs/guides/connecting-tools-with-mcp.md",
           "docs/guides/running-and-debugging.md",
+          "docs/guides/debugging-a-failed-run.md",
           "docs/guides/evaluating-with-replay.md",
           "docs/guides/kernel-repl.md",
           "docs/guides/components-and-preludes.md",

--- a/mix.exs
+++ b/mix.exs
@@ -434,7 +434,7 @@ defmodule PtcRunner.MixProject do
   defp package do
     [
       files:
-        ~w(lib rel docs examples/kernel-tutorial examples/kernel-inspection-lab examples/llm-replay examples/mcp/filesystem .formatter.exs mix.exs README.md LICENSE CHANGELOG.md priv/function_audit.exs priv/functions.exs priv/java_interop.exs priv/java_interop_oracle_cases.exs priv/java_interop_oracle_baseline.json priv/java_oracle_versions.exs priv/preludes priv/schemas priv/spec priv/semantic_build_inventory.exs priv/semantic_build_projection.json),
+        ~w(lib rel docs examples/kernel-tutorial examples/kernel-inspection-lab examples/llm-replay examples/mcp/filesystem examples/debug-a-failed-run .formatter.exs mix.exs README.md LICENSE CHANGELOG.md priv/function_audit.exs priv/functions.exs priv/java_interop.exs priv/java_interop_oracle_cases.exs priv/java_interop_oracle_baseline.json priv/java_oracle_versions.exs priv/preludes priv/schemas priv/spec priv/semantic_build_inventory.exs priv/semantic_build_projection.json),
       licenses: ["MIT"],
       links: %{
         "GitHub" => "https://github.com/andreasronge/ptc_runner",

--- a/priv/preludes/kernel/debug.nav.clj
+++ b/priv/preludes/kernel/debug.nav.clj
@@ -1,0 +1,43 @@
+(ns debug.nav
+  "Typed navigation over one immutable private run-evidence capture. The mission must select its correlated inspection snapshot provider under the conventional alias debug.nav."
+  {:visibility :prompt})
+
+(defn runs
+  "List captured runs. Example: (debug.nav/runs {\"status\" \"error\" \"limit\" 5})."
+  {:signature "(options :map) -> :map"}
+  [options]
+  (cap/unwrap! (tool/debug.nav.runs options)))
+
+(defn open
+  "Open a run and discover available collections, filters, identifiers, and completeness fields. Example: (debug.nav/open \"run-id\")."
+  {:signature "(run-id :string) -> :map"}
+  [run-id]
+  (cap/unwrap! (tool/debug.nav.open {"run_id" run-id})))
+
+(defn read
+  "Read one native evidence page. Put collection and advertised filters directly in options; do not nest them under filters. Example: (debug.nav/read \"run-id\" {\"collection\" \"turns\" \"evaluation_id\" \"mission-evaluation-9\"})."
+  {:signature "(run-id :string, options :map) -> :map"}
+  [run-id options]
+  (cap/unwrap! (tool/debug.nav.read (assoc options "run_id" run-id))))
+
+(defn follow
+  "Follow one typed relationship returned by an evidence item. The relationship supplies the exact target collection and filters; options may contain only limit and cursor. Unavailable or filterless relationships are refused. Returns the original relationship beside the complete native page envelope. Example: (debug.nav/follow run-id relationship {\"limit\" 20})."
+  {:signature "(run-id :string, relationship :map, options :map) -> :map"}
+  [run-id relationship options]
+  (if (not (empty? (dissoc options "limit" "cursor")))
+    (fail "debug.nav/follow options may contain only limit and cursor")
+    (let [state (get relationship "state")
+          filters (get relationship "filters")
+          collection (get relationship "target_collection")]
+      (if (or (= state "unavailable")
+              (not (map? filters))
+              (not (string? collection)))
+        (fail "cannot follow an unavailable or filterless relationship")
+        {"relationship" relationship
+         "page"
+         (read
+           run-id
+           (assoc
+             (merge filters (select-keys options ["limit" "cursor"]))
+             "collection"
+             collection))}))))

--- a/priv/preludes/kernel/debug.nav.clj
+++ b/priv/preludes/kernel/debug.nav.clj
@@ -21,7 +21,7 @@
   (cap/unwrap! (tool/debug.nav.read (assoc options "run_id" run-id))))
 
 (defn follow
-  "Follow one typed relationship returned by an evidence item. The relationship supplies the exact target collection and filters; options may contain only limit and cursor. Unavailable or filterless relationships are refused. Returns the original relationship beside the complete native page envelope. Example: (debug.nav/follow run-id relationship {\"limit\" 20})."
+  "Follow one typed relationship returned by an evidence item. The relationship supplies the exact target collection and filters; options may contain only limit and cursor. Check the relationship first: one whose state is \"unavailable\", or whose filters are null, cannot be followed and calling follow on it fails the program instead of returning a page. Returns the original relationship beside the complete native page envelope. Example: (debug.nav/follow run-id relationship {\"limit\" 20})."
   {:signature "(run-id :string, relationship :map, options :map) -> :map"}
   [run-id relationship options]
   (if (not (empty? (dissoc options "limit" "cursor")))

--- a/test/ptc_runner/kernel/agent_library_test.exs
+++ b/test/ptc_runner/kernel/agent_library_test.exs
@@ -486,6 +486,12 @@ defmodule PtcRunner.Kernel.AgentLibraryTest do
           }
         end)
 
+      {:ok, inspection_sink} =
+        InspectionSink.start(
+          run_id: "contract-exhaustion-#{max_turns}",
+          trace_id: "contract-exhaustion-#{max_turns}"
+        )
+
       {:ok, config} =
         agent_config(responses, [],
           agent_main: true,
@@ -496,7 +502,8 @@ defmodule PtcRunner.Kernel.AgentLibraryTest do
             }
           },
           result_contract: result_contract,
-          result_contract_source: "manifest.json"
+          result_contract_source: "manifest.json",
+          inspection_sink: inspection_sink
         )
 
       assert {:error,
@@ -517,6 +524,27 @@ defmodule PtcRunner.Kernel.AgentLibraryTest do
                event.type == "run-stopped" and event.data[:failure_kind] == "result-contract" and
                  event.data[:agent_turns] == max_turns and event.data[:constraint] == :minimum
              end)
+
+      # The authenticated diagnostic carries `CommandContractAuthority` and
+      # `CommandPath` structs. Publishing them verbatim used to poison the
+      # inspection sink, replacing the real outcome with an
+      # `inspection_sink_error` and destroying the evidence the failed run needs.
+      assert {:ok, records} = InspectionSink.records(inspection_sink)
+      assert diagnostic = Enum.find(records, &(&1["record_type"] == "execution-error"))
+      assert diagnostic["payload"]["reason"] == "result_contract_failed"
+
+      assert Map.take(
+               diagnostic["payload"]["details"],
+               ~w(agent_turns constraint contract_source violations)
+             ) ==
+               %{
+                 "agent_turns" => max_turns,
+                 "constraint" => "minimum",
+                 "contract_source" => "manifest.json",
+                 "violations" => [%{"kind" => "minimum", "path" => "/sum"}]
+               }
+
+      refute Map.has_key?(diagnostic["payload"]["details"], "contract_authority")
     end
   end
 

--- a/test/ptc_runner/kernel/debug_a_failed_run_example_test.exs
+++ b/test/ptc_runner/kernel/debug_a_failed_run_example_test.exs
@@ -41,8 +41,11 @@ defmodule PtcRunner.Kernel.DebugAFailedRunExampleTest do
     assert evidence["boundary_kind"] == "workflow_failed"
     assert evidence["nested_evaluations"] == 2
 
-    # The generated program carries the requirement, and the reached rule
-    # carries the defect. Together they are what makes a diagnosis supportable.
+    # The generated program carries both values the check ran on, and the
+    # reached rule carries the defect. Without the literal order in the capture
+    # a wrong input would be indistinguishable from a wrong component, so this
+    # is exactly what makes the example's diagnosis supported.
+    assert evidence["generated_source"] =~ ~s|(orders/place {"subtotal" 100})|
     assert evidence["generated_source"] =~ ~s|(get quote "total") 120|
     assert Enum.any?(evidence["reached_sources"], &(&1 =~ "(+ subtotal 2)"))
     refute Enum.any?(evidence["reached_sources"], &(&1 =~ "pricing.discount"))
@@ -51,6 +54,35 @@ defmodule PtcRunner.Kernel.DebugAFailedRunExampleTest do
     # the report keeps that honest `incomplete` rather than hiding it.
     assert evidence["evidence_states"] == ["complete", "incomplete", "unavailable"]
     assert evidence["diagnosis"] == nil
+  end
+
+  # The walk's component bound has to cover the roots too, not only later
+  # rounds. Reproducing that with a real >64-component closure would cost far
+  # more than it proves, so drive the same code path by zeroing the bound in a
+  # throwaway copy: every root is then withheld. Before the bound covered root
+  # seeding, the roots were followed regardless and the closure came back
+  # non-empty and complete.
+  @tag :tmp_dir
+  test "a withheld root leaves the closure empty and explicitly incomplete", %{
+    tmp_dir: directory
+  } do
+    example = Path.join(directory, "debug-a-failed-run")
+    File.cp_r!(@example, example)
+    File.rm_rf!(Path.join(example, "target/.ptc"))
+    File.rm_rf!(Path.join(example, "debugger/.ptc"))
+
+    walk = Path.join(example, "debugger/evidence.walk.clj")
+    source = File.read!(walk)
+    assert String.contains?(source, "(- 64 (count seen))")
+    File.write!(walk, String.replace(source, "(- 64 (count seen))", "(- 0 (count seen))"))
+
+    assert {_output, 5} = run(Path.join(example, "target.ptc-project.json"))
+    assert {_output, 0} = run(Path.join(example, "debugger.ptc-project.json"))
+
+    evidence = private_result!(Path.join(example, "debugger/.ptc/results"))
+
+    assert evidence["dependency_closure"] == []
+    assert evidence["closure_complete"] == false
   end
 
   defp run(project) do

--- a/test/ptc_runner/kernel/debug_a_failed_run_example_test.exs
+++ b/test/ptc_runner/kernel/debug_a_failed_run_example_test.exs
@@ -31,7 +31,12 @@ defmodule PtcRunner.Kernel.DebugAFailedRunExampleTest do
 
     # The walk follows frozen dependency edges, so it reaches exactly the
     # closure the failing call used and never the unused decoy component.
-    assert evidence["dependency_closure"] == ["orders", "pricing.tax", "pricing.rule"]
+    # `pricing.tax` branches, so a walk that followed only its first edge
+    # would silently drop one of these.
+    assert Enum.sort(evidence["dependency_closure"]) ==
+             ["orders", "pricing.base", "pricing.rule", "pricing.tax"]
+
+    assert evidence["closure_complete"] == true
     assert evidence["terminal_reason"] == "explicit_failure"
     assert evidence["boundary_kind"] == "workflow_failed"
     assert evidence["nested_evaluations"] == 2
@@ -39,7 +44,7 @@ defmodule PtcRunner.Kernel.DebugAFailedRunExampleTest do
     # The generated program carries the requirement, and the reached rule
     # carries the defect. Together they are what makes a diagnosis supportable.
     assert evidence["generated_source"] =~ ~s|(get quote "total") 120|
-    assert List.last(evidence["reached_sources"]) =~ "(+ subtotal 2)"
+    assert Enum.any?(evidence["reached_sources"], &(&1 =~ "(+ subtotal 2)"))
     refute Enum.any?(evidence["reached_sources"], &(&1 =~ "pricing.discount"))
 
     # A run that fails by calling `fail` proves no direct boundary producer, so

--- a/test/ptc_runner/kernel/debug_a_failed_run_example_test.exs
+++ b/test/ptc_runner/kernel/debug_a_failed_run_example_test.exs
@@ -1,0 +1,65 @@
+defmodule PtcRunner.Kernel.DebugAFailedRunExampleTest do
+  use ExUnit.Case, async: true
+
+  @moduletag :slow
+  @moduletag timeout: 180_000
+
+  @root Path.expand("../../..", __DIR__)
+  @example Path.join(@root, "examples/debug-a-failed-run")
+
+  # The example tests are the only place the whole path is exercised the way an
+  # operator meets it: a real `mix ptc run` capturing a private trace and
+  # inspection pair, and a second real run installing that capture as a
+  # snapshot provider. An in-process Kernel run would prove neither the
+  # provider alias binding nor the JSON projection the CLI forces.
+  @tag :tmp_dir
+  test "one PTC run walks another run's captured failure to its dependency source", %{
+    tmp_dir: directory
+  } do
+    example = Path.join(directory, "debug-a-failed-run")
+    File.cp_r!(@example, example)
+    File.rm_rf!(Path.join(example, "target/.ptc"))
+    File.rm_rf!(Path.join(example, "debugger/.ptc"))
+
+    assert {target_output, 5} = run(Path.join(example, "target.ptc-project.json"))
+    assert target_output =~ "execution/workflow_failed"
+
+    assert {debugger_output, 0} = run(Path.join(example, "debugger.ptc-project.json"))
+    assert Jason.decode!(debugger_output) == %{"artifact_class" => "private", "status" => "ok"}
+
+    evidence = private_result!(Path.join(example, "debugger/.ptc/results"))
+
+    # The walk follows frozen dependency edges, so it reaches exactly the
+    # closure the failing call used and never the unused decoy component.
+    assert evidence["dependency_closure"] == ["orders", "pricing.tax", "pricing.rule"]
+    assert evidence["terminal_reason"] == "explicit_failure"
+    assert evidence["boundary_kind"] == "workflow_failed"
+    assert evidence["nested_evaluations"] == 2
+
+    # The generated program carries the requirement, and the reached rule
+    # carries the defect. Together they are what makes a diagnosis supportable.
+    assert evidence["generated_source"] =~ ~s|(get quote "total") 120|
+    assert List.last(evidence["reached_sources"]) =~ "(+ subtotal 2)"
+    refute Enum.any?(evidence["reached_sources"], &(&1 =~ "pricing.discount"))
+
+    # A run that fails by calling `fail` proves no direct boundary producer, so
+    # the report keeps that honest `incomplete` rather than hiding it.
+    assert evidence["evidence_states"] == ["complete", "incomplete", "unavailable"]
+    assert evidence["diagnosis"] == nil
+  end
+
+  defp run(project) do
+    System.cmd(
+      System.find_executable("mix"),
+      ["ptc", "run", project],
+      cd: @root,
+      env: [{"MIX_ENV", "test"}, {"MIX_QUIET", "1"}],
+      stderr_to_stdout: true
+    )
+  end
+
+  defp private_result!(directory) do
+    [path] = Path.wildcard(Path.join(directory, "*.private.json"))
+    path |> File.read!() |> Jason.decode!()
+  end
+end

--- a/test/ptc_runner/kernel/debug_nav_test.exs
+++ b/test/ptc_runner/kernel/debug_nav_test.exs
@@ -1,0 +1,289 @@
+defmodule PtcRunner.Kernel.DebugNavTest do
+  use ExUnit.Case, async: true
+
+  alias PtcRunner.Kernel
+  alias PtcRunner.Kernel.Library
+  alias PtcRunner.Lisp
+  alias PtcRunner.Lisp.Prelude
+  alias PtcRunner.Lisp.TrustedTool
+
+  test "the shipped component exposes the bounded navigation surface" do
+    assert {:ok, component} = Library.component("debug.nav")
+    assert component.dependencies == ["cap"]
+
+    assert {:ok, components} = Library.resolve_components([{:library, "debug.nav"}])
+    assert {:ok, bundle} = Kernel.compile_bundle(components)
+
+    for ref <- ~w(debug.nav/runs debug.nav/open debug.nav/read debug.nav/follow) do
+      assert {:ok, _export} = Prelude.fetch_export(bundle.prelude, ref)
+    end
+
+    # Navigation policy only. Anything that chooses a diagnosis, ranks a
+    # suspect, or aggregates an incident belongs to the caller, not here.
+    assert bundle.prelude
+           |> Prelude.prompt_exports()
+           |> Enum.filter(&(&1.namespace == "debug.nav"))
+           |> Enum.map(& &1.ref)
+           |> Enum.sort() ==
+             ~w(debug.nav/follow debug.nav/open debug.nav/read debug.nav/runs)
+  end
+
+  test "runs, open, and read delegate the unwrapped native page unchanged" do
+    assert run(~S|(debug.nav/runs {"status" "error" "limit" 5})|) == %{
+             "items" => [failed_run()],
+             "next_cursor" => nil
+           }
+
+    assert_receive {:runs_arguments, %{"status" => "error", "limit" => 5}}
+
+    assert %{"collections" => _collections} = run(~S|(debug.nav/open "run-1")|)
+    assert_receive {:open_arguments, %{"run_id" => "run-1"}}
+
+    assert run(~S|(debug.nav/read "run-1" {"collection" "turns"})|) == %{
+             "items" => [turn()],
+             "next_cursor" => nil
+           }
+
+    assert_receive {:read_arguments, %{"collection" => "turns", "run_id" => "run-1"}}
+  end
+
+  test "follow preserves a typed relationship and its complete native page" do
+    result =
+      run(~S|(debug.nav/follow
+        "run-1"
+        {"rel" "generated_source"
+         "semantics" "association"
+         "target_collection" "generated_sources"
+         "filters" {"evaluation_id" "mission-evaluation-9"}
+         "state" "complete"}
+        {"limit" 7})|)
+
+    assert result["relationship"]["rel"] == "generated_source"
+
+    # Cursors, omitted counts, snapshot identity, and truncation are native
+    # page facts; the hop must not summarize or drop them.
+    assert result["page"] == %{
+             "items" => [
+               %{"evaluation_id" => "mission-evaluation-9", "source" => "(orders/place 100)"}
+             ],
+             "next_cursor" => "next-page",
+             "omitted_count" => 1,
+             "snapshot_hash" => "sha256:snapshot",
+             "truncated" => true
+           }
+
+    assert_receive {:read_arguments,
+                    %{
+                      "collection" => "generated_sources",
+                      "evaluation_id" => "mission-evaluation-9",
+                      "limit" => 7,
+                      "run_id" => "run-1"
+                    }}
+  end
+
+  test "follow retains an incomplete or ambiguous relationship state" do
+    for state <- ~w(incomplete ambiguous) do
+      result =
+        run(~s|(debug.nav/follow
+          "run-1"
+          {"rel" "direct_boundary_producer"
+           "semantics" "causation"
+           "target_collection" "activity"
+           "filters" {"evaluation_id" "mission-evaluation-9"}
+           "state" "#{state}"}
+          {})|)
+
+      assert result["relationship"]["state"] == state
+      assert result["page"]["items"] == [%{"evaluation_id" => "mission-evaluation-9"}]
+    end
+  end
+
+  test "follow refuses unavailable relationships and caller filter overrides" do
+    unavailable = ~S|(debug.nav/follow
+      "run-1"
+      {"rel" "generated_source"
+       "semantics" "association"
+       "target_collection" "generated_sources"
+       "filters" nil
+       "state" "unavailable"}
+      {})|
+
+    assert {:ok, %{return: {:__ptc_fail__, reason}}} = run_result(unavailable)
+    assert reason =~ "cannot follow"
+
+    # A null-filtered relationship is never followable, whatever its state.
+    filterless = ~S|(debug.nav/follow
+      "run-1"
+      {"rel" "dependency_prelude_source"
+       "semantics" "dependency"
+       "target_collection" "prelude_sources"
+       "filters" nil
+       "state" "incomplete"}
+      {})|
+
+    assert {:ok, %{return: {:__ptc_fail__, filterless_reason}}} = run_result(filterless)
+    assert filterless_reason =~ "cannot follow"
+
+    override = ~S|(debug.nav/follow
+      "run-1"
+      {"rel" "generated_source"
+       "semantics" "association"
+       "target_collection" "generated_sources"
+       "filters" {"evaluation_id" "mission-evaluation-9"}
+       "state" "complete"}
+      {"evaluation_id" "different"})|
+
+    assert {:ok, %{return: {:__ptc_fail__, override_reason}}} = run_result(override)
+    assert override_reason =~ "limit and cursor"
+  end
+
+  test "a walker reaches dependency source from a turn without an extra exact read" do
+    program = ~S"""
+    (let [turn (first (get (debug.nav/read "run-1" {"collection" "turns"}) "items"))
+          generated (first (get turn "generated"))
+          referenced (first
+                       (filter
+                         #(= (get % "rel") "referenced_prelude_source")
+                         (get generated "relationships")))
+          component (first (get (get (debug.nav/follow "run-1" referenced {}) "page") "items"))
+          dependency (first
+                       (filter
+                         #(= (get % "rel") "dependency_prelude_source")
+                         (get component "relationships")))]
+      [(get component "component_id")
+       (get (first (get (get (debug.nav/follow "run-1" dependency {}) "page") "items"))
+            "component_id")])
+    """
+
+    assert run(program) == ["orders", "pricing.tax"]
+  end
+
+  defp run(source) do
+    {:ok, result} = run_result(source)
+    result.return
+  end
+
+  defp run_result(source) do
+    {:ok, components} = Library.resolve_components([{:library, "debug.nav"}])
+    {:ok, bundle} = Kernel.compile_bundle(components)
+
+    Lisp.run_native(source,
+      prelude: bundle.prelude,
+      tools: tools(),
+      filter_context: false,
+      caller: :kernel
+    )
+  end
+
+  defp tools do
+    owner = self()
+
+    %{
+      "debug.nav.runs" =>
+        tool(fn arguments ->
+          send(owner, {:runs_arguments, arguments})
+          %{"items" => [failed_run()], "next_cursor" => nil}
+        end),
+      "debug.nav.open" =>
+        tool(fn arguments ->
+          send(owner, {:open_arguments, arguments})
+          %{"collections" => ["turns", "generated_sources", "prelude_sources"]}
+        end),
+      "debug.nav.read" =>
+        tool(fn arguments ->
+          send(owner, {:read_arguments, arguments})
+          read(arguments)
+        end),
+      "cap-list" => tool(fn _arguments -> [] end),
+      "cap-describe" => tool(fn _arguments -> %{} end)
+    }
+  end
+
+  defp tool(callback) do
+    %TrustedTool{
+      function: fn arguments -> %{status: :ok, value: callback.(arguments)} end
+    }
+  end
+
+  defp read(%{"collection" => "turns"}), do: %{"items" => [turn()], "next_cursor" => nil}
+
+  defp read(%{"collection" => "generated_sources", "evaluation_id" => evaluation_id}) do
+    %{
+      "items" => [%{"evaluation_id" => evaluation_id, "source" => "(orders/place 100)"}],
+      "next_cursor" => "next-page",
+      "omitted_count" => 1,
+      "snapshot_hash" => "sha256:snapshot",
+      "truncated" => true
+    }
+  end
+
+  defp read(%{"collection" => "activity", "evaluation_id" => evaluation_id}),
+    do: %{"items" => [%{"evaluation_id" => evaluation_id}], "next_cursor" => nil}
+
+  defp read(%{"collection" => "prelude_sources", "component_id" => component_id} = arguments) do
+    %{
+      "items" => [prelude_source(component_id, arguments["mission_name"])],
+      "next_cursor" => nil
+    }
+  end
+
+  defp failed_run, do: %{"run_id" => "run-1", "status" => "error"}
+
+  # Mirrors the shape `RunAnalysisRelationships` publishes: the generated entry
+  # embedded in a turn carries the same relationships as its `generated_sources`
+  # item, and a prelude source carries its occurrence-qualified dependencies.
+  defp turn do
+    %{
+      "turn" => 1,
+      "feedback" => [],
+      "generated" => [
+        %{
+          "evaluation_id" => "mission-evaluation-9",
+          "source" => "(orders/place 100)",
+          "relationships" => [
+            relation("producing_turn", "turns", %{"evaluation_id" => "mission-evaluation-9"}),
+            relation("referenced_prelude_source", "prelude_sources", %{
+              "component_id" => "orders",
+              "environment" => "mission",
+              "mission_name" => "default"
+            })
+          ]
+        }
+      ]
+    }
+  end
+
+  defp prelude_source("orders", mission_name) do
+    %{
+      "component_id" => "orders",
+      "mission_name" => mission_name,
+      "source" => "(ns orders)",
+      "relationships" => [
+        relation("dependency_prelude_source", "prelude_sources", %{
+          "component_id" => "pricing.tax",
+          "environment" => "mission",
+          "mission_name" => "default"
+        })
+      ]
+    }
+  end
+
+  defp prelude_source(component_id, mission_name) do
+    %{
+      "component_id" => component_id,
+      "mission_name" => mission_name,
+      "source" => "(ns #{component_id})",
+      "relationships" => []
+    }
+  end
+
+  defp relation(rel, target_collection, filters) do
+    %{
+      "rel" => rel,
+      "semantics" => "association",
+      "target_collection" => target_collection,
+      "filters" => filters,
+      "state" => "complete"
+    }
+  end
+end

--- a/test/ptc_runner/kernel/run_analysis_test.exs
+++ b/test/ptc_runner/kernel/run_analysis_test.exs
@@ -594,6 +594,54 @@ defmodule PtcRunner.Kernel.RunAnalysisTest do
     end
   end
 
+  test "prelude dependency relations stay exact at the accepted capture ceiling" do
+    # A manifest may install 128 components per environment across 16 missions,
+    # so the relationship pass must index occurrences rather than rescan the
+    # run's preludes per edge. This also repeats every component ID in every
+    # mission, which is the case a bare component ID cannot distinguish.
+    missions = Enum.map(1..16, &"mission-#{&1}")
+    component_ids = Enum.map(0..127, &"component.#{&1}")
+
+    # Each component depends on its immediate predecessor: a 128-deep chain
+    # that satisfies the strictly-earlier-position rule.
+    dependency_indices = [[] | Enum.map(1..127, &[&1 - 1])]
+
+    preludes =
+      for mission <- missions, component_id <- component_ids do
+        prelude("mission", mission, component_id)
+      end
+
+    collections = prelude_collections(preludes)
+
+    trace_facts = %{
+      "run" => %{
+        "missions" =>
+          Map.new(missions, fn mission ->
+            {mission, %{"prelude" => graph(component_ids, dependency_indices)}}
+          end)
+      }
+    }
+
+    attached = RunAnalysisRelationships.attach(collections, trace_facts)
+    assert length(attached.effective_preludes) == 16 * 128
+
+    # Every edge resolves to its own mission's copy, never another mission's.
+    for mission <- ["mission-1", "mission-9", "mission-16"] do
+      assert dependency_relations(attached, "mission", mission, "component.0") == []
+
+      assert [
+               %{
+                 "filters" => %{
+                   "component_id" => "component.126",
+                   "environment" => "mission",
+                   "mission_name" => ^mission
+                 },
+                 "state" => "complete"
+               }
+             ] = dependency_relations(attached, "mission", mission, "component.127")
+    end
+  end
+
   test "generated entries embedded in turns carry the same relationships as generated_sources" do
     source = %{
       "run_id" => "run",

--- a/test/ptc_runner/kernel/run_analysis_test.exs
+++ b/test/ptc_runner/kernel/run_analysis_test.exs
@@ -492,6 +492,151 @@ defmodule PtcRunner.Kernel.RunAnalysisTest do
     assert source_relation["filters"] == %{"evaluation_id" => "mission-eval"}
   end
 
+  test "prelude dependency relations qualify the exact occurrence of a repeated component" do
+    collections =
+      prelude_collections([
+        prelude("workflow", nil, "shared"),
+        prelude("mission", "reader", "base"),
+        prelude("mission", "reader", "shared"),
+        prelude("mission", "writer", "other"),
+        prelude("mission", "writer", "shared")
+      ])
+
+    trace_facts = %{
+      "run" => %{
+        "workflow_prelude" => graph(["shared"], [[]]),
+        "missions" => %{
+          "reader" => %{"prelude" => graph(["base", "shared"], [[], [0]])},
+          "writer" => %{"prelude" => graph(["other", "shared"], [[], [0]])}
+        }
+      }
+    }
+
+    attached = RunAnalysisRelationships.attach(collections, trace_facts)
+
+    # `shared` occurs three times with three different dependency sets. A bare
+    # component ID cannot distinguish them, so each edge must carry its
+    # environment and mission name.
+    assert dependency_relations(attached, "workflow", nil, "shared") == []
+
+    assert dependency_relations(attached, "mission", "reader", "shared") == [
+             %{
+               "rel" => "dependency_prelude_source",
+               "semantics" => "dependency",
+               "target_collection" => "prelude_sources",
+               "filters" => %{
+                 "component_id" => "base",
+                 "environment" => "mission",
+                 "mission_name" => "reader"
+               },
+               "state" => "complete"
+             }
+           ]
+
+    assert [%{"filters" => %{"component_id" => "other", "mission_name" => "writer"}}] =
+             dependency_relations(attached, "mission", "writer", "shared")
+  end
+
+  test "prelude dependency relations report an unavailable occurrence rather than a bare id" do
+    collections =
+      prelude_collections([
+        prelude("mission", "reader", "shared"),
+        prelude("mission", "writer", "base")
+      ])
+
+    trace_facts = %{
+      "run" => %{
+        "missions" => %{
+          "reader" => %{"prelude" => graph(["base", "shared"], [[], [0]])},
+          "writer" => %{"prelude" => graph(["base"], [[]])}
+        }
+      }
+    }
+
+    attached = RunAnalysisRelationships.attach(collections, trace_facts)
+
+    # `base` exists in the capture, but not as the reader occurrence the edge
+    # names, so the state must not claim the writer's copy is followable here.
+    assert [%{"state" => "unavailable"} = relation] =
+             dependency_relations(attached, "mission", "reader", "shared")
+
+    assert relation["filters"]["mission_name"] == "reader"
+  end
+
+  test "prelude dependency relations refuse a graph that breaks the positional contract" do
+    malformed = [
+      {"misaligned outer list", graph(["base", "shared"], [[]])},
+      {"index out of bounds", graph(["base", "shared"], [[], [7]])},
+      {"forward reference", graph(["base", "shared"], [[1], []])},
+      {"self reference", graph(["base", "shared"], [[], [1]])},
+      {"repeated index", graph(["base", "shared"], [[], [0, 0]])},
+      {"descending indices", graph(["a", "b", "c"], [[], [0], [1, 0]])},
+      {"repeated component id", graph(["shared", "shared"], [[], [0]])},
+      {"non-integer index", graph(["base", "shared"], [[], ["0"]])},
+      {"missing dependency_indices", %{"component_ids" => ["base", "shared"]}},
+      {"absent graph", nil}
+    ]
+
+    for {label, prelude_graph} <- malformed do
+      collections = prelude_collections([prelude("mission", "reader", "shared")])
+
+      trace_facts = %{"run" => %{"missions" => %{"reader" => %{"prelude" => prelude_graph}}}}
+      attached = RunAnalysisRelationships.attach(collections, trace_facts)
+
+      assert [
+               %{
+                 "rel" => "dependency_prelude_source",
+                 "filters" => nil,
+                 "state" => "incomplete"
+               }
+             ] = dependency_relations(attached, "mission", "reader", "shared"),
+             "expected #{label} to be reported as incomplete"
+    end
+  end
+
+  test "generated entries embedded in turns carry the same relationships as generated_sources" do
+    source = %{
+      "run_id" => "run",
+      "sequence" => 4,
+      "evaluation_id" => "mission-eval",
+      "environment" => "mission",
+      "mission_name" => "default",
+      "prelude_calls_available?" => true,
+      "prelude_calls" => [%{"component_id" => "orders"}]
+    }
+
+    embedded =
+      Map.merge(source, %{"association" => "source_match", "association_ambiguous?" => false})
+
+    turn = %{"run_id" => "run", "stream_id" => "stream-1", "generated" => [embedded]}
+
+    collections = %{
+      turns: [turn],
+      turns_by_run_id: %{"run" => %{items: [turn], evidence: %{"complete?" => true}}},
+      effective_preludes: [prelude("mission", "default", "orders")],
+      generated_sources: [source],
+      execution_errors: []
+    }
+
+    attached =
+      RunAnalysisRelationships.attach(collections, %{
+        "run" => %{
+          "missions" => %{"default" => %{"prelude" => graph(["orders"], [[]])}}
+        }
+      })
+
+    expected = hd(attached.generated_sources)["relationships"]
+    assert Enum.any?(expected, &(&1["rel"] == "referenced_prelude_source"))
+
+    # A generic walker reading `turns` must be able to follow straight from the
+    # embedded entry, without an extra exact `generated_sources` read.
+    assert [%{"relationships" => ^expected} = entry] = hd(attached.turns)["generated"]
+    assert entry["association"] == "source_match"
+
+    assert [%{"relationships" => ^expected}] =
+             hd(attached.turns_by_run_id["run"].items)["generated"]
+  end
+
   test "typed relations do not trust an inspection producer without its canonical parent edge" do
     collections = %{
       turns: [],
@@ -946,6 +1091,37 @@ defmodule PtcRunner.Kernel.RunAnalysisTest do
       "arguments" => %{"messages" => messages, "system" => "system"},
       "result" => %{"status" => "ok", "value" => Map.delete(assistant, "role")}
     }
+  end
+
+  defp prelude_collections(preludes) do
+    %{
+      turns: [],
+      turns_by_run_id: %{"run" => %{items: [], evidence: %{"complete?" => true}}},
+      effective_preludes: preludes,
+      generated_sources: [],
+      execution_errors: []
+    }
+  end
+
+  defp prelude(environment, mission_name, component_id) do
+    %{
+      "run_id" => "run",
+      "environment" => environment,
+      "mission_name" => mission_name,
+      "component_id" => component_id
+    }
+  end
+
+  defp graph(component_ids, dependency_indices),
+    do: %{"component_ids" => component_ids, "dependency_indices" => dependency_indices}
+
+  defp dependency_relations(attached, environment, mission_name, component_id) do
+    attached.effective_preludes
+    |> Enum.find(
+      &(&1["environment"] == environment and &1["mission_name"] == mission_name and
+          &1["component_id"] == component_id)
+    )
+    |> Map.fetch!("relationships")
   end
 
   defp follow(analysis, run_id, relationship) do


### PR DESCRIPTION
Extracts the production-ready debugging substrate from the `origin/codex/self-repair-obvious` research spike (pinned tip `f87a9e91`). This is an extraction, not a merge: none of the spike's repair loop, incident aggregator, `mix ptc.repair`, phased-agent changes, `terminal_only`, or `tmp/self-repair-*` files are here.

The goal is structural navigation, not a diagnosis oracle. An ordinary second PTC run can walk an immutable failed run — boundary error, generated program, referenced prelude source, frozen dependency closure — and the substrate exposes evidence and typed links without ever choosing a cause.

## What's here

**1. Inspection keeps authenticated result-contract failures.** An authenticated `result_contract_failed` diagnostic retains `CommandContractAuthority` and `CommandPath` structs. They are correct at the runtime error boundary but are not JSON inspection values, so emitting them poisoned the inspection sink and replaced the real outcome with `inspection_sink_error` — the run most in need of debugging lost its own evidence. Only the inspection copy is projected: the attestation is dropped and each already-authorized path becomes a JSON Pointer. The runtime error is unchanged.

This was confirmed on a live run, not only in the regression test: a DeepSeek agent whose report violated its result contract now publishes `{"constraint": "type", "violations": [{"kind": "type", "path": "/evidence"}]}` where it previously destroyed the artifact.

**2. Occurrence-qualified prelude dependency relationships.** Effective prelude sources now carry `dependency_prelude_source` edges. A component ID alone is not an occurrence identity — the same component can be frozen into the workflow environment and several missions with different edges — so every filter repeats its environment and, for a mission occurrence, its mission name.

The trace-log schema only requires `dependency_indices` to be lists of non-negative integers, but the frozen-bundle contract is stronger. The complete positional contract is validated before any row is used: alignment with unique component IDs, in-bounds indices, per-row uniqueness, ascending order, and the strictly-earlier-position rule. Any other graph yields one honest `incomplete` relation rather than a guessed or nil-target edge.

**3. Projection parity for turns.** Generated entries embedded in `turns` now carry the same `relationships` list as the matching `generated_sources` item, so a walker starting from a model turn no longer needs an extra exact read just to obtain followable links. The relationships are mirrored from the single computed set, not recomputed in a second place.

**4. The `debug.nav` prelude** — `runs`, `open`, `read`, and a safe `follow`. `follow` takes a typed relationship exactly as an item published it, refuses an unavailable or filterless one and any caller filter beyond `limit`/`cursor`, and returns the relationship beside the unchanged native page envelope, so cursors, completeness, and relationship state survive the hop.

On the provider binding the spike flagged: current main names snapshot-provider capabilities `<alias>.runs/open/read` for a manifest install, and the stable `analysis-*` names only for a REPL profile. The stable names cannot reach a manifest-driven debugger, so the conventional `debug.nav` alias is kept and the moduledoc states the requirement.

**5. The guide and a credential-free example.** `docs/guides/debugging-a-failed-run.md` covers the whole path, separates canonical-trace sanitization from private inspection authority, and gives the four evidence states the meaning a walker must respect. `examples/debug-a-failed-run/` backs every claim: the target prices an order through `orders` → `pricing.tax` → {`pricing.base`, `pricing.rule`}, the rule adds 2 where the captured call requires 20, and `pricing.discount` is a decoy outside the closure.

## Verification

Two integration tests drive both applications through the real `mix ptc run` CLI. `mix precommit`, `mix docs --warnings-as-errors`, and `mix ptc.verify_docs` all pass.

The live arm ran against `openrouter:deepseek/deepseek-v4-flash` and produced the finding that shaped the example. Given a capture whose generated program referenced `data/params`, the model correctly answered `insufficient-evidence`: the capture retained the comparison but not the values compared, so a wrong input was indistinguishable from a wrong component. That was right, so the target now generates its check against the literal order, and against that capture the model traced the branching chain and correctly named `pricing.rule`. A third run was confidently wrong, blaming the component that never calls the decoy. The guide reports all three, because a contract-valid report is not a correct one.

## Review

Five `codex review` rounds plus a follow-up. Findings applied: the example was excluded from the Hex package; adding it exposed that `mix hex.build` selects by glob and ignores `.gitignore`, so a credential placed in a packaged example directory would ship — the agent example now names its env file with `--env-file` instead. The relationship pass was O(P×(graph+P×deps)) and is now indexed once. The example walk followed one edge per component, bypassed its own bound at the roots, and could report a partial closure as whole; it is now a bounded breadth-first traversal with a `closure_complete` flag, regression-tested by zeroing the bound.

## One unrelated fix, because it blocked this PR

`LLMUsageSummary.field/2` falls back from a string key to the atom form, and `String.to_existing_atom/1` raises when nothing has created that atom yet — which depends on which modules the VM happens to have loaded. This branch's added test files were enough to change that ordering.

With ExUnit seed 552533 and `--max-cases 4`, the exact shape CI runs: `origin/main` passes 6385 tests, this branch aborted on `binary_to_existing_atom("connector_snapshots")`. The same two tests also fail on plain `origin/main` when `trace_log_test.exs` runs alone, so the fault was never this branch's — only ever hidden by ordering. Fixed here because it blocked CI; it matches the guard `FlexAccess` already applies to the same conversion.

No unit test covers it: the failing lookup key is a module constant and atom existence is global VM state a test cannot remove. Verified by the deterministic reproduction above, which now passes 6385 tests on this branch.

## Reported, not fixed

A private-classed project run with `artifacts.result: false` exits `70 internal/internal_error` instead of a classified diagnostic. It still reproduces on this branch's base:

```console
mix ptc run examples/debug-a-failed-run/target.ptc-project.json
# then set artifacts.result to false in debugger.ptc-project.json
mix ptc run examples/debug-a-failed-run/debugger.ptc-project.json
```

Setting `result: true` succeeds, which is why the example does. Left alone as unrelated scope.

## Scope claim

The strongest supported claim is unchanged from the spike: for a complete single-call failure whose relevant implementation lies in the called component's dependency closure, a domain-neutral projection selects the frozen sources. Discovery outside that closure, and repair of nonlocal or weakly specified defects, are not established, and the guide says so.

https://claude.ai/code/session_01XwrSFHRsb4VK9tSFgbHb7r
