### PR TITLE
fix(cli): name the conflicting pair when analysis directories overlap

### DIFF
--- a/docs/guides/kernel-repl.md
+++ b/docs/guides/kernel-repl.md
@@ -233,7 +233,13 @@ mix ptc transcript RUN_ID \
 The destination is reserved at owner-only mode before capture. Incomplete or
 ambiguous evidence fails without publication. The trace, inspection, and
 output directories must be pairwise physically separate: none may equal or
-contain another.
+contain another. A rejection names the two conflicting switches and how they
+overlap, without disclosing any path:
+
+```text
+directories for --traces and --inspection must be physically separate;
+--traces contains --inspection
+```
 
 ### Private analysis without a terminal
 
@@ -287,7 +293,20 @@ does not contain evaluated source, exact query payloads, private values, prints,
 or REPL history.
 
 The output directory cannot equal, contain, or be contained by a resource
-directory, including through physical aliases.
+directory or by the parent of `--output`/`--private-output`, including through
+physical aliases. A rejection names the first conflicting pair by the option or
+resource that supplied each directory, and the physical relationship between
+them:
+
+```text
+directories for --resource traces and --session-trace-dir must be physically
+separate; --resource traces contains --session-trace-dir
+```
+
+Two spellings that reach one directory through a symbolic link report that they
+`resolve to the same physical directory`. Without `--session-trace-dir` the
+conflicting role is `the auto-created session trace directory`. Diagnostics
+never disclose supplied paths, resolved paths, or symlink targets.
 
 ## Use JSON Lines in automation
 
@@ -314,6 +333,30 @@ Validation or setup can therefore emit only `command-error`; persistence
 failure follows earlier records without claiming `session-closed`. Records use
 schema version 1. Evaluation records contain the bounded mission result and no
 extra raw-source copy.
+
+A `command-error` rejecting a physical-separation conflict adds a
+`directory_conflict` object beside the existing `category` and `message`, so
+automation does not parse prose:
+
+```json
+{
+  "schema_version": 1,
+  "type": "command-error",
+  "category": "cli",
+  "message": "directories for --resource traces and --session-trace-dir must be physically separate; --resource traces contains --session-trace-dir",
+  "directory_conflict": {
+    "left_role": "resource.traces",
+    "right_role": "session_trace",
+    "relation": "left_contains_right"
+  }
+}
+```
+
+Roles are `resource.NAME`, `session_trace`, `session_trace_auto`, `output`, and
+`private_output`. `relation` is `same`, `left_contains_right`, or
+`right_contains_left`; `same` covers both an identical directory and distinct
+spellings that reach one directory through a symbolic link. The object carries
+no path.
 
 By default, one failed expression stops later ones. Continue requested
 expressions while preserving the final nonzero status with:

--- a/docs/guides/running-and-debugging.md
+++ b/docs/guides/running-and-debugging.md
@@ -285,9 +285,10 @@ mix ptc transcript RUN_ID \
 
 The command reserves an owner-only destination before capture. Trace,
 inspection, and output directories must be pairwise physically separate: no
-directory may equal, contain, or be contained by either of the others.
-Ambiguous, incomplete, changed, unsupported, or oversized evidence fails
-without a partial output.
+directory may equal, contain, or be contained by either of the others. A
+rejection names the two conflicting switches and their physical relationship,
+and discloses no path. Ambiguous, incomplete, changed, unsupported, or
+oversized evidence fails without a partial output.
 
 Use `private-run-analysis-v1` when you need several correlated questions or
 custom PTC-Lisp analysis. Its results can include exact messages, generated

--- a/lib/ptc_runner/kernel/analysis_directory.ex
+++ b/lib/ptc_runner/kernel/analysis_directory.ex
@@ -8,6 +8,25 @@ defmodule PtcRunner.Kernel.AnalysisDirectory do
           required(:lineage) => MapSet.t(identity())
         }
 
