### PR TITLE
fix(kernel): record a closed rejection class on capability-stopped

### DIFF
--- a/docs/reference/debug-navigation.md
+++ b/docs/reference/debug-navigation.md
@@ -34,8 +34,15 @@ Two artifacts matter, and they carry different authority.
 A **canonical trace** is bounded operational evidence: run and evaluation
 lifecycle, capability names and outcomes, counts, and a sanitized failure
 taxonomy. It contains no prompts, model responses, capability payloads, or
-generated source. A workflow's own `fail` value never reaches it; an
-unrecognized `kind` is retained only as a one-way fingerprint.
+generated source.
+
+A failed capability attempt records its closed envelope `kind` and `reason`
+on the `capability-stopped` event. An unrecognized envelope atom is retained
+only as a one-way fingerprint.
+
+A workflow's own `fail` value never reaches the public trace as prose. An
+unrecognized `fail` kind is retained only as a one-way fingerprint on
+`run-stopped`; that taxonomy is separate from the capability-stopped class.
 
 A **private inspection artifact** is an explicit `0600` host development
 authority. It adds the frozen component sources, the exact generated programs,

--- a/docs/trace-log-contract.md
+++ b/docs/trace-log-contract.md
@@ -646,6 +646,13 @@ The generic Kernel emits lifecycle, subordinate-evaluation, capability,
 resource, annotation, and terminal facts. Providers may attach safe typed
 metadata without making Kernel understand provider-specific transcripts.
 
+A `capability-stopped` event with `status: "error"` carries the closed Lisp
+envelope `kind` and, when present, `reason` — the same payload-free class
+`execution_errors` already expose. An unrecognized envelope atom is retained
+only as a one-way fingerprint (`kind_fingerprint` / `reason_fingerprint`).
+Arguments, results, details, and messages stay off this event. Successful
+stops omit these fields.
+
 The implemented private event policy stores the same canonical event
 vocabulary as the normal policy. It changes sink failure behavior, file
 permissions, and discovery; it does not capture prompts, responses, capability

--- a/lib/ptc_runner/kernel/dispatcher.ex
+++ b/lib/ptc_runner/kernel/dispatcher.ex
@@ -5,8 +5,11 @@ defmodule PtcRunner.Kernel.Dispatcher do
   Dispatch validates normalized arguments, atomically reserves environment and
   provider-task budgets in `PtcRunner.Kernel.RunState`, emits canonical attempt
   events, runs the trusted callback in a monitored heap-limited process, and
-  constructs the uniform Lisp result envelope. Completion is checked against
-  run closure so late results cannot re-enter Lisp.
+  constructs the uniform Lisp result envelope. An error `capability-stopped`
+  event carries the closed envelope `kind` and `reason`; an unrecognized atom
+  is retained only as a one-way fingerprint, and details stay off that event.
+  Completion is checked against run closure so late results cannot
+  re-enter Lisp.
 
   Mission failures after callback entry are classified with the capability's
   declared effect. Read failures keep an explicit typed provider retry policy.
@@ -415,6 +418,7 @@ defmodule PtcRunner.Kernel.Dispatcher do
             status: result.status,
             duration_ms: Events.duration_ms(started_ms)
           })
