### PR TITLE
perf(kernel): compose compiled prelude artifacts

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -12,6 +12,7 @@ many concurrent multi-turn sessions).
 |---|---|---|
 | `mix bench.check` | Deterministic nightly/release gate for sandbox child eval reductions vs committed baseline; also prints the heap table informationally | custom Mix task |
 | `mix bench.heap` / `heap_baseline.exs` | Heap cost of every embedding unit vs `baselines/heap.json`: idle floor without Mix, `Lisp.run`, `compile_bundle`, `Kernel.run`, concurrency 1..128 | custom Mix task |
+| `prelude_bundle.exs` | Bundle preparation phases, composition vs aggregate recompilation, retained artifacts, 1..128-component scaling, identical/distinct preparations, and a shipped `agent.core` execution-overhead proxy | custom script |
 | `lisp_throughput.exs` | Per-program latency: parse / analyze / full run; per-archetype; latency under `parallel:` load | Benchee |
 | `lisp_profile.exs` | Function-level call_time + call_count, aggregated across the per-run sandbox processes | OTP `:tprof` |
 | `lisp_concurrency.exs` | Aggregate throughput vs concurrency; scheduler microstate; GC pressure | `:msacc` + `:erlang.statistics` |
@@ -23,6 +24,7 @@ mix bench.check                             # gates reductions, reports heap
 mix bench.check --write-baseline --reason "accepted cause"
 mix bench.heap                              # gates heap
 mix run bench/heap_baseline.exs             # reports heap; --write re-records
+mix run bench/prelude_bundle.exs            # PTC_PRELUDE_BENCH_SAMPLES defaults to 7
 mix run bench/lisp_throughput.exs
 mix run bench/lisp_profile.exs              # PROFILE_ITERS env var (default 3000)
 mix run bench/lisp_concurrency.exs