+  @typedoc """
+  How two resolved directories sit relative to each other on the filesystem.
+
+  `:same` covers both an identical path and distinct paths that resolve to one
+  physical directory through a symbolic link; an alias is a cause of `:same`,
+  not a relationship of its own. Only `:separate` satisfies the physical
+  separation rule.
+  """
+  @type relationship :: :separate | :same | :left_contains_right | :right_contains_left
+
+  @typedoc """
+  A resolved directory tagged with the caller's own name for its role.
+
+  Roles are opaque here: the kernel never interprets them, and callers use
+  them to attribute a rejection to the option or resource that supplied the
+  directory.
+  """
+  @type labelled :: {term(), resolved()}
+
   @doc false
   @spec resolve(term()) :: {:ok, resolved()} | {:error, :directory_identity_unavailable}
   def resolve(directory) when is_binary(directory) do
@@ -28,34 +47,52 @@ defmodule PtcRunner.Kernel.AnalysisDirectory do
   def resolve(_directory), do: {:error, :directory_identity_unavailable}
 
   @doc false
-  @spec resolve_all([term()]) ::
-          {:ok, [resolved()]} | {:error, :directory_identity_unavailable}
-  def resolve_all(directories) when is_list(directories) do
-    Enum.reduce_while(directories, {:ok, []}, fn directory, {:ok, resolved} ->
-      case resolve(directory) do
-        {:ok, value} -> {:cont, {:ok, [value | resolved]}}
-        {:error, _reason} = error -> {:halt, error}
-      end
-    end)
-  end
-
-  def resolve_all(_directories), do: {:error, :directory_identity_unavailable}
-
-  @doc false
   @spec pairwise_separate?([resolved()]) :: boolean()
   def pairwise_separate?(directories) when is_list(directories) do
-    Enum.with_index(directories)
-    |> Enum.all?(fn {%{identity: identity, lineage: lineage}, index} ->
-      directories
-      |> Enum.drop(index + 1)
-      |> Enum.all?(fn %{identity: other_identity, lineage: other_lineage} ->
-        not MapSet.member?(other_lineage, identity) and
-          not MapSet.member?(lineage, other_identity)
-      end)
-    end)
+    directories
+    |> Enum.map(&{nil, &1})
+    |> first_conflict()
+    |> is_nil()
   end
 
   def pairwise_separate?(_directories), do: false
+
+  @doc false
+  @spec relationship(resolved(), resolved()) :: relationship()
+  def relationship(
+        %{identity: left_identity, lineage: left_lineage},
+        %{identity: right_identity, lineage: right_lineage}
+      ) do
+    cond do
+      left_identity == right_identity -> :same
+      MapSet.member?(right_lineage, left_identity) -> :left_contains_right
+      MapSet.member?(left_lineage, right_identity) -> :right_contains_left
+      true -> :separate
+    end
+  end
+
+  @doc """
+  Returns the first pair of labelled directories that are not physically
+  separate, in the caller's own order, or `nil` when every pair is separate.
+
+  The pair is reported as `{left_role, right_role, relationship}` so a
+  frontend can attribute the rejection without re-deriving it.
+  """
+  @spec first_conflict([labelled()]) :: {term(), term(), relationship()} | nil
+  def first_conflict(directories) when is_list(directories) do
+    directories
+    |> Enum.with_index()
+    |> Enum.find_value(fn {{left_role, left}, index} ->
+      directories
+      |> Enum.drop(index + 1)
+      |> Enum.find_value(fn {right_role, right} ->
+        case relationship(left, right) do
+          :separate -> nil
+          conflict -> {left_role, right_role, conflict}
+        end
+      end)
+    end)
+  end
 
   defp physical_directory_path(directory) do
     relative = Path.relative_to(directory, "/")