+          |> Events.put_rejection_class(result)
 
         :telemetry.execute(
           [:ptc_runner, :capability, :stop],

--- a/lib/ptc_runner/kernel/events.ex
+++ b/lib/ptc_runner/kernel/events.ex
@@ -8,6 +8,7 @@ defmodule PtcRunner.Kernel.Events do
 
   alias PtcRunner.Kernel.EventSink
   alias PtcRunner.Kernel.RunState
+  alias PtcRunner.Kernel.SafeMetadata
 
   @doc "Emits an event and records fail-closed sink failure in run state."
   def emit(_state, nil, _type, _data), do: :ok
@@ -43,6 +44,19 @@ defmodule PtcRunner.Kernel.Events do
   @doc "Returns non-negative elapsed monotonic milliseconds."
   def duration_ms(started_ms),
     do: max(System.monotonic_time(:millisecond) - started_ms, 0)
+
+  @doc """
+  Copies a payload-free rejection class from an error envelope onto event data.
+
+  Known Kernel envelope `kind` and `reason` atoms remain readable. An
+  unrecognized atom is retained only as a one-way fingerprint. Details,
+  messages, and caller-supplied strings stay off the canonical event.
+  Successful results omit these fields.
+  """
+  @spec put_rejection_class(map(), term()) :: map()
+  def put_rejection_class(data, result) when is_map(data) do
+    Map.merge(data, SafeMetadata.rejection_class(result))
+  end
 
   defp digest_prefix(value, bytes) do
     value

--- a/lib/ptc_runner/kernel/runtime_tools.ex
+++ b/lib/ptc_runner/kernel/runtime_tools.ex
@@ -934,7 +934,14 @@ defmodule PtcRunner.Kernel.RuntimeTools do
     end
   end
 
-  @doc "Wraps an internal runtime callback with canonical capability events."
+  @doc """
+  Wraps an internal runtime callback with canonical capability events.
+
+  An error `capability-stopped` event carries the closed envelope `kind` and
+  `reason` when those atoms belong to the Kernel vocabulary. An unrecognized
+  atom is retained only as a one-way fingerprint. Arguments, details, and
+  messages stay off the event.
+  """
   def instrument(state, event_sink, environment, name, callback, attributes \\ %{})
       when environment in [:workflow, :mission] and is_binary(name) and is_function(callback, 1) and
              is_map(attributes) do
@@ -953,19 +960,18 @@ defmodule PtcRunner.Kernel.RuntimeTools do
         :ok ->
           result = callback.(arguments)
 
-          _ =
-            Events.emit(
-              state,
-              event_sink,
-              "capability-stopped",
-              Map.merge(attributes, %{
-                capability_id: capability_id,
-                environment: environment,
-                name: name,
-                status: result_status(result),
-                duration_ms: Events.duration_ms(started_ms)
-              })
-            )
+          stopped =
+            attributes
+            |> Map.merge(%{
+              capability_id: capability_id,
+              environment: environment,
+              name: name,
+              status: result_status(result),
+              duration_ms: Events.duration_ms(started_ms)
+            })
+            |> Events.put_rejection_class(result)
+
+          _ = Events.emit(state, event_sink, "capability-stopped", stopped)
 
           result
 

--- a/lib/ptc_runner/kernel/safe_metadata.ex
+++ b/lib/ptc_runner/kernel/safe_metadata.ex
@@ -44,6 +44,75 @@ defmodule PtcRunner.Kernel.SafeMetadata do
     authentication-failed payment-required rate-limited tool-calling-unsupported denied not-found timeout
     invalid-request unavailable transport-error internal domain-error invalid-result
   )
+  @capability_rejection_kinds [
+    :capability_denied,
+    :capability_unavailable,
+    :event_sink_error,
+    :inspection_sink_error,
+    :invalid_annotation,
+    :invalid_result,
+    :limit_exceeded,
+    :protocol_error,
+    :provider_error,
+    :result_exceeded,
+    :timeout
+  ]
+  @capability_rejection_reasons [
+    :ambiguous_arguments,
+    :argument_exceeded,
+    :authentication_failed,
+    :capability_absent,
+    :capability_quota,
+    :denied,
+    :domain_error,
+    :event_sink_error,
+    :exception,
+    :exit,
+    :input_validation_unavailable,
+    :inspection_sink_error,
+    :internal,
+    :invalid_arguments,
+    :invalid_capability_description_request,
+    :invalid_capability_list_request,
+    :invalid_kernel_check_source_request,
+    :invalid_kernel_eval_request,
+    :invalid_llm_provider_failure,
+    :invalid_mission_inventory_request,
+    :invalid_mission_model_context_request,
+    :invalid_model_alias,
+    :invalid_provider_return,
+    :invalid_request,
+    :invalid_result,
+    :invalid_result_contract_failure,
+    :invalid_result_contract_request,
+    :invalid_runtime_limit_failure,
+    :invalid_runtime_remaining_request,
+    :invalid_runtime_usage_request,
+    :invalid_workflow_annotation,
+    :live_provider_tasks,
+    :model_alias_required,
+    :not_found,
+    :output_schema_mismatch,
+    :payment_required,
+    :protocol_errors,
+    :provider_exit,
+    :provider_heap_exceeded,
+    :provider_result_limit,
+    :provider_timeout,
+    :rate_limited,
+    :reservation_held,
+    :resolver_unavailable,
+    :run_closed,
+    :run_deadline,
+    :stale_evaluation,
+    :throw,
+    :timeout,
+    :tool_calling_unsupported,
+    :transport_error,
+    :unavailable,
+    :unknown_mission,
+    :unknown_model_alias
+  ]
 
   @spec normalize_labels(term()) :: {:ok, map()} | {:error, :invalid_safe_metadata}
   @doc "Validates labels and fingerprints caller-defined identifier fields."
