### PR TITLE
fix(cli): make the init scaffold return the documented greeting

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ ptc run hello-ptc/ptc-project.json
 ```
 
 ```json
-{}
+{"greeting":"hello world"}
 ```
 
 This verifies the executable and creates a structured trace without contacting

--- a/docs/guides/manifests-and-capabilities.md
+++ b/docs/guides/manifests-and-capabilities.md
@@ -21,10 +21,10 @@ The generated application is deliberately small:
 {
   "version": 1,
   "workflow": {
-    "components": [{"id": "app.main", "path": "main.clj"}],
-    "entry": "app.main/run"
+    "components": [{"id": "main", "path": "main.clj"}],
+    "entry": "main/run"
   },
-  "input": {"value": {}}
+  "input": {"value": {"name": "world"}}
 }
 ```
 

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -19,7 +19,7 @@ ptc run hello-ptc/ptc-project.json
 ```
 
 ```json
-{}
+{"greeting":"hello world"}
 ```
 
 `init` creates an application, a project document with local artifact settings,

--- a/lib/ptc_runner/kernel/command_initializer.ex
+++ b/lib/ptc_runner/kernel/command_initializer.ex
@@ -23,7 +23,7 @@ defmodule PtcRunner.Kernel.CommandInitializer do
   (ns main)
 
   (defn run [input]
-    (return input))
+    (return {"greeting" (str "hello " (get input "name"))}))
   """
 
   @manifest """
@@ -39,7 +39,7 @@ defmodule PtcRunner.Kernel.CommandInitializer do
       "entry": "main/run"
     },
     "input": {
-      "value": {}
+      "value": {"name": "world"}
     }
   }
   """

--- a/test/ptc_runner/kernel/command_initializer_test.exs
+++ b/test/ptc_runner/kernel/command_initializer_test.exs
@@ -14,7 +14,7 @@ defmodule PtcRunner.Kernel.CommandInitializerTest do
   (ns main)
 
   (defn run [input]
-    (return input))
+    (return {"greeting" (str "hello " (get input "name"))}))
   """
 
   @manifest """
@@ -30,7 +30,7 @@ defmodule PtcRunner.Kernel.CommandInitializerTest do
       "entry": "main/run"
     },
     "input": {
-      "value": {}
+      "value": {"name": "world"}
     }
   }
   """

--- a/test/ptc_runner/kernel/project_command_test.exs
+++ b/test/ptc_runner/kernel/project_command_test.exs
@@ -15,8 +15,10 @@ defmodule PtcRunner.Kernel.ProjectCommandTest do
     assert {:ok, %CommandOutcome{}} = CommandEngine.dispatch(["init", target])
     project = Path.join(target, "ptc-project.json")
 
-    assert {:ok, %CommandOutcome{envelope: %{"status" => "ok", "run_ref" => run_ref}}} =
+    assert {:ok, %CommandOutcome{envelope: %{"status" => "ok", "run_ref" => run_ref} = envelope}} =
              CommandEngine.dispatch(["run", project])
+
+    assert envelope["result"]["value"] == %{"greeting" => "hello world"}
 
     assert [trace] = Path.wildcard(Path.join([target, ".ptc", "traces", "*.jsonl"]))
     assert File.regular?(trace)

--- a/test/ptc_runner/viewer_launch_adapter_test.exs
+++ b/test/ptc_runner/viewer_launch_adapter_test.exs
@@ -16,7 +16,7 @@ defmodule PtcRunner.ViewerLaunchAdapterTest do
 
     project = Path.join(target, "ptc-project.json")
     input_name = "viewer-input.json"
-    File.write!(Path.join(target, input_name), Jason.encode!(%{"hello" => "viewer"}))
+    File.write!(Path.join(target, input_name), Jason.encode!(%{"name" => "viewer"}))
     test_process = self()
 
     report = fn run_id, frame ->
@@ -35,7 +35,7 @@ defmodule PtcRunner.ViewerLaunchAdapterTest do
                report
              )
 
-    assert output =~ "viewer"
+    assert output =~ "hello viewer"
     assert_receive {:live_frame, run_id, %{phase: "ok", label: "hello-ptc · hello.core/run"}}
     assert is_binary(run_id)
   end


### PR DESCRIPTION
## What

`ptc init`'s scaffold was an identity workflow returning its empty input, so the primary onboarding example (README and quickstart) printed `{}` — demonstrating nothing. The generated `main.clj` now builds a greeting from the manifest input (`{"name": "world"}`):

```clojure
(ns main)

(defn run [input]
  (return {"greeting" (str "hello " (get input "name"))}))
```

Three lines that demonstrate input access, a built-in call, and a structured return, and `ptc init hello-ptc && ptc run hello-ptc/ptc-project.json` now prints `{"greeting":"hello world"}`.

## Also aligned

- `README.md` and `docs/guides/quickstart.md`: example output `{}` → `{"greeting":"hello world"}`
- `docs/guides/manifests-and-capabilities.md`: the quoted generated manifest had already drifted (`app.main` vs actual `main`); now matches the real scaffold including the new input
- `viewer_launch_adapter_test`: the alternate-input test relied on the identity scaffold; it now feeds `{"name":"viewer"}` and asserts `hello viewer`, which proves the same input flow more strongly

## Verification

- Failing-first envelope assertion added to `project_command_test` (was `"value" => %{}`)
- Real CLI smoke: `mix ptc init && mix ptc run` prints exactly `{"greeting":"hello world"}` (example tests use `:native` projection, so the suite alone doesn't prove the CLI path)
- All init-dispatching test files pass: command_initializer, project_command, command_engine, command_frontend, viewer_frontend, viewer_launch_adapter (224 tests)
- `MIX_ENV=dev mix docs --warnings-as-errors` clean
- Codex independent review: one P2 (README output still `{}`), fixed in 8aa95c6a; no other findings