### PR TITLE
feat(agent): reject out-of-range bounded agent options instead of silently using defaults

### DIFF
--- a/docs/agent-library-reference.md
+++ b/docs/agent-library-reference.md
@@ -127,11 +127,14 @@ it does not add task-specific prompt policy.
 | `consolidate_at_turns_remaining` | omitted | integer, 1–effective `max_turns` | Adds generic consolidation guidance at and below this remaining-turn count. |
 | `result_envelope` | `true` | boolean | Changes only `agent.core/run`; `false` returns the raw value. |
 
-For the four `max_*` options, an out-of-range integer falls back to the
-documented default. Signature validation rejects wrong value types before the
-loop starts. `consolidate_at_turns_remaining` is different: an out-of-range
-value fails with `invalid-agent-config/invalid-consolidation-threshold` before
-a provider request.
+For the four `max_*` options, an omitted or `nil` value selects the documented
+default, and an out-of-range integer fails with
+`invalid-agent-config/option-out-of-range` before any provider request or
+mission evaluation; the failure value names the option and its accepted
+inclusive range. Signature validation rejects wrong value types before the
+loop starts. `consolidate_at_turns_remaining` fails the same way with
+`invalid-agent-config/invalid-consolidation-threshold` when set outside `1` to
+the effective `max_turns`.
 
 Omitted or `nil` `mission` selects `default`. An empty, non-string, or unknown
 mission fails; the loop never falls back to a different environment.

--- a/lib/ptc_runner/kernel/safe_metadata.ex
+++ b/lib/ptc_runner/kernel/safe_metadata.ex
@@ -22,6 +22,7 @@ defmodule PtcRunner.Kernel.SafeMetadata do
   @progress_stages ~w(started planning executing validating completed failed)
   @agent_action_kinds ~w(tool-call protocol-error provider-error)
   @failure_kinds ~w(
+    invalid-agent-config
     invalid-input
     invalid-prompt
     invalid-transcript

--- a/priv/preludes/kernel/agent.core.clj
+++ b/priv/preludes/kernel/agent.core.clj
@@ -12,10 +12,20 @@
       next-state
       (fail (result/error :invalid-prompt :invalid-transition)))))
 