--- a/lib/ptc_runner/kernel/directory_separation.ex
+++ b/lib/ptc_runner/kernel/directory_separation.ex
@@ -1,0 +1,57 @@
+defmodule PtcRunner.Kernel.DirectorySeparation do
+  @moduledoc false
+
+  alias PtcRunner.Kernel.AnalysisDirectory
+
+  @typedoc """
+  What a caller supplied a directory for.
+
+  `id` is the stable machine identifier reported to automation; `label` is the
+  option or resource spelling shown to an operator. Neither carries a path.
+  """
+  @type role :: %{required(:id) => binary(), required(:label) => binary()}
+
+  @type conflict :: %{
+          required(:left_role) => binary(),
+          required(:right_role) => binary(),
+          required(:relation) => binary(),
+          required(:message) => binary()
+        }
+
+  @doc """
+  Verifies that every supplied directory is physically separate from the rest.
+
+  On rejection the first conflicting pair is reported with both roles and
+  their physical relationship. Diagnostics never disclose supplied paths,
+  resolved paths, symlink targets, or directory identities: a caller learns
+  which two roles collide and how, and nothing about the filesystem beyond it.
+  """
+  @spec verify([{role(), AnalysisDirectory.resolved()}]) :: :ok | {:error, conflict()}
+  def verify(directories) when is_list(directories) do
+    case AnalysisDirectory.first_conflict(directories) do
+      nil ->
+        :ok
+
+      {left, right, relationship} ->
+        {:error,
+         %{
+           left_role: left.id,
+           right_role: right.id,
+           relation: Atom.to_string(relationship),
+           message: message(left.label, right.label, relationship)
+         }}
+    end
+  end
+
+  defp message(left, right, :same),
+    do: separation_required(left, right) <> "; they resolve to the same physical directory"
+
+  defp message(left, right, :left_contains_right),
+    do: separation_required(left, right) <> "; #{left} contains #{right}"
+
+  defp message(left, right, :right_contains_left),
+    do: separation_required(left, right) <> "; #{right} contains #{left}"
+
+  defp separation_required(left, right),
+    do: "directories for #{left} and #{right} must be physically separate"
+end

--- a/lib/ptc_runner/repl_frontend.ex
+++ b/lib/ptc_runner/repl_frontend.ex
@@ -77,6 +77,7 @@ defmodule PtcRunner.ReplFrontend do
   alias PtcRunner.Kernel.CommandArguments
   alias PtcRunner.Kernel.CommandRuntime
   alias PtcRunner.Kernel.DeterministicJSON
+  alias PtcRunner.Kernel.DirectorySeparation
   alias PtcRunner.Kernel.ManifestRepl
   alias PtcRunner.Kernel.PublicationHandle
   alias PtcRunner.Kernel.ReplSession
@@ -373,11 +374,14 @@ defmodule PtcRunner.ReplFrontend do
 
   defp run_profile_session(opts, arguments) do
     case reserve_profile_result(opts) do
-      {:ok, result_handle} ->
+      {:ok, nil} ->
+        run_profile_session(opts, arguments, nil, nil)
+
+      {:ok, result_handle, result_role} ->
         try do
-          run_profile_session(opts, arguments, result_handle)
+          run_profile_session(opts, arguments, result_handle, result_role)
         after
-          if result_handle, do: PublicationHandle.discard(result_handle)
+          PublicationHandle.discard(result_handle)
         end
 
       {:error, _reason} ->
@@ -385,11 +389,17 @@ defmodule PtcRunner.ReplFrontend do
     end
   end
 
-  defp run_profile_session(opts, arguments, result_handle) do
+  defp run_profile_session(opts, arguments, result_handle, result_role) do
     with {:ok, recipe} <- AnalysisProfileRegistry.fetch(opts[:profile]),
          {:ok, resources} <- profile_resources(opts, recipe),
          {:ok, output_directory, temporary?} <- profile_output_directory(opts) do
-      case separate_directories(Map.values(resources), output_directory, result_handle) do
+      case separate_directories(
+             resources,
+             output_directory,
+             temporary?,
+             result_handle,
+             result_role
+           ) do
         {:ok, output_identity} ->
           start_profile_session(
             opts,
@@ -401,9 +411,9 @@ defmodule PtcRunner.ReplFrontend do
             result_handle
           )
 
-        {:error, message} ->
+        {:error, message, extra} ->
           cleanup_temporary_directory(output_directory, temporary?)
-          command_error(opts, :cli, message)
+          command_error(opts, :cli, message, extra)
       end
     else
       {:error, category, message} -> command_error(opts, category, message)
@@ -412,10 +422,24 @@ defmodule PtcRunner.ReplFrontend do
 
   defp reserve_profile_result(opts) do
     case {opts[:output], opts[:private_output]} do