--- a/bench/prelude_bundle.exs
+++ b/bench/prelude_bundle.exs
@@ -1,0 +1,408 @@
+defmodule PtcRunner.Bench.PreludeBundleCharacterization do
+  @moduledoc false
+
+  alias PtcRunner.Bench.Baseline
+  alias PtcRunner.Kernel
+  alias PtcRunner.Kernel.Component
+  alias PtcRunner.Kernel.FrozenBundle
+  alias PtcRunner.Kernel.Library
+  alias PtcRunner.Lisp
+  alias PtcRunner.Lisp.Prelude.Compiler
+
+  @default_samples 7
+  @scale_counts [1, 5, 14, 20, 64, 128]
+
+  def run do
+    samples = positive_env!("PTC_PRELUDE_BENCH_SAMPLES", @default_samples)
+    all = library_components!()
+    agent_core = Library.resolve_components([{:library, "agent.core"}]) |> ok!()
+    mixed = mixed_components!(agent_core)
+
+    IO.puts("PTC-Lisp bundle characterization")
+    IO.puts("samples=#{samples}")
+    IO.inspect(Baseline.provenance(), label: "provenance")
+
+    characterize("all shipped", all, samples)
+    characterize("agent.core closure", agent_core, samples)
+    characterize("mixed shipped/custom/override", mixed, samples)
+    scaling(samples)
+    repeated_preparation(agent_core, samples)
+    execution_proxy(agent_core, samples)
+  end
+
+  defp characterize(label, components, samples) do
+    ordered = order_components!(components)
+    descriptions = describe_components!(ordered)
+    compiled = compile_descriptions!(ordered, descriptions)
+    source = Enum.map_join(ordered, "\n", & &1.source)
+    namespace_deps = namespace_dependencies(compiled)
+    metadata = component_metadata(compiled)
+    composed = Compiler.compose(Enum.map(compiled, & &1.prelude), source, metadata) |> ok!()
+    frozen = frozen_bundle!(compiled, composed, :metadata_only)
+    retained = frozen_bundle!(compiled, composed, :compiled_components)
+
+    phases = [
+      phase("component validation", samples, fn -> validate_components!(components) end),
+      phase("component description", samples, fn -> describe_components!(ordered) end),
+      phase("per-component compilation", samples, fn ->
+        compile_descriptions!(ordered, descriptions)
+      end),
+      phase("aggregate recompilation", samples, fn ->
+        Compiler.compile_unlocated(source, namespace_deps: namespace_deps) |> ok!()
+      end),
+      phase("artifact composition", samples, fn ->
+        Compiler.compose(Enum.map(compiled, & &1.prelude), source, metadata) |> ok!()
+      end),
+      phase("metadata-only sealing", samples, fn ->
+        frozen_bundle!(compiled, composed, :metadata_only)
+      end),
+      phase("callable-component sealing proxy", samples, fn ->
+        frozen_bundle!(compiled, composed, :compiled_components)
+      end),
+      phase("full bundle compilation", samples, fn ->
+        Kernel.compile_bundle(components) |> ok!()
+      end)
+    ]
+
+    IO.puts(
+      "\n#{label} (#{length(components)} components, #{source_bytes(components)} source bytes)"
+    )
+
+    IO.puts("phase | median wall us | median retained process heap bytes | result external bytes")
+
+    Enum.each(phases, fn row ->
+      IO.puts("#{row.name} | #{row.wall_us} | #{row.heap_bytes} | #{row.external_bytes}")
+    end)
+
+    by_name = Map.new(phases, &{&1.name, &1.wall_us})
+
+    legacy_proxy =
+      Enum.sum([
+        by_name["component validation"],
+        by_name["component description"],
+        by_name["per-component compilation"],
+        by_name["aggregate recompilation"],
+        by_name["callable-component sealing proxy"]
+      ])
+
+    composed_proxy =
+      Enum.sum([
+        by_name["component validation"],
+        by_name["component description"],
+        by_name["per-component compilation"],
+        by_name["artifact composition"],
+        by_name["metadata-only sealing"]
+      ])
+
+    IO.puts("phase-sum preparation proxy | wall us")
+    IO.puts("aggregate-recompile/callable-retention proxy | #{legacy_proxy}")
+    IO.puts("composed/metadata-only proxy | #{composed_proxy}")
+
+    IO.puts("artifact | external bytes")
+    IO.puts("aggregate prelude | #{:erlang.external_size(composed)}")
+    IO.puts("metadata-only components | #{:erlang.external_size(frozen.components)}")
+    IO.puts("retained callable components | #{:erlang.external_size(retained.components)}")
+    IO.puts("metadata-only frozen bundle | #{:erlang.external_size(frozen)}")
+    IO.puts("callable-component frozen proxy | #{:erlang.external_size(retained)}")
+  end
+
+  defp scaling(samples) do
+    IO.puts("\nsynthetic component-count scaling")
+    IO.puts("components | source bytes | median full preparation us | external bytes")
+
+    Enum.each(@scale_counts, fn count ->
+      components = synthetic_components(count, 0)
+      row = phase("scale", min(samples, 3), fn -> Kernel.compile_bundle(components) |> ok!() end)
+
+      IO.puts("#{count} | #{source_bytes(components)} | #{row.wall_us} | #{row.external_bytes}")
+    end)
+  end
+
+  defp repeated_preparation(components, samples) do
+    identical =
+      median_wall_us(samples, fn ->
+        Kernel.compile_bundle(components) |> ok!()
+      end)
+
+    distinct =
+      1..samples
+      |> Enum.map(fn revision ->
+        changed = replace_leaf_source(components, revision)
+        wall_us(fn -> Kernel.compile_bundle(changed) |> ok!() end)
+      end)
+      |> Baseline.median()
+
+    IO.puts("\nrepeated preparation")
+    IO.puts("identical bundle median wall us | #{identical}")
+    IO.puts("distinct identity median wall us | #{distinct}")
+    IO.puts("scope | no global cache; both rows exercise ordinary bounded compilation")
+  end
+
+  # This pure call crosses the shipped agent.core closure and evaluator without
+  # provider/model latency. It is an execution-overhead proxy, not a claim to
+  # reproduce an external model turn; compare it with real replay telemetry
+  # before considering a second execution backend.
+  defp execution_proxy(components, samples) do
+    bundle = Kernel.compile_bundle(components) |> ok!()
+
+    tools =
+      bundle.prelude.exports
+      |> Enum.flat_map(& &1.requires)
+      |> Enum.map(&String.replace_prefix(&1, "tool:", ""))
+      |> Enum.uniq()
+      |> Map.new(&{&1, fn _arguments -> nil end})
+
+    wall =
+      median_wall_us(samples, fn ->
+        Lisp.run("(agent.feedback/turn-budget 4 2)", prelude: bundle.prelude, tools: tools)
+        |> ok!()
+      end)
+
+    IO.puts("\nagent.core execution proxy")
+    IO.puts("pure shipped closure median wall us | #{wall}")
+  end
+
+  defp phase(name, samples, fun) do
+    fun.()
+
+    measurements =
+      for _sample <- 1..samples do
+        measured_process(fun)
+      end
+
+    %{
+      name: name,
+      wall_us: measurements |> Enum.map(& &1.wall_us) |> Baseline.median(),
+      heap_bytes: measurements |> Enum.map(& &1.heap_bytes) |> Baseline.median(),
+      external_bytes: measurements |> Enum.map(& &1.external_bytes) |> Baseline.median()
+    }
+  end
+
+  defp measured_process(fun) do
+    caller = self()
+
+    {pid, monitor} =
+      spawn_monitor(fn ->
+        {:memory, before_bytes} = Process.info(self(), :memory)
+        started = System.monotonic_time()
+        result = fun.()
+        elapsed = System.monotonic_time() - started
+        {:memory, after_bytes} = Process.info(self(), :memory)
+
+        send(caller, {
+          self(),
+          %{
+            wall_us: System.convert_time_unit(elapsed, :native, :microsecond),
+            heap_bytes: max(after_bytes - before_bytes, 0),
+            external_bytes: :erlang.external_size(result)
+          }
+        })
+      end)
+
+    receive do
+      {^pid, measurement} ->
+        receive do
+          {:DOWN, ^monitor, :process, ^pid, :normal} ->
+            measurement
+
+          {:DOWN, ^monitor, :process, ^pid, reason} ->
+            raise "benchmark worker failed: #{inspect(reason)}"
+        end
+
+      {:DOWN, ^monitor, :process, ^pid, reason} ->
+        raise "benchmark worker exited before reporting: #{inspect(reason)}"
+    end
+  end
+
+  defp validate_components!(components) do
+    Enum.map(components, fn component ->
+      Component.new(
+        id: component.id,
+        source: component.source,
+        dependencies: component.dependencies,
+        origin: component.origin
+      )
+      |> ok!()
+    end)
+  end
+
+  defp describe_components!(ordered) do
+    Map.new(ordered, fn component ->
+      {component.id, Compiler.describe_unlocated(component.source) |> ok!()}
+    end)
+  end
+
+  defp compile_descriptions!(ordered, descriptions) do
+    Enum.reduce(ordered, [], fn component, compiled ->
+      dependencies = Enum.filter(compiled, &(&1.id in component.dependencies))
+      namespaces = Map.fetch!(descriptions, component.id).namespaces
+
+      dependency_namespaces =
+        dependencies |> Enum.flat_map(& &1.namespaces) |> Enum.uniq() |> Enum.sort()
+
+      namespace_deps = Map.new(namespaces, &{&1, dependency_namespaces})
+
+      prelude =
+        Compiler.compile_description(Map.fetch!(descriptions, component.id),
+          deps: Enum.map(dependencies, & &1.prelude),
+          namespace_deps: namespace_deps
+        )
+        |> ok!()
+
+      compiled ++
+        [
+          %{
+            id: component.id,
+            dependencies: component.dependencies,
+            origin: component.origin,
+            source_hash: hash(component.source),
+            namespaces: namespaces,
+            prelude: prelude
+          }
+        ]
+    end)
+  end
+
+  defp frozen_bundle!(compiled, prelude, retention) do
+    components =
+      case retention do
+        :metadata_only -> Enum.map(compiled, &Map.delete(&1, :prelude))
+        :compiled_components -> compiled
+      end
+
+    hash = FrozenBundle.identity(components) |> ok!()
+
+    %FrozenBundle{
+      components: components,
+      component_ids: Enum.map(components, & &1.id),
+      hash: hash,
+      prelude: prelude
+    }
+    |> FrozenBundle.seal()
+  end
+
+  defp namespace_dependencies(compiled) do
+    by_id = Map.new(compiled, &{&1.id, &1})
+
+    compiled
+    |> Enum.flat_map(fn component ->
+      dependencies =
+        component.dependencies
+        |> Enum.flat_map(&Map.fetch!(by_id, &1).namespaces)
+        |> Enum.uniq()
+        |> Enum.sort()
+
+      Enum.map(component.namespaces, &{&1, dependencies})
+    end)
+    |> Map.new()
+  end
+
+  defp component_metadata(compiled),
+    do: Enum.map(compiled, &Map.take(&1, [:id, :origin, :source_hash, :namespaces]))
+
+  defp order_components!(components), do: order_components!(components, MapSet.new(), [])
+
+  defp order_components!(components, resolved, ordered) do
+    if length(ordered) == length(components) do
+      Enum.reverse(ordered)
+    else
+      ready =
+        components
+        |> Enum.reject(&MapSet.member?(resolved, &1.id))
+        |> Enum.filter(&Enum.all?(&1.dependencies, fn id -> MapSet.member?(resolved, id) end))
+        |> Enum.sort_by(& &1.id)
+
+      case ready do
+        [component | _rest] ->
+          order_components!(components, MapSet.put(resolved, component.id), [component | ordered])
+
+        [] ->
+          raise "benchmark components are not a closed acyclic graph"
+      end
+    end
+  end
+
+  defp library_components!, do: Library.components(Library.component_ids()) |> ok!()
+
+  defp mixed_components!(agent_core) do
+    overridden =
+      Enum.map(agent_core, fn
+        %Component{id: "agent.prompt"} = component ->
+          %{
+            component
+            | source: component.source <> "\n;; benchmark override\n",
+              origin: "benchmark:override"
+          }
+
+        component ->
+          component
+      end)
+
+    custom =
+      Component.new(
+        id: "bench.custom",
+        dependencies: ["agent.core"],
+        origin: "benchmark:custom",
+        source: "(ns bench.custom) (defn answer [] 42)"
+      )
+      |> ok!()
+
+    [custom | overridden]
+  end
+
+  defp synthetic_components(count, revision) do
+    Enum.map(1..count, fn index ->
+      id = "synthetic.#{index}"
+
+      Component.new(
+        id: id,
+        origin: "benchmark:synthetic",
+        source: "(ns #{id}) (defn value [] #{index + revision})"
+      )
+      |> ok!()
+    end)
+  end
+
+  defp replace_leaf_source(components, revision) do
+    leaf = components |> Enum.filter(&(&1.dependencies == [])) |> Enum.min_by(& &1.id)
+
+    Enum.map(components, fn
+      %Component{id: id} = component when id == leaf.id ->
+        %{component | source: component.source <> "\n;; identity #{revision}\n"}
+
+      component ->
+        component
+    end)
+  end
+
+  defp median_wall_us(samples, fun) do
+    fun.()
+    1..samples |> Enum.map(fn _sample -> wall_us(fun) end) |> Baseline.median()
+  end
+
+  defp wall_us(fun) do
+    started = System.monotonic_time()
+    fun.()
+    System.convert_time_unit(System.monotonic_time() - started, :native, :microsecond)
+  end
+
+  defp source_bytes(components), do: Enum.sum(Enum.map(components, &byte_size(&1.source)))
+  defp hash(source), do: :crypto.hash(:sha256, source) |> Base.encode16(case: :lower)
+  defp ok!({:ok, value}), do: value
+  defp ok!({:error, reason}), do: raise("benchmark operation failed: #{inspect(reason)}")
+
+  defp positive_env!(name, default) do
+    case System.get_env(name) do
+      nil ->
+        default
+
+      value ->
+        case Integer.parse(value) do
+          {integer, ""} when integer > 0 -> integer
+          _invalid -> raise "#{name} must be a positive integer"
+        end
+    end
+  end
+end
+
+PtcRunner.Bench.PreludeBundleCharacterization.run()

--- a/docs/maintainers/kernel.md
+++ b/docs/maintainers/kernel.md
@@ -187,6 +187,21 @@ forms through ordinary `Evaluation` rather than the workflow evaluator.
 graph into a `FrozenBundle`. Compilation records public exports and transitive
 `tool:*` requirements but grants no capability.
 
+Each source is parsed once into a compiler description, then compiled in
+dependency order against only its declared namespace scope. The bundle
+compiler rejects namespace collisions explicitly and composes those validated
+Core artifacts into the aggregate prelude; it does not recompile concatenated
+source. `FrozenBundle.components` retains only each component's ID, direct
+dependencies, origin, source hash, and namespaces. Callable per-component
+preludes exist only during bounded compilation, so bundle attestation does not
+serialize a duplicate callable graph.
+
+Within one `RunCoordinator.prepare/2` or direct provider-bearing build,
+byte-identical normalized workflow and mission component sets reuse the same
+sealed bundle. This reuse is local to that preparation: there is no process,
+ETS table, `persistent_term`, or cross-preparation cache, and a cache hit grants
+no authority.
+
 Compiler-rendered strings do not cross the command boundary. Prelude analysis
 represents an unknown namespace as bounded structured detail: the rejected
 namespace plus the canonical sorted list owned by the Lisp namespace diagnostic

