### PR TITLE
perf(hooks): scope pre-commit format and credo to staged files

### DIFF
--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -7,8 +7,12 @@ take effect without reinstalling them.
 The pre-commit hook is the fast path: it runs format, compile, and credo
 only when staged Elixir, config, or Mix files belong to a project, and it
 passes those staged `.ex`/`.exs` paths to format and credo so a one-file
-commit does not analyze the whole tree. Credo consistency checks that compare
-the whole project therefore wait for `mix precommit` and pre-push. Compile
+commit does not analyze the whole tree. Nested launcher sources are kept off
+the root format and credo argument lists — those configs never included them,
+and an explicit path would apply the wrong rules — while a staged
+`.formatter.exs` or `.credo.exs` still runs that checker unscoped. Credo
+consistency checks that compare the whole project therefore wait for
+`mix precommit` and pre-push unless the Credo config itself changed. Compile
 stays project-wide because Mix is incremental and `--warnings-as-errors` has
 to see the build.
 Scoped tests run only for staged `*_test.exs` files, with `:slow` excluded.

--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -4,6 +4,15 @@ Run `./scripts/install-hooks.sh` once per clone. The installed hooks are small
 wrappers around the tracked implementations in this directory, so hook updates
 take effect without reinstalling them.
 
+The pre-commit hook is the fast path: it runs format, compile, and credo
+only when staged Elixir, config, or Mix files belong to a project, and it
+passes those staged `.ex`/`.exs` paths to format and credo so a one-file
+commit does not analyze the whole tree. Credo consistency checks that compare
+the whole project therefore wait for `mix precommit` and pre-push. Compile
+stays project-wide because Mix is incremental and `--warnings-as-errors` has
+to see the build.
+Scoped tests run only for staged `*_test.exs` files, with `:slow` excluded.
+
 The pre-push hook classifies the pushed and dirty paths, then invokes the same
 repository-owned root, Viewer, launcher, release, or documentation entry
 points as GitHub Actions. For mixed documentation and code changes, ExDoc runs

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -11,6 +11,8 @@ START_TIME=$(date +%s)
 
 PROJECTS=("." "ptc_viewer")
 
+# Newline-delimited names, same as before this change. Paths with embedded
+# newlines need `git diff -z`; that is outside this scoped-format slice.
 ALL_STAGED=$(git diff --cached --name-only --diff-filter=ACMR)
 ALL_DELETED=$(git diff --cached --diff-filter=D --name-only)
 ALL_RENAMED=$(git diff --cached --diff-filter=R --name-only)
