### PR TITLE
fix(kernel): make both forensic surfaces report what they withheld

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Reconstructed conversations carry the `system` prompt that shaped each turn.
+  It appears on the first turn of every stream and on every later turn whose
+  prompt differs from the one before it, so `ptc transcript` and the Viewer's
+  conversation view no longer certify a transcript as complete while omitting
+  the instructions the run was given. Stream linkage keys on request messages
+  alone, so an absent `system` means "unchanged since the previous turn of this
+  stream" rather than "none was sent".
+
 - Raised capability callbacks now retain their bounded exception class,
   message, and formatted stacktrace only in explicitly enabled private
   inspection. Inspection V7 correlates that sensitive evidence with the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,11 +26,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reconstructed conversations carry the `system` prompt that shaped each turn,
   so `ptc transcript` and the Viewer's conversation view no longer certify a
   transcript as complete while omitting the instructions the run was given.
-  Every `turns` item keeps its own prompt, since that collection is filtered
-  and paginated; a presented conversation repeats it only when it changes, and
-  the first turn of every presented stream always carries it. Stream linkage
-  keys on request messages alone, so an elided `system` means "unchanged since
-  the previous presented turn" rather than "none was sent".
+  Each returned page is compacted on its own, after filtering and pagination,
+  so every stream in a page starts with its effective prompt while an unchanged
+  prompt is not repeated on every turn. Stream linkage keys on request messages
+  alone, so an elided `system` means "unchanged since the last turn in this
+  page that carried one" rather than "none was sent".
 
 - A run listing or counters query now reports the trace files its source kind
   refused to read, as `excluded_private_trace_files` or

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   alone, so an absent `system` means "unchanged since the previous turn of this
   stream" rather than "none was sent".
 
+- A run listing or counters query now reports the trace files its source kind
+  refused to read, as `excluded_private_trace_files` or
+  `excluded_sanitized_trace_files`. A project whose traces are all private no
+  longer answers an empty Viewer run list as though no runs existed; the run
+  picker names the exclusion and the `viewer.private` setting that reads them.
+  `omitted_count` keeps its single pagination meaning.
+
 - Raised capability callbacks now retain their bounded exception class,
   message, and formatted stacktrace only in explicitly enabled private
   inspection. Inspection V7 correlates that sensitive evidence with the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,13 +23,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Reconstructed conversations carry the `system` prompt that shaped each turn.
-  It appears on the first turn of every stream and on every later turn whose
-  prompt differs from the one before it, so `ptc transcript` and the Viewer's
-  conversation view no longer certify a transcript as complete while omitting
-  the instructions the run was given. Stream linkage keys on request messages
-  alone, so an absent `system` means "unchanged since the previous turn of this
-  stream" rather than "none was sent".
+- Reconstructed conversations carry the `system` prompt that shaped each turn,
+  so `ptc transcript` and the Viewer's conversation view no longer certify a
+  transcript as complete while omitting the instructions the run was given.
+  Every `turns` item keeps its own prompt, since that collection is filtered
+  and paginated; a presented conversation repeats it only when it changes, and
+  the first turn of every presented stream always carries it. Stream linkage
+  keys on request messages alone, so an elided `system` means "unchanged since
+  the previous presented turn" rather than "none was sent".
 
 - A run listing or counters query now reports the trace files its source kind
   refused to read, as `excluded_private_trace_files` or

--- a/docs/reference/debug-navigation.md
+++ b/docs/reference/debug-navigation.md
@@ -229,6 +229,18 @@ A diagnosis is supported when every edge it rests on is `complete` and the
 pages it read were not truncated. Otherwise the honest report is insufficient
 evidence, naming which edge was missing.
 
+### What the completeness fields do and do not claim
+
+A conversation's `complete?` is the conjunction of three specific facts: the
+canonical run reached a terminal event with no dropped events, no expected
+model exchange is missing, and no turn or generated-source association is
+ambiguous. It is a statement about the reconstruction, not a promise that every
+field of every record is present. `ptc transcript` refuses to write a file at
+all unless `complete?` holds and `ambiguous?` does not, so that field is always
+`true` in a published transcript; read it over
+`/api/analysis/runs/{id}/conversation`, which applies no such gate, when you
+need it to be able to say no.
+
 ## Run the credential-free example
 
 The checked-in example needs no credential or network access. `target/` prices

--- a/docs/reference/debug-navigation.md
+++ b/docs/reference/debug-navigation.md
@@ -241,6 +241,21 @@ all unless `complete?` holds and `ambiguous?` does not, so that field is always
 `/api/analysis/runs/{id}/conversation`, which applies no such gate, when you
 need it to be able to say no.
 
+`omitted_count` is pagination: how many selected items this page did not
+return. It never reports evidence withheld by policy. A source grant that
+withheld trace files of the other kind reports that separately, as
+`excluded_private_trace_files` or `excluded_sanitized_trace_files` on a run
+listing or counters query.
+
+### Join on correlation ids, never on sequence numbers
+
+A transcript turn and a canonical trace event live in different sequence
+spaces. Turn `request_sequence` orders records inside the inspection snapshot;
+canonical `sequence` orders the run's event stream. Turn 1 reporting request
+sequence 12 says nothing about canonical event 12, which is an unrelated
+record. Correlation identifiers — `capability-5`, `mission-evaluation-9` — are
+the same in both artifacts and are the only sound join key.
+
 ## Run the credential-free example
 
 The checked-in example needs no credential or network access. `target/` prices

--- a/docs/trace-log-contract.md
+++ b/docs/trace-log-contract.md
@@ -481,13 +481,17 @@ turn with the newly added messages, response, matching generated programs, and
 stable stream/turn identity. Turn numbers start at one independently within
 each reconstructed stream; `{stream_id, turn}` is the identity, while
 `request_sequence` only orders records inside the inspection snapshot. It must
-not be compared with canonical activity sequence numbers. A turn carries the
-`system` prompt that shaped it whenever that prompt differs from the previous
-turn of the same stream, and the first turn of every stream always carries it.
-An absent `system` therefore means "unchanged since the previous turn", never
-"none was sent": stream linkage keys on the request messages alone, so one
-stream can span turns whose evaluated program supplied different prompts. Exact
-raw model requests remain available through `model_exchanges`. Page-level
+not be compared with canonical activity sequence numbers. Every `turns` item
+carries the `system` prompt that shaped it, because the collection is filtered
+and paginated: a caller must never receive a turn whose prompt was elided
+against a turn it did not receive. A presented conversation is the whole
+selection at once, so there an unchanged prompt is elided and only changes are
+repeated; the first turn of every presented stream always carries its prompt.
+An elided `system` means "unchanged since the previous presented turn of this
+stream", never "none was sent": stream linkage keys on the request messages
+alone, so one stream can span turns whose evaluated program supplied different
+prompts. Exact raw model requests remain available through `model_exchanges`.
+Page-level
 `evidence` reports canonical completeness, missing exchanges, and ambiguity
 separately from pagination. Interrupted model inputs remain raw evidence but
 are excluded from `turns`, so the canonical missing-exchange count records the

--- a/docs/trace-log-contract.md
+++ b/docs/trace-log-contract.md
@@ -470,9 +470,13 @@ turn with the newly added messages, response, matching generated programs, and
 stable stream/turn identity. Turn numbers start at one independently within
 each reconstructed stream; `{stream_id, turn}` is the identity, while
 `request_sequence` only orders records inside the inspection snapshot. It must
