### PR TITLE
docs(preludes): explain prompt overrides

### DIFF
--- a/docs/guides/building-agents.md
+++ b/docs/guides/building-agents.md
@@ -77,6 +77,9 @@ retain prompts, responses, generated source, and tool payloads. Use replay to
 hold model responses fixed while comparing a prompt or prelude candidate, then
 promote a change only after evaluating its evidence.
 
+The short [core-prompt replacement tutorial](components-and-preludes.md#trial-a-different-core-prompt)
+shows how to materialize and run an `agent.prompt` candidate.
+
 Use the [agent library reference](../agent-library-reference.md) for exact entry
 functions, options, outcomes, turn protocol, feedback, retry behavior, and
 concurrency limits. See [Customize agent components](components-and-preludes.md)

--- a/docs/guides/components-and-preludes.md
+++ b/docs/guides/components-and-preludes.md
@@ -22,6 +22,52 @@ Start with it, then introduce a custom component under a new ID when the
 application needs different prompts, feedback, retry policy, continuation, or
 completion rules.
 
+## Trial a different core prompt
+
+Selecting `agent.core` also selects its `agent.prompt` dependency. A component
+override can therefore trial a replacement prompt without changing the
+application manifest. The replacement keeps the installed component ID and
+dependencies and must provide the three functions `agent.core` calls:
+
+```clojure
+(ns agent.prompt "Application prompt policy." {:visibility :discoverable})
+
+(defn initial-state [cfg]
+  {:turns-remaining (get cfg "max_turns")})
+
+(defn render {:effect :read} [_state]
+  "Use run_ptc_lisp to solve the task. Return the completed value; do not answer in prose.")
+
+(defn transition [state event]
+  (assoc state :turns-remaining (get event :turns-remaining)))
+```
+
+In a source checkout, save that source as `custom-agent-prompt.clj`, then
+materialize and run the candidate:
+
+```console
+mkdir -p private
+mix ptc.materialize ptc.json \
+  --workflow \
+  --component agent.prompt \
+  --source custom-agent-prompt.clj \
+  --out private/agent-prompt-candidate
+
+mix ptc run ptc.json \
+  --component-override-descriptor private/agent-prompt-candidate/descriptor.json
+```
+
+The descriptor binds the candidate bytes to the exact installed
+`agent.prompt` source they replace. The override applies to this invocation
+only; project files do not store component overrides. See [Evaluate changes
+with replay](evaluating-with-replay.md#evaluate-the-candidate-without-installing-it)
+for the descriptor fields and replay comparison.
+
+The active bundle cannot be replaced during its run. A workflow may return
+candidate source as its result, but materialization and execution happen in a
+later host invocation so the replacement is compiled, hashed, and validated
+before it becomes active.
+
 Each component declares its direct namespace dependencies. Selecting a library
 installs its immutable dependency closure, but does not grant tool authority.
 Mission tools still come only from providers installed by the operator and

--- a/docs/guides/evaluating-with-replay.md
+++ b/docs/guides/evaluating-with-replay.md
@@ -102,7 +102,11 @@ more than once.
 ## Evaluate the candidate without installing it
 
 `--component-override-descriptor` replaces one component already selected by
-the manifest:
+the manifest. A transitively selected component is also eligible, so selecting
+`agent.core` makes its `agent.prompt` dependency available as a workflow
+override target.
+
+The descriptor contains the replacement instruction, not the source itself:
 
 ```json
 {
@@ -114,12 +118,28 @@ the manifest:
 }
 ```
 
+| Field | Meaning |
+| --- | --- |
+| `target` | The workflow bundle, or one exact mission bundle |
+| `component_id` | An already-selected component whose source will be replaced |
+| `base_source_hash` | Hash of the installed source the candidate was derived from |
+| `source_hash` | Hash of the candidate source bytes |
+| `path` | Candidate source path relative to the descriptor directory |
+| `provenance` | Optional operator assertions about how the candidate was authored |
+
 For a mission component, use
 `{"environment": "mission", "mission": "reader"}` as the target. The
-candidate path is confined to the descriptor directory. `source_hash`
-identifies the candidate bytes; `base_source_hash` prevents evaluation against
-a component version from which it was not derived. Dependencies, signatures,
-exports, and capability requirements are checked normally.
+candidate path is confined to the descriptor directory. PtcRunner verifies
+both hashes before compiling: `source_hash` prevents substituted candidate
+bytes, while `base_source_hash` rejects a candidate built for a component that
+has since changed. The source is read once, and those verified bytes are the
+bytes compiled.
+
+An override preserves the selected component's ID and declared dependencies;
+it cannot add a component or change the graph. The replacement still passes
+the normal dependency, signature, export, capability-requirement, and bundle
+checks. The descriptor contains no source, credentials, provider grants, or
+installation instruction.
 
 Candidate creation is a trusted build step and is not currently exposed by the
 standalone executable. The source-checkout tool for maintainers is documented
@@ -128,7 +148,14 @@ is a repository document rather than a page the executable carries.
 
 The optional closed `provenance` object may contain `run_id`, `prompt_hash`,
 `authored_at`, and `accept_widened_effect`. These are operator claims rather
-than proof of origin.
+than proof of origin. `mix ptc.materialize` writes the candidate and completed
+descriptor as owner-only files and calculates the candidate path and hash from
+the bytes it publishes.
+
+The active bundle stays immutable for the whole run. A run may author source,
+but only a later host invocation can materialize it and start with the newly
+compiled bundle. Component-override switches are invocation-only and are not
+stored in `ptc-project.json`.
 
 Run the unchanged baseline and the override with the same replay installation,
 inputs, host ceilings, and content snapshots. Compare their values, envelopes,

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -187,8 +187,10 @@ component without installing it. A trusted build step creates the owner-only
 candidate and descriptor from model-authored source. The
 [replay evaluation guide](../guides/evaluating-with-replay.md) owns the complete workflow
 for holding model responses fixed, gating effect changes, and comparing a
-baseline with that candidate. Candidate creation is not currently a standalone
-command; the source-checkout tool belongs to the maintainer documentation.
+baseline with that candidate, and its descriptor reference defines every
+field. Candidate creation is not currently a standalone command; a source
+checkout provides `mix ptc.materialize` as documented in the
+[core-prompt replacement tutorial](../guides/components-and-preludes.md#trial-a-different-core-prompt).
 
 ## Read results and failures
 

--- a/site/guides/building-agents/index.html
+++ b/site/guides/building-agents/index.html
@@ -125,7 +125,8 @@ composition shapes.</p><p>Do not automatically retry an indeterminate write. Kee
 explicit and reconcile an unknown outcome before continuing.</p><h2 id="inspect-and-improve">Inspect and improve</h2><p>Every agent run produces a canonical trace. Opt-in private inspection can also
 retain prompts, responses, generated source, and tool payloads. Use replay to
 hold model responses fixed while comparing a prompt or prelude candidate, then
-promote a change only after evaluating its evidence.</p><p>Use the <a href="/reference/agent-library-reference/">agent library reference</a> for exact entry
+promote a change only after evaluating its evidence.</p><p>The short <a href="/guides/components-and-preludes/#trial-a-different-core-prompt">core-prompt replacement tutorial</a>
+shows how to materialize and run an <code class="inline">agent.prompt</code> candidate.</p><p>Use the <a href="/reference/agent-library-reference/">agent library reference</a> for exact entry
 functions, options, outcomes, turn protocol, feedback, retry behavior, and
 concurrency limits. See <a href="/guides/components-and-preludes/">Customize agent components</a>
 for dependency and replacement rules, and <a href="/guides/evaluating-with-replay/">Evaluate changes with

--- a/site/guides/components-and-preludes/index.html
+++ b/site/guides/components-and-preludes/index.html
@@ -106,7 +106,35 @@ policies, libraries, or complete agent loops.</p></blockquote><p>Most applicatio
 }</code></pre><p>The shipped <code class="inline">agent.core</code> loop is a replaceable library, not Kernel behavior.
 Start with it, then introduce a custom component under a new ID when the
 application needs different prompts, feedback, retry policy, continuation, or
-completion rules.</p><p>Each component declares its direct namespace dependencies. Selecting a library
+completion rules.</p><h2 id="trial-a-different-core-prompt">Trial a different core prompt</h2><p>Selecting <code class="inline">agent.core</code> also selects its <code class="inline">agent.prompt</code> dependency. A component
+override can therefore trial a replacement prompt without changing the
+application manifest. The replacement keeps the installed component ID and
+dependencies and must provide the three functions <code class="inline">agent.core</code> calls:</p><pre><code class="clojure language-clojure">(ns agent.prompt &quot;Application prompt policy.&quot; {:visibility :discoverable})
+
+(defn initial-state [cfg]
+  {:turns-remaining (get cfg &quot;max_turns&quot;)})
+
+(defn render {:effect :read} [_state]
+  &quot;Use run_ptc_lisp to solve the task. Return the completed value; do not answer in prose.&quot;)
+
+(defn transition [state event]
+  (assoc state :turns-remaining (get event :turns-remaining)))</code></pre><p>In a source checkout, save that source as <code class="inline">custom-agent-prompt.clj</code>, then
+materialize and run the candidate:</p><pre><code class="console language-console">mkdir -p private
+mix ptc.materialize ptc.json \
+  --workflow \
+  --component agent.prompt \
+  --source custom-agent-prompt.clj \
+  --out private/agent-prompt-candidate
+
+mix ptc run ptc.json \
+  --component-override-descriptor private/agent-prompt-candidate/descriptor.json</code></pre><p>The descriptor binds the candidate bytes to the exact installed
+<code class="inline">agent.prompt</code> source they replace. The override applies to this invocation
+only; project files do not store component overrides. See <a href="/guides/evaluating-with-replay/#evaluate-the-candidate-without-installing-it">Evaluate changes
+with replay</a>
+for the descriptor fields and replay comparison.</p><p>The active bundle cannot be replaced during its run. A workflow may return
+candidate source as its result, but materialization and execution happen in a
+later host invocation so the replacement is compiled, hashed, and validated
+before it becomes active.</p><p>Each component declares its direct namespace dependencies. Selecting a library
 installs its immutable dependency closure, but does not grant tool authority.
 Mission tools still come only from providers installed by the operator and
 selected for that mission.</p><p>Keep reusable components narrow:</p><ul><li>expose a small documented public surface;</li><li>declare signatures where model-written calls benefit from validation;</li><li>keep prompt-visible helpers focused on the task contract;</li><li>separate workflow policy from mission-only task functions; and</li><li>use a new component ID for a permanently customized prompt or loop.</li></ul><p>Use the <a href="/reference/component-contracts/">components-and-preludes reference</a>

--- a/site/guides/evaluating-with-replay/index.html
+++ b/site/guides/evaluating-with-replay/index.html
@@ -130,23 +130,35 @@ envelope also reports the miss in usage: that alias's <code class="inline">succe
 0 while <code class="inline">calls</code> increments, and <code class="inline">capability_refusals</code> records
 <code class="inline">workflow/provider_error/not_found</code>.</p><p>An ordered <code class="inline">responses</code> sequence supports workflows that make the same request
 more than once.</p><h2 id="evaluate-the-candidate-without-installing-it">Evaluate the candidate without installing it</h2><p><code class="inline">--component-override-descriptor</code> replaces one component already selected by
-the manifest:</p><pre><code class="json language-json">{
+the manifest. A transitively selected component is also eligible, so selecting
+<code class="inline">agent.core</code> makes its <code class="inline">agent.prompt</code> dependency available as a workflow
+override target.</p><p>The descriptor contains the replacement instruction, not the source itself:</p><pre><code class="json language-json">{
   &quot;target&quot;: {&quot;environment&quot;: &quot;workflow&quot;},
   &quot;component_id&quot;: &quot;my.agent&quot;,
   &quot;base_source_hash&quot;: &quot;sha256:&lt;64 lowercase hex&gt;&quot;,
   &quot;source_hash&quot;: &quot;sha256:&lt;64 lowercase hex&gt;&quot;,
   &quot;path&quot;: &quot;candidate.clj&quot;
-}</code></pre><p>For a mission component, use
+}</code></pre><div class="table-wrap"><table><thead><tr><th style="text-align: left;">Field</th><th style="text-align: left;">Meaning</th></tr></thead><tbody><tr><td style="text-align: left;"><code class="inline">target</code></td><td style="text-align: left;">The workflow bundle, or one exact mission bundle</td></tr><tr><td style="text-align: left;"><code class="inline">component_id</code></td><td style="text-align: left;">An already-selected component whose source will be replaced</td></tr><tr><td style="text-align: left;"><code class="inline">base_source_hash</code></td><td style="text-align: left;">Hash of the installed source the candidate was derived from</td></tr><tr><td style="text-align: left;"><code class="inline">source_hash</code></td><td style="text-align: left;">Hash of the candidate source bytes</td></tr><tr><td style="text-align: left;"><code class="inline">path</code></td><td style="text-align: left;">Candidate source path relative to the descriptor directory</td></tr><tr><td style="text-align: left;"><code class="inline">provenance</code></td><td style="text-align: left;">Optional operator assertions about how the candidate was authored</td></tr></tbody></table></div><p>For a mission component, use
 <code class="inline">{&quot;environment&quot;: &quot;mission&quot;, &quot;mission&quot;: &quot;reader&quot;}</code> as the target. The
-candidate path is confined to the descriptor directory. <code class="inline">source_hash</code>
-identifies the candidate bytes; <code class="inline">base_source_hash</code> prevents evaluation against
-a component version from which it was not derived. Dependencies, signatures,
-exports, and capability requirements are checked normally.</p><p>Candidate creation is a trusted build step and is not currently exposed by the
+candidate path is confined to the descriptor directory. PtcRunner verifies
+both hashes before compiling: <code class="inline">source_hash</code> prevents substituted candidate
+bytes, while <code class="inline">base_source_hash</code> rejects a candidate built for a component that
+has since changed. The source is read once, and those verified bytes are the
+bytes compiled.</p><p>An override preserves the selected component's ID and declared dependencies;
+it cannot add a component or change the graph. The replacement still passes
+the normal dependency, signature, export, capability-requirement, and bundle
+checks. The descriptor contains no source, credentials, provider grants, or
+installation instruction.</p><p>Candidate creation is a trusted build step and is not currently exposed by the
 standalone executable. The source-checkout tool for maintainers is documented
 under &quot;Materialize candidate source&quot; in <code class="inline">docs/maintainers/embedding.md</code>, which
 is a repository document rather than a page the executable carries.</p><p>The optional closed <code class="inline">provenance</code> object may contain <code class="inline">run_id</code>, <code class="inline">prompt_hash</code>,
 <code class="inline">authored_at</code>, and <code class="inline">accept_widened_effect</code>. These are operator claims rather
-than proof of origin.</p><p>Run the unchanged baseline and the override with the same replay installation,
+than proof of origin. <code class="inline">mix ptc.materialize</code> writes the candidate and completed
+descriptor as owner-only files and calculates the candidate path and hash from
+the bytes it publishes.</p><p>The active bundle stays immutable for the whole run. A run may author source,
+but only a later host invocation can materialize it and start with the newly
+compiled bundle. Component-override switches are invocation-only and are not
+stored in <code class="inline">ptc-project.json</code>.</p><p>Run the unchanged baseline and the override with the same replay installation,
 inputs, host ceilings, and content snapshots. Compare their values, envelopes,
 usage, and canonical traces. Replay removes model sampling as a variable; it
 does not make external MCP content deterministic unless that content is also

--- a/site/reference/cli/index.html
+++ b/site/reference/cli/index.html
@@ -183,8 +183,10 @@ component without installing it. A trusted build step creates the owner-only
 candidate and descriptor from model-authored source. The
 <a href="/guides/evaluating-with-replay/">replay evaluation guide</a> owns the complete workflow
 for holding model responses fixed, gating effect changes, and comparing a
-baseline with that candidate. Candidate creation is not currently a standalone
-command; the source-checkout tool belongs to the maintainer documentation.</p><h2 id="read-results-and-failures">Read results and failures</h2><p>A successful normal run prints the compact JSON result value. A private run
+baseline with that candidate, and its descriptor reference defines every
+field. Candidate creation is not currently a standalone command; a source
+checkout provides <code class="inline">mix ptc.materialize</code> as documented in the
+<a href="/guides/components-and-preludes/#trial-a-different-core-prompt">core-prompt replacement tutorial</a>.</p><h2 id="read-results-and-failures">Read results and failures</h2><p>A successful normal run prints the compact JSON result value. A private run
 does not print its value. The V2 envelope records the result class, artifact
 states, bounded usage, retained-memory counts, and the closed diagnostic when
 one exists.</p><p>Capability failures normally enter PTC-Lisp as recoverable envelopes so the


### PR DESCRIPTION
## Summary

- add a brief `agent.prompt` replacement tutorial using `mix ptc.materialize`
- document every component override descriptor field and its hash/path guarantees
- clarify transitive override targets, preserved dependencies, project-file limitations, and the immutable-run boundary
- regenerate the affected static site pages

## Verification

- tutorial candidate passed `mix ptc.materialize` against `examples/kernel-tutorial/04-multi-turn-agent/ptc.json`
- `mix test test/ptc_runner/kernel/agent_library_test.exs:3571`
- `MIX_ENV=dev mix docs --warnings-as-errors`
- `mix precommit`
- pre-push documentation and published-link gates