--- a/lib/ptc_runner/kernel/bundle_compiler.ex
+++ b/lib/ptc_runner/kernel/bundle_compiler.ex
@@ -3,15 +3,14 @@ defmodule PtcRunner.Kernel.BundleCompiler do
   Internal implementation of `PtcRunner.Kernel.compile_bundle/1`.
 
   It bounds the closed component set, resolves its component-ID dependency DAG
-  deterministically, compiles the combined prelude in a bounded worker, limits
-  diagnostics and artifact size, and seals the resulting bundle.
+  deterministically, composes the validated component preludes in a bounded
+  worker, limits diagnostics and artifact size, and seals the resulting bundle.
   """
 
   alias PtcRunner.Kernel.BoundedWorker
   alias PtcRunner.Kernel.CompileDiagnostic
   alias PtcRunner.Kernel.Component
   alias PtcRunner.Kernel.FrozenBundle
-  alias PtcRunner.Lisp.Parser
   alias PtcRunner.Lisp.Prelude.Compiler
   alias PtcRunner.Lisp.Prelude.ErrorSpan
   alias PtcRunner.Lisp.Prelude.ValidationError
@@ -39,23 +38,26 @@ defmodule PtcRunner.Kernel.BundleCompiler do
   def compile(_components), do: {:error, %{reason: :invalid_components}}
 
   @doc false
-  @spec compile_named(map(), integer(), non_neg_integer(), pos_integer()) ::
+  @spec compile_named(map(), integer(), non_neg_integer(), pos_integer(), [tuple()]) ::
           {:ok, map()} | {:error, {map(), [Component.t()]}}
-  def compile_named(missions, deadline_ms, initial_bytes, max_bytes)
+  def compile_named(missions, deadline_ms, initial_bytes, max_bytes, reusable)
       when is_map(missions) and is_integer(deadline_ms) and is_integer(initial_bytes) and
-             initial_bytes >= 0 and is_integer(max_bytes) and max_bytes > 0 do
+             initial_bytes >= 0 and is_integer(max_bytes) and max_bytes > 0 and
+             is_list(reusable) do
+    cache = reusable_cache(reusable)
+
     Enum.reduce_while(
       missions |> Enum.sort_by(&elem(&1, 0)),
-      {:ok, %{}, initial_bytes},
-      fn {name, %{components: components}}, {:ok, bundles, bytes} ->
-        result = if components == [], do: {:ok, nil}, else: compile(components, deadline_ms)
+      {:ok, %{}, initial_bytes, cache},
+      fn {name, %{components: components}}, {:ok, bundles, bytes, compiled_cache} ->
+        result = compile_reusing(components, deadline_ms, compiled_cache)
 
         case result do
-          {:ok, bundle} ->
+          {:ok, bundle, next_cache} ->
             next_bytes = bytes + if(is_nil(bundle), do: 0, else: :erlang.external_size(bundle))
 
             if next_bytes <= max_bytes,
-              do: {:cont, {:ok, Map.put(bundles, name, bundle), next_bytes}},
+              do: {:cont, {:ok, Map.put(bundles, name, bundle), next_bytes, next_cache}},
               else: {:halt, {:error, {%{reason: :bundle_limit_exceeded}, components}}}
 
           {:error, failure} ->
@@ -64,10 +66,56 @@ defmodule PtcRunner.Kernel.BundleCompiler do
       end
     )
     |> case do
-      {:ok, bundles, _bytes} -> {:ok, bundles}
+      {:ok, bundles, _bytes, _cache} -> {:ok, bundles}
       {:error, {_failure, _components}} = error -> error
     end
   end
+
+  defp reusable_cache(reusable) do
+    Enum.reduce(reusable, %{}, fn
+      {components, %FrozenBundle{} = bundle}, cache ->
+        case component_cache_key(components) do
+          nil -> cache
+          key -> Map.put(cache, key, bundle)
+        end
+
+      _invalid, cache ->
+        cache
+    end)
+  end
+
+  defp compile_reusing([], _deadline_ms, cache), do: {:ok, nil, cache}
+
+  defp compile_reusing(components, deadline_ms, cache) do
+    if deadline_ms <= System.monotonic_time(:millisecond) do
+      {:error, %{reason: :bundle_compile_timeout}}
+    else
+      compile_reusing_before_deadline(components, deadline_ms, cache)
+    end
+  end
+
+  defp compile_reusing_before_deadline(components, deadline_ms, cache) do
+    key = component_cache_key(components)
+
+    case Map.fetch(cache, key) do
+      {:ok, bundle} ->
+        {:ok, bundle, cache}
+
+      :error ->
+        case compile(components, deadline_ms) do
+          {:ok, bundle} -> {:ok, bundle, Map.put(cache, key, bundle)}
+          {:error, _failure} = error -> error
+        end
+    end
+  end
+
+  defp component_cache_key(components) when is_list(components) do
+    if Enum.all?(components, &match?(%Component{}, &1)),
+      do: Enum.sort_by(components, & &1.id),
+      else: nil
+  end
+
+  defp component_cache_key(_components), do: nil
 
   @doc false
   def compile(components, deadline_ms) when is_list(components) and is_integer(deadline_ms) do
@@ -109,10 +157,11 @@ defmodule PtcRunner.Kernel.BundleCompiler do
          {:ok, ordered} <- topological_order(by_id),
          {:ok, compiled} <- describe_ordered(ordered),
          {:ok, prelude} <- compile_prelude(ordered, compiled),
-         {:ok, hash} <- FrozenBundle.identity(compiled) do
+         frozen_components = Enum.map(compiled, &Map.delete(&1, :prelude)),
+         {:ok, hash} <- FrozenBundle.identity(frozen_components) do
       bundle = %FrozenBundle{
-        components: compiled,
-        component_ids: Enum.map(compiled, & &1.id),
+        components: frozen_components,
+        component_ids: Enum.map(frozen_components, & &1.id),
         hash: hash,
         prelude: prelude
       }
@@ -247,12 +296,13 @@ defmodule PtcRunner.Kernel.BundleCompiler do
 
   defp describe_ordered(components) do
     Enum.reduce_while(components, {:ok, []}, fn component, {:ok, compiled} ->
-      with {:ok, namespaces} <- component_namespaces(component.source),
+      with {:ok, description} <- Compiler.describe_unlocated(component.source),
+           namespaces = description.namespaces,
            dependencies = dependency_components(compiled, component.dependencies),
            namespace_deps =
              Map.new(namespaces, &{&1, dependency_namespaces(dependencies)}),
            {:ok, prelude} <-
-             Compiler.compile_unlocated(component.source,
+             Compiler.compile_description(description,
                deps: Enum.map(dependencies, & &1.prelude),
                namespace_deps: namespace_deps
              ) do
@@ -300,18 +350,19 @@ defmodule PtcRunner.Kernel.BundleCompiler do
   end
 
   defp compile_prelude(components, compiled) do
-    namespace_deps = namespace_dependencies(compiled)
     source = Enum.map_join(components, "\n", & &1.source)
 
-    Compiler.compile_unlocated(source, namespace_deps: namespace_deps)
+    metadata =
+      Enum.map(compiled, fn component ->
+        Map.take(component, [:id, :origin, :source_hash, :namespaces])
+      end)
+
+    compiled
+    |> Enum.map(& &1.prelude)
+    |> Compiler.compose(source, metadata)
     |> case do
       {:ok, prelude} ->
-        metadata =
-          Enum.map(compiled, fn component ->
-            Map.take(component, [:id, :origin, :source_hash, :namespaces])
-          end)
-
-        {:ok, %{prelude | metadata: Map.put(prelude.metadata, :components, metadata)}}
+        {:ok, prelude}
 
       {:error, error} ->
         {:error,
@@ -323,57 +374,11 @@ defmodule PtcRunner.Kernel.BundleCompiler do
     end
   end
 
-  defp namespace_dependencies(components) do
-    by_id = Map.new(components, &{&1.id, &1})
-
-    components
-    |> Enum.flat_map(fn component ->
-      dependency_namespaces =
-        component.dependencies
-        |> Enum.flat_map(&Map.fetch!(by_id, &1).namespaces)
-        |> Enum.uniq()
-        |> Enum.sort()
-
-      Enum.map(component.namespaces, &{&1, dependency_namespaces})
-    end)
-    |> Map.new()
-  end
-
-  defp component_namespaces(source) do
-    case Parser.parse_with_position(source) do
-      {:ok, ast} ->
-        namespaces = ast |> top_level_forms() |> Enum.flat_map(&namespace_form/1) |> Enum.uniq()
-
-        if namespaces == [],
-          do: {:error, "component declares no namespace"},
-          else: {:ok, namespaces}
-
-      {:error, {:parse_error, message, position}} ->
-        {:error, ValidationError.new(:parse_error, message, span: parse_position_span(position))}
-    end
-  end
-
-  defp parse_position_span(position) when is_integer(position) and position >= 0,
-    do: {position, 0}
-
-  defp parse_position_span(_position), do: nil
-
-  defp top_level_forms({:program, forms}), do: forms
-  defp top_level_forms(form), do: [form]
-
-  defp namespace_form({:list, [{:symbol, name}, {:symbol, namespace} | _metadata]})
-       when name in [:ns, "ns"],
-       do: [to_string(namespace)]
-
-  defp namespace_form(_form), do: []
-
   defp source_hash(source),
     do: :crypto.hash(:sha256, source) |> Base.encode16(case: :lower)
 
   defp error_message(%{message: message}) when is_binary(message),
     do: String.slice(message, 0, 4_096)
-
-  defp error_message(error), do: inspect(error, limit: 10, printable_limit: 4_096)
 
   # Only reasons with fixed, catalog-owned public projections cross the bundle
   # boundary. Every other compiler reason deliberately retains the generic
@@ -390,8 +395,6 @@ defmodule PtcRunner.Kernel.BundleCompiler do
       :error -> nil
     end
   end
-
-  defp compile_details(_error), do: nil
 
   # The locator crosses the diagnostic-size gate before being consumed. Strip
   # the source-derived message and bound the remaining namespace/ref strings so
@@ -412,8 +415,6 @@ defmodule PtcRunner.Kernel.BundleCompiler do
         nil
     end
   end
-
-  defp span_locator(_error), do: nil
 
   # Span attribution is optional diagnostic work, so it runs only after the
   # bounded compilation result is final. A costly scan can therefore lose its

--- a/lib/ptc_runner/kernel/frozen_bundle.ex
+++ b/lib/ptc_runner/kernel/frozen_bundle.ex
@@ -2,10 +2,13 @@ defmodule PtcRunner.Kernel.FrozenBundle do
   @moduledoc """
   An immutable, deterministically ordered component compilation result.
 
