### PR TITLE
docs(mcp): publish the 2026-07-28 wire schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- ptc-runner.dev now publishes the pinned MCP 2026-07-28 wire schema at
+  `/schemas/mcp-2026-07-28.schema.json`, which is what a third-party author
+  needs to write a server PtcRunner can acquire. It is upstream's document
+  with two corrections PtcRunner maintains, both stated in the file. The MCP
+  reference names the discovery, tool-list, tool-call, and error definitions a
+  server must satisfy, and records the narrower result policy PtcRunner
+  enforces on top of them.
 - ptc-runner.dev now serves the guides, installation routes, and reference
   documentation as generated pages under `/guides/`, `/installation/`, and
   `/reference/`, behind a sectioned sidebar that is also spliced into the

--- a/LICENSES/Apache-2.0.txt
+++ b/LICENSES/Apache-2.0.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -59,3 +59,14 @@ SPDX-License-Identifier = "MIT"
 path = ["**/*.hrl", "**/*.app.src", "**/rebar.config", "**/rebar.lock", "**/*.dag"]
 SPDX-FileCopyrightText = "2025 Andreas Ronge"
 SPDX-License-Identifier = "MIT"
+
+[[annotations]]
+path = [
+  "priv/schemas/mcp-input-request-2026-07-28.schema.json",
+  "site/schemas/mcp-2026-07-28.schema.json"
+]
+SPDX-FileCopyrightText = [
+  "2024-2025 Model Context Protocol a Series of LF Projects, LLC.",
+  "2026 Andreas Ronge"
+]
+SPDX-License-Identifier = "Apache-2.0 AND MIT"

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,47 @@
+# Third-party notices
+
+## Model Context Protocol wire schema
+
+Two files derive from
+`modelcontextprotocol/modelcontextprotocol@5f5440bb26a62e2cf3440b92da5a667efa03b267`:
+`site/schemas/mcp-2026-07-28.schema.json`, the published wire schema, and
+`priv/schemas/mcp-input-request-2026-07-28.schema.json`, the `InputRequest`
+dependency closure the runtime validates against.
+At that commit the upstream project states that new specification contributions
+and relicensed contributions are Apache-2.0, while contributions whose authors
+had not consented to relicensing remain MIT.
+
+Copyright (c) 2024-2025 Model Context Protocol a Series of LF Projects, LLC.
+
+The Apache-2.0 terms are in `LICENSES/Apache-2.0.txt`. The MIT terms applicable
+to upstream portions are:
+
+> Permission is hereby granted, free of charge, to any person obtaining a copy
+> of this software and associated documentation files (the "Software"), to deal
+> in the Software without restriction, including without limitation the rights
+> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+> copies of the Software, and to permit persons to whom the Software is
+> furnished to do so, subject to the following conditions:
+>
+> The above copyright notice and this permission notice shall be included in all
+> copies or substantial portions of the Software.
+>
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+> SOFTWARE.
+
+Both files restore JSON numbers and nulls to `JSONValue` from the canonical
+TypeScript definition, which the generated upstream schema narrows to integer
+and omits null. The published wire schema additionally adds `$id`, `title`, and
+provenance metadata, and the `PtcRunnerJSONRPCErrorResponse` overlay; the
+input-request file is the extracted closure of `InputRequest`. Each file's own
+`$comment` states its changes.
+
+The wire schema is published at
+<https://ptc-runner.dev/schemas/mcp-2026-07-28.schema.json> and is in neither
+the Hex package nor the standalone release. The input-request closure is
+compiled into the runtime and ships in both.

