### PR TITLE
fix(mcp): classify -32602 discovery answers as an unsupported profile

### DIFF
--- a/lib/ptc_runner/kernel/mcp_protocol.ex
+++ b/lib/ptc_runner/kernel/mcp_protocol.ex
@@ -73,7 +73,12 @@ defmodule PtcRunner.Kernel.MCPProtocol do
   @rfc3339_datetime ~r/\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})\z/i
   @max_schema_depth 16
   @input_required_methods ~w(tools/call prompts/get resources/read)
-  @unsupported_protocol_version_codes [-32_601, -32_022]
+  # A legacy server answers an unknown pre-`initialize` request with an
+  # implementation-defined error; the stdio backward-compatibility rules name
+  # `-32601` and `-32602` as the common pair. `-32022` is the modern
+  # `UnsupportedProtocolVersionError`. All three mean the endpoint does not
+  # serve the pinned profile, which is the only distinction this client draws.
+  @unsupported_protocol_version_codes [-32_601, -32_602, -32_022]
   # A maximum-depth schema in tools/list occupies four envelope containers,
   # `2 * depth - 1` schema containers, and `depth` const/enum instance
   # containers: 4 + 31 + 16 = 51 at the configured limits.

--- a/test/ptc_runner/kernel/mcp_protocol_test.exs
+++ b/test/ptc_runner/kernel/mcp_protocol_test.exs
@@ -221,7 +221,7 @@ defmodule PtcRunner.Kernel.MCPProtocolTest do
   end
 
   test "classifies only discovery's standard unsupported-profile errors specially" do
-    for code <- [-32_601, -32_022] do
+    for code <- [-32_601, -32_602, -32_022] do
       response = %{
         "error" => %{
           "code" => code,


### PR DESCRIPTION
## Summary

A legacy MCP server answers an unknown pre-`initialize` request with an
implementation-defined error. The [stdio backward-compatibility rules](https://modelcontextprotocol.io/specification/2026-07-28/basic/transports/stdio#backward-compatibility)
name `-32601` and `-32602` as the common pair, but `mcp_protocol.ex` recognized
only `-32601`.

So two legacy servers in the same situation got two different answers, decided
by which code the server happened to pick:

| Discovery answer | Before | After |
| --- | --- | --- |
| `-32601` | `provider_protocol_version_unsupported` | unchanged |
| `-32602` | `provider_unavailable` — *"the selected provider could not be acquired"* | `provider_protocol_version_unsupported` |
| `-32022` | `provider_protocol_version_unsupported` | unchanged |
| `-32603` | `provider_unavailable` | unchanged |

`-32602` now gets the diagnosis that already describes it:

```
provider_acquisition/provider_protocol_version_unsupported:
  the installed endpoint does not support MCP protocol 2026-07-28
```

One constant, one test line.

## Deliberate non-changes

- **No fallback handshake.** PtcRunner serves the pinned `2026-07-28` profile
  only. The spec permits this: *"A client that only supports modern versions
  does not need to probe, but probing is still RECOMMENDED."* Probe-first is
  already what we do; only one outcome was mislabelled.
- **No new diagnostic code and no message change.** The existing message is
  accurate for a legacy endpoint — it genuinely does not support `2026-07-28`.
  Splitting it would trade a plain sentence for protocol jargon and add guide
  text to read.
- **No documentation change.** `docs/reference/mcp.md` mentions `-32601` only
  as a fact about one named npm package; that statement is still true.
- **`-32603` stays `provider_unavailable`.** The spec's third bucket is "any
  other error", but `-32603` is *Internal error* — a real server fault, not an
  unknown-method signal. Widening that far would swallow genuine remote
  failures. `-32601`/`-32602` are the two the spec names.
- **HTTP path untouched.** `mcp_source.ex:1853` pins status `400` to `-32022`
  and status `404` to `-32601`, and passes only those two as `expected_code`,
  so widening the guard list cannot loosen that pairing. The exact
  status/code matrix test proves it.

## Not fixed by this

A legacy server that answers `server/discover` with *silence* rather than an
error still expires into `provider_acquisition_timeout` ("raise the budget"),
which is unhelpful advice. From outside, a slow cold `npx` start and a silent
legacy server are indistinguishable — separating them requires actually
attempting `initialize`. Out of scope here; see #1495.

## Test plan

Failing test written first (`-32602` returned `:mcp_remote_error`), then the fix.

- [x] `mix test test/ptc_runner/kernel/mcp_protocol_test.exs test/ptc_runner/kernel/mcp_source_test.exs` — 77 passed, including the exact HTTP status/code matrix
- [x] `mix test test/ptc_runner/kernel/command_engine_test.exs test/ptc_runner/kernel/acquisition_reason_test.exs test/ptc_runner/kernel/mcp_oauth` — 306 passed
- [x] `mix credo --strict lib/ptc_runner/kernel/mcp_protocol.ex` — no issues
- [x] pre-commit hook (format / compile --warnings-as-errors / credo / scoped tests)

Refs #1495.