### PR TITLE
fix(kernel): admit pre-execution diagnostics in private sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Private analysis sessions now admit bounded pre-execution diagnostics
+  (`:parse_error`, `:invalid_arity`, `:invalid_form`, symbol/compile limits,
+  and tool-resolution faults) when no capability has run in that evaluation.
+  An arity mistake such as `(defn foo)` reports the analyzer's fixed message
+  instead of the private-result redaction, while post-capability faults of the
+  same kind remain withheld.
+
 - MCP stdio now retains bounded child stderr in the private inspection
   artifact, so operator diagnostics that a well-behaved server can only put on
   stderr are no longer dropped after the launcher captures them. Overflow from

--- a/docs/reference/repl.md
+++ b/docs/reference/repl.md
@@ -375,8 +375,11 @@ private data.
 
 Private evaluation diagnostics never forward arbitrary evaluator text that
 could quote captured evidence. Safe diagnostics may rebuild names found
-verbatim in the operator's submitted source; otherwise the message is visibly
-redacted while the fault kind, continuation effect, and usage remain exact.
+verbatim in the operator's submitted source, or admit a bounded message for a
+pre-execution fault (parse, analyze, symbol-limit, compile-budget, or
+tool-resolution) when no capability has run in that evaluation; otherwise the
+message is visibly redacted while the fault kind, continuation effect, and
+usage remain exact.
 
 ## Keep analysis traces separate
 

--- a/lib/ptc_runner/kernel/analysis_session.ex
+++ b/lib/ptc_runner/kernel/analysis_session.ex
@@ -12,10 +12,11 @@ defmodule PtcRunner.Kernel.AnalysisSession do
   every host must eventually call `stop/1`.
 
   A session whose profile declares a private result class projects its failure
-  messages through `PtcRunner.Kernel.PrivateDiagnostic`, which rebuilds them
-  from the submitted source instead of forwarding evaluator text. Every error
-  map this module emits carries `message_redacted?` so a withheld diagnostic is
-  distinguishable from one that was never produced.
+  messages through `PtcRunner.Kernel.PrivateDiagnostic`, which rebuilds
+  source-derived names or admits bounded pre-execution diagnostics instead of
+  forwarding arbitrary evaluator text. Every error map this module emits
+  carries `message_redacted?` so a withheld diagnostic is distinguishable from
+  one that was never produced.
   """
   use GenServer
 
@@ -472,7 +473,7 @@ defmodule PtcRunner.Kernel.AnalysisSession do
        do: nil
 
   defp error_projection(result, state, source) do
-    details = Map.get(result, :details, %{})
+    details = private_diagnostic_details(result)
     kind = Map.get(result, :kind, result.outcome)
     {message, redacted?} = error_message(kind, details, state, source)
 
@@ -488,8 +489,28 @@ defmodule PtcRunner.Kernel.AnalysisSession do
     }
   end
 
-  # A private session never forwards evaluator message text; it rebuilds what
-  # the operator's own source already says. See `PrivateDiagnostic`.
+  # Prefer the top-level activity flag when present so a path that records
+  # activity only there cannot be admitted as pre-execution.
+  defp private_diagnostic_details(result) do
+    details = Map.get(result, :details, %{})
+
+    case Map.fetch(result, :capability_activity?) do
+      {:ok, activity?} when is_map(details) ->
+        Map.put(details, :capability_activity?, activity?)
+
+      {:ok, _activity?} ->
+        %{capability_activity?: result.capability_activity?}
+
+      :error when is_map(details) ->
+        details
+
+      :error ->
+        %{}
+    end
+  end
+
+  # A private session never forwards arbitrary evaluator text; see
+  # `PrivateDiagnostic` for the two admission rules.
   defp error_message(
          kind,
          details,

--- a/lib/ptc_runner/kernel/private_diagnostic.ex
+++ b/lib/ptc_runner/kernel/private_diagnostic.ex
@@ -6,22 +6,47 @@ defmodule PtcRunner.Kernel.PrivateDiagnostic do
   text: that text can quote a captured record, and a host may route diagnostics
   somewhere the result itself never goes. It may still tell the operator what
   went wrong, because the fault often describes nothing but the operator's own
-  submitted source.
+  submitted source — or, for a narrower class, nothing that evaluation could
+  yet have captured.
 
-  Such a message is therefore **rebuilt, never forwarded**. A message is
-  produced only for a fault kind that carries structured, source-derived
-  detail, and every name in it must appear verbatim in the submitted source.
-  Every other byte is a literal in this module. Anything outside that
-  allowlist — and any detail whose shape is not exactly what the allowlist
-  expects — collapses to `redacted_message/0`.
+  Two admission rules apply, both **rebuild-or-bound, never raw forward** of
+  untrusted evaluator prose outside their footing:
+
+  1. **Source-derived structured detail** (today `:unbound_var`). A message is
+     rebuilt only when every name appears verbatim in the submitted source.
+     Every other byte is a literal in this module.
+
+  2. **Pre-execution kinds.** Parse, analyze, symbol-limit, compile-budget, and
+     tool-resolution faults are produced before the first capability call, so
+     no captured record has entered the evaluation. Their evaluator message is
+     admitted only when `details.capability_activity?` is not `true`, and only
+     after a byte/UTF-8 bound at this boundary. The kind allowlist is the
+     durable contract; the activity flag is the enforcement that keeps the
+     footing true if a kind later gains a post-capability producer.
 
   `details` is evaluator output and is treated as untrusted: it selects among
-  fixed shapes, it never carries provenance.
+  fixed shapes, it never carries provenance. Anything outside those rules
+  collapses to `redacted_message/0`.
   """
 
   @redacted "private evaluation failed; diagnostic withheld by the private result policy"
   @max_names 32
   @max_name_bytes 128
