### PR TITLE
docs(guides): make the provider-selection example runnable

### DIFF
--- a/docs/guides/host-configuration.md
+++ b/docs/guides/host-configuration.md
@@ -41,8 +41,32 @@ resources.
 
 Install MCP tools with the same separation: the host fixes the transport and
 public tool mapping, while the application selects the alias and may narrow a
-write-bearing tool set. Follow [Connect an MCP tool](connecting-tools-with-mcp.md)
-for one complete workflow.
+write-bearing tool set. The `workspace` alias selected in
+[Configure an application](manifests-and-capabilities.md) is installed as a
+second entry under the same `install` object:
+
+```json
+{
+  "workspace": {
+    "source": "mcp",
+    "installation_revision": "workspace-v1",
+    "transport": {
+      "type": "stdio",
+      "command": "node",
+      "args": ["server.js"]
+    },
+    "tools": {
+      "read_text_file": {"as": "workspace.read", "effect": "read"}
+    },
+    "ceilings": {"timeout_ms": 15000, "max_result_bytes": 262144}
+  }
+}
+```
+
+The upstream operation name and server command belong to the server you run;
+the public `as` name and its `read` or `write` effect are the operator's
+choice. Follow [Connect an MCP tool](connecting-tools-with-mcp.md) for one
+complete workflow against a checked-in server.
 
 The [host-configuration reference](../reference/host-installation.md) owns the
 complete credential forms, provider sources, transport rules, OAuth behavior,

--- a/docs/guides/manifests-and-capabilities.md
+++ b/docs/guides/manifests-and-capabilities.md
@@ -28,13 +28,18 @@ The generated application is deliberately small:
 }
 ```
 
-Add a provider only after the operator has installed its alias. Model access
-belongs to the trusted workflow; task tools belong to the mission that runs
-model-authored programs:
+Add a provider only after the operator has installed its alias. Every provider
+the application uses is selected at the top level, under `providers.workflow`
+for model access the trusted workflow holds, and under `providers.mission` for
+the task tools that missions running model-authored programs may hold. Add both
+scopes to the manifest above:
 
 ```json
 {
-  "providers": {"workflow": [{"name": "model"}]},
+  "providers": {
+    "workflow": [{"name": "model"}],
+    "mission": [{"name": "workspace"}]
+  },
   "missions": {
     "default": {
       "components": [],
@@ -44,7 +49,15 @@ model-authored programs:
 }
 ```
 
-Validate structure and selected authority before running:
+A mission's own `providers` list can only narrow what `providers.mission`
+already selected; naming an alias there does not introduce it, and a name
+absent from `providers.mission` is rejected. Omitting a name is the point: the
+grant is then absent from that mission's environment.
+
+Install the aliases first, then validate. Both commands resolve the selected
+providers against the host document, so they report the selected provider as
+not installed until [host configuration](host-configuration.md) declares
+`model` and `workspace`:
 
 ```console
 ptc validate my-application/ptc-project.json

--- a/site/guides/host-configuration/index.html
+++ b/site/guides/host-configuration/index.html
@@ -120,8 +120,26 @@ ptc models ptc-project.json</code></pre><p>Plain <code class="inline">doctor</co
 providers. <code class="inline">--connect</code> is an explicit connectivity probe and may consume remote
 resources.</p><p>Install MCP tools with the same separation: the host fixes the transport and
 public tool mapping, while the application selects the alias and may narrow a
-write-bearing tool set. Follow <a href="/guides/connecting-tools-with-mcp/">Connect an MCP tool</a>
-for one complete workflow.</p><p>The <a href="/reference/host-installation/">host-configuration reference</a> owns the
+write-bearing tool set. The <code class="inline">workspace</code> alias selected in
+<a href="/guides/manifests-and-capabilities/">Configure an application</a> is installed as a
+second entry under the same <code class="inline">install</code> object:</p><pre><code class="json language-json">{
+  &quot;workspace&quot;: {
+    &quot;source&quot;: &quot;mcp&quot;,
+    &quot;installation_revision&quot;: &quot;workspace-v1&quot;,
+    &quot;transport&quot;: {
+      &quot;type&quot;: &quot;stdio&quot;,
+      &quot;command&quot;: &quot;node&quot;,
+      &quot;args&quot;: [&quot;server.js&quot;]
+    },
+    &quot;tools&quot;: {
+      &quot;read_text_file&quot;: {&quot;as&quot;: &quot;workspace.read&quot;, &quot;effect&quot;: &quot;read&quot;}
+    },
+    &quot;ceilings&quot;: {&quot;timeout_ms&quot;: 15000, &quot;max_result_bytes&quot;: 262144}
+  }
+}</code></pre><p>The upstream operation name and server command belong to the server you run;
+the public <code class="inline">as</code> name and its <code class="inline">read</code> or <code class="inline">write</code> effect are the operator's
+choice. Follow <a href="/guides/connecting-tools-with-mcp/">Connect an MCP tool</a> for one
+complete workflow against a checked-in server.</p><p>The <a href="/reference/host-installation/">host-configuration reference</a> owns the
 complete credential forms, provider sources, transport rules, OAuth behavior,
 data classes, ceilings, and diagnostics.</p>
 </article>

--- a/site/guides/manifests-and-capabilities/index.html
+++ b/site/guides/manifests-and-capabilities/index.html
@@ -109,17 +109,28 @@ ptc run my-application/ptc-project.json</code></pre><p>The generated application
     &quot;entry&quot;: &quot;main/run&quot;
   },
   &quot;input&quot;: {&quot;value&quot;: {&quot;name&quot;: &quot;world&quot;}}
-}</code></pre><p>Add a provider only after the operator has installed its alias. Model access
-belongs to the trusted workflow; task tools belong to the mission that runs
-model-authored programs:</p><pre><code class="json language-json">{
-  &quot;providers&quot;: {&quot;workflow&quot;: [{&quot;name&quot;: &quot;model&quot;}]},
+}</code></pre><p>Add a provider only after the operator has installed its alias. Every provider
+the application uses is selected at the top level, under <code class="inline">providers.workflow</code>
+for model access the trusted workflow holds, and under <code class="inline">providers.mission</code> for
+the task tools that missions running model-authored programs may hold. Add both
+scopes to the manifest above:</p><pre><code class="json language-json">{
+  &quot;providers&quot;: {
+    &quot;workflow&quot;: [{&quot;name&quot;: &quot;model&quot;}],
+    &quot;mission&quot;: [{&quot;name&quot;: &quot;workspace&quot;}]
+  },
   &quot;missions&quot;: {
     &quot;default&quot;: {
       &quot;components&quot;: [],
       &quot;providers&quot;: [&quot;workspace&quot;]
     }
   }
-}</code></pre><p>Validate structure and selected authority before running:</p><pre><code class="console language-console">ptc validate my-application/ptc-project.json
+}</code></pre><p>A mission's own <code class="inline">providers</code> list can only narrow what <code class="inline">providers.mission</code>
+already selected; naming an alias there does not introduce it, and a name
+absent from <code class="inline">providers.mission</code> is rejected. Omitting a name is the point: the
+grant is then absent from that mission's environment.</p><p>Install the aliases first, then validate. Both commands resolve the selected
+providers against the host document, so they report the selected provider as
+not installed until <a href="/guides/host-configuration/">host configuration</a> declares
+<code class="inline">model</code> and <code class="inline">workspace</code>:</p><pre><code class="console language-console">ptc validate my-application/ptc-project.json
 ptc doctor my-application/ptc-project.json</code></pre><p>Use the <a href="/reference/application-manifest/">application-manifest reference</a>
 for every field, validation rule, mission shape, provider-selection rule,
 event policy, and limit. Continue with <a href="/guides/host-configuration/">host configuration</a>