-      {nil, nil} -> {:ok, nil}
-      {path, nil} when is_binary(path) -> PublicationHandle.reserve(path, :result, 0o600)
-      {nil, path} when is_binary(path) -> PublicationHandle.reserve(path, :result, 0o600)
-      _ -> {:error, :invalid_destination}
+      {nil, nil} ->
+        {:ok, nil}
+
+      {path, nil} when is_binary(path) ->
+        reserved_result(path, %{id: "output", label: "--output"})
+
+      {nil, path} when is_binary(path) ->
+        reserved_result(path, %{id: "private_output", label: "--private-output"})
+
+      _ ->
+        {:error, :invalid_destination}
+    end
+  end
+
+  defp reserved_result(path, role) do
+    case PublicationHandle.reserve(path, :result, 0o600) do
+      {:ok, handle} -> {:ok, handle, role}
+      {:error, _reason} = error -> error
     end
   end
 
@@ -511,23 +535,61 @@ defmodule PtcRunner.ReplFrontend do
     _exception -> {:error, :setup, "could not create a private session trace directory"}
   end
 
-  defp separate_directories(input_directories, output_directory, result_handle) do
-    with {:ok, output} <- AnalysisDirectory.resolve(output_directory),
-         {:ok, inputs} <- AnalysisDirectory.resolve_all(input_directories),
-         {:ok, result_outputs} <- result_output_directories(result_handle),
-         true <- AnalysisDirectory.pairwise_separate?([output | result_outputs ++ inputs]) do
+  defp separate_directories(resources, output_directory, temporary?, result_handle, result_role) do
+    with {:ok, inputs} <- resource_directories(resources),
+         {:ok, {_role, output} = session_trace} <-
+           resolve_role_directory(output_directory, session_trace_role(temporary?)),
+         {:ok, result_outputs} <- result_output_directories(result_handle, result_role),
+         :ok <- DirectorySeparation.verify(inputs ++ [session_trace] ++ result_outputs) do
       {:ok, output.identity}
     else
-      _ -> {:error, "input and session trace directories must be physically separate"}
+      {:error, {:unavailable, role}} ->
+        {:error, "#{role.label} became unavailable before the analysis session started", %{}}
+
+      {:error, conflict} ->
+        {:error, conflict.message,
+         %{
+           "directory_conflict" => %{
+             "left_role" => conflict.left_role,
+             "right_role" => conflict.right_role,
+             "relation" => conflict.relation
+           }
+         }}
     end
   end
 
-  defp result_output_directories(nil), do: {:ok, []}
+  defp resource_directories(resources) do
+    resources
+    |> Enum.sort()
+    |> Enum.reduce_while({:ok, []}, fn {name, directory}, {:ok, resolved} ->
+      role = %{id: "resource.#{name}", label: "--resource #{name}"}
 
-  defp result_output_directories(handle) do
-    case handle |> PublicationHandle.path() |> Path.dirname() |> AnalysisDirectory.resolve() do
-      {:ok, directory} -> {:ok, [directory]}
-      {:error, _reason} -> {:error, :invalid_result_directory}
+      case resolve_role_directory(directory, role) do
+        {:ok, labelled} -> {:cont, {:ok, resolved ++ [labelled]}}
+        {:error, _reason} = error -> {:halt, error}
+      end
+    end)
+  end
+
+  defp resolve_role_directory(directory, role) do
+    case AnalysisDirectory.resolve(directory) do
+      {:ok, resolved} -> {:ok, {role, resolved}}
+      {:error, _reason} -> {:error, {:unavailable, role}}
+    end
+  end
+
+  defp session_trace_role(true),
+    do: %{id: "session_trace_auto", label: "the auto-created session trace directory"}
+
+  defp session_trace_role(false),
+    do: %{id: "session_trace", label: "--session-trace-dir"}
+
+  defp result_output_directories(nil, _role), do: {:ok, []}
+
+  defp result_output_directories(handle, role) do
+    case handle |> PublicationHandle.path() |> Path.dirname() |> resolve_role_directory(role) do
+      {:ok, labelled} -> {:ok, [labelled]}
+      {:error, _reason} = error -> error
     end
   end
 

--- a/lib/ptc_runner/transcript_frontend.ex
+++ b/lib/ptc_runner/transcript_frontend.ex
@@ -16,6 +16,7 @@ defmodule PtcRunner.TranscriptFrontend do
   alias PtcRunner.Kernel.CommandRuntime
   alias PtcRunner.Kernel.ConversationProjection
   alias PtcRunner.Kernel.DeterministicJSON