-not be compared with canonical activity sequence numbers. The collection omits
-the repeated system prompt; exact raw model requests remain available through
-`model_exchanges`. Page-level
+not be compared with canonical activity sequence numbers. A turn carries the
+`system` prompt that shaped it whenever that prompt differs from the previous
+turn of the same stream, and the first turn of every stream always carries it.
+An absent `system` therefore means "unchanged since the previous turn", never
+"none was sent": stream linkage keys on the request messages alone, so one
+stream can span turns whose evaluated program supplied different prompts. Exact
+raw model requests remain available through `model_exchanges`. Page-level
 `evidence` reports canonical completeness, missing exchanges, and ambiguity
 separately from pagination. Interrupted model inputs remain raw evidence but
 are excluded from `turns`, so the canonical missing-exchange count records the

--- a/docs/trace-log-contract.md
+++ b/docs/trace-log-contract.md
@@ -92,6 +92,17 @@ JSONL files are written in canonical sequence order. Directory loading is
 deterministic: discover supported files, normalize paths, sort them, then load
 in sorted order under one aggregate byte cap.
 
+One directory holds both sanitized and private trace files, and one source
+grant reads exactly one kind. A run listing and a counters query therefore
+report the trace files that grant refused to read, as
+`excluded_private_trace_files` on a sanitized source and
+`excluded_sanitized_trace_files` on a private-only source. The field is absent
+when nothing was excluded, and inspection artifacts are never counted: they are
+a separate artifact class rather than withheld runs. Run-scoped answers never
+carry the field. The count is advisory evidence about the directory, not part
+of the source identity, so a concurrent write to the kind a grant does not read
+never invalidates the evidence it does read.
+
 Normal trace sinks sanitize before persistence. Private canonical event sinks
 use the separate fail-closed policy specified by the event-sink section of the
 `PtcRunner.Kernel.EventSink` module documentation, but retain the same event
@@ -592,7 +603,8 @@ Every collection query has:
 - a deterministic opaque cursor;
 - deterministic ordering and tie-breakers;
 - maximum encoded and retained result sizes under one result ceiling;
-- truncation and omitted-count metadata;
+- truncation and omitted-count metadata, which report pagination only and
+  never source-kind exclusion;
 - one aggregate source-read byte cap;
 - bounded filter/tag/name lengths and counts.
 

--- a/docs/trace-log-contract.md
+++ b/docs/trace-log-contract.md
@@ -481,17 +481,16 @@ turn with the newly added messages, response, matching generated programs, and
 stable stream/turn identity. Turn numbers start at one independently within
 each reconstructed stream; `{stream_id, turn}` is the identity, while
 `request_sequence` only orders records inside the inspection snapshot. It must
-not be compared with canonical activity sequence numbers. Every `turns` item
-carries the `system` prompt that shaped it, because the collection is filtered
-and paginated: a caller must never receive a turn whose prompt was elided
-against a turn it did not receive. A presented conversation is the whole
-selection at once, so there an unchanged prompt is elided and only changes are
-repeated; the first turn of every presented stream always carries its prompt.
-An elided `system` means "unchanged since the previous presented turn of this
-stream", never "none was sent": stream linkage keys on the request messages
-alone, so one stream can span turns whose evaluated program supplied different
-prompts. Exact raw model requests remain available through `model_exchanges`.
-Page-level
+not be compared with canonical activity sequence numbers. A turn carries the
+`system` prompt that shaped it. Each returned page is compacted on its own,
+after filtering and pagination, so every stream present in a page starts with
+its effective prompt and an unchanged prompt is not repeated on every turn.
+An elided `system` therefore means "unchanged since the last turn in this page
+that carried one", never "none was sent": stream linkage keys on the request
+messages alone, so one stream can span turns whose evaluated program supplied
+different prompts. Compaction is idempotent, so a presented conversation
+re-compacts the pages it collected without losing a prompt at a page seam.
+Exact raw model requests remain available through `model_exchanges`. Page-level
 `evidence` reports canonical completeness, missing exchanges, and ambiguity
 separately from pagination. Interrupted model inputs remain raw evidence but
 are excluded from `turns`, so the canonical missing-exchange count records the

--- a/lib/ptc_runner/kernel/conversation_projection.ex
+++ b/lib/ptc_runner/kernel/conversation_projection.ex
@@ -130,17 +130,40 @@ defmodule PtcRunner.Kernel.ConversationProjection do
   # the first turn of every presented stream always carries its prompt.
   defp elide_repeated_system(turns) do
     turns
-    |> Enum.map_reduce(:no_previous_turn, fn turn, previous ->
-      {elide_unchanged_system(turn, previous), {:previous_system, turn["system"]}}
+    |> Enum.map_reduce(:no_previous_turn, &elide_system/2)
+    |> elem(0)
+  end
+
+  # An elided turn still means "same prompt as the last one that carried it",
+  # so comparison tracks the last present value rather than the previous turn.
+  # That makes the compaction idempotent, which is what lets a page be
+  # compacted once on the way out and again on the way into a presentation.
+  defp elide_system(turn, last) do
+    cond do
+      not Map.has_key?(turn, "system") -> {turn, last}
+      last == {:system, turn["system"]} -> {Map.delete(turn, "system"), last}
+      true -> {turn, {:system, turn["system"]}}
+    end
+  end
+
+  @doc false
+  @spec compact_turns([map()]) :: [map()]
+  # Applied to one selected page of `turns`, after filtering and pagination.
+  # Every page is therefore self-describing -- each stream in it starts with
+  # its effective prompt -- while an unchanged prompt is not repeated on every
+  # turn, which would otherwise push a prompt-heavy run past the aggregate byte
+  # ceiling the whole-conversation collectors enforce over raw items.
+  def compact_turns(items) when is_list(items) do
+    items
+    |> Enum.map_reduce(%{}, fn item, seen ->
+      stream_id = item["stream_id"]
+      {elided, last} = elide_system(item, Map.get(seen, stream_id, :no_previous_turn))
+      {elided, Map.put(seen, stream_id, last)}
     end)
     |> elem(0)
   end
 
-  defp elide_unchanged_system(turn, {:previous_system, system}) do
-    if turn["system"] == system, do: Map.delete(turn, "system"), else: turn
-  end
-
-  defp elide_unchanged_system(turn, :no_previous_turn), do: turn
+  def compact_turns(items), do: items
 
   defp conversation_streams(exchanges) do
     result = streams(exchanges)

--- a/lib/ptc_runner/kernel/conversation_projection.ex
+++ b/lib/ptc_runner/kernel/conversation_projection.ex
@@ -11,7 +11,8 @@ defmodule PtcRunner.Kernel.ConversationProjection do
 
     items =
       Enum.flat_map(reconstructed.streams, fn stream ->
-        Enum.map(stream["turns"], fn turn ->
+        stream["turns"]
+        |> Enum.map_reduce(:no_previous_turn, fn turn, previous_system ->
           generated =
             turn["assistant"]
             |> generated_sources()
@@ -25,11 +26,15 @@ defmodule PtcRunner.Kernel.ConversationProjection do
               )
             end)
 
-          turn
-          |> Map.delete("system")
-          |> Map.put("stream_id", stream["stream_id"])
-          |> Map.put("generated", generated)
+          item =
+            turn
+            |> retain_changed_system(previous_system)
+            |> Map.put("stream_id", stream["stream_id"])
+            |> Map.put("generated", generated)
+
+          {item, {:previous_system, turn["system"]}}
         end)
+        |> elem(0)
       end)
 
     expected = MapSet.new(Map.get(trace_facts, "expected_model_exchange_ids", []))