+  @max_pre_execution_message_bytes 4_096
+
+  # Kinds whose constructors run in parse/analyze/compile or the pre-execution
+  # tool guard. Runtime cousins such as `:arity_error` stay outside this set.
+  @pre_execution_kinds [
+    :parse_error,
+    :invalid_arity,
+    :invalid_form,
+    :symbol_limit_exceeded,
+    :compile_timeout,
+    :compile_memory_exceeded,
+    :unknown_tool,
+    :private_tool_unauthorized,
+    :unknown_namespace
+  ]
 
   alias PtcRunner.Lisp.Eval.Helpers
 
@@ -42,6 +67,15 @@ defmodule PtcRunner.Kernel.PrivateDiagnostic do
     case admitted_names(names, source) do
       {[], _dropped?} -> {@redacted, true}
       {admitted, dropped?} -> {unbound_var_message(admitted, dropped?), dropped?}
+    end
+  end
+
+  def project(kind, details, _source)
+      when kind in @pre_execution_kinds and is_map(details) do
+    if capability_idle?(details) do
+      admit_pre_execution_message(details)
+    else
+      {@redacted, true}
     end
   end
 
@@ -89,5 +123,40 @@ defmodule PtcRunner.Kernel.PrivateDiagnostic do
       nil -> ""
       hint -> ". Hint: #{hint}"
     end
+  end
+
+  # Explicit `true` means a capability ran in this evaluation: the pre-execution
+  # footing no longer holds, even if the kind is still on the allowlist. Absent
+  # or `false` keeps the admit path open for compile-time Steps that never set
+  # the flag and for `release_failure/5`, which always records it.
+  defp capability_idle?(%{capability_activity?: true}), do: false
+  defp capability_idle?(_details), do: true
+
+  defp admit_pre_execution_message(details) do
+    case Map.get(details, :message) do
+      message when is_binary(message) and message != "" ->
+        if String.valid?(message) do
+          {clip_utf8(message, @max_pre_execution_message_bytes), false}
+        else
+          {@redacted, true}
+        end
+
+      _other ->
+        {@redacted, true}
+    end
+  end
+
+  defp clip_utf8(value, max_bytes) when byte_size(value) <= max_bytes, do: value
+
+  defp clip_utf8(value, max_bytes) do
+    value
+    |> binary_part(0, max_bytes)
+    |> trim_invalid_suffix()
+  end
+
+  defp trim_invalid_suffix(value) do
+    if String.valid?(value),
+      do: value,
+      else: trim_invalid_suffix(binary_part(value, 0, byte_size(value) - 1))
   end
 end

--- a/site/reference/repl/index.html
+++ b/site/reference/repl/index.html
@@ -277,8 +277,11 @@ terminal check. Unattended output may enter shell logs, coding-agent
 transcripts, or provider logs. Authorize every downstream sink for the same
 private data.</p><p>Private evaluation diagnostics never forward arbitrary evaluator text that
 could quote captured evidence. Safe diagnostics may rebuild names found