+  alias PtcRunner.Kernel.DirectorySeparation
   alias PtcRunner.Kernel.PrivateRunAnalysisProfile
   alias PtcRunner.Kernel.PublicationHandle
   alias PtcRunner.Kernel.RunAnalysis
@@ -203,25 +204,16 @@ defmodule PtcRunner.TranscriptFrontend do
   end
 
   defp validate_separation(trace, private, output) do
-    cond do
-      not AnalysisDirectory.pairwise_separate?([trace, private]) ->
-        separation_error("--traces", "--inspection")
+    labelled = [
+      {%{id: "traces", label: "--traces"}, trace},
+      {%{id: "inspection", label: "--inspection"}, private},
+      {%{id: "private_output", label: "--private-output"}, output}
+    ]
 
-      not AnalysisDirectory.pairwise_separate?([trace, output]) ->
-        separation_error("--traces", "--private-output")
-
-      not AnalysisDirectory.pairwise_separate?([private, output]) ->
-        separation_error("--inspection", "--private-output")
-
-      true ->
-        :ok
+    case DirectorySeparation.verify(labelled) do
+      :ok -> :ok
+      {:error, %{message: message}} -> {:error, :source_separation_failed, message}
     end
-  end
-
-  defp separation_error(first, second) do
-    {:error, :source_separation_failed,
-     "directories for #{first} and #{second} must be physically separate; " <>
-       "neither may contain the other"}
   end
 
   defp destination_error(:destination_exists),

--- a/test/mix/tasks/ptc_repl_test.exs
+++ b/test/mix/tasks/ptc_repl_test.exs
@@ -903,37 +903,249 @@ defmodule PtcRunner.ReplFrontendTest do
   end
 
   @tag :tmp_dir
-  test "profile mode rejects nested and symlink-parent output directories", %{tmp_dir: directory} do
+  test "profile mode names the conflicting pair and its physical relationship", %{
+    tmp_dir: directory
+  } do
     source = Path.join(directory, "source")
     nested = Path.join(source, "nested")
     alias_root = Path.join(directory, "alias")
     deep = Path.join(source, "deep")
     deep_output = Path.join(deep, "output")
+    outer = Path.join(directory, "outer")
+    inner_source = Path.join(outer, "inner-source")
     File.mkdir!(source)
     File.mkdir!(nested)
     File.mkdir!(deep)
     File.mkdir!(deep_output)
-    seed_trace(source, "seed")
-
-    assert_raise Mix.Error, ~r/physically separate/, fn ->
-      run_repl(profile_args(source, nested) ++ ["-e", "42"])
-    end
-
+    File.mkdir!(outer)
+    File.mkdir!(inner_source)
     File.ln_s!(directory, alias_root)
-    aliased_nested = Path.join(alias_root, "source/nested")
+    seed_trace(source, "seed")
+    seed_trace(inner_source, "seed")
 
-    assert_raise Mix.Error, ~r/physically separate/, fn ->
-      run_repl(profile_args(source, aliased_nested) ++ ["-e", "42"])
-    end
+    cases = [
+      {"equal", source, source,
+       "directories for --resource traces and --session-trace-dir must be physically " <>
+         "separate; they resolve to the same physical directory"},
+      {"nested", source, nested,
+       "directories for --resource traces and --session-trace-dir must be physically " <>
+         "separate; --resource traces contains --session-trace-dir"},
+      {"reverse nested", inner_source, outer,
+       "directories for --resource traces and --session-trace-dir must be physically " <>
+         "separate; --session-trace-dir contains --resource traces"},
+      {"symlink alias", source, Path.join(alias_root, "source"),
+       "directories for --resource traces and --session-trace-dir must be physically " <>
+         "separate; they resolve to the same physical directory"},
+      {"symlink parent", source, Path.join(alias_root, "source/deep/output"),
+       "directories for --resource traces and --session-trace-dir must be physically " <>
+         "separate; --resource traces contains --session-trace-dir"}
+    ]
 
-    File.rm!(alias_root)
-    File.ln_s!(deep, alias_root)
+    for {label, traces, session_trace_dir, message} <- cases do
+      error =
+        assert_raise Mix.Error, fn ->
+          run_repl(profile_args(traces, session_trace_dir) ++ ["-e", "42"])
+        end
 
