### PR TITLE
fix(cli): keep TLS logger notices off doctor stdout

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -5,4 +5,8 @@ import Config
 config :req_llm, load_dotenv: false
 config :llm_db, load_dotenv: false
 
+# Packaged `ptc` writes machine-readable reports to stdout. OTP's default
+# handler uses standard_io, so a TLS alert would prefix that JSON (#1583).
+config :logger, :default_handler, config: [type: :standard_error]
+
 # Production environment configuration

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -44,7 +44,9 @@ manifest or package rejected during application validation is likewise
 reported as a failed `application` check instead of an internal command error.
 Complete readiness reports, including `readiness: "failed"`, are written to
 stdout. Failed reports retain their nonzero exit status; failures that cannot
-produce a complete report are written to stderr.
+produce a complete report are written to stderr. Runtime logger output,
+including TLS handshake alerts, is written to stderr so stdout remains one
+JSON document.
 `--show-model-selectors` adds only safe selectors.
 
 Every readiness report carries `usage`, on the LLM rows a run reports. Each

--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -294,7 +294,8 @@ When direct endpoint acquisition does dial the server, `ptc run` and
 
 These diagnostics name only the installed provider occurrence. They never
 include the endpoint, DNS response, certificate, TLS alert text, Mint value, or
-operating-system error. Other connection failures retain the generic
+operating-system error. OTP may still write the handshake alert on stderr;
+stdout of `ptc doctor` remains one JSON document. Other connection failures retain the generic
 `provider_unavailable` code. OAuth discovery and token traffic retain their
 existing closed authorization transport errors rather than exposing endpoint
 causes through grant state.

--- a/lib/mix/tasks/ptc.ex
+++ b/lib/mix/tasks/ptc.ex
@@ -17,7 +17,8 @@ defmodule Mix.Tasks.Ptc do
   Complete doctor readiness reports, including `readiness: "failed"`, are
   written to standard output. A failed readiness report retains its nonzero
   exit status; failures without a complete report are written to standard
