### PR TITLE
fix(ci): classify standing paths so the launcher matrix stays a signal

### DIFF
--- a/scripts/ci/classify-changes.sh
+++ b/scripts/ci/classify-changes.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 
 # Classify repository-relative changed paths into independently testable scopes.
-# Unknown paths deliberately select every scope so new repository areas cannot
+# Known standing files have explicit arms so the catch-all stays a fail-safe
+# for new repository areas, not the default for ordinary tracked paths.
+# Unknown paths deliberately select every scope so those new areas cannot
 # silently bypass CI. The same classifier is suitable for CI and local hooks.
 
 set -euo pipefail
@@ -55,8 +57,9 @@ while IFS= read -r path || [ -n "$path" ]; do
   fi
 
   case "$path" in
-    docs/plans/*|Plans/*)
-      # Disposable plans do not participate in product or documentation gates.
+    docs/plans/*|Plans/*|.claude/*)
+      # Disposable plans and agent tooling do not participate in product or
+      # documentation gates.
       ;;
 
     docs/function-reference.md|docs/java-interop.md|docs/kernel-limits-reference.md|\
@@ -67,7 +70,9 @@ while IFS= read -r path || [ -n "$path" ]; do
       ;;
 
     docs/*|README.md|CHANGELOG.md|LICENSES/*|ptc_runner_launcher/README.md|\
-      ptc_runner_launcher/CHANGELOG.md|ptc_viewer/README.md|ptc_viewer/CHANGELOG.md)
+      ptc_runner_launcher/CHANGELOG.md|ptc_viewer/README.md|ptc_viewer/CHANGELOG.md|\
+      AGENTS.md|CLAUDE.md|usage-rules.md|.env.example|.lycheeignore|\
+      .gitattributes|cliff.toml|REUSE.toml|site/*|dev/*)
       docs=true
       ;;
 
@@ -85,6 +90,10 @@ while IFS= read -r path || [ -n "$path" ]; do
 
     examples/mcp/filesystem/*|test/ptc_runner/kernel/filesystem_mcp_e2e_test.exs)
       mcp_filesystem=true
+      ;;
+
+    examples/*|bench/*)
+      core=true
       ;;
 
     test/support/mcp_go_stateless/*|test/ptc_runner/kernel/mcp_remote_e2e_test.exs)
@@ -130,8 +139,13 @@ while IFS= read -r path || [ -n "$path" ]; do
       ;;
 
     .github/*|scripts/*|.githooks/*|.formatter.exs|.credo.exs|\
-      .dialyzer_ignore.exs|.tool-versions)
+      .dialyzer_ignore.exs|.tool-versions|mise.toml)
       select_all
+      ;;
+
+    .duplication-baseline.json|.ex_dna.exs|conformance_inventory.json|\
+      Dockerfile|.dockerignore|rel/*)
+      core=true
       ;;
 
     .gitignore|LICENSE*)

--- a/test/githooks/pre_push_test.exs
+++ b/test/githooks/pre_push_test.exs
@@ -110,6 +110,21 @@ defmodule PtcRunner.GitHooks.PrePushTest do
     assert List.last(invocations) == "ci-gate launcher"
   end
 
+  test "example changes run the core gate without the launcher companion" do
+    %{repo: repo, mix_marker: mix_marker, path: path} =
+      git_repo_with_change("examples/kernel-tutorial/03-file-agent/agent.clj")
+
+    {output, status} = run_hook(repo, path)
+
+    assert status == 0, output
+    assert output =~ "core tests"
+    refute output =~ "launcher validation"
+
+    invocations = mix_marker |> File.read!() |> String.split("\n", trim: true)
+    assert "ci-gate core-tests" in invocations
+    refute "ci-gate launcher" in invocations
+  end
+
   test "launcher-only changes run the launcher gate" do
     %{repo: repo, mix_marker: mix_marker, path: path} =
       git_repo_with_change("ptc_runner_launcher/c_src/launcher.c")

--- a/test/scripts/classify_changes_test.exs
+++ b/test/scripts/classify_changes_test.exs
@@ -51,9 +51,41 @@ defmodule PtcRunner.Scripts.ClassifyChangesTest do
              |> Map.put("mcp_filesystem", "true")
   end
 
+  test "known standing paths do not fall through to every scope" do
+    docs = only(["docs"])
+    core = only(["core"])
+    every_scope = only(~w(core launcher mcp_http mcp_filesystem java viewer docs))
+
+    for {path, expected} <- [
+          {"AGENTS.md", docs},
+          {"CLAUDE.md", docs},
+          {"usage-rules.md", docs},
+          {".env.example", docs},
+          {".lycheeignore", docs},
+          {".gitattributes", docs},
+          {"cliff.toml", docs},
+          {"REUSE.toml", docs},
+          {"site/index.html", docs},
+          {"dev/mix/tasks/ptc.verify_docs.ex", docs},
+          {".duplication-baseline.json", core},
+          {".ex_dna.exs", core},
+          {"conformance_inventory.json", core},
+          {"bench/lisp_throughput.exs", core},
+          {"Dockerfile", core},
+          {".dockerignore", core},
+          {"rel/overlays/bin/ptc", core},
+          {"examples/kernel-tutorial/03-file-agent/agent.clj", core},
+          {"examples/mcp/filesystem/src/index.ts", only(["mcp_filesystem"])},
+          {".claude/skills/precommit/SKILL.md", all_false()},
+          {"mise.toml", every_scope}
+        ] do
+      assert classify([path]) == expected, path
+    end
+  end
+
   test "unknown paths conservatively select every scope" do
     assert classify(["new-area/contract.data"]) ==
-             Map.new(all_false(), fn {scope, _value} -> {scope, "true"} end)
+             only(~w(core launcher mcp_http mcp_filesystem java viewer docs))
   end
 
   test "non-canonical executable-guide entries conservatively select every scope" do
@@ -62,7 +94,7 @@ defmodule PtcRunner.Scripts.ClassifyChangesTest do
           "./docs/maintainers/development-setup.md"
         ] do
       assert classify(["docs/maintainers/development-setup.md"], registry: entry <> "\n") ==
-               Map.new(all_false(), fn {scope, _value} -> {scope, "true"} end)
+               only(~w(core launcher mcp_http mcp_filesystem java viewer docs))
     end
   end
 
@@ -96,6 +128,10 @@ defmodule PtcRunner.Scripts.ClassifyChangesTest do
       [scope, value] = String.split(line, "=", parts: 2)
       {scope, value}
     end)
+  end
+
+  defp only(scopes) do
+    Enum.reduce(scopes, all_false(), &Map.put(&2, &1, "true"))
   end
 
   defp all_false do


### PR DESCRIPTION
## Summary

- Give long-tracked files explicit scopes in `scripts/ci/classify-changes.sh` so they stop falling through to `*) select_all`. Editing `AGENTS.md`, `examples/`, the duplication baseline, and similar standing paths no longer rebuilds the 4-OS launcher matrix.
- Keep `*)` as `select_all` for genuinely new repository areas. `mise.toml` joins `.tool-versions` in that intentional full-gate set.
- Cover each new arm in `test/scripts/classify_changes_test.exs`, keep the unknown-path fail-safe test, and assert that an example change runs core without the launcher companion.

This is Change 1 from #1493. It does **not** shrink the PR launcher matrix to Ubuntu-only (Change 2): real `ptc_runner_launcher/**` changes still get all four OSes. The merge-base vs `base.sha` lead stays a follow-up.

Closes #1493

## Test plan

- [x] `mix test test/scripts/classify_changes_test.exs test/githooks/pre_push_test.exs:113`
- [x] `mix precommit`
- [x] Pre-push hook (full gate, including launcher) on push
- [ ] After merge, incidental launcher-matrix rate should track commits that actually touch `ptc_runner_launcher/**` plus intentional `select_all` paths (`mix.exs`, `.github/*`, `scripts/*`)


Made with [Cursor](https://cursor.com)