### PR TITLE
fix(inspection): retain capability exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Raised capability callbacks now retain their bounded exception class,
+  message, and formatted stacktrace only in explicitly enabled private
+  inspection. Inspection V7 correlates that sensitive evidence with the
+  capability attempt. When retention succeeds, the Lisp result and canonical
+  event stream keep the existing closed `provider_error / exception` envelope;
+  a required private-inspection retention failure remains fail-closed as
+  `inspection_sink_error`.
+
 - Private inspection now retains an authenticated `result_contract_failed`
   diagnostic instead of destroying it. The retained runtime details carry
   internal contract-authority and command-path structs, which are not JSON

--- a/docs/guides/debugging-a-failed-run.md
+++ b/docs/guides/debugging-a-failed-run.md
@@ -37,8 +37,11 @@ unrecognized `kind` is retained only as a one-way fingerprint.
 A **private inspection artifact** is an explicit `0600` host development
 authority. It adds the frozen component sources, the exact generated programs,
 capability arguments and results, model exchanges, prints, and detailed
-failures. Read it only through an authorized private sink, and never publish it
-alongside a normal trace.
+failures. Raised capability callbacks can include their bounded exception
+message and formatted stacktrace here, but never in the correlated canonical
+trace. Those strings may contain secrets or local paths and cannot be reliably
+redacted. Read the artifact only through an authorized private sink, and never
+publish it alongside a normal trace.
 
 A project document captures both:
 

--- a/docs/guides/running-and-debugging.md
+++ b/docs/guides/running-and-debugging.md
@@ -215,8 +215,12 @@ mix ptc run ptc.json \
 
 Each inspection artifact includes the frozen component sources. It adds
 execution prints and any provider-backed private activity that occurred. A
-failure can add detailed `execution-error` evidence. Read it only through an
-authorized private sink.
+failure can add detailed `execution-error` evidence. A raised capability
+callback additionally records its bounded exception class, message, and
+formatted stacktrace while the canonical trace retains only the closed
+`provider_error / exception` category. Exception text and stacktrace paths can
+contain sensitive data and are not reliably redactable; read the artifact only
+through an authorized private sink.
 
 To debug compilation with the manifest bundle, use manifest mode:
 

--- a/docs/trace-log-contract.md
+++ b/docs/trace-log-contract.md
@@ -442,9 +442,14 @@ collections as unavailable and reject reads without changing authority.
 Every raw `model_exchanges` and `capability_calls` item carries `complete?`.
 Completed items retain their result, output sequence, and output timestamp.
 An interrupted input-only attempt has `complete?: false` and omits those three
-terminal fields. The run metadata counts all admitted attempts and separately
-reports `incomplete_model_exchanges` and `incomplete_capability_calls`, including
-zero on complete runs.
+terminal fields. When a callback raised under inspection authority, the item
+also carries an `exception` object plus `exception_sequence` and
+`exception_timestamp`; these fields remain present if interruption occurred
+after the exception evidence was retained but before the normalized output was
+retained. Items without such evidence omit the fields rather than setting them
+to null. The run metadata counts all admitted attempts and separately reports
+`capability_exceptions`, `incomplete_model_exchanges`, and
+`incomplete_capability_calls`, including zero on complete runs.
 
 `turns` is the only compiled convenience collection. Each item is one model
 turn with the newly added messages, response, matching generated programs, and
@@ -652,7 +657,7 @@ JSON object with this exact envelope:
 
 ```json
 {
-  "schema_version": 6,
+  "schema_version": 7,
   "run_id": "run-id",
   "trace_id": "trace-id",
   "sequence": 1,
@@ -664,7 +669,7 @@ JSON object with this exact envelope:
 ```
 
 Keys are exact. `sequence` is positive and strictly increasing within the
-artifact. The timestamp is UTC ISO 8601. Except for the V6 `run-result`,
+artifact. The timestamp is UTC ISO 8601. Except for `run-result`,
 `correlation` contains exactly one of `capability_id`, `evaluation_id`, or
 `component_id`. Capability and evaluation values must occur in the canonical
 trace for the same run unless that trace explicitly proves the corresponding
@@ -675,6 +680,7 @@ types and payloads are:
 | Record type | Correlation | Exact payload fields |
 | --- | --- | --- |
 | `capability-input` | `capability_id` | `environment`, `name`, `arguments` |
+| `capability-exception` | `capability_id` | `environment`, `name`, `exception_class`, `message`, `message_truncated`, `stacktrace`, `stacktrace_truncated` |
 | `capability-output` | `capability_id` | `environment`, `name`, `result` |
 | `evaluation-source` | `evaluation_id` | `environment`, `program_kind`, `source`, `source_hash`, `source_bytes` |
 | `evaluation-analysis` | `evaluation_id` | `environment`, `mission_name`, `prelude_calls` |
@@ -685,14 +691,15 @@ types and payloads are:
 | `execution-error` | `evaluation_id` | `environment`, `kind`, `reason`, `details` |
 
 Named-mission ownership is explicit. Mission `capability-input`,
-`capability-output`, `evaluation-source`, `evaluation-analysis`,
+`capability-exception`, `capability-output`, `evaluation-source`, `evaluation-analysis`,
 `prelude-source`, `mcp-request`, and `mcp-response` payloads require
 `mission_name`; workflow payloads forbid it.
 Prelude uniqueness is `(environment, mission_name, component_id)`, so the same
 component ID can be inspected independently in multiple missions. Every
 mission-owned query result preserves `mission_name`.
 
-V6 includes at most one successful terminal-result record:
+V7 retains the successful terminal-result record introduced in V6, at most one
+per run:
 
 | Record type | Correlation | Exact payload fields |
 | --- | --- | --- |
@@ -711,6 +718,21 @@ rejected unless the supplied value is already strict JSON. `result` is the
 bounded Dispatcher envelope returned to Lisp, so `llm-request` input/output
 records contain the provider-neutral model request and normalized response, and
 MCP records contain the public connector arguments and normalized result/error.
+When a capability callback raises, `capability-exception` retains the exception
+module name, its message at no more than 4,096 valid UTF-8 bytes, and a formatted
+stacktrace at no more than 64 frames and 65,536 valid UTF-8 bytes. Independent
+flags say whether either string was truncated or unavailable. Formatting does
+not generically inspect or retain the raw exception struct or callback
+arguments. The exception-defined message formatter does receive that struct,
+however, and its authored text plus source paths in a stacktrace can expose
+embedded payloads, credentials, or other sensitive data that cannot be reliably
+redacted. This record therefore exists only under explicit private-inspection
+authority. Exit, throw, timeout, provider-process death, and inspection-disabled
+runs retain no exception record. The normalized `capability-output` and
+canonical `capability-stopped` event remain the existing closed
+`provider_error / exception` shape when private retention succeeds. Failure to
+retain the required exception record follows the existing fail-closed
+inspection contract and replaces that outcome with `inspection_sink_error`.
 `evaluation-source` is emitted only for subordinate mission evaluation. Its
 hash and byte count must equal the corresponding canonical
 `evaluation-started` fields. After successful static analysis of that source,
@@ -742,7 +764,9 @@ not treated as provenance. An empty complete list means the direct result did
 not expose a valid child identity; a false completion flag forbids that
 conclusion. The value itself is not duplicated in this metadata.
 
-The input record is accepted before the callback starts. A subordinate
+The input record is accepted before the callback starts. A raised callback's
+exception record is accepted after the bounded provider worker has stopped and
+before its normalized output is accepted. A subordinate
 `evaluation-started` event is attempted before its source record is accepted,
 and the source record is accepted before Lisp execution starts. The output
 record is accepted after normalization and before the canonical stop event. A
@@ -752,12 +776,16 @@ execution. Failure after an external read has completed fails the run but
 cannot retroactively undo that read.
 
 Artifact validation rejects ambiguous joins before persistence or Viewer
-pinning. There may be at most one input and one output for a capability ID, one
+pinning. There may be at most one input, exception, and output for a capability ID, one
 source and one subsequent analysis for an evaluation ID, and one source for an
 environment/component pair.
-A capability output requires an earlier matching input; an input without an
-output is valid only as an interrupted attempt. Private queries retain that
-input as `complete?: false` and do not synthesize terminal fields. MCP provider
+A capability exception requires an earlier matching input, must precede any
+output, and must repeat the exact environment, mission, and public capability
+name. A following output must be the closed non-retryable
+`provider_error / exception` envelope. An input, or input plus exception,
+without an output is valid only as an interrupted retained prefix. Private
+queries retain that input as `complete?: false` and do not synthesize terminal
+fields. MCP provider
 exchange projections still require a validated request/response pair; the
 inspection sink retains each pair atomically so interruption cannot leave a
 request without its response. Private
@@ -833,7 +861,7 @@ JSONL.
 
 A host-installed inspection snapshot composes its correlated canonical trace
 through the three navigation operations. `analysis/open` includes an eligible
-immutable V6 result value and canonical `result_hash`; an unknown run and a
+immutable V7 result value and canonical `result_hash`; an unknown run and a
 known run without an eligible result remain distinct internally. Both encoded
 and retained sizes must fit the snapshot result ceiling. Possessing a private
 canonical event source, local Viewer access, or the active run does not imply