-    assert_raise Mix.Error, ~r/physically separate/, fn ->
-      run_repl(profile_args(source, Path.join(alias_root, "output")) ++ ["-e", "42"])
+      assert error.message =~ message, "#{label} case reported: #{error.message}"
+      refute error.message =~ directory
     end
 
     assert File.ls!(nested) == []
+    assert File.ls!(deep_output) == []
+  end
+
+  test "profile mode attributes a conflict with the auto-created session trace directory" do
+    # No --session-trace-dir, so the session trace directory is generated under
+    # the system temporary directory - which this resource contains.
+    error =
+      assert_raise Mix.Error, fn ->
+        run_repl([
+          "--profile",
+          "run-analysis-v1",
+          "--resource",
+          "traces=#{System.tmp_dir!()}",
+          "-e",
+          "42"
+        ])
+      end
+
+    assert error.message =~
+             "directories for --resource traces and the auto-created session trace " <>
+               "directory must be physically separate; --resource traces contains " <>
+               "the auto-created session trace directory"
+
+    refute error.message =~ System.tmp_dir!()
+  end
+
+  @tag :tmp_dir
+  test "profile mode attributes source and result destination conflicts to their own options",
+       %{tmp_dir: directory} do
+    fixture = PrivateInspectionFixture.create!(directory, "separation")
+    nested_inspection = Path.join(fixture.traces, "inspection")
+    File.mkdir!(nested_inspection)
+
+    private_args = [
+      "--profile",
+      "private-run-analysis-v1",
+      "--private-unattended",
+      "-e",
+      "42"
+    ]
+
+    resources = fn traces, inspection ->
+      ["--resource", "traces=#{traces}", "--resource", "inspection=#{inspection}"]
+    end
+
+    error =
+      assert_raise Mix.Error, fn ->
+        run_repl(
+          private_args ++
+            resources.(fixture.traces, nested_inspection) ++
+            ["--session-trace-dir", fixture.output]
+        )
+      end
+
+    assert error.message =~
+             "directories for --resource inspection and --resource traces must be " <>
+               "physically separate; --resource traces contains --resource inspection"
+
+    # A --private-output whose parent sits inside an input directory is attributed
+    # to --private-output, never generically to the input.
+    error =
+      assert_raise Mix.Error, fn ->
+        run_repl(
+          private_args ++
+            resources.(fixture.traces, fixture.inspection) ++
+            [
+              "--session-trace-dir",
+              fixture.output,
+              "--private-output",
+              Path.join(fixture.traces, "result.private.json")
+            ]
+        )
+      end
+
+    assert error.message =~
+             "directories for --resource traces and --private-output must be physically " <>
+               "separate; they resolve to the same physical directory"
+
+    refute File.exists?(Path.join(fixture.traces, "result.private.json"))
+    refute error.message =~ directory
+  end
+
+  @tag :tmp_dir
+  test "profile mode leaves non-conflicting sibling directories accepted", %{tmp_dir: directory} do
+    source = Path.join(directory, "source")
+    output_directory = Path.join(directory, "output")
+    results = Path.join(directory, "results")
+    Enum.each([source, output_directory, results], &File.mkdir!/1)
+    seed_trace(source, "seed")
+
+    result = Path.join(results, "value.json")
+
+    capture_io(fn ->
+      run_repl(profile_args(source, output_directory) ++ ["--output", result, "-e", "42"])
+    end)
+
+    assert File.read!(result) |> Jason.decode!() == 42
+  end
+
+  @tag :tmp_dir
+  test "profile mode names a session trace and result destination conflict", %{
+    tmp_dir: directory
+  } do
+    source = Path.join(directory, "source")
+    output_directory = Path.join(directory, "output")
+    File.mkdir!(source)
+    File.mkdir!(output_directory)
+    seed_trace(source, "seed")
+
+    result = Path.join(output_directory, "value.json")
+
+    error =
+      assert_raise Mix.Error, fn ->
+        run_repl(profile_args(source, output_directory) ++ ["--output", result, "-e", "42"])
+      end
+
+    assert error.message =~
+             "directories for --session-trace-dir and --output must be physically " <>
+               "separate; they resolve to the same physical directory"
+
+    refute File.exists?(result)
+    refute error.message =~ directory
+  end
+
+  @tag :tmp_dir
+  test "profile mode reports the same first conflicting pair when several conflict", %{
+    tmp_dir: directory
+  } do
+    # traces contains inspection, the session trace directory, and the
+    # --private-output parent, so four pairs conflict at once. Input pairs are
+    # ordered before the session trace and the result destination, so the
+    # reported pair is stable rather than incidental.
+    fixture = PrivateInspectionFixture.create!(directory, "ordering")
+
+    argv = [
+      "--profile",
+      "private-run-analysis-v1",
+      "--private-unattended",
+      "--resource",
+      "traces=#{directory}",
+      "--resource",
+      "inspection=#{fixture.inspection}",
+      "--session-trace-dir",
+      fixture.output,
+      "--private-output",
+      Path.join(fixture.traces, "value.private.json"),
+      "-e",
+      "42"
+    ]
+
+    messages =
+      for _attempt <- 1..3 do
+        assert_raise(Mix.Error, fn -> run_repl(argv) end).message
+      end
+
+    for message <- messages do
+      assert message =~
+               "directories for --resource inspection and --resource traces must be " <>
+                 "physically separate; --resource traces contains --resource inspection"
+    end
+  end
+
+  @tag :tmp_dir
+  test "profile JSONL reports a directory conflict as structured roles", %{tmp_dir: directory} do
+    source = Path.join(directory, "source")
+    nested = Path.join(source, "nested")
+    File.mkdir!(source)
+    File.mkdir!(nested)
+    seed_trace(source, "seed")
+
+    output =
+      capture_io(fn ->
+        assert_raise Mix.Error, fn ->
+          run_repl(profile_args(source, nested) ++ ["--format", "jsonl", "-e", "42"])
+        end
+      end)
+
+    assert [record] = decode_jsonl(output)
+
+    assert record["schema_version"] == 1
+    assert record["type"] == "command-error"
+    assert record["category"] == "cli"
+
+    assert record["message"] ==
+             "directories for --resource traces and --session-trace-dir must be physically " <>
+               "separate; --resource traces contains --session-trace-dir"
+
+    assert record["directory_conflict"] == %{
+             "left_role" => "resource.traces",
+             "right_role" => "session_trace",
+             "relation" => "left_contains_right"
+           }
+
+    refute output =~ directory
   end
 
   @tag :tmp_dir