@@ -128,6 +197,24 @@ defmodule PtcRunner.Kernel.SafeMetadata do
 
   def failure_taxonomy(_value), do: %{}
 
+  @spec rejection_class(term()) :: map()
+  @doc """
+  Projects a Lisp capability error envelope to a payload-free rejection class.
+
+  Known Kernel `kind` and `reason` atoms remain readable on canonical
+  `capability-stopped` events. An unrecognized atom is retained only as a
+  one-way fingerprint so a missed Kernel class still groups without putting
+  the atom name on the public trace. Non-atoms, details, and messages produce
+  no public fields.
+  """
+  def rejection_class(%{status: :error} = result) when is_map(result) and not is_struct(result) do
+    %{}
+    |> put_rejection_atom(result, :kind, @capability_rejection_kinds, "capability-kind:")
+    |> put_rejection_atom(result, :reason, @capability_rejection_reasons, "capability-reason:")
+  end
+
+  def rejection_class(_result), do: %{}
+
   @doc "Projects an agent LLM failure to one closed, payload-free provider class."
   @spec llm_provider_failure(term()) :: map()
   def llm_provider_failure(value) when is_map(value) and not is_struct(value) do
@@ -206,6 +293,23 @@ defmodule PtcRunner.Kernel.SafeMetadata do
       "sha256:" <> (:crypto.hash(:sha256, value) |> Base.encode16(case: :lower))
     end
   end
