### PR TITLE
fix(test): keep stderr out of the downstream run envelope assertion

### DIFF
--- a/test/mix/tasks/ptc_run_downstream_test.exs
+++ b/test/mix/tasks/ptc_run_downstream_test.exs
@@ -44,18 +44,36 @@ defmodule Mix.Tasks.Ptc.RunDownstreamTest do
 
     assert build_status == 0, build_output
 
+    # Keep stderr out of the decoded output: provider preflight warns there
+    # (e.g. model_uncataloged for the fake host config below) without
+    # dirtying the stdout envelope. System.cmd cannot capture the streams
+    # separately, so route stderr through a file.
+    stderr_path = Path.join(dir, "ptc_run_stderr.log")
+
     {output, status} =
       System.cmd(
-        System.find_executable("mix"),
-        ["ptc", "run", manifest_path, "--host-config", host_path],
+        System.find_executable("sh"),
+        [
+          "-c",
+          ~S(exec mix ptc run "$1" --host-config "$2" 2>"$3"),
+          "sh",
+          manifest_path,
+          host_path,
+          stderr_path
+        ],
         cd: dir,
-        env: env,
-        stderr_to_stdout: true
+        env: env
       )
 
-    assert status == 0, output
+    stderr = File.read!(stderr_path)
+
+    assert status == 0, output <> stderr
 
     assert Jason.decode!(output) == %{}
+
+    # Tolerate exactly the deliberate preflight warning and nothing else,
+    # whether or not the configured model is in the shipped ReqLLM catalog.
+    assert stderr == "" or stderr =~ ~r/\Awarning: model_uncataloged: [^\n]+\n+\z/, stderr
   end
 
   defp write_consumer_project(dir) do


### PR DESCRIPTION
## Why the Nightly workflow is red

`Mix.Tasks.Ptc.RunDownstreamTest` has failed the last two Nightly runs ([Aug 16](https://github.com/andreasronge/ptc_runner/actions/runs/31924455521), [Aug 17](https://github.com/andreasronge/ptc_runner/actions/runs/31991442451)) with:

```
** (Jason.DecodeError) unexpected byte at position 0: 0x77 ("w")
```

Since 1a859601 (#1417), provider preflight deliberately emits a PtcRunner-owned `model_uncataloged` warning when the configured model is not an exact ReqLLM catalog entry. The test's fake host config installs `openrouter:deepseek/deepseek-v4-flash-0731`, which is uncataloged, so every `mix ptc run` now warns on stderr at startup. The test ran the command with `stderr_to_stdout: true` and decoded the merged stream, so the warning prefix broke the JSON parse. The stdout envelope itself was never dirtied — the warning goes only to stderr — so this is a test-harness conflation, not a CLI regression. It only surfaced nightly because the test is `:nightly`-tagged and excluded from PR gates.

## Fix

Capture stderr through a file instead of merging it into stdout:

- stdout must decode to the exact `{}` run envelope, as before
- stderr must be empty or exactly one anchored `model_uncataloged` warning line — nothing else

This keeps the test's noise-catching intent on both streams while tolerating catalog drift in either direction (model gets cataloged → empty stderr still passes; stays uncataloged → the single warning still passes).

## Verification

- Reproduced the exact CI failure in a fresh worktree with the unmodified test, then confirmed it passes after the change: `mix test test/mix/tasks/ptc_run_downstream_test.exs --include nightly`
- Verified manually that the warning goes to stderr and stdout stays a clean `{}`
- codex review: no P1 findings; its P2 (substring stderr filter too permissive) is addressed by the anchored whole-content match