--- a/lib/ptc_runner/kernel/capability_exception_diagnostic.ex
+++ b/lib/ptc_runner/kernel/capability_exception_diagnostic.ex
@@ -1,0 +1,188 @@
+defmodule PtcRunner.Kernel.CapabilityExceptionDiagnostic do
+  @moduledoc false
+
+  alias PtcRunner.Kernel.InspectionRecordTypes
+  alias PtcRunner.Utf8
+
+  @capture_timeout_ms 250
+  @capture_heap_words 1_000_000
+  @max_stacktrace_frames 64
+  @message_unavailable "exception message unavailable"
+  @stacktrace_unavailable "stacktrace unavailable"
+
+  @doc false
+  @spec capture(Exception.t(), Exception.stacktrace()) :: map()
+  def capture(%{__struct__: exception_class} = exception, stacktrace)
+      when is_atom(exception_class) and is_list(stacktrace) do
+    {message, message_truncated?} = exception_message(exception)
+    {formatted_stacktrace, stacktrace_truncated?} = formatted_stacktrace(stacktrace)
+
+    %{
+      exception_class: exception_class(exception_class),
+      message: message,
+      message_truncated: message_truncated?,
+      stacktrace: formatted_stacktrace,
+      stacktrace_truncated: stacktrace_truncated?
+    }
+  end
+
+  @doc false
+  @spec start(Exception.t(), Exception.stacktrace(), pid()) ::
+          {:ok, pid(), binary()} | {:error, binary()}
+  def start(%{__struct__: exception_class} = exception, stacktrace, owner)
+      when is_atom(exception_class) and is_list(stacktrace) and is_pid(owner) do
+    exception_class = exception_class(exception_class)
+
+    try do
+      pid =
+        Process.spawn(
+          fn ->
+            owner_ref = Process.monitor(owner)
+
+            receive do
+              {:capture, received_exception, received_stacktrace} ->
+                receive do
+                  :capture ->
+                    diagnostic = capture(received_exception, received_stacktrace)
+                    send(owner, {:capability_exception_diagnostic, self(), diagnostic})
+
+                  {:DOWN, ^owner_ref, :process, ^owner, _reason} ->
+                    :ok
+                after
+                  @capture_timeout_ms -> :ok
+                end
+
+              {:DOWN, ^owner_ref, :process, ^owner, _reason} ->
+                :ok
+            after
+              @capture_timeout_ms -> :ok
+            end
+          end,
+          max_heap_size: %{
+            size: @capture_heap_words,
+            kill: true,
+            error_logger: false,
+            include_shared_binaries: true
+          }
+        )
+
+      send(pid, {:capture, exception, stacktrace})
+      {:ok, pid, exception_class}
+    rescue
+      _exception -> {:error, exception_class}
+    catch
+      _kind, _reason -> {:error, exception_class}
+    end
+  end
+
+  @doc false
+  @spec await(pid(), binary()) :: map()
+  def await(pid, exception_class) when is_pid(pid) and is_binary(exception_class) do
+    ref = Process.monitor(pid)
+    send(pid, :capture)
+
+    receive do
+      {:capability_exception_diagnostic, ^pid, diagnostic} ->
+        Process.demonitor(ref, [:flush])
+        diagnostic
+
+      {:DOWN, ^ref, :process, ^pid, _reason} ->
+        unavailable(exception_class)
+    after
+      @capture_timeout_ms ->
+        Process.exit(pid, :kill)
+        await_down(ref, pid)
+        flush_diagnostic(pid)
+        unavailable(exception_class)
+    end
+  end
+
+  @doc false
+  @spec cancel(pid()) :: :ok
+  def cancel(pid) when is_pid(pid) do
+    ref = Process.monitor(pid)
+    Process.exit(pid, :kill)
+    await_down(ref, pid)
+    flush_diagnostic(pid)
+  end
+
+  @doc false
+  @spec unavailable(binary()) :: map()
+  def unavailable(exception_class) when is_binary(exception_class) do
+    %{
+      exception_class: exception_class,
+      message: @message_unavailable,
+      message_truncated: true,
+      stacktrace: @stacktrace_unavailable,
+      stacktrace_truncated: true
+    }
+  end
+
+  defp exception_message(exception) do
+    case safely(fn -> exception.__struct__.message(exception) end) do
+      {:ok, message} when is_binary(message) ->
+        bound(message, InspectionRecordTypes.max_exception_message_bytes(), false)
+
+      _unavailable ->
+        {@message_unavailable, true}
+    end
+  end
+
+  defp formatted_stacktrace(stacktrace) do
+    {frames, remainder} = Enum.split(stacktrace, @max_stacktrace_frames)
+
+    case safely(fn ->
+           frames
+           |> Enum.map(&without_arguments/1)
+           |> Exception.format_stacktrace()
+         end) do
+      {:ok, formatted} when is_binary(formatted) ->
+        bound(
+          formatted,
+          InspectionRecordTypes.max_exception_stacktrace_bytes(),
+          remainder != []
+        )
+
+      _unavailable ->
+        {@stacktrace_unavailable, true}
+    end
+  end
+
+  defp without_arguments({module, function, arguments, location}) when is_list(arguments),
+    do: {module, function, length(arguments), location}
+
+  defp without_arguments(frame), do: frame
+
+  defp safely(fun) do
+    {:ok, fun.()}
+  rescue
+    _exception -> :error
+  catch
+    _kind, _reason -> :error
+  end
+
+  defp bound(value, max_bytes, already_truncated?) do
+    bounded = Utf8.truncate_valid(value, max_bytes)
+    {bounded, already_truncated? or bounded != value}
+  end
+
+  defp exception_class(exception_class) do
+    exception_class
+    |> Atom.to_string()
+    |> Utf8.truncate_valid(InspectionRecordTypes.max_exception_class_bytes())
+  end
+
+  defp await_down(ref, pid) do
+    receive do
+      {:DOWN, ^ref, :process, ^pid, _reason} -> :ok
+    end
+  end
+
+  defp flush_diagnostic(pid) do
+    receive do
+      {:capability_exception_diagnostic, ^pid, _diagnostic} -> :ok
+    after
+      0 -> :ok
+    end
+  end
+end