### PR DESCRIPTION
## Problem

`docs/guides/manifests-and-capabilities.md` is the single source for both the
website page and `ptc docs manifests-and-capabilities`
(`documentation_library.ex:38`). Its provider snippet could not run, and the
surrounding prose pointed the reader away from the actual rule.

Four defects, all reproduced against the source:

1. **The snippet omits the pool it narrows.** It selected `"workspace"` in the
   mission but never declared it under `providers.mission`. `manifest.ex:381-394`
   only admits mission provider names present in `providers.mission`, so with no
   such block the admissible set is empty and *every* non-empty array fails.
   `["model"]` failed identically — the name was irrelevant.

2. **The prose points the wrong way.** "task tools belong to the mission that
   runs model-authored programs" reads as *declare it under the mission*. The
   rule is the opposite: everything is selected at top level and a mission only
   subtracts. `docs/reference/application-manifest.md:110-111` states this
   correctly; the guide never did, and the guide is what a reader hits first.

3. **Unmarked fragment.** A bare `{ … }` following a *complete* manifest, but
   missing `version`/`workflow`/`input`. Copied wholesale it yields
   `required_property_missing` at `/version`.

4. **The validate step could not pass.** Even with (1) fixed, `ptc validate`
   returns `provider_declaration/provider_unknown`. No guide in the chain ever
   installed a `workspace` alias — `host-configuration.md` installed only
   `model`, and the sole `workspace` install lived in
   `docs/reference/host-installation.md:47`. Following the guide chain start to
   finish never made the example validate.

## Fix

- Declare both scopes in the snippet (`providers.workflow` + `providers.mission`),
  matching the shape the checked-in tutorial already uses.
- State the narrowing rule in prose: a mission's list can only narrow what
  `providers.mission` selected; naming an alias there does not introduce it.
- Frame the block as an addition to the manifest above, not a standalone document.
- Order installation before validation, and say plainly that both commands report
  the provider as not installed until the host document declares the aliases.
- Add the `workspace` MCP install to `host-configuration.md` so the guide chain
  composes end to end.

## Verification

A manifest and host document assembled *only* from the corrected guides:

```
$ ptc validate chain/ptc-project.json
{"application_content_digest":"sha256:77d6330a…","provider_activity":false,…}

$ ptc doctor chain/ptc-project.json
… provider/model/local: pass, provider/model/selection: declarative,
  provider/workspace/local: pass, provider/workspace/selection: declarative …
```

Before the fix these returned `schema_violation at /missions/*/providers` and
`provider_declaration/provider_unknown` respectively.

Regenerated site pages with `mix ptc.gen_docs`;
`MIX_ENV=dev mix docs --warnings-as-errors` clean;
`documentation_links_test` + `command_docs_test` green (24 passed).

## Deliberately not in this PR

`command_application_diagnostic.ex:149`'s catch-all
`projection(_role, _reason) -> {:schema_violation, nil}` discards the precise
`:unknown_mission_provider` that `manifest.ex:391` produces (and collapses
`:duplicate_mission_provider` the same way). That is the reason this bug was
hard to self-diagnose, but adding a diagnostic code touches
`diagnostic_catalog.ex`, `command_contract.ex`, the generated exit-status
catalog, and its tests — a distinct mechanism from the guide fix. Filed
separately.

Also left alone: the `*` in `/missions/*/providers`. `command_path.ex:24-32`
elides author-chosen map keys deliberately, and the mission name is not the
missing information.