### PR TITLE
docs(repl): frame private manifest gate as intentional (#1219)

### DIFF
--- a/docs/reference/repl.md
+++ b/docs/reference/repl.md
@@ -160,8 +160,12 @@ ptc repl --manifest ptc.json --trace trace.jsonl
 A private manifest requires an attached terminal and
 `--private-terminal` before provider activity. It rejects scripts, stdin,
 `--eval`, `--load`, JSON Lines, and detached execution; private values and
-prints may reach only that authorized terminal. Private traces use the reserved
-`.private.jsonl` suffix and owner-only permissions.
+prints may reach only that authorized terminal. Unlike private analysis
+profiles, there is no `--private-unattended` path: a private manifest can
+carry caller-supplied private input, not only runtime telemetry, so the gate
+stays interactive-only by design. The terminal check remains an accident
+guard, not access control. Private traces use the reserved `.private.jsonl`
+suffix and owner-only permissions.
 
 The session owner retains the continuation, event sink, and provider resources.
 Normal close, abort, caller death, worker failure, and deadline failure converge

--- a/lib/ptc_runner/kernel/manifest_repl.ex
+++ b/lib/ptc_runner/kernel/manifest_repl.ex
@@ -8,6 +8,16 @@ defmodule PtcRunner.Kernel.ManifestRepl do
   terminal authority is decided before the opening owner starts. A successful
   opening returns a process-affine `PtcRunner.Kernel.ReplSession` whose owner
   retains one provider session for every evaluation and owns terminal cleanup.
+
+  A private manifest requires `private_terminal: true` and an attached stdin
+  and stdout before provider activity, and admits only interactive input. That
+  attached-terminal check is an **accident guard, not access control** — the
+  same `isatty` limits documented on
+  `PtcRunner.Kernel.AnalysisSessionBuilder`. Unlike private analysis profiles,
+  there is deliberately no unattended private destination here: a private
+  manifest can carry caller-supplied private *input*, not only captured runtime
+  telemetry, so the gate stays interactive-only by design rather than offering
+  a `--private-unattended` equivalent.
   """
 
   alias PtcRunner.Kernel.AnalysisTerminal

--- a/site/reference/repl/index.html
+++ b/site/reference/repl/index.html
@@ -166,8 +166,12 @@ reference</a> for the full language surface.</p><p>Persist canonical session eve
 ptc repl --manifest ptc.json --trace trace.jsonl</code></pre><p>A private manifest requires an attached terminal and
 <code class="inline">--private-terminal</code> before provider activity. It rejects scripts, stdin,
 <code class="inline">--eval</code>, <code class="inline">--load</code>, JSON Lines, and detached execution; private values and
-prints may reach only that authorized terminal. Private traces use the reserved
-<code class="inline">.private.jsonl</code> suffix and owner-only permissions.</p><p>The session owner retains the continuation, event sink, and provider resources.
+prints may reach only that authorized terminal. Unlike private analysis
+profiles, there is no <code class="inline">--private-unattended</code> path: a private manifest can
+carry caller-supplied private input, not only runtime telemetry, so the gate
+stays interactive-only by design. The terminal check remains an accident
+guard, not access control. Private traces use the reserved <code class="inline">.private.jsonl</code>
+suffix and owner-only permissions.</p><p>The session owner retains the continuation, event sink, and provider resources.
 Normal close, abort, caller death, worker failure, and deadline failure converge
 on bounded cleanup before final trace persistence.</p><h2 id="query-public-traces">Query public traces</h2><p>Select the fixed public profile and its required resource:</p><pre><code class="console language-console">ptc repl --project ptc-project.json \
   --profile run-analysis-v1 \


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Closes #1219 with the **doc-only** option: keep the private manifest REPL interactive-only (`--private-terminal` + attached terminal; no `--private-unattended` equivalent), and document that as a deliberate decision rather than an oversight.
- `ManifestRepl` moduledoc now states the gate is an accident guard (same `isatty` limits as `AnalysisSessionBuilder`) and explains why unattended private destinations stay analysis-only: a private manifest can carry caller-supplied private *input*, not only captured runtime telemetry.
- REPL reference (+ generated site page) mirrors that framing next to the existing private-manifest paragraph.

## Test plan

- [x] `mix ptc.gen_docs --check` green after regenerating `site/reference/repl/index.html`
- [ ] CI on this PR
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-baff5e46-4901-4007-bc03-695f228b290b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-baff5e46-4901-4007-bc03-695f228b290b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