+
+  defp put_rejection_atom(class, result, key, allowed, prefix) do
+    case result do
+      %{^key => value} when is_atom(value) and not is_boolean(value) and not is_nil(value) ->
+        if value in allowed do
+          Map.put(class, key, value)
+        else
+          Map.put(class, fingerprint_key(key), fingerprint(prefix <> Atom.to_string(value)))
+        end
+
+      _missing_or_open ->
+        class
+    end
+  end
+
+  defp fingerprint_key(:kind), do: :kind_fingerprint
+  defp fingerprint_key(:reason), do: :reason_fingerprint
 
   defp fetch_failure_kind(value) do
     Enum.find_value(value, fn {key, kind} ->

--- a/test/ptc_runner/kernel/core_contract_test.exs
+++ b/test/ptc_runner/kernel/core_contract_test.exs
@@ -26,6 +26,7 @@ defmodule PtcRunner.Kernel.CoreContractTest do
   alias PtcRunner.Kernel.RuntimeTools
   alias PtcRunner.Kernel.SafeMetadata
   alias PtcRunner.Kernel.SourceCheck
+  alias PtcRunner.Kernel.TraceLog
   alias PtcRunner.Kernel.ValueContract
   alias PtcRunner.Kernel.WorkflowEnvironment
   alias PtcRunner.Lisp.Format
@@ -2210,6 +2211,8 @@ defmodule PtcRunner.Kernel.CoreContractTest do
 
     assert %{data: %{environment: :workflow, name: "add"}} = started
     assert %{data: %{environment: :workflow, name: "add", status: :ok}} = stopped
+    refute Map.has_key?(stopped.data, :kind)
+    refute Map.has_key?(stopped.data, :reason)
   end
 
   test "ambiguous normalized capability arguments are rejected before provider dispatch" do
@@ -3691,6 +3694,71 @@ defmodule PtcRunner.Kernel.CoreContractTest do
     refute String.contains?(encoded_events, private)
     refute String.contains?(encoded_events, prompt)
     refute String.contains?(encoded_events, session)
+  end
+
+  test "a rejected workflow annotation records the closed class on capability-stopped" do
+    assert {:ok, components} = Library.components(["runtime", "workflow.event"])
+    assert {:ok, bundle} = Kernel.compile_bundle(components)
+    {:ok, workflow} = WorkflowEnvironment.new(bundle: bundle)
+    {:ok, mission} = MissionEnvironment.new([])
+    {:ok, limits} = Limits.new()
+    {:ok, sink} = EventSink.start(:normal, limits, run_id: "rejected-annotation-class")
+
+    {:ok, config} =
+      RunConfig.new(
+        workflow_environment: workflow,
+        missions: %{"default" => mission},
+        input: %{},
+        limits: limits,
+        event_sink: sink
+      )
+
+    secret = "PRIVATE_GENERATED_SOURCE_(return_42)"
+
+    assert {:ok,
+            %{
+              value: %{
+                "status" => "error",
+                "kind" => "invalid_annotation",
+                "reason" => "invalid_workflow_annotation"
+              }
+            }} =
+             Kernel.run(
+               ~s|(return (workflow.event/annotate "progress" {"stage" "started" "source" "#{secret}"}))|,
+               config
+             )
+
+    assert %{
+             data: %{
+               name: "workflow-annotate",
+               status: :error,
+               kind: :invalid_annotation,
+               reason: :invalid_workflow_annotation
+             }
+           } =
+             Enum.find(
+               EventSink.events(sink),
+               &(&1.type == "capability-stopped")
+             )
+
+    refute inspect(EventSink.events(sink)) =~ secret
+
+    assert {:ok, trace_log} = TraceLog.new(source: sink)
+
+    assert {:ok, %{"items" => items}} =
+             TraceLog.query(trace_log, :list_turns, %{
+               "run_id" => "rejected-annotation-class",
+               "capability" => "workflow-annotate"
+             })
+
+    assert Enum.any?(items, fn
+             %{"type" => "capability-stopped", "data" => data} ->
+               data["kind"] == "invalid_annotation" and
+                 data["reason"] == "invalid_workflow_annotation"
+
+             _other ->
+               false
+           end)
   end
 
   test "terminal workflow results and retained mission memory use Kernel limits and state" do

--- a/test/ptc_runner/kernel/dispatcher_effect_test.exs
+++ b/test/ptc_runner/kernel/dispatcher_effect_test.exs
@@ -247,7 +247,7 @@ defmodule PtcRunner.Kernel.DispatcherEffectTest do
              retryable?: false
            }
 
-    assert %{data: %{status: :error}} =
+    assert %{data: %{status: :error, kind: :provider_error, reason: :exception}} =
              Enum.find(events, &(&1.type == "capability-stopped"))
 
     refute Enum.any?(events, &(&1.type == "limit-exceeded"))
@@ -257,6 +257,23 @@ defmodule PtcRunner.Kernel.DispatcherEffectTest do
     assert diagnostic["payload"]["message_truncated"]
     assert diagnostic["payload"]["stacktrace_truncated"]
     assert output["payload"]["result"]["reason"] == "exception"
+  end
+
+  test "capability-stopped carries the closed rejection class without the payload" do
+    secret = "SECRET_PROVIDER_DETAIL"
+
+    {result, events} =
+      dispatch_mission_with_events([], 100, fn ->
+        {:error, ProviderError.new(:unavailable, secret, retryable?: true)}
+      end)
+
+    assert %{status: :error, kind: :provider_error, reason: :unavailable, details: ^secret} =
+             result
+
+    stopped = Enum.find(events, &(&1.type == "capability-stopped"))
+    assert %{data: %{status: :error, kind: :provider_error, reason: :unavailable}} = stopped
+    refute Map.has_key?(stopped.data, :details)
+    refute inspect(stopped) =~ secret
   end
 
   test "workflow raises retain diagnostics without mission attribution" do