-  Bundles contain compiled component metadata, ordered component IDs, an
-  aggregate graph hash, and the compiled PTC-Lisp prelude. The graph hash is
-  bare lowercase SHA-256 over the canonical `ptc.frozen-bundle.v2` framing of
-  every component ID, source hash, and sorted unique direct dependency list.
+  Bundles contain bounded component provenance (`id`, direct dependencies,
+  origin, source hash, and namespaces), ordered component IDs, an aggregate
+  graph hash, and one composed compiled PTC-Lisp prelude. Per-component
+  callable preludes are transient compiler inputs and are not retained. The
+  graph hash is bare lowercase SHA-256 over the canonical
+  `ptc.frozen-bundle.v2` framing of every component ID, source hash, and sorted
+  unique direct dependency list.
   It therefore changes when code or dependency edges change and does not
   depend on Erlang external-term encoding.
 

--- a/lib/ptc_runner/kernel/run_builder.ex
+++ b/lib/ptc_runner/kernel/run_builder.ex
@@ -766,7 +766,9 @@ defmodule PtcRunner.Kernel.RunBuilder do
            mission_bundles(
              request.package.missions,
              deadline,
-             :erlang.external_size(workflow_bundle)
+             :erlang.external_size(workflow_bundle),
+             request.package.workflow_components,
+             workflow_bundle
            ),
          :ok <- RunCoordinator.validate_entry(workflow_bundle, request.package.entry),
          :ok <-
@@ -862,8 +864,14 @@ defmodule PtcRunner.Kernel.RunBuilder do
     end)
   end
 
-  defp mission_bundles(missions, deadline, initial_bytes) do
-    case BundleCompiler.compile_named(missions, deadline, initial_bytes, 4_000_000) do
+  defp mission_bundles(missions, deadline, initial_bytes, workflow_components, workflow_bundle) do
+    case BundleCompiler.compile_named(
+           missions,
+           deadline,
+           initial_bytes,
+           4_000_000,
+           [{workflow_components, workflow_bundle}]
+         ) do
       {:ok, bundles} -> {:ok, bundles}
       {:error, {_failure, _components}} -> {:error, :invalid_mission_bundle}
     end

--- a/lib/ptc_runner/kernel/run_coordinator.ex
+++ b/lib/ptc_runner/kernel/run_coordinator.ex
@@ -56,7 +56,9 @@ defmodule PtcRunner.Kernel.RunCoordinator do
            compile_named_missions(
              request.package.missions,
              compile_deadline,
-             external_size(workflow_bundle)
+             external_size(workflow_bundle),
+             request.package.workflow_components,
+             workflow_bundle
            ),
          :ok <- validate_entry(workflow_bundle, request.package.entry),
          :ok <-
@@ -364,12 +366,19 @@ defmodule PtcRunner.Kernel.RunCoordinator do
     end
   end
 
-  defp compile_named_missions(missions, deadline_ms, initial_bytes) do
+  defp compile_named_missions(
+         missions,
+         deadline_ms,
+         initial_bytes,
+         workflow_components,
+         workflow_bundle
+       ) do
     case BundleCompiler.compile_named(
            missions,
            deadline_ms,
            initial_bytes,
-           @mission_bundles_bytes
+           @mission_bundles_bytes,
+           [{workflow_components, workflow_bundle}]
          ) do
       {:ok, bundles} -> {:ok, bundles}
       {:error, {failure, components}} -> {:error, bundle_diagnostic(failure, components)}

--- a/lib/ptc_runner/lisp/analyze/conditionals.ex
+++ b/lib/ptc_runner/lisp/analyze/conditionals.ex
@@ -626,6 +626,10 @@ defmodule PtcRunner.Lisp.Analyze.Conditionals do
 
   defp gensym(prefix) do
     n = :erlang.unique_integer([:positive])
-    {:var, :"__#{prefix}_#{n}"}
+
+    # The leading NUL cannot be authored as a PTC-Lisp identifier, so an
+    # internal temporary cannot shadow or be shadowed by source even though
+    # Core variable names intentionally support binaries.
+    {:var, IO.iodata_to_binary([<<0>>, "__ptc_", prefix, "_", Integer.to_string(n)])}
   end
 end

--- a/lib/ptc_runner/lisp/core_to_source.ex
+++ b/lib/ptc_runner/lisp/core_to_source.ex
@@ -37,6 +37,8 @@ defmodule PtcRunner.Lisp.CoreToSource do
     :prelude_ref,
     :prelude_tool_refs
   ]
+  @internal_temporary_prefix <<0, "__ptc_">>
+  @serialized_temporary_prefix "__ptc_serialized_"
 
   @doc """
   Convert a Core AST node to a PTC-Lisp source string.
@@ -53,190 +55,193 @@ defmodule PtcRunner.Lisp.CoreToSource do
       "(+ 1 2)"
   """
   @spec format(term()) :: String.t()
+  def format(value), do: value |> encode_internal_temporaries() |> do_format()
+
+  @spec do_format(term()) :: String.t()
 
   # Literals
-  def format(nil), do: "nil"
-  def format(true), do: "true"
-  def format(false), do: "false"
-  def format(n) when is_integer(n), do: Integer.to_string(n)
+  defp do_format(nil), do: "nil"
+  defp do_format(true), do: "true"
+  defp do_format(false), do: "false"
+  defp do_format(n) when is_integer(n), do: Integer.to_string(n)
 
-  def format(n) when is_float(n) do
+  defp do_format(n) when is_float(n) do
     :erlang.float_to_binary(n, [:short])
   end
 
-  def format(:infinity), do: "##Inf"
-  def format(:negative_infinity), do: "##-Inf"
-  def format(:nan), do: "##NaN"
-  def format(keyword) when is_atom(keyword), do: ":#{keyword}"
+  defp do_format(:infinity), do: "##Inf"
+  defp do_format(:negative_infinity), do: "##-Inf"
+  defp do_format(:nan), do: "##NaN"
+  defp do_format(keyword) when is_atom(keyword), do: ":#{keyword}"
 