@@ -115,6 +120,20 @@ defmodule PtcRunner.Kernel.ConversationProjection do
       "trace_snapshot_hash" => page["trace_snapshot_hash"]
     }
   end
+
+  # The system prompt is the instruction set that shaped a turn, and the
+  # evaluated program supplies it per call, so two turns of one stream can
+  # carry different prompts: stream linkage keys on `arguments.messages`
+  # alone. Dropping it hid the field a transcript is most often opened for,
+  # and repeating an unchanged prompt on every turn would multiply the largest
+  # constant in the projection against the result-byte limit. Carry it
+  # whenever it changes; its absence means "unchanged from the previous turn
+  # of this stream", and the first turn of every stream always carries it.
+  defp retain_changed_system(turn, {:previous_system, system}) do
+    if turn["system"] == system, do: Map.delete(turn, "system"), else: turn
+  end
+
+  defp retain_changed_system(turn, :no_previous_turn), do: turn
 
   defp conversation_streams(exchanges) do
     result = streams(exchanges)

--- a/lib/ptc_runner/kernel/conversation_projection.ex
+++ b/lib/ptc_runner/kernel/conversation_projection.ex
@@ -11,8 +11,7 @@ defmodule PtcRunner.Kernel.ConversationProjection do
 
     items =
       Enum.flat_map(reconstructed.streams, fn stream ->
-        stream["turns"]
-        |> Enum.map_reduce(:no_previous_turn, fn turn, previous_system ->
+        Enum.map(stream["turns"], fn turn ->
           generated =
             turn["assistant"]
             |> generated_sources()
@@ -26,15 +25,10 @@ defmodule PtcRunner.Kernel.ConversationProjection do
               )
             end)
 
-          item =
-            turn
-            |> retain_changed_system(previous_system)
-            |> Map.put("stream_id", stream["stream_id"])
-            |> Map.put("generated", generated)
-
-          {item, {:previous_system, turn["system"]}}
+          turn
+          |> Map.put("stream_id", stream["stream_id"])
+          |> Map.put("generated", generated)
         end)
-        |> elem(0)
       end)
 
     expected = MapSet.new(Map.get(trace_facts, "expected_model_exchange_ids", []))
@@ -103,6 +97,7 @@ defmodule PtcRunner.Kernel.ConversationProjection do
           turns
           |> Enum.sort_by(&{&1["turn"] || 0, &1["request_sequence"] || 0})
           |> Enum.map(&Map.drop(&1, ~w(stream_id run_id trace_id)))
+          |> elide_repeated_system()
 
         %{"stream_id" => stream_id, "turns" => turns}
       end)
@@ -124,16 +119,28 @@ defmodule PtcRunner.Kernel.ConversationProjection do
   # The system prompt is the instruction set that shaped a turn, and the
   # evaluated program supplies it per call, so two turns of one stream can
   # carry different prompts: stream linkage keys on `arguments.messages`
-  # alone. Dropping it hid the field a transcript is most often opened for,
-  # and repeating an unchanged prompt on every turn would multiply the largest
-  # constant in the projection against the result-byte limit. Carry it
-  # whenever it changes; its absence means "unchanged from the previous turn
-  # of this stream", and the first turn of every stream always carries it.
-  defp retain_changed_system(turn, {:previous_system, system}) do
+  # alone. Every compiled item therefore keeps its own prompt -- `turns` is
+  # filtered and paginated downstream, and eliding before that selection would
+  # hand a caller a page whose prompt was dropped on a turn it never received.
+  #
+  # A presented conversation is the whole selection at once, so there the
+  # repeat is redundant, and repeating an unchanged prompt on every turn would
+  # multiply the largest constant in the result against its byte ceiling. Elide
+  # it only here, only against the previous turn of the same presented stream:
+  # the first turn of every presented stream always carries its prompt.
+  defp elide_repeated_system(turns) do
+    turns
+    |> Enum.map_reduce(:no_previous_turn, fn turn, previous ->
+      {elide_unchanged_system(turn, previous), {:previous_system, turn["system"]}}
+    end)
+    |> elem(0)
+  end
+
+  defp elide_unchanged_system(turn, {:previous_system, system}) do
     if turn["system"] == system, do: Map.delete(turn, "system"), else: turn
   end
 
-  defp retain_changed_system(turn, :no_previous_turn), do: turn
+  defp elide_unchanged_system(turn, :no_previous_turn), do: turn
 
   defp conversation_streams(exchanges) do
     result = streams(exchanges)

--- a/lib/ptc_runner/kernel/inspection_query.ex
+++ b/lib/ptc_runner/kernel/inspection_query.ex
@@ -552,6 +552,7 @@ defmodule PtcRunner.Kernel.InspectionQuery do
       projection.items
       |> Enum.filter(&collection_match?(:turns, &1, arguments))
       |> paginate(page, source_id, max_bytes, metadata)
+      |> compact_turn_page()
     else
       false -> {:error, :invalid_query}
       :error -> {:error, :not_found}
@@ -654,6 +655,13 @@ defmodule PtcRunner.Kernel.InspectionQuery do
 
     if valid?, do: :ok, else: {:error, :invalid_query}
   end
+
+  # Compaction only ever shrinks a page, so it cannot invalidate the byte
+  # fitting `paginate/4` already performed.
+  defp compact_turn_page({:ok, %{"items" => items} = page}) when is_list(items),
+    do: {:ok, Map.put(page, "items", ConversationProjection.compact_turns(items))}
+
+  defp compact_turn_page(result), do: result
 
   defp collection_match?(:turns, item, arguments) do
     equal_filter?(item, arguments, "stream_id") and

--- a/lib/ptc_runner/kernel/trace_log.ex
+++ b/lib/ptc_runner/kernel/trace_log.ex
@@ -142,7 +142,7 @@ defmodule PtcRunner.Kernel.TraceLog do
   @doc "Executes one validated, source-scoped bounded trace query."
   def query(%__MODULE__{} = trace_log, operation, arguments)
       when operation in [:list_runs, :get_run, :list_turns, :counters] and is_map(arguments) do
-    with {:ok, events, source_id} <- load(trace_log),
+    with {:ok, events, source_id, source_metadata} <- load(trace_log),
          do:
            execute(
              operation,
@@ -151,7 +151,7 @@ defmodule PtcRunner.Kernel.TraceLog do
              arguments,
              trace_log.max_result_bytes,
              trace_log.source_kind,
-             %{}
+             source_presence_metadata(operation, source_metadata)
            )
   end
 
@@ -206,6 +206,17 @@ defmodule PtcRunner.Kernel.TraceLog do
         _metadata
       ),
       do: {:error, :invalid_query}
