### PR TITLE
docs(agents): add Cursor Cloud environment setup notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -197,6 +197,44 @@ must be generic and not overlap existing domains unless asked.
   test is as simple as the code it tests, delete it.
 - No `Process.sleep` — use monitors or async helpers.
 
+## Cursor Cloud specific instructions
+
+Durable, non-obvious notes for Cloud Agents. The toolchain, hooks, and standard
+commands are already documented in `docs/maintainers/development-setup.md` and
+the `## Commands` section above — read those first; this section only records
+what is specific to running in the Cloud VM.
+
+- **Toolchain lives under `mise`.** Erlang/Elixir/Java are pinned in `mise.toml`
+  and managed by `mise` (installed at `~/.local/bin/mise`). Interactive shells
+  activate it automatically via `~/.bashrc`, so `mix`/`elixir` are on `PATH`. In
+  a non-interactive script that is *not* sourced from `~/.bashrc`, prefix
+  commands with `~/.local/bin/mise exec -- …` (for example
+  `~/.local/bin/mise exec -- mix test`) so the pinned tools resolve.
+- **Reinstalling deps does not rebuild.** The startup update script only runs
+  `mix deps.get`; run `mix compile` yourself after pulling changes or editing
+  `mix.exs`/`mix.lock`/prelude sources. The bundled native launcher's C binary
+  is (re)built by `mix compile` via `elixir_make` (needs a C compiler, already
+  present).
+- **Smoke test the runtime offline.** `mix ptc run <project.json>` needs no
+  network for the deterministic examples:
+  `examples/kernel-tutorial/01-orders.ptc-project.json` and
+  `examples/llm-replay/ptc-project.json`. Model-backed examples/tests need
+  `OPENROUTER_API_KEY` (see the `## Commands` section).
+- **The Viewer is a web app you must start explicitly.** `mix ptc viewer
+  <project.json>` boots a Plug/Bandit HTTP server (not Phoenix) *inside the same
+  BEAM*; by default it binds `127.0.0.1` on an OS-chosen free port and tries to
+  open a browser. In the headless VM, pass `--port <PORT> --listen 127.0.0.1`
+  and open the printed URL yourself. It only shows runs that already produced a
+  trace, so run a project once before launching it.
+- **`mix test` is the default gate (~3 min, 6800+ tests).** It excludes
+  `:e2e`, `:scheduled_e2e`, `:nightly`, `:soak`, and `:clojure` by default;
+  those need extra prerequisites (API key, Babashka/JVM, MCP servers) per
+  `docs/maintainers/development-setup.md`.
+- **latin1 locale warning is harmless.** A tmux/login shell that does not export
+  a UTF-8 `LANG` makes the BEAM print a "native name encoding of latin1"
+  warning. Export `LANG=C.UTF-8` (or `ELIXIR_ERL_OPTIONS="+fnu"`) for that
+  shell; it does not affect correctness.
+
 <!-- usage-rules-start -->
 <!-- usage_rules-start -->
 ## usage_rules usage


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Set up the Cloud Agent development environment for PtcRunner and recorded durable, non-obvious run caveats for future agents under a new `## Cursor Cloud specific instructions` section in `AGENTS.md`.

No product code changed — this PR only adds documentation. The environment itself (toolchain + dependency refresh) is captured in the Cloud Agent update script, not committed here.

## Environment that was set up

- **Toolchain:** installed `mise` and the versions pinned in `mise.toml` — Erlang/OTP `29.0.3`, Elixir `1.20.2-otp-29`, Temurin Java `21` (Erlang came as a precompiled binary; installing was fast). Installed system build deps for the native launcher's C compile.
- **Dependencies:** `mix deps.get` for the root, `ptc_viewer/`, and `ptc_runner_launcher/`; `mix compile` (root + Viewer + native launcher).
- **Update script (startup dependency refresh):** `mise install --yes` then `mix deps.get` for the three projects, all via `mise exec --` so it works in a non-interactive shell.

## Verification

| Concern | Command | Result |
| --- | --- | --- |
| Build | `mix compile` | Clean (root + Viewer + native C launcher) |
| Lint | `mix credo --strict` | `17698 mods/funs, found no issues.` |
| Tests | `mix test` | `6822 passed, 386 excluded`, 0 failures (~170s) |
| Run (CLI) | `mix ptc init` + `mix ptc run …` | `{"greeting":"hello world"}`, orders + replay outputs match docs |
| Run (Viewer) | `mix ptc viewer … --port 4000` | Bandit server served the canonical trace UI at `127.0.0.1:4000` |

CLI hello-world + offline examples:

```
mix ptc run <scaffold>/ptc-project.json                          => {"greeting":"hello world"}
mix ptc run examples/kernel-tutorial/01-orders.ptc-project.json  => {"order_count":3,"paid_count":2,"paid_total":335.75,"pending_ids":["A-101"]}
mix ptc run examples/llm-replay/ptc-project.json                 => {"content":"Frozen answer"}
```

Viewer web app demo (Runs list → canonical trace → execution transcript → REPL):

[ptc_viewer_demo.mp4](https://cursor.com/agents/bc-cc0ca2fe-2c68-414a-b92a-073b846508bf/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fptc_viewer_demo.mp4)

[PTC Viewer runs list](https://cursor.com/agents/bc-cc0ca2fe-2c68-414a-b92a-073b846508bf/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fviewer_d4d62.webp)
[PTC Viewer canonical trace detail](https://cursor.com/agents/bc-cc0ca2fe-2c68-414a-b92a-073b846508bf/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fviewer_30f45.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cc0ca2fe-2c68-414a-b92a-073b846508bf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cc0ca2fe-2c68-414a-b92a-073b846508bf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

