### PR TITLE
feat(viewer): show run labels and LLM totals

### DIFF
--- a/docs/guides/running-and-debugging.md
+++ b/docs/guides/running-and-debugging.md
@@ -34,6 +34,12 @@ Browse completed runs locally:
 ptc viewer ptc-project.json
 ```
 
+The Runs list uses a matching project `labels.name` as its readable headline,
+keeps the command run ID underneath, and shows finite label tags. When every
+successful model call reported a metric, the row also shows full-run input and
+output tokens and provider-reported cost. Missing prices or usage stay absent
+rather than being presented as zero or as a partial total.
+
 When the Live tab launches provider-backed work, pass an exact dotenv file
 with `--env-file FILE` or declare `host.env_file` in the project. The Viewer
 does not search implicitly for `.env`.

--- a/docs/trace-log-contract.md
+++ b/docs/trace-log-contract.md
@@ -339,6 +339,9 @@ sufficient to select a run without loading its activity:
 - total and subordinate-evaluation counts;
 - workflow and mission capability-call counts;
 - LLM-call summary derived from named `llm-request` events when applicable;
+- full-run `llm_usage_total` input, output, and provider-reported cost values,
+  with each field omitted unless every successful LLM call reports that field
+  and the canonical trace retained every event;
 - error count and duration summary;
 - one-way fingerprints of caller-supplied name/model/provider labels, plus
   finite canonical tag keys and enumerated values;

--- a/lib/ptc_runner/kernel/llm_usage_summary.ex
+++ b/lib/ptc_runner/kernel/llm_usage_summary.ex
@@ -9,6 +9,7 @@ defmodule PtcRunner.Kernel.LLMUsageSummary do
   @max_terminal_events 65_536
   @max_rows 128
   @max_result_bytes 1_000_000
+  @total_keys ~w(input output total_cost)
   @event_keys ~w(schema_version run_id trace_id sequence timestamp type data)
   @event_type ~r/\A[a-z][a-z0-9-]{0,127}\z/
   @name ~r/\A[a-z][a-z0-9._-]{0,127}\z/
@@ -48,6 +49,38 @@ defmodule PtcRunner.Kernel.LLMUsageSummary do
       "llm_usage_by_model" => rows(model_counters),
       "unattributed_model_calls" => unattributed
     }
+  end
+
+  @spec totals([map()]) :: map()
+  def totals(events) when is_list(events) do
+    terminal? = Enum.any?(events, &(field(&1, "type") == "run-stopped"))
+    dropped? = Enum.any?(events, &(field(&1, "type") == "events-dropped"))
+
+    if not terminal? or dropped? do
+      %{}
+    else
+      successful =
+        Enum.filter(events, fn event ->
+          llm_usage_event?(event) and stringify(field(event, "data", "status")) == "ok"
+        end)
+
+      Map.new(@total_keys, fn key -> {key, complete_total(successful, key)} end)
+      |> Map.reject(fn {_key, value} -> is_nil(value) end)
+    end
+  end
+
+  defp complete_total([], _key), do: nil
+
+  defp complete_total(events, key) do
+    Enum.reduce_while(events, 0, fn event, total ->
+      with usage when is_map(usage) <- field(event, "data", "usage"),
+           {:ok, normalized} <- LLMUsage.normalize(usage),
+           {:ok, value} <- Map.fetch(normalized, key) do
+        {:cont, total + value}
+      else
+        _missing_or_invalid -> {:halt, nil}
+      end
+    end)
   end
 
   defp reduce(events, model_lookup) do

--- a/lib/ptc_runner/kernel/trace_log.ex
+++ b/lib/ptc_runner/kernel/trace_log.ex
@@ -2598,6 +2598,7 @@ defmodule PtcRunner.Kernel.TraceLog do
       "workflow_capability_calls" => workflow_calls,
       "mission_capability_calls" => mission_calls,
       "llm_calls" => capability_name_count(events, "llm-request"),
+      "llm_usage_total" => LLMUsageSummary.totals(events),
       "error_count" => Enum.count(events, &error_event?/1),
       "duration_ms" => duration_ms(started, stopped),
       "workflow_prelude" => event_data(started, "workflow_prelude", empty_prelude()),

--- a/lib/ptc_runner/kernel/viewer_project_adapter.ex
+++ b/lib/ptc_runner/kernel/viewer_project_adapter.ex
@@ -23,6 +23,7 @@ defmodule PtcRunner.Kernel.ViewerProjectAdapter do
   alias PtcRunner.Kernel.LimitCatalog
   alias PtcRunner.Kernel.Limits
   alias PtcRunner.Kernel.Manifest
+  alias PtcRunner.Kernel.SafeMetadata
 
   @type environment :: %{
           name: binary(),
@@ -34,6 +35,7 @@ defmodule PtcRunner.Kernel.ViewerProjectAdapter do
 
   @type project :: %{
           name: binary(),
+          name_fingerprint: binary() | nil,
           manifest: binary(),
           entry: binary(),
           input: map(),
@@ -64,10 +66,12 @@ defmodule PtcRunner.Kernel.ViewerProjectAdapter do
     case Manifest.load(manifest_path, host.limits) do
       {:ok, manifest} ->
         document = manifest.document
+        label_name = get_in(document, ["labels", "name"])
 
         {:ok,
          %{
            name: Keyword.get(opts, :name) || display_name(document, manifest_path),
+           name_fingerprint: if(label_name, do: SafeMetadata.fingerprint(label_name)),
            manifest: manifest_path,
            entry: manifest.entry,
            input: manifest.input,

--- a/ptc_viewer/priv/static/css/styles.css
+++ b/ptc_viewer/priv/static/css/styles.css
@@ -152,6 +152,7 @@ button:focus-visible, textarea:focus-visible, summary:focus-visible {
 }
 .file-picker-back { flex-shrink: 0; }
 .file-picker-current { display: flex; align-items: center; gap: 10px; min-width: 0; }
+.file-picker-current-name { display: flex; flex-direction: column; min-width: 0; }
 .file-picker-current strong {
   font-family: monospace;
   font-weight: 500;
@@ -160,6 +161,8 @@ button:focus-visible, textarea:focus-visible, summary:focus-visible {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+.file-picker-current small,
+.file-picker-run-id { color: var(--muted); font: 10px monospace; }
 
 .file-picker-list { display: flex; flex-direction: column; gap: 4px; margin-top: 12px; max-height: 400px; overflow-y: auto; }
 .file-picker-item {
@@ -182,8 +185,11 @@ button:focus-visible, textarea:focus-visible, summary:focus-visible {
 .file-picker-item:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
 .file-picker-item .filename { font-family: monospace; color: var(--accent); }
 .file-picker-item .file-meta { display: flex; gap: 12px; align-items: center; flex-shrink: 0; }
+.file-picker-identity { display: flex; flex-direction: column; min-width: 0; }
 .file-picker-item .modified { font-size: 11px; color: var(--muted); }
 .file-picker-item .size { font-size: 11px; color: var(--muted); }
+.file-picker-usage { color: var(--fg); font-size: 11px; white-space: nowrap; }
+.file-picker-tag { padding: 1px 5px; border-radius: 3px; background: var(--bg-hover); color: var(--muted); font-size: 10px; white-space: nowrap; }
 
 /* === Summary Stats === */
 .summary {

--- a/ptc_viewer/priv/static/js/app.js
+++ b/ptc_viewer/priv/static/js/app.js
@@ -5,6 +5,7 @@ import { createAnalyzeButton, createReplController, nextTabName, readViewerConfi
 import { createRunCatalog } from './run-catalog.js';
 import { createLiveController, liveTokenFromSearch } from './live.js';
 import { commitCurrentLoad } from './current-load.js';
+import { displayRunName, formatRunUsage, searchableRunFields } from './run-display.js';
 import { truncate } from './utils.js';
 
 function formatDate(isoString) {
@@ -22,6 +23,7 @@ const state = {
   analyzeActions: new Set(),
   runs: [],
   page: null,
+  project: null,
   catalogGeneration: 0,
   routeGeneration: 0,
   query: '',
@@ -100,8 +102,8 @@ function renderRunPicker() {
 function matchesQuery(run, query) {
   if (!query) return true;
   const needle = query.toLowerCase();
-  return [run.run_id, run.name, run.status, run.trace_id, run.workflow_prelude?.hash]
-    .some(field => typeof field === 'string' && field.toLowerCase().includes(needle));
+  return searchableRunFields(run, state.project)
+    .some(field => field.toLowerCase().includes(needle));
 }
 
 function RunPicker() {
@@ -114,6 +116,7 @@ function RunPicker() {
   // the list. That control is the only "back to runs" affordance, replacing
   // the tab-plus-breadcrumb pair that used to sit two labels apart.
   if (selected) {
+    const displayName = displayRunName(selected, state.project);
     return html`
       <div class="file-picker-bar">
         <button type="button" class="btn secondary file-picker-back" onClick=${() => selectRun(null)}>