-  def format({:string, s}), do: ~s("#{escape_string(s)}")
-  def format({:keyword, k}), do: ":#{k}"
+  defp do_format({:string, s}), do: ~s("#{escape_string(s)}")
+  defp do_format({:keyword, k}), do: ":#{k}"
 
   # Delegate {:literal, v} to Formatter (used for compile-time constants)
-  def format({:literal, v}), do: Formatter.format(v)
+  defp do_format({:literal, v}), do: Formatter.format(v)
 
   # Raw runtime values (from step.memory, not Core AST)
-  def format(%LispKeyword{name: name} = keyword) do
+  defp do_format(%LispKeyword{name: name} = keyword) do
     if LispKeyword.valid?(keyword), do: ":#{name}", else: raise(ArgumentError, "invalid keyword")
   end
 
-  def format(%SymbolRef{name: name} = symbol_ref) do
+  defp do_format(%SymbolRef{name: name} = symbol_ref) do
     if SymbolRef.valid?(symbol_ref),
       do: "'#{name}",
       else: raise(ArgumentError, "invalid symbol reference")
   end
 
-  def format(s) when is_binary(s), do: ~s("#{escape_string(s)}")
-  def format(list) when is_list(list), do: "[#{format_list(list)}]"
+  defp do_format(s) when is_binary(s), do: ~s("#{escape_string(s)}")
+  defp do_format(list) when is_list(list), do: "[#{format_list(list)}]"
 
-  def format(%MapSet{map: map}) when is_map(map),
+  defp do_format(%MapSet{map: map}) when is_map(map),
     do: "\#{#{map |> Map.keys() |> format_list()}}"
 
-  def format(map) when is_map(map) and not is_struct(map) do
+  defp do_format(map) when is_map(map) and not is_struct(map) do
     inner =
-      Enum.map_join(map, " ", fn {k, v} -> "#{format_map_key(k)} #{format(v)}" end)
+      Enum.map_join(map, " ", fn {k, v} -> "#{format_map_key(k)} #{do_format(v)}" end)
 
     "{#{inner}}"
   end
 
   # Variables and data access
-  def format({:var, name}), do: to_string(name)
-  def format({:symbol_ref, name}) when is_binary(name), do: "'#{name}"
-  def format({:data, key}), do: "data/#{key}"
-  def format({:runtime_callable, namespace, name}), do: "#{namespace}/#{name}"
-  def format({:prelude_ref, ref}), do: ref
+  defp do_format({:var, name}), do: to_string(name)
+  defp do_format({:symbol_ref, name}) when is_binary(name), do: "'#{name}"
+  defp do_format({:data, key}), do: "data/#{key}"
+  defp do_format({:runtime_callable, namespace, name}), do: "#{namespace}/#{name}"
+  defp do_format({:prelude_ref, ref}), do: ref
 
-  def format({:prelude_call, ref, arguments}) do
+  defp do_format({:prelude_call, ref, arguments}) do
     "(#{ref} #{format_list(arguments)})"
   end
 
-  def format({:java_ref, reference_id}), do: java_reference_source(reference_id)
-  def format({:java_field, reference_id}), do: java_reference_source(reference_id)
+  defp do_format({:java_ref, reference_id}), do: java_reference_source(reference_id)
+  defp do_format({:java_field, reference_id}), do: java_reference_source(reference_id)
 
-  def format({tag, reference_id, arguments}) when tag in [:java_static, :java_new] do
+  defp do_format({tag, reference_id, arguments}) when tag in [:java_static, :java_new] do
     "(#{java_reference_source(reference_id)} #{format_list(arguments)})"
   end
 
-  def format({:java_instance, reference_id, receiver, arguments}) do
+  defp do_format({:java_instance, reference_id, receiver, arguments}) do
     {:ok, reference} = JavaSurface.fetch_reference(reference_id)
     {:ok, class} = JavaSurface.fetch_class(reference.class_id)
     "(#{class.name}/#{reference.member} #{format_list([receiver | arguments])})"
   end
 
-  def format({:java_dot, member_family_id, receiver, arguments}) do
+  defp do_format({:java_dot, member_family_id, receiver, arguments}) do
     {:ok, source} = JavaSurface.member_family_source(member_family_id)
     "(#{source} #{format_list([receiver | arguments])})"
   end
 
   # Collections
-  def format({:vector, elems}) do
+  defp do_format({:vector, elems}) do
     "[#{format_list(elems)}]"
   end
 
-  def format({:map, pairs}) do
+  defp do_format({:map, pairs}) do
     inner =
-      Enum.map_join(pairs, " ", fn {k, v} -> "#{format(k)} #{format(v)}" end)
+      Enum.map_join(pairs, " ", fn {k, v} -> "#{do_format(k)} #{do_format(v)}" end)
 
     "{#{inner}}"
   end
 
-  def format({:set, elems}) do
+  defp do_format({:set, elems}) do
     "\#{#{format_list(elems)}}"
   end
 
   # Let bindings
-  def format({:let, bindings, body}) do
+  defp do_format({:let, bindings, body}) do
     bindings_str =
       Enum.map_join(bindings, " ", fn {:binding, pattern, value} ->
-        "#{format_pattern(pattern)} #{format(value)}"
+        "#{format_pattern(pattern)} #{do_format(value)}"
       end)
 
-    "(let [#{bindings_str}] #{format(body)})"
+    "(let [#{bindings_str}] #{do_format(body)})"
   end
 
   # Anonymous function
-  def format({:fn, params, body}) do
-    "(fn [#{format_params(params)}] #{format(body)})"
+  defp do_format({:fn, params, body}) do
+    "(fn [#{format_params(params)}] #{do_format(body)})"
   end
 
-  def format({:fn, name, params, body}) do
-    "(fn #{name} [#{format_params(params)}] #{format(body)})"
+  defp do_format({:fn, name, params, body}) do
+    "(fn #{name} [#{format_params(params)}] #{do_format(body)})"
   end
 
   # Loop with tail recursion
-  def format({:loop, bindings, body}) do
+  defp do_format({:loop, bindings, body}) do
     bindings_str =
       Enum.map_join(bindings, " ", fn {:binding, pattern, value} ->
-        "#{format_pattern(pattern)} #{format(value)}"
+        "#{format_pattern(pattern)} #{do_format(value)}"
       end)
 
-    "(loop [#{bindings_str}] #{format(body)})"
+    "(loop [#{bindings_str}] #{do_format(body)})"
   end
 
   # Function call
-  def format({:call, {:var, name}, args}) do
+  defp do_format({:call, {:var, name}, args}) do
     "(#{name} #{format_list(args)})"
   end
 
-  def format({:call, target, args}) do
-    "(#{format(target)} #{format_list(args)})"
+  defp do_format({:call, target, args}) do
+    "(#{do_format(target)} #{format_list(args)})"
   end
 
   # Tool call
-  def format({:tool_call, name, args}) do
+  defp do_format({:tool_call, name, args}) do
     "(tool/#{name} #{format_list(args)})"
   end
 
   # Definitions retain the only source-representable metadata: a docstring.
-  def format({tag, name, value, metadata}) when tag in [:def, :defonce] do
-    "(#{tag} #{name}#{definition_metadata_source!(metadata)} #{format(value)})"
+  defp do_format({tag, name, value, metadata}) when tag in [:def, :defonce] do
+    "(#{tag} #{name}#{definition_metadata_source!(metadata)} #{do_format(value)})"
   end
 
   # Control flow
-  def format({:if, condition, then_branch, else_branch}) do
-    "(if #{format(condition)} #{format(then_branch)} #{format(else_branch)})"
+  defp do_format({:if, condition, then_branch, else_branch}) do
+    "(if #{do_format(condition)} #{do_format(then_branch)} #{do_format(else_branch)})"
   end
 
-  def format({:do, exprs}) do
+  defp do_format({:do, exprs}) do
     "(do #{format_list(exprs)})"
   end
 
-  def format({:and, exprs}) do
+  defp do_format({:and, exprs}) do
     "(and #{format_list(exprs)})"
   end
 
-  def format({:or, exprs}) do
+  defp do_format({:or, exprs}) do
     "(or #{format_list(exprs)})"
   end
 
   # Control signals
-  def format({:return, value}) do
-    "(return #{format(value)})"
+  defp do_format({:return, value}) do
+    "(return #{do_format(value)})"
   end
 
-  def format({:fail, value}) do
-    "(fail #{format(value)})"
+  defp do_format({:fail, value}) do
+    "(fail #{do_format(value)})"
   end
 
   # Recur
-  def format({:recur, args}) do
+  defp do_format({:recur, args}) do
     "(recur #{format_list(args)})"
   end
 
   # Turn history
