### PR TITLE
docs(traces): give the trace page an entry point

### DIFF
--- a/docs/maintainers/trace-log-contract.md
+++ b/docs/maintainers/trace-log-contract.md
@@ -8,15 +8,60 @@
 inspection artifact.
 
 This page defines what a canonical trace and a private inspection artifact
-contain, and how each may be queried. It is a repository document rather than
-part of the user documentation set; the executable carries it as
-`ptc docs traces` for navigating a run's evidence. Owner-process lifecycle,
-immutable capture, publication mechanics, and the contract-test inventory are
-implementation concerns and live in the Kernel maintainer guide
-(`docs/maintainers/kernel.md`) and beside the code in the
-`PtcRunner.Kernel.TraceLog`,
-`PtcRunner.Kernel.EventSink`, `PtcRunner.Kernel.InspectionSink`, and
-`PtcRunner.Kernel.InspectionArtifact` module documentation.
+contain, and how each may be queried. It is the field guide to the record
+vocabulary, not a walkthrough: for the evidence graph and the debugging path
+through it, read the
+[debug-navigation reference](../reference/debug-navigation.md) first.
+Owner-process lifecycle, immutable capture, publication mechanics, and the
+contract-test inventory are implementation concerns and live in the Kernel
+maintainer guide (`docs/maintainers/kernel.md`) and beside the code in the
+`PtcRunner.Kernel.TraceLog`, `PtcRunner.Kernel.EventSink`,
+`PtcRunner.Kernel.InspectionSink`, and `PtcRunner.Kernel.InspectionArtifact`
+module documentation.
+
+## Producing and opening a capture
+
+Nothing here is queryable until a run writes a trace. A canonical trace alone
+answers the public `activity` collection; every other collection additionally
+needs the private inspection artifact, which a run only writes when asked.
+
+Both destinations must already exist: `--trace-dir` names an existing
+directory, and `--inspect` names a file inside one.
+
+```bash
+mkdir -p traces traces-private
+
+# Canonical trace only — supports analysis/runs, analysis/open, and activity.
+ptc run PROJECT.json --trace-dir traces/
+
+# Trace plus private inspection — additionally supports every private
+# collection: turns, model_exchanges, generated_sources, and the rest.
+ptc run PROJECT.json --trace-dir traces/ \
+  --inspect traces-private/run.inspection.jsonl
+```
+
+A project document can capture both instead of the two switches; see
+[project configuration](../reference/project-files.md).
+
+Two code-owned profiles read those artifacts. `run-analysis-v1` takes the
+canonical trace and grants the three `analysis-*` capabilities.
+`private-run-analysis-v1` additionally takes the inspection artifact, and
+requires an authorized private sink because the records it returns carry exact
+prompts, generated source, and capability payloads.
+
+```bash
+# Public: canonical evidence only.
+ptc repl --profile run-analysis-v1 --resource traces=traces/
+
+# Private: adds every private collection. --resource takes the DIRECTORY
+# holding the artifact, not the .inspection.jsonl path --inspect was given.
+ptc repl --profile private-run-analysis-v1 --private-terminal \
+  --resource traces=traces/ --resource inspection=traces-private/
+```
+
+Use `--private-unattended` in place of `--private-terminal` when no terminal is
+attached, and `--load QUERY.clj` to run forms non-interactively. `ptc repl
+--describe-profile NAME` prints either profile's static contract.
 
 ## Purpose and boundary
 
@@ -216,9 +261,13 @@ The shipped analysis prelude exposes a small navigation namespace:
 Examples:
 
 ```clojure
+;; Either profile.
 (analysis/runs {"status" "error" "tags" {"stage" "failed"} "limit" 20})
 (analysis/open "run-id")
 (analysis/read "run-id" {"collection" "activity" "limit" 100})
+
+;; private-run-analysis-v1 only: every collection but `activity` is private
+;; authority, and returns an :invalid_request envelope under the public profile.
 (analysis/read "run-id" {"collection" "turns" "limit" 20})
 (analysis/read "run-id" {"collection" "generated_sources"
                          "prelude_call" "workspace/read"})


### PR DESCRIPTION
Follow-up to #1538, which split this page but left it unusable as an entry
point. Reviewing the shipped page against a real run surfaced four gaps; two of
them were regressions #1538 introduced.

## The problem

`docs/guides/agent-cli-usage.md:80` points agents at `ptc docs traces` for the
record vocabulary. The page contained **no `ptc` command at all** — 834 lines
describing what a trace holds, with nothing telling a reader how to produce one
or open it.

## What changed

**A "Producing and opening a capture" section**, placed before the ownership
and architecture material. It carries the two `ptc run` forms that write the
artifacts and the two `ptc repl` profiles that read them. Both destinations must
already exist — omitting the `mkdir` fails with
`destination/inspection_directory_missing` — so the recipe includes it. It also
flags that `--inspect` takes a *file* while `--resource inspection=` takes the
*directory* holding it, which is easy to get wrong.

**`run-analysis-v1` and `private-run-analysis-v1` are named again.** #1538 moved
the profile inventory into `kernel.md`, leaving the page documenting `analysis/*`
capabilities without naming the profile that grants them. The pre-split page
mentioned `run-analysis-v1` twice; the shipped one, zero times.

**The private examples are marked at the point of use.** Eight of nine
collections are `authority: :private` — only `activity` is public. Two of the
five examples therefore failed as written under the default profile, returning
`invalid_request` / "private evidence unavailable in this analysis recipe",
with the caveat ~200 lines further down.

**A link to the debug-navigation reference**, which is the page that actually
walks the evidence path. The embedded copy rewrites it to `ptc docs debug`. The
page previously had no outbound link at all, and opened by telling the reader it
was "a repository document rather than part of the user documentation set" —
accurate about the tier, unhelpful to someone the executable had just handed it
to.

## Verification

Every recipe and example was run against a real trace from
`examples/llm-replay` (deterministic, no API key):

| Check | Result |
| --- | --- |
| `ptc run --trace-dir` | writes the canonical trace |
| `ptc run --trace-dir --inspect` | writes both artifacts |
| the same without `mkdir` | fails — which is why the recipe includes it |
| 3 public examples under `run-analysis-v1` | evaluate, exit 0 |
| 2 private examples under `private-run-analysis-v1` | evaluate, exit 0 |
| `turns` under `run-analysis-v1` | reproduces the documented rejection |

Plus `documentation_guidelines_test`, `documentation_links_test`,
`command_frontend_test`, `safe_metadata_test` (63 passed),
`MIX_ENV=dev mix docs --warnings-as-errors`, and `mix ptc.gen_docs --check`
(37 site pages; the page stays off ptc-runner.dev).