-verbatim in the operator's submitted source; otherwise the message is visibly
-redacted while the fault kind, continuation effect, and usage remain exact.</p><h2 id="keep-analysis-traces-separate">Keep analysis traces separate</h2><p>Profile sessions write a separate safe canonical trace, never into their input
+verbatim in the operator's submitted source, or admit a bounded message for a
+pre-execution fault (parse, analyze, symbol-limit, compile-budget, or
+tool-resolution) when no capability has run in that evaluation; otherwise the
+message is visibly redacted while the fault kind, continuation effect, and
+usage remain exact.</p><h2 id="keep-analysis-traces-separate">Keep analysis traces separate</h2><p>Profile sessions write a separate safe canonical trace, never into their input
 tree:</p><pre><code class="console language-console">ptc repl \
   --profile run-analysis-v1 \
   --resource traces=tmp/tutorial-traces \

--- a/test/ptc_runner/kernel/private_diagnostic_test.exs
+++ b/test/ptc_runner/kernel/private_diagnostic_test.exs
@@ -43,10 +43,82 @@ defmodule PtcRunner.Kernel.PrivateDiagnosticTest do
              PrivateDiagnostic.project(:unbound_var, %{unbound_names: ["leaked"]}, "(g 1)")
   end
 
+  test "admits a bounded pre-execution message when no capability has run" do
+    message = "Analysis error: expected (defn name [params] body)"
+
+    assert {^message, false} =
+             PrivateDiagnostic.project(
+               :invalid_arity,
+               %{message: message, capability_activity?: false},
+               "(defn foo)"
+             )
+  end
+
+  test "pre-execution admission covers the compile and tool-resolution kinds" do
+    message = "fixed pre-execution diagnostic"
+
+    for kind <- [
+          :parse_error,
+          :invalid_arity,
+          :invalid_form,
+          :symbol_limit_exceeded,
+          :compile_timeout,
+          :compile_memory_exceeded,
+          :unknown_tool,
+          :private_tool_unauthorized,
+          :unknown_namespace
+        ] do
+      assert {^message, false} =
+               PrivateDiagnostic.project(
+                 kind,
+                 %{message: message, capability_activity?: false},
+                 "(g 1)"
+               )
+    end
+  end
+
+  test "still redacts a pre-execution kind once a capability has run" do
+    assert {@redacted, true} =
+             PrivateDiagnostic.project(
+               :invalid_arity,
+               %{
+                 message: "expected (defn name [params] body)",
+                 capability_activity?: true
+               },
+               "(defn foo)"
+             )
+  end
+
+  test "clips an oversized pre-execution message at the admission boundary" do
+    message = String.duplicate("a", 5_000)
+
+    assert {admitted, false} =
+             PrivateDiagnostic.project(
+               :parse_error,
+               %{message: message, capability_activity?: false},
+               "("
+             )
+
+    assert byte_size(admitted) < byte_size(message)
+    assert byte_size(admitted) <= 4_096
+    assert String.valid?(admitted)
+  end
+
   test "redacts evaluator-produced diagnostics of every other kind" do
-    for kind <- [:not_callable, :type_error, :capability_error, :memory_exceeded, nil] do
+    for kind <- [
+          :not_callable,
+          :type_error,
+          :capability_error,
+          :memory_exceeded,
+          :arity_error,
+          nil
+        ] do
       assert {@redacted, true} =
-               PrivateDiagnostic.project(kind, %{message: "quotes a private record"}, "(g 1)")
+               PrivateDiagnostic.project(
+                 kind,
+                 %{message: "quotes a private record", capability_activity?: false},
+                 "(g 1)"
+               )
     end
   end
 

--- a/test/ptc_runner/kernel/run_analysis_profile_test.exs
+++ b/test/ptc_runner/kernel/run_analysis_profile_test.exs
@@ -627,6 +627,79 @@ defmodule PtcRunner.Kernel.PrivateRunAnalysisProfileTest do
   end
 
   @tag :tmp_dir