-  def format({:turn_history, n}) when n in 1..3, do: "*#{n}"
+  defp do_format({:turn_history, n}) when n in 1..3, do: "*#{n}"
 
   # Parallel operations
-  def format({:pmap, fn_expr, coll_exprs}) do
-    "(pmap #{format(fn_expr)} #{format_list(coll_exprs)})"
+  defp do_format({:pmap, fn_expr, coll_exprs}) do
+    "(pmap #{do_format(fn_expr)} #{format_list(coll_exprs)})"
   end
 
-  def format({:pcalls, fn_exprs}) do
+  defp do_format({:pcalls, fn_exprs}) do
     "(pcalls #{format_list(fn_exprs)})"
   end
 
   # Juxt
-  def format({:juxt, fns}) do
+  defp do_format({:juxt, fns}) do
     "(juxt #{format_list(fns)})"
   end
 
@@ -398,18 +403,24 @@ defmodule PtcRunner.Lisp.CoreToSource do
        when is_map(metadata) do
     semantic_metadata = Enum.filter(@prelude_semantic_metadata, &Map.has_key?(metadata, &1))
 
-    cond do
-      Map.has_key?(metadata, :prelude_ref) ->
-        {:ok, {:prelude_ref, Map.fetch!(metadata, :prelude_ref)}}
+    result =
+      cond do
+        Map.has_key?(metadata, :prelude_ref) ->
+          {:ok, {:prelude_ref, Map.fetch!(metadata, :prelude_ref)}}
 
-      semantic_metadata != [] ->
-        {:error, {:non_exportable_closure_metadata, path, Enum.sort(semantic_metadata)}}
+        semantic_metadata != [] ->
+          {:error, {:non_exportable_closure_metadata, path, Enum.sort(semantic_metadata)}}
 
-      Map.has_key?(metadata, :fn_name) ->
-        {:ok, {:fn, Map.fetch!(metadata, :fn_name), params, body}}
+        Map.has_key?(metadata, :fn_name) ->
+          {:ok, {:fn, Map.fetch!(metadata, :fn_name), params, body}}
 
-      true ->
-        {:ok, {:fn, params, body}}
+        true ->
+          {:ok, {:fn, params, body}}
+      end
+
+    case result do
+      {:ok, source_ast} -> {:ok, encode_internal_temporaries(source_ast)}
+      {:error, _reason} = error -> error
     end
   end
 
@@ -456,13 +467,13 @@ defmodule PtcRunner.Lisp.CoreToSource do
 
   defp definition_metadata_source!(%{docstring: docstring} = metadata)
        when map_size(metadata) == 1 and is_binary(docstring),
-       do: " " <> format({:string, docstring})
+       do: " " <> do_format({:string, docstring})
 
   defp definition_metadata_source!(_metadata),
     do: raise(ArgumentError, "definition metadata has no lossless source form")
 
   defp safe_format(value, path) do
-    {:ok, format(value)}
+    {:ok, do_format(value)}
   rescue
     _exception -> {:error, {:non_exportable_source_value, path, value}}
   end
@@ -840,12 +851,88 @@ defmodule PtcRunner.Lisp.CoreToSource do
        ),
        do: find_source_name(source_ast, path)
 
-  defp find_valid_closure_source_name(source_ast, closure, params, body, path) do
+  defp find_valid_closure_source_name(source_ast, closure, _params, _body, path) do
+    {params, body} = serialized_closure_parts(source_ast)
+
     with :ok <- validate_identifier_source_collisions(source_ast, path),
          :ok <- validate_closure_capture(closure, path),
          :ok <- validate_pattern_params(params, path ++ [:closure_params]),
          do: find_source_name(body, path ++ [:closure_body])
   end
+
+  defp serialized_closure_parts({:fn, params, body}), do: {params, body}
+  defp serialized_closure_parts({:fn, _name, params, body}), do: {params, body}
+
+  # Analyzer temporaries use a NUL-prefixed binary namespace that source cannot
+  # author, so they cannot collide with user bindings and never allocate atoms.
+  # Before exporting a closure, alpha-rename those variables to fresh legal
+  # identifiers while avoiding every textual value already present in its AST.
+  defp encode_internal_temporaries(source_ast) do
+    {temporary_names, used_names} = collect_temporary_names(source_ast)
+
+    {renames, _used_names, _next_index} =
+      Enum.reduce(temporary_names, {%{}, used_names, 0}, fn name, {renames, used, index} ->
+        {encoded, next_index} = next_serialized_temporary(used, index)
+        {Map.put(renames, name, encoded), MapSet.put(used, encoded), next_index}
+      end)
+
+    rewrite_internal_temporaries(source_ast, renames)
+  end
+
+  defp collect_temporary_names(source_ast) do
+    {names, _seen, used} = collect_temporary_names(source_ast, {[], MapSet.new(), MapSet.new()})
+    {Enum.reverse(names), used}
+  end
+
+  defp collect_temporary_names({:var, name}, {names, seen, used})
+       when is_binary(name) do
+    if String.starts_with?(name, @internal_temporary_prefix) do
+      if MapSet.member?(seen, name),
+        do: {names, seen, used},
+        else: {[name | names], MapSet.put(seen, name), used}
+    else
+      {names, seen, MapSet.put(used, name)}
+    end
+  end
+
+  defp collect_temporary_names({:literal, _value}, accumulator), do: accumulator
+
+  defp collect_temporary_names(value, {names, seen, used})
+       when is_atom(value) or is_binary(value),
+       do: {names, seen, MapSet.put(used, to_string(value))}
+
+  defp collect_temporary_names(value, accumulator) when is_list(value),
+    do: Enum.reduce(value, accumulator, &collect_temporary_names/2)
+
+  defp collect_temporary_names(value, accumulator) when is_tuple(value),
+    do: value |> Tuple.to_list() |> Enum.reduce(accumulator, &collect_temporary_names/2)
+
+  defp collect_temporary_names(_value, accumulator), do: accumulator
+
+  defp next_serialized_temporary(used_names, index) do
+    candidate = @serialized_temporary_prefix <> Integer.to_string(index)
+
+    if MapSet.member?(used_names, candidate),
+      do: next_serialized_temporary(used_names, index + 1),
+      else: {candidate, index + 1}
+  end
+
+  defp rewrite_internal_temporaries({:var, name}, renames) when is_binary(name),
+    do: {:var, Map.get(renames, name, name)}
+
+  defp rewrite_internal_temporaries({:literal, _value} = literal, _renames), do: literal
+
+  defp rewrite_internal_temporaries(value, renames) when is_list(value),
+    do: Enum.map(value, &rewrite_internal_temporaries(&1, renames))
+
+  defp rewrite_internal_temporaries(value, renames) when is_tuple(value) do
+    value
+    |> Tuple.to_list()
+    |> Enum.map(&rewrite_internal_temporaries(&1, renames))
+    |> List.to_tuple()
+  end
+
+  defp rewrite_internal_temporaries(value, _renames), do: value
 
   defp preserve_closure_source_name_error(params, body, path, structural_error) do
     candidate =
@@ -1690,7 +1777,7 @@ defmodule PtcRunner.Lisp.CoreToSource do
           ""
 
         _ ->
-          entries = Enum.map_join(defaults, " ", fn {k, v} -> "#{k} #{format(v)}" end)
+          entries = Enum.map_join(defaults, " ", fn {k, v} -> "#{k} #{do_format(v)}" end)
           ":or {#{entries}}"
       end
 
@@ -1710,11 +1797,11 @@ defmodule PtcRunner.Lisp.CoreToSource do
 
   defp format_map_key(k)
        when k in [nil, true, false, :infinity, :negative_infinity, :nan],
-       do: format(k)
+       do: do_format(k)
 
   defp format_map_key(k) when is_atom(k), do: ":#{k}"
   defp format_map_key(%LispKeyword{name: name}), do: ":#{name}"
-  defp format_map_key(k), do: format(k)
+  defp format_map_key(k), do: do_format(k)
 
   defp escape_string(s) do
     s

--- a/lib/ptc_runner/lisp/prelude/compiler.ex
+++ b/lib/ptc_runner/lisp/prelude/compiler.ex
@@ -36,6 +36,7 @@ defmodule PtcRunner.Lisp.Prelude.Compiler do
   alias PtcRunner.Lisp.Eval
   alias PtcRunner.Lisp.Parser
   alias PtcRunner.Lisp.Prelude
+  alias PtcRunner.Lisp.Prelude.Description
   alias PtcRunner.Lisp.Prelude.ErrorSpan
   alias PtcRunner.Lisp.Prelude.Export
   alias PtcRunner.Lisp.Prelude.Spec