+
+  @doc false
+  @spec source_presence_metadata(atom(), map()) :: map()
+  # Only the two operations that answer "what does this source hold" carry the
+  # exclusion count. A run-scoped answer would attach it to a single run,
+  # where it would state nothing true about that run.
+  def source_presence_metadata(operation, metadata)
+      when operation in [:list_runs, :counters] and is_map(metadata),
+      do: metadata
+
+  def source_presence_metadata(_operation, _metadata), do: %{}
 
   @doc false
   @spec compile_analysis([map()], :sanitized | :private | map()) :: map()
@@ -291,7 +302,8 @@ defmodule PtcRunner.Kernel.TraceLog do
              run_sources: %{binary() => :sanitized | :private},
              source_id: binary(),
              source_bytes: non_neg_integer(),
-             file_count: non_neg_integer()
+             file_count: non_neg_integer(),
+             excluded_trace_files: %{optional(binary()) => pos_integer()}
            }}
           | {:error, atom()}
   def capture_directory(directory, opts \\ [])
@@ -359,7 +371,8 @@ defmodule PtcRunner.Kernel.TraceLog do
              run_sources: %{binary() => :sanitized | :private},
              source_id: binary(),
              source_bytes: non_neg_integer(),
-             file_count: 1
+             file_count: 1,
+             excluded_trace_files: %{optional(binary()) => pos_integer()}
            }}
           | {:error, atom()}
   def capture_file(path, opts \\ [])
@@ -1746,6 +1759,7 @@ defmodule PtcRunner.Kernel.TraceLog do
     |> EventSink.events()
     |> normalize()
     |> validate_loaded(trace_log.max_source_bytes)
+    |> with_source_metadata(%{})
   catch
     :exit, _reason -> {:error, :source_unavailable}
   end
@@ -1753,15 +1767,17 @@ defmodule PtcRunner.Kernel.TraceLog do
   defp load(%__MODULE__{source: {:file, path}, max_source_bytes: max_bytes}) do
     with {:ok, source} <- read_regular_file(path, max_bytes),
          {:ok, events} <- decode_jsonl(source),
-         do: validate_loaded(events, max_bytes)
+         do: events |> validate_loaded(max_bytes) |> with_source_metadata(%{})
   end
 
   defp load(%__MODULE__{source: {:directory, directory}, max_source_bytes: max_bytes} = trace_log) do
     with {:ok, %File.Stat{type: :directory}} <- File.lstat(directory),
-         {:ok, names} <- File.ls(directory),
-         {:ok, events} <-
-           load_files(directory, supported_names(names, trace_log.source_kind), max_bytes) do
-      validate_loaded(events, max_bytes)
+         {:ok, listed} <- File.ls(directory),
+         names = supported_names(listed, trace_log.source_kind),
+         {:ok, events} <- load_files(directory, names, max_bytes) do
+      events
+      |> validate_loaded(max_bytes)
+      |> with_source_metadata(excluded_trace_files(listed, names, trace_log.source_kind))
     else
       {:error, reason} = error when reason in [:source_limit_exceeded, :malformed_source] ->
         error
@@ -1771,15 +1787,41 @@ defmodule PtcRunner.Kernel.TraceLog do
     end
   end
 
+  defp with_source_metadata({:ok, events, source_id}, metadata),
+    do: {:ok, events, source_id, metadata}
+
+  defp with_source_metadata({:error, _reason} = error, _metadata), do: error
+
+  # One trace directory holds both sanitized and private artifacts, and one
+  # query boundary reads exactly one kind. Staying silent about the other kind
+  # made an all-private project answer an empty run listing, so name the files
+  # this source kind refused to read. The count is advisory and deliberately
+  # outside `source_id`: a concurrent write to the kind this boundary does not
+  # read must not invalidate the evidence it does read.
+  defp excluded_trace_files(listed, accepted, source_kind) do
+    accepted = MapSet.new(accepted)
+
+    case Enum.count(listed, &(trace_file_name?(&1) and not MapSet.member?(accepted, &1))) do
+      0 -> %{}
+      excluded -> %{exclusion_key(source_kind) => excluded}
+    end
+  end
+
+  defp exclusion_key(:sanitized), do: "excluded_private_trace_files"
+  defp exclusion_key(:private), do: "excluded_sanitized_trace_files"
+
   defp supported_names(names, source_kind) do
     names
     |> Enum.filter(&supported_name?(&1, source_kind))
     |> Enum.sort()
   end
 
-  defp supported_name?(name, source_kind) do
+  defp supported_name?(name, source_kind),
+    do: trace_file_name?(name) and private_path?(name) == (source_kind == :private)
+
+  defp trace_file_name?(name) do
     Path.basename(name) == name and String.ends_with?(name, ".jsonl") and
-      not inspection_path?(name) and private_path?(name) == (source_kind == :private)
+      not inspection_path?(name)
   end
 
   defp capture_directory_files(
@@ -1792,7 +1834,7 @@ defmodule PtcRunner.Kernel.TraceLog do
          capture_hook,
          listing_hook
        ) do
-    with {:ok, before_inventory} <-
+    with {:ok, before_inventory, excluded} <-
            directory_inventory(
              directory,
              source_kind,
@@ -1801,8 +1843,8 @@ defmodule PtcRunner.Kernel.TraceLog do
              include_sanitized,
              listing_hook
            ) do
-      capture_inventory(
-        directory,
+      directory
+      |> capture_inventory(
         before_inventory,
         max_source_bytes,
         capture_hook,
@@ -1817,8 +1859,17 @@ defmodule PtcRunner.Kernel.TraceLog do
           )
         end
       )
+      |> put_excluded_trace_files(excluded)
     end
   end
+
+  # The exclusion count is reported beside the capture, never inside the
+  # inventory the capture re-verifies: a concurrent write to the kind this
+  # capture does not read must not fail it as a changed source.
+  defp put_excluded_trace_files({:ok, capture}, excluded),
+    do: {:ok, %{capture | excluded_trace_files: excluded}}
+
+  defp put_excluded_trace_files({:error, _reason} = error, _excluded), do: error
 
   defp capture_inventory(
          directory,
@@ -1847,7 +1898,8 @@ defmodule PtcRunner.Kernel.TraceLog do
          run_sources: run_sources,
          source_id: source_id,
          source_bytes: source_bytes,
-         file_count: length(after_verify_inventory.files)
+         file_count: length(after_verify_inventory.files),
+         excluded_trace_files: %{}
        }}
     end
   end
@@ -1882,11 +1934,12 @@ defmodule PtcRunner.Kernel.TraceLog do
        ) do
     with {:ok, %File.Stat{type: :directory} = directory_stat} <-
            File.lstat(directory, time: :posix),
-         {:ok, names} <- bounded_directory_names(directory, max_directory_entries, listing_hook),
+         {:ok, listed} <- bounded_directory_names(directory, max_directory_entries, listing_hook),
          {:ok, names} <-
-           bounded_capture_names(names, source_kind, include_sanitized, max_trace_files),
+           bounded_capture_names(listed, source_kind, include_sanitized, max_trace_files),
          {:ok, files} <- inventory_files(directory, names) do
-      {:ok, %{directory: stat_identity(directory_stat), files: files}}
+      {:ok, %{directory: stat_identity(directory_stat), files: files},
+       excluded_trace_files(listed, names, source_kind)}
     else
       {:ok, %File.Stat{}} -> {:error, :malformed_source}
       {:error, :source_limit_exceeded} = error -> error