--- a/test/mix/tasks/ptc_transcript_test.exs
+++ b/test/mix/tasks/ptc_transcript_test.exs
@@ -82,17 +82,25 @@ defmodule Mix.Tasks.PtcTranscriptTest do
     alias_root = Path.join(root, "root-alias")
     File.ln_s!(root, alias_root)
     aliased_traces = Path.join(alias_root, "traces")
+    nested_inspection = Path.join(fixture.traces, "nested-inspection")
+    File.mkdir!(nested_inspection)
 
     cases = [
       {fixture.traces, fixture.traces, Path.join(fixture.output, "same-source.json"),
-       ["--traces", "--inspection"]},
-      {fixture.traces, fixture.inspection, Path.join(root, "ancestor-output.json"),
-       ["--traces", "--private-output"]},
+       "directories for --traces and --inspection must be physically separate; " <>
+         "they resolve to the same physical directory"},
       {fixture.traces, aliased_traces, Path.join(fixture.output, "aliased-source.json"),
-       ["--traces", "--inspection"]}
+       "directories for --traces and --inspection must be physically separate; " <>
+         "they resolve to the same physical directory"},
+      {fixture.traces, nested_inspection, Path.join(fixture.output, "nested-source.json"),
+       "directories for --traces and --inspection must be physically separate; " <>
+         "--traces contains --inspection"},
+      {fixture.traces, fixture.inspection, Path.join(root, "ancestor-output.json"),
+       "directories for --traces and --private-output must be physically separate; " <>
+         "--private-output contains --traces"}
     ]
 