@@ -91,17 +92,54 @@ defmodule PtcRunner.Lisp.Prelude.Compiler do
     do: compile_source(source, opts)
 
   defp compile_source(source, opts) do
+    with {:ok, description} <- describe_unlocated(source),
+         do: compile_description(description, opts)
+  end
+
+  @doc false
+  @spec describe_unlocated(String.t()) ::
+          {:ok, Description.t()} | {:error, ValidationError.t()}
+  def describe_unlocated(source) when is_binary(source) do
     with {:ok, {:program, forms}} <- parse(source),
          {:ok, specs, ns_meta} <- collect_specs(forms),
-         :ok <- validate_spec_effects(specs),
+         :ok <- validate_spec_effects(specs) do
+      {:ok,
+       %Description{
+         source: source,
+         specs: specs,
+         namespace_metadata: ns_meta,
+         namespaces: ns_meta |> Map.keys() |> Enum.sort()
+       }}
+    end
+  catch
+    {:unrecognized_prelude_node, tag} -> unrecognized_node_error(tag)
+  end
+
+  @doc false
+  @spec compile_description(Description.t(), keyword()) ::
+          {:ok, Prelude.t()} | {:error, ValidationError.t()}
+  def compile_description(%Description{} = description, opts \\ []) when is_list(opts) do
+    compile_description_unchecked(description, opts)
+  catch
+    {:unrecognized_prelude_node, tag} -> unrecognized_node_error(tag)
+  end
+
+  defp compile_description_unchecked(
+         %Description{
+           source: source,
+           specs: specs,
+           namespace_metadata: ns_meta,
+           namespaces: namespaces
+         },
+         opts
+       ) do
+    with :ok <- validate_spec_effects(specs),
          {:ok, dep_ctx} <- build_dep_context(ns_meta, opts),
          :ok <- reject_dep_refs_in_defs(specs, dep_ctx),
          form_graph = build_form_graph(specs, dep_ctx),
          {:ok, exports} <- build_exports(specs, ns_meta, form_graph, dep_ctx),
          {:ok, private_env} <- build_runtime(specs, exports, dep_ctx),
          :ok <- validate_constant_contracts(exports, private_env) do
-      namespaces = ns_meta |> Map.keys() |> Enum.sort()
-
       {:ok,
        %Prelude{
          namespaces: namespaces,
@@ -112,17 +150,76 @@ defmodule PtcRunner.Lisp.Prelude.Compiler do
          metadata: %{namespaces: ns_meta}
        }}
     end
-  catch
-    # The raw-AST walkers fail CLOSED on an unrecognized node (see
-    # `leaf_or_reject/2`). Convert that throw into the prelude's normal error
-    # channel — the contract is "compile failures are RETURNED, never raised".
-    {:unrecognized_prelude_node, tag} ->
-      {:error,
-       ValidationError.new(
-         :unrecognized_node,
-         "prelude body contains an unrecognized syntax node `#{inspect(tag)}`; refusing to " <>
-           "compile because its tool requirements cannot be safely determined (fail-closed)"
-       )}
+  end
+
+  # The raw-AST walkers fail CLOSED on an unrecognized node (see
+  # `leaf_or_reject/2`). Convert that throw into the prelude's normal error
+  # channel — the contract is "compile failures are RETURNED, never raised".
+  defp unrecognized_node_error(tag) do
+    {:error,
+     ValidationError.new(
+       :unrecognized_node,
+       "prelude body contains an unrecognized syntax node `#{inspect(tag)}`; refusing to " <>
+         "compile because its tool requirements cannot be safely determined (fail-closed)"
+     )}
+  end
+
+  @doc false
+  @spec compose([Prelude.t()], String.t(), [map()]) ::
+          {:ok, Prelude.t()} | {:error, ValidationError.t()}
+  def compose(preludes, aggregate_source, components)
+      when is_list(preludes) and is_binary(aggregate_source) and is_list(components) do
+    with :ok <- unique_composed_namespaces(preludes) do
+      {:ok,
+       %Prelude{
+         namespaces: preludes |> Enum.flat_map(& &1.namespaces) |> Enum.sort(),
+         exports: Enum.flat_map(preludes, & &1.exports),
+         private_env: merge_prelude_map(preludes, :private_env),
+         source_hash: source_hash(aggregate_source),
+         form_graph: merge_prelude_map(preludes, :form_graph),
+         metadata: %{
+           namespaces: merge_namespace_metadata(preludes),
+           components: components
+         }
+       }}
+    end
+  end
+
+  defp unique_composed_namespaces(preludes) do
+    preludes
+    |> Enum.reduce_while(MapSet.new(), fn
+      %Prelude{namespaces: namespaces}, seen ->
+        case Enum.find(namespaces, &MapSet.member?(seen, &1)) do
+          nil ->
+            {:cont, Enum.reduce(namespaces, seen, &MapSet.put(&2, &1))}
+
+          namespace ->
+            {:halt,
+             {:error,
+              ValidationError.new(
+                :invalid_namespace,
+                "namespace `#{namespace}` is declared by more than one component",
+                namespace: namespace
+              )}}
+        end
+
+      _invalid, _seen ->
+        {:halt, {:error, ValidationError.new(:compile_error, "invalid compiled prelude")}}
+    end)
+    |> case do
+      %MapSet{} -> :ok
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp merge_prelude_map(preludes, field) do
+    Enum.reduce(preludes, %{}, &Map.merge(&2, Map.fetch!(&1, field)))
+  end
+
+  defp merge_namespace_metadata(preludes) do
+    Enum.reduce(preludes, %{}, fn prelude, metadata ->
+      Map.merge(metadata, Map.get(prelude.metadata, :namespaces, %{}))
+    end)
   end
 
   # ============================================================

--- a/lib/ptc_runner/lisp/prelude/description.ex
+++ b/lib/ptc_runner/lisp/prelude/description.ex
@@ -1,0 +1,15 @@
+defmodule PtcRunner.Lisp.Prelude.Description do
+  @moduledoc false
+
+  alias PtcRunner.Lisp.Prelude.Spec
+
+  @enforce_keys [:source, :specs, :namespace_metadata, :namespaces]
+  defstruct [:source, :specs, :namespace_metadata, :namespaces]
+
+  @type t :: %__MODULE__{
+          source: String.t(),
+          specs: [Spec.t()],
+          namespace_metadata: %{String.t() => map()},
+          namespaces: [String.t()]
+        }
+end

--- a/test/ptc_runner/kernel/bundle_composition_test.exs
+++ b/test/ptc_runner/kernel/bundle_composition_test.exs
@@ -1,0 +1,78 @@
+defmodule PtcRunner.Kernel.BundleCompositionTest do
+  use ExUnit.Case, async: true
+
+  alias PtcRunner.Kernel
+  alias PtcRunner.Kernel.BundleCompiler
+  alias PtcRunner.Kernel.Component
+  alias PtcRunner.Lisp
+  alias PtcRunner.Lisp.Prelude.Compiler
+
+  @base_source """
+  (ns base "Base helpers.")
+
+  (defn- offset [value] (+ value 2))
+  (defn make-adder [value] (fn [extra] (offset (+ value extra))))
+  """
+
+  @consumer_source """
+  (ns consumer "Consumer helpers.")
+
+  (defn answer [] ((base/make-adder 39) 1))
+  """
+
+  test "described source compiles without reparsing through the public source path" do
+    assert {:ok, description} = Compiler.describe_unlocated(@base_source)
+    assert description.namespaces == ["base"]
+    assert {:ok, described} = Compiler.compile_description(description)
+    assert {:ok, ordinary} = Compiler.compile_unlocated(@base_source)
+
+    assert Map.take(described, [:namespaces, :exports, :form_graph, :metadata, :source_hash]) ==
+             Map.take(ordinary, [:namespaces, :exports, :form_graph, :metadata, :source_hash])
+  end
+
+  test "composed component artifacts preserve aggregate protected facts and runtime behavior" do
+    base = component!("base", @base_source)
+    consumer = component!("consumer", @consumer_source, ["base"])
+
+    assert {:ok, bundle} = Kernel.compile_bundle([consumer, base])
+
+    aggregate_source = @base_source <> "\n" <> @consumer_source
+
+    assert {:ok, fresh} =
+             Compiler.compile_unlocated(aggregate_source,
+               namespace_deps: %{"base" => [], "consumer" => ["base"]}
+             )
+
+    assert Map.take(bundle.prelude, [:namespaces, :exports, :form_graph, :source_hash]) ==
+             Map.take(fresh, [:namespaces, :exports, :form_graph, :source_hash])
+
+    assert bundle.prelude.metadata.namespaces == fresh.metadata.namespaces
+
+    assert Enum.sort(Map.keys(bundle.prelude.private_env)) ==
+             Enum.sort(Map.keys(fresh.private_env))
+
+    for prelude <- [bundle.prelude, fresh] do
+      assert {:ok, step} = Lisp.run("(consumer/answer)", prelude: prelude)
+      assert step.return == 42
+    end
+  end
+
+  test "preparation-local reuse still honors the shared absolute deadline" do
+    component = component!("base", @base_source)
+    assert {:ok, bundle} = Kernel.compile_bundle([component])
+
+    assert {:error, {%{reason: :bundle_compile_timeout}, [^component]}} =
+             BundleCompiler.compile_named(
+               %{"mission" => %{components: [component]}},
+               System.monotonic_time(:millisecond) - 1,
+               0,
+               4_000_000,
+               [{[component], bundle}]
+             )
+  end
+
+  defp component!(id, source, dependencies \\ []) do
+    {:ok, component} = Component.new(id: id, source: source, dependencies: dependencies)
+    component
+  end
+end

