### PR TITLE
fix(viewer): combine private evidence with public REPL

### DIFF
--- a/docs/reference/project-files.md
+++ b/docs/reference/project-files.md
@@ -84,7 +84,11 @@ absolute paths and `..` traversal are rejected. The generated schema is
 
 Inspection requires traces because private records must correlate with a
 canonical run. `viewer.private` is a separate explicit local grant: creating a
-private artifact does not automatically expose it to Viewer.
+private artifact does not automatically expose it to Viewer. `viewer.repl`
+independently enables the browser REPL, including when `viewer.private` is
+`true`. REPL evaluations remain fixed to the public `run-analysis-v1` profile
+and its immutable normal-trace snapshot; they cannot query the private evidence
+displayed elsewhere in the Viewer.
 
 ## Artifact layout
 
@@ -143,6 +147,10 @@ and correlated inspection directories are captured before the listener starts;
 HTTP requests select only a run ID and never a filesystem path. Browser opening
 is a bounded convenience, and additionally requires an attached terminal:
 missing or failing platform openers do not stop Viewer.
+
+The REPL and private-data settings are orthogonal. Enabling both presents the
+public-trace REPL alongside the private evidence panels without adding private
+inspection authority to the evaluation session.
 
 Viewer-started workflows and missions use the project's `host.env_file` when
 one is declared. `ptc viewer ptc-project.json --env-file FILE` supplies an

--- a/lib/ptc_runner/viewer_frontend.ex
+++ b/lib/ptc_runner/viewer_frontend.ex
@@ -339,8 +339,8 @@ defmodule PtcRunner.ViewerFrontend do
       live_trace_refresh: fn run_id -> ViewerSnapshotStore.refresh(snapshots, run_id) end,
       launch: launch_spec(project, callbacks.frontend, callbacks.env_file),
       project_adapter: fn -> describe_project(project) end,
-      repl_adapter: repl_adapter(project, private?),
-      repl_config: repl_config(project, private?)
+      repl_adapter: repl_adapter(project),
+      repl_config: repl_config(project)
     ]
   end
 
@@ -389,15 +389,15 @@ defmodule PtcRunner.ViewerFrontend do
     ViewerProjectAdapter.describe(project.application, opts)
   end
 
-  defp repl_adapter(%{viewer: %{repl: true}}, false),
+  defp repl_adapter(%{viewer: %{repl: true}}),
     do: PtcRunner.Kernel.ViewerReplAdapter
 
-  defp repl_adapter(_project, _private?), do: nil
+  defp repl_adapter(_project), do: nil
 
-  defp repl_config(%{viewer: %{repl: true}, artifact_root: root}, false),
+  defp repl_config(%{viewer: %{repl: true}, artifact_root: root}),
     do: %{trace_dir: Path.join(root, "traces"), profile_id: "run-analysis-v1"}
 
-  defp repl_config(_project, _private?), do: %{}
+  defp repl_config(_project), do: %{}
 
   defp valid_env_file?(nil), do: true
 

--- a/ptc_viewer/priv/static/css/styles.css
+++ b/ptc_viewer/priv/static/css/styles.css
@@ -1878,6 +1878,17 @@ button:focus-visible, textarea:focus-visible, summary:focus-visible {
   border-radius: 7px;
   background: rgba(86, 156, 214, 0.07);
 }
+.repl-authority-badge {
+  display: inline-block;
+  margin-right: 8px;
+  padding: 2px 7px;
+  border: 1px solid rgba(86, 156, 214, 0.55);
+  border-radius: 999px;
+  color: #9cdcfe;
+  font-size: 0.78rem;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
 .repl-provenance code { color: #9cdcfe; }
 .repl-session-strip {
   display: flex;

--- a/ptc_viewer/priv/static/index.html
+++ b/ptc_viewer/priv/static/index.html
@@ -48,8 +48,10 @@
       <div id="repl-status" class="repl-status" role="status" aria-live="polite"></div>
 
       <div class="repl-provenance">
-        PTC-Lisp executes only against an immutable normal-trace snapshot using the
+        <strong class="repl-authority-badge">Public trace only</strong>
+        PTC-Lisp executes against an immutable normal-trace snapshot using the
         <span id="repl-profile-banner">server-selected analysis profile</span>.
+        Private evidence shown elsewhere in the Viewer is unavailable to evaluations.
       </div>
 
       <div id="repl-session-strip" class="repl-session-strip" aria-label="Session summary">

--- a/test/ptc_runner/viewer_frontend_test.exs
+++ b/test/ptc_runner/viewer_frontend_test.exs
@@ -26,6 +26,34 @@ defmodule PtcRunner.ViewerFrontendTest do
   end
 
   @tag :tmp_dir
+  test "the private-data grant and public analysis REPL can be enabled together", %{
+    tmp_dir: directory
+  } do
+    project_path = viewer_project(directory, %{"private" => true, "repl" => true})
+
+    assert {:ok, viewer, address, port} = ViewerFrontend.start(project_path)
+    on_exit(fn -> if Process.alive?(viewer), do: PtcViewer.stop(viewer) end)
+
+    origin = "http://#{:inet.ntoa(address)}:#{port}"
+    page_config = viewer_page_config(origin)
+
+    assert page_config["repl_enabled"] == true
+
+    bootstrap =
+      Req.get!(origin <> "/api/repl",
+        headers: [
+          {"sec-fetch-site", "same-origin"},
+          {"x-ptc-viewer-page-nonce", page_config["page_bootstrap_nonce"]}
+        ]
+      )
+
+    assert bootstrap.status == 200
+    assert bootstrap.body["session"]["profile_id"] == "run-analysis-v1"
+    assert bootstrap.body["session"]["namespaces"] == ["analysis", "cap"]
+    assert :ok = PtcViewer.stop(viewer)
+  end
+
+  @tag :tmp_dir
   test "project command configures Live project details and its fixed launch target", %{
     tmp_dir: directory
   } do
@@ -295,6 +323,12 @@ defmodule PtcRunner.ViewerFrontendTest do
   end
 
   defp live_nonce(base_url) do
+    base_url
+    |> viewer_page_config()
+    |> Map.fetch!("live_mutation_nonce")
+  end
+
+  defp viewer_page_config(base_url) do
     assert {:ok, %{status: 200, body: body}} = Req.get(base_url <> "/")
 
     [encoded] =
@@ -305,7 +339,6 @@ defmodule PtcRunner.ViewerFrontendTest do
     encoded
     |> Base.url_decode64!(padding: false)
     |> Jason.decode!()
-    |> Map.fetch!("live_mutation_nonce")
   end
 
   defp launch_workflow(base_url, nonce, input) do


### PR DESCRIPTION
## Summary

- allow `viewer.private` and `viewer.repl` in the same Viewer instance
- keep REPL evaluation fixed to the public `run-analysis-v1` profile and label that authority in the UI
- document the orthogonal grants and add a regression test for the combined configuration

## Root cause

The Viewer frontend omitted its REPL adapter whenever private panels were enabled, even though the REPL backend already fixes each session to public-trace authority. That silently coupled display access to evaluation authority.

## Validation

- `mix precommit`
- `MIX_ENV=dev mix docs --warnings-as-errors`
- focused Viewer frontend and REPL HTTP tests: 15 passed
- nested Viewer suite: 108 passed
- full pre-push gate, including 6,592 core tests, static analysis, Dialyzer, release verification, docs, and Viewer validation
- browser-tested the chapter 2 tutorial Viewer: private generated source and model conversation remain visible, the REPL renders its “Public trace only” badge, and `(analysis/runs {"limit" 1})` evaluates successfully
- one independent Codex review with no actionable findings