@@ -1910,7 +1963,7 @@ defmodule PtcRunner.Kernel.TraceLog do
            include_sanitized,
            listing_hook
          ) do
-      {:ok, inventory} -> {:ok, inventory}
+      {:ok, inventory, _excluded} -> {:ok, inventory}
       {:error, _reason} -> {:error, :source_changed}
     end
   end

--- a/lib/ptc_runner/kernel/trace_snapshot.ex
+++ b/lib/ptc_runner/kernel/trace_snapshot.ex
@@ -433,6 +433,7 @@ defmodule PtcRunner.Kernel.TraceSnapshot do
         capture_id: capture.source_id,
         captured_at: DateTime.utc_now(),
         file_count: capture.file_count,
+        excluded_trace_files: capture.excluded_trace_files,
         source: source,
         run_count: capture.events |> MapSet.new(& &1["run_id"]) |> MapSet.size(),
         snapshot_hash: SafeMetadata.fingerprint(capture.source_id),
@@ -443,8 +444,10 @@ defmodule PtcRunner.Kernel.TraceSnapshot do
   end
 
   defp query_with_snapshot_hash(state, operation, arguments) do
-    snapshot_hash = state.info.snapshot_hash
-    metadata = %{"snapshot_hash" => snapshot_hash}
+    metadata =
+      %{"snapshot_hash" => state.info.snapshot_hash}
+      |> Map.merge(TraceLog.source_presence_metadata(operation, state.info.excluded_trace_files))
+
     snapshot_query(state, operation, arguments, state.max_result_bytes, metadata)
   end
 

--- a/ptc_viewer/priv/static/css/styles.css
+++ b/ptc_viewer/priv/static/css/styles.css
@@ -138,6 +138,7 @@ button:focus-visible, textarea:focus-visible, summary:focus-visible {
 }
 .file-picker-search:focus { outline: 2px solid var(--accent); outline-offset: -1px; }
 .file-picker-empty { margin: 12px 2px 0; font-size: 12px; color: var(--muted); }
+.file-picker-note { margin: 6px 2px 0; font-size: 12px; color: var(--muted); }
 
 /* Compact bar shown while a run is open: names the run and is the single
    control that returns to the list. */