--- a/lib/ptc_runner/kernel/dispatcher.ex
+++ b/lib/ptc_runner/kernel/dispatcher.ex
@@ -32,6 +32,7 @@ defmodule PtcRunner.Kernel.Dispatcher do
   """
 
   alias PtcRunner.Kernel.Capability
+  alias PtcRunner.Kernel.CapabilityExceptionDiagnostic
   alias PtcRunner.Kernel.CapabilityInvocation
   alias PtcRunner.Kernel.Events
   alias PtcRunner.Kernel.EventSink
@@ -317,7 +318,7 @@ defmodule PtcRunner.Kernel.Dispatcher do
 
     case Events.emit(state, event_sink, "capability-started", data) do
       :ok ->
-        {result, input_captured?} =
+        {invocation_result, input_captured?} =
           case inspection_input(
                  inspection_sink,
                  capability_id,
@@ -341,8 +342,28 @@ defmodule PtcRunner.Kernel.Dispatcher do
               {inspection_failure(state), false}
           end
 
+        {result, exception_diagnostic} = split_exception_diagnostic(invocation_result)
+
+        inspection_attempt = %{
+          sink: inspection_sink,
+          capability_id: capability_id,
+          environment: environment,
+          name: public_name,
+          mission_name: invocation.event_attributes[:mission_name]
+        }
+
+        {result, output_allowed?} =
+          maybe_capture_exception(
+            result,
+            exception_diagnostic,
+            input_captured?,
+            state,
+            inspection_attempt,
+            capability
+          )
+
         result =
-          if input_captured? do
+          if output_allowed? do
             case inspection_output(
                    inspection_sink,
                    capability_id,
@@ -425,8 +446,81 @@ defmodule PtcRunner.Kernel.Dispatcher do
     )
   end
 
+  defp maybe_capture_exception(
+         result,
+         _diagnostic,
+         false,
+         _state,
+         _inspection_attempt,
+         _capability
+       ),
+       do: {result, false}
+
+  defp maybe_capture_exception(
+         result,
+         nil,
+         true,
+         _state,
+         _inspection_attempt,
+         _capability
+       ),
+       do: {result, true}
+
+  defp maybe_capture_exception(
+         result,
+         diagnostic,
+         true,
+         state,
+         inspection_attempt,
+         capability
+       ) do
+    case inspection_exception(
+           inspection_attempt.sink,
+           inspection_attempt.capability_id,
+           inspection_attempt.environment,
+           inspection_attempt.name,
+           diagnostic,
+           inspection_attempt.mission_name
+         ) do
+      :ok ->
+        {result, true}
+
+      {:error, :inspection_sink_error} ->
+        failed =
+          state
+          |> inspection_failure()
+          |> post_invocation_failure(inspection_attempt.environment, capability)
+
+        {failed, false}
+    end
+  end
+
+  defp inspection_exception(
+         sink,
+         capability_id,
+         environment,
+         name,
+         diagnostic,
+         mission_name
+       ) do
+    InspectionSink.emit(
+      sink,
+      "capability-exception",
+      %{capability_id: capability_id},
+      environment
+      |> capability_inspection_identity(name, mission_name)
+      |> Map.merge(diagnostic)
+    )
+  end
+
   defp capability_inspection_payload(environment, name, key, value, mission_name) do
-    %{key => value, environment: environment, name: name}
+    environment
+    |> capability_inspection_identity(name, mission_name)
+    |> Map.put(key, value)
+  end
+
+  defp capability_inspection_identity(environment, name, mission_name) do
+    %{environment: environment, name: name}
     |> then(fn payload ->
       if environment == :mission and is_binary(mission_name),
         do: Map.put(payload, :mission_name, mission_name),
@@ -490,7 +584,7 @@ defmodule PtcRunner.Kernel.Dispatcher do
 
           receive do
             ^go ->
-              result = safely_invoke(capability.callback, arguments, context)
+              result = safely_invoke(capability.callback, arguments, context, parent)
 
               if terminal_provider_failure?(result),
                 do: RunState.mark_evaluation_terminal_provider_failure(state)
@@ -538,6 +632,8 @@ defmodule PtcRunner.Kernel.Dispatcher do
             normalize_result(state, environment, capability, result)
 
           {:error, :run_closed} ->
+            cancel_exception_diagnostic(result)
+
             state
             |> limit_error(nil, :run_closed)
             |> post_invocation_failure(environment, capability)
@@ -575,14 +671,44 @@ defmodule PtcRunner.Kernel.Dispatcher do
     }
   end
 
-  defp safely_invoke(callback, arguments, context) do
+  defp safely_invoke(callback, arguments, context, diagnostic_owner) do
     if is_function(callback, 2), do: callback.(arguments, context), else: callback.(arguments)
   rescue
-    _exception -> {:raised, :exception}
+    exception -> raised_exception(exception, __STACKTRACE__, context, diagnostic_owner)
   catch
     :exit, _reason -> {:raised, :exit}
     _kind, _reason -> {:raised, :throw}
   end
+
+  defp raised_exception(
+         exception,
+         stacktrace,
+         %{inspection_sink: %InspectionSink{}},
+         diagnostic_owner
+       ) do
+    case CapabilityExceptionDiagnostic.start(exception, stacktrace, diagnostic_owner) do
+      {:ok, pid, exception_class} ->
+        {:raised, :exception, {:diagnostic_worker, pid, exception_class}}
+
+      {:error, exception_class} ->
+        {:raised, :exception, {:diagnostic_unavailable, exception_class}}
+    end
+  end
+
+  defp raised_exception(_exception, _stacktrace, _context, _diagnostic_owner),
+    do: {:raised, :exception}
+
+  defp split_exception_diagnostic({:with_exception_diagnostic, result, diagnostic}),
+    do: {result, diagnostic}
+
+  defp split_exception_diagnostic(result), do: {result, nil}
+
+  defp cancel_exception_diagnostic(
+         {:raised, :exception, {:diagnostic_worker, pid, _exception_class}}
+       ),
+       do: CapabilityExceptionDiagnostic.cancel(pid)
+
+  defp cancel_exception_diagnostic(_result), do: :ok
 
   defp normalize_result(state, environment, capability, {:ok, value}) do
     cap = capability_result_limit(state)
@@ -645,6 +771,28 @@ defmodule PtcRunner.Kernel.Dispatcher do
       environment,
       capability
     )
+  end
+
+  defp normalize_result(
+         state,
+         environment,
+         capability,
+         {:raised, :exception, {:diagnostic_worker, pid, exception_class}}
+       ) do
+    {:with_exception_diagnostic,
+     normalize_result(state, environment, capability, {:raised, :exception}),
+     CapabilityExceptionDiagnostic.await(pid, exception_class)}
+  end
+
+  defp normalize_result(
+         state,
+         environment,
+         capability,
+         {:raised, :exception, {:diagnostic_unavailable, exception_class}}
+       ) do
+    {:with_exception_diagnostic,
+     normalize_result(state, environment, capability, {:raised, :exception}),
+     CapabilityExceptionDiagnostic.unavailable(exception_class)}
   end
 
   defp normalize_result(_state, environment, capability, _result),

--- a/lib/ptc_runner/kernel/inspection_artifact.ex
+++ b/lib/ptc_runner/kernel/inspection_artifact.ex
@@ -15,14 +15,15 @@ defmodule PtcRunner.Kernel.InspectionArtifact do
   whose bytes must match. It rejects symlinks,
   changed files, content above 16 MB, any record above 2,000,000 encoded bytes,
   excessive structural depth, malformed lines, mixed identities, non-contiguous
-  sequences, and records outside the exact V6 vocabulary. Private records use
+  sequences, and records outside the exact V7 vocabulary. Private records use
   a required `mission_name` on mission-owned source and capability
   records while forbidding it on workflow-owned records. Effective prelude
   source is proven, not asserted: the `prelude-source` records of an
   environment must name exactly the components the canonical `run-started`
   projection lists, and their source hashes must reduce back to the bundle
   identity that projection committed to. Self-consistent source a caller
-  computed for itself therefore cannot pass as the source that compiled. V6 joins at most one
+  computed for itself therefore cannot pass as the source that compiled. V7
+  joins at most one
   static prelude-call analysis to each subordinate evaluation source and also
   admits at most one strictly JSON terminal result whose self-hash must match
   the successful canonical `run-stopped` event. A missing capability or
@@ -56,7 +57,7 @@ defmodule PtcRunner.Kernel.InspectionArtifact do
   @bundle_hash ~r/\A[0-9a-f]{64}\z/
   @max_bytes 16_000_000
   @max_record_bytes 2_000_000
-  @schema_version 6
+  @schema_version 7
   @suffix ".inspection.jsonl"
   @envelope_keys ~w(schema_version run_id trace_id sequence timestamp record_type correlation payload)
 
@@ -364,6 +365,7 @@ defmodule PtcRunner.Kernel.InspectionArtifact do
   defp validate_record_set(records) do
     initial = %{
       inputs: %{},
+      exceptions: MapSet.new(),
       outputs: MapSet.new(),
       mcp_requests: %{},
       mcp_responses: MapSet.new(),
@@ -406,6 +408,21 @@ defmodule PtcRunner.Kernel.InspectionArtifact do
 
   defp validate_record_join(
          %{
+           "record_type" => "capability-exception",
+           "correlation" => %{"capability_id" => id},
+           "payload" => %{"environment" => environment, "name" => name} = payload
+         },
+         state
+       ) do
+    if Map.get(state.inputs, id) == {environment, payload["mission_name"], name} and
+         not MapSet.member?(state.exceptions, id) and
+         not MapSet.member?(state.outputs, id),
+       do: {:cont, {:ok, %{state | exceptions: MapSet.put(state.exceptions, id)}}},
+       else: invalid_record_join()
+  end
+
+  defp validate_record_join(
+         %{
            "record_type" => "capability-output",
            "correlation" => %{"capability_id" => id},
            "payload" => %{"environment" => environment, "name" => name} = payload
@@ -413,7 +430,8 @@ defmodule PtcRunner.Kernel.InspectionArtifact do
          state
        ) do
     if Map.get(state.inputs, id) == {environment, payload["mission_name"], name} and
-         not MapSet.member?(state.outputs, id),
+         not MapSet.member?(state.outputs, id) and
+         valid_exception_output?(state, id, payload["result"]),
        do: {:cont, {:ok, %{state | outputs: MapSet.put(state.outputs, id)}}},
        else: invalid_record_join()
   end
@@ -495,6 +513,19 @@ defmodule PtcRunner.Kernel.InspectionArtifact do
   defp validate_record_join(%{"record_type" => "run-result"}, _state),
     do: invalid_record_join()
 
+  defp valid_exception_output?(state, id, result) do
+    not MapSet.member?(state.exceptions, id) or
+      match?(
+        %{
+          "status" => "error",
+          "kind" => "provider_error",
+          "reason" => "exception",
+          "retryable?" => false
+        },
+        result
+      )
+  end
+
   defp mission_join?({"mission", mission_name, _name}, mission_name) when is_binary(mission_name),
     do: true
 
@@ -530,7 +561,7 @@ defmodule PtcRunner.Kernel.InspectionArtifact do
            "correlation" => correlation,
            "payload" => payload
          },
-         6
+         7
        ) do
     correlation == %{} and exact_keys?(payload, ~w(result_hash value)) and
       ResultIdentity.valid_hash?(payload["result_hash"]) and
@@ -543,7 +574,7 @@ defmodule PtcRunner.Kernel.InspectionArtifact do
            "correlation" => %{"capability_id" => id},
            "payload" => payload
          },
-         6
+         7
        )
        when record_type in ["capability-input", "capability-output"] do
     value_key = if record_type == "capability-input", do: "arguments", else: "result"
@@ -558,11 +589,21 @@ defmodule PtcRunner.Kernel.InspectionArtifact do
 
   defp valid_shape?(
          %{
+           "record_type" => "capability-exception",
+           "correlation" => %{"capability_id" => id},
+           "payload" => payload
+         },
+         7
+       ),
+       do: InspectionRecordTypes.valid_capability_exception?(id, payload)
+
+  defp valid_shape?(
+         %{
            "record_type" => record_type,
            "correlation" => correlation,
            "payload" => payload
          },
-         6
+         7
        )
        when record_type in ["mcp-request", "mcp-response"] do
     request_id = correlation["request_id"]
@@ -582,7 +623,7 @@ defmodule PtcRunner.Kernel.InspectionArtifact do
            "correlation" => %{"component_id" => id},
            "payload" => payload
          },
-         6
+         7
        ) do
     valid_id?(id) and is_binary(payload["source"]) and
       payload["source_bytes"] == byte_size(payload["source"]) and
@@ -599,7 +640,7 @@ defmodule PtcRunner.Kernel.InspectionArtifact do
            "correlation" => %{"evaluation_id" => id},
            "payload" => payload
          },
-         6
+         7
        ) do
     exact_keys?(
       payload,
@@ -616,7 +657,7 @@ defmodule PtcRunner.Kernel.InspectionArtifact do
            "correlation" => %{"evaluation_id" => id},
            "payload" => payload
          },
-         6
+         7
        ) do
     exact_keys?(payload, ~w(environment mission_name prelude_calls)) and valid_id?(id) and
       valid_id?(payload["mission_name"]) and payload["environment"] == "mission" and
@@ -629,7 +670,7 @@ defmodule PtcRunner.Kernel.InspectionArtifact do
            "correlation" => %{"evaluation_id" => id},
            "payload" => payload
          },
-         6
+         7
        ) do
     exact_keys?(payload, ~w(environment prints truncated)) and
       valid_id?(id) and payload["environment"] == "workflow" and
@@ -643,7 +684,7 @@ defmodule PtcRunner.Kernel.InspectionArtifact do
            "correlation" => %{"evaluation_id" => id},
            "payload" => payload
          },
-         6
+         7
        ) do
     exact_keys?(payload, ~w(environment kind reason details)) and
       valid_id?(id) and payload["environment"] == "workflow" and
@@ -652,7 +693,7 @@ defmodule PtcRunner.Kernel.InspectionArtifact do
       InspectionRecordTypes.valid_boundary_producer_details?(payload["details"])
   end
 
-  defp valid_shape?(_record, 6), do: false
+  defp valid_shape?(_record, 7), do: false
 
   defp valid_prelude_calls?(calls) when is_list(calls) do
     Enum.all?(calls, fn call ->
@@ -1354,7 +1395,7 @@ defmodule PtcRunner.Kernel.InspectionArtifact do
     do: match?({:ok, _datetime, 0}, DateTime.from_iso8601(timestamp))
 
   defp valid_timestamp?(_timestamp), do: false
-  defp record_types(6), do: InspectionRecordTypes.all()
+  defp record_types(7), do: InspectionRecordTypes.all()
   defp valid_request_id?(id), do: is_integer(id) and id > 0
   defp valid_id?(id), do: is_binary(id) and byte_size(id) in 1..256 and String.valid?(id)
   defp sha256(value), do: :crypto.hash(:sha256, value) |> Base.encode16(case: :lower)

--- a/lib/ptc_runner/kernel/inspection_query.ex
+++ b/lib/ptc_runner/kernel/inspection_query.ex
@@ -29,7 +29,8 @@ defmodule PtcRunner.Kernel.InspectionQuery do
   environment, and exact bounded diagnostic payload.
   Projections include `mission_name` on every mission-owned result so
   repeated component and capability names remain unambiguous.
-  V6 adds one singular, non-paginated terminal `result` projection per run and
+  V7 adds correlated private callback exception diagnostics to capability
+  attempts. V6 added one singular, non-paginated terminal `result` projection per run and
   joins static prelude-call analysis to generated source by `evaluation_id`.
   Generated source and reconstructed turns copy the canonical
   `parent_evaluation_id` edge rather than inferring one from snapshot-local
@@ -157,6 +158,7 @@ defmodule PtcRunner.Kernel.InspectionQuery do
         "model_exchanges" => length(model_exchanges),
         "incomplete_model_exchanges" => incomplete_count(model_exchanges),
         "capability_calls" => length(capability_calls),
+        "capability_exceptions" => exception_count(capability_pairs),
         "incomplete_capability_calls" => incomplete_count(capability_calls),
         "generated_sources" => length(generated_sources),
         "evaluation_analyses" => map_size(evaluation_analyses),
@@ -202,10 +204,20 @@ defmodule PtcRunner.Kernel.InspectionQuery do
       |> records_of_type("capability-output")
       |> Map.new(&{&1["correlation"]["capability_id"], &1})
 
+    exceptions =
+      records
+      |> records_of_type("capability-exception")
+      |> Map.new(&{&1["correlation"]["capability_id"], &1})
+
     pairs =
       inputs
       |> Enum.map(fn {capability_id, input} ->
-        capability_pair(capability_id, input, Map.get(outputs, capability_id))
+        capability_pair(
+          capability_id,
+          input,
+          Map.get(outputs, capability_id),
+          Map.get(exceptions, capability_id)
+        )
       end)
       |> Enum.sort_by(& &1["input_sequence"])
 
@@ -248,18 +260,36 @@ defmodule PtcRunner.Kernel.InspectionQuery do
     end
   end
 
-  defp capability_pair(capability_id, input, nil) do
+  defp capability_pair(capability_id, input, nil, exception) do
     capability_input(capability_id, input)
     |> Map.put("complete?", false)
+    |> maybe_put_exception(exception)
   end
 
-  defp capability_pair(capability_id, input, output) do
+  defp capability_pair(capability_id, input, output, exception) do
     capability_input(capability_id, input)
     |> Map.merge(%{
       "complete?" => true,
       "output_sequence" => output["sequence"],
       "output_timestamp" => output["timestamp"],
       "result" => output["payload"]["result"]
+    })
+    |> maybe_put_exception(exception)
+  end
+
+  defp maybe_put_exception(item, nil), do: item
+
+  defp maybe_put_exception(item, exception) do
+    payload = exception["payload"]
+
+    Map.merge(item, %{
+      "exception_sequence" => exception["sequence"],
+      "exception_timestamp" => exception["timestamp"],
+      "exception" =>
+        Map.take(
+          payload,
+          ~w(exception_class message message_truncated stacktrace stacktrace_truncated)
+        )
     })
   end
 
@@ -280,6 +310,7 @@ defmodule PtcRunner.Kernel.InspectionQuery do
   end
 
   defp incomplete_count(items), do: Enum.count(items, &(&1["complete?"] == false))
+  defp exception_count(items), do: Enum.count(items, &Map.has_key?(&1, "exception"))
 
   defp provider_pair(capability_id, request_id, request, response) do
     request_payload = request["payload"]

--- a/lib/ptc_runner/kernel/inspection_record_types.ex
+++ b/lib/ptc_runner/kernel/inspection_record_types.ex
@@ -9,11 +9,39 @@ defmodule PtcRunner.Kernel.InspectionRecordTypes do
   divergence either module is free to make on its own.
   """
 