@@ -71,27 +73,50 @@ run_project_gates() {
     mix deps.compile > /dev/null 2>&1 || true
   fi
 
+  # Format and credo take the staged Elixir paths so a one-file commit does
+  # not pay for the whole tree. Compile stays unscoped: Mix is incremental,
+  # and warnings-as-errors has to see the project. Paths are relative to the
+  # project cwd after `pushd`, kept as a Bash array so spaces survive as one
+  # Mix argument. Sorted so the re-run hint is stable.
+  #
+  # Credo consistency checks (exception names, parameter-pattern style) are
+  # weaker on a subset; `mix precommit` and pre-push still run full credo.
+  local elixir_files=()
+  if [ -n "$has_elixir" ]; then
+    local elixir_list=$has_elixir
+    if [ "$proj" != "." ]; then
+      elixir_list=$(printf '%s\n' "$elixir_list" | sed "s|^${proj}/||")
+    fi
+    local elixir_file
+    while IFS= read -r elixir_file; do
+      [ -n "$elixir_file" ] && elixir_files+=("$elixir_file")
+    done < <(printf '%s\n' "$elixir_list" | grep -v '^$' | LC_ALL=C sort)
+  fi
+
   # Static checks share ONE mix invocation (one BEAM boot) instead of a
   # separate `mix` process per check. `mix do a + b + c` fails fast on the
   # first non-zero task. (cwd is the project dir, so `project_has_dep "."`.)
-  local checks=""
-  if [ -n "$has_elixir" ]; then
-    checks="format --check-formatted"
+  local checks=()
+  if [ ${#elixir_files[@]} -gt 0 ]; then
+    checks+=(format --check-formatted "${elixir_files[@]}")
   fi
   if [ -n "$has_elixir" ] || [ -n "$has_config" ] || [ -n "$has_mix" ]; then
-    checks="${checks:+$checks + }compile --warnings-as-errors"
+    if [ ${#checks[@]} -gt 0 ]; then
+      checks+=(+)
+    fi
+    checks+=(compile --warnings-as-errors)
   fi
-  if [ -n "$has_elixir" ] && project_has_dep "." "credo"; then
-    checks="${checks:+$checks + }credo --strict"
+  if [ ${#elixir_files[@]} -gt 0 ] && project_has_dep "." "credo"; then
+    checks+=(+ credo --strict "${elixir_files[@]}")
   fi
 
-  if [ -n "$checks" ]; then
-    echo "  ⏳ mix do $checks"
-    # shellcheck disable=SC1010,SC2086  # controlled `mix do` task list
-    if ! static_out=$(mix do $checks 2>&1); then
+  if [ ${#checks[@]} -gt 0 ]; then
+    echo "  ⏳ mix do ${checks[*]}"
+    # shellcheck disable=SC1010  # `+` is mix do's task separator
+    if ! static_out=$(mix do "${checks[@]}" 2>&1); then
       echo "  ❌ Static checks failed in $label:"
       echo "$static_out" | tail -40
-      echo "  Re-run: (cd $proj && mix do $checks)"
+      echo "  Re-run: (cd $(printf '%q' "$proj") && mix do $(printf '%q ' "${checks[@]}"))"
       popd > /dev/null
       exit 1
     fi
@@ -108,18 +133,22 @@ run_project_gates() {
   # *is* redundant with `test/test_helper.exs`, and is kept only for symmetry.
   #
   # `:nightly` needs no flag here: `test/test_helper.exs` excludes it globally.
-  local changed_tests
+  local changed_tests=()
+  local test_list=""
   if [ "$proj" = "." ]; then
-    changed_tests=$(echo "$staged" | grep -E '^test/.*_test\.exs$' || true)
+    test_list=$(printf '%s\n' "$staged" | grep -E '^test/.*_test\.exs$' || true)
   else
-    changed_tests=$(echo "$staged" | grep -E "^${proj}/test/.*_test\.exs$" \
-                      | sed "s|^${proj}/||" || true)
+    test_list=$(printf '%s\n' "$staged" | grep -E "^${proj}/test/.*_test\.exs$" \
+                  | sed "s|^${proj}/||" || true)
   fi
+  local test_file
+  while IFS= read -r test_file; do
+    [ -n "$test_file" ] && changed_tests+=("$test_file")
+  done < <(printf '%s\n' "$test_list")
 
-  if [ -n "$changed_tests" ]; then
+  if [ ${#changed_tests[@]} -gt 0 ]; then
     echo "  ⏳ Running scoped tests (excluding :slow)..."
-    # shellcheck disable=SC2086  # word-split the space-separated file list
-    if ! test_out=$(mix test $changed_tests --exclude clojure --exclude slow 2>&1); then
+    if ! test_out=$(mix test "${changed_tests[@]}" --exclude clojure --exclude slow 2>&1); then
       echo "  ❌ Tests failed in $label:"
       echo "$test_out" | tail -40
       popd > /dev/null

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -73,15 +73,23 @@ run_project_gates() {
     mix deps.compile > /dev/null 2>&1 || true
   fi
 
-  # Format and credo take the staged Elixir paths so a one-file commit does
-  # not pay for the whole tree. Compile stays unscoped: Mix is incremental,
-  # and warnings-as-errors has to see the project. Paths are relative to the
-  # project cwd after `pushd`, kept as a Bash array so spaces survive as one
-  # Mix argument. Sorted so the re-run hint is stable.
+  # Format and credo take the staged Elixir paths those tools own so a
+  # one-file commit does not pay for the whole tree. Nested companions
+  # (`ptc_runner_launcher/`) stay out: the root formatter and Credo configs
+  # do not include them, and passing explicit paths would apply the wrong
+  # rules. Compile stays unscoped: Mix is incremental, and
+  # warnings-as-errors has to see the project (including the launcher path
+  # dependency). Paths are relative to the project cwd after `pushd`, kept
+  # as a Bash array so spaces survive as one Mix argument. Sorted so the
+  # re-run hint is stable.
   #
-  # Credo consistency checks (exception names, parameter-pattern style) are
-  # weaker on a subset; `mix precommit` and pre-push still run full credo.
+  # A staged `.formatter.exs` / `.credo.exs` rewrites the checker itself, so
+  # that task runs unscoped. Credo consistency checks (exception names,
+  # parameter-pattern style) are weaker on a subset; `mix precommit` and
+  # pre-push still run full credo.
   local elixir_files=()
+  local format_unscoped=0
+  local credo_unscoped=0
   if [ -n "$has_elixir" ]; then
     local elixir_list=$has_elixir
     if [ "$proj" != "." ]; then
@@ -89,7 +97,16 @@ run_project_gates() {
     fi
     local elixir_file
     while IFS= read -r elixir_file; do
-      [ -n "$elixir_file" ] && elixir_files+=("$elixir_file")
+      [ -n "$elixir_file" ] || continue
+      case "$elixir_file" in
+        mix.exs|.formatter.exs|.credo.exs|config/*|lib/*|test/*) ;;
+        *) continue ;;
+      esac
+      case "$elixir_file" in
+        .formatter.exs) format_unscoped=1 ;;
+        .credo.exs) credo_unscoped=1 ;;
+      esac
+      elixir_files+=("$elixir_file")
     done < <(printf '%s\n' "$elixir_list" | grep -v '^$' | LC_ALL=C sort)
   fi
 
@@ -97,7 +114,9 @@ run_project_gates() {
   # separate `mix` process per check. `mix do a + b + c` fails fast on the
   # first non-zero task. (cwd is the project dir, so `project_has_dep "."`.)
   local checks=()
-  if [ ${#elixir_files[@]} -gt 0 ]; then
+  if [ "$format_unscoped" = 1 ]; then
+    checks+=(format --check-formatted)
+  elif [ ${#elixir_files[@]} -gt 0 ]; then
     checks+=(format --check-formatted "${elixir_files[@]}")
   fi
   if [ -n "$has_elixir" ] || [ -n "$has_config" ] || [ -n "$has_mix" ]; then
@@ -106,8 +125,12 @@ run_project_gates() {
     fi
     checks+=(compile --warnings-as-errors)
   fi
-  if [ ${#elixir_files[@]} -gt 0 ] && project_has_dep "." "credo"; then
-    checks+=(+ credo --strict "${elixir_files[@]}")
+  if project_has_dep "." "credo"; then
+    if [ "$credo_unscoped" = 1 ]; then
+      checks+=(+ credo --strict)
+    elif [ ${#elixir_files[@]} -gt 0 ]; then
+      checks+=(+ credo --strict "${elixir_files[@]}")
+    fi
   fi
 
   if [ ${#checks[@]} -gt 0 ]; then

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -7,6 +7,14 @@ history preserves them. Current architecture belongs in the
 contracts belong in the owning module documentation, and user-facing behavior
 belongs in guides or retained specifications.
 
+## Local gates
+
+- [`faster-hooks.md`](faster-hooks.md)
+  records measured warm times for the git pre-commit hook, `mix precommit`,
+  and git pre-push, and the slices that can still shrink them. The 185s
+  `async: false` serial floor is the only way to make push substantially
+  faster; overlapping more gates on push is already spent.
+
 ## Remaining Kernel product work
 
 - [`lisp-kernel/promote-authored-component.md`](lisp-kernel/promote-authored-component.md)

--- a/docs/plans/faster-hooks.md
+++ b/docs/plans/faster-hooks.md
@@ -1,0 +1,242 @@
+# Faster git hooks and `mix precommit`
+
+**Status:** active; slices 1 and 2 implemented. Measurements from a warm
+worktree on 2026-08-18 (Elixir on a 10-scheduler Mac, HEAD `d9a814b0`).
+
+The three local gates are easy to conflate, and they do not cost the same:
+
+| Gate | When | What it runs | Warm wall |
+| --- | --- | --- | --- |
+| `.githooks/pre-commit` | `git commit` | Staged-project format, compile, credo; scoped tests with `--exclude slow` | **13s** for static checks (target `<10s`) |
+| `mix precommit` | agents, before every commit | Nested fetch, quality, full core tests, Viewer, launcher package, core release | **~7.7 min** serial |
+| `.githooks/pre-push` | `git push` | Docs, then core tests, then concurrent static+Dialyzer / release / Viewer, then launcher | **~6.8 min** when core is selected |
+
+GitHub Actions runs the same scripts as parallel jobs. A typical core PR is
+about **4.5 min** wall, with Core tests as the critical path (4:10 including
+setup). Local push is slower because tests and the deterministic tail cannot
+all start together.
+
+## What was measured
+
+Warm times in `/Users/andreasronge/projects/ptc_runner-perf-faster-hooks`
+after the first compile in that tree. The first `mix compile --warnings-as-errors`
+took 20s (seeded `_build` from the main checkout); a second compile took **2.7s**.
+
+| Step | Seconds |
+| --- | ---: |
+| Mix boot (`mix help compile`) | 1 |
+| `mix compile --warnings-as-errors` (truly warm) | 2.7 |
+| `mix format --check-formatted` (776 files) | 2 |
+| `mix format --check-formatted lib/ptc_runner.ex` | 0 |
+| `mix credo --strict` (776 files) | 12 (later 9.5s analysis) |
+| `mix credo --strict lib/ptc_runner.ex` | 1 |
+| `mix xref` cycles | 3 |
+| `mix ptc.validate_spec` | 2 |
+| `mix ptc.gen_docs --check` | 3 |
+| `mix ptc.conformance_report --check-inventory` | 3 |
+| `scripts/duplication_gate.sh check` | 23 |
+| `mix ptc.audit_upstream` | 8 |
+| `mix deps.unlock --check-unused` | 0 |
+| pre-commit `mix do format + compile + credo` | **13** |
+| Viewer gate | 6 |
+| Docs gate (`MIX_ENV=dev`) | 35 |
+| Dialyzer | 62 |
+| Core tests (`CI=1`) | **252** |
+| Core release | **121** |
+| Launcher `mix precommit` without `mix clean` | 31 |
+
+Core tests printed:
+
+```
+Finished in 245.5 seconds (60.3s async, 185.2s sync)
+6681 passed (122 doctests, 5 properties, 6554 tests), 368 excluded
+```
+
+The serial floor is **75% of suite wall**. Five StreamData properties are not
+a meaningful lever; dropping `CI=1`'s 300-run setting would not change push
+time in a way worth diverging from CI.
+
+Reconstructed serial `mix precommit` (quality ≈ 50s after a warm compile):
+
+```
+preflight (~2) + quality (~50) + tests (252) + viewer (6)
++ launcher (~31, more with mix clean) + release (121)
+≈ 462s
+```
+
+Reconstructed pre-push with core selected, after the existing concurrent tail
+(`7c47dd4c`):
+
+```
+docs (35) + tests (252) + max(static+Dialyzer ≈ 120, release 121, Viewer 6)
+≈ 408s
+```
+
+## Why overlapping more gates barely helps push
+
+The pre-push tail already overlaps the three deterministic lanes. Two of those
+lanes are the same length: static+Dialyzer (~120s) and release (121s). Static
+analysis and Dialyzer share `_build/test` with the suite, so they cannot start
+until tests finish. Release uses `_build/prod` and *could* overlap tests, but
+that only shortens the tail from `max(120, 121)` to `120` — about one second.
+
+Starting release during tests is also the load pattern the hook comments
+refuse: timing-sensitive `async: false` tests have already flaked under
+unrelated background work. Do not spend a slice on overlapping tests with
+release or Dialyzer.
+
+`mix precommit` is different. It still runs quality, tests, Viewer, launcher,
+and release **back to back**. The same lane idea the push hook already has
+would cut it from ~7.7 min to about **5.1 min** (`max(quality+tests, release)`),
+with tests overlapping only the last ~70s of release (mostly the async
+portion of the suite). That is the one structural overlap that still has a
+large payoff.
+
+## The expensive double run
+
+`AGENTS.md` asks for `mix precommit` before every commit and a full pre-push
+on `git push`. An agent that follows both pays ~7.7 min then ~6.8 min, and
+repeats tests, quality, Viewer, and release. That duplicated 15-minute loop
+is larger than any remaining overlap inside a single gate.
+
+The git pre-commit hook is already the fast commit path. `mix precommit` is a
+third, almost-full CI.
+
+## Serial tests, not Mix boots, dominate
+
+- 250 files / 5541 tests are `async: true`.
+- 59 files / 850 tests are `async: false` on purpose.
+- **10 Lisp files / 523 tests** use `use ExUnit.Case` with no `async:` option,
+  so they are serial by Elixir default. They are pure unit modules
+  (`runtime_arithmetic`, `signature/coercion`, `spec_validator`, …) with no
+  `Application.put_env`, `System.put_env`, or `File.cd`. This looks accidental.
+
+Largest intentional serial module: `test/ptc_runner/kernel/command_engine_test.exs`
+(159 tests, 266 KB). A handful of cases need `Application.put_env` / `File.cd`;
+the rest sit in the same serial queue because they share the module.
+
+## What not to do
+
+- Do not lower ExUnit `max_cases` or add `--trace` / `--slowest` to make a
+  gate look faster. `--trace` pins `--max-cases` to 1 (measured 259s on CI
+  when that happened).
+- Do not exclude `:slow` from `mix precommit`, pre-push, or CI. That tag exists
+  only for the git pre-commit hook; excluding it globally dropped correctness
+  tests from every PR to save 14s.
+- Do not tag more tests `:nightly` to shrink the push suite. `:nightly` means
+  "unverified on pull requests".
+- Do not overlap the suite with Dialyzer, release, or the launcher on
+  pre-push. The remaining win is ~1s and the flake cost is documented.
+- Do not change StreamData's `CI=1` 300-run setting for local push. Five
+  properties.
+- Do not regenerate `priv/semantic_build_projection.json` as part of this work.
+
+## Slices, cheapest first
+
+### 1. Scope git pre-commit format and credo to staged files — done
+
+Implemented in this branch: `.githooks/pre-commit` passes sorted staged
+`.ex`/`.exs` paths (Viewer-relative under `ptc_viewer/`) to `mix format` and
+`mix credo`. Compile stays unscoped. Covered by `test/githooks/pre_commit_test.exs`.
+
+### 2. Mark the ten accidentally serial Lisp modules `async: true` — done
+
+The ten `use ExUnit.Case` Lisp modules now declare `async: true`.
+
+### 3. Stop paying for `mix precommit` and pre-push back to back
+
+Pick one policy and write it in `AGENTS.md` plus `.githooks/README.md`:
+
+- **A (recommended for agents):** `mix precommit` keeps quality + nested
+  fetch, and drops the full suite, Viewer, launcher package, and release.
+  Those already run on push. Commit cost falls from ~7.7 min to ~1 min.
+  Push stays the CI-equivalent gate.
+- **B:** Keep `mix precommit` comprehensive, and teach agents not to run it
+  immediately before `git push`. Weaker, because the instruction is easy to
+  ignore.
+- **C:** Stamp file: pre-push skips a script whose digest and HEAD match a
+  successful `mix precommit`. More machinery, easy to get wrong with dirty
+  trees.
+
+Do not silently drop Dialyzer or docs from push. Those are the parts
+`mix precommit` already omits.
+
+### 4. Give `mix precommit` the same concurrent lanes as pre-push
+
+If slice 3 is not taken, extract the lane helper from `.githooks/pre-push`
+into a repository script both entry points call:
+
+- lane A: quality then tests (`_build/test`, shared Mix lock)
+- lane B: core release (`_build/prod`)
+- lane C: Viewer
+- lane D: launcher package
+
+Expected warm wall ≈ `max(302, 121)` ≈ **5.1 min** vs 7.7 min. Tests overlap
+only the tail of release, after quality, during mostly-async work. Keep
+`PTC_PRE_PUSH_SERIAL=1` as the escape hatch. GitHub Actions is already
+parallel jobs and must keep calling the individual scripts.
+
+### 5. Drop `mix clean` from `scripts/ci/launcher-package.sh` if evidence allows
+
+The launcher alias already sets `elixir_make` `force_build`. `mix clean`
+throws away the seeded `_build` on every `mix precommit` and forces a native
+rebuild. A warm launcher `mix precommit` without clean is 31s; with clean it
+is a from-scratch compile. The `mix clean` line is asserted in
+`test/scripts/ci_gates_test.exs`, so removing it is a contract change. Prove
+`force_build` still rebuilds the NIF, then delete the clean.
+
+### 6. Shrink the duplication gate's 23s
+
+Hex ExDNA 1.5.x has no `--cache`. The cache is tested only on the unreleased
+candidate job (`PTC_EX_DNA_PATH`). When that cache ships, enable it for the
+ordinary local gate. Until then, chaining `mix compile` out of
+`duplication_gate.sh` (quality already compiled) saves one Mix boot, not 23s.
+
+Optionally run ExDNA in parallel with credo after one compile: both are
+read-mostly on a warm `_build/test`. Measure; do not assume.
+
+### 7. Split oversized `async: false` modules
+
+This is the only way to cut the 185s serial floor, and therefore the only way
+to make **git push** substantially faster. Start with modules that mix
+pure unit tests with a few global-state cases:
+
+- `command_engine_test.exs` (159 tests)
+- `mcp_source_test.exs` (52)
+- `ptc_repl_test.exs` (54 mix-task tests; many may have to stay serial)
+- `provider_active_session_test.exs` (41)
+- `host_installation_test.exs` (34)
+
+Move cases that do not call `File.cd`, `Application.put_env`, or
+`System.put_env` into `async: true` modules. Leave a thin serial sibling for
+the rest. Do not invent a wrapper that still mutates VM-global state from
+async tests.
+
+Re-measure `mix test` wall and the `async`/`sync` split after each split.
+Stop when the serial floor is no longer the majority of suite wall, or when
+the remaining serial tests are all genuinely global.
+
+### 8. Small quality-script hygiene
+
+`scripts/ci/core-quality.sh` boots Mix seven times; `duplication_gate.sh`
+boots it twice more. `mix do compile --warnings-as-errors + format
+--check-formatted + credo --strict + xref graph …` is already 13s including
+credo. Chaining the cheap `ptc.*` checks into the same invocation saves a few
+seconds, not a minute. Worth doing while touching the script; not a slice on
+its own.
+
+## Acceptance
+
+A slice is done when:
+
+- the measured warm time for the gate it claims to change is recorded in the
+  PR, against the numbers above;
+- `scripts/ci/core-tests.sh` still sets `CI=1` and does not reduce scheduler
+  count;
+- GitHub Actions still calls the same per-concern scripts (no second
+  implementation of a gate);
+- independent review of hook or CI-script changes follows
+  `docs/maintainers/coding-agent-review.md`.
+
+Delete this plan when the chosen slices have landed and the durable contract
+(what each gate runs) lives in `.githooks/README.md` and `AGENTS.md`.

--- a/test/githooks/pre_commit_test.exs
+++ b/test/githooks/pre_commit_test.exs
@@ -153,6 +153,71 @@ defmodule PtcRunner.GitHooks.PreCommitTest do
            """
   end
 
+  test "runs format unscoped when .formatter.exs is staged" do
+    %{repo: repo, path: path, mix_marker: mix_marker} =
+      git_repo_with_staged([".formatter.exs"])
+
+    {output, status} = run_hook(repo, path)
+
+    assert status == 0, output
+
+    assert File.read!(mix_marker) == """
+           cwd=repo
+           arg=do
+           arg=format
+           arg=--check-formatted
+           arg=+
+           arg=compile
+           arg=--warnings-as-errors
+           arg=+
+           arg=credo
+           arg=--strict
+           arg=.formatter.exs
+           ---
+           """
+  end
+
+  test "runs credo unscoped when .credo.exs is staged" do
+    %{repo: repo, path: path, mix_marker: mix_marker} =
+      git_repo_with_staged([".credo.exs"])
+
+    {output, status} = run_hook(repo, path)
+
+    assert status == 0, output
+
+    assert File.read!(mix_marker) == """
+           cwd=repo
+           arg=do
+           arg=format
+           arg=--check-formatted
+           arg=.credo.exs
+           arg=+
+           arg=compile
+           arg=--warnings-as-errors
+           arg=+
+           arg=credo
+           arg=--strict
+           ---
+           """
+  end
+
+  test "does not pass launcher sources to root format or credo" do
+    %{repo: repo, path: path, mix_marker: mix_marker} =
+      git_repo_with_staged(["ptc_runner_launcher/lib/launcher.ex"])
+
+    {output, status} = run_hook(repo, path)
+
+    assert status == 0, output
+
+    assert File.read!(mix_marker) == """
+           cwd=repo
+           arg=do
+           arg=compile
+           arg=--warnings-as-errors
+           ---
+           """
+  end
+
   defp git_repo_with_staged(paths, opts \\ []) do
     root =
       Path.join(

--- a/test/githooks/pre_commit_test.exs
+++ b/test/githooks/pre_commit_test.exs
@@ -1,0 +1,242 @@
+defmodule PtcRunner.GitHooks.PreCommitTest do
+  use ExUnit.Case, async: true
+
+  alias PtcRunner.TestSupport.GitEnv
+
+  @hook Path.expand("../../.githooks/pre-commit", __DIR__)
+  @git_env GitEnv.clear()
+
+  test "passes staged Elixir files to format and credo, not the whole tree" do
+    %{repo: repo, path: path, mix_marker: mix_marker} =
+      git_repo_with_staged(["lib/example.ex"])
+
+    {output, status} = run_hook(repo, path)
+
+    assert status == 0, output
+
+    assert File.read!(mix_marker) == """
+           cwd=repo
+           arg=do
+           arg=format
+           arg=--check-formatted
+           arg=lib/example.ex
+           arg=+
+           arg=compile
+           arg=--warnings-as-errors
+           arg=+
+           arg=credo
+           arg=--strict
+           arg=lib/example.ex
+           ---
+           """
+  end
+
+  test "passes every staged Elixir file and leaves compile unscoped" do
+    %{repo: repo, path: path, mix_marker: mix_marker} =
+      git_repo_with_staged(["lib/b.ex", "lib/a.ex", "test/a_test.exs"])
+
+    {output, status} = run_hook(repo, path)
+
+    assert status == 0, output
+
+    assert File.read!(mix_marker) == """
+           cwd=repo
+           arg=do
+           arg=format
+           arg=--check-formatted
+           arg=lib/a.ex
+           arg=lib/b.ex
+           arg=test/a_test.exs
+           arg=+
+           arg=compile
+           arg=--warnings-as-errors
+           arg=+
+           arg=credo
+           arg=--strict
+           arg=lib/a.ex
+           arg=lib/b.ex
+           arg=test/a_test.exs
+           ---
+           cwd=repo
+           arg=test
+           arg=test/a_test.exs
+           arg=--exclude
+           arg=clojure
+           arg=--exclude
+           arg=slow
+           ---
+           """
+  end
+
+  test "keeps a whitespace Elixir path as one Mix argument" do
+    %{repo: repo, path: path, mix_marker: mix_marker} =
+      git_repo_with_staged(["lib/my module.ex", "test/my module_test.exs"])
+
+    {output, status} = run_hook(repo, path)
+
+    assert status == 0, output
+
+    assert File.read!(mix_marker) == """
+           cwd=repo
+           arg=do
+           arg=format
+           arg=--check-formatted
+           arg=lib/my module.ex
+           arg=test/my module_test.exs
+           arg=+
+           arg=compile
+           arg=--warnings-as-errors
+           arg=+
+           arg=credo
+           arg=--strict
+           arg=lib/my module.ex
+           arg=test/my module_test.exs
+           ---
+           cwd=repo
+           arg=test
+           arg=test/my module_test.exs
+           arg=--exclude
+           arg=clojure
+           arg=--exclude
+           arg=slow
+           ---
+           """
+  end
+
+  test "rewrites Viewer paths relative to ptc_viewer/ and skips credo there" do
+    %{repo: repo, path: path, mix_marker: mix_marker} =
+      git_repo_with_staged(["ptc_viewer/lib/ptc_viewer.ex"], viewer?: true)
+
+    {output, status} = run_hook(repo, path)
+
+    assert status == 0, output
+    assert output =~ "Project: ptc_viewer/"
+    refute output =~ "Project: root"
+
+    assert File.read!(mix_marker) == """
+           cwd=ptc_viewer
+           arg=do
+           arg=format
+           arg=--check-formatted
+           arg=lib/ptc_viewer.ex
+           arg=+
+           arg=compile
+           arg=--warnings-as-errors
+           ---
+           """
+  end
+
+  test "skips Mix when the index has no Elixir, config, or mix files" do
+    %{repo: repo, path: path, mix_marker: mix_marker} =
+      git_repo_with_staged(["docs/guides/replay.md"])
+
+    {output, status} = run_hook(repo, path)
+
+    assert status == 0, output
+    refute File.exists?(mix_marker)
+  end
+
+  test "compiles mix.lock changes without format or credo" do
+    %{repo: repo, path: path, mix_marker: mix_marker} =
+      git_repo_with_staged(["mix.lock"])
+
+    {output, status} = run_hook(repo, path)
+
+    assert status == 0, output
+
+    assert File.read!(mix_marker) == """
+           cwd=repo
+           arg=do
+           arg=compile
+           arg=--warnings-as-errors
+           ---
+           """
+  end
+
+  defp git_repo_with_staged(paths, opts \\ []) do
+    root =
+      Path.join(
+        System.tmp_dir!(),
+        "ptc-pre-commit-#{System.unique_integer([:positive, :monotonic])}"
+      )
+
+    repo = Path.join(root, "repo")
+    bin = Path.join(root, "bin")
+    mix_marker = Path.join(root, "mix-called")
+    File.mkdir_p!(repo)
+    File.mkdir_p!(bin)
+    on_exit(fn -> File.rm_rf!(root) end)
+
+    File.mkdir_p!(Path.join(repo, ".githooks"))
+    File.cp!(@hook, Path.join(repo, ".githooks/pre-commit"))
+    File.chmod!(Path.join(repo, ".githooks/pre-commit"), 0o755)
+
+    fake_mix = Path.join(bin, "mix")
+
+    File.write!(fake_mix, """
+    #!/bin/sh
+    {
+      printf 'cwd=%s\\n' "$(basename "$PWD")"
+      for arg in "$@"; do
+        printf 'arg=%s\\n' "$arg"
+      done
+      printf -- '---\\n'
+    } >> "$MIX_MARKER"
+    exit 0
+    """)
+
+    File.chmod!(fake_mix, 0o755)
+
+    git!(repo, ["init", "--quiet"])
+    git!(repo, ["config", "user.email", "pre-commit@example.test"])
+    git!(repo, ["config", "user.name", "Pre-commit Test"])
+
+    File.write!(Path.join(repo, "mix.exs"), "{:credo, \"~> 1.7\"}\n")
+    File.write!(Path.join(repo, "mix.lock"), "%{}\n")
+
+    if opts[:viewer?] do
+      File.mkdir_p!(Path.join(repo, "ptc_viewer"))
+
+      File.write!(
+        Path.join(repo, "ptc_viewer/mix.exs"),
+        "defmodule PtcViewer.MixProject do\nend\n"
+      )
+    end
+
+    git!(repo, ["add", "."])
+    git!(repo, ["commit", "--quiet", "-m", "base"])
+
+    Enum.each(paths, fn path ->
+      full_path = Path.join(repo, path)
+      File.mkdir_p!(Path.dirname(full_path))
+      File.write!(full_path, "staged\n")
+    end)
+
+    git!(repo, ["add", "--"] ++ paths)
+
+    %{
+      repo: repo,
+      path: bin <> ":" <> System.fetch_env!("PATH"),
+      mix_marker: mix_marker
+    }
+  end
+
+  defp run_hook(repo, path) do
+    System.cmd("bash", [Path.join(repo, ".githooks/pre-commit")],
+      cd: repo,
+      env: @git_env ++ [{"MIX_MARKER", mix_marker_from_path(path)}, {"PATH", path}],
+      stderr_to_stdout: true
+    )
+  end
+
+  defp mix_marker_from_path(path) do
+    path |> String.split(":") |> hd() |> Path.dirname() |> Path.join("mix-called")
+  end
+
+  defp git!(repo, args) do
+    {output, 0} =
+      System.cmd("git", args, cd: repo, env: @git_env, stderr_to_stdout: true)
+
+    String.trim(output)
+  end
+end

--- a/test/ptc_runner/lisp/runtime_arithmetic_test.exs
+++ b/test/ptc_runner/lisp/runtime_arithmetic_test.exs
@@ -1,5 +1,5 @@
 defmodule PtcRunner.Lisp.RuntimeArithmeticTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   # ============================================================
   # Rounding Functions

--- a/test/ptc_runner/lisp/runtime_bitwise_test.exs
+++ b/test/ptc_runner/lisp/runtime_bitwise_test.exs
@@ -1,5 +1,5 @@
 defmodule PtcRunner.Lisp.RuntimeBitwiseTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   # Bitwise operations (#825). Values chosen to match Clojure/JVM exactly
   # (BEAM integers are arbitrary-precision two's-complement, which agrees

--- a/test/ptc_runner/lisp/runtime_flex_access_test.exs
+++ b/test/ptc_runner/lisp/runtime_flex_access_test.exs
@@ -1,5 +1,5 @@
 defmodule PtcRunner.Lisp.RuntimeFlexAccessTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   alias PtcRunner.Lisp.Runtime
 

--- a/test/ptc_runner/lisp/runtime_nested_keys_test.exs
+++ b/test/ptc_runner/lisp/runtime_nested_keys_test.exs
@@ -1,5 +1,5 @@
 defmodule PtcRunner.Lisp.RuntimeNestedKeysTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   alias PtcRunner.Lisp.Runtime
   alias PtcRunner.Lisp.Runtime.FlexAccess

--- a/test/ptc_runner/lisp/runtime_string_test.exs
+++ b/test/ptc_runner/lisp/runtime_string_test.exs
@@ -1,5 +1,5 @@
 defmodule PtcRunner.Lisp.RuntimeStringTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   alias PtcRunner.Lisp.Runtime
 

--- a/test/ptc_runner/lisp/signature/coercion_test.exs
+++ b/test/ptc_runner/lisp/signature/coercion_test.exs
@@ -1,5 +1,5 @@
 defmodule PtcRunner.Lisp.Signature.CoercionTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   doctest PtcRunner.Lisp.Signature.Coercion
 
   alias PtcRunner.Lisp.Signature.Coercion

--- a/test/ptc_runner/lisp/signature/parser_test.exs
+++ b/test/ptc_runner/lisp/signature/parser_test.exs
@@ -1,5 +1,5 @@
 defmodule PtcRunner.Lisp.Signature.ParserTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   alias PtcRunner.Lisp.Signature.Parser
 

--- a/test/ptc_runner/lisp/signature/validator_test.exs
+++ b/test/ptc_runner/lisp/signature/validator_test.exs
@@ -1,5 +1,5 @@
 defmodule PtcRunner.Lisp.Signature.ValidatorTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   alias PtcRunner.Lisp.Signature
   alias PtcRunner.Lisp.Signature.Validator

--- a/test/ptc_runner/lisp/spec_validator_test.exs
+++ b/test/ptc_runner/lisp/spec_validator_test.exs
@@ -1,5 +1,5 @@
 defmodule PtcRunner.Lisp.SpecValidatorTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   alias PtcRunner.Lisp.SpecValidator
 

--- a/test/ptc_runner/lisp/vector_key_test.exs
+++ b/test/ptc_runner/lisp/vector_key_test.exs
@@ -1,5 +1,5 @@
 defmodule PtcRunner.Lisp.VectorKeyTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   alias PtcRunner.Lisp.Runtime
 
   test "avg-by with vector path" do


### PR DESCRIPTION
## Summary

- Scope the git pre-commit format and Credo checks to staged `.ex`/`.exs` files (quoted Mix argv) instead of the whole tree. Compile stays unscoped. Formatter/Credo configs force an unscoped run when those files are staged; launcher sources are not passed to root format/Credo.
- Mark ten Lisp test modules `async: true` that were accidentally serial (Elixir's default). They do not mutate VM-global env or the working directory.
- Investigation and remaining slices live in `docs/plans/faster-hooks.md`. This PR is slices 1 and 2 only.

## Test plan

- [x] `mix test test/githooks/pre_commit_test.exs`
- [x] Focused run of the ten Lisp modules after `async: true`
- [x] Independent Codex review of the hook argv / config / launcher exclusions
- [x] Full pre-push on `perf/faster-hooks` (docs, core tests, static+Dialyzer, release, Viewer, launcher)
- [ ] Confirm a one-file Elixir commit only Credo-checks that file
- [ ] CI green on this PR


Made with [Cursor](https://cursor.com)