--- a/ptc_viewer/priv/static/js/app.js
+++ b/ptc_viewer/priv/static/js/app.js
@@ -5,7 +5,7 @@ import { createAnalyzeButton, createReplController, nextTabName, readViewerConfi
 import { createRunCatalog } from './run-catalog.js';
 import { createLiveController, liveTokenFromSearch } from './live.js';
 import { commitCurrentLoad } from './current-load.js';
-import { displayRunName, formatRunUsage, searchableRunFields } from './run-display.js';
+import { displayRunName, emptyRunsMessage, excludedTraceNote, formatRunUsage, searchableRunFields } from './run-display.js';
 import { truncate } from './utils.js';
 
 function formatDate(isoString) {
@@ -110,6 +110,7 @@ function RunPicker() {
   const { runs, page, query, selectedRunId } = state;
   const visible = runs.filter(run => matchesQuery(run, query));
   const selected = runs.find(run => run.run_id === selectedRunId) || null;
+  const excluded = excludedTraceNote(page);
 
   // With a run open the list is reference material, not the task at hand: it
   // collapses to one control that both names the current run and returns to
@@ -139,6 +140,7 @@ function RunPicker() {
     <div class="file-picker-panel">
       <div class="file-picker-header">
         <h3>Kernel runs <span class="file-picker-count">${runs.length}${page?.truncated ? '+' : ''}</span></h3>
+        ${runs.length > 0 && excluded && html`<p class="file-picker-note">${excluded}</p>`}
         <input type="search" class="file-picker-search" placeholder="Filter by run id, status or bundle"
                aria-label="Filter runs" value=${query}
                onInput=${event => { state.query = event.currentTarget.value; renderRunPicker(); }} />
@@ -146,7 +148,7 @@ function RunPicker() {
       <div class="file-picker-list">
         ${visible.map(run => html`<${RunRow} key=${run.run_id} run=${run} />`)}
         ${!visible.length && html`<p class="file-picker-empty">
-          ${runs.length ? `No run matches “${query}”.` : 'No canonical runs in this trace directory.'}
+          ${runs.length ? `No run matches “${query}”.` : emptyRunsMessage(page)}
         </p>`}
         ${page?.next_cursor && !query && html`<${LoadMoreRuns} cursor=${page.next_cursor} />`}
       </div>

--- a/ptc_viewer/priv/static/js/run-display.js
+++ b/ptc_viewer/priv/static/js/run-display.js
@@ -32,3 +32,35 @@ export function searchableRunFields(run, project) {
     ...Object.entries(run?.tags || {}).flat()
   ].filter(field => typeof field === 'string');
 }
+
+// A trace directory holds sanitized and private artifacts, and one Viewer
+// source grant reads exactly one kind. Reporting the runs it read as the runs
+// that exist sent a tester hunting a rendering bug in a Viewer that was
+// working, so name the files the grant refused to read and the setting that
+// reads them.
+export function excludedTraceNote(page) {
+  const privateFiles = countedExclusion(page?.excluded_private_trace_files);
+  const sanitizedFiles = countedExclusion(page?.excluded_sanitized_trace_files);
+
+  if (privateFiles) {
+    return `${privateFiles} private trace ${plural(privateFiles, 'file')} excluded — set "viewer": { "private": true } in ptc-project.json to read them.`;
+  }
+
+  if (sanitizedFiles) {
+    return `${sanitizedFiles} sanitized trace ${plural(sanitizedFiles, 'file')} excluded — this Viewer reads private traces only.`;
+  }
+
+  return null;
+}
+
+export function emptyRunsMessage(page) {
+  return excludedTraceNote(page) || 'No canonical runs in this trace directory.';
+}
+
+function countedExclusion(value) {
+  return Number.isSafeInteger(value) && value > 0 ? value : 0;
+}
+
+function plural(count, noun) {
+  return count === 1 ? noun : `${noun}s`;
+}

--- a/ptc_viewer/priv/static/js/semantic-conversation.js
+++ b/ptc_viewer/priv/static/js/semantic-conversation.js
@@ -75,6 +75,7 @@ function Conversation({ conversation }) {
             <details key=${turn.request_sequence} open>
               <summary>Turn ${turn.turn}</summary>
               <pre>${JSON.stringify({
+                system: turn.system,
                 messages_added: turn.messages_added,
                 assistant: turn.assistant,
                 generated: turn.generated,

--- a/ptc_viewer/test/ptc_viewer/semantic_conversation_test.exs
+++ b/ptc_viewer/test/ptc_viewer/semantic_conversation_test.exs
@@ -47,6 +47,41 @@ defmodule PtcViewer.SemanticConversationTest do
     assert ambiguous =~ "Ambiguous conversation branches were not guessed into a stream."
   end
 
+  test "a rendered turn shows the system prompt that shaped it", %{tmp_dir: directory} do
+    rendered =
+      render(directory, %{
+        "complete?" => true,
+        "ambiguous?" => false,
+        "missing_exchange_count" => 0,
+        "streams" => [
+          %{
+            "stream_id" => "stream-1",
+            "turns" => [
+              %{
+                "turn" => 1,
+                "request_sequence" => 1,
+                "system" => "you price orders in cents",
+                "messages_added" => [%{"role" => "user", "content" => "price it"}],
+                "outcome" => "ok"
+              },
+              %{
+                "turn" => 2,
+                "request_sequence" => 3,
+                "messages_added" => [%{"role" => "user", "content" => "again"}],
+                "outcome" => "ok"
+              }
+            ]
+          }
+        ]
+      })
+
+    assert rendered =~ "you price orders in cents"
+
+    # An unchanged prompt is carried once per stream, so the second turn
+    # renders without repeating it rather than showing an empty field.
+    refute rendered =~ ~s("system": null)
+  end
+
   defp render(directory, conversation) do
     metadata_path = Path.join(directory, "metadata.json")
     turns_path = Path.join(directory, "turns.json")

--- a/ptc_viewer/test/run_display.mjs
+++ b/ptc_viewer/test/run_display.mjs
@@ -1,6 +1,8 @@
 import assert from 'node:assert/strict';
 import {
   displayRunName,
+  emptyRunsMessage,
+  excludedTraceNote,
   formatRunUsage,
   searchableRunFields
 } from '../priv/static/js/run-display.js';
@@ -32,5 +34,34 @@ assert.deepEqual(formatRunUsage(null), []);
 
 assert(searchableRunFields(run, matchingProject).includes('chief-of-staff-02-granting-data'));
 assert(searchableRunFields(run, matchingProject).includes('agent'));
+
+// An empty listing must not claim the directory is empty when the source kind
+// withheld every run in it.
+assert.equal(
+  emptyRunsMessage({ items: [], omitted_count: 0 }),
+  'No canonical runs in this trace directory.'
+);
+
+assert.equal(
+  emptyRunsMessage({ items: [], omitted_count: 0, excluded_private_trace_files: 3 }),
+  '3 private trace files excluded — set "viewer": { "private": true } in ptc-project.json to read them.'
+);
+
+assert.equal(
+  excludedTraceNote({ excluded_private_trace_files: 1 }),
+  '1 private trace file excluded — set "viewer": { "private": true } in ptc-project.json to read them.'
+);
+
+assert.equal(
+  excludedTraceNote({ excluded_sanitized_trace_files: 2 }),
+  '2 sanitized trace files excluded — this Viewer reads private traces only.'
+);
+
+// Pagination is a different number, and an absent or unusable count is not an
+// exclusion to report.
+assert.equal(excludedTraceNote({ omitted_count: 12 }), null);
+assert.equal(excludedTraceNote({ excluded_private_trace_files: 0 }), null);
+assert.equal(excludedTraceNote({ excluded_private_trace_files: '3' }), null);
+assert.equal(excludedTraceNote(null), null);
 
 process.stdout.write('ok');

--- a/test/mix/tasks/ptc_transcript_test.exs
+++ b/test/mix/tasks/ptc_transcript_test.exs
@@ -45,6 +45,7 @@ defmodule Mix.Tasks.PtcTranscriptTest do
                  %{
                    "turns" => [
                      %{
+                       "system" => system,
                        "messages_added" => [%{"content" => prompt}],
                        "response" => %{"value" => %{"answer" => answer}}
                      }
@@ -55,6 +56,10 @@ defmodule Mix.Tasks.PtcTranscriptTest do
            } = output |> File.read!() |> Jason.decode!()
 
     assert run_id == fixture.run_id
+
+    # A transcript that certifies its own completeness cannot omit the
+    # instructions that shaped the run.
+    assert system == "private-system-#{run_id}"
     assert prompt == "private-prompt-#{run_id}"
     assert answer == "private-answer-#{run_id}"
     assert File.stat!(output).mode |> Bitwise.band(0o777) == 0o600

--- a/test/ptc_runner/kernel/conversation_projection_test.exs
+++ b/test/ptc_runner/kernel/conversation_projection_test.exs
@@ -110,6 +110,36 @@ defmodule PtcRunner.Kernel.ConversationProjectionTest do
       assert turn["system"] == "instructions v1"
     end
 
+    test "each selected page starts every stream in it with that stream's prompt" do
+      items = [
+        %{"stream_id" => "stream-1", "turn" => 1, "system" => "a"},
+        %{"stream_id" => "stream-1", "turn" => 2, "system" => "a"},
+        %{"stream_id" => "stream-2", "turn" => 1, "system" => "b"},
+        %{"stream_id" => "stream-2", "turn" => 2, "system" => "b"}
+      ]
+
+      compacted = ConversationProjection.compact_turns(items)
+
+      assert Enum.map(compacted, &Map.get(&1, "system", :elided)) == ["a", :elided, "b", :elided]
+
+      # A later page is compacted on its own, so it never elides against a turn
+      # the caller was not handed.
+      later = ConversationProjection.compact_turns(Enum.drop(items, 1))
+      assert Enum.map(later, &Map.get(&1, "system", :elided)) == ["a", "b", :elided]
+    end
+
+    test "compaction is idempotent, so a page may be compacted again on presentation" do
+      items = [
+        %{"stream_id" => "stream-1", "turn" => 1, "system" => "a"},
+        %{"stream_id" => "stream-1", "turn" => 2, "system" => "a"},
+        %{"stream_id" => "stream-1", "turn" => 3, "system" => "b"}
+      ]
+
+      once = ConversationProjection.compact_turns(items)
+      assert ConversationProjection.compact_turns(once) == once
+      assert Enum.map(once, &Map.get(&1, "system", :elided)) == ["a", :elided, "b"]
+    end
+
     test "an exchange sent without a system prompt says so rather than staying silent" do
       assert %{"streams" => [%{"turns" => [turn]}]} =
                present([exchange("llm-1", 1, [user("start")], nil, "one")])

--- a/test/ptc_runner/kernel/conversation_projection_test.exs
+++ b/test/ptc_runner/kernel/conversation_projection_test.exs
@@ -63,6 +63,53 @@ defmodule PtcRunner.Kernel.ConversationProjectionTest do
       assert mission_turn["system"] == "mission instructions"
     end
 
+    test "every compiled turn keeps its own prompt, because turns are filtered downstream" do
+      first = exchange("llm-1", 1, [user("start")], "instructions v1", "one")
+
+      second =
+        exchange(
+          "llm-2",
+          3,
+          [user("start"), assistant("one"), user("again")],
+          "instructions v1",
+          "two"
+        )
+
+      projection = ConversationProjection.compile([first, second], [], @trace_facts)
+
+      assert Enum.map(projection.items, & &1["system"]) == ["instructions v1", "instructions v1"]
+    end
+
+    test "a presented page that starts mid-stream still carries its prompt" do
+      first = exchange("llm-1", 1, [user("start")], "instructions v1", "one")
+
+      second =
+        exchange(
+          "llm-2",
+          3,
+          [user("start"), assistant("one"), user("again")],
+          "instructions v1",
+          "two"
+        )
+
+      projection = ConversationProjection.compile([first, second], [], @trace_facts)
+
+      # `turns` filters and paginates before presentation, so a caller can be
+      # handed the second turn without ever seeing the first. Eliding against a
+      # turn the caller did not receive would drop the prompt entirely while
+      # still reporting complete evidence.
+      later_page = %{
+        "items" => Enum.filter(projection.items, &(&1["turn"] == 2)),
+        "evidence" => projection.evidence
+      }
+
+      assert %{"streams" => [%{"turns" => [turn]}]} =
+               ConversationProjection.present_page(later_page)
+
+      assert turn["turn"] == 2
+      assert turn["system"] == "instructions v1"
+    end
+
     test "an exchange sent without a system prompt says so rather than staying silent" do
       assert %{"streams" => [%{"turns" => [turn]}]} =
                present([exchange("llm-1", 1, [user("start")], nil, "one")])

--- a/test/ptc_runner/kernel/conversation_projection_test.exs
+++ b/test/ptc_runner/kernel/conversation_projection_test.exs
@@ -1,0 +1,96 @@
+defmodule PtcRunner.Kernel.ConversationProjectionTest do
+  use ExUnit.Case, async: true
+
+  alias PtcRunner.Kernel.ConversationProjection
+
+  @trace_facts %{
+    "terminal?" => true,
+    "events_dropped?" => false,
+    "expected_model_exchange_ids" => []
+  }
+
+  describe "system prompts" do
+    test "one stream carries its system prompt on the first turn and on every change" do
+      first = exchange("llm-1", 1, [user("start")], "instructions v1", "one")
+
+      second =
+        exchange(
+          "llm-2",
+          3,
+          [user("start"), assistant("one"), user("again")],
+          "instructions v1",
+          "two"
+        )
+
+      third =
+        exchange(
+          "llm-3",
+          5,
+          [user("start"), assistant("one"), user("again"), assistant("two"), user("more")],
+          "instructions v2",
+          "three"
+        )
+
+      assert %{
+               "streams" => [
+                 %{
+                   "turns" => [
+                     %{"turn" => 1} = turn_one,
+                     %{"turn" => 2} = turn_two,
+                     %{"turn" => 3} = turn_three
+                   ]
+                 }
+               ]
+             } = present([first, second, third])
+
+      assert turn_one["system"] == "instructions v1"
+      refute Map.has_key?(turn_two, "system")
+      assert turn_three["system"] == "instructions v2"
+    end
+
+    test "every stream carries its own system prompt on its first turn" do
+      first = exchange("llm-1", 1, [user("start")], "workflow instructions", "one")
+      second = exchange("llm-2", 3, [user("elsewhere")], "mission instructions", "two")
+
+      assert %{
+               "streams" => [
+                 %{"turns" => [workflow_turn]},
+                 %{"turns" => [mission_turn]}
+               ]
+             } = present([first, second])
+
+      assert workflow_turn["system"] == "workflow instructions"
+      assert mission_turn["system"] == "mission instructions"
+    end
+
+    test "an exchange sent without a system prompt says so rather than staying silent" do
+      assert %{"streams" => [%{"turns" => [turn]}]} =
+               present([exchange("llm-1", 1, [user("start")], nil, "one")])
+
+      assert Map.has_key?(turn, "system")
+      assert turn["system"] == nil
+    end
+  end
+
+  defp present(exchanges) do
+    projection = ConversationProjection.compile(exchanges, [], @trace_facts)
+
+    ConversationProjection.present_page(%{
+      "items" => projection.items,
+      "evidence" => projection.evidence
+    })
+  end
+
+  defp exchange(capability_id, sequence, messages, system, content) do
+    %{
+      "capability_id" => capability_id,
+      "input_sequence" => sequence,
+      "output_sequence" => sequence + 1,
+      "arguments" => %{"messages" => messages, "system" => system},
+      "result" => %{"status" => "ok", "value" => %{"content" => content}}
+    }
+  end
+
+  defp user(content), do: %{"role" => "user", "content" => content}
+  defp assistant(content), do: %{"role" => "assistant", "content" => content}
+end

--- a/test/ptc_runner/kernel/run_analysis_test.exs
+++ b/test/ptc_runner/kernel/run_analysis_test.exs
@@ -122,7 +122,11 @@ defmodule PtcRunner.Kernel.RunAnalysisTest do
              })
 
     assert prompt == "private-prompt-#{run_id}"
-    refute Map.has_key?(turn, "system")
+
+    # The instructions that shaped the turn are the first thing a failed run is
+    # opened for, and the conversation is the one view that certifies its own
+    # completeness. It carries them.
+    assert turn["system"] == "private-system-#{run_id}"
 
     assert {:ok, %{"items" => [%{"arguments" => %{"system" => "private-system-" <> ^run_id}}]}} =
              RunAnalysis.query(analysis, :read, %{

--- a/test/ptc_runner/kernel/trace_log_test.exs
+++ b/test/ptc_runner/kernel/trace_log_test.exs
@@ -783,6 +783,62 @@ defmodule PtcRunner.Kernel.TraceLogTest do
   end
 
   @tag :tmp_dir
+  test "run listings report the trace files their source kind refused to read", %{
+    tmp_dir: directory
+  } do
+    File.write!(Path.join(directory, "normal.jsonl"), jsonl_event("normal", 1, "run-started"))
+
+    File.write!(
+      Path.join(directory, "run.inspection.jsonl"),
+      jsonl_event("inspection", 1, "run-started")
+    )
+
+    assert :ok =
+             TraceLog.append_jsonl(
+               Path.join(directory, "secret.private.jsonl"),
+               [decoded_event("private", 1, "run-started")],
+               private: true
+             )
+
+    assert {:ok, sanitized_log} = TraceLog.new(source: {:directory, directory})
+    assert {:ok, private_log} = TraceLog.new(source: {:private_directory, directory})
+
+    assert {:ok, %{"items" => [%{"run_id" => "normal"}]} = page} =
+             TraceLog.query(sanitized_log, :list_runs, %{})
+
+    assert page["excluded_private_trace_files"] == 1
+    refute Map.has_key?(page, "excluded_sanitized_trace_files")
+
+    # Exclusion and pagination are different numbers. Nothing was truncated
+    # here, and the field that reports truncation must keep saying so.
+    assert page["omitted_count"] == 0
+
+    assert {:ok, %{"excluded_private_trace_files" => 1}} =
+             TraceLog.query(sanitized_log, :counters, %{})
+
+    # A run-scoped answer would attach a directory-wide exclusion to one run,
+    # where it states nothing true about that run.
+    assert {:ok, run} = TraceLog.query(sanitized_log, :get_run, %{"run_id" => "normal"})
+    refute Map.has_key?(run, "excluded_private_trace_files")
+
+    assert {:ok, %{"items" => [%{"run_id" => "private"}]} = private_page} =
+             TraceLog.query(private_log, :list_runs, %{})
+
+    assert private_page["excluded_sanitized_trace_files"] == 1
+  end
+
+  @tag :tmp_dir
+  test "a run listing with nothing excluded reports no exclusion at all", %{tmp_dir: directory} do
+    File.write!(Path.join(directory, "normal.jsonl"), jsonl_event("normal", 1, "run-started"))
+
+    assert {:ok, sanitized_log} = TraceLog.new(source: {:directory, directory})
+    assert {:ok, page} = TraceLog.query(sanitized_log, :list_runs, %{})
+
+    refute Map.has_key?(page, "excluded_private_trace_files")
+    refute Map.has_key?(page, "excluded_sanitized_trace_files")
+  end
+
+  @tag :tmp_dir
   test "private trace creation reports chmod failures without raising", %{tmp_dir: directory} do
     path = Path.join(directory, "chmod-failure.private.jsonl")
     event = decoded_event("private-chmod", 1, "run-started")

--- a/test/ptc_runner/kernel/trace_snapshot_test.exs
+++ b/test/ptc_runner/kernel/trace_snapshot_test.exs
@@ -125,6 +125,43 @@ defmodule PtcRunner.Kernel.TraceSnapshotTest do
   end
 
   @tag :tmp_dir
+  test "a sanitized snapshot names the private trace files it did not read", %{
+    tmp_dir: directory
+  } do
+    write_events(Path.join(directory, "normal.jsonl"), [event("normal", 1, "run-started")])
+    write_events(Path.join(directory, "one.private.jsonl"), [event("one", 1, "run-started")])
+    write_events(Path.join(directory, "two.private.jsonl"), [event("two", 1, "run-started")])
+
+    write_events(Path.join(directory, "ignored.inspection.jsonl"), [
+      event("inspection", 1, "run-started")
+    ])
+
+    assert {:ok, snapshot} = TraceSnapshot.start({:directory, directory}, owner: self())
+    on_exit(fn -> TraceSnapshot.stop(snapshot) end)
+
+    assert {:ok, %{"items" => [%{"run_id" => "normal"}]} = page} =
+             TraceSnapshot.query(snapshot, :list_runs, %{})
+
+    # Inspection artifacts are a different artifact class, not runs this
+    # source kind withheld, so they are never counted as excluded.
+    assert page["excluded_private_trace_files"] == 2
+
+    assert {:ok, run} = TraceSnapshot.query(snapshot, :get_run, %{"run_id" => "normal"})
+    refute Map.has_key?(run, "excluded_private_trace_files")
+
+    # The private-authorized capture is a superset of the sanitized one, so it
+    # withholds nothing and claims no exclusion.
+    assert {:ok, private_snapshot} =
+             TraceSnapshot.start({:private_authorized_directory, directory}, owner: self())
+
+    on_exit(fn -> TraceSnapshot.stop(private_snapshot) end)
+
+    assert {:ok, private_page} = TraceSnapshot.query(private_snapshot, :list_runs, %{})
+    refute Map.has_key?(private_page, "excluded_private_trace_files")
+    refute Map.has_key?(private_page, "excluded_sanitized_trace_files")
+  end
+
+  @tag :tmp_dir
   test "private-authorized capture rejects one run split across source classes", %{
     tmp_dir: directory
   } do


### PR DESCRIPTION
Closes #1481.

Both forensic surfaces published a completeness claim that did not cover what
they withheld. Neither claim was false in its own terms; both were read as
covering more than they verify, and the cost was a debugging session spent on
the tooling instead of the run.

## The system prompt is in the conversation

`ConversationProjection` captured `arguments.system` per turn and then deleted
it, so `ptc transcript` and `/api/analysis/runs/{id}/conversation` certified
themselves complete while omitting the instructions that shaped the run — the
usual root cause of "why did my agent do that?".

A turn now carries `system`. It is not repeated unconditionally on purpose:
the evaluated program supplies the prompt per `llm` call, so it can change
mid-stream, and repeating an unchanged prompt on every turn multiplies the
largest constant in the result against the byte ceiling the
whole-conversation collectors enforce.

Where that compaction happens matters, and the first two attempts got it
wrong — both caught by the codex review (see below). It now runs at the **page
boundary**: `InspectionQuery` compacts each selected page of `turns` after
filtering and pagination, so every stream present in a page starts with its
effective prompt. Elision compares against the last turn that carried one
rather than the previous turn, which makes it idempotent, so `present_page/1`
re-compacts collected pages and removes the per-page seams without losing a
prompt at one. An elided `system` means "unchanged since the last turn in this
page that carried one", never "none was sent" — a turn sent no prompt carries
`"system": null`.

`complete?` itself is unchanged. It means exactly what it says — canonical
completeness ∧ no missing exchanges ∧ no ambiguity — and renaming a precise
field to cover a projection gap would have been the wrong lever. What is
documented now is what it does not claim, and that `ptc transcript` gates on
it, so the field is always `true` in a published transcript and only the
Viewer API can ever answer no.

The Viewer's conversation panel renders the field too; it built an explicit
whitelist that dropped it.

## A source that withholds runs says so

A trace directory holds sanitized and private artifacts and one source grant
reads exactly one kind, silently, at the filename filter. A project whose
traces are all private therefore answered `{"items": [], "omitted_count": 0}` —
an active assertion that nothing was hidden, for a directory where everything
was.

`omitted_count` is deliberately untouched. It is pagination in both
implementations (`trace_log.ex`, `inspection_query.ex`) and the two numbers do
not even share a unit: one counts unreturned items, the other unread files.
Overloading it would have made both unreadable.

Run listings and counters now carry `excluded_private_trace_files` or
`excluded_sanitized_trace_files`, absent when nothing was excluded.
Constraints worth knowing:

- Inspection artifacts are never counted. They are a separate artifact class,
  not withheld runs.
- Run-scoped answers (`get_run`, `list_turns`) never carry the field; it would
  state nothing true about a run.
- The count is advisory and stays outside `source_id` and the re-verified
  capture inventory, so a concurrent write to the kind a grant does not read
  cannot fail the capture it does read as `:source_changed`.

The Viewer's run picker names the exclusion and the setting that reads it,
replacing "No canonical runs in this trace directory."

## Also in the issue

The transcript/canonical sequence-space hazard is now documented where it
bites: join on correlation ids, never on sequence numbers.

The hashed `labels` item is **not** included. It is not a bug — `SafeMetadata`
reduces every caller-supplied name/model/provider to a one-way SHA-256
fingerprint before it reaches a canonical event, by design and by moduledoc.
Reading `order-pricer` back out requires read-time resolution against the
manifest, which is what #1393 did for the Viewer's Bundle column. It deserves
its own issue rather than riding along in a bug fix.

## Codex review

One independent review plus two follow-ups in the same session. Both findings
were real and both are fixed in their own commits:

- **[P1]** The first attempt elided while compiling the stream, before `turns`
  is filtered and paginated. A caller reading a later page — or filtering to a
  single turn — could receive a turn whose prompt had been elided against a
  turn it never saw, while the page still reported `complete?: true`. That is
  the same defect class this branch exists to close. Fixed in `87abf9fa`.
- **[P2]** Keeping the prompt on every raw item then meant the collectors
  validated their 1 MB aggregate over fully repeated prompts, so a prompt-heavy
  run could fail collection although the presented conversation fits. Fixed in
  `20b5beb1` by compacting at the page boundary.

A third round asked for idempotent compaction inside
`InspectionPageCollector` and `RunAnalysis.collect` as well, to remove the
page-seam duplicates before each aggregate check. **Not done, deliberately.**
After `20b5beb1` the residual is one prompt per stream per page — bounded by
ten copies on a 1000-turn transcript at a 100-item page limit, against a 1 MB
ceiling that already has to hold every message and response — and closing it
means teaching two collections-agnostic collectors about one collection's
field. The cost outweighs the remaining bytes. Happy to take it if you disagree.

## Verification

All six `mix precommit` gates run individually and green: `preflight`,
`core-quality`, `core-tests` (6655 passed), `viewer` (111 passed),
`launcher-package`, `core-release`.