+  test "a private session admits pre-execution arity and form diagnostics", %{tmp_dir: root} do
+    fixture = PrivateInspectionFixture.create!(root)
+    {:ok, session, _info} = start_internal_session(fixture)
+    on_exit(fn -> AnalysisSession.stop(session) end)
+
+    assert {:ok,
+            %{
+              status: :error,
+              error: %{
+                kind: :invalid_arity,
+                message: arity_message,
+                message_redacted?: false,
+                capability_activity?: false
+              }
+            }} = AnalysisSession.evaluate(session, "(defn foo)")
+
+    assert arity_message =~ "expected (defn name [params] body)"
+    refute arity_message =~ "private result policy"
+
+    assert {:ok,
+            %{
+              status: :error,
+              error: %{
+                kind: :invalid_form,
+                message: form_message,
+                message_redacted?: false,
+                capability_activity?: false
+              }
+            }} = AnalysisSession.evaluate(session, "(let [x] x)")
+
+    assert form_message =~ "even number of forms"
+    refute form_message =~ "private result policy"
+
+    assert {:ok,
+            %{
+              status: :error,
+              error: %{
+                kind: :parse_error,
+                message: parse_message,
+                message_redacted?: false,
+                capability_activity?: false
+              }
+            }} = AnalysisSession.evaluate(session, "(unclosed")
+
+    assert is_binary(parse_message) and parse_message != ""
+    refute parse_message =~ "private result policy"
+  end
+
+  @tag :tmp_dir
+  test "a private session names a prelude arity fault without opening evidence", %{tmp_dir: root} do
+    fixture = PrivateInspectionFixture.create!(root)
+    {:ok, session, _info} = start_internal_session(fixture)
+    on_exit(fn -> AnalysisSession.stop(session) end)
+
+    # Same shape as the operator detour in #1175: analysis/runs takes one options
+    # map, while analysis/read takes [run-id options]. Calling read the way runs
+    # is taught is an analyzer arity fault before any capability executes.
+    assert {:ok,
+            %{
+              status: :error,
+              error: %{
+                kind: :invalid_arity,
+                message: message,
+                message_redacted?: false,
+                capability_activity?: false
+              }
+            }} = AnalysisSession.evaluate(session, ~s|(analysis/read "x")|)
+
+    assert message =~ "argument"
+    refute message =~ "private result policy"
+  end
+
+  @tag :tmp_dir
   test "resource directories whose artifacts sit one level down are refused", %{tmp_dir: root} do
     fixture = PrivateInspectionFixture.create!(Path.join(root, "nested"))
     nested_traces = Path.join(root, "nested-traces")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #1175.

Private analysis sessions withheld parse/analyze/tool-resolution messages that cannot contain captured records. After #1174, only `:unbound_var` was rebuilt from source-verified names; every other pre-execution fault still collapsed to the fixed redaction string.

## Change

`PtcRunner.Kernel.PrivateDiagnostic` gains a second admission rule:

- **Allowlisted pre-execution kinds** (`:parse_error`, `:invalid_arity`, `:invalid_form`, `:symbol_limit_exceeded`, `:compile_timeout`, `:compile_memory_exceeded`, `:unknown_tool`, `:private_tool_unauthorized`, `:unknown_namespace`)
- **Only when `capability_activity?` is not `true`** for that evaluation (so a later post-capability producer of the same kind stays redacted)
- **Bounded at the admission point** (4 KiB / valid UTF-8), rather than asserting every analyzer message is a literal forever

```clojure
(defn foo)
;=> Error (invalid_arity): Analysis error: expected (defn name [params] body)

(analysis/read "x")
;=> Error (invalid_arity): … expects 2 argument(s), got 1
```

Runtime cousins such as `:arity_error` and post-capability faults remain withheld. `AnalysisSession` merges a top-level `capability_activity?` into the details map before projection so a path that records activity only there cannot be admitted as pre-execution.

## Non-goals

- Structured rebuild of analyzer messages (the #1174 `unbound_names` pattern)
- Granting `kernel/check-source` to the private profile
- Changing public-session diagnostics

## Verification

- Focused unit + private-run-analysis integration tests for `(defn foo)`, `(let [x] x)`, parse errors, and prelude arity
- `mix precommit`
- `git push` pre-push gate (docs, core tests, Dialyzer, release, Viewer)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-43895b59-3456-4828-b744-5a8fef793873?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-43895b59-3456-4828-b744-5a8fef793873&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