--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -42,6 +42,47 @@ profile, despite starting and serving legacy clients normally.
 [`ptc-fs-mcp@0.1.0`](https://www.npmjs.com/package/ptc-fs-mcp) implements the
 required profile and is the deterministic baseline for this reference.
 
+### Implement the wire profile
+
+The pinned protocol definitions are published as
+[`mcp-2026-07-28.schema.json`](https://ptc-runner.dev/schemas/mcp-2026-07-28.schema.json).
+That document is the final upstream 2026-07-28 schema plus the two corrections
+PtcRunner maintains and upstream does not publish: `JSONValue` accepts JSON
+numbers and nulls, which the generated upstream document drops, and
+`PtcRunnerJSONRPCErrorResponse` is the failure envelope described below. A
+tools server needs these definitions:
+
+| Exchange | Request definition | Success-response definition |
+| --- | --- | --- |
+| Negotiate the profile | `DiscoverRequest` | `DiscoverResultResponse` |
+| Publish the tool catalog | `ListToolsRequest` | `ListToolsResultResponse` |
+| Invoke one tool | `CallToolRequest` | `CallToolResultResponse` |
+
+`PtcRunnerJSONRPCErrorResponse` is the failure envelope for all three. Resolve
+each as `#/$defs/NAME` inside the served document. Its `id` is the same positive
+integer sent with the request. Its closed `error` object requires an integer
+`code` and a UTF-8 `message` of at most 4,096 bytes, with optional JSON `data`;
+no other envelope or error fields are accepted. Requests carry
+`io.modelcontextprotocol/protocolVersion`, `io.modelcontextprotocol/clientInfo`,
+and an empty `io.modelcontextprotocol/clientCapabilities` object under
+`params._meta`.
+
+PtcRunner deliberately implements a narrower client policy than the complete
+schema surface. Every successful result includes `resultType: "complete"`.
+Discovery advertises `2026-07-28` in `supportedVersions` and a `tools`
+capability. Discovery and tool-list pages include a non-negative `ttlMs` and a
+`cacheScope` of `public` or `private`; all pages in one catalog traversal keep
+the same scope. Tool names are unique, and a selected tool has an object
+`inputSchema`. A tool call returns text blocks or embedded text resources;
+`structuredContent` is accepted only when the selected tool published an
+object `outputSchema`. Binary resources, image and audio blocks, task results,
+and server requests for sampling, elicitation, or roots are unsupported.
+Schema-valid `input_required` results are refused rather than fulfilled because
+the client advertises none of those capabilities.
+
+The schema defines wire shape. The bounds and closed-result rules above remain
+runtime policy, so passing the schema alone is necessary but not sufficient.
+
 A cold `npx` launch can spend more than the default budget before that protocol
 response arrives. Acquisition derives one per-operation budget and then applies
 it to each step separately: once to starting the transport, which for stdio

--- a/scripts/build_site.sh
+++ b/scripts/build_site.sh
@@ -11,6 +11,12 @@
 # keeps the hosted document and the runtime validator the same bytes; a second
 # copy checked in under `site/` would drift silently.
 #
+# `site/schemas/mcp-2026-07-28.schema.json` is deliberately the other way
+# round. It is vendored from upstream MCP, nothing in the runtime reads it, and
+# so there is no second copy for it to drift from: the file under `site/` is
+# the source, and this page is its only distribution. It still passes the `$id`
+# check below, because it is served like any other schema.
+#
 # Every published schema declares its own URL in `$id`, and the runtime hard
 # codes those URLs. A renamed or newly added schema would therefore publish to
 # a path nobody resolves, so the assembly below verifies that each `$id` still
@@ -171,9 +177,10 @@ for schema in "${schemas[@]}"; do
 done
 
 # Identity is checked against the assembled artifact, not against the sources
-# copied into it. Validating only `priv/schemas/` would leave any schema that
-# arrived some other way -- a stray `site/**/*.schema.json`, say -- published
-# unchecked while this guard still claimed to cover the site.
+# copied into it. Validating only `priv/schemas/` would leave every schema that
+# arrived some other way -- the vendored `site/schemas/*.schema.json`, or a
+# stray one -- published unchecked while this guard still claimed to cover the
+# site.
 python3 - "$output_dir" "$site_origin" <<'IDENTITY' || exit 65
 import json
 import pathlib
@@ -292,4 +299,6 @@ done <<< "$references"
 
 [ "$missing" -eq 0 ] || exit 65
 
-echo "Assembled $output_dir ($published schemas)"
+served="$(find "$output_dir" -name '*.schema.json' | wc -l | tr -d ' ')"
+
+echo "Assembled $output_dir ($served schemas, $published of them from priv/schemas)"

--- a/scripts/ci/classify-changes.sh
+++ b/scripts/ci/classify-changes.sh
@@ -69,6 +69,14 @@ while IFS= read -r path || [ -n "$path" ]; do
       docs=true
       ;;
 
+    site/schemas/mcp-*.schema.json)
+      # Published rather than shipped, but not documentation-only: the core
+      # suite validates the requests PtcRunner actually sends against these
+      # definitions, so an edit here can break `core` and not just the site.
+      core=true
+      docs=true
+      ;;
+
     docs/*|README.md|CHANGELOG.md|LICENSES/*|ptc_runner_launcher/README.md|\
       ptc_runner_launcher/CHANGELOG.md|ptc_viewer/README.md|ptc_viewer/CHANGELOG.md|\
       AGENTS.md|CLAUDE.md|usage-rules.md|.env.example|.lycheeignore|\

--- a/site/reference/mcp/index.html
+++ b/site/reference/mcp/index.html
@@ -122,7 +122,32 @@ Upgrade or replace the MCP server rather than adding a fallback handshake.</p><p
 <code class="inline">-32601 Method not found</code>. It is therefore not compatible with this PtcRunner
 profile, despite starting and serving legacy clients normally.
 <a href="https://www.npmjs.com/package/ptc-fs-mcp"><code class="inline">ptc-fs-mcp@0.1.0</code></a> implements the
-required profile and is the deterministic baseline for this reference.</p><p>A cold <code class="inline">npx</code> launch can spend more than the default budget before that protocol
+required profile and is the deterministic baseline for this reference.</p><h3 id="implement-the-wire-profile">Implement the wire profile</h3><p>The pinned protocol definitions are published as
+<a href="https://ptc-runner.dev/schemas/mcp-2026-07-28.schema.json"><code class="inline">mcp-2026-07-28.schema.json</code></a>.
+That document is the final upstream 2026-07-28 schema plus the two corrections
+PtcRunner maintains and upstream does not publish: <code class="inline">JSONValue</code> accepts JSON
+numbers and nulls, which the generated upstream document drops, and
+<code class="inline">PtcRunnerJSONRPCErrorResponse</code> is the failure envelope described below. A
+tools server needs these definitions:</p><div class="table-wrap"><table><thead><tr><th style="text-align: left;">Exchange</th><th style="text-align: left;">Request definition</th><th style="text-align: left;">Success-response definition</th></tr></thead><tbody><tr><td style="text-align: left;">Negotiate the profile</td><td style="text-align: left;"><code class="inline">DiscoverRequest</code></td><td style="text-align: left;"><code class="inline">DiscoverResultResponse</code></td></tr><tr><td style="text-align: left;">Publish the tool catalog</td><td style="text-align: left;"><code class="inline">ListToolsRequest</code></td><td style="text-align: left;"><code class="inline">ListToolsResultResponse</code></td></tr><tr><td style="text-align: left;">Invoke one tool</td><td style="text-align: left;"><code class="inline">CallToolRequest</code></td><td style="text-align: left;"><code class="inline">CallToolResultResponse</code></td></tr></tbody></table></div><p><code class="inline">PtcRunnerJSONRPCErrorResponse</code> is the failure envelope for all three. Resolve
+each as <code class="inline">#/$defs/NAME</code> inside the served document. Its <code class="inline">id</code> is the same positive
+integer sent with the request. Its closed <code class="inline">error</code> object requires an integer
+<code class="inline">code</code> and a UTF-8 <code class="inline">message</code> of at most 4,096 bytes, with optional JSON <code class="inline">data</code>;
+no other envelope or error fields are accepted. Requests carry
+<code class="inline">io.modelcontextprotocol/protocolVersion</code>, <code class="inline">io.modelcontextprotocol/clientInfo</code>,
+and an empty <code class="inline">io.modelcontextprotocol/clientCapabilities</code> object under
+<code class="inline">params._meta</code>.</p><p>PtcRunner deliberately implements a narrower client policy than the complete
+schema surface. Every successful result includes <code class="inline">resultType: &quot;complete&quot;</code>.
+Discovery advertises <code class="inline">2026-07-28</code> in <code class="inline">supportedVersions</code> and a <code class="inline">tools</code>
+capability. Discovery and tool-list pages include a non-negative <code class="inline">ttlMs</code> and a
+<code class="inline">cacheScope</code> of <code class="inline">public</code> or <code class="inline">private</code>; all pages in one catalog traversal keep
+the same scope. Tool names are unique, and a selected tool has an object
+<code class="inline">inputSchema</code>. A tool call returns text blocks or embedded text resources;
+<code class="inline">structuredContent</code> is accepted only when the selected tool published an
+object <code class="inline">outputSchema</code>. Binary resources, image and audio blocks, task results,
+and server requests for sampling, elicitation, or roots are unsupported.
+Schema-valid <code class="inline">input_required</code> results are refused rather than fulfilled because
+the client advertises none of those capabilities.</p><p>The schema defines wire shape. The bounds and closed-result rules above remain
+runtime policy, so passing the schema alone is necessary but not sufficient.</p><p>A cold <code class="inline">npx</code> launch can spend more than the default budget before that protocol
 response arrives. Acquisition derives one per-operation budget and then applies
 it to each step separately: once to starting the transport, which for stdio
 covers launcher staging and the child spawn, and again to each discovery request,

--- a/site/schemas/index.html
+++ b/site/schemas/index.html
@@ -31,6 +31,8 @@ editor at one to get completion and validation while authoring:</p>
 declarations do not belong in the project file, and project choices do not become part of
 application content identity.</p>
 
+<h2>PtcRunner documents</h2>
+
 <div class="schema">
   <h3><a href="/schemas/ptc-project-config.schema.json">ptc-project-config.schema.json</a></h3>
   <span class="role">operator or project checkout</span>
@@ -66,8 +68,35 @@ application content identity.</p>
   <span class="url mono">https://ptc-runner.dev/schemas/ptc-command-envelope-v2.schema.json</span>
 </div>
 
-<p class="muted-note">Each schema is published verbatim from <code>priv/schemas/</code> in the
-repository, so the hosted copy and the runtime validator are always the same bytes.</p>
+<p class="muted-note">Each schema above is published verbatim from <code>priv/schemas/</code> in
+the repository, so the hosted copy and the runtime validator are always the same bytes.</p>
+
+<h2>Model Context Protocol</h2>
+
+<p>PtcRunner speaks exactly one MCP revision, <code>2026-07-28</code>, and refuses anything
+older. A copy of that wire schema is published here because upstream&rsquo;s generated document
+is not quite the wire PtcRunner implements: <code>JSONValue</code> there narrows numbers to
+integers and omits null, and the closed JSON-RPC error envelope PtcRunner accepts has no
+upstream definition at all. Those two corrections are the entire delta &mdash; everything else
+is upstream byte-for-byte at commit <code>5f5440bb</code> &mdash; and the document states them
+in its own <code>$comment</code>.</p>
+
+<div class="schema">
+  <h3><a href="/schemas/mcp-2026-07-28.schema.json">mcp-2026-07-28.schema.json</a></h3>
+  <span class="role">third-party MCP server author</span>
+  <p>The definitions a tools server must satisfy to be acquirable: <code>DiscoverRequest</code>,
+  <code>ListToolsRequest</code>, <code>CallToolRequest</code>, their result responses, and
+  <code>PtcRunnerJSONRPCErrorResponse</code>. Wire shape only &mdash; the
+  <a href="/reference/mcp/">MCP reference</a> owns the narrower runtime policy, which a
+  schema-valid server can still fail.</p>
+  <span class="url mono">https://ptc-runner.dev/schemas/mcp-2026-07-28.schema.json</span>
+</div>
+
+<p class="muted-note">Third-party, and licensed accordingly: Apache-2.0 and MIT, per
+<a href="https://github.com/andreasronge/ptc_runner/blob/main/THIRD_PARTY_NOTICES.md">THIRD_PARTY_NOTICES.md</a>.
+It has no runtime validator to stay identical to, so it is checked in under <code>site/</code>
+and this page is its only distribution &mdash; it is in neither the Hex package nor the
+standalone release.</p>
 
 <footer>
   <a href="/">&larr; PtcRunner</a>

--- a/site/schemas/mcp-2026-07-28.schema.json
+++ b/site/schemas/mcp-2026-07-28.schema.json
@@ -1,0 +1,4007 @@
+{
+  "$id": "https://ptc-runner.dev/schemas/mcp-2026-07-28.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "MCP 2026-07-28 wire schema",
+  "$comment": "Vendored from modelcontextprotocol/modelcontextprotocol@5f5440bb26a62e2cf3440b92da5a667efa03b267 schema/2026-07-28/schema.json; see THIRD_PARTY_NOTICES.md for licensing and provenance. Beyond this header PtcRunner changes the upstream document in exactly two ways: JSONValue restores number and null from the canonical TypeScript definition, because the generated JSON Schema narrows number to integer and omits null; and PtcRunnerJSONRPCErrorResponse is added, used with DiscoverRequest, DiscoverResultResponse, ListToolsRequest, ListToolsResultResponse, CallToolRequest, and CallToolResultResponse. See ptc docs mcp for the supported subset and the closed result policy PtcRunner enforces on top of this schema.",
+  "$defs": {
+    "Annotations": {
+      "description": "Optional annotations for the client. The client can use annotations to inform how objects are used or displayed",
+      "properties": {
+        "audience": {
+          "description": "Describes who the intended audience of this object or data is.\n\nIt can include multiple entries to indicate content useful for multiple audiences (e.g., `[\"user\", \"assistant\"]`).",
+          "items": {
+            "$ref": "#/$defs/Role"
+          },
+          "type": "array"
+        },
+        "lastModified": {
+          "description": "The moment the resource was last modified, as an ISO 8601 formatted string.\n\nShould be an ISO 8601 formatted string (e.g., \"2025-01-12T15:00:58Z\").\n\nExamples: last activity timestamp in an open file, timestamp when the resource\nwas attached, etc.",
+          "type": "string"
+        },
+        "priority": {
+          "description": "Describes how important this data is for operating the server.\n\nA value of 1 means \"most important,\" and indicates that the data is\neffectively required, while 0 means \"least important,\" and indicates that\nthe data is entirely optional.",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        }
+      },
+      "type": "object"
+    },
+    "AudioContent": {
+      "description": "Audio provided to or from an LLM.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "annotations": {
+          "$ref": "#/$defs/Annotations",
+          "description": "Optional annotations for the client."
+        },
+        "data": {
+          "description": "The base64-encoded audio data.",
+          "format": "byte",
+          "type": "string"
+        },
+        "mimeType": {
+          "description": "The MIME type of the audio. Different providers may support different audio types.",
+          "type": "string"
+        },
+        "type": {
+          "const": "audio",
+          "type": "string"
+        }
+      },
+      "required": [
+        "data",
+        "mimeType",
+        "type"
+      ],
+      "type": "object"
+    },
+    "BaseMetadata": {
+      "description": "Base interface for metadata with name (identifier) and title (display name) properties.",
+      "properties": {
+        "name": {
+          "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+          "type": "string"
+        },
+        "title": {
+          "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for {@link Tool},\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "BlobResourceContents": {
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "blob": {
+          "description": "A base64-encoded string representing the binary data of the item.",
+          "format": "byte",
+          "type": "string"
+        },
+        "mimeType": {
+          "description": "The MIME type of this resource, if known.",
+          "type": "string"
+        },
+        "uri": {
+          "description": "The URI of this resource.",
+          "format": "uri",
+          "type": "string"
+        }
+      },
+      "required": [
+        "blob",
+        "uri"
+      ],
+      "type": "object"
+    },
+    "BooleanSchema": {
+      "properties": {
+        "default": {
+          "type": "boolean"
+        },
+        "description": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "type": {
+          "const": "boolean",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "CacheableResult": {
+      "description": "A result that supports a time-to-live (TTL) hint for client-side caching.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/ResultMetaObject"
+        },
+        "cacheScope": {
+          "description": "Indicates the intended scope of the cached response, analogous to HTTP\n`Cache-Control: public` vs `Cache-Control: private`.\n\n- `\"public\"`: The response does not contain user-specific data. Any\n  client or intermediary (e.g., shared gateway, caching proxy) MAY cache\n  the response and serve it across authorization contexts.\n- `\"private\"`: The response MAY be cached and reused only within the\n  same authorization context. Caches MUST NOT be shared across\n  authorization contexts (e.g., a different access token requires a\n  different cache).",
+          "enum": [
+            "private",
+            "public"
+          ],
+          "type": "string"
+        },
+        "resultType": {
+          "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
+          "type": "string"
+        },
+        "ttlMs": {
+          "description": "A hint from the server indicating how long (in milliseconds) the\nclient MAY cache this response before re-fetching. Semantics are\nanalogous to HTTP Cache-Control max-age.\n\n- If 0, The response SHOULD be considered immediately stale,\n  The client MAY re-fetch every time the result is needed.\n- If positive, the client SHOULD consider the result fresh for this many\n  milliseconds after receiving the response.",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "cacheScope",
+        "resultType",
+        "ttlMs"
+      ],
+      "type": "object"
+    },
+    "CallToolRequest": {
+      "description": "Used by the client to invoke a tool provided by the server.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "tools/call",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/CallToolRequestParams"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "CallToolRequestParams": {
+      "description": "Parameters for a `tools/call` request.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/RequestMetaObject"
+        },
+        "arguments": {
+          "additionalProperties": {},
+          "description": "Arguments to use for the tool call.",
+          "type": "object"
+        },
+        "inputResponses": {
+          "$ref": "#/$defs/InputResponses"
+        },
+        "name": {
+          "description": "The name of the tool.",
+          "type": "string"
+        },
+        "requestState": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "_meta",
+        "name"
+      ],
+      "type": "object"
+    },
+    "CallToolResult": {
+      "description": "The result returned by the server for a {@link CallToolRequesttools/call} request.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/ResultMetaObject"
+        },
+        "content": {
+          "description": "A list of content objects that represent the unstructured result of the tool call.",
+          "items": {
+            "$ref": "#/$defs/ContentBlock"
+          },
+          "type": "array"
+        },
+        "isError": {
+          "description": "Whether the tool call ended in an error.\n\nIf not set, this is assumed to be false (the call was successful).\n\nAny errors that originate from the tool SHOULD be reported inside the result\nobject, with `isError` set to true, _not_ as an MCP protocol-level error\nresponse. Otherwise, the LLM would not be able to see that an error occurred\nand self-correct.\n\nHowever, any errors in _finding_ the tool, an error indicating that the\nserver does not support tool calls, or any other exceptional conditions,\nshould be reported as an MCP error response.",
+          "type": "boolean"
+        },
+        "resultType": {
+          "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
+          "type": "string"
+        },
+        "structuredContent": {
+          "description": "An optional JSON value that represents the structured result of the tool call.\n\nThis can be any JSON value (object, array, string, number, boolean, or null)\nthat conforms to the tool's outputSchema if one is defined."
+        }
+      },
+      "required": [
+        "content",
+        "resultType"
+      ],
+      "type": "object"
+    },
+    "CallToolResultResponse": {
+      "description": "A successful response from the server for a {@link CallToolRequesttools/call} request.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "result": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/InputRequiredResult"
+            },
+            {
+              "$ref": "#/$defs/CallToolResult"
+            }
+          ]
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "result"
+      ],
+      "type": "object"
+    },
+    "CancelledNotification": {
+      "description": "This notification is sent by the client to indicate that it is cancelling a request it previously issued.\n\nOn stdio, the server also sends this notification, solely to terminate a {@link SubscriptionsListenRequestsubscriptions/listen} stream: it references the ID of the `subscriptions/listen` request that opened the stream. Servers MUST NOT use this notification to cancel any other request.\n\nThe request SHOULD still be in-flight, but due to communication latency, it is always possible that this notification MAY arrive after the request has already finished.\n\nThis notification indicates that the result will be unused, so any associated processing SHOULD cease.",
+      "properties": {
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "notifications/cancelled",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/CancelledNotificationParams"
+        }
+      },
+      "required": [
+        "jsonrpc",
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "CancelledNotificationParams": {
+      "description": "Parameters for a `notifications/cancelled` notification.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/NotificationMetaObject"
+        },
+        "reason": {
+          "description": "An optional string describing the reason for the cancellation. This MAY be logged or presented to the user.",
+          "type": "string"
+        },
+        "requestId": {
+          "$ref": "#/$defs/RequestId",
+          "description": "The ID of the request to cancel.\n\nThis MUST correspond to the ID of a request the client previously issued."
+        }
+      },
+      "required": [
+        "requestId"
+      ],
+      "type": "object"
+    },
+    "ClientCapabilities": {
+      "description": "Capabilities a client may support. Known capabilities are defined here, in this schema, but this is not a closed set: any client can define its own, additional capabilities.",
+      "properties": {
+        "elicitation": {
+          "description": "Present if the client supports elicitation from the server.",
+          "properties": {
+            "form": {
+              "$ref": "#/$defs/JSONObject"
+            },
+            "url": {
+              "$ref": "#/$defs/JSONObject"
+            }
+          },
+          "type": "object"
+        },
+        "experimental": {
+          "additionalProperties": {
+            "$ref": "#/$defs/JSONObject"
+          },
+          "description": "Experimental, non-standard capabilities that the client supports.",
+          "type": "object"
+        },
+        "extensions": {
+          "additionalProperties": {
+            "$ref": "#/$defs/JSONObject"
+          },
+          "description": "Optional MCP extensions that the client supports. Keys are extension identifiers\n(e.g., \"io.modelcontextprotocol/oauth-client-credentials\"), and values are\nper-extension settings objects. An empty object indicates support with no settings.\n\nKeys MUST follow the {@link MetaObject`_meta` key naming rules}, with a\nmandatory prefix.",
+          "type": "object"
+        },
+        "roots": {
+          "description": "Present if the client supports listing roots.",
+          "properties": {},
+          "type": "object"
+        },
+        "sampling": {
+          "description": "Present if the client supports sampling from an LLM.",
+          "properties": {
+            "context": {
+              "$ref": "#/$defs/JSONObject",
+              "description": "Whether the client supports context inclusion via `includeContext` parameter.\nIf not declared, servers SHOULD only use `includeContext: \"none\"` (or omit it)."
+            },
+            "tools": {
+              "$ref": "#/$defs/JSONObject",
+              "description": "Whether the client supports tool use via `tools` and `toolChoice` parameters."
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "ClientNotification": {
+      "description": "This notification is sent by the client to indicate that it is cancelling a request it previously issued.\n\nOn stdio, the server also sends this notification, solely to terminate a {@link SubscriptionsListenRequestsubscriptions/listen} stream: it references the ID of the `subscriptions/listen` request that opened the stream. Servers MUST NOT use this notification to cancel any other request.\n\nThe request SHOULD still be in-flight, but due to communication latency, it is always possible that this notification MAY arrive after the request has already finished.\n\nThis notification indicates that the result will be unused, so any associated processing SHOULD cease.",
+      "properties": {
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "notifications/cancelled",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/CancelledNotificationParams"
+        }
+      },
+      "required": [
+        "jsonrpc",
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "ClientRequest": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/DiscoverRequest"
+        },
+        {
+          "$ref": "#/$defs/ListResourcesRequest"
+        },
+        {
+          "$ref": "#/$defs/ListResourceTemplatesRequest"
+        },
+        {
+          "$ref": "#/$defs/ReadResourceRequest"
+        },
+        {
+          "$ref": "#/$defs/SubscriptionsListenRequest"
+        },
+        {
+          "$ref": "#/$defs/ListPromptsRequest"
+        },
+        {
+          "$ref": "#/$defs/GetPromptRequest"
+        },
+        {
+          "$ref": "#/$defs/ListToolsRequest"
+        },
+        {
+          "$ref": "#/$defs/CallToolRequest"
+        },
+        {
+          "$ref": "#/$defs/CompleteRequest"
+        }
+      ]
+    },
+    "ClientResult": {
+      "$ref": "#/$defs/Result",
+      "description": "Common result fields."
+    },
+    "CompleteRequest": {
+      "description": "A request from the client to the server, to ask for completion options.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "completion/complete",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/CompleteRequestParams"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "CompleteRequestParams": {
+      "description": "Parameters for a `completion/complete` request.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/RequestMetaObject"
+        },
+        "argument": {
+          "description": "The argument's information",
+          "properties": {
+            "name": {
+              "description": "The name of the argument",
+              "type": "string"
+            },
+            "value": {
+              "description": "The value of the argument to use for completion matching.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name",
+            "value"
+          ],
+          "type": "object"
+        },
+        "context": {
+          "description": "Additional, optional context for completions",
+          "properties": {
+            "arguments": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Previously-resolved variables in a URI template or prompt.",
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "ref": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PromptReference"
+            },
+            {
+              "$ref": "#/$defs/ResourceTemplateReference"
+            }
+          ]
+        }
+      },
+      "required": [
+        "_meta",
+        "argument",
+        "ref"
+      ],
+      "type": "object"
+    },
+    "CompleteResult": {
+      "description": "The result returned by the server for a {@link CompleteRequestcompletion/complete} request.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/ResultMetaObject"
+        },
+        "completion": {
+          "properties": {
+            "hasMore": {
+              "description": "Indicates whether there are additional completion options beyond those provided in the current response, even if the exact total is unknown.",
+              "type": "boolean"
+            },
+            "total": {
+              "description": "The total number of completion options available. This can exceed the number of values actually sent in the response.",
+              "type": "integer"
+            },
+            "values": {
+              "description": "An array of completion values. Must not exceed 100 items.",
+              "items": {
+                "type": "string"
+              },
+              "maxItems": 100,
+              "type": "array"
+            }
+          },
+          "required": [
+            "values"
+          ],
+          "type": "object"
+        },
+        "resultType": {
+          "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "completion",
+        "resultType"
+      ],
+      "type": "object"
+    },
+    "CompleteResultResponse": {
+      "description": "A successful response from the server for a {@link CompleteRequestcompletion/complete} request.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "result": {
+          "$ref": "#/$defs/CompleteResult"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "result"
+      ],
+      "type": "object"
+    },
+    "ContentBlock": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/TextContent"
+        },
+        {
+          "$ref": "#/$defs/ImageContent"
+        },
+        {
+          "$ref": "#/$defs/AudioContent"
+        },
+        {
+          "$ref": "#/$defs/ResourceLink"
+        },
+        {
+          "$ref": "#/$defs/EmbeddedResource"
+        }
+      ]
+    },
+    "CreateMessageRequest": {
+      "description": "A request from the server to sample an LLM via the client. The client has full discretion over which model to select. The client should also inform the user before beginning sampling, to allow them to inspect the request (human in the loop) and decide whether to approve it.",
+      "properties": {
+        "method": {
+          "const": "sampling/createMessage",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/CreateMessageRequestParams"
+        }
+      },
+      "required": [
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "CreateMessageRequestParams": {
+      "description": "Parameters for a `sampling/createMessage` request.",
+      "properties": {
+        "includeContext": {
+          "description": "A request to include context from one or more MCP servers (including the caller), to be attached to the prompt.\nThe client MAY ignore this request.\n\nDefault is `\"none\"`. The values `\"thisServer\"` and `\"allServers\"` are deprecated (SEP-2596): servers SHOULD\nomit this field or use `\"none\"`, and SHOULD only use the deprecated values if the client declares\n{@link ClientCapabilities.sampling.context}.",
+          "enum": [
+            "allServers",
+            "none",
+            "thisServer"
+          ],
+          "type": "string"
+        },
+        "maxTokens": {
+          "description": "The requested maximum number of tokens to sample (to prevent runaway completions).\n\nThe client MAY choose to sample fewer tokens than the requested maximum.",
+          "type": "integer"
+        },
+        "messages": {
+          "items": {
+            "$ref": "#/$defs/SamplingMessage"
+          },
+          "type": "array"
+        },
+        "metadata": {
+          "$ref": "#/$defs/JSONObject",
+          "description": "Optional metadata to pass through to the LLM provider. The format of this metadata is provider-specific."
+        },
+        "modelPreferences": {
+          "$ref": "#/$defs/ModelPreferences",
+          "description": "The server's preferences for which model to select. The client MAY ignore these preferences."
+        },
+        "stopSequences": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "systemPrompt": {
+          "description": "An optional system prompt the server wants to use for sampling. The client MAY modify or omit this prompt.",
+          "type": "string"
+        },
+        "temperature": {
+          "type": "number"
+        },
+        "toolChoice": {
+          "$ref": "#/$defs/ToolChoice",
+          "description": "Controls how the model uses tools.\nThe client MUST return an error if this field is provided but {@link ClientCapabilities.sampling.tools} is not declared.\nDefault is `{ mode: \"auto\" }`."
+        },
+        "tools": {
+          "description": "Tools that the model may use during generation.\nThe client MUST return an error if this field is provided but {@link ClientCapabilities.sampling.tools} is not declared.",
+          "items": {
+            "$ref": "#/$defs/Tool"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "maxTokens",
+        "messages"
+      ],
+      "type": "object"
+    },
+    "CreateMessageResult": {
+      "description": "The result returned by the client for a {@link CreateMessageRequestsampling/createMessage} request.\nThe client should inform the user before returning the sampled message, to allow them\nto inspect the response (human in the loop) and decide whether to allow the server to see it.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "content": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TextContent"
+            },
+            {
+              "$ref": "#/$defs/ImageContent"
+            },
+            {
+              "$ref": "#/$defs/AudioContent"
+            },
+            {
+              "$ref": "#/$defs/ToolUseContent"
+            },
+            {
+              "$ref": "#/$defs/ToolResultContent"
+            },
+            {
+              "items": {
+                "$ref": "#/$defs/SamplingMessageContentBlock"
+              },
+              "type": "array"
+            }
+          ]
+        },
+        "model": {
+          "description": "The name of the model that generated the message.",
+          "type": "string"
+        },
+        "role": {
+          "$ref": "#/$defs/Role"
+        },
+        "stopReason": {
+          "description": "The reason why sampling stopped, if known.\n\nStandard values:\n- `\"endTurn\"`: Natural end of the assistant's turn\n- `\"stopSequence\"`: A stop sequence was encountered\n- `\"maxTokens\"`: Maximum token limit was reached\n- `\"toolUse\"`: The model wants to use one or more tools\n\nThis field is an open string to allow for provider-specific stop reasons.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "content",
+        "model",
+        "role"
+      ],
+      "type": "object"
+    },
+    "Cursor": {
+      "description": "An opaque token used to represent a cursor for pagination.",
+      "type": "string"
+    },
+    "DiscoverRequest": {
+      "description": "A request from the client asking the server to advertise its supported\nprotocol versions, capabilities, and other metadata. Servers **MUST**\nimplement `server/discover`. Clients **MAY** call it but are not required\nto — version negotiation can also happen inline via per-request `_meta`.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "server/discover",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/RequestParams"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "DiscoverResult": {
+      "description": "The result returned by the server for a {@link DiscoverRequestserver/discover} request.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/ResultMetaObject"
+        },
+        "cacheScope": {
+          "description": "Indicates the intended scope of the cached response, analogous to HTTP\n`Cache-Control: public` vs `Cache-Control: private`.\n\n- `\"public\"`: The response does not contain user-specific data. Any\n  client or intermediary (e.g., shared gateway, caching proxy) MAY cache\n  the response and serve it across authorization contexts.\n- `\"private\"`: The response MAY be cached and reused only within the\n  same authorization context. Caches MUST NOT be shared across\n  authorization contexts (e.g., a different access token requires a\n  different cache).",
+          "enum": [
+            "private",
+            "public"
+          ],
+          "type": "string"
+        },
+        "capabilities": {
+          "$ref": "#/$defs/ServerCapabilities",
+          "description": "The capabilities of the server."
+        },
+        "instructions": {
+          "description": "Natural-language guidance describing the server and its features.\n\nThis can be used by clients to improve an LLM's understanding of\navailable tools (e.g., by including it in a system prompt). It should\nfocus on information that helps the model use the server effectively\nand should not duplicate information already in tool descriptions.",
+          "type": "string"
+        },
+        "resultType": {
+          "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
+          "type": "string"
+        },
+        "supportedVersions": {
+          "description": "MCP Protocol Versions this server supports. The client should choose a\nversion from this list for use in subsequent requests.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "ttlMs": {
+          "description": "A hint from the server indicating how long (in milliseconds) the\nclient MAY cache this response before re-fetching. Semantics are\nanalogous to HTTP Cache-Control max-age.\n\n- If 0, The response SHOULD be considered immediately stale,\n  The client MAY re-fetch every time the result is needed.\n- If positive, the client SHOULD consider the result fresh for this many\n  milliseconds after receiving the response.",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "cacheScope",
+        "capabilities",
+        "resultType",
+        "supportedVersions",
+        "ttlMs"
+      ],
+      "type": "object"
+    },
+    "DiscoverResultResponse": {
+      "description": "A successful response from the server for a {@link DiscoverRequestserver/discover} request.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "result": {
+          "$ref": "#/$defs/DiscoverResult"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "result"
+      ],
+      "type": "object"
+    },
+    "ElicitRequest": {
+      "description": "A request from the server to elicit additional information from the user via the client.",
+      "properties": {
+        "method": {
+          "const": "elicitation/create",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/ElicitRequestParams"
+        }
+      },
+      "required": [
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "ElicitRequestFormParams": {
+      "description": "The parameters for a request to elicit non-sensitive information from the user via a form in the client.",
+      "properties": {
+        "message": {
+          "description": "The message to present to the user describing what information is being requested.",
+          "type": "string"
+        },
+        "mode": {
+          "const": "form",
+          "description": "The elicitation mode.",
+          "type": "string"
+        },
+        "requestedSchema": {
+          "description": "A restricted subset of JSON Schema.\nOnly top-level properties are allowed, without nesting.",
+          "properties": {
+            "$schema": {
+              "type": "string"
+            },
+            "properties": {
+              "additionalProperties": {
+                "$ref": "#/$defs/PrimitiveSchemaDefinition"
+              },
+              "type": "object"
+            },
+            "required": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "type": {
+              "const": "object",
+              "type": "string"
+            }
+          },
+          "required": [
+            "properties",
+            "type"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "message",
+        "requestedSchema"
+      ],
+      "type": "object"
+    },
+    "ElicitRequestParams": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/ElicitRequestFormParams"
+        },
+        {
+          "$ref": "#/$defs/ElicitRequestURLParams"
+        }
+      ],
+      "description": "The parameters for a request to elicit additional information from the user via the client."
+    },
+    "ElicitRequestURLParams": {
+      "description": "The parameters for a request to elicit information from the user via a URL in the client.",
+      "properties": {
+        "message": {
+          "description": "The message to present to the user explaining why the interaction is needed.",
+          "type": "string"
+        },
+        "mode": {
+          "const": "url",
+          "description": "The elicitation mode.",
+          "type": "string"
+        },
+        "url": {
+          "description": "The URL that the user should navigate to.",
+          "format": "uri",
+          "type": "string"
+        }
+      },
+      "required": [
+        "message",
+        "mode",
+        "url"
+      ],
+      "type": "object"
+    },
+    "ElicitResult": {
+      "description": "The result returned by the client for an {@link ElicitRequestelicitation/create} request.",
+      "properties": {
+        "action": {
+          "description": "The user action in response to the elicitation.\n- `\"accept\"`: User submitted the form/confirmed the action\n- `\"decline\"`: User explicitly declined the action\n- `\"cancel\"`: User dismissed without making an explicit choice",
+          "enum": [
+            "accept",
+            "cancel",
+            "decline"
+          ],
+          "type": "string"
+        },
+        "content": {
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": [
+                  "string",
+                  "integer",
+                  "boolean"
+                ]
+              }
+            ]
+          },
+          "description": "The submitted form data, only present when action is `\"accept\"` and mode was `\"form\"`.\nContains values matching the requested schema.\nOmitted for out-of-band mode responses.",
+          "type": "object"
+        }
+      },
+      "required": [
+        "action"
+      ],
+      "type": "object"
+    },
+    "EmbeddedResource": {
+      "description": "The contents of a resource, embedded into a prompt or tool call result.\n\nIt is up to the client how best to render embedded resources for the benefit\nof the LLM and/or the user.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "annotations": {
+          "$ref": "#/$defs/Annotations",
+          "description": "Optional annotations for the client."
+        },
+        "resource": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TextResourceContents"
+            },
+            {
+              "$ref": "#/$defs/BlobResourceContents"
+            }
+          ]
+        },
+        "type": {
+          "const": "resource",
+          "type": "string"
+        }
+      },
+      "required": [
+        "resource",
+        "type"
+      ],
+      "type": "object"
+    },
+    "EmptyResult": {
+      "$ref": "#/$defs/Result",
+      "description": "Common result fields."
+    },
+    "EnumSchema": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/UntitledSingleSelectEnumSchema"
+        },
+        {
+          "$ref": "#/$defs/TitledSingleSelectEnumSchema"
+        },
+        {
+          "$ref": "#/$defs/UntitledMultiSelectEnumSchema"
+        },
+        {
+          "$ref": "#/$defs/TitledMultiSelectEnumSchema"
+        },
+        {
+          "$ref": "#/$defs/LegacyTitledEnumSchema"
+        }
+      ]
+    },
+    "Error": {
+      "properties": {
+        "code": {
+          "description": "The error type that occurred.",
+          "type": "integer"
+        },
+        "data": {
+          "description": "Additional information about the error. The value of this member is defined by the sender (e.g. detailed error information, nested errors etc.)."
+        },
+        "message": {
+          "description": "A short description of the error. The message SHOULD be limited to a concise single sentence.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "code",
+        "message"
+      ],
+      "type": "object"
+    },
+    "GetPromptRequest": {
+      "description": "Used by the client to get a prompt provided by the server.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "prompts/get",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/GetPromptRequestParams"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "GetPromptRequestParams": {
+      "description": "Parameters for a `prompts/get` request.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/RequestMetaObject"
+        },
+        "arguments": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Arguments to use for templating the prompt.",
+          "type": "object"
+        },
+        "inputResponses": {
+          "$ref": "#/$defs/InputResponses"
+        },
+        "name": {
+          "description": "The name of the prompt or prompt template.",
+          "type": "string"
+        },
+        "requestState": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "_meta",
+        "name"
+      ],
+      "type": "object"
+    },
+    "GetPromptResult": {
+      "description": "The result returned by the server for a {@link GetPromptRequestprompts/get} request.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/ResultMetaObject"
+        },
+        "description": {
+          "description": "An optional description for the prompt.",
+          "type": "string"
+        },
+        "messages": {
+          "items": {
+            "$ref": "#/$defs/PromptMessage"
+          },
+          "type": "array"
+        },
+        "resultType": {
+          "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "messages",
+        "resultType"
+      ],
+      "type": "object"
+    },
+    "GetPromptResultResponse": {
+      "description": "A successful response from the server for a {@link GetPromptRequestprompts/get} request.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "result": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/InputRequiredResult"
+            },
+            {
+              "$ref": "#/$defs/GetPromptResult"
+            }
+          ]
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "result"
+      ],
+      "type": "object"
+    },
+    "HeaderMismatchError": {
+      "description": "Returned when a server rejects a request because the values in the HTTP\nheaders do not match the corresponding values in the request body, or\nbecause required headers are missing or malformed. For HTTP, the response\nstatus code MUST be `400 Bad Request`.",
+      "properties": {
+        "error": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Error"
+            },
+            {
+              "properties": {
+                "code": {
+                  "const": -32020,
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "code"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        }
+      },
+      "required": [
+        "error",
+        "jsonrpc"
+      ],
+      "type": "object"
+    },
+    "Icon": {
+      "description": "An optionally-sized icon that can be displayed in a user interface.",
+      "properties": {
+        "mimeType": {
+          "description": "Optional MIME type override if the source MIME type is missing or generic.\nFor example: `\"image/png\"`, `\"image/jpeg\"`, or `\"image/svg+xml\"`.",
+          "type": "string"
+        },
+        "sizes": {
+          "description": "Optional array of strings that specify sizes at which the icon can be used.\nEach string should be in WxH format (e.g., `\"48x48\"`, `\"96x96\"`) or `\"any\"` for scalable formats like SVG.\n\nIf not provided, the client should assume that the icon can be used at any size.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "src": {
+          "description": "A standard URI pointing to an icon resource. May be an HTTP/HTTPS URL or a\n`data:` URI with Base64-encoded image data.\n\nConsumers SHOULD take steps to ensure URLs serving icons are from the\nsame domain as the client/server or a trusted domain.\n\nConsumers SHOULD take appropriate precautions when consuming SVGs as they can contain\nexecutable JavaScript.",
+          "format": "uri",
+          "type": "string"
+        },
+        "theme": {
+          "description": "Optional specifier for the theme this icon is designed for. `\"light\"` indicates\nthe icon is designed to be used with a light background, and `\"dark\"` indicates\nthe icon is designed to be used with a dark background.\n\nIf not provided, the client should assume the icon can be used with any theme.",
+          "enum": [
+            "dark",
+            "light"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "src"
+      ],
+      "type": "object"
+    },
+    "Icons": {
+      "description": "Base interface to add `icons` property.",
+      "properties": {
+        "icons": {
+          "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
+          "items": {
+            "$ref": "#/$defs/Icon"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "ImageContent": {
+      "description": "An image provided to or from an LLM.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "annotations": {
+          "$ref": "#/$defs/Annotations",
+          "description": "Optional annotations for the client."
+        },
+        "data": {
+          "description": "The base64-encoded image data.",
+          "format": "byte",
+          "type": "string"
+        },
+        "mimeType": {
+          "description": "The MIME type of the image. Different providers may support different image types.",
+          "type": "string"
+        },
+        "type": {
+          "const": "image",
+          "type": "string"
+        }
+      },
+      "required": [
+        "data",
+        "mimeType",
+        "type"
+      ],
+      "type": "object"
+    },
+    "Implementation": {
+      "description": "Describes the MCP implementation.",
+      "properties": {
+        "description": {
+          "description": "An optional human-readable description of what this implementation does.\n\nThis can be used by clients or servers to provide context about their purpose\nand capabilities. For example, a server might describe the types of resources\nor tools it provides, while a client might describe its intended use case.",
+          "type": "string"
+        },
+        "icons": {
+          "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
+          "items": {
+            "$ref": "#/$defs/Icon"
+          },
+          "type": "array"
+        },
+        "name": {
+          "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+          "type": "string"
+        },
+        "title": {
+          "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for {@link Tool},\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+          "type": "string"
+        },
+        "version": {
+          "description": "The version of this implementation.",
+          "type": "string"
+        },
+        "websiteUrl": {
+          "description": "An optional URL of the website for this implementation.",
+          "format": "uri",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "version"
+      ],
+      "type": "object"
+    },
+    "InputRequest": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/CreateMessageRequest"
+        },
+        {
+          "$ref": "#/$defs/ListRootsRequest"
+        },
+        {
+          "$ref": "#/$defs/ElicitRequest"
+        }
+      ]
+    },
+    "InputRequests": {
+      "additionalProperties": {
+        "$ref": "#/$defs/InputRequest"
+      },
+      "description": "A map of server-initiated requests that the client must fulfill.\nKeys are server-assigned identifiers; values are the request objects.",
+      "type": "object"
+    },
+    "InputRequiredResult": {
+      "description": "An InputRequiredResult sent by the server to indicate that additional input is needed\nbefore the request can be completed.\n\nAt least one of `inputRequests` or `requestState` MUST be present.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/ResultMetaObject"
+        },
+        "inputRequests": {
+          "$ref": "#/$defs/InputRequests"
+        },
+        "requestState": {
+          "type": "string"
+        },
+        "resultType": {
+          "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "resultType"
+      ],
+      "type": "object"
+    },
+    "InputResponse": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/CreateMessageResult"
+        },
+        {
+          "$ref": "#/$defs/ListRootsResult"
+        },
+        {
+          "$ref": "#/$defs/ElicitResult"
+        }
+      ]
+    },
+    "InputResponseRequestParams": {
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/RequestMetaObject"
+        },
+        "inputResponses": {
+          "$ref": "#/$defs/InputResponses"
+        },
+        "requestState": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "_meta"
+      ],
+      "type": "object"
+    },
+    "InputResponses": {
+      "additionalProperties": {
+        "$ref": "#/$defs/InputResponse"
+      },
+      "description": "A map of client responses to server-initiated requests.\nKeys correspond to the keys in the {@link InputRequests} map;\nvalues are the client's result for each request.",
+      "type": "object"
+    },
+    "InternalError": {
+      "description": "A JSON-RPC error indicating that an internal error occurred on the receiver. This error is returned when the receiver encounters an unexpected condition that prevents it from fulfilling the request.",
+      "properties": {
+        "code": {
+          "const": -32603,
+          "description": "The error type that occurred.",
+          "type": "integer"
+        },
+        "data": {
+          "description": "Additional information about the error. The value of this member is defined by the sender (e.g. detailed error information, nested errors etc.)."
+        },
+        "message": {
+          "description": "A short description of the error. The message SHOULD be limited to a concise single sentence.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "code",
+        "message"
+      ],
+      "type": "object"
+    },
+    "InvalidParamsError": {
+      "description": "A JSON-RPC error indicating that the method parameters are invalid or malformed.\n\nIn MCP, this error is returned in various contexts when request parameters fail validation:\n\n- **Tools**: Unknown tool name or invalid tool arguments\n- **Prompts**: Unknown prompt name or missing required arguments\n- **Pagination**: Invalid or expired cursor values\n- **Logging**: Invalid log level\n- **Elicitation**: Server requests an elicitation mode not declared in client capabilities\n- **Sampling**: Missing tool result or tool results mixed with other content",
+      "properties": {
+        "code": {
+          "const": -32602,
+          "description": "The error type that occurred.",
+          "type": "integer"
+        },
+        "data": {
+          "description": "Additional information about the error. The value of this member is defined by the sender (e.g. detailed error information, nested errors etc.)."
+        },
+        "message": {
+          "description": "A short description of the error. The message SHOULD be limited to a concise single sentence.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "code",
+        "message"
+      ],
+      "type": "object"
+    },
+    "InvalidRequestError": {
+      "description": "A JSON-RPC error indicating that the request is not a valid request object. This error is returned when the message structure does not conform to the JSON-RPC 2.0 specification requirements for a request (e.g., missing required fields like `jsonrpc` or `method`, or using invalid types for these fields).",
+      "properties": {
+        "code": {
+          "const": -32600,
+          "description": "The error type that occurred.",
+          "type": "integer"
+        },
+        "data": {
+          "description": "Additional information about the error. The value of this member is defined by the sender (e.g. detailed error information, nested errors etc.)."
+        },
+        "message": {
+          "description": "A short description of the error. The message SHOULD be limited to a concise single sentence.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "code",
+        "message"
+      ],
+      "type": "object"
+    },
+    "JSONArray": {
+      "items": {
+        "$ref": "#/$defs/JSONValue"
+      },
+      "type": "array"
+    },
+    "JSONObject": {
+      "additionalProperties": {
+        "$ref": "#/$defs/JSONValue"
+      },
+      "type": "object"
+    },
+    "JSONRPCErrorResponse": {
+      "description": "A response to a request that indicates an error occurred.",
+      "properties": {
+        "error": {
+          "$ref": "#/$defs/Error"
+        },
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        }
+      },
+      "required": [
+        "error",
+        "jsonrpc"
+      ],
+      "type": "object"
+    },
+    "PtcRunnerJSONRPCErrorResponse": {
+      "additionalProperties": false,
+      "description": "PtcRunner's closed JSON-RPC failure envelope. The positive integer id must equal the request id. message is additionally limited to 4096 UTF-8 bytes at runtime; maxLength expresses the corresponding character ceiling.",
+      "properties": {
+        "error": {
+          "additionalProperties": false,
+          "properties": {
+            "code": {
+              "type": "integer"
+            },
+            "data": {
+              "$ref": "#/$defs/JSONValue"
+            },
+            "message": {
+              "maxLength": 4096,
+              "type": "string"
+            }
+          },
+          "required": [
+            "code",
+            "message"
+          ],
+          "type": "object"
+        },
+        "id": {
+          "minimum": 1,
+          "type": "integer"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        }
+      },
+      "required": [
+        "error",
+        "id",
+        "jsonrpc"
+      ],
+      "type": "object"
+    },
+    "JSONRPCMessage": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/JSONRPCRequest"
+        },
+        {
+          "$ref": "#/$defs/JSONRPCNotification"
+        },
+        {
+          "$ref": "#/$defs/JSONRPCResultResponse"
+        },
+        {
+          "$ref": "#/$defs/JSONRPCErrorResponse"
+        }
+      ],
+      "description": "Refers to any valid JSON-RPC object that can be decoded off the wire, or encoded to be sent."
+    },
+    "JSONRPCNotification": {
+      "description": "A notification which does not expect a response.",
+      "properties": {
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "type": "string"
+        },
+        "params": {
+          "additionalProperties": {},
+          "type": "object"
+        }
+      },
+      "required": [
+        "jsonrpc",
+        "method"
+      ],
+      "type": "object"
+    },
+    "JSONRPCRequest": {
+      "description": "A request that expects a response.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "type": "string"
+        },
+        "params": {
+          "additionalProperties": {},
+          "type": "object"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "method"
+      ],
+      "type": "object"
+    },
+    "JSONRPCResponse": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/JSONRPCResultResponse"
+        },
+        {
+          "$ref": "#/$defs/JSONRPCErrorResponse"
+        }
+      ],
+      "description": "A response to a request, containing either the result or error."
+    },
+    "JSONRPCResultResponse": {
+      "description": "A successful (non-error) response to a request.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "result": {
+          "$ref": "#/$defs/Result"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "result"
+      ],
+      "type": "object"
+    },
+    "JSONValue": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/JSONObject"
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/JSONValue"
+          },
+          "type": "array"
+        },
+        {
+          "type": [
+            "string",
+            "number",
+            "integer",
+            "boolean",
+            "null"
+          ]
+        }
+      ]
+    },
+    "LegacyTitledEnumSchema": {
+      "description": "Use {@link TitledSingleSelectEnumSchema} instead.\nThis interface will be removed in a future version.",
+      "properties": {
+        "default": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "enum": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "enumNames": {
+          "description": "(Legacy) Display names for enum values.\nNon-standard according to JSON schema 2020-12.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "title": {
+          "type": "string"
+        },
+        "type": {
+          "const": "string",
+          "type": "string"
+        }
+      },
+      "required": [
+        "enum",
+        "type"
+      ],
+      "type": "object"
+    },
+    "ListPromptsRequest": {
+      "description": "Sent from the client to request a list of prompts and prompt templates the server has.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "prompts/list",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/PaginatedRequestParams"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "ListPromptsResult": {
+      "description": "The result returned by the server for a {@link ListPromptsRequestprompts/list} request.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/ResultMetaObject"
+        },
+        "cacheScope": {
+          "description": "Indicates the intended scope of the cached response, analogous to HTTP\n`Cache-Control: public` vs `Cache-Control: private`.\n\n- `\"public\"`: The response does not contain user-specific data. Any\n  client or intermediary (e.g., shared gateway, caching proxy) MAY cache\n  the response and serve it across authorization contexts.\n- `\"private\"`: The response MAY be cached and reused only within the\n  same authorization context. Caches MUST NOT be shared across\n  authorization contexts (e.g., a different access token requires a\n  different cache).",
+          "enum": [
+            "private",
+            "public"
+          ],
+          "type": "string"
+        },
+        "nextCursor": {
+          "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
+          "type": "string"
+        },
+        "prompts": {
+          "items": {
+            "$ref": "#/$defs/Prompt"
+          },
+          "type": "array"
+        },
+        "resultType": {
+          "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
+          "type": "string"
+        },
+        "ttlMs": {
+          "description": "A hint from the server indicating how long (in milliseconds) the\nclient MAY cache this response before re-fetching. Semantics are\nanalogous to HTTP Cache-Control max-age.\n\n- If 0, The response SHOULD be considered immediately stale,\n  The client MAY re-fetch every time the result is needed.\n- If positive, the client SHOULD consider the result fresh for this many\n  milliseconds after receiving the response.",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "cacheScope",
+        "prompts",
+        "resultType",
+        "ttlMs"
+      ],
+      "type": "object"
+    },
+    "ListPromptsResultResponse": {
+      "description": "A successful response from the server for a {@link ListPromptsRequestprompts/list} request.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "result": {
+          "$ref": "#/$defs/ListPromptsResult"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "result"
+      ],
+      "type": "object"
+    },
+    "ListResourceTemplatesRequest": {
+      "description": "Sent from the client to request a list of resource templates the server has.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "resources/templates/list",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/PaginatedRequestParams"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "ListResourceTemplatesResult": {
+      "description": "The result returned by the server for a {@link ListResourceTemplatesRequestresources/templates/list} request.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/ResultMetaObject"
+        },
+        "cacheScope": {
+          "description": "Indicates the intended scope of the cached response, analogous to HTTP\n`Cache-Control: public` vs `Cache-Control: private`.\n\n- `\"public\"`: The response does not contain user-specific data. Any\n  client or intermediary (e.g., shared gateway, caching proxy) MAY cache\n  the response and serve it across authorization contexts.\n- `\"private\"`: The response MAY be cached and reused only within the\n  same authorization context. Caches MUST NOT be shared across\n  authorization contexts (e.g., a different access token requires a\n  different cache).",
+          "enum": [
+            "private",
+            "public"
+          ],
+          "type": "string"
+        },
+        "nextCursor": {
+          "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
+          "type": "string"
+        },
+        "resourceTemplates": {
+          "items": {
+            "$ref": "#/$defs/ResourceTemplate"
+          },
+          "type": "array"
+        },
+        "resultType": {
+          "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
+          "type": "string"
+        },
+        "ttlMs": {
+          "description": "A hint from the server indicating how long (in milliseconds) the\nclient MAY cache this response before re-fetching. Semantics are\nanalogous to HTTP Cache-Control max-age.\n\n- If 0, The response SHOULD be considered immediately stale,\n  The client MAY re-fetch every time the result is needed.\n- If positive, the client SHOULD consider the result fresh for this many\n  milliseconds after receiving the response.",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "cacheScope",
+        "resourceTemplates",
+        "resultType",
+        "ttlMs"
+      ],
+      "type": "object"
+    },
+    "ListResourceTemplatesResultResponse": {
+      "description": "A successful response from the server for a {@link ListResourceTemplatesRequestresources/templates/list} request.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "result": {
+          "$ref": "#/$defs/ListResourceTemplatesResult"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "result"
+      ],
+      "type": "object"
+    },
+    "ListResourcesRequest": {
+      "description": "Sent from the client to request a list of resources the server has.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "resources/list",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/PaginatedRequestParams"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "ListResourcesResult": {
+      "description": "The result returned by the server for a {@link ListResourcesRequestresources/list} request.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/ResultMetaObject"
+        },
+        "cacheScope": {
+          "description": "Indicates the intended scope of the cached response, analogous to HTTP\n`Cache-Control: public` vs `Cache-Control: private`.\n\n- `\"public\"`: The response does not contain user-specific data. Any\n  client or intermediary (e.g., shared gateway, caching proxy) MAY cache\n  the response and serve it across authorization contexts.\n- `\"private\"`: The response MAY be cached and reused only within the\n  same authorization context. Caches MUST NOT be shared across\n  authorization contexts (e.g., a different access token requires a\n  different cache).",
+          "enum": [
+            "private",
+            "public"
+          ],
+          "type": "string"
+        },
+        "nextCursor": {
+          "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
+          "type": "string"
+        },
+        "resources": {
+          "items": {
+            "$ref": "#/$defs/Resource"
+          },
+          "type": "array"
+        },
+        "resultType": {
+          "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
+          "type": "string"
+        },
+        "ttlMs": {
+          "description": "A hint from the server indicating how long (in milliseconds) the\nclient MAY cache this response before re-fetching. Semantics are\nanalogous to HTTP Cache-Control max-age.\n\n- If 0, The response SHOULD be considered immediately stale,\n  The client MAY re-fetch every time the result is needed.\n- If positive, the client SHOULD consider the result fresh for this many\n  milliseconds after receiving the response.",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "cacheScope",
+        "resources",
+        "resultType",
+        "ttlMs"
+      ],
+      "type": "object"
+    },
+    "ListResourcesResultResponse": {
+      "description": "A successful response from the server for a {@link ListResourcesRequestresources/list} request.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "result": {
+          "$ref": "#/$defs/ListResourcesResult"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "result"
+      ],
+      "type": "object"
+    },
+    "ListRootsRequest": {
+      "description": "Sent from the server to request a list of root URIs from the client. Roots allow\nservers to ask for specific directories or files to operate on. A common example\nfor roots is providing a set of repositories or directories a server should operate\non.\n\nThis request is typically used when the server needs to understand the file system\nstructure or access specific locations that the client has permission to read from.",
+      "properties": {
+        "method": {
+          "const": "roots/list",
+          "type": "string"
+        },
+        "params": {
+          "properties": {
+            "_meta": {
+              "$ref": "#/$defs/MetaObject"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "required": [
+        "method"
+      ],
+      "type": "object"
+    },
+    "ListRootsResult": {
+      "description": "The result returned by the client for a {@link ListRootsRequestroots/list} request.\nThis result contains an array of {@link Root} objects, each representing a root directory\nor file that the server can operate on.",
+      "properties": {
+        "roots": {
+          "items": {
+            "$ref": "#/$defs/Root"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "roots"
+      ],
+      "type": "object"
+    },
+    "ListToolsRequest": {
+      "description": "Sent from the client to request a list of tools the server has.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "tools/list",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/PaginatedRequestParams"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "ListToolsResult": {
+      "description": "The result returned by the server for a {@link ListToolsRequesttools/list} request.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/ResultMetaObject"
+        },
+        "cacheScope": {
+          "description": "Indicates the intended scope of the cached response, analogous to HTTP\n`Cache-Control: public` vs `Cache-Control: private`.\n\n- `\"public\"`: The response does not contain user-specific data. Any\n  client or intermediary (e.g., shared gateway, caching proxy) MAY cache\n  the response and serve it across authorization contexts.\n- `\"private\"`: The response MAY be cached and reused only within the\n  same authorization context. Caches MUST NOT be shared across\n  authorization contexts (e.g., a different access token requires a\n  different cache).",
+          "enum": [
+            "private",
+            "public"
+          ],
+          "type": "string"
+        },
+        "nextCursor": {
+          "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
+          "type": "string"
+        },
+        "resultType": {
+          "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
+          "type": "string"
+        },
+        "tools": {
+          "items": {
+            "$ref": "#/$defs/Tool"
+          },
+          "type": "array"
+        },
+        "ttlMs": {
+          "description": "A hint from the server indicating how long (in milliseconds) the\nclient MAY cache this response before re-fetching. Semantics are\nanalogous to HTTP Cache-Control max-age.\n\n- If 0, The response SHOULD be considered immediately stale,\n  The client MAY re-fetch every time the result is needed.\n- If positive, the client SHOULD consider the result fresh for this many\n  milliseconds after receiving the response.",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "cacheScope",
+        "resultType",
+        "tools",
+        "ttlMs"
+      ],
+      "type": "object"
+    },
+    "ListToolsResultResponse": {
+      "description": "A successful response from the server for a {@link ListToolsRequesttools/list} request.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "result": {
+          "$ref": "#/$defs/ListToolsResult"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "result"
+      ],
+      "type": "object"
+    },
+    "LoggingLevel": {
+      "description": "The severity of a log message.\n\nThese map to syslog message severities, as specified in RFC-5424:\nhttps://datatracker.ietf.org/doc/html/rfc5424#section-6.2.1",
+      "enum": [
+        "alert",
+        "critical",
+        "debug",
+        "emergency",
+        "error",
+        "info",
+        "notice",
+        "warning"
+      ],
+      "type": "string"
+    },
+    "LoggingMessageNotification": {
+      "description": "JSONRPCNotification of a log message passed from server to client. The client opts in by setting `\"io.modelcontextprotocol/logLevel\"` in a request's `_meta`.",
+      "properties": {
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "notifications/message",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/LoggingMessageNotificationParams"
+        }
+      },
+      "required": [
+        "jsonrpc",
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "LoggingMessageNotificationParams": {
+      "description": "Parameters for a `notifications/message` notification.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/NotificationMetaObject"
+        },
+        "data": {
+          "description": "The data to be logged, such as a string message or an object. Any JSON serializable type is allowed here."
+        },
+        "level": {
+          "$ref": "#/$defs/LoggingLevel",
+          "description": "The severity of this log message."
+        },
+        "logger": {
+          "description": "An optional name of the logger issuing this message.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "data",
+        "level"
+      ],
+      "type": "object"
+    },
+    "MetaObject": {
+      "description": "Represents the contents of a `_meta` field, which clients and servers use to attach additional metadata to their interactions.\n\nCertain key names are reserved by MCP for protocol-level metadata; implementations MUST NOT make assumptions about values at these keys. Additionally, specific schema definitions may reserve particular names for purpose-specific metadata, as declared in those definitions.\n\nValid keys have two segments:\n\n**Prefix:**\n- Optional — if specified, MUST be a series of _labels_ separated by dots (`.`), followed by a slash (`/`).\n- Labels MUST start with a letter and end with a letter or digit. Interior characters may be letters, digits, or hyphens (`-`).\n- Implementations SHOULD use reverse DNS notation (e.g., `com.example/` rather than `example.com/`).\n- Any prefix where the second label is `modelcontextprotocol` or `mcp` is **reserved** for MCP use. For example: `io.modelcontextprotocol/`, `dev.mcp/`, `org.modelcontextprotocol.api/`, and `com.mcp.tools/` are all reserved. However, `com.example.mcp/` is NOT reserved, as the second label is `example`.\n\n**Name:**\n- Unless empty, MUST start and end with an alphanumeric character (`[a-z0-9A-Z]`).\n- Interior characters may be alphanumeric, hyphens (`-`), underscores (`_`), or dots (`.`).",
+      "type": "object"
+    },
+    "MethodNotFoundError": {
+      "description": "A JSON-RPC error indicating that the requested method does not exist or is not available.\n\nIn MCP, a server returns this error when a client invokes a method the server does not implement — either a genuinely unknown method, or one gated behind a server capability the server did not advertise (e.g., calling `prompts/list` when the `prompts` capability was not advertised).\n\nA request that requires a client capability the client did not declare is signalled instead by {@link MissingRequiredClientCapabilityError} (`-32021`).",
+      "properties": {
+        "code": {
+          "const": -32601,
+          "description": "The error type that occurred.",
+          "type": "integer"
+        },
+        "data": {
+          "description": "Additional information about the error. The value of this member is defined by the sender (e.g. detailed error information, nested errors etc.)."
+        },
+        "message": {
+          "description": "A short description of the error. The message SHOULD be limited to a concise single sentence.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "code",
+        "message"
+      ],
+      "type": "object"
+    },
+    "MissingRequiredClientCapabilityError": {
+      "description": "Returned when processing a request requires a capability the client did not\ndeclare in `clientCapabilities`. For HTTP, the response status code MUST be\n`400 Bad Request`.",
+      "properties": {
+        "error": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Error"
+            },
+            {
+              "properties": {
+                "code": {
+                  "const": -32021,
+                  "type": "integer"
+                },
+                "data": {
+                  "properties": {
+                    "requiredCapabilities": {
+                      "$ref": "#/$defs/ClientCapabilities",
+                      "description": "The capabilities the server requires from the client to process this request."
+                    }
+                  },
+                  "required": [
+                    "requiredCapabilities"
+                  ],
+                  "type": "object"
+                }
+              },
+              "required": [
+                "code",
+                "data"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        }
+      },
+      "required": [
+        "error",
+        "jsonrpc"
+      ],
+      "type": "object"
+    },
+    "ModelHint": {
+      "description": "Hints to use for model selection.\n\nKeys not declared here are currently left unspecified by the spec and are up\nto the client to interpret.",
+      "properties": {
+        "name": {
+          "description": "A hint for a model name.\n\nThe client SHOULD treat this as a substring of a model name; for example:\n - `claude-3-5-sonnet` should match `claude-3-5-sonnet-20241022`\n - `sonnet` should match `claude-3-5-sonnet-20241022`, `claude-3-sonnet-20240229`, etc.\n - `claude` should match any Claude model\n\nThe client MAY also map the string to a different provider's model name or a different model family, as long as it fills a similar niche; for example:\n - `gemini-1.5-flash` could match `claude-3-haiku-20240307`",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ModelPreferences": {
+      "description": "The server's preferences for model selection, requested of the client during sampling.\n\nBecause LLMs can vary along multiple dimensions, choosing the \"best\" model is\nrarely straightforward.  Different models excel in different areas—some are\nfaster but less capable, others are more capable but more expensive, and so\non. This interface allows servers to express their priorities across multiple\ndimensions to help clients make an appropriate selection for their use case.\n\nThese preferences are always advisory. The client MAY ignore them. It is also\nup to the client to decide how to interpret these preferences and how to\nbalance them against other considerations.",
+      "properties": {
+        "costPriority": {
+          "description": "How much to prioritize cost when selecting a model. A value of 0 means cost\nis not important, while a value of 1 means cost is the most important\nfactor.",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        },
+        "hints": {
+          "description": "Optional hints to use for model selection.\n\nIf multiple hints are specified, the client MUST evaluate them in order\n(such that the first match is taken).\n\nThe client SHOULD prioritize these hints over the numeric priorities, but\nMAY still use the priorities to select from ambiguous matches.",
+          "items": {
+            "$ref": "#/$defs/ModelHint"
+          },
+          "type": "array"
+        },
+        "intelligencePriority": {
+          "description": "How much to prioritize intelligence and capabilities when selecting a\nmodel. A value of 0 means intelligence is not important, while a value of 1\nmeans intelligence is the most important factor.",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        },
+        "speedPriority": {
+          "description": "How much to prioritize sampling speed (latency) when selecting a model. A\nvalue of 0 means speed is not important, while a value of 1 means speed is\nthe most important factor.",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        }
+      },
+      "type": "object"
+    },
+    "MultiSelectEnumSchema": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/UntitledMultiSelectEnumSchema"
+        },
+        {
+          "$ref": "#/$defs/TitledMultiSelectEnumSchema"
+        }
+      ]
+    },
+    "Notification": {
+      "properties": {
+        "method": {
+          "type": "string"
+        },
+        "params": {
+          "additionalProperties": {},
+          "type": "object"
+        }
+      },
+      "required": [
+        "method"
+      ],
+      "type": "object"
+    },
+    "NotificationMetaObject": {
+      "description": "Extends {@link MetaObject} with additional notification-specific fields. All key naming rules from `MetaObject` apply.",
+      "properties": {
+        "io.modelcontextprotocol/subscriptionId": {
+          "$ref": "#/$defs/RequestId",
+          "description": "Identifies the subscription stream a notification was delivered on. The\nserver MUST include this key on every notification delivered via a\n{@link SubscriptionsListenRequestsubscriptions/listen} stream, so the\nclient can correlate the notification with the originating subscription.\nThe key is absent on notifications not delivered via a subscription\nstream (e.g. progress notifications for an in-flight request), which is\nwhy it is optional here.\n\nThe value is the JSON-RPC ID of the `subscriptions/listen` request that\nopened the stream."
+        }
+      },
+      "type": "object"
+    },
+    "NotificationParams": {
+      "description": "Common params for any notification.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/NotificationMetaObject"
+        }
+      },
+      "type": "object"
+    },
+    "NumberSchema": {
+      "properties": {
+        "default": {
+          "type": "number"
+        },
+        "description": {
+          "type": "string"
+        },
+        "maximum": {
+          "type": "number"
+        },
+        "minimum": {
+          "type": "number"
+        },
+        "title": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "integer",
+            "number"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "PaginatedRequest": {
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/PaginatedRequestParams"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "PaginatedRequestParams": {
+      "description": "Common params for paginated requests.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/RequestMetaObject"
+        },
+        "cursor": {
+          "description": "An opaque token representing the current pagination position.\nIf provided, the server should return results starting after this cursor.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "_meta"
+      ],
+      "type": "object"
+    },
+    "PaginatedResult": {
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/ResultMetaObject"
+        },
+        "nextCursor": {
+          "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
+          "type": "string"
+        },
+        "resultType": {
+          "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "resultType"
+      ],
+      "type": "object"
+    },
+    "ParseError": {
+      "description": "A JSON-RPC error indicating that invalid JSON was received by the server. This error is returned when the server cannot parse the JSON text of a message.",
+      "properties": {
+        "code": {
+          "const": -32700,
+          "description": "The error type that occurred.",
+          "type": "integer"
+        },
+        "data": {
+          "description": "Additional information about the error. The value of this member is defined by the sender (e.g. detailed error information, nested errors etc.)."
+        },
+        "message": {
+          "description": "A short description of the error. The message SHOULD be limited to a concise single sentence.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "code",
+        "message"
+      ],
+      "type": "object"
+    },
+    "PrimitiveSchemaDefinition": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/StringSchema"
+        },
+        {
+          "$ref": "#/$defs/NumberSchema"
+        },
+        {
+          "$ref": "#/$defs/BooleanSchema"
+        },
+        {
+          "$ref": "#/$defs/UntitledSingleSelectEnumSchema"
+        },
+        {
+          "$ref": "#/$defs/TitledSingleSelectEnumSchema"
+        },
+        {
+          "$ref": "#/$defs/UntitledMultiSelectEnumSchema"
+        },
+        {
+          "$ref": "#/$defs/TitledMultiSelectEnumSchema"
+        },
+        {
+          "$ref": "#/$defs/LegacyTitledEnumSchema"
+        }
+      ],
+      "description": "Restricted schema definitions that only allow primitive types\nwithout nested objects or arrays."
+    },
+    "ProgressNotification": {
+      "description": "An out-of-band notification used to inform the receiver of a progress update for a long-running request.",
+      "properties": {
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "notifications/progress",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/ProgressNotificationParams"
+        }
+      },
+      "required": [
+        "jsonrpc",
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "ProgressNotificationParams": {
+      "description": "Parameters for a {@link ProgressNotificationnotifications/progress} notification.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/NotificationMetaObject"
+        },
+        "message": {
+          "description": "An optional message describing the current progress.",
+          "type": "string"
+        },
+        "progress": {
+          "description": "The progress thus far. This should increase every time progress is made, even if the total is unknown.",
+          "type": "number"
+        },
+        "progressToken": {
+          "$ref": "#/$defs/ProgressToken",
+          "description": "The progress token which was given in the initial request, used to associate this notification with the request that is proceeding."
+        },
+        "total": {
+          "description": "Total number of items to process (or total progress required), if known.",
+          "type": "number"
+        }
+      },
+      "required": [
+        "progress",
+        "progressToken"
+      ],
+      "type": "object"
+    },
+    "ProgressToken": {
+      "description": "A progress token, used to associate progress notifications with the original request.",
+      "type": [
+        "string",
+        "integer"
+      ]
+    },
+    "Prompt": {
+      "description": "A prompt or prompt template that the server offers.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "arguments": {
+          "description": "A list of arguments to use for templating the prompt.",
+          "items": {
+            "$ref": "#/$defs/PromptArgument"
+          },
+          "type": "array"
+        },
+        "description": {
+          "description": "An optional description of what this prompt provides",
+          "type": "string"
+        },
+        "icons": {
+          "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
+          "items": {
+            "$ref": "#/$defs/Icon"
+          },
+          "type": "array"
+        },
+        "name": {
+          "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+          "type": "string"
+        },
+        "title": {
+          "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for {@link Tool},\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "PromptArgument": {
+      "description": "Describes an argument that a prompt can accept.",
+      "properties": {
+        "description": {
+          "description": "A human-readable description of the argument.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+          "type": "string"
+        },
+        "required": {
+          "description": "Whether this argument must be provided.",
+          "type": "boolean"
+        },
+        "title": {
+          "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for {@link Tool},\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "PromptListChangedNotification": {
+      "description": "An optional notification from the server to the client, informing it that the list of prompts it offers has changed. This is only delivered on a {@link SubscriptionsListenRequestsubscriptions/listen} stream when the client requested it via the `promptsListChanged` filter field.",
+      "properties": {
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "notifications/prompts/list_changed",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/NotificationParams"
+        }
+      },
+      "required": [
+        "jsonrpc",
+        "method"
+      ],
+      "type": "object"
+    },
+    "PromptMessage": {
+      "description": "Describes a message returned as part of a prompt.\n\nThis is similar to {@link SamplingMessage}, but also supports the embedding of\nresources from the MCP server.",
+      "properties": {
+        "content": {
+          "$ref": "#/$defs/ContentBlock"
+        },
+        "role": {
+          "$ref": "#/$defs/Role"
+        }
+      },
+      "required": [
+        "content",
+        "role"
+      ],
+      "type": "object"
+    },
+    "PromptReference": {
+      "description": "Identifies a prompt.",
+      "properties": {
+        "name": {
+          "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+          "type": "string"
+        },
+        "title": {
+          "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for {@link Tool},\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+          "type": "string"
+        },
+        "type": {
+          "const": "ref/prompt",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "type"
+      ],
+      "type": "object"
+    },
+    "ReadResourceRequest": {
+      "description": "Sent from the client to the server, to read a specific resource URI.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "resources/read",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/ReadResourceRequestParams"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "ReadResourceRequestParams": {
+      "description": "Parameters for a `resources/read` request.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/RequestMetaObject"
+        },
+        "inputResponses": {
+          "$ref": "#/$defs/InputResponses"
+        },
+        "requestState": {
+          "type": "string"
+        },
+        "uri": {
+          "description": "The URI of the resource. The URI can use any protocol; it is up to the server how to interpret it.",
+          "format": "uri",
+          "type": "string"
+        }
+      },
+      "required": [
+        "_meta",
+        "uri"
+      ],
+      "type": "object"
+    },
+    "ReadResourceResult": {
+      "description": "The result returned by the server for a {@link ReadResourceRequestresources/read} request.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/ResultMetaObject"
+        },
+        "cacheScope": {
+          "description": "Indicates the intended scope of the cached response, analogous to HTTP\n`Cache-Control: public` vs `Cache-Control: private`.\n\n- `\"public\"`: The response does not contain user-specific data. Any\n  client or intermediary (e.g., shared gateway, caching proxy) MAY cache\n  the response and serve it across authorization contexts.\n- `\"private\"`: The response MAY be cached and reused only within the\n  same authorization context. Caches MUST NOT be shared across\n  authorization contexts (e.g., a different access token requires a\n  different cache).",
+          "enum": [
+            "private",
+            "public"
+          ],
+          "type": "string"
+        },
+        "contents": {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/TextResourceContents"
+              },
+              {
+                "$ref": "#/$defs/BlobResourceContents"
+              }
+            ]
+          },
+          "type": "array"
+        },
+        "resultType": {
+          "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
+          "type": "string"
+        },
+        "ttlMs": {
+          "description": "A hint from the server indicating how long (in milliseconds) the\nclient MAY cache this response before re-fetching. Semantics are\nanalogous to HTTP Cache-Control max-age.\n\n- If 0, The response SHOULD be considered immediately stale,\n  The client MAY re-fetch every time the result is needed.\n- If positive, the client SHOULD consider the result fresh for this many\n  milliseconds after receiving the response.",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "cacheScope",
+        "contents",
+        "resultType",
+        "ttlMs"
+      ],
+      "type": "object"
+    },
+    "ReadResourceResultResponse": {
+      "description": "A successful response from the server for a {@link ReadResourceRequestresources/read} request.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "result": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/InputRequiredResult"
+            },
+            {
+              "$ref": "#/$defs/ReadResourceResult"
+            }
+          ]
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "result"
+      ],
+      "type": "object"
+    },
+    "Request": {
+      "properties": {
+        "method": {
+          "type": "string"
+        },
+        "params": {
+          "additionalProperties": {},
+          "type": "object"
+        }
+      },
+      "required": [
+        "method"
+      ],
+      "type": "object"
+    },
+    "RequestId": {
+      "description": "A uniquely identifying ID for a request in JSON-RPC.",
+      "type": [
+        "string",
+        "integer"
+      ]
+    },
+    "RequestMetaObject": {
+      "description": "Extends {@link MetaObject} with additional request-specific fields. All key naming rules from `MetaObject` apply.",
+      "properties": {
+        "io.modelcontextprotocol/clientCapabilities": {
+          "$ref": "#/$defs/ClientCapabilities",
+          "description": "The client's capabilities for this specific request. Required.\n\nCapabilities are declared per-request rather than once at initialization;\nan empty object means the client supports no optional capabilities.\nServers MUST NOT infer capabilities from prior requests."
+        },
+        "io.modelcontextprotocol/clientInfo": {
+          "$ref": "#/$defs/Implementation",
+          "description": "Identifies the client software making the request. Clients SHOULD\ninclude this field on every request unless specifically configured not\nto do so.\n\nThe {@link Implementation} schema requires `name` and `version`; other\nfields are optional.\n\nThe value is self-reported by the client and is not verified by the\nprotocol. It is intended for display, logging, and debugging. Servers\nSHOULD NOT use it to change their behavior, and SHOULD NOT rely on it for\nsecurity decisions."
+        },
+        "io.modelcontextprotocol/logLevel": {
+          "$ref": "#/$defs/LoggingLevel",
+          "description": "The desired log level for this request. Optional.\n\nIf absent, the server MUST NOT send any {@link LoggingMessageNotificationnotifications/message}\nnotifications for this request. The client opts in to log messages by\nexplicitly setting a level. Replaces the former `logging/setLevel` RPC."
+        },
+        "io.modelcontextprotocol/protocolVersion": {
+          "description": "The MCP Protocol Version being used for this request. Required.\n\nFor the HTTP transport, this value MUST match the `MCP-Protocol-Version`\nheader; otherwise the server MUST return a `400 Bad Request`. If the\nserver does not support the requested version, it MUST return an\n{@link UnsupportedProtocolVersionError}.",
+          "type": "string"
+        },
+        "progressToken": {
+          "$ref": "#/$defs/ProgressToken",
+          "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by {@link ProgressNotificationnotifications/progress}). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
+        }
+      },
+      "required": [
+        "io.modelcontextprotocol/clientCapabilities",
+        "io.modelcontextprotocol/protocolVersion"
+      ],
+      "type": "object"
+    },
+    "RequestParams": {
+      "description": "Common params for any request.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/RequestMetaObject"
+        }
+      },
+      "required": [
+        "_meta"
+      ],
+      "type": "object"
+    },
+    "Resource": {
+      "description": "A known resource that the server is capable of reading.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "annotations": {
+          "$ref": "#/$defs/Annotations",
+          "description": "Optional annotations for the client."
+        },
+        "description": {
+          "description": "A description of what this resource represents.\n\nThis can be used by clients to improve the LLM's understanding of available resources. It can be thought of like a \"hint\" to the model.",
+          "type": "string"
+        },
+        "icons": {
+          "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
+          "items": {
+            "$ref": "#/$defs/Icon"
+          },
+          "type": "array"
+        },
+        "mimeType": {
+          "description": "The MIME type of this resource, if known.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+          "type": "string"
+        },
+        "size": {
+          "description": "The size of the raw resource content, in bytes (i.e., before base64 encoding or any tokenization), if known.\n\nThis can be used by Hosts to display file sizes and estimate context window usage.",
+          "type": "integer"
+        },
+        "title": {
+          "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for {@link Tool},\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+          "type": "string"
+        },
+        "uri": {
+          "description": "The URI of this resource.",
+          "format": "uri",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "uri"
+      ],
+      "type": "object"
+    },
+    "ResourceContents": {
+      "description": "The contents of a specific resource or sub-resource.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "mimeType": {
+          "description": "The MIME type of this resource, if known.",
+          "type": "string"
+        },
+        "uri": {
+          "description": "The URI of this resource.",
+          "format": "uri",
+          "type": "string"
+        }
+      },
+      "required": [
+        "uri"
+      ],
+      "type": "object"
+    },
+    "ResourceLink": {
+      "description": "A resource that the server is capable of reading, included in a prompt or tool call result.\n\nNote: resource links returned by tools are not guaranteed to appear in the results of {@link ListResourcesRequestresources/list} requests.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "annotations": {
+          "$ref": "#/$defs/Annotations",
+          "description": "Optional annotations for the client."
+        },
+        "description": {
+          "description": "A description of what this resource represents.\n\nThis can be used by clients to improve the LLM's understanding of available resources. It can be thought of like a \"hint\" to the model.",
+          "type": "string"
+        },
+        "icons": {
+          "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
+          "items": {
+            "$ref": "#/$defs/Icon"
+          },
+          "type": "array"
+        },
+        "mimeType": {
+          "description": "The MIME type of this resource, if known.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+          "type": "string"
+        },
+        "size": {
+          "description": "The size of the raw resource content, in bytes (i.e., before base64 encoding or any tokenization), if known.\n\nThis can be used by Hosts to display file sizes and estimate context window usage.",
+          "type": "integer"
+        },
+        "title": {
+          "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for {@link Tool},\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+          "type": "string"
+        },
+        "type": {
+          "const": "resource_link",
+          "type": "string"
+        },
+        "uri": {
+          "description": "The URI of this resource.",
+          "format": "uri",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "type",
+        "uri"
+      ],
+      "type": "object"
+    },
+    "ResourceListChangedNotification": {
+      "description": "An optional notification from the server to the client, informing it that the list of resources it can read from has changed. This is only delivered on a {@link SubscriptionsListenRequestsubscriptions/listen} stream when the client requested it via the `resourcesListChanged` filter field.",
+      "properties": {
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "notifications/resources/list_changed",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/NotificationParams"
+        }
+      },
+      "required": [
+        "jsonrpc",
+        "method"
+      ],
+      "type": "object"
+    },
+    "ResourceRequestParams": {
+      "description": "Common params for resource-related requests.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/RequestMetaObject"
+        },
+        "uri": {
+          "description": "The URI of the resource. The URI can use any protocol; it is up to the server how to interpret it.",
+          "format": "uri",
+          "type": "string"
+        }
+      },
+      "required": [
+        "_meta",
+        "uri"
+      ],
+      "type": "object"
+    },
+    "ResourceTemplate": {
+      "description": "A template description for resources available on the server.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "annotations": {
+          "$ref": "#/$defs/Annotations",
+          "description": "Optional annotations for the client."
+        },
+        "description": {
+          "description": "A description of what this template is for.\n\nThis can be used by clients to improve the LLM's understanding of available resources. It can be thought of like a \"hint\" to the model.",
+          "type": "string"
+        },
+        "icons": {
+          "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
+          "items": {
+            "$ref": "#/$defs/Icon"
+          },
+          "type": "array"
+        },
+        "mimeType": {
+          "description": "The MIME type for all resources that match this template. This should only be included if all resources matching this template have the same type.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+          "type": "string"
+        },
+        "title": {
+          "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for {@link Tool},\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+          "type": "string"
+        },
+        "uriTemplate": {
+          "description": "A URI template (according to RFC 6570) that can be used to construct resource URIs.",
+          "format": "uri-template",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "uriTemplate"
+      ],
+      "type": "object"
+    },
+    "ResourceTemplateReference": {
+      "description": "A reference to a resource or resource template definition.",
+      "properties": {
+        "type": {
+          "const": "ref/resource",
+          "type": "string"
+        },
+        "uri": {
+          "description": "The URI or URI template of the resource.",
+          "format": "uri-template",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "uri"
+      ],
+      "type": "object"
+    },
+    "ResourceUpdatedNotification": {
+      "description": "A notification from the server to the client, informing it that a resource has changed and may need to be read again. This is only sent for resources the client opted in to via the `resourceSubscriptions` field of a {@link SubscriptionsListenRequestsubscriptions/listen} request.",
+      "properties": {
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "notifications/resources/updated",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/ResourceUpdatedNotificationParams"
+        }
+      },
+      "required": [
+        "jsonrpc",
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "ResourceUpdatedNotificationParams": {
+      "description": "Parameters for a `notifications/resources/updated` notification.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/NotificationMetaObject"
+        },
+        "uri": {
+          "description": "The URI of the resource that has been updated. This might be a sub-resource of the one that the client actually subscribed to.",
+          "format": "uri",
+          "type": "string"
+        }
+      },
+      "required": [
+        "uri"
+      ],
+      "type": "object"
+    },
+    "Result": {
+      "additionalProperties": {},
+      "description": "Common result fields.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/ResultMetaObject"
+        },
+        "resultType": {
+          "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "resultType"
+      ],
+      "type": "object"
+    },
+    "ResultMetaObject": {
+      "description": "Extends {@link MetaObject} with additional result-specific fields. All key naming rules from `MetaObject` apply.",
+      "properties": {
+        "io.modelcontextprotocol/serverInfo": {
+          "$ref": "#/$defs/Implementation",
+          "description": "Identifies the server software producing the response. Servers SHOULD\ninclude this field on every response unless specifically configured not\nto do so.\n\nThe {@link Implementation} schema requires `name` and `version`; other\nfields are optional.\n\nThe value is self-reported by the server and is not verified by the\nprotocol. It is intended for display, logging, and debugging. Clients\nSHOULD NOT use it to change their behavior, and SHOULD NOT rely on it for\nsecurity decisions."
+        }
+      },
+      "type": "object"
+    },
+    "ResultType": {
+      "description": "Indicates the type of a {@link Result} object, allowing the client to\ndetermine how to parse the response.\n\ncomplete - the request completed successfully and the result contains the final content.\ninput_required - the request requires additional input and the result contains an {@link InputRequiredResult} object with instructions for the client to provide additional input before retrying the original request.",
+      "type": "string"
+    },
+    "Role": {
+      "description": "The sender or recipient of messages and data in a conversation.",
+      "enum": [
+        "assistant",
+        "user"
+      ],
+      "type": "string"
+    },
+    "Root": {
+      "description": "Represents a root directory or file that the server can operate on.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "name": {
+          "description": "An optional name for the root. This can be used to provide a human-readable\nidentifier for the root, which may be useful for display purposes or for\nreferencing the root in other parts of the application.",
+          "type": "string"
+        },
+        "uri": {
+          "description": "The URI identifying the root. This *must* start with `file://` for now.\nThis restriction may be relaxed in future versions of the protocol to allow\nother URI schemes.",
+          "format": "uri",
+          "type": "string"
+        }
+      },
+      "required": [
+        "uri"
+      ],
+      "type": "object"
+    },
+    "SamplingMessage": {
+      "description": "Describes a message issued to or received from an LLM API.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "content": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TextContent"
+            },
+            {
+              "$ref": "#/$defs/ImageContent"
+            },
+            {
+              "$ref": "#/$defs/AudioContent"
+            },
+            {
+              "$ref": "#/$defs/ToolUseContent"
+            },
+            {
+              "$ref": "#/$defs/ToolResultContent"
+            },
+            {
+              "items": {
+                "$ref": "#/$defs/SamplingMessageContentBlock"
+              },
+              "type": "array"
+            }
+          ]
+        },
+        "role": {
+          "$ref": "#/$defs/Role"
+        }
+      },
+      "required": [
+        "content",
+        "role"
+      ],
+      "type": "object"
+    },
+    "SamplingMessageContentBlock": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/TextContent"
+        },
+        {
+          "$ref": "#/$defs/ImageContent"
+        },
+        {
+          "$ref": "#/$defs/AudioContent"
+        },
+        {
+          "$ref": "#/$defs/ToolUseContent"
+        },
+        {
+          "$ref": "#/$defs/ToolResultContent"
+        }
+      ]
+    },
+    "ServerCapabilities": {
+      "description": "Capabilities that a server may support. Known capabilities are defined here, in this schema, but this is not a closed set: any server can define its own, additional capabilities.",
+      "properties": {
+        "completions": {
+          "$ref": "#/$defs/JSONObject",
+          "description": "Present if the server supports argument autocompletion suggestions."
+        },
+        "experimental": {
+          "additionalProperties": {
+            "$ref": "#/$defs/JSONObject"
+          },
+          "description": "Experimental, non-standard capabilities that the server supports.",
+          "type": "object"
+        },
+        "extensions": {
+          "additionalProperties": {
+            "$ref": "#/$defs/JSONObject"
+          },
+          "description": "Optional MCP extensions that the server supports. Keys are extension identifiers\n(e.g., \"io.modelcontextprotocol/tasks\"), and values are per-extension settings\nobjects. An empty object indicates support with no settings.\n\nKeys MUST follow the {@link MetaObject`_meta` key naming rules}, with a\nmandatory prefix.",
+          "type": "object"
+        },
+        "logging": {
+          "$ref": "#/$defs/JSONObject",
+          "description": "Present if the server supports sending log messages to the client."
+        },
+        "prompts": {
+          "description": "Present if the server offers any prompt templates.",
+          "properties": {
+            "listChanged": {
+              "description": "Whether this server supports notifications for changes to the prompt list.",
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        },
+        "resources": {
+          "description": "Present if the server offers any resources to read.",
+          "properties": {
+            "listChanged": {
+              "description": "Whether this server supports notifications for changes to the resource list.",
+              "type": "boolean"
+            },
+            "subscribe": {
+              "description": "Whether this server supports subscribing to resource updates.",
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        },
+        "tools": {
+          "description": "Present if the server offers any tools to call.",
+          "properties": {
+            "listChanged": {
+              "description": "Whether this server supports notifications for changes to the tool list.",
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "ServerNotification": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/CancelledNotification"
+        },
+        {
+          "$ref": "#/$defs/ProgressNotification"
+        },
+        {
+          "$ref": "#/$defs/ResourceListChangedNotification"
+        },
+        {
+          "$ref": "#/$defs/SubscriptionsAcknowledgedNotification"
+        },
+        {
+          "$ref": "#/$defs/ResourceUpdatedNotification"
+        },
+        {
+          "$ref": "#/$defs/PromptListChangedNotification"
+        },
+        {
+          "$ref": "#/$defs/ToolListChangedNotification"
+        },
+        {
+          "$ref": "#/$defs/LoggingMessageNotification"
+        }
+      ]
+    },
+    "ServerResult": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/Result"
+        },
+        {
+          "$ref": "#/$defs/InputRequiredResult"
+        },
+        {
+          "$ref": "#/$defs/DiscoverResult"
+        },
+        {
+          "$ref": "#/$defs/ListResourcesResult"
+        },
+        {
+          "$ref": "#/$defs/ListResourceTemplatesResult"
+        },
+        {
+          "$ref": "#/$defs/ReadResourceResult"
+        },
+        {
+          "$ref": "#/$defs/SubscriptionsListenResult"
+        },
+        {
+          "$ref": "#/$defs/ListPromptsResult"
+        },
+        {
+          "$ref": "#/$defs/GetPromptResult"
+        },
+        {
+          "$ref": "#/$defs/ListToolsResult"
+        },
+        {
+          "$ref": "#/$defs/CallToolResult"
+        },
+        {
+          "$ref": "#/$defs/CompleteResult"
+        }
+      ]
+    },
+    "SingleSelectEnumSchema": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/UntitledSingleSelectEnumSchema"
+        },
+        {
+          "$ref": "#/$defs/TitledSingleSelectEnumSchema"
+        }
+      ]
+    },
+    "StringSchema": {
+      "properties": {
+        "default": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "format": {
+          "enum": [
+            "date",
+            "date-time",
+            "email",
+            "uri"
+          ],
+          "type": "string"
+        },
+        "maxLength": {
+          "type": "integer"
+        },
+        "minLength": {
+          "type": "integer"
+        },
+        "title": {
+          "type": "string"
+        },
+        "type": {
+          "const": "string",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "SubscriptionFilter": {
+      "description": "The set of notification types a client may opt in to on a\n{@link SubscriptionsListenRequestsubscriptions/listen} request.\n\nEach notification type is **opt-in**; the server **MUST NOT** send\nnotification types the client has not explicitly requested here.",
+      "properties": {
+        "promptsListChanged": {
+          "description": "If true, receive {@link PromptListChangedNotificationnotifications/prompts/list_changed}.",
+          "type": "boolean"
+        },
+        "resourceSubscriptions": {
+          "description": "Subscribe to {@link ResourceUpdatedNotificationnotifications/resources/updated} for these resource URIs.\nReplaces the former `resources/subscribe` RPC.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "resourcesListChanged": {
+          "description": "If true, receive {@link ResourceListChangedNotificationnotifications/resources/list_changed}.",
+          "type": "boolean"
+        },
+        "toolsListChanged": {
+          "description": "If true, receive {@link ToolListChangedNotificationnotifications/tools/list_changed}.",
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "SubscriptionsAcknowledgedNotification": {
+      "description": "Sent by the server to acknowledge that a\n{@link SubscriptionsListenRequestsubscriptions/listen} subscription has been\nestablished and to report which notification types it agreed to honor.\n\nThis notification MUST be the first message the server sends carrying the\nsubscription's ID in `io.modelcontextprotocol/subscriptionId`. The server MUST\nNOT send any notification on the subscription before acknowledging it. On\nstdio, where every subscription shares one channel, this ordering is defined\nper subscription ID and not per channel: messages belonging to other\nsubscriptions MAY be interleaved before it.",
+      "properties": {
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "notifications/subscriptions/acknowledged",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/SubscriptionsAcknowledgedNotificationParams"
+        }
+      },
+      "required": [
+        "jsonrpc",
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "SubscriptionsAcknowledgedNotificationParams": {
+      "description": "Parameters for a {@link SubscriptionsAcknowledgedNotificationnotifications/subscriptions/acknowledged} notification.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/NotificationMetaObject"
+        },
+        "notifications": {
+          "$ref": "#/$defs/SubscriptionFilter",
+          "description": "The subset of requested notification types the server agreed to honor.\nOnly includes notification types the server actually supports; if the\nclient requested an unsupported type (e.g., `promptsListChanged` when\nthe server has no prompts), it is omitted from this set."
+        }
+      },
+      "required": [
+        "notifications"
+      ],
+      "type": "object"
+    },
+    "SubscriptionsListenRequest": {
+      "description": "Sent from the client to open a long-lived channel for receiving notifications\noutside the context of a specific request. Replaces the previous HTTP GET\nendpoint and ensures consistent behavior between HTTP and STDIO.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "subscriptions/listen",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/SubscriptionsListenRequestParams"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "method",
+        "params"
+      ],
+      "type": "object"
+    },
+    "SubscriptionsListenRequestParams": {
+      "description": "Parameters for a {@link SubscriptionsListenRequestsubscriptions/listen} request.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/RequestMetaObject"
+        },
+        "notifications": {
+          "$ref": "#/$defs/SubscriptionFilter",
+          "description": "The notifications the client opts in to on this stream. The server\n**MUST NOT** send notification types the client has not explicitly\nrequested."
+        }
+      },
+      "required": [
+        "_meta",
+        "notifications"
+      ],
+      "type": "object"
+    },
+    "SubscriptionsListenResult": {
+      "description": "The response to a {@link SubscriptionsListenRequestsubscriptions/listen}\nrequest, signalling that the subscription has ended gracefully (for example,\nduring server shutdown). Because the listen stream is long-lived, this result\nis sent only when the server tears the subscription down; an abrupt transport\nclose carries no response. The result body is otherwise empty.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/SubscriptionsListenResultMetaObject"
+        },
+        "resultType": {
+          "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "_meta",
+        "resultType"
+      ],
+      "type": "object"
+    },
+    "SubscriptionsListenResultMetaObject": {
+      "description": "Extends {@link ResultMetaObject} with the subscription-stream identifier carried by a\n{@link SubscriptionsListenResult}. All key naming rules from `MetaObject` apply.",
+      "properties": {
+        "io.modelcontextprotocol/serverInfo": {
+          "$ref": "#/$defs/Implementation",
+          "description": "Identifies the server software producing the response. Servers SHOULD\ninclude this field on every response unless specifically configured not\nto do so.\n\nThe {@link Implementation} schema requires `name` and `version`; other\nfields are optional.\n\nThe value is self-reported by the server and is not verified by the\nprotocol. It is intended for display, logging, and debugging. Clients\nSHOULD NOT use it to change their behavior, and SHOULD NOT rely on it for\nsecurity decisions."
+        },
+        "io.modelcontextprotocol/subscriptionId": {
+          "$ref": "#/$defs/RequestId",
+          "description": "Identifies the subscription stream this response closes, so the client can\ncorrelate it with the originating subscription — mirroring the same key on\nthe stream's notifications. The value is the JSON-RPC ID of the\n`subscriptions/listen` request that opened the stream (and equals this\nresponse's `id`)."
+        }
+      },
+      "required": [
+        "io.modelcontextprotocol/subscriptionId"
+      ],
+      "type": "object"
+    },
+    "SubscriptionsListenResultResponse": {
+      "description": "A successful response from the server for a {@link SubscriptionsListenRequestsubscriptions/listen}\nrequest, sent when the server tears the subscription down gracefully.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "result": {
+          "$ref": "#/$defs/SubscriptionsListenResult"
+        }
+      },
+      "required": [
+        "id",
+        "jsonrpc",
+        "result"
+      ],
+      "type": "object"
+    },
+    "TextContent": {
+      "description": "Text provided to or from an LLM.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "annotations": {
+          "$ref": "#/$defs/Annotations",
+          "description": "Optional annotations for the client."
+        },
+        "text": {
+          "description": "The text content of the message.",
+          "type": "string"
+        },
+        "type": {
+          "const": "text",
+          "type": "string"
+        }
+      },
+      "required": [
+        "text",
+        "type"
+      ],
+      "type": "object"
+    },
+    "TextResourceContents": {
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "mimeType": {
+          "description": "The MIME type of this resource, if known.",
+          "type": "string"
+        },
+        "text": {
+          "description": "The text of the item. This must only be set if the item can actually be represented as text (not binary data).",
+          "type": "string"
+        },
+        "uri": {
+          "description": "The URI of this resource.",
+          "format": "uri",
+          "type": "string"
+        }
+      },
+      "required": [
+        "text",
+        "uri"
+      ],
+      "type": "object"
+    },
+    "TitledMultiSelectEnumSchema": {
+      "description": "Schema for multiple-selection enumeration with display titles for each option.",
+      "properties": {
+        "default": {
+          "description": "Optional default value.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "description": {
+          "description": "Optional description for the enum field.",
+          "type": "string"
+        },
+        "items": {
+          "description": "Schema for array items with enum options and display labels.",
+          "properties": {
+            "anyOf": {
+              "description": "Array of enum options with values and display labels.",
+              "items": {
+                "properties": {
+                  "const": {
+                    "description": "The constant enum value.",
+                    "type": "string"
+                  },
+                  "title": {
+                    "description": "Display title for this option.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "const",
+                  "title"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "anyOf"
+          ],
+          "type": "object"
+        },
+        "maxItems": {
+          "description": "Maximum number of items to select.",
+          "type": "integer"
+        },
+        "minItems": {
+          "description": "Minimum number of items to select.",
+          "type": "integer"
+        },
+        "title": {
+          "description": "Optional title for the enum field.",
+          "type": "string"
+        },
+        "type": {
+          "const": "array",
+          "type": "string"
+        }
+      },
+      "required": [
+        "items",
+        "type"
+      ],
+      "type": "object"
+    },
+    "TitledSingleSelectEnumSchema": {
+      "description": "Schema for single-selection enumeration with display titles for each option.",
+      "properties": {
+        "default": {
+          "description": "Optional default value.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Optional description for the enum field.",
+          "type": "string"
+        },
+        "oneOf": {
+          "description": "Array of enum options with values and display labels.",
+          "items": {
+            "properties": {
+              "const": {
+                "description": "The enum value.",
+                "type": "string"
+              },
+              "title": {
+                "description": "Display label for this option.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "const",
+              "title"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "title": {
+          "description": "Optional title for the enum field.",
+          "type": "string"
+        },
+        "type": {
+          "const": "string",
+          "type": "string"
+        }
+      },
+      "required": [
+        "oneOf",
+        "type"
+      ],
+      "type": "object"
+    },
+    "Tool": {
+      "description": "Definition for a tool the client can call.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "annotations": {
+          "$ref": "#/$defs/ToolAnnotations",
+          "description": "Optional additional tool information.\n\nDisplay name precedence order is: `title`, `annotations.title`, then `name`."
+        },
+        "description": {
+          "description": "A human-readable description of the tool.\n\nThis can be used by clients to improve the LLM's understanding of available tools. It can be thought of like a \"hint\" to the model.",
+          "type": "string"
+        },
+        "icons": {
+          "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
+          "items": {
+            "$ref": "#/$defs/Icon"
+          },
+          "type": "array"
+        },
+        "inputSchema": {
+          "additionalProperties": {},
+          "description": "A JSON Schema object defining the expected parameters for the tool.\n\nTool arguments are always JSON objects, so `type: \"object\"` is required at the root.\nBeyond that, any JSON Schema 2020-12 keyword may appear alongside `type` — including\ncomposition keywords (`oneOf`, `anyOf`, `allOf`, `not`), conditional keywords\n(`if`/`then`/`else`), reference keywords (`$ref`, `$defs`, `$anchor`), and any other\nstandard validation or annotation keywords.\n\nProperty schemas may carry an `x-mcp-header` annotation to mirror the\nargument value into an HTTP header on the Streamable HTTP transport. See\nthe Streamable HTTP transport specification for the validity and\nextraction rules.\n\nDefaults to JSON Schema 2020-12 when no explicit `$schema` is provided.",
+          "properties": {
+            "$schema": {
+              "type": "string"
+            },
+            "type": {
+              "const": "object",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "type": "object"
+        },
+        "name": {
+          "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+          "type": "string"
+        },
+        "outputSchema": {
+          "additionalProperties": {},
+          "description": "An optional JSON Schema object defining the structure of the tool's output returned in\nthe structuredContent field of a {@link CallToolResult}. This can be any valid JSON Schema 2020-12.\n\nDefaults to JSON Schema 2020-12 when no explicit `$schema` is provided.",
+          "properties": {
+            "$schema": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "title": {
+          "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for {@link Tool},\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+          "type": "string"
+        }
+      },
+      "required": [
+        "inputSchema",
+        "name"
+      ],
+      "type": "object"
+    },
+    "ToolAnnotations": {
+      "description": "Additional properties describing a {@link Tool} to clients.\n\nNOTE: all properties in `ToolAnnotations` are **hints**.\nThey are not guaranteed to provide a faithful description of\ntool behavior (including descriptive properties like `title`).\n\nClients should never make tool use decisions based on `ToolAnnotations`\nreceived from untrusted servers.",
+      "properties": {
+        "destructiveHint": {
+          "description": "If true, the tool may perform destructive updates to its environment.\nIf false, the tool performs only additive updates.\n\n(This property is meaningful only when `readOnlyHint == false`)\n\nDefault: true",
+          "type": "boolean"
+        },
+        "idempotentHint": {
+          "description": "If true, calling the tool repeatedly with the same arguments\nwill have no additional effect on its environment.\n\n(This property is meaningful only when `readOnlyHint == false`)\n\nDefault: false",
+          "type": "boolean"
+        },
+        "openWorldHint": {
+          "description": "If true, this tool may interact with an \"open world\" of external\nentities. If false, the tool's domain of interaction is closed.\nFor example, the world of a web search tool is open, whereas that\nof a memory tool is not.\n\nDefault: true",
+          "type": "boolean"
+        },
+        "readOnlyHint": {
+          "description": "If true, the tool does not modify its environment.\n\nDefault: false",
+          "type": "boolean"
+        },
+        "title": {
+          "description": "A human-readable title for the tool.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ToolChoice": {
+      "description": "Controls tool selection behavior for sampling requests.",
+      "properties": {
+        "mode": {
+          "description": "Controls the tool use ability of the model:\n- `\"auto\"`: Model decides whether to use tools (default)\n- `\"required\"`: Model MUST use at least one tool before completing\n- `\"none\"`: Model MUST NOT use any tools",
+          "enum": [
+            "auto",
+            "none",
+            "required"
+          ],
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ToolListChangedNotification": {
+      "description": "An optional notification from the server to the client, informing it that the list of tools it offers has changed. This is only delivered on a {@link SubscriptionsListenRequestsubscriptions/listen} stream when the client requested it via the `toolsListChanged` filter field.",
+      "properties": {
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "notifications/tools/list_changed",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/NotificationParams"
+        }
+      },
+      "required": [
+        "jsonrpc",
+        "method"
+      ],
+      "type": "object"
+    },
+    "ToolResultContent": {
+      "description": "The result of a tool use, provided by the user back to the assistant.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject",
+          "description": "Optional metadata about the tool result. Clients SHOULD preserve this field when\nincluding tool results in subsequent sampling requests to enable caching optimizations."
+        },
+        "content": {
+          "description": "The unstructured result content of the tool use.\n\nThis has the same format as {@link CallToolResult.content} and can include text, images,\naudio, resource links, and embedded resources.",
+          "items": {
+            "$ref": "#/$defs/ContentBlock"
+          },
+          "type": "array"
+        },
+        "isError": {
+          "description": "Whether the tool use resulted in an error.\n\nIf true, the content typically describes the error that occurred.\nDefault: false",
+          "type": "boolean"
+        },
+        "structuredContent": {
+          "description": "An optional structured result value.\n\nThis can be any JSON value (object, array, string, number, boolean, or null).\nIf the tool defined an {@link Tool.outputSchema}, this SHOULD conform to that schema."
+        },
+        "toolUseId": {
+          "description": "The ID of the tool use this result corresponds to.\n\nThis MUST match the ID from a previous {@link ToolUseContent}.",
+          "type": "string"
+        },
+        "type": {
+          "const": "tool_result",
+          "type": "string"
+        }
+      },
+      "required": [
+        "content",
+        "toolUseId",
+        "type"
+      ],
+      "type": "object"
+    },
+    "ToolUseContent": {
+      "description": "A request from the assistant to call a tool.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject",
+          "description": "Optional metadata about the tool use. Clients SHOULD preserve this field when\nincluding tool uses in subsequent sampling requests to enable caching optimizations."
+        },
+        "id": {
+          "description": "A unique identifier for this tool use.\n\nThis ID is used to match tool results to their corresponding tool uses.",
+          "type": "string"
+        },
+        "input": {
+          "additionalProperties": {},
+          "description": "The arguments to pass to the tool, conforming to the tool's input schema.",
+          "type": "object"
+        },
+        "name": {
+          "description": "The name of the tool to call.",
+          "type": "string"
+        },
+        "type": {
+          "const": "tool_use",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "input",
+        "name",
+        "type"
+      ],
+      "type": "object"
+    },
+    "UnsupportedProtocolVersionError": {
+      "description": "Returned when the request's protocol version is unknown to the server or\nunsupported (e.g., a known experimental or draft version the server has\nchosen not to implement). For HTTP, the response status code MUST be\n`400 Bad Request`.",
+      "properties": {
+        "error": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Error"
+            },
+            {
+              "properties": {
+                "code": {
+                  "const": -32022,
+                  "type": "integer"
+                },
+                "data": {
+                  "properties": {
+                    "requested": {
+                      "description": "The protocol version that was requested by the client.",
+                      "type": "string"
+                    },
+                    "supported": {
+                      "description": "Protocol versions the server supports. The client should choose a\nmutually supported version from this list and retry.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "requested",
+                    "supported"
+                  ],
+                  "type": "object"
+                }
+              },
+              "required": [
+                "code",
+                "data"
+              ],
+              "type": "object"
+            }
+          ]
+        },
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        }
+      },
+      "required": [
+        "error",
+        "jsonrpc"
+      ],
+      "type": "object"
+    },
+    "UntitledMultiSelectEnumSchema": {
+      "description": "Schema for multiple-selection enumeration without display titles for options.",
+      "properties": {
+        "default": {
+          "description": "Optional default value.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "description": {
+          "description": "Optional description for the enum field.",
+          "type": "string"
+        },
+        "items": {
+          "description": "Schema for the array items.",
+          "properties": {
+            "enum": {
+              "description": "Array of enum values to choose from.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "type": {
+              "const": "string",
+              "type": "string"
+            }
+          },
+          "required": [
+            "enum",
+            "type"
+          ],
+          "type": "object"
+        },
+        "maxItems": {
+          "description": "Maximum number of items to select.",
+          "type": "integer"
+        },
+        "minItems": {
+          "description": "Minimum number of items to select.",
+          "type": "integer"
+        },
+        "title": {
+          "description": "Optional title for the enum field.",
+          "type": "string"
+        },
+        "type": {
+          "const": "array",
+          "type": "string"
+        }
+      },
+      "required": [
+        "items",
+        "type"
+      ],
+      "type": "object"
+    },
+    "UntitledSingleSelectEnumSchema": {
+      "description": "Schema for single-selection enumeration without display titles for options.",
+      "properties": {
+        "default": {
+          "description": "Optional default value.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Optional description for the enum field.",
+          "type": "string"
+        },
+        "enum": {
+          "description": "Array of enum values to choose from.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "title": {
+          "description": "Optional title for the enum field.",
+          "type": "string"
+        },
+        "type": {
+          "const": "string",
+          "type": "string"
+        }
+      },
+      "required": [
+        "enum",
+        "type"
+      ],
+      "type": "object"
+    }
+  }
+}

--- a/test/ptc_runner/kernel/mcp_protocol_test.exs
+++ b/test/ptc_runner/kernel/mcp_protocol_test.exs
@@ -4,6 +4,8 @@ defmodule PtcRunner.Kernel.MCPProtocolTest do
   alias PtcRunner.Kernel.JSONSchema
   alias PtcRunner.Kernel.MCPProtocol
 
+  @wire_schema_path Path.expand("../../../site/schemas/mcp-2026-07-28.schema.json", __DIR__)
+
   @input_schema %{
     "type" => "object",
     "properties" => %{"query" => %{"type" => "string"}},
@@ -1063,5 +1065,146 @@ defmodule PtcRunner.Kernel.MCPProtocolTest do
       assert {:error, :mcp_invalid_result} =
                MCPProtocol.normalize_tool_result(result, output_validator)
     end
+  end
+
+  # The wire schema is published, not shipped: it addresses ptc-runner.dev and
+  # reaches server authors from there. What has to stay true locally is that
+  # the document PtcRunner publishes still describes the bytes PtcRunner
+  # sends, so this validates real requests against the served definitions.
+  test "published wire schema accepts the exchanges PtcRunner actually sends" do
+    schema = @wire_schema_path |> File.read!() |> Jason.decode!()
+
+    assert schema["$id"] ==
+             "https://ptc-runner.dev/schemas/mcp-2026-07-28.schema.json"
+
+    for definition <- ~w(
+          DiscoverRequest
+          DiscoverResultResponse
+          ListToolsRequest
+          ListToolsResultResponse
+          CallToolRequest
+          CallToolResultResponse
+          PtcRunnerJSONRPCErrorResponse
+        ) do
+      assert is_map(schema["$defs"][definition]), "missing MCP definition #{definition}"
+    end
+
+    metadata = %{
+      "io.modelcontextprotocol/protocolVersion" => "2026-07-28",
+      "io.modelcontextprotocol/clientInfo" => %{"name" => "ptc_runner", "version" => "0.x"},
+      "io.modelcontextprotocol/clientCapabilities" => %{}
+    }
+
+    assert_schema_definition!(
+      schema,
+      "DiscoverRequest",
+      MCPProtocol.request(1, "server/discover", %{}, metadata)
+    )
+
+    assert_schema_definition!(schema, "DiscoverResultResponse", %{
+      "jsonrpc" => "2.0",
+      "id" => 1,
+      "result" => %{
+        "resultType" => "complete",
+        "supportedVersions" => ["2026-07-28"],
+        "capabilities" => %{"tools" => %{}},
+        "ttlMs" => 0,
+        "cacheScope" => "private"
+      }
+    })
+
+    assert_schema_definition!(
+      schema,
+      "ListToolsRequest",
+      MCPProtocol.request(2, "tools/list", %{}, metadata)
+    )
+
+    assert_schema_definition!(schema, "ListToolsResultResponse", %{
+      "jsonrpc" => "2.0",
+      "id" => 2,
+      "result" => %{
+        "resultType" => "complete",
+        "tools" => [
+          %{
+            "name" => "lookup",
+            "description" => "Look up one value.",
+            "inputSchema" => %{
+              "type" => "object",
+              "properties" => %{"query" => %{"type" => "string"}},
+              "required" => ["query"]
+            }
+          }
+        ],
+        "ttlMs" => 0,
+        "cacheScope" => "private"
+      }
+    })
+
+    assert_schema_definition!(
+      schema,
+      "CallToolRequest",
+      MCPProtocol.request(
+        3,
+        "tools/call",
+        %{"name" => "lookup", "arguments" => %{"fraction" => 1.5, "missing" => nil}},
+        metadata
+      )
+    )
+
+    assert_schema_definition!(schema, "CallToolResultResponse", %{
+      "jsonrpc" => "2.0",
+      "id" => 3,
+      "result" => %{
+        "resultType" => "complete",
+        "content" => [%{"type" => "text", "text" => "found"}],
+        "isError" => false
+      }
+    })
+
+    error_response = %{
+      "jsonrpc" => "2.0",
+      "id" => 3,
+      "error" => %{"code" => -32_603, "message" => "Method not found", "data" => nil}
+    }
+
+    assert_schema_definition!(schema, "PtcRunnerJSONRPCErrorResponse", error_response)
+
+    assert {:ok, ^error_response} =
+             error_response |> Jason.encode!() |> MCPProtocol.decode_response(3)
+
+    assert {:error, :mcp_remote_error} = MCPProtocol.outcome(error_response, "tools/call")
+
+    refute_schema_definition!(schema, "PtcRunnerJSONRPCErrorResponse", %{
+      error_response
+      | "id" => "3"
+    })
+
+    oversized = put_in(error_response, ["error", "message"], String.duplicate("€", 1_366))
+    assert_schema_definition!(schema, "PtcRunnerJSONRPCErrorResponse", oversized)
+    assert {:error, :mcp_protocol_error} = MCPProtocol.outcome(oversized, "tools/call")
+  end
+
+  defp assert_schema_definition!(schema, definition, value) do
+    validator = schema_definition_validator(schema, definition)
+
+    assert {:ok, _validated} = JSV.validate(value, validator, cast: false)
+  end
+
+  defp refute_schema_definition!(schema, definition, value) do
+    validator = schema_definition_validator(schema, definition)
+
+    assert {:error, _details} = JSV.validate(value, validator, cast: false)
+  end
+
+  defp schema_definition_validator(schema, definition) do
+    JSV.build!(
+      %{
+        "$schema" => schema["$schema"],
+        "$defs" => schema["$defs"],
+        "$ref" => "#/$defs/#{definition}"
+      },
+      atoms: false,
+      warnings: :silent
+    )
   end
 end

--- a/test/scripts/classify_changes_test.exs
+++ b/test/scripts/classify_changes_test.exs
@@ -66,6 +66,10 @@ defmodule PtcRunner.Scripts.ClassifyChangesTest do
           {"cliff.toml", docs},
           {"REUSE.toml", docs},
           {"site/index.html", docs},
+          # The vendored MCP wire schema is served from `site/`, but the core
+          # suite validates PtcRunner's own requests against it.
+          {"site/schemas/mcp-2026-07-28.schema.json",
+           all_false() |> Map.put("core", "true") |> Map.put("docs", "true")},
           {"dev/mix/tasks/ptc.verify_docs.ex", docs},
           {".duplication-baseline.json", core},
           {".ex_dna.exs", core},


### PR DESCRIPTION
## Summary

- publish the pinned MCP 2026-07-28 wire schema at `https://ptc-runner.dev/schemas/mcp-2026-07-28.schema.json`
- document the exact discovery, `tools/list`, `tools/call`, and error definitions a server must implement, and the narrower result policy PtcRunner enforces on top of them
- record on the schemas page why PtcRunner maintains a copy at all
- preserve upstream MCP licensing for both derived files

## Investigation

`ptc-fs-mcp@0.1.0` is published and the downstream migration landed in #1537, so the remaining half of #1495 was that a third-party author had no obtainable wire schema — nothing they wrote could be acquired.

The published document is upstream's, with two corrections PtcRunner maintains and upstream does not publish:

- `JSONValue` accepts JSON numbers and nulls, which the generated upstream document narrows away
- `PtcRunnerJSONRPCErrorResponse` is the closed failure envelope, which has no upstream definition

Those two deltas are exactly what an author cannot get from upstream, and they are the reason a copy exists. Everything else is upstream byte-for-byte at `5f5440bb`.

## Published, not shipped

An earlier revision of this branch embedded the schema in every installation as `ptc docs schema-mcp`. That was dropped. Offline access is not a requirement — an author writing an MCP server has a network — and it cost 150 KB in every package and release, roughly 37k tokens for an agent that read the page, and the full Apache-2.0 distribution tail on artifacts (`licenses:`, a release license-copy step, package `files:` entries, two verify-script blocks). None of that remains; `mix.exs` and both verify scripts are byte-identical to `main`.

Two consequences worth naming in review:

- `site/schemas/mcp-2026-07-28.schema.json` needs the `$id` that `build_site.sh`'s identity guard requires, and `$comment` states that addition alongside the two real deltas, as Apache-2.0 §4(b) requires of a modified file.
- The core suite reads that file, but `site/*` selected only the docs gate. `classify-changes.sh` now routes `site/schemas/mcp-*.schema.json` to `core`, so the suite that validates against it also gates edits to it.

## Pre-existing gap fixed in passing

`priv/schemas/mcp-input-request-2026-07-28.schema.json` is extracted from the same upstream commit, ships in the Hex package and the standalone release, and has carried no attribution since before this branch. REUSE and `THIRD_PARTY_NOTICES.md` now cover both files.

Whether the *artifacts* must also carry the Apache-2.0 text on that file's account is a separate call and is deliberately not made here — it is a pre-existing condition of `main`, and re-adding the shipping tail is the thing this revision set out to remove.

## Validation

- `mix precommit`
- `MIX_ENV=dev mix docs --warnings-as-errors`
- `scripts/build_site.sh` — 5 schemas, `$id` identity and root-relative link guards pass; page rendered and checked in a browser
- `scripts/verify_core_package.sh`, plus a package listing confirming no vendored schema and no license files in the tarball
- 155 targeted tests (`mcp_protocol_test`, `mcp_source_test`, `command_docs_test`, `test/scripts/`, `test/githooks/`)

Rebased onto `main` at `69820789`, after #1573 (the other half of #1495) landed.

Closes #1495