--- a/test/ptc_runner/kernel/runtime_tools_test.exs
+++ b/test/ptc_runner/kernel/runtime_tools_test.exs
@@ -2,17 +2,21 @@ defmodule PtcRunner.Kernel.RuntimeToolsTest do
   use ExUnit.Case, async: true
 
   @moduledoc """
-  Direct coverage of the trusted runtime-limit callback.
+  Direct coverage of trusted runtime-tool callbacks.
 
-  The route is private to the shipped `agent.core` namespace, so a component
-  test cannot reach the argument validation — the grant refuses the call before
-  the arguments are read. These exercise the closed reason set itself.
+  The runtime-limit route is private to the shipped `agent.core` namespace, so a
+  component test cannot reach the argument validation — the grant refuses the
+  call before the arguments are read. Those cases exercise the closed reason
+  set itself. Instrumented capability events are the public evidence for
+  reserved routes such as `workflow-annotate`.
   """
 
+  alias PtcRunner.Kernel.EventSink
   alias PtcRunner.Kernel.Limits
   alias PtcRunner.Kernel.RunState
   alias PtcRunner.Kernel.RuntimeLimitDiagnostic
   alias PtcRunner.Kernel.RuntimeTools
+  alias PtcRunner.Kernel.SafeMetadata
   alias PtcRunner.Lisp.TrustedError
 
   setup do
@@ -77,5 +81,83 @@ defmodule PtcRunner.Kernel.RuntimeToolsTest do
   test "an unproven subordinate-evaluation claim is still refused", %{callback: callback} do
     assert %{status: :error, kind: :protocol_error, reason: :invalid_runtime_limit_failure} =
              callback.(%{"proof" => "forged-without-a-refusal"})
+  end
+
+  test "a rejected instrumented call records the closed class on capability-stopped" do
+    secret = "PRIVATE_ANNOTATION_DETAIL"
+
+    {_result, stopped} =
+      instrumented_call(fn _ ->
+        %{
+          status: :error,
+          kind: :invalid_annotation,
+          reason: :invalid_workflow_annotation,
+          details: secret
+        }
+      end)
+
+    assert %{
+             name: "workflow-annotate",
+             status: :error,
+             kind: :invalid_annotation,
+             reason: :invalid_workflow_annotation
+           } = stopped.data
+
+    refute Map.has_key?(stopped.data, :details)
+    refute inspect(stopped) =~ secret
+  end
+
+  test "a successful instrumented call does not invent a rejection class" do
+    {_result, stopped} = instrumented_call(fn _ -> %{status: :ok} end)
+
+    assert %{name: "workflow-annotate", status: :ok} = stopped.data
+    refute Map.has_key?(stopped.data, :kind)
+    refute Map.has_key?(stopped.data, :reason)
+  end
+
+  test "non-atom rejection fields stay off the canonical capability-stopped event" do
+    {_result, stopped} =
+      instrumented_call(fn _ ->
+        %{status: :error, kind: "PRIVATE_KIND", reason: "PRIVATE_REASON"}
+      end)
+
+    assert %{name: "workflow-annotate", status: :error} = stopped.data
+    refute Map.has_key?(stopped.data, :kind)
+    refute Map.has_key?(stopped.data, :reason)
+    refute inspect(stopped) =~ "PRIVATE"
+  end
+
+  test "unrecognized envelope atoms are fingerprinted rather than copied" do
+    {_result, stopped} =
+      instrumented_call(fn _ ->
+        %{status: :error, kind: :secret_rejection_kind, reason: :secret_rejection_reason}
+      end)
+
+    assert %{name: "workflow-annotate", status: :error} = stopped.data
+    refute Map.has_key?(stopped.data, :kind)
+    refute Map.has_key?(stopped.data, :reason)
+
+    assert stopped.data.kind_fingerprint ==
+             SafeMetadata.fingerprint("capability-kind:secret_rejection_kind")
+
+    assert stopped.data.reason_fingerprint ==
+             SafeMetadata.fingerprint("capability-reason:secret_rejection_reason")
+
+    refute inspect(stopped) =~ "secret_rejection"
+  end
+
+  defp instrumented_call(callback) do
+    {:ok, limits} = Limits.new()
+    {:ok, state} = RunState.start(limits)
+    {:ok, sink} = EventSink.start(:normal, limits, run_id: "runtime-tools-instrument")
+
+    result = RuntimeTools.instrument(state, sink, :workflow, "workflow-annotate", callback).(%{})
+
+    stopped =
+      sink
+      |> EventSink.events()
+      |> Enum.find(&(&1.type == "capability-stopped"))
+
+    {result, stopped}
   end
 end