-  error.
+  error. Runtime logger output, including TLS handshake alerts, is written
+  to standard error so standard output remains one JSON document.
   """
   use Mix.Task
 

--- a/lib/ptc_runner/cli_logger.ex
+++ b/lib/ptc_runner/cli_logger.ex
@@ -1,0 +1,45 @@
+defmodule PtcRunner.CLILogger do
+  @moduledoc false
+
+  @handler_keys [:level, :filter_default, :filters, :formatter]
+
+  @doc false
+  @spec install_stderr_handler() :: :ok
+  def install_stderr_handler do
+    case :logger.get_handler_config(:default) do
+      {:ok, config} -> attach_stderr_handler(config)
+      {:error, _reason} -> :ok
+    end
+  end
+
+  defp attach_stderr_handler(%{module: :logger_std_h, config: %{type: :standard_error}}),
+    do: :ok
+
+  defp attach_stderr_handler(%{module: :logger_std_h} = config) do
+    _ = :logger.remove_handler(:default)
+
+    handler_config =
+      config
+      |> Map.take(@handler_keys)
+      |> Map.put(:config, %{type: :standard_error})
+
+    case :logger.add_handler(:default, :logger_std_h, handler_config) do
+      :ok -> :ok
+      {:error, _reason} -> add_fallback_stderr_handler()
+    end
+  end
+
+  defp attach_stderr_handler(_other), do: :ok
+
+  defp add_fallback_stderr_handler do
+    _ =
+      :logger.add_handler(:default, :logger_std_h, %{
+        formatter: Logger.default_formatter(),
+        filters: [remote_gl: {&:logger_filters.remote_gl/2, :stop}],
+        filter_default: :log,
+        config: %{type: :standard_error}
+      })
+
+    :ok
+  end
+end

--- a/lib/ptc_runner/mix_command_adapter.ex
+++ b/lib/ptc_runner/mix_command_adapter.ex
@@ -1,6 +1,7 @@
 defmodule PtcRunner.MixCommandAdapter do
   @moduledoc false
 
+  alias PtcRunner.CLILogger
   alias PtcRunner.Kernel.CommandPresentation
   alias PtcRunner.Kernel.CommandRouter
   alias PtcRunner.Kernel.CommandRuntime
@@ -40,6 +41,10 @@ defmodule PtcRunner.MixCommandAdapter do
   @doc false
   @spec run_task([binary()], keyword()) :: CommandPresentation.t() | no_return()
   def run_task(args, frontend_opts) when is_list(args) and is_list(frontend_opts) do
+    # Mix starts Logger before project config is applied, and logger_std_h
+    # cannot change `type` on a running handler. Reinstall so `mix ptc`
+    # matches the packaged CLI (#1583).
+    CLILogger.install_stderr_handler()
     presentation = execute(args, frontend_opts)
 
     case presentation do

--- a/lib/ptc_runner/standalone_cli.ex
+++ b/lib/ptc_runner/standalone_cli.ex
@@ -1,6 +1,7 @@
 defmodule PtcRunner.StandaloneCLI do
   @moduledoc false
 
+  alias PtcRunner.CLILogger
   alias PtcRunner.Kernel.CommandPresentation
   alias PtcRunner.Kernel.CommandRouter
   alias PtcRunner.Kernel.CommandRuntime
@@ -36,6 +37,9 @@ defmodule PtcRunner.StandaloneCLI do
   @doc false
   @spec main([binary()]) :: no_return()
   def main(argv) do
+    # OTP's default handler writes to stdout. A TLS handshake alert during
+    # `ptc doctor --connect` would otherwise prefix the JSON report (#1583).
+    CLILogger.install_stderr_handler()
     presentation = execute(argv)
     # The dump is Logger reporting the writer's :terminated; removing the
     # default handler after the command has produced its presentation, and

--- a/site/reference/cli/index.html
+++ b/site/reference/cli/index.html
@@ -109,7 +109,9 @@ manifest or package rejected during application validation is likewise
 reported as a failed <code class="inline">application</code> check instead of an internal command error.
 Complete readiness reports, including <code class="inline">readiness: &quot;failed&quot;</code>, are written to
 stdout. Failed reports retain their nonzero exit status; failures that cannot
-produce a complete report are written to stderr.
+produce a complete report are written to stderr. Runtime logger output,
+including TLS handshake alerts, is written to stderr so stdout remains one
+JSON document.
 <code class="inline">--show-model-selectors</code> adds only safe selectors.</p><p>Every readiness report carries <code class="inline">usage</code>, on the LLM rows a run reports. Each
 probed model alias contributes one call with the tokens and cost the provider
 attributed to it, so a CI step can account for what the check spent:</p><pre><code class="json language-json">{&quot;usage&quot;: {&quot;llm_usage_state&quot;: &quot;available&quot;,

--- a/site/reference/mcp/index.html
+++ b/site/reference/mcp/index.html
@@ -255,7 +255,8 @@ connection and is marked retryable;</li><li><code class="inline">provider_endpoi
 resolve; and</li><li><code class="inline">provider_endpoint_tls_failed</code> means an admitted TLS configuration or
 protocol alert prevented the handshake.</li></ul><p>These diagnostics name only the installed provider occurrence. They never
 include the endpoint, DNS response, certificate, TLS alert text, Mint value, or
-operating-system error. Other connection failures retain the generic
+operating-system error. OTP may still write the handshake alert on stderr;
+stdout of <code class="inline">ptc doctor</code> remains one JSON document. Other connection failures retain the generic
 <code class="inline">provider_unavailable</code> code. OAuth discovery and token traffic retain their
 existing closed authorization transport errors rather than exposing endpoint
 causes through grant state.</p><p>Supported static schemes are <code class="inline">bearer</code>, <code class="inline">basic</code>, and header-named <code class="inline">api_key</code>.

--- a/test/ptc_runner/cli_logger_test.exs
+++ b/test/ptc_runner/cli_logger_test.exs
@@ -1,0 +1,122 @@
+defmodule PtcRunner.CLILoggerTest do
+  @moduledoc """
+  Packaged `ptc` and `mix ptc` must keep runtime logger output off stdout so a
+  doctor JSON report remains parseable when OTP logs a TLS alert (#1583).
+  """
+
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureIO
+
+  alias PtcRunner.CLILogger
+  alias PtcRunner.MixCommandAdapter
+
+  @notice "TLS :client: In state :certify generated CLIENT ALERT: Fatal - Certificate Expired"
+
+  setup do
+    previous_level = Logger.level()
+    {:ok, original} = :logger.get_handler_config(:default)
+    Logger.configure(level: :notice)
+
+    on_exit(fn ->
+      Logger.configure(level: previous_level)
+      restore_handler(original)
+    end)
+
+    :ok
+  end
+
+  test "a TLS-style logger notice lands on stdout until the CLI handler is attached" do
+    attach_std_handler(:standard_io)
+
+    {user, stderr} = capture_notice(@notice)
+
+    assert user =~ "Certificate Expired"
+    refute stderr =~ "Certificate Expired"
+  end
+
+  test "installing the CLI handler keeps a TLS-style notice off stdout" do
+    attach_std_handler(:standard_io)
+    assert CLILogger.install_stderr_handler() == :ok
+
+    {user, stderr} = capture_notice(@notice)
+
+    refute user =~ "Certificate Expired"
+    assert stderr =~ "Certificate Expired"
+
+    report = ~s({"checks":[{"code":"provider_endpoint_tls_failed"}]}\n)
+
+    stdout =
+      capture_io(fn ->
+        capture_io(:user, fn ->
+          capture_io(:stderr, fn ->
+            :logger.notice(@notice)
+            Logger.flush()
+            IO.write(report)
+          end)
+        end)
+      end)
+
+    assert Jason.decode!(String.trim(stdout)) == %{
+             "checks" => [%{"code" => "provider_endpoint_tls_failed"}]
+           }
+  end
+
+  test "mix ptc attaches the default logger to standard_error before running" do
+    attach_std_handler(:standard_io)
+
+    capture_io(fn ->
+      MixCommandAdapter.run_task(["help"])
+    end)
+
+    assert {:ok, %{config: %{type: :standard_error}}} = :logger.get_handler_config(:default)
+  end
+
+  defp capture_notice(message) do
+    parent = self()
+
+    user =
+      capture_io(:user, fn ->
+        stderr =
+          capture_io(:stderr, fn ->
+            :logger.notice(message)
+            Logger.flush()
+          end)
+
+        send(parent, {:stderr, stderr})
+      end)
+
+    assert_received {:stderr, stderr}
+    {user, stderr}
+  end
+
+  defp attach_std_handler(type) do
+    {:ok, config} = :logger.get_handler_config(:default)
+    _ = :logger.remove_handler(:default)
+
+    :ok =
+      :logger.add_handler(:default, :logger_std_h, %{
+        level: config.level,
+        filter_default: config.filter_default,
+        filters: config.filters,
+        formatter: config.formatter,
+        config: %{type: type}
+      })
+  end
+
+  defp restore_handler(%{module: module} = config) do
+    _ = :logger.remove_handler(:default)
+    type = get_in(config, [:config, :type]) || :standard_io
+
+    _ =
+      :logger.add_handler(config.id, module, %{
+        level: config.level,
+        filter_default: config.filter_default,
+        filters: config.filters,
+        formatter: config.formatter,
+        config: %{type: type}
+      })
+
+    :ok
+  end
+end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #1583.

`ptc doctor --connect` against a TLS-broken endpoint wrote an OTP logger notice to **stdout**, so the JSON readiness report could not be parsed. The check itself was already correct (`provider_endpoint_tls_failed`). Connection-refused and DNS failures were already clean; only the TLS path emitted a logger line.

## Change

- Point the packaged CLI default logger at stderr (`config/prod.exs`).
- Reinstall the Mix `ptc` handler the same way at `run_task/2`. Mix starts Logger before project config, and `logger_std_h` cannot change `type` at runtime.
- Leave `PtcRunner.Application` alone so embedding hosts keep their logger.
- Keep removing the default handler after the command and before writing the presentation, so `ptc docs | head` still exits 141 with empty stderr (#1498).

## Tests

- Reproduction: a TLS-style `:notice` lands on stdout when the handler is `standard_io`.
- Fix: after `CLILogger.install_stderr_handler/0`, the notice is on stderr and a JSON report on stdout still parses.
- `mix ptc` (`run_task/2`) attaches the handler to `standard_error` before running.

## Verification

- Independent review: approve, no blocking findings.
- `mix precommit`: passed.
- Repository pre-push gates: passed (ExDoc, 6941 core tests, Credo/Dialyzer, release, Viewer).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-938c5b36-02ab-40cc-a917-0048cb392dd9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-938c5b36-02ab-40cc-a917-0048cb392dd9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

