### PR TITLE
feat(site): stamp version, commit, and build time on the front page

### DIFF
--- a/docs/maintainers/site.md
+++ b/docs/maintainers/site.md
@@ -85,6 +85,25 @@ target page's actual ids. A typo therefore fails `mix ptc.gen_docs --check`
 instead of shipping as a dead link, and `scripts/build_site.sh` re-validates
 the root-relative references in the assembled artifact.
 
+## The build stamp
+
+The front page footer names the version from `mix.exs`, the commit being
+published, and the UTC build time. The values are not checked in: `site/`
+carries `@BUILD_VERSION@`, `@BUILD_COMMIT@`, `@BUILD_COMMIT_SHORT@`, and
+`@BUILD_TIMESTAMP@`, and `scripts/build_site.sh` resolves them in the assembled
+copy. Stamping the source instead would put a rewritten `index.html` in every
+diff and make each deploy a commit.
+
+Read the stamp as *when the site was built*, not as *the tip of `main`*. Pages
+deploys on changes to `site/`, the published schemas, the build script, and its
+own workflow, so a commit that touches neither leaves the stamp where it was —
+correctly, because nothing being served changed.
+
+The substitution is verified rather than assumed. The build fails when no page
+carried a token, which is what a renamed or deleted placeholder looks like, and
+when any `@BUILD_*@` token survives into the artifact. Without those two checks
+a page could publish a footer that quietly lost half its stamp.
+
 ## The diagrams
 
 Both are image-model output, not hand-drawn assets, so the prompts below are

--- a/scripts/build_site.sh
+++ b/scripts/build_site.sh
@@ -88,6 +88,70 @@ mkdir -p "$output_dir/schemas"
 
 cp -R "$project_root/site/." "$output_dir/"
 
+# Build provenance, stamped into the assembled copy only. The tokens live in
+# the checked-in pages so that nothing rewrites `site/` -- a stamped source
+# file would land in every diff and turn each deploy into a commit.
+#
+# The stamp describes the build, not the tip of `main`: the Pages workflow
+# publishes on site and schema changes, so the commit named below is the last
+# one that could have altered what is being served.
+version="$(sed -n 's/^[[:space:]]*version: "\([^"]*\)".*/\1/p' "$project_root/mix.exs" | head -1)"
+[ -n "$version" ] || {
+  echo 'could not read the project version from mix.exs' >&2
+  exit 65
+}
+
+commit="$(git -C "$project_root" rev-parse HEAD)" || {
+  echo 'could not resolve the commit being published' >&2
+  exit 65
+}
+
+built_at="$(date -u '+%Y-%m-%d %H:%M UTC')"
+
+# Substitution is verified, not assumed. A page that renames or drops a token
+# would otherwise publish a footer missing the half nobody looked at, so the
+# build fails when no page was stamped and when any token survives.
+python3 - "$output_dir" "$version" "$commit" "$built_at" <<'STAMP' || exit 65
+import pathlib
+import re
+import sys
+
+output_dir = pathlib.Path(sys.argv[1])
+version, commit, built_at = sys.argv[2:5]
+
+replacements = {
+    "@BUILD_VERSION@": version,
+    "@BUILD_COMMIT@": commit,
+    "@BUILD_COMMIT_SHORT@": commit[:7],
+    "@BUILD_TIMESTAMP@": built_at,
+}
+
+stamped = 0
+leftover = []
+
+for page in sorted(output_dir.rglob("*.html")):
+    text = page.read_text(encoding="utf-8")
+    replaced = text
+
+    for token, value in replacements.items():
+        replaced = replaced.replace(token, value)
+
+    if replaced != text:
+        page.write_text(replaced, encoding="utf-8")
+        stamped += 1
+
+    for token in re.findall(r"@BUILD_[A-Z_]*@", replaced):
+        leftover.append("%s: unresolved %s" % (page.name, token))
+
+if not stamped:
+    sys.stderr.write("no page carries a @BUILD_*@ token; the footer stamp is gone\n")
+    sys.exit(65)
+
+if leftover:
+    sys.stderr.write("\n".join(leftover) + "\n")
+    sys.exit(65)
+STAMP
+
 # Without `nullglob` an unmatched pattern survives as a literal filename, and
 # the loop below would report a missing schema as a JSON decode failure instead
 # of reaching the count check.

--- a/site/index.html
+++ b/site/index.html
@@ -284,6 +284,9 @@ open in the viewer. The same <code>ptc run</code> drives agentic projects.</p>
 <footer>
   MIT licensed. Built from
   <a href="https://github.com/andreasronge/ptc_runner">andreasronge/ptc_runner</a>.
+  <span class="build-stamp">v@BUILD_VERSION@ &middot;
+    <a href="https://github.com/andreasronge/ptc_runner/commit/@BUILD_COMMIT@">@BUILD_COMMIT_SHORT@</a>
+    &middot; built @BUILD_TIMESTAMP@</span>
 </footer>
 
 </main>

--- a/site/style.css
+++ b/site/style.css
@@ -132,3 +132,6 @@ footer {
   margin-top: 4rem; padding-top: 1.25rem; border-top: 1px solid var(--border);
   color: var(--muted); font-size: .85rem;
 }
+footer .build-stamp {
+  display: block; margin-top: .4rem; font-variant-numeric: tabular-nums;
+}


### PR DESCRIPTION
## What

The ptc-runner.dev front page footer now carries a build stamp:

> MIT licensed. Built from andreasronge/ptc_runner.
> **v0.13.0 · [5138ac9](https://github.com/andreasronge/ptc_runner/commit/5138ac99330408904efb4277f47bdfa06653bc22) · built 2026-08-20 14:37 UTC**

Version comes from `mix.exs`, the commit from `git rev-parse HEAD` (short form
displayed, full sha in the link), the time from `date -u`.

## How

`site/index.html` holds `@BUILD_VERSION@`, `@BUILD_COMMIT@`,
`@BUILD_COMMIT_SHORT@`, and `@BUILD_TIMESTAMP@`. `scripts/build_site.sh`
resolves them in the assembled copy only, so `site/` is never rewritten —
stamping the source would put a modified `index.html` in every diff and make
each deploy a commit.

## What the stamp means

It describes **the build, not the tip of `main`**. `pages.yml` deploys on
changes to `site/`, the published schemas, the build script, and its own
workflow; a commit touching none of those leaves the stamp where it was, which
is correct because nothing being served changed. Deploy triggers are
deliberately unchanged here.

## Fail-closed guards

Substitution is verified, not assumed. The build exits 65 when:

- no page carried a token — what a renamed or deleted placeholder looks like
- any `@BUILD_*@` token survives into the artifact

Without both, a page could publish a footer that quietly lost half its stamp.

## Verification

- `scripts/build_site.sh` assembles cleanly (4 schemas); footer read back from
  the rendered page in a browser
- both guards exercised — each exits 65 with its own message
- `mix ptc.gen_docs --check` passes (37 site pages); the footer sits outside
  the generated sidebar markers

No Elixir source changed, and `docs/maintainers/site.md` is not in the ExDoc
extras, so the Dialyzer and ExDoc gates have no surface here.

## Note

A failed build leaves a partially-stamped output directory on disk. Harmless in
CI, where a failed job never reaches the deploy step, but locally you rebuild
rather than trust the directory.