--- a/test/ptc_runner/kernel/safe_metadata_test.exs
+++ b/test/ptc_runner/kernel/safe_metadata_test.exs
@@ -91,6 +91,60 @@ defmodule PtcRunner.Kernel.SafeMetadataTest do
     end
   end
 
+  describe "capability rejection class" do
+    test "keeps known Kernel envelope atoms readable" do
+      assert SafeMetadata.rejection_class(%{
+               status: :error,
+               kind: :invalid_annotation,
+               reason: :invalid_workflow_annotation,
+               details: "PRIVATE PAYLOAD"
+             }) == %{kind: :invalid_annotation, reason: :invalid_workflow_annotation}
+    end
+
+    test "fingerprints unrecognized atoms instead of copying them" do
+      class =
+        SafeMetadata.rejection_class(%{
+          status: :error,
+          kind: :secret_rejection_kind,
+          reason: :secret_rejection_reason
+        })
+
+      assert class == %{
+               kind_fingerprint:
+                 SafeMetadata.fingerprint("capability-kind:secret_rejection_kind"),
+               reason_fingerprint:
+                 SafeMetadata.fingerprint("capability-reason:secret_rejection_reason")
+             }
+
+      refute inspect(class) =~ "secret_rejection"
+    end
+
+    test "fingerprints an unknown reason beside a known kind" do
+      class =
+        SafeMetadata.rejection_class(%{
+          status: :error,
+          kind: :protocol_error,
+          reason: :secret_rejection_reason
+        })
+
+      assert class.kind == :protocol_error
+      refute Map.has_key?(class, :reason)
+
+      assert class.reason_fingerprint ==
+               SafeMetadata.fingerprint("capability-reason:secret_rejection_reason")
+    end
+
+    test "omits non-atoms and successful envelopes" do
+      assert SafeMetadata.rejection_class(%{
+               status: :error,
+               kind: "PRIVATE_KIND",
+               reason: "PRIVATE_REASON"
+             }) == %{}
+
+      assert SafeMetadata.rejection_class(%{status: :ok, kind: :invalid_annotation}) == %{}
+    end
+  end
+
   describe "LLM provider failure taxonomy" do
     test "retains only a closed class from the nested provider envelope" do
       failure = %{


### PR DESCRIPTION
## Summary
- Failed capability attempts (including `workflow-annotate`) now record a payload-free envelope `kind` and `reason` on the public `capability-stopped` event, the same class `execution_errors` already expose.
- Known Kernel atoms stay readable. Unrecognized atoms are one-way fingerprinted (`kind_fingerprint` / `reason_fingerprint`) instead of copied onto the trace. Arguments, details, and messages stay off the event.
- Follow-up to #1508, which fixed the annotation vocabulary mismatch and filed #1505.

Closes #1505

## Test plan
- [x] `mix precommit`
- [ ] PR CI (core tests, static, release, Viewer)
- Kernel coverage: instrumented RuntimeTools errors, Dispatcher provider errors, rejected `workflow-annotate` on both EventSink and TraceLog `:list_turns`
- Unknown envelope atoms fingerprint; strings and successful stops omit the class


Made with [Cursor](https://cursor.com)