-  @record_types ~w(capability-input capability-output evaluation-source evaluation-analysis prelude-source mcp-request mcp-response execution-prints execution-error run-result)
+  @record_types ~w(capability-input capability-exception capability-output evaluation-source evaluation-analysis prelude-source mcp-request mcp-response execution-prints execution-error run-result)
+  @max_exception_class_bytes 1_024
+  @max_exception_message_bytes 4_096
+  @max_exception_stacktrace_bytes 65_536
 
   @spec all() :: [binary()]
   @doc "Returns every record type admitted by the current schema."
   def all, do: @record_types
+
+  @doc false
+  @spec max_exception_class_bytes() :: pos_integer()
+  def max_exception_class_bytes, do: @max_exception_class_bytes
+
+  @doc false
+  @spec max_exception_message_bytes() :: pos_integer()
+  def max_exception_message_bytes, do: @max_exception_message_bytes
+
+  @doc false
+  @spec max_exception_stacktrace_bytes() :: pos_integer()
+  def max_exception_stacktrace_bytes, do: @max_exception_stacktrace_bytes
+
+  @doc false
+  @spec valid_capability_exception?(binary(), map()) :: boolean()
+  def valid_capability_exception?(id, payload) when is_map(payload) do
+    valid_id?(id) and valid_capability_identity?(payload) and
+      bounded_string?(payload["exception_class"], @max_exception_class_bytes, false) and
+      bounded_string?(payload["message"], @max_exception_message_bytes, true) and
+      is_boolean(payload["message_truncated"]) and
+      bounded_string?(payload["stacktrace"], @max_exception_stacktrace_bytes, true) and
+      is_boolean(payload["stacktrace_truncated"])
+  end
+
+  def valid_capability_exception?(_id, _payload), do: false
 
   @doc false
   @spec valid_boundary_producer_details?(map()) :: boolean()
@@ -33,6 +61,31 @@ defmodule PtcRunner.Kernel.InspectionRecordTypes do
   end
 
   defp valid_boundary_producer?(_producer), do: false
+
+  defp valid_capability_identity?(%{"environment" => "workflow", "name" => name} = payload) do
+    Map.keys(payload) |> Enum.sort() ==
+      ~w(environment exception_class message message_truncated name stacktrace stacktrace_truncated) and
+      valid_id?(name)
+  end
+
+  defp valid_capability_identity?(
+         %{
+           "environment" => "mission",
+           "mission_name" => mission_name,
+           "name" => name
+         } = payload
+       ) do
+    Map.keys(payload) |> Enum.sort() ==
+      ~w(environment exception_class message message_truncated mission_name name stacktrace stacktrace_truncated) and
+      valid_id?(mission_name) and valid_id?(name)
+  end
+
+  defp valid_capability_identity?(_payload), do: false
+
+  defp bounded_string?(value, max_bytes, empty?) do
+    is_binary(value) and String.valid?(value) and byte_size(value) <= max_bytes and
+      (empty? or value != "")
+  end
 
   defp valid_id?(id),
     do: is_binary(id) and byte_size(id) in 1..256 and String.valid?(id)