-(defn- positive-int-or [value default maximum]
-  (if (and (integer? value) (pos? value) (<= value maximum))
-    value
-    default))
+;; An explicitly out-of-range option is a caller mistake, not an omission:
+;; silently substituting the default would make an invalid value
+;; indistinguishable from leaving the option out and could spend more work
+;; than the caller requested.
+(defn- bounded-option [cfg option default maximum]
+  (let [value (get cfg option)]
+    (if (nil? value)
+      default
+      (if (and (integer? value) (pos? value) (<= value maximum))
+        value
+        (fail (assoc (result/error :invalid-agent-config :option-out-of-range)
+                     :option option
+                     :min 1
+                     :max maximum))))))
 
 (defn- completed-event [type turn max-turns]
   {:type type
@@ -119,14 +129,14 @@
   generated-program error without misclassifying provider failure as subject
   behavior."
   [task cfg validate-result?]
-  (let [max-turns (positive-int-or (get cfg "max_turns") 4 128)
+  (let [max-turns (bounded-option cfg "max_turns" 4 128)
         consolidate-at-turns-remaining
         (consolidation-threshold
           (get cfg "consolidate_at_turns_remaining")
           max-turns)
-        max-program-chars (positive-int-or (get cfg "max_program_chars") 64000 1000000)
-        max-observation-chars (positive-int-or (get cfg "max_observation_chars") 2048 65536)
-        max-transcript-chars (positive-int-or (get cfg "max_transcript_chars") 262144 1000000)
+        max-program-chars (bounded-option cfg "max_program_chars" 64000 1000000)
+        max-observation-chars (bounded-option cfg "max_observation_chars" 2048 65536)
+        max-transcript-chars (bounded-option cfg "max_transcript_chars" 262144 1000000)
         effective-cfg (assoc cfg
                              "max_turns" max-turns
                              "max_program_chars" max-program-chars

--- a/test/ptc_runner/kernel/agent_library_test.exs
+++ b/test/ptc_runner/kernel/agent_library_test.exs
@@ -1183,7 +1183,7 @@ defmodule PtcRunner.Kernel.AgentLibraryTest do
     assert system =~ ~S|\u2029|
   end
 
-  test "agent.core bounds out-of-range public limit configuration" do
+  test "agent.core rejects out-of-range bounded options before any provider request" do
     response = %{
       content: nil,
       tool_calls: [
@@ -1191,13 +1191,105 @@ defmodule PtcRunner.Kernel.AgentLibraryTest do
       ]
     }
 
-    {:ok, config} = agent_config([response])
+    out_of_range = [
+      {"max_turns", 0},
+      {"max_turns", 129},
+      {"max_program_chars", 0},
+      {"max_program_chars", 1_000_001},
+      {"max_observation_chars", 0},
+      {"max_observation_chars", 65_537},
+      {"max_transcript_chars", 0},
+      {"max_transcript_chars", 1_000_001}
+    ]
 
-    assert {:ok, %{value: %{"ok" => true, "value" => 42}}} =
-             Kernel.run(
-               ~S|(agent.core/run "Compute" {"max_turns" 129 "max_program_chars" -1})|,
-               config
-             )
+    for {option, value} <- out_of_range do
+      {:ok, config} = agent_config([response])
+
+      assert {:error,
+              %{
+                kind: :workflow_failed,
+                reason: :explicit_failure,
+                details: %{failure_kind: "invalid-agent-config"},
+                usage: usage
+              }} =
+               Kernel.run(
+                 ~s|(agent.core/run "Compute" {"#{option}" #{value}})|,
+                 config
+               )
+
+      assert usage.subordinate_evaluations == 0
+      refute_receive {:agent_request, _request}
+    end
+  end
+
+  test "agent.core accepts bounded options at their documented range endpoints" do
+    response = %{
+      content: nil,
+      tool_calls: [
+        %{id: "call-1", name: "run_ptc_lisp", args: %{"program" => "(return 42)"}}
+      ]
+    }
+
+    accepted = [
+      ~S|{"max_turns" 128 "max_program_chars" 1000000 "max_observation_chars" 65536 "max_transcript_chars" 1000000}|,
+      ~S|{"max_turns" 1}|,
+      ~S|{"max_turns" nil "max_program_chars" nil "max_observation_chars" nil "max_transcript_chars" nil}|,
+      ~S|{}|
+    ]
+
+    for cfg <- accepted do
+      {:ok, config} = agent_config([response])
+
+      assert {:ok, %{value: %{"ok" => true, "value" => 42}}} =
+               Kernel.run(~s|(agent.core/run "Compute" #{cfg})|, config)
+    end
+  end
+
+  test "every agent entry rejects an out-of-range bounded option consistently" do
+    response = %{
+      content: nil,
+      tool_calls: [
+        %{id: "call-1", name: "run_ptc_lisp", args: %{"program" => "(return 42)"}}
+      ]
+    }
+
+    core_entries = [
+      ~S|(agent.core/run "Compute" {"max_turns" 0})|,
+      ~S|(return (agent.core/run-value "Compute" {"max_turns" 0}))|,
+      ~S|(return (agent.core/run-outcome "Compute" {"max_turns" 0}))|,
+      ~S|(return (agent.core/run-result-value "Compute" {"max_turns" 0}))|
+    ]
+
+    for source <- core_entries do
+      {:ok, config} = agent_config([response])
+
+      assert {:error,
+              %{
+                kind: :workflow_failed,
+                reason: :explicit_failure,
+                details: %{failure_kind: "invalid-agent-config"}
+              }} = Kernel.run(source, config)
+
+      refute_receive {:agent_request, _request}
+    end
+
+    input = %{
+      "input" => %{
+        "task" => "Compute",
+        "agent" => %{"max_turns" => 0}
+      }
+    }
+
+    {:ok, config} = agent_config([response], [], agent_main: true, input: input)
+
+    assert {:error,
+            %{
+              kind: :workflow_failed,
+              reason: :explicit_failure,
+              details: %{failure_kind: "invalid-agent-config"}
+            }} = Kernel.run("(agent.main/run data/input)", config)
+
+    refute_receive {:agent_request, _request}
   end
 
   test "agent.core rejects a consolidation threshold outside the effective turn budget" do
@@ -1268,27 +1360,6 @@ defmodule PtcRunner.Kernel.AgentLibraryTest do
     assert tool_message["role"] == "tool"
     assert tool_message["content"] =~ "Preview truncated"
     assert tool_message["content"] |> success_feedback_body() |> String.length() <= 65_536
-
-    {:ok, fallback_config} =
-      agent_config(responses, [],
-        prompt_source: tiny_prompt_source(),
-        mission_capabilities: [large_observation]
-      )
-
-    assert {:ok, _result} =
-             Kernel.run(
-               ~S|(agent.core/run "Inspect" {"max_turns" 2 "max_observation_chars" 65537 "max_transcript_chars" 1000000})|,
-               fallback_config
-             )
-
-    assert_receive {:agent_request, _first_request}
-    assert_receive {:agent_request, fallback_request}
-
-    assert fallback_request["messages"]
-           |> List.last()
-           |> Map.fetch!("content")
-           |> success_feedback_body()
-           |> String.length() <= 2_048
   end
 
   test "agent receives a bounded shape preview while full successful data remains in history" do


### PR DESCRIPTION
Closes #1456.

## Problem

The four bounded `max_*` agent options (`max_turns`, `max_program_chars`, `max_observation_chars`, `max_transcript_chars`) silently fell back to their documented defaults when an integer was outside the documented range. `{"max_turns" 0}` ran with 4 turns, making an explicitly invalid value indistinguishable from omission and able to spend more work than the caller requested.

## Change

- `agent.core` now distinguishes omission from invalid input: omitted or `nil` selects the documented default; an in-range integer is used; an out-of-range integer fails with `invalid-agent-config/option-out-of-range` — the failure value names the option and its accepted inclusive range (`:option`, `:min`, `:max`) — before any provider request or mission evaluation.
- All five entries (`agent.core/run`, `run-value`, `run-outcome`, `run-result-value`, `agent.main/run`) share the validation through `run-outcome*`.
- `invalid-agent-config` joins `SafeMetadata`'s closed public failure-kind vocabulary, so the failure class stays readable in public error details instead of being fingerprinted (this also benefits the existing consolidation-threshold and invalid-mission failures).
- Wrong value types continue to fail through the declared prelude signatures; the configuration map stays open.
- Agent library reference updated alongside the behavior.

## Verification

- New integration tests: rejection immediately below and above each option's range with no provider request and zero subordinate evaluations; acceptance at range endpoints, explicit `nil`, and full omission; per-entry consistency across all five entries.
- Removed the test half that asserted the old silent fallback.
- `mix test`: 6542 passed. `mix format --check-formatted`, `mix credo` on touched file, and `mix ptc.gen_docs` staleness all clean.
- Independent codex review (fresh, against origin/main): no actionable findings.