-    for {traces, inspection, output, switches} <- cases do
+    for {traces, inspection, output, message} <- cases do
       presentation =
         MixCommandAdapter.execute(
           transcript_argv(fixture, output, traces: traces, inspection: inspection)
@@ -100,8 +108,7 @@ defmodule Mix.Tasks.PtcTranscriptTest do
 
       assert presentation.exit_status == 1
       assert presentation.stderr =~ "transcript/source_separation_failed"
-      assert presentation.stderr =~ "physically separate"
-      Enum.each(switches, &assert(presentation.stderr =~ &1))
+      assert presentation.stderr =~ message
       refute presentation.stderr =~ root
       refute File.exists?(output)
     end


### PR DESCRIPTION
Closes #1433.

## Problem

Physical-separation rejections collapsed four directory roles into one message.
`ptc repl --profile` dropped resource names before validating, so every conflict
read:

```text
input and session trace directories must be physically separate
```

That is not merely vague. The checked set also contains the parent of
`--output`/`--private-output`, so when that was the conflicting directory the
message named two roles that were not involved. The same `with/else _ ->` also
reported an unresolvable directory as a separation failure.

`AnalysisDirectory.pairwise_separate?/1` computed the offending pair and its
relationship, then returned a bare boolean — the #1166 shape one layer down.

## Change

- `AnalysisDirectory.relationship/2` returns `:separate | :same |
  :left_contains_right | :right_contains_left`, and `first_conflict/1` returns
  the first non-separate pair of caller-labelled directories.
  `pairwise_separate?/1` is now defined in terms of it, so there is one
  implementation. A symlink alias is a cause of `:same`, not a relationship of
  its own. `resolve_all/1` became unreachable and was deleted.
- New `PtcRunner.Kernel.DirectorySeparation` renders the single diagnostic that
  `ptc repl --profile` and `ptc transcript` both use, so equivalent rules read
  identically.
- `ptc repl --profile` carries each directory's role through validation instead
  of `Map.values(resources)`, and splits the collapsed `else`.

```text
directories for --resource traces and --session-trace-dir must be physically
separate; --resource traces contains --session-trace-dir
```

```text
directories for --inspection and --private-output must be physically separate;
they resolve to the same physical directory
```

## Privacy

Diagnostics disclose no supplied path, resolved path, symlink target, or
directory identity. A caller learns which two roles collide and how, and
nothing else about the filesystem. Tests assert no path leaks, extending the
contract the transcript frontend already had.

Role labels cannot smuggle a path: resource names are gated by
`parse_resources/2` against the recipe's declared names before reaching a
message.

## JSONL

`command-error` gains an additive, path-free `directory_conflict` object beside
the unchanged `category` and `message`, so unattended agents do not parse prose:

```json
{
  "schema_version": 1,
  "type": "command-error",
  "category": "cli",
  "message": "directories for --resource traces and --session-trace-dir must be physically separate; --resource traces contains --session-trace-dir",
  "directory_conflict": {
    "left_role": "resource.traces",
    "right_role": "session_trace",
    "relation": "left_contains_right"
  }
}
```

Roles are `resource.NAME`, `session_trace`, `session_trace_auto`, `output`, and
`private_output`. Without `--session-trace-dir` the generated directory is named
as `the auto-created session trace directory` rather than as an option the
caller never passed. `--output` and `--private-output` are distinguished by
which one actually supplied the destination.

## Deliberately unchanged

- The kernel-side check in `AnalysisSessionBuilder.validate_profile_separation/3`
  stays terse. It is defense in depth at an authority boundary and must not
  depend on CLI vocabulary.
- Invalid-resource attribution — which resource was a bad path — remains scoped
  to #1166.

## Coverage

Equal, nested, reverse-nested, symlink-alias, and symlink-parent for
`--resource traces` vs `--session-trace-dir`; `--resource traces` vs
`--resource inspection`; a `--private-output` parent conflict attributed to
`--private-output`; `--session-trace-dir` vs the `--output` parent; the
auto-created role; the JSONL object with pre-existing fields asserted
unchanged; a three-role non-conflicting-sibling regression; and stable
first-pair selection when four pairs conflict at once.

Note: a trailing symlink as `--session-trace-dir` is rejected earlier by
`AnalysisDirectory.resolve/1`, which requires a normal directory. Alias
collisions therefore arise only from intermediate path segments, and the tests
exercise them that way.

## Verification

Every new and extended test was confirmed failing against the pre-fix tree
before being accepted. `mix precommit` passes (6403 tests),
`MIX_ENV=dev mix docs --warnings-as-errors` passes, and
`MIX_ENV=test mix dialyzer` reports 0 errors. Two independent `codex review`
rounds against a rechecked base returned no findings.

https://claude.ai/code/session_01VLGmnYfkejuM3Enm5H6TXY