--- a/lib/ptc_runner/kernel/inspection_sink.ex
+++ b/lib/ptc_runner/kernel/inspection_sink.ex
@@ -2,8 +2,8 @@ defmodule PtcRunner.Kernel.InspectionSink do
   @moduledoc """
   Required, bounded in-memory owner for sensitive developer inspection records.
 
-  Capture is host-enabled, fail-closed, and V6-only. The closed vocabulary
-  contains capability input/output, subordinate evaluation source and static
+  Capture is host-enabled, fail-closed, and V7-only. The closed vocabulary
+  contains capability input/exception/output, subordinate evaluation source and static
   prelude-call analysis, effective prelude source, correlated exact MCP
   request/response bodies, and workflow execution prints/errors, plus at most
   one strictly JSON terminal result bound to its deterministic canonical hash.
@@ -164,7 +164,7 @@ defmodule PtcRunner.Kernel.InspectionSink do
        owner_transferable?: true,
        run_id: run_id,
        trace_id: trace_id,
-       schema_version: 6,
+       schema_version: 7,
        max_record_bytes: max_record_bytes,
        max_total_bytes: max_total_bytes,
        sequence: 0,
@@ -297,7 +297,7 @@ defmodule PtcRunner.Kernel.InspectionSink do
     end
   end
 
-  defp shape("run-result", correlation, payload, 6) do
+  defp shape("run-result", correlation, payload, 7) do
     valid? =
       if correlation == %{} and exact_payload(payload, ~w(result_hash value)) and
            ResultIdentity.valid_hash?(payload["result_hash"]) do
@@ -309,7 +309,7 @@ defmodule PtcRunner.Kernel.InspectionSink do
     ok_or_error(valid?)
   end
 
-  defp shape("capability-input", %{"capability_id" => id}, payload, 6) do
+  defp shape("capability-input", %{"capability_id" => id}, payload, 7) do
     valid? =
       valid_id?(id) and
         ((payload["environment"] == "workflow" and
@@ -322,7 +322,10 @@ defmodule PtcRunner.Kernel.InspectionSink do
     ok_or_error(valid?)
   end
 
-  defp shape("capability-output", %{"capability_id" => id}, payload, 6) do
+  defp shape("capability-exception", %{"capability_id" => id}, payload, 7),
+    do: ok_or_error(InspectionRecordTypes.valid_capability_exception?(id, payload))
+
+  defp shape("capability-output", %{"capability_id" => id}, payload, 7) do
     valid? =
       valid_id?(id) and
         ((payload["environment"] == "workflow" and
@@ -335,7 +338,7 @@ defmodule PtcRunner.Kernel.InspectionSink do
     ok_or_error(valid?)
   end
 
-  defp shape("evaluation-source", %{"evaluation_id" => id}, payload, 6) do
+  defp shape("evaluation-source", %{"evaluation_id" => id}, payload, 7) do
     valid? =
       exact_payload(
         payload,
@@ -348,7 +351,7 @@ defmodule PtcRunner.Kernel.InspectionSink do
     ok_or_error(valid?)
   end
 
-  defp shape("evaluation-analysis", %{"evaluation_id" => id}, payload, 6) do
+  defp shape("evaluation-analysis", %{"evaluation_id" => id}, payload, 7) do
     valid? =
       exact_payload(payload, ~w(environment mission_name prelude_calls)) and valid_id?(id) and
         valid_id?(payload["mission_name"]) and payload["environment"] == "mission" and
@@ -357,7 +360,7 @@ defmodule PtcRunner.Kernel.InspectionSink do
     ok_or_error(valid?)
   end
 
-  defp shape("prelude-source", %{"component_id" => id}, payload, 6) do
+  defp shape("prelude-source", %{"component_id" => id}, payload, 7) do
     valid? =
       valid_id?(id) and
         ((payload["environment"] == "workflow" and
@@ -371,7 +374,7 @@ defmodule PtcRunner.Kernel.InspectionSink do
     ok_or_error(valid?)
   end
 
-  defp shape(record_type, correlation, payload, 6)
+  defp shape(record_type, correlation, payload, 7)
        when record_type in ["mcp-request", "mcp-response"] do
     request_id = correlation["request_id"]
 
@@ -387,7 +390,7 @@ defmodule PtcRunner.Kernel.InspectionSink do
     ok_or_error(valid?)
   end
 
-  defp shape("execution-prints", %{"evaluation_id" => id}, payload, 6) do
+  defp shape("execution-prints", %{"evaluation_id" => id}, payload, 7) do
     valid? =
       exact_payload(payload, ~w(environment prints truncated)) and valid_id?(id) and
         payload["environment"] == "workflow" and
@@ -397,7 +400,7 @@ defmodule PtcRunner.Kernel.InspectionSink do
     ok_or_error(valid?)
   end
 
-  defp shape("execution-error", %{"evaluation_id" => id}, payload, 6) do
+  defp shape("execution-error", %{"evaluation_id" => id}, payload, 7) do
     valid? =
       exact_payload(payload, ~w(environment kind reason details)) and valid_id?(id) and
         payload["environment"] == "workflow" and
@@ -408,7 +411,7 @@ defmodule PtcRunner.Kernel.InspectionSink do
     ok_or_error(valid?)
   end
 
-  defp shape(_record_type, _correlation, _payload, 6), do: {:error, :invalid_record}
+  defp shape(_record_type, _correlation, _payload, 7), do: {:error, :invalid_record}
 
   # `normalize/1` recurses, so nesting is bounded before it runs. The retained
   # record wraps correlation and payload at exactly one level, so bounding that
@@ -434,7 +437,7 @@ defmodule PtcRunner.Kernel.InspectionSink do
     }
   end
 
-  defp validate_raw_result("run-result", payload, 6) when is_map(payload) do
+  defp validate_raw_result("run-result", payload, 7) when is_map(payload) do
     case {Map.fetch(payload, :value), Map.fetch(payload, "value")} do
       {{:ok, value}, :error} -> strict_json(value)
       {:error, {:ok, value}} -> strict_json(value)
@@ -442,7 +445,7 @@ defmodule PtcRunner.Kernel.InspectionSink do
     end
   end
 
-  defp validate_raw_result("run-result", _payload, 6), do: {:error, :invalid_record}
+  defp validate_raw_result("run-result", _payload, 7), do: {:error, :invalid_record}
   defp validate_raw_result(_record_type, _payload, _schema_version), do: :ok
 
   defp strict_json(value) do

--- a/lib/ptc_runner/kernel/run_analysis.ex
+++ b/lib/ptc_runner/kernel/run_analysis.ex
@@ -71,6 +71,7 @@ defmodule PtcRunner.Kernel.RunAnalysis do
       sequence_domain: "private_inspection",
       identifier_locations: %{
         "capability_id" => "capability_id",
+        "exception_sequence" => "exception_sequence",
         "input_sequence" => "input_sequence",
         "output_sequence" => "output_sequence"
       },
@@ -86,6 +87,7 @@ defmodule PtcRunner.Kernel.RunAnalysis do
       sequence_domain: "private_inspection",
       identifier_locations: %{
         "capability_id" => "capability_id",
+        "exception_sequence" => "exception_sequence",
         "input_sequence" => "input_sequence",
         "output_sequence" => "output_sequence"
       },

--- a/ptc_viewer/test/ptc_viewer/server_test.exs
+++ b/ptc_viewer/test/ptc_viewer/server_test.exs
@@ -5,7 +5,7 @@ defmodule PtcViewer.ServerTest do
 
   test "inspection startup preserves an unsupported schema version error" do
     assert {:error,
-            {:unsupported_inspection_schema_version, %{artifact_version: 4, supported_version: 6}}} =
+            {:unsupported_inspection_schema_version, %{artifact_version: 4, supported_version: 7}}} =
              PtcViewer.start(
                inspection_file: "run.inspection.jsonl",
                inspection_adapter: TestInspectionAdapter,

--- a/ptc_viewer/test/support/inspection_test_adapter.ex
+++ b/ptc_viewer/test/support/inspection_test_adapter.ex
@@ -3,7 +3,7 @@ defmodule PtcViewer.TestInspectionAdapter do
 
   def pin_inspection(_path, _trace_source) do
     {:error,
-     {:unsupported_inspection_schema_version, %{artifact_version: 4, supported_version: 6}}}
+     {:unsupported_inspection_schema_version, %{artifact_version: 4, supported_version: 7}}}
   end
 
   def conversation(_source, _run_id), do: {:error, :not_called}

--- a/test/mix/tasks/ptc_repl_test.exs
+++ b/test/mix/tasks/ptc_repl_test.exs
@@ -478,7 +478,7 @@ defmodule PtcRunner.ReplFrontendTest do
   end
 
   @tag :tmp_dir
-  test "inspection analysis recursively reads a private V6 trace and correlated result", %{
+  test "inspection analysis recursively reads a private V7 trace and correlated result", %{
     tmp_dir: directory
   } do
     value = %{"answer" => 42}
@@ -578,6 +578,7 @@ defmodule PtcRunner.ReplFrontendTest do
 
     assert opened["inspection"]["counts"] == %{
              "capability_calls" => 2,
+             "capability_exceptions" => 0,
              "effective_preludes" => 0,
              "evaluation_analyses" => 0,
              "execution_errors" => 0,
@@ -618,7 +619,7 @@ defmodule PtcRunner.ReplFrontendTest do
     PrivateInspectionFixture.rewrite_schema!(fixture.inspection, 4)
 
     message =
-      ~r/ptc repl profile setup failed: an inspection artifact declares schema version 4; this build supports version 6/
+      ~r/ptc repl profile setup failed: an inspection artifact declares schema version 4; this build supports version 7/
 
     capture_io(fn ->
       assert_raise Mix.Error, message, fn ->

--- a/test/mix/tasks/ptc_transcript_test.exs
+++ b/test/mix/tasks/ptc_transcript_test.exs
@@ -188,7 +188,7 @@ defmodule Mix.Tasks.PtcTranscriptTest do
     assert presentation.exit_status == 1
     assert presentation.stderr =~ "error: transcript/unsupported_schema:"
     assert presentation.stderr =~ "schema version 4 is unsupported"
-    assert presentation.stderr =~ "supports version 6"
+    assert presentation.stderr =~ "supports version 7"
     refute File.exists?(output)
   end
 

--- a/test/ptc_runner/kernel/acquisition_reason_test.exs
+++ b/test/ptc_runner/kernel/acquisition_reason_test.exs
@@ -107,7 +107,7 @@ defmodule PtcRunner.Kernel.AcquisitionReasonTest do
 
   test "an unsupported inspection schema tuple remains a local environment failure" do
     reason =
-      {:unsupported_inspection_schema_version, %{artifact_version: 4, supported_version: 6}}
+      {:unsupported_inspection_schema_version, %{artifact_version: 4, supported_version: 7}}
 
     diagnostic = AcquisitionReason.diagnostic(reason, @occurrence)
 

--- a/test/ptc_runner/kernel/artifact_publisher_test.exs
+++ b/test/ptc_runner/kernel/artifact_publisher_test.exs
@@ -89,7 +89,7 @@ defmodule PtcRunner.Kernel.ArtifactPublisherTest do
 
     records = [
       %{
-        "schema_version" => 6,
+        "schema_version" => 7,
         "run_id" => run_id,
         "trace_id" => trace_id,
         "sequence" => 1,

--- a/test/ptc_runner/kernel/bounded_worker_test.exs
+++ b/test/ptc_runner/kernel/bounded_worker_test.exs
@@ -161,8 +161,8 @@ defmodule PtcRunner.Kernel.BoundedWorkerTest do
       end)
 
     assert_receive {:timeout_worker, worker}
-    assert_receive {:timeout_cleanup, ^caller}
     worker_ref = Process.monitor(worker)
+    assert_receive {:timeout_cleanup, ^caller}
     Process.exit(caller, :kill)
     assert_receive {:DOWN, ^worker_ref, :process, ^worker, :killed}
   end

--- a/test/ptc_runner/kernel/capability_exception_diagnostic_test.exs
+++ b/test/ptc_runner/kernel/capability_exception_diagnostic_test.exs
@@ -1,0 +1,73 @@
+defmodule PtcRunner.Kernel.CapabilityExceptionDiagnosticTest do
+  use ExUnit.Case, async: true
+
+  alias PtcRunner.Kernel.CapabilityExceptionDiagnostic
+  alias PtcRunner.Kernel.InspectionRecordTypes
+  alias PtcRunner.TestSupport.ObservedException
+
+  test "bounds messages at valid UTF-8 byte boundaries" do
+    for {message, truncated?} <- [
+          {String.duplicate("x", 4_096), false},
+          {String.duplicate("x", 4_097), true},
+          {String.duplicate("å", 2_049), true}
+        ] do
+      diagnostic =
+        CapabilityExceptionDiagnostic.capture(%ObservedException{value: message}, [])
+
+      assert diagnostic.message_truncated == truncated?
+      assert String.valid?(diagnostic.message)
+
+      assert byte_size(diagnostic.message) <=
+               InspectionRecordTypes.max_exception_message_bytes()
+    end
+  end
+
+  test "limits formatted stacktrace frames and bytes" do
+    long_file = String.duplicate("x", 2_000) |> String.to_charlist()
+    frame = {__MODULE__, :fixture, 0, [file: long_file, line: 1]}
+
+    diagnostic =
+      CapabilityExceptionDiagnostic.capture(
+        %ObservedException{value: "boom"},
+        List.duplicate(frame, 65)
+      )
+
+    assert diagnostic.stacktrace_truncated
+    assert String.valid?(diagnostic.stacktrace)
+
+    assert byte_size(diagnostic.stacktrace) <=
+             InspectionRecordTypes.max_exception_stacktrace_bytes()
+  end
+
+  test "formats stack frames without inspecting callback arguments" do
+    diagnostic =
+      CapabilityExceptionDiagnostic.capture(
+        %ObservedException{value: "boom"},
+        [{__MODULE__, :fixture, ["private-argument-secret"], [file: ~c"private.ex", line: 1]}]
+      )
+
+    assert diagnostic.stacktrace =~ "fixture/1"
+    refute diagnostic.stacktrace =~ "private-argument-secret"
+  end
+
+  test "a broken exception message formatter cannot mask the diagnostic" do
+    diagnostic =
+      CapabilityExceptionDiagnostic.capture(%ObservedException{mode: :raise}, [])
+
+    assert diagnostic.message == "exception message unavailable"
+    assert diagnostic.message_truncated
+    assert diagnostic.exception_class == "Elixir.PtcRunner.TestSupport.ObservedException"
+  end
+
+  test "an unclaimed diagnostic worker expires without retaining its exception" do
+    assert {:ok, pid, _exception_class} =
+             CapabilityExceptionDiagnostic.start(
+               %ObservedException{value: "private"},
+               [],
+               self()
+             )
+
+    ref = Process.monitor(pid)
+    assert_receive {:DOWN, ^ref, :process, ^pid, :normal}, 500
+  end
+end

--- a/test/ptc_runner/kernel/dispatcher_effect_test.exs
+++ b/test/ptc_runner/kernel/dispatcher_effect_test.exs
@@ -11,6 +11,7 @@ defmodule PtcRunner.Kernel.DispatcherEffectTest do
   alias PtcRunner.Kernel.ProviderError
   alias PtcRunner.Kernel.RunState
   alias PtcRunner.Kernel.WorkflowEnvironment
+  alias PtcRunner.TestSupport.ObservedException
   alias PtcRunner.TestSupport.TestHelpers
 
   @effects [:read, :write, :unknown]
@@ -155,6 +156,203 @@ defmodule PtcRunner.Kernel.DispatcherEffectTest do
 
   test "raised mission callbacks are non-retryable" do
     assert_unclassified_mission_failure(fn -> raise "private failure" end, :exception)
+  end
+
+  test "raised callbacks retain a correlated private diagnostic without changing the public result" do
+    {:ok, inspection_sink} =
+      InspectionSink.start(
+        run_id: "dispatcher-exception-run",
+        trace_id: "dispatcher-exception-trace"
+      )
+
+    result =
+      dispatch_mission(:read, fn -> raise "private failure" end, inspection_sink: inspection_sink)
+
+    assert result == %{
+             status: :error,
+             kind: :provider_error,
+             reason: :exception,
+             retryable?: false
+           }
+
+    assert {:ok, [input, diagnostic, output]} = InspectionSink.records(inspection_sink)
+    assert input["record_type"] == "capability-input"
+
+    assert %{
+             "record_type" => "capability-exception",
+             "correlation" => %{"capability_id" => capability_id},
+             "payload" => %{
+               "environment" => "mission",
+               "mission_name" => "default",
+               "name" => "effect-fixture",
+               "exception_class" => "Elixir.RuntimeError",
+               "message" => "private failure",
+               "message_truncated" => false,
+               "stacktrace" => stacktrace,
+               "stacktrace_truncated" => false
+             }
+           } = diagnostic
+
+    assert input["correlation"] == %{"capability_id" => capability_id}
+    assert stacktrace =~ "dispatcher_effect_test.exs"
+
+    assert output["record_type"] == "capability-output"
+    assert output["correlation"] == %{"capability_id" => capability_id}
+
+    assert output["payload"]["result"] == %{
+             "status" => "error",
+             "kind" => "provider_error",
+             "reason" => "exception",
+             "retryable?" => false
+           }
+  end
+
+  test "inspection-disabled raises do not format or retain exception details" do
+    owner = self()
+
+    assert %{
+             status: :error,
+             kind: :provider_error,
+             reason: :exception,
+             retryable?: false
+           } =
+             dispatch_mission(:read, fn ->
+               :erlang.raise(
+                 :error,
+                 %ObservedException{owner: owner, value: "inspection-disabled-secret"},
+                 []
+               )
+             end)
+
+    refute_receive {:exception_message_formatted, _message}
+  end
+
+  test "a blocking exception formatter cannot change the public or canonical outcome" do
+    {:ok, inspection_sink} =
+      InspectionSink.start(
+        run_id: "blocking-formatter-run",
+        trace_id: "blocking-formatter-trace"
+      )
+
+    callback = fn ->
+      :erlang.raise(:error, %ObservedException{mode: :block}, [])
+    end
+
+    {result, events} = dispatch_mission_with_events([], 100, callback, inspection_sink)
+
+    assert result == %{
+             status: :error,
+             kind: :provider_error,
+             reason: :exception,
+             retryable?: false
+           }
+
+    assert %{data: %{status: :error}} =
+             Enum.find(events, &(&1.type == "capability-stopped"))
+
+    refute Enum.any?(events, &(&1.type == "limit-exceeded"))
+
+    assert {:ok, [_input, diagnostic, output]} = InspectionSink.records(inspection_sink)
+    assert diagnostic["payload"]["message"] == "exception message unavailable"
+    assert diagnostic["payload"]["message_truncated"]
+    assert diagnostic["payload"]["stacktrace_truncated"]
+    assert output["payload"]["result"]["reason"] == "exception"
+  end
+
+  test "workflow raises retain diagnostics without mission attribution" do
+    {:ok, inspection_sink} =
+      InspectionSink.start(
+        run_id: "workflow-exception-run",
+        trace_id: "workflow-exception-trace"
+      )
+
+    assert %{kind: :provider_error, reason: :exception} =
+             dispatch_workflow(fn -> raise "workflow failure" end,
+               inspection_sink: inspection_sink
+             )
+
+    assert {:ok, [_input, diagnostic, _output]} = InspectionSink.records(inspection_sink)
+    assert diagnostic["record_type"] == "capability-exception"
+    assert diagnostic["payload"]["environment"] == "workflow"
+    refute Map.has_key?(diagnostic["payload"], "mission_name")
+  end
+
+  test "exit and throw retain no exception diagnostic" do
+    for callback <- [fn -> exit(:private_failure) end, fn -> throw(:private_failure) end] do
+      {:ok, inspection_sink} =
+        InspectionSink.start(
+          run_id: "non-exception-run-#{System.unique_integer([:positive])}",
+          trace_id: "non-exception-trace"
+        )
+
+      assert %{kind: :provider_error} =
+               dispatch_mission(:read, callback, inspection_sink: inspection_sink)
+
+      assert {:ok, [input, output]} = InspectionSink.records(inspection_sink)
+      assert input["record_type"] == "capability-input"
+      assert output["record_type"] == "capability-output"
+    end
+  end
+
+  test "exception diagnostic sink failure preserves the terminal inspection contract" do
+    for effect <- [:read, :write] do
+      {:ok, inspection_sink} =
+        InspectionSink.start(
+          run_id: "exception-sink-failure-#{effect}",
+          trace_id: "exception-sink-failure-trace",
+          max_record_bytes: 2_000,
+          max_total_bytes: 10_000
+        )
+
+      result =
+        dispatch_mission(
+          effect,
+          fn ->
+            :erlang.raise(
+              :error,
+              %ObservedException{value: String.duplicate("private", 1_000)},
+              []
+            )
+          end,
+          inspection_sink: inspection_sink
+        )
+
+      assert result.kind == :inspection_sink_error
+      assert result.reason == :inspection_sink_error
+      assert result.retryable? == false
+
+      if effect == :write,
+        do: assert(result.mutation_state == :indeterminate),
+        else: refute(Map.has_key?(result, :mutation_state))
+    end
+  end
+
+  test "private exception capture leaves the canonical failure projection unchanged" do
+    {:ok, inspection_sink} =
+      InspectionSink.start(
+        run_id: "canonical-separation-run",
+        trace_id: "canonical-separation-trace"
+      )
+
+    callback = fn -> raise "canonical-separation-private-secret" end
+
+    {captured_result, captured_events} =
+      dispatch_mission_with_events([], 100, callback, inspection_sink)
+
+    {plain_result, plain_events} = dispatch_mission_with_events([], 100, callback)
+
+    assert captured_result == plain_result
+
+    captured_stop = Enum.find(captured_events, &(&1.type == "capability-stopped"))
+    plain_stop = Enum.find(plain_events, &(&1.type == "capability-stopped"))
+
+    assert Map.drop(captured_stop.data, [:duration_ms, :capability_id]) ==
+             Map.drop(plain_stop.data, [:duration_ms, :capability_id])
+
+    canonical = inspect(captured_events)
+    refute canonical =~ "canonical-separation-private-secret"
+    refute canonical =~ "RuntimeError"
+    refute canonical =~ "dispatcher_effect_test.exs"
   end
 
   test "exiting mission callbacks are non-retryable" do
@@ -539,7 +737,7 @@ defmodule PtcRunner.Kernel.DispatcherEffectTest do
     )
   end
 
-  defp dispatch_workflow(callback) do
+  defp dispatch_workflow(callback, opts \\ []) do
     {:ok, state} = RunState.start(Limits.defaults())
     {:ok, capability} = capability(:read, callback)
     {:ok, environment} = WorkflowEnvironment.new(capabilities: [capability])
@@ -552,11 +750,11 @@ defmodule PtcRunner.Kernel.DispatcherEffectTest do
       %{},
       TestHelpers.dispatch_context(state, :workflow, 100),
       nil,
-      nil
+      Keyword.get(opts, :inspection_sink)
     )
   end
 
-  defp dispatch_mission_with_events(limit_opts, timeout_ms, callback) do
+  defp dispatch_mission_with_events(limit_opts, timeout_ms, callback, inspection_sink \\ nil) do
     {:ok, limits} = Limits.new(limit_opts)
     {:ok, state} = RunState.start(limits)
     {:ok, sink} = EventSink.start(:normal, limits, run_id: "mission-limit-attribution")
@@ -579,7 +777,7 @@ defmodule PtcRunner.Kernel.DispatcherEffectTest do
           mission_name: "reader"
         },
         sink,
-        nil
+        inspection_sink
       )
 
     {result, EventSink.events(sink)}

--- a/test/ptc_runner/kernel/inspection_sink_test.exs
+++ b/test/ptc_runner/kernel/inspection_sink_test.exs
@@ -48,13 +48,35 @@ defmodule PtcRunner.Kernel.InspectionSinkTest do
     assert :ok =
              InspectionSink.emit(
                sink,
+               "capability-exception",
+               %{capability_id: "cap-1"},
+               %{
+                 environment: :mission,
+                 mission_name: "default",
+                 name: "remote.read",
+                 exception_class: RuntimeError,
+                 message: "private failure",
+                 message_truncated: false,
+                 stacktrace: "    private stacktrace",
+                 stacktrace_truncated: false
+               }
+             )
+
+    assert :ok =
+             InspectionSink.emit(
+               sink,
                "capability-output",
                %{"capability_id" => "cap-1"},
                %{
                  environment: :mission,
                  mission_name: "default",
                  name: "remote.read",
-                 result: %{status: :ok, value: 42}
+                 result: %{
+                   status: :error,
+                   kind: :provider_error,
+                   reason: :exception,
+                   retryable?: false
+                 }
                }
              )
 
@@ -89,19 +111,33 @@ defmodule PtcRunner.Kernel.InspectionSinkTest do
                }
              )
 
-    assert {:ok, [input, output, source, analysis, prelude]} = InspectionSink.records(sink)
+    assert {:ok, [input, exception, output, source, analysis, prelude]} =
+             InspectionSink.records(sink)
 
-    assert Enum.map([input, output, source, analysis, prelude], & &1["sequence"]) == [
+    assert Enum.map([input, exception, output, source, analysis, prelude], & &1["sequence"]) == [
              1,
              2,
              3,
              4,
-             5
+             5,
+             6
            ]
 
-    assert Enum.all?([input, output, source, analysis, prelude], &(&1["schema_version"] == 6))
+    assert Enum.all?(
+             [input, exception, output, source, analysis, prelude],
+             &(&1["schema_version"] == 7)
+           )
+
     assert input["payload"]["environment"] == "mission"
-    assert output["payload"]["result"] == %{"status" => "ok", "value" => 42}
+    assert exception["payload"]["exception_class"] == "Elixir.RuntimeError"
+
+    assert output["payload"]["result"] == %{
+             "status" => "error",
+             "kind" => "provider_error",
+             "reason" => "exception",
+             "retryable?" => false
+           }
+
     assert source["payload"]["source"] == @source
 
     assert analysis["payload"]["prelude_calls"] == [
@@ -158,7 +194,7 @@ defmodule PtcRunner.Kernel.InspectionSinkTest do
              )
 
     assert {:ok, [request_record, response_record]} = InspectionSink.records(sink)
-    assert request_record["schema_version"] == 6
+    assert request_record["schema_version"] == 7
     assert request_record["payload"]["body"] == request
     assert response_record["payload"]["body"] == response
   end
@@ -207,7 +243,7 @@ defmodule PtcRunner.Kernel.InspectionSinkTest do
              )
 
     assert {:ok, [prints_record, error_record]} = InspectionSink.records(sink)
-    assert prints_record["schema_version"] == 6
+    assert prints_record["schema_version"] == 7
     assert prints_record["correlation"] == %{"evaluation_id" => "eval-1"}
 
     assert prints_record["payload"] == %{
@@ -361,7 +397,7 @@ defmodule PtcRunner.Kernel.InspectionSinkTest do
              InspectionSink.emit(sink, "run-result", %{}, %{result_hash: hash, value: value})
 
     assert {:ok, [record]} = InspectionSink.records(sink)
-    assert record["schema_version"] == 6
+    assert record["schema_version"] == 7
     assert record["correlation"] == %{}
     assert record["payload"] == %{"result_hash" => hash, "value" => value}
 
@@ -494,6 +530,29 @@ defmodule PtcRunner.Kernel.InspectionSinkTest do
 
     assert {:ok, [input, output]} = InspectionSink.records(sink)
 
+    exception = %{
+      input
+      | "record_type" => "capability-exception",
+        "payload" => %{
+          "environment" => "mission",
+          "mission_name" => "default",
+          "name" => "read",
+          "exception_class" => "Elixir.RuntimeError",
+          "message" => "private failure",
+          "message_truncated" => false,
+          "stacktrace" => "    private stacktrace",
+          "stacktrace_truncated" => false
+        }
+    }
+
+    exception_output =
+      put_in(output, ["payload", "result"], %{
+        "status" => "error",
+        "kind" => "provider_error",
+        "reason" => "exception",
+        "retryable?" => false
+      })
+
     events = [
       %{
         run_id: "run-1",
@@ -516,6 +575,41 @@ defmodule PtcRunner.Kernel.InspectionSinkTest do
                duplicate_input,
                events
              )
+
+    assert :ok =
+             InspectionArtifact.persist(
+               Path.join(dir, "exception-prefix.inspection.jsonl"),
+               resequence([input, exception]),
+               events
+             )
+
+    assert :ok =
+             InspectionArtifact.persist(
+               Path.join(dir, "exception-complete.inspection.jsonl"),
+               resequence([input, exception, exception_output]),
+               events
+             )
+
+    for {name, invalid_records} <- [
+          {"exception-only", [exception]},
+          {"duplicate-exception", [input, exception, exception]},
+          {"exception-after-output", [input, exception_output, exception]},
+          {"exception-success-output", [input, exception, output]},
+          {"oversized-exception",
+           [
+             input,
+             put_in(exception, ["payload", "message"], String.duplicate("x", 4_097))
+           ]},
+          {"extra-exception-field", [input, put_in(exception, ["payload", "extra"], true)]},
+          {"mismatched-exception", [input, put_in(exception, ["payload", "name"], "other")]}
+        ] do
+      assert {:error, :invalid_inspection_artifact} =
+               InspectionArtifact.persist(
+                 Path.join(dir, "#{name}.inspection.jsonl"),
+                 resequence(invalid_records),
+                 events
+               )
+    end
 
     assert {:error, :invalid_inspection_artifact} =
              InspectionArtifact.persist(
@@ -859,7 +953,7 @@ defmodule PtcRunner.Kernel.InspectionSinkTest do
       records
       |> hd()
       |> Jason.encode!()
-      |> String.replace_prefix("{", ~S|{"schema_version":6,|)
+      |> String.replace_prefix("{", ~S|{"schema_version":7,|)
 
     File.write!(duplicate, duplicate_line <> "\n")
     assert {:error, :malformed_inspection_artifact} = InspectionArtifact.load(duplicate)
@@ -891,7 +985,7 @@ defmodule PtcRunner.Kernel.InspectionSinkTest do
     )
 
     assert {:error,
-            {:unsupported_inspection_schema_version, %{artifact_version: 4, supported_version: 6}}} =
+            {:unsupported_inspection_schema_version, %{artifact_version: 4, supported_version: 7}}} =
              InspectionArtifact.load(unsupported)
 
     mixed = Path.join(dir, "mixed-schema.inspection.jsonl")
@@ -901,7 +995,7 @@ defmodule PtcRunner.Kernel.InspectionSinkTest do
     assert {:error, :invalid_inspection_artifact} = InspectionArtifact.load(mixed)
 
     capability_input = %{
-      "schema_version" => 6,
+      "schema_version" => 7,
       "run_id" => "run-1",
       "trace_id" => "trace-1",
       "sequence" => 1,
@@ -1116,7 +1210,7 @@ defmodule PtcRunner.Kernel.InspectionSinkTest do
     nested = Enum.reduce(1..64, true, fn _level, value -> [value] end)
 
     record = %{
-      "schema_version" => 6,
+      "schema_version" => 7,
       "run_id" => "deep",
       "trace_id" => "deep",
       "sequence" => 1,

--- a/test/ptc_runner/kernel/inspection_snapshot_test.exs
+++ b/test/ptc_runner/kernel/inspection_snapshot_test.exs
@@ -111,13 +111,80 @@ defmodule PtcRunner.Kernel.InspectionSnapshotTest do
             }} = limited_result.callback.(%{"run_id" => run_id})
   end
 
+  @tag :tmp_dir
+  test "projects complete and interrupted capability exception evidence", %{tmp_dir: root} do
+    {trace, inspection} = source_directories(root)
+    write_run(trace, inspection, "exception-complete", :exception)
+    write_run(trace, inspection, "exception-prefix", :exception_prefix)
+
+    {:ok, trace_snapshot} = TraceSnapshot.start({:directory, trace}, owner: self())
+
+    {:ok, snapshot} =
+      InspectionSnapshot.start({:directory, inspection}, trace_snapshot, owner: self())
+
+    on_exit(fn ->
+      InspectionSnapshot.stop(snapshot)
+      TraceSnapshot.stop(trace_snapshot)
+    end)
+
+    assert {:ok,
+            %{
+              "counts" => %{"capability_exceptions" => 1}
+            }} = InspectionSnapshot.query(snapshot, :get_run, %{"run_id" => "exception-complete"})
+
+    assert {:ok,
+            %{
+              "items" => [
+                %{"name" => "workspace.read", "complete?" => true} = complete
+              ]
+            }} =
+             InspectionSnapshot.query(snapshot, :capability_calls, %{
+               "run_id" => "exception-complete"
+             })
+
+    assert complete["input_sequence"] < complete["exception_sequence"]
+    assert complete["exception_sequence"] < complete["output_sequence"]
+    assert is_binary(complete["exception_timestamp"])
+
+    assert complete["exception"] == %{
+             "exception_class" => "Elixir.RuntimeError",
+             "message" => "private exception-complete failure",
+             "message_truncated" => false,
+             "stacktrace" => "    private stacktrace",
+             "stacktrace_truncated" => false
+           }
+
+    assert {:ok,
+            %{
+              "items" => [
+                %{"name" => "workspace.read", "complete?" => false} = interrupted
+              ]
+            }} =
+             InspectionSnapshot.query(snapshot, :capability_calls, %{
+               "run_id" => "exception-prefix"
+             })
+
+    assert interrupted["exception"]["message"] == "private exception-prefix failure"
+    assert interrupted["input_sequence"] < interrupted["exception_sequence"]
+    refute Map.has_key?(interrupted, "result")
+    refute Map.has_key?(interrupted, "output_sequence")
+
+    assert {:ok, %{"items" => [model_exchange]}} =
+             InspectionSnapshot.query(snapshot, :model_exchanges, %{
+               "run_id" => "exception-complete"
+             })
+
+    refute Map.has_key?(model_exchange, "exception")
+    refute Map.has_key?(model_exchange, "exception_sequence")
+  end
+
   test "effective preludes qualify repeated component IDs by mission" do
     records =
       ["reader", "writer"]
       |> Enum.with_index(1)
       |> Enum.map(fn {mission_name, sequence} ->
         %{
-          "schema_version" => 6,
+          "schema_version" => 7,
           "run_id" => "qualified-preludes",
           "trace_id" => "trace-qualified-preludes",
           "sequence" => sequence,
@@ -243,7 +310,7 @@ defmodule PtcRunner.Kernel.InspectionSnapshotTest do
 
     assert {:ok,
             %{
-              "items" => [%{"run_id" => "mcp-run", "schema_version" => 6}],
+              "items" => [%{"run_id" => "mcp-run", "schema_version" => 7}],
               "next_cursor" => nil,
               "snapshot_hash" => ^snapshot_hash
             }} =
@@ -890,7 +957,7 @@ defmodule PtcRunner.Kernel.InspectionSnapshotTest do
     on_exit(fn -> TraceSnapshot.stop(trace_snapshot) end)
 
     assert {:error,
-            {:unsupported_inspection_schema_version, %{artifact_version: 4, supported_version: 6}}} =
+            {:unsupported_inspection_schema_version, %{artifact_version: 4, supported_version: 7}}} =
              InspectionSnapshot.start({:directory, inspection}, trace_snapshot, owner: self())
   end
 
@@ -1164,12 +1231,32 @@ defmodule PtcRunner.Kernel.InspectionSnapshotTest do
       })
     end
 
-    emit!(sink, "capability-output", %{capability_id: "tool-#{run_id}"}, %{
-      environment: :mission,
-      mission_name: "default",
-      name: "workspace.read",
-      result: %{status: :ok, value: %{"text" => "secret-#{run_id}"}}
-    })
+    if variant in [:exception, :exception_prefix] do
+      emit!(sink, "capability-exception", %{capability_id: "tool-#{run_id}"}, %{
+        environment: :mission,
+        mission_name: "default",
+        name: "workspace.read",
+        exception_class: RuntimeError,
+        message: "private #{run_id} failure",
+        message_truncated: false,
+        stacktrace: "    private stacktrace",
+        stacktrace_truncated: false
+      })
+    end
+
+    if variant != :exception_prefix do
+      result =
+        if variant == :exception,
+          do: %{status: :error, kind: :provider_error, reason: :exception, retryable?: false},
+          else: %{status: :ok, value: %{"text" => "secret-#{run_id}"}}
+
+      emit!(sink, "capability-output", %{capability_id: "tool-#{run_id}"}, %{
+        environment: :mission,
+        mission_name: "default",
+        name: "workspace.read",
+        result: result
+      })
+    end
 
     emit!(sink, "evaluation-source", %{evaluation_id: "eval-#{run_id}"}, %{
       environment: :mission,
@@ -1220,7 +1307,7 @@ defmodule PtcRunner.Kernel.InspectionSnapshotTest do
 
   defp inspection_record(run_id, trace_id, sequence, record_type, correlation, payload) do
     %{
-      "schema_version" => 6,
+      "schema_version" => 7,
       "run_id" => run_id,
       "trace_id" => trace_id,
       "sequence" => sequence,

--- a/test/ptc_runner/kernel/mcp_source_test.exs
+++ b/test/ptc_runner/kernel/mcp_source_test.exs
@@ -557,7 +557,7 @@ defmodule PtcRunner.Kernel.MCPSourceTest do
     assert Enum.map(requests, & &1["correlation"]) |> MapSet.new() ==
              Enum.map(responses, & &1["correlation"]) |> MapSet.new()
 
-    assert Enum.all?(records, &(&1["schema_version"] == 6))
+    assert Enum.all?(records, &(&1["schema_version"] == 7))
     assert Enum.all?(requests ++ responses, &(&1["payload"]["mission_name"] == "default"))
 
     encoded_inspection = File.read!(inspection_path)

--- a/test/ptc_runner/kernel/provider_session_test.exs
+++ b/test/ptc_runner/kernel/provider_session_test.exs
@@ -1177,7 +1177,9 @@ defmodule PtcRunner.Kernel.ProviderSessionTest do
     Process.send_after(suspender, :resume, 300)
 
     assert {:ok, deadline} = ProviderSession.anchor_cleanup_deadline(session)
-    assert Deadline.remaining(deadline) <= 700
+    # Allow timer/monotonic-clock granularity while staying well below the
+    # roughly 1,000 ms that a dequeue-time anchor would incorrectly retain.
+    assert Deadline.remaining(deadline) <= 750
     assert :ok = ProviderSession.close(session)
   end
 

--- a/test/support/observed_exception.ex
+++ b/test/support/observed_exception.ex
@@ -1,0 +1,21 @@
+defmodule PtcRunner.TestSupport.ObservedException do
+  @moduledoc false
+
+  defexception [:owner, :value, mode: :value]
+
+  @impl Exception
+  def message(%__MODULE__{mode: :raise}), do: raise("message formatter failed")
+
+  def message(%__MODULE__{mode: :block}) do
+    receive do
+      :never -> "unreachable"
+    end
+  end
+
+  def message(%__MODULE__{owner: owner, value: value}) when is_pid(owner) and is_binary(value) do
+    send(owner, {:exception_message_formatted, value})
+    value
+  end
+
+  def message(%__MODULE__{value: value}) when is_binary(value), do: value
+end


### PR DESCRIPTION
## Summary

- add inspection schema V7 with a bounded private `capability-exception` record ordered between capability input and output
- isolate exception formatting in a monitored, time- and heap-bounded worker; omit callback arguments from formatted frames
- project exception evidence into capability/model queries while preserving the closed public and canonical failure envelope when retention succeeds
- update artifact validation, fixtures, Viewer coverage, operator docs, and changelog
- harden two pre-existing timing-sensitive tests exposed by the CI-shaped pre-push run

## Reviews

- plan reviewed in 3 focused passes
- implementation reviewed in 3 passes; all findings resolved and the final pass reported no remaining actionable findings

## Verification

- `mix precommit` — 6,448 root tests, 55 Viewer tests, 42 launcher tests, plus package/release and static gates
- `MIX_ENV=dev mix docs --warnings-as-errors`
- pre-push CI-equivalent gate — core tests, Credo, duplication, spec/conformance, Dialyzer, release verification, and Viewer validation

Closes #1288