--- a/test/ptc_runner/kernel/command_engine_test.exs
+++ b/test/ptc_runner/kernel/command_engine_test.exs
@@ -5811,6 +5811,47 @@ defmodule PtcRunner.Kernel.CommandEngineTest do
   end
 
   @tag :tmp_dir
+  test "preparation reuses a byte-identical workflow bundle for missions", %{tmp_dir: directory} do
+    source = """
+    (ns app)
+    (defn run [input]
+      (return (case (:mode input) :first 1 0)))
+    """
+
+    application =
+      write_application(
+        directory,
+        "prepared-bundle-reuse",
+        valid_manifest(%{
+          "missions" => %{
+            "first" => %{
+              "components" => [%{"id" => "app", "path" => "main.clj"}],
+              "data" => %{}
+            },
+            "second" => %{
+              "components" => [%{"id" => "app", "path" => "main.clj"}],
+              "data" => %{}
+            }
+          }
+        }),
+        %{"main.clj" => source}
+      )
+
+    assert {:ok, request} =
+             ApplicationPackage.request_directory(application, result_projection: :json)
+
+    assert {:ok, registry} = ProviderRegistry.new()
+    assert {:ok, prepared} = RunCoordinator.prepare(request, catalog_for(registry))
+
+    assert prepared.mission_bundles == %{
+             "first" => prepared.workflow_bundle,
+             "second" => prepared.workflow_bundle
+           }
+
+    assert :ok = PreparedRun.close(prepared)
+  end
+
+  @tag :tmp_dir
   test "a prepared run cannot bypass provider declaration preparation", %{tmp_dir: directory} do
     application =
       write_application(

--- a/test/ptc_runner/kernel/core_contract_test.exs
+++ b/test/ptc_runner/kernel/core_contract_test.exs
@@ -1539,11 +1539,24 @@ defmodule PtcRunner.Kernel.CoreContractTest do
     assert first_component.id == "first"
     assert second_component.id == "second"
 
+    assert first_component |> Map.keys() |> Enum.sort() ==
+             [:dependencies, :id, :namespaces, :origin, :source_hash]
+
+    refute Map.has_key?(first_component, :prelude)
+    refute Map.has_key?(second_component, :prelude)
+
     assert {:error, %{reason: :missing_component_dependency}} =
              Kernel.compile_bundle([%{first | dependencies: ["missing"]}])
 
     assert {:error, %{reason: :component_cycle}} =
              Kernel.compile_bundle([%{first | dependencies: ["second"]}, second])
+  end
+
+  test "component bundles reject duplicate namespaces before artifact composition" do
+    {:ok, first} = Component.new(id: "first", source: "(ns shared) (defn first [] 1)")
+    {:ok, second} = Component.new(id: "second", source: "(ns shared) (defn second [] 2)")
+
+    assert {:error, %{reason: :bundle_compile_error}} = Kernel.compile_bundle([first, second])
   end
 
   test "bundle compilation confines large artifacts with independent heap and artifact limits" do

--- a/test/ptc_runner/lisp/core_to_source_test.exs
+++ b/test/ptc_runner/lisp/core_to_source_test.exs
@@ -212,6 +212,22 @@ defmodule PtcRunner.Lisp.CoreToSourceTest do
       assert ast1 == ast2
     end
 
+    test "analyzer-generated case and condp temporaries format as parseable source" do
+      source =
+        "(let [__ptc_serialized_0 42 x 1] " <>
+          "[__ptc_serialized_0 (case x 1 :one :other) (condp = x 1 :one :other)])"
+
+      assert {:ok, raw_ast} = Parser.parse(source)
+      assert {:ok, core_ast} = Analyze.analyze(raw_ast)
+
+      reformatted = CoreToSource.format(core_ast)
+
+      refute String.contains?(reformatted, <<0>>)
+      assert {:ok, _raw_ast} = Parser.parse(reformatted)
+      assert {:ok, %{return: [42, one, one]}} = Lisp.run_native(reformatted)
+      assert one == Keyword.new("one")
+    end
+
     test "def with expression" do
       {ast1, ast2, _} = roundtrip("(def x (+ 1 2))")
       assert ast1 == ast2
@@ -375,12 +391,13 @@ defmodule PtcRunner.Lisp.CoreToSourceTest do
     test "round-trips analyzer-generated temporary identifiers" do
       assert {:ok, first} =
                Lisp.run_native("""
-               (fn [x]
+               (fn [__ptc_serialized_0 x]
                  [(case x 1 :one :other)
                   (condp = x 1 :one :other)
                   (cond-> x true inc)
                   (some-> x inc)
-                  (when-first [item [x]] item)])
+                  (when-first [item [x]] item)
+                  __ptc_serialized_0])
                """)
 
       closure = first.return
@@ -393,8 +410,8 @@ defmodule PtcRunner.Lisp.CoreToSourceTest do
       for source <- ["(def f #{closure_source})", namespace_source] do
         assert {:ok, hydrated} = Lisp.run_native(source)
 
-        assert {:ok, %{return: [one, one, 2, 2, 1]}} =
-                 Lisp.run_native("(f 1)", memory: hydrated.memory)
+        assert {:ok, %{return: [one, one, 2, 2, 1, "authored"]}} =
+                 Lisp.run_native(~S|(f "authored" 1)|, memory: hydrated.memory)
 
         assert one == Keyword.new("one")
       end

--- a/test/ptc_runner/lisp/prelude/compiler_atom_growth_test.exs
+++ b/test/ptc_runner/lisp/prelude/compiler_atom_growth_test.exs
@@ -1,0 +1,26 @@
+defmodule PtcRunner.Lisp.Prelude.CompilerAtomGrowthTest do
+  use ExUnit.Case, async: false
+
+  alias PtcRunner.Lisp.Prelude.Compiler
+
+  @source """
+  (ns atom-safe)
+
+  (defn choose [value]
+    (case value
+      :first 1
+      :second 2
+      0))
+  """
+
+  test "repeated conditional compilation does not grow the atom table" do
+    assert {:ok, _prelude} = Compiler.compile(@source)
+    before = :erlang.system_info(:atom_count)
+
+    for _iteration <- 1..25 do
+      assert {:ok, _prelude} = Compiler.compile(@source)
+    end
+
+    assert :erlang.system_info(:atom_count) == before
+  end
+end


### PR DESCRIPTION
## Summary

- parse and compile each prelude component once, then compose the validated artifacts instead of recompiling concatenated source
- retain metadata-only component provenance and reuse identical workflow/mission bundles within one preparation
- replace conditional gensym atoms with collision-safe binary temporaries and alpha-rename them at source-export boundaries
- add composition, cache reuse, atom-growth, formatter/export regression coverage, and a reproducible prelude-bundle characterization benchmark

## Characterization

On the local 14-component shipped bundle (7-sample median), composition reduced the old aggregate-recompile proxy from 24,365 us to 12,732 us (47.7%) and retained artifact size from 397,889 bytes to 200,378 bytes (49.6%). The benchmark also covers agent.core, mixed custom/override components, 1–128 component scaling, identical/distinct preparations, and execution overhead.

## Validation

- mix precommit
- MIX_ENV=dev mix docs --warnings-as-errors
- scripts/ci/core-tests.sh: 6,840 passed before rebase
- pre-push core suite: 6,843 passed (122 doctests, 5 properties, 6,716 tests)
- Dialyzer: 0 errors
- Viewer: 115 passed
- release verification passed
- four independent Codex review invocations; final cumulative review against current origin/main reported no actionable findings

Closes #1564