@@ -123,7 +126,10 @@ function RunPicker() {
           <span class=${`trace-kind badge-${selected.status === 'ok' ? 'agent' : 'error'}`}>
             ${selected.status || 'incomplete'}
           </span>
-          <strong>${selected.run_id}</strong>
+          <span class="file-picker-current-name">
+            <strong>${displayName}</strong>
+            ${displayName !== selected.run_id && html`<small>${selected.run_id}</small>`}
+          </span>
         </span>
       </div>
     `;
@@ -149,20 +155,27 @@ function RunPicker() {
 }
 
 function RunRow({ run }) {
-  // The run ID identifies the run; the bundle hash identifies the workflow and
-  // is shared by every run of it, so it is a secondary fact rather than the
-  // row's headline.
+  const displayName = displayRunName(run, state.project);
+  const usage = formatRunUsage(run.llm_usage_total);
+
   return html`
     <button type="button" class="file-picker-item" onClick=${() => selectRun(run.run_id)}>
       <span class="file-picker-main">
         <span class=${`trace-kind badge-${run.status === 'ok' ? 'agent' : 'error'}`}>
           ${run.status || 'incomplete'}
         </span>
-        <span class="filename">${run.run_id}</span>
+        <span class="file-picker-identity">
+          <span class="filename">${displayName}</span>
+          ${displayName !== run.run_id && html`<span class="file-picker-run-id">${run.run_id}</span>`}
+        </span>
       </span>
       <span class="file-meta">
         ${run.start_timestamp && html`<span class="modified">${formatDate(run.start_timestamp)}</span>`}
         <span class="size">${run.evaluations ?? 0} evaluations</span>
+        ${usage.map(value => html`<span class="file-picker-usage">${value}</span>`)}
+        ${Object.entries(run.tags || {}).map(([key, value]) => html`
+          <span class="file-picker-tag">${key}: ${value}</span>
+        `)}
         <span class="file-picker-query" title=${run.workflow_prelude?.hash || ''}>
           ${shortenHash(run.workflow_prelude?.hash)}
         </span>
@@ -333,6 +346,7 @@ function renderRun(data, { fresh = false, routeGeneration = state.routeGeneratio
 
   const container = document.getElementById('view-container');
   renderKernelTranscript(container, data, {
+    title: displayRunName(metadata, state.project),
     onLoadMore: async button => {
       button.disabled = true;
       button.textContent = 'Loading…';
@@ -462,6 +476,11 @@ if (config.live_enabled) {
   state.live = createLiveController({
     mutationNonce: config.live_mutation_nonce,
     liveToken,
+    onProject: project => {
+      state.project = project;
+      renderRunPicker();
+      if (state.currentRun) renderRun(state.currentRun);
+    },
     onInspectRun: runId => {
       void runCatalog.refresh();
       selectRun(runId);

--- a/ptc_viewer/priv/static/js/kernel-transcript.js
+++ b/ptc_viewer/priv/static/js/kernel-transcript.js
@@ -88,7 +88,7 @@ function KernelTranscript({
 
   return html`
     <section class="kernel-transcript">
-      <${Hero} metadata=${metadata} transcript=${transcript}
+      <${Hero} metadata=${metadata} transcript=${transcript} title=${options.title}
                eventCount=${events.length} truncatedPage=${partial} />
       <${Provenance} />
       <${Reference} metadata=${metadata} transcript=${transcript}
@@ -104,16 +104,16 @@ function KernelTranscript({
 
 // --- Identity and summary -------------------------------------------------
 
-function Hero({ metadata, transcript, eventCount, truncatedPage }) {
+function Hero({ metadata, transcript, title: displayTitle, eventCount, truncatedPage }) {
   const status = metadata.status || (metadata.complete ? 'complete' : 'incomplete');
   const bundle = metadata.workflow_prelude?.hash;
-  // The run ID is the identity a reader recognises and can act on; the bundle
-  // hash identifies the workflow, and two runs of one workflow share it. It
-  // stays available as a secondary fact rather than as the heading.
-  const title = metadata.run_id || metadata.name || 'Kernel run';
+  // A host-supplied display label can replace the cryptic run ID as the title;
+  // the canonical ID remains a fact readers can copy and act on.
+  const title = displayTitle || metadata.run_id || metadata.name || 'Kernel run';
   // Sanitized traces carry hashed model/provider identities; they are shown
   // abbreviated with the full value on hover, like every other digest here.
   const facts = [
+    ['Run ID', title !== metadata.run_id ? metadata.run_id : null],
     ['Trace', metadata.trace_id],
     ['Duration', duration(metadata.duration_ms)],
     ['Model', abbreviate(metadata.model), metadata.model],

--- a/ptc_viewer/priv/static/js/live.js
+++ b/ptc_viewer/priv/static/js/live.js
@@ -27,7 +27,7 @@ export function launchPollDelay(responseOk, launch) {
   return launch?.status === 'running' ? 1500 : null;
 }
 
-export function createLiveController({ onInspectRun, onLiveCount, mutationNonce, liveToken } = {}) {
+export function createLiveController({ onInspectRun, onLiveCount, onProject, mutationNonce, liveToken } = {}) {
   const runsEl = document.getElementById('live-runs');
   const runsHeadEl = document.getElementById('live-runs-head');
   const clearEndedEl = document.getElementById('live-clear-ended');
@@ -53,6 +53,7 @@ export function createLiveController({ onInspectRun, onLiveCount, mutationNonce,
   // launch card's environment chips.
   loadProject(liveToken)
     .then(project => {
+      onProject?.(project);
       initProject(projectEl, project);
       return initLaunch(launchEl, project, mutationNonce, liveToken);
     })

--- a/ptc_viewer/priv/static/js/run-display.js
+++ b/ptc_viewer/priv/static/js/run-display.js
@@ -1,0 +1,34 @@
+const FINGERPRINT = /^sha256:[0-9a-f]{64}$/;
+
+export function displayRunName(run, project) {
+  if (project?.name && project?.name_fingerprint && run?.name === project.name_fingerprint) {
+    return project.name;
+  }
+
+  if (typeof run?.name === 'string' && !FINGERPRINT.test(run.name)) return run.name;
+  return run?.run_id || 'Unknown run';
+}
+
+export function formatRunUsage(usage) {
+  if (!usage || typeof usage !== 'object') return [];
+
+  const fields = [];
+  if (Number.isSafeInteger(usage.input) && usage.input >= 0) fields.push(`${usage.input.toLocaleString('en-US')} in`);
+  if (Number.isSafeInteger(usage.output) && usage.output >= 0) fields.push(`${usage.output.toLocaleString('en-US')} out`);
+  if (typeof usage.total_cost === 'number' && Number.isFinite(usage.total_cost) && usage.total_cost >= 0) {
+    fields.push(`cost ${usage.total_cost.toLocaleString('en-US', { maximumSignificantDigits: 6 })}`);
+  }
+  return fields;
+}
+
+export function searchableRunFields(run, project) {
+  return [
+    run?.run_id,
+    run?.name,
+    displayRunName(run, project),
+    run?.status,
+    run?.trace_id,
+    run?.workflow_prelude?.hash,
+    ...Object.entries(run?.tags || {}).flat()
+  ].filter(field => typeof field === 'string');
+}

--- a/ptc_viewer/test/ptc_viewer/run_display_test.exs
+++ b/ptc_viewer/test/ptc_viewer/run_display_test.exs
@@ -1,0 +1,8 @@
+defmodule PtcViewer.RunDisplayTest do
+  use ExUnit.Case, async: true
+
+  test "run names and usage totals have stable user-facing projections" do
+    script = Path.expand("../run_display.mjs", __DIR__)
+    assert {"ok", 0} = System.cmd("node", [script], stderr_to_stdout: true)
+  end
+end

--- a/ptc_viewer/test/run_display.mjs
+++ b/ptc_viewer/test/run_display.mjs
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict';
+import {
+  displayRunName,
+  formatRunUsage,
+  searchableRunFields
+} from '../priv/static/js/run-display.js';
+
+const run = {
+  run_id: 'cmd-616240gsqd5q3hrzd857ar9xzh',
+  name: `sha256:${'a'.repeat(64)}`,
+  tags: { mode: 'agent' },
+  llm_usage_total: { input: 12345, output: 678, total_cost: 0.0042 }
+};
+
+const matchingProject = { name: 'chief-of-staff-02-granting-data', name_fingerprint: run.name };
+assert.equal(displayRunName(run, matchingProject), 'chief-of-staff-02-granting-data');
+assert.equal(displayRunName(run, { name: 'another-project', name_fingerprint: `sha256:${'b'.repeat(64)}` }), run.run_id);
+assert.equal(displayRunName({ ...run, name: 'readable-legacy-name' }, null), 'readable-legacy-name');
+
+assert.deepEqual(formatRunUsage(run.llm_usage_total), [
+  '12,345 in',
+  '678 out',
+  'cost 0.0042'
+]);
+assert.deepEqual(formatRunUsage({ input: 0, output: 0, total_cost: 0 }), [
+  '0 in',
+  '0 out',
+  'cost 0'
+]);
+assert.deepEqual(formatRunUsage({ input: 7 }), ['7 in']);
+assert.deepEqual(formatRunUsage(null), []);
+
+assert(searchableRunFields(run, matchingProject).includes('chief-of-staff-02-granting-data'));
+assert(searchableRunFields(run, matchingProject).includes('agent'));
+
+process.stdout.write('ok');

--- a/test/ptc_runner/kernel/llm_usage_summary_test.exs
+++ b/test/ptc_runner/kernel/llm_usage_summary_test.exs
@@ -129,6 +129,54 @@ defmodule PtcRunner.Kernel.LLMUsageSummaryTest do
     end
   end
 
+  test "run totals publish only metrics reported by every successful call" do
+    complete = [
+      llm_stopped_event(1, %{"input" => 3, "output" => 2, "total_cost" => 0.25}),
+      llm_stopped_event(2, %{"input" => 5, "output" => 4, "total_cost" => 0.5}),
+      event(3, "run-stopped", %{"outcome" => "ok"})
+    ]
+
+    assert LLMUsageSummary.totals(complete) == %{
+             "input" => 8,
+             "output" => 6,
+             "total_cost" => 0.75
+           }
+
+    partially_reported = [
+      llm_stopped_event(1, %{"input" => 3, "output" => 2, "total_cost" => 0.25}),
+      llm_stopped_event(2, %{"input" => 5}),
+      event(3, "run-stopped", %{"outcome" => "ok"})
+    ]
+
+    assert LLMUsageSummary.totals(partially_reported) == %{"input" => 8}
+  end
+
+  test "run totals are unavailable when usage or trace events are missing" do
+    missing_usage =
+      event(1, "capability-stopped", %{
+        "environment" => "workflow",
+        "name" => "llm-request",
+        "alias" => "writer",
+        "installation_revision" => "stable-v1",
+        "status" => "ok"
+      })
+
+    assert LLMUsageSummary.totals([
+             missing_usage,
+             event(2, "run-stopped", %{"outcome" => "ok"})
+           ]) == %{}
+
+    assert LLMUsageSummary.totals([llm_stopped_event(1, %{"input" => 3})]) == %{}
+
+    dropped = [
+      llm_stopped_event(1, %{"input" => 3, "output" => 2, "total_cost" => 0.25}),
+      event(2, "events-dropped", %{"counts" => %{"capability-stopped" => 1}}),
+      event(3, "run-stopped", %{"outcome" => "ok"})
+    ]
+
+    assert LLMUsageSummary.totals(dropped) == %{}
+  end
+
   defp event(sequence, type, data) do
     %{
       "schema_version" => 2,

--- a/test/ptc_runner/kernel/trace_log_test.exs
+++ b/test/ptc_runner/kernel/trace_log_test.exs
@@ -1124,6 +1124,37 @@ defmodule PtcRunner.Kernel.TraceLogTest do
              TraceLog.query_loaded(events, "models", :counters, %{}, 100, :sanitized)
   end
 
+  test "run summaries expose complete per-run LLM usage totals" do
+    events = [
+      decoded_event("usage-total", 1, "run-started"),
+      decoded_event("usage-total", 2, "capability-stopped", %{
+        "environment" => "workflow",
+        "name" => "llm-request",
+        "alias" => "writer",
+        "installation_revision" => "stable-v1",
+        "status" => "ok",
+        "usage" => %{"input" => 120, "output" => 30, "total_cost" => 0.0042}
+      }),
+      decoded_event("usage-total", 3, "run-stopped", %{"outcome" => "ok"})
+    ]
+
+    assert {:ok, %{"items" => [run]}} =
+             TraceLog.query_loaded(
+               events,
+               "usage-total",
+               :list_runs,
+               %{},
+               100_000,
+               :sanitized
+             )
+
+    assert run["llm_usage_total"] == %{
+             "input" => 120,
+             "output" => 30,
+             "total_cost" => 0.0042
+           }
+  end
+
   test "invalid or ambiguous LLM snapshots make calls unattributed without failing counters" do
     valid = TestHelpers.llm_snapshot("writer", "stable-v1", "openrouter:vendor/model-a")
     tampered = put_in(valid, ["acquisition", "resolved_model"], "openrouter:vendor/model-b")

--- a/test/ptc_runner/kernel/viewer_project_adapter_test.exs
+++ b/test/ptc_runner/kernel/viewer_project_adapter_test.exs
@@ -2,6 +2,7 @@ defmodule PtcRunner.Kernel.ViewerProjectAdapterTest do
   use ExUnit.Case, async: true
 
   alias PtcRunner.Kernel.LimitCatalog
+  alias PtcRunner.Kernel.SafeMetadata
   alias PtcRunner.Kernel.ViewerProjectAdapter
 
   @demo_manifest "examples/viewer-live-dashboard/ptc.json"
@@ -14,6 +15,7 @@ defmodule PtcRunner.Kernel.ViewerProjectAdapterTest do
 
     test "reports its label, entry, and the path as configured", %{project: project} do
       assert project.name == "live-dashboard-demo"
+      assert project.name_fingerprint == SafeMetadata.fingerprint("live-dashboard-demo")
       assert project.manifest == @demo_manifest
       assert project.entry == "demo.live/run"
       assert %{"topics" => topics} = project.input


### PR DESCRIPTION
## Summary

- show a matching project labels.name as the readable Runs-list and run-detail headline while retaining the canonical run ID
- show finite run tags plus complete full-run input/output tokens and provider-reported cost
- omit each accounting metric unless every successful LLM call reported it; omit all totals for incomplete or event-dropped traces
- document the Viewer behavior and trace projection

## Verification

- mix precommit (6,594 root tests, 109 Viewer tests, 42 launcher tests, static analysis, Dialyzer, docs/schema checks, package and release verification)
- MIX_ENV=dev mix docs --warnings-as-errors
- browser-tested the Runs catalog and selected-run view with a matching project label, tags, input/output totals, and cost

One unrelated provider-session cleanup timing test failed on the first full precommit pass, passed at the exact reported line and seed, and the complete precommit rerun passed.