### PR TITLE
fix(kernel): count unmatched in-flight LLM starts as missing usage

### DIFF
--- a/docs/maintainers/trace-log-contract.md
+++ b/docs/maintainers/trace-log-contract.md
@@ -457,10 +457,13 @@ Snapshot lookup uses all events from the run-filter-selected runs before a
 mission filter narrows counted calls. Capability events continue to carry only
 alias/revision routing identity; they do not duplicate model identity. The
 additional rows remain subject to the existing aggregate result-byte limit.
-The command envelope additionally publishes `llm_usage_state`; unavailable or
-invalid terminal evidence produces `"unavailable"` with null aggregate fields,
-whereas a validated run with no calls produces `"available"`, empty arrays,
-and zero unattributed calls.
+The command envelope additionally publishes `llm_usage_state`. Terminal
+accounting pairs `llm-request` start and stop events by `capability_id`; an
+unmatched start is an observed call with unknown usage (`missing_usage_calls`
+increments even when `successful_calls` does not). Dropped
+`capability-started` or `capability-stopped` events, or a malformed pairing,
+produce `"unavailable"` with null aggregate fields. A validated run with no
+calls produces `"available"`, empty arrays, and zero unattributed calls.
 
 ## Pagination, ordering, and bounds
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -67,7 +67,9 @@ it spent nothing. A failure that did activate one reports
 `"llm_usage_state": "unavailable"` and a null list rather than claiming zero:
 the request may have been billed with no result left to account for it. As in a
 run, `total_cost` is omitted when any call could not be priced, and
-`missing_usage_calls` counts the calls a provider reported no tokens for.
+`missing_usage_calls` counts calls whose usage may exist but was not observed,
+including an in-flight request stopped by the run clock. It is not limited to
+successful completions.
 
 ## Read the embedded documentation
 
@@ -168,13 +170,20 @@ For runs that produce a validated terminal event batch, `execution.usage`
 includes `llm_usage` grouped by alias and installation revision,
 `llm_usage_by_model` grouped by an attested public resolved model, and
 `unattributed_model_calls`. Rows report call counts, usage-presence counts, and
-summed token and `total_cost` values. A row includes `total_cost` only when
-every successful call has valid usage that reports cost; otherwise the
-aggregate cost remains unknown and is omitted, not reported as zero.
+summed token and `total_cost` values. Terminal accounting pairs each
+`llm-request` `capability-started` with its `capability-stopped` by
+`capability_id`. An unmatched start is one observed call with unknown usage:
+`calls` increments, `successful_calls` does not, and `missing_usage_calls`
+increments. A row includes `total_cost` only when every call that could carry
+usage has valid priced usage; an unmatched or unpriced call leaves the
+aggregate cost unknown and omitted, not reported as zero, while measured
+input/output totals are retained. `llm_usage_state: "available"` means the
+terminal batch could be reconstructed, not that every call supplied usage.
 `llm_usage_state: "unavailable"` pairs all three
-aggregate fields with `null` when terminal evidence cannot be validated, while
-preserving other known usage. Non-empty `events_dropped` means an available
-summary covers retained evidence and may not be complete.
+aggregate fields with `null` when terminal evidence cannot be validated,
+including dropped `capability-started` or `capability-stopped` events, while
+preserving other known usage. Non-empty `events_dropped` for other event types
+means an available summary covers retained evidence and may not be complete.
 
 Artifact publication currently requires a Unix host with POSIX-compatible
 `mkdir` and `id`; trace append also needs `sh` and either `lockf` or `flock`.

--- a/lib/ptc_runner/kernel/command_contract.ex
+++ b/lib/ptc_runner/kernel/command_contract.ex
@@ -594,10 +594,12 @@ defmodule PtcRunner.Kernel.CommandContract do
 
   defp doctor_usage_valid?(_usage, _activity, _aliases), do: false
 
-  # The counter relationships `LLMUsageSummary` produces: a row exists because
-  # calls happened, a probed call that failed leaves no result to report at all,
-  # each success either reported usage or did not, and one that did not leaves
-  # the total cost incomplete.
+  # The counter relationships `LLMUsageSummary` produces. A row exists because
+  # calls happened. Each success is either measured or missing usage, unmatched
+  # in-flight starts are missing even though they are not successes, and a
+  # known failed completion does not become missing merely because it carries
+  # no usage. `missing_usage_calls` may therefore exceed `successful_calls`.
+  # Any missing call leaves the aggregate cost incomplete.
   defp usage_row_coherent?(%{
          "calls" => calls,
          "successful_calls" => successful,
@@ -606,7 +608,8 @@ defmodule PtcRunner.Kernel.CommandContract do
          "usage" => usage
        })
        when is_map(usage) do
-    calls >= 1 and successful == calls and measured + missing == calls and
+    calls >= 1 and successful <= calls and measured <= successful and
+      successful <= measured + missing and measured + missing <= calls and
       (measured > 0 or usage == %{}) and
       (missing == 0 or not Map.has_key?(usage, "total_cost"))
   end

--- a/lib/ptc_runner/kernel/llm_usage_summary.ex
+++ b/lib/ptc_runner/kernel/llm_usage_summary.ex
@@ -176,8 +176,9 @@ defmodule PtcRunner.Kernel.LLMUsageSummary do
     }
   end
 
-  # Dropped start or stop events can hide an in-flight LLM request, so a
-  # retained batch is not enough to reconstruct terminal accounting.
+  # Dropped start or stop events can hide an in-flight LLM request. Named
+  # drop buckets are authoritative; `$overflow` means further types were
+  # dropped and those types are unknown, so accounting fails closed.
   defp validate_accounting_retention(events) do
     dropped? =
       Enum.any?(events, fn event ->
@@ -190,7 +191,8 @@ defmodule PtcRunner.Kernel.LLMUsageSummary do
 
   defp accounting_relevant_drop?(counts) when is_map(counts) do
     positive_count?(counts, "capability-started") or
-      positive_count?(counts, "capability-stopped")
+      positive_count?(counts, "capability-stopped") or
+      positive_count?(counts, "$overflow")
   end
 
   defp accounting_relevant_drop?(_counts), do: false
@@ -213,8 +215,9 @@ defmodule PtcRunner.Kernel.LLMUsageSummary do
 
       state ->
         unmatched =
-          Enum.map(state.open, fn {_id, start} ->
-            %{start | outcome: :unknown, usage: nil}
+          Enum.flat_map(state.open, fn
+            {_id, %{llm?: true} = start} -> [%{start | outcome: :unknown, usage: nil}]
+            {_id, _foreign} -> []
           end)
 
         {:ok, Enum.reverse(state.calls, unmatched)}
@@ -230,34 +233,69 @@ defmodule PtcRunner.Kernel.LLMUsageSummary do
         {:halt, error}
 
       {:start, id, record} ->
-        if Map.has_key?(state.open, id) or MapSet.member?(state.seen, id) do
-          {:halt, {:error, :invalid_event_batch}}
-        else
-          {:cont, %{state | open: Map.put(state.open, id, record)}}
-        end
+        occupy(state, id, record)
+
+      {:occupy, id} ->
+        occupy(state, id, %{llm?: false})
 
       {:stop, id, stop} ->
-        case Map.pop(state.open, id) do
-          {nil, _open} ->
-            {:halt, {:error, :invalid_event_batch}}
+        reconcile_llm_stop(state, id, stop)
 
-          {start, open} ->
-            if start.alias == stop.alias and start.revision == stop.revision do
-              call = %{start | outcome: stop.outcome, usage: stop.usage}
+      {:foreign_stop, id} ->
+        reconcile_foreign_stop(state, id)
+    end
+  end
 
-              {:cont,
-               %{
-                 state
-                 | open: open,
-                   seen: MapSet.put(state.seen, id),
-                   calls: [call | state.calls]
-               }}
-            else
-              {:halt, {:error, :invalid_event_batch}}
-            end
+  defp occupy(state, id, record) do
+    if occupied?(state, id) do
+      {:halt, {:error, :invalid_event_batch}}
+    else
+      {:cont, %{state | open: Map.put(state.open, id, record)}}
+    end
+  end
+
+  defp reconcile_llm_stop(state, id, stop) do
+    case Map.pop(state.open, id) do
+      {nil, _open} ->
+        {:halt, {:error, :invalid_event_batch}}
+
+      {%{llm?: false}, _open} ->
+        {:halt, {:error, :invalid_event_batch}}
+
+      {start, open} ->
+        if start.alias == stop.alias and start.revision == stop.revision and
+             start.environment == stop.environment do
+          call = %{start | outcome: stop.outcome, usage: stop.usage}
+
+          {:cont,
+           %{
+             state
+             | open: open,
+               seen: MapSet.put(state.seen, id),
+               calls: [call | state.calls]
+           }}
+        else
+          {:halt, {:error, :invalid_event_batch}}
         end
     end
   end
+
+  defp reconcile_foreign_stop(state, id) do
+    cond do
+      MapSet.member?(state.seen, id) ->
+        {:halt, {:error, :invalid_event_batch}}
+
+      match?(%{llm?: true}, Map.get(state.open, id)) ->
+        {:halt, {:error, :invalid_event_batch}}
+
+      true ->
+        {_record, open} = Map.pop(state.open, id)
+        {:cont, %{state | open: open, seen: MapSet.put(state.seen, id)}}
+    end
+  end
+
+  defp occupied?(state, id),
+    do: Map.has_key?(state.open, id) or MapSet.member?(state.seen, id)
 
   defp llm_accounting_event(event) do
     type = field(event, "type")
@@ -270,9 +308,25 @@ defmodule PtcRunner.Kernel.LLMUsageSummary do
       type == "capability-stopped" and name == "llm-request" ->
         parse_llm_identity(event, :stop)
 
+      type == "capability-started" ->
+        occupy_foreign_id(event)
+
+      type == "capability-stopped" ->
+        foreign_stop_id(event)
+
       true ->
         :ignore
     end
+  end
+
+  defp occupy_foreign_id(event) do
+    id = field(event, "data", "capability_id")
+    if valid_id?(id), do: {:occupy, id}, else: :ignore
+  end
+
+  defp foreign_stop_id(event) do
+    id = field(event, "data", "capability_id")
+    if valid_id?(id), do: {:foreign_stop, id}, else: :ignore
   end
 
   defp parse_llm_identity(event, kind) do
@@ -282,9 +336,11 @@ defmodule PtcRunner.Kernel.LLMUsageSummary do
 
     if valid_id?(id) and valid_llm_name?(alias_name) and valid_llm_name?(revision) do
       record = %{
+        llm?: true,
         run_id: field(event, "run_id"),
         alias: alias_name,
         revision: revision,
+        environment: stringify(field(event, "data", "environment")),
         outcome: stop_outcome(event),
         usage: field(event, "data", "usage")
       }

--- a/lib/ptc_runner/kernel/llm_usage_summary.ex
+++ b/lib/ptc_runner/kernel/llm_usage_summary.ex
@@ -264,7 +264,8 @@ defmodule PtcRunner.Kernel.LLMUsageSummary do
 
       {start, open} ->
         if start.alias == stop.alias and start.revision == stop.revision and
-             start.environment == stop.environment do
+             start.environment == stop.environment and
+             start.mission_name == stop.mission_name do
           call = %{start | outcome: stop.outcome, usage: stop.usage}
 
           {:cont,
@@ -341,6 +342,7 @@ defmodule PtcRunner.Kernel.LLMUsageSummary do
         alias: alias_name,
         revision: revision,
         environment: stringify(field(event, "data", "environment")),
+        mission_name: stringify(field(event, "data", "mission_name")),
         outcome: stop_outcome(event),
         usage: field(event, "data", "usage")
       }

--- a/lib/ptc_runner/kernel/llm_usage_summary.ex
+++ b/lib/ptc_runner/kernel/llm_usage_summary.ex
@@ -18,13 +18,18 @@ defmodule PtcRunner.Kernel.LLMUsageSummary do
           required(String.t()) => [map()] | non_neg_integer()
         }
 
+  # Terminal accounting pairs `llm-request` starts and stops by
+  # `capability_id`. An unmatched start is an observed call with unknown
+  # usage; it is not synthesized into a stop event.
   @spec terminal([map()]) :: {:ok, summary()} | {:error, :invalid_event_batch}
   def terminal(events) when is_list(events) do
     with true <- length(events) <= @max_terminal_events,
          {:ok, normalized} <- normalize_events(events),
          true <- JSONValue.value?(normalized),
          :ok <- validate_terminal_batch(normalized),
-         summary <- summarize(normalized),
+         :ok <- validate_accounting_retention(normalized),
+         {:ok, calls} <- reconcile_llm_calls(normalized),
+         summary <- summarize_calls(calls, normalized),
          true <- length(summary["llm_usage"]) <= @max_rows,
          true <- length(summary["llm_usage_by_model"]) <= @max_rows,
          :ok <- ResultLimit.validate(summary, @max_result_bytes) do
@@ -41,14 +46,11 @@ defmodule PtcRunner.Kernel.LLMUsageSummary do
   @spec summarize([map()], [map()] | nil) :: summary()
   def summarize(events, attribution_events \\ nil) when is_list(events) do
     attribution_events = attribution_events || events
-    model_lookup = model_lookup(attribution_events)
-    {alias_counters, model_counters, unattributed} = reduce(events, model_lookup)
 
-    %{
-      "llm_usage" => rows(alias_counters),
-      "llm_usage_by_model" => rows(model_counters),
-      "unattributed_model_calls" => unattributed
-    }
+    events
+    |> Enum.filter(&llm_usage_event?/1)
+    |> Enum.map(&call_from_stop/1)
+    |> summarize_calls(attribution_events)
   end
 
   @doc """
@@ -86,8 +88,12 @@ defmodule PtcRunner.Kernel.LLMUsageSummary do
         "alias" => alias_name,
         "installation_revision" => revision
       }),
-      usage,
-      stringify(status) == "ok"
+      %{
+        alias: alias_name,
+        revision: revision,
+        outcome: if(stringify(status) == "ok", do: :ok, else: :error),
+        usage: usage
+      }
     )
   end
 
@@ -159,29 +165,168 @@ defmodule PtcRunner.Kernel.LLMUsageSummary do
     end)
   end
 
-  defp reduce(events, model_lookup) do
-    events
-    |> Enum.filter(&llm_usage_event?/1)
-    |> Enum.reduce({%{}, %{}, 0}, fn event, {aliases, models, unattributed} ->
-      alias_name = field(event, "data", "alias")
-      revision = field(event, "data", "installation_revision")
-      success? = stringify(field(event, "data", "status")) == "ok"
-      usage = field(event, "data", "usage")
-      alias_key = {alias_name, revision}
+  defp summarize_calls(calls, attribution_events) do
+    {alias_counters, model_counters, unattributed} =
+      reduce_calls(calls, model_lookup(attribution_events))
+
+    %{
+      "llm_usage" => rows(alias_counters),
+      "llm_usage_by_model" => rows(model_counters),
+      "unattributed_model_calls" => unattributed
+    }
+  end
+
+  # Dropped start or stop events can hide an in-flight LLM request, so a
+  # retained batch is not enough to reconstruct terminal accounting.
+  defp validate_accounting_retention(events) do
+    dropped? =
+      Enum.any?(events, fn event ->
+        field(event, "type") == "events-dropped" and
+          accounting_relevant_drop?(field(event, "data", "counts"))
+      end)
+
+    if dropped?, do: {:error, :invalid_event_batch}, else: :ok
+  end
+
+  defp accounting_relevant_drop?(counts) when is_map(counts) do
+    positive_count?(counts, "capability-started") or
+      positive_count?(counts, "capability-stopped")
+  end
+
+  defp accounting_relevant_drop?(_counts), do: false
+
+  defp positive_count?(counts, key) do
+    case field(counts, key) do
+      count when is_integer(count) and count > 0 -> true
+      _absent -> false
+    end
+  end
+
+  defp reconcile_llm_calls(events) do
+    case Enum.reduce_while(
+           events,
+           %{open: %{}, seen: MapSet.new(), calls: []},
+           &reconcile_event/2
+         ) do
+      {:error, :invalid_event_batch} = error ->
+        error
+
+      state ->
+        unmatched =
+          Enum.map(state.open, fn {_id, start} ->
+            %{start | outcome: :unknown, usage: nil}
+          end)
+
+        {:ok, Enum.reverse(state.calls, unmatched)}
+    end
+  end
+
+  defp reconcile_event(event, state) do
+    case llm_accounting_event(event) do
+      :ignore ->
+        {:cont, state}
+
+      {:error, :invalid_event_batch} = error ->
+        {:halt, error}
+
+      {:start, id, record} ->
+        if Map.has_key?(state.open, id) or MapSet.member?(state.seen, id) do
+          {:halt, {:error, :invalid_event_batch}}
+        else
+          {:cont, %{state | open: Map.put(state.open, id, record)}}
+        end
+
+      {:stop, id, stop} ->
+        case Map.pop(state.open, id) do
+          {nil, _open} ->
+            {:halt, {:error, :invalid_event_batch}}
+
+          {start, open} ->
+            if start.alias == stop.alias and start.revision == stop.revision do
+              call = %{start | outcome: stop.outcome, usage: stop.usage}
+
+              {:cont,
+               %{
+                 state
+                 | open: open,
+                   seen: MapSet.put(state.seen, id),
+                   calls: [call | state.calls]
+               }}
+            else
+              {:halt, {:error, :invalid_event_batch}}
+            end
+        end
+    end
+  end
+
+  defp llm_accounting_event(event) do
+    type = field(event, "type")
+    name = stringify(field(event, "data", "name"))
+
+    cond do
+      type == "capability-started" and name == "llm-request" ->
+        parse_llm_identity(event, :start)
+
+      type == "capability-stopped" and name == "llm-request" ->
+        parse_llm_identity(event, :stop)
+
+      true ->
+        :ignore
+    end
+  end
+
+  defp parse_llm_identity(event, kind) do
+    id = field(event, "data", "capability_id")
+    alias_name = field(event, "data", "alias")
+    revision = field(event, "data", "installation_revision")
+
+    if valid_id?(id) and valid_llm_name?(alias_name) and valid_llm_name?(revision) do
+      record = %{
+        run_id: field(event, "run_id"),
+        alias: alias_name,
+        revision: revision,
+        outcome: stop_outcome(event),
+        usage: field(event, "data", "usage")
+      }
+
+      {kind, id, record}
+    else
+      {:error, :invalid_event_batch}
+    end
+  end
+
+  defp valid_llm_name?(value), do: is_binary(value) and value =~ @name
+
+  defp stop_outcome(event) do
+    if stringify(field(event, "data", "status")) == "ok", do: :ok, else: :error
+  end
+
+  defp call_from_stop(event) do
+    %{
+      run_id: field(event, "run_id"),
+      alias: field(event, "data", "alias"),
+      revision: field(event, "data", "installation_revision"),
+      outcome: stop_outcome(event),
+      usage: field(event, "data", "usage")
+    }
+  end
+
+  defp reduce_calls(calls, model_lookup) do
+    Enum.reduce(calls, {%{}, %{}, 0}, fn call, {aliases, models, unattributed} ->
+      alias_key = {call.alias, call.revision}
 
       aliases =
         update_counter(
           aliases,
           alias_key,
           Map.merge(empty_row(), %{
-            "alias" => alias_name,
-            "installation_revision" => revision
+            "alias" => call.alias,
+            "installation_revision" => call.revision
           }),
-          usage,
-          success?
+          call
         )
 
-      lookup_key = {field(event, "run_id"), alias_name, revision}
+      lookup_key = {call.run_id, call.alias, call.revision}
 
       case Map.get(model_lookup, lookup_key) do
         {model, 1} ->
@@ -190,8 +335,7 @@ defmodule PtcRunner.Kernel.LLMUsageSummary do
               models,
               model,
               Map.put(empty_row(), "resolved_model", model),
-              usage,
-              success?
+              call
             )
 
           {aliases, models, unattributed}
@@ -229,18 +373,18 @@ defmodule PtcRunner.Kernel.LLMUsageSummary do
     }
   end
 
-  defp update_counter(counters, key, initial, usage, success?) do
+  defp update_counter(counters, key, initial, call) do
     {current, cost_complete?} = Map.get(counters, key, {initial, true})
 
     row =
       current
       |> Map.update!("calls", &(&1 + 1))
-      |> Map.update!("successful_calls", &(&1 + if(success?, do: 1, else: 0)))
+      |> Map.update!("successful_calls", &(&1 + if(call.outcome == :ok, do: 1, else: 0)))
 
-    Map.put(counters, key, update_usage(row, cost_complete?, usage, success?))
+    Map.put(counters, key, update_usage(row, cost_complete?, call))
   end
 
-  defp update_usage(row, cost_complete?, usage, true) when is_map(usage) do
+  defp update_usage(row, cost_complete?, %{outcome: :ok, usage: usage}) when is_map(usage) do
     case LLMUsage.normalize(usage) do
       {:ok, normalized} ->
         row =
@@ -255,10 +399,11 @@ defmodule PtcRunner.Kernel.LLMUsageSummary do
     end
   end
 
-  defp update_usage(row, _cost_complete?, _usage, true),
-    do: {Map.update!(row, "missing_usage_calls", &(&1 + 1)), false}
+  defp update_usage(row, _cost_complete?, %{outcome: outcome})
+       when outcome in [:ok, :unknown],
+       do: {Map.update!(row, "missing_usage_calls", &(&1 + 1)), false}
 
-  defp update_usage(row, cost_complete?, _usage, false), do: {row, cost_complete?}
+  defp update_usage(row, cost_complete?, %{outcome: :error}), do: {row, cost_complete?}
 
   defp sum_usage(left, right),
     do: Map.merge(left, right, fn _key, first, second -> first + second end)

--- a/site/reference/cli/index.html
+++ b/site/reference/cli/index.html
@@ -124,7 +124,9 @@ it spent nothing. A failure that did activate one reports
 <code class="inline">&quot;llm_usage_state&quot;: &quot;unavailable&quot;</code> and a null list rather than claiming zero:
 the request may have been billed with no result left to account for it. As in a
 run, <code class="inline">total_cost</code> is omitted when any call could not be priced, and
-<code class="inline">missing_usage_calls</code> counts the calls a provider reported no tokens for.</p><h2 id="read-the-embedded-documentation">Read the embedded documentation</h2><p>Every installation carries the language specification, references, and JSON
+<code class="inline">missing_usage_calls</code> counts calls whose usage may exist but was not observed,
+including an in-flight request stopped by the run clock. It is not limited to
+successful completions.</p><h2 id="read-the-embedded-documentation">Read the embedded documentation</h2><p>Every installation carries the language specification, references, and JSON
 Schemas that describe its own version. <code class="inline">ptc docs</code> lists them; <code class="inline">ptc docs PAGE</code>
 prints one page verbatim to stdout:</p><pre><code class="console language-console">ptc docs
 ptc docs agent-guide
@@ -171,13 +173,20 @@ checkout directory.</p><p>For runs that produce a validated terminal event batch
 includes <code class="inline">llm_usage</code> grouped by alias and installation revision,
 <code class="inline">llm_usage_by_model</code> grouped by an attested public resolved model, and
 <code class="inline">unattributed_model_calls</code>. Rows report call counts, usage-presence counts, and
-summed token and <code class="inline">total_cost</code> values. A row includes <code class="inline">total_cost</code> only when
-every successful call has valid usage that reports cost; otherwise the
-aggregate cost remains unknown and is omitted, not reported as zero.
+summed token and <code class="inline">total_cost</code> values. Terminal accounting pairs each
+<code class="inline">llm-request</code> <code class="inline">capability-started</code> with its <code class="inline">capability-stopped</code> by
+<code class="inline">capability_id</code>. An unmatched start is one observed call with unknown usage:
+<code class="inline">calls</code> increments, <code class="inline">successful_calls</code> does not, and <code class="inline">missing_usage_calls</code>
+increments. A row includes <code class="inline">total_cost</code> only when every call that could carry
+usage has valid priced usage; an unmatched or unpriced call leaves the
+aggregate cost unknown and omitted, not reported as zero, while measured
+input/output totals are retained. <code class="inline">llm_usage_state: &quot;available&quot;</code> means the
+terminal batch could be reconstructed, not that every call supplied usage.
 <code class="inline">llm_usage_state: &quot;unavailable&quot;</code> pairs all three
-aggregate fields with <code class="inline">null</code> when terminal evidence cannot be validated, while
-preserving other known usage. Non-empty <code class="inline">events_dropped</code> means an available
-summary covers retained evidence and may not be complete.</p><p>Artifact publication currently requires a Unix host with POSIX-compatible
+aggregate fields with <code class="inline">null</code> when terminal evidence cannot be validated,
+including dropped <code class="inline">capability-started</code> or <code class="inline">capability-stopped</code> events, while
+preserving other known usage. Non-empty <code class="inline">events_dropped</code> for other event types
+means an available summary covers retained evidence and may not be complete.</p><p>Artifact publication currently requires a Unix host with POSIX-compatible
 <code class="inline">mkdir</code> and <code class="inline">id</code>; trace append also needs <code class="inline">sh</code> and either <code class="inline">lockf</code> or <code class="inline">flock</code>.
 Private artifacts and newly created traces require trusted ancestry, safe
 ownership, and restrictive modes. Preflight refuses unsafe or unwritable

--- a/test/ptc_runner/kernel/command_doctor_test.exs
+++ b/test/ptc_runner/kernel/command_doctor_test.exs
@@ -175,6 +175,16 @@ defmodule PtcRunner.Kernel.CommandDoctorTest do
       "usage" => %{"input" => 12}
     }
 
+    unmatched = %{
+      "alias" => "model",
+      "installation_revision" => "model-v1",
+      "calls" => 1,
+      "successful_calls" => 0,
+      "usage_calls" => 0,
+      "missing_usage_calls" => 1,
+      "usage" => %{}
+    }
+
     selected = %{
       "alias" => "model",
       "source" => "llm",
@@ -190,6 +200,12 @@ defmodule PtcRunner.Kernel.CommandDoctorTest do
 
     assert CommandContract.valid_doctor_failure_result?(valid, primary, [])
 
+    unmatched_valid =
+      valid
+      |> put_in(["usage"], %{"llm_usage_state" => "available", "llm_usage" => [unmatched]})
+
+    assert CommandContract.valid_doctor_failure_result?(unmatched_valid, primary, [])
+
     tampered = [
       # Spend attributed to a declaration the same report does not list.
       put_in(valid, ["usage", "llm_usage", Access.at(0), "alias"], "other"),
@@ -198,8 +214,7 @@ defmodule PtcRunner.Kernel.CommandDoctorTest do
       |> put_in(["model_aliases", Access.at(0), "default"], nil),
       # Counters that no measurement could have produced.
       put_in(valid, ["usage", "llm_usage", Access.at(0), "calls"], 0),
-      put_in(valid, ["usage", "llm_usage", Access.at(0), "successful_calls"], 1),
-      put_in(valid, ["usage", "llm_usage", Access.at(0), "usage_calls"], 0),
+      put_in(valid, ["usage", "llm_usage", Access.at(0), "usage_calls"], 2),
       put_in(valid, ["usage", "llm_usage", Access.at(0), "missing_usage_calls"], 0),
       # Tokens summed from calls that reported none.
       valid

--- a/test/ptc_runner/kernel/command_engine_global_state_test.exs
+++ b/test/ptc_runner/kernel/command_engine_global_state_test.exs
@@ -668,4 +668,111 @@ defmodule PtcRunner.Kernel.CommandEngineGlobalStateTest do
     assert outcome.envelope["error"]["code"] == "internal_error"
     assert MapSet.difference(host_installation_owners(), owners_before) == MapSet.new()
   end
+
+  @tag :tmp_dir
+  @tag timeout: 30_000
+  test "an in-flight LLM call cancelled by a timeout reports missing usage", %{tmp_dir: directory} do
+    keys = [:llm_adapter, :host_llm_test_owner, :host_llm_test_block, :host_llm_test_result]
+
+    previous = Map.new(keys, &{&1, Application.fetch_env(:ptc_runner, &1)})
+
+    Application.put_env(:ptc_runner, :llm_adapter, PtcRunner.TestSupport.HostLLMAdapter)
+    Application.put_env(:ptc_runner, :host_llm_test_owner, self())
+    Application.put_env(:ptc_runner, :host_llm_test_block, true)
+
+    on_exit(fn ->
+      Enum.each(previous, fn
+        {key, {:ok, value}} -> Application.put_env(:ptc_runner, key, value)
+        {key, :error} -> Application.delete_env(:ptc_runner, key)
+      end)
+    end)
+
+    host_path =
+      write_host_config(directory, "timeout-inflight", %{
+        "credentials" => %{"key" => %{"literal" => "test-key"}},
+        "install" => %{
+          "model" => %{
+            "source" => "llm",
+            "installation_revision" => "model-v1",
+            "model" => "openrouter:test/model",
+            "credential" => "key"
+          }
+        }
+      })
+
+    manifest =
+      valid_manifest(%{
+        "workflow" => %{
+          "components" => [
+            %{"id" => "app", "path" => "main.clj", "dependencies" => ["llm"]},
+            %{"library" => "llm"}
+          ],
+          "entry" => "app/run"
+        },
+        "providers" => %{
+          "workflow" => [%{"name" => "model", "config" => %{}}],
+          "mission" => []
+        },
+        "limits" => %{
+          "evaluation_timeout_ms" => 15_000,
+          "workflow_timeout_ms" => 1_000,
+          "run_duration_ms" => 30_000
+        }
+      })
+
+    application =
+      write_application(directory, "timeout-inflight", manifest, %{
+        "main.clj" => ~S|(ns app) (defn run [_input] (llm/request {"messages" []}))|
+      })
+
+    # Dispatcher emits `capability-started` before invoking the adapter, so
+    # receiving the blocked request is the synchronization that the start is
+    # already in the terminal batch. The evaluation is then killed while the
+    # provider worker is still blocked, leaving no matching stop. The workflow
+    # clock is the binding limit so that kill wins against the dispatcher's
+    # provider-await timer: when `run_duration_ms` is the tighter bound, that
+    # timer can emit a matched failed stop (`missing_usage_calls` stays 0).
+    # No sleep.
+    task =
+      Task.async(fn ->
+        CommandEngine.dispatch(["run", application, "--host-config", host_path])
+      end)
+
+    receive do
+      {:host_llm_ensure_ready, _pid} ->
+        assert_receive {:host_llm_request, _model, _request}, 10_000
+
+      {:host_llm_request, _model, _request} ->
+        :ok
+    after
+      10_000 ->
+        flunk("did not observe the in-flight LLM request after capability-started")
+    end
+
+    assert {:error, %CommandOutcome{} = outcome} = Task.await(task, 15_000)
+    assert outcome.envelope["error"]["code"] in ["run_timeout", "runtime_limit_exceeded"]
+
+    usage = outcome.envelope["execution"]["usage"]
+    assert usage["llm_usage_state"] == "available"
+
+    expected_counters = %{
+      "calls" => 1,
+      "successful_calls" => 0,
+      "usage_calls" => 0,
+      "missing_usage_calls" => 1,
+      "usage" => %{}
+    }
+
+    assert [row] = usage["llm_usage"]
+    assert Map.take(row, Map.keys(expected_counters)) == expected_counters
+    assert row["alias"] == "model"
+    assert row["installation_revision"] == "model-v1"
+    refute Map.has_key?(row["usage"], "total_cost")
+
+    alias_calls = Enum.reduce(usage["llm_usage"], 0, &(&2 + &1["calls"]))
+    model_calls = Enum.reduce(usage["llm_usage_by_model"], 0, &(&2 + &1["calls"]))
+    assert model_calls + usage["unattributed_model_calls"] == alias_calls
+
+    assert_schema_valid(outcome.envelope)
+  end
 end

--- a/test/ptc_runner/kernel/command_engine_test.exs
+++ b/test/ptc_runner/kernel/command_engine_test.exs
@@ -4464,12 +4464,23 @@ defmodule PtcRunner.Kernel.CommandEngineTest do
       "usage" => %{"input" => 4}
     }
 
+    unmatched_row = %{
+      "alias" => "writer",
+      "installation_revision" => "stable-v1",
+      "calls" => 1,
+      "successful_calls" => 0,
+      "usage_calls" => 0,
+      "missing_usage_calls" => 1,
+      "usage" => %{}
+    }
+
     with_llm =
       classified
       |> put_in(["execution", "usage", "llm_usage"], [llm_row])
       |> put_in(["execution", "usage", "unattributed_model_calls"], 1)
 
     assert_schema_valid(with_llm)
+    assert_schema_valid(put_in(with_llm, ["execution", "usage", "llm_usage"], [unmatched_row]))
 
     for invalid <- [
           put_in(with_llm, ["execution", "usage", "llm_usage", Access.at(0), "extra"], true),

--- a/test/ptc_runner/kernel/llm_usage_summary_test.exs
+++ b/test/ptc_runner/kernel/llm_usage_summary_test.exs
@@ -412,6 +412,39 @@ defmodule PtcRunner.Kernel.LLMUsageSummaryTest do
         llm_started_event(2, "capability-open"),
         event(3, "events-dropped", %{"counts" => %{"capability-stopped" => 1}}),
         event(4, "run-stopped", %{"outcome" => "timeout"})
+      ],
+      [
+        started,
+        llm_started_event(2, "capability-open"),
+        event(3, "events-dropped", %{"counts" => %{"$overflow" => 1}}),
+        event(4, "run-stopped", %{"outcome" => "timeout"})
+      ],
+      [
+        started,
+        llm_started_event(2, "capability-name"),
+        event(3, "capability-stopped", %{
+          "environment" => "workflow",
+          "name" => "http-request",
+          "capability_id" => "capability-name",
+          "status" => "error"
+        }),
+        stopped
+      ],
+      [
+        started,
+        llm_started_event(2, "capability-env"),
+        llm_stopped_event(3, "capability-env", %{"input" => 1}, %{"environment" => "mission"}),
+        stopped
+      ],
+      [
+        started,
+        event(2, "capability-started", %{
+          "environment" => "workflow",
+          "name" => "http-request",
+          "capability_id" => "capability-shared"
+        }),
+        llm_started_event(3, "capability-shared"),
+        stopped
       ]
     ]
 
@@ -432,6 +465,30 @@ defmodule PtcRunner.Kernel.LLMUsageSummaryTest do
     ]
 
     assert {:ok, %{"llm_usage" => [%{"calls" => 1, "usage_calls" => 1}]}} =
+             LLMUsageSummary.terminal(events)
+  end
+
+  test "an unmatched LLM start next to a completed non-LLM capability stays available" do
+    snapshot = TestHelpers.llm_snapshot("writer", "stable-v1", "openrouter:writer/model")
+
+    events = [
+      event(1, "run-started", %{"missions" => %{}, "connector_snapshots" => [snapshot]}),
+      event(2, "capability-started", %{
+        "environment" => "workflow",
+        "name" => "http-request",
+        "capability_id" => "capability-http"
+      }),
+      event(3, "capability-stopped", %{
+        "environment" => "workflow",
+        "name" => "http-request",
+        "capability_id" => "capability-http",
+        "status" => "ok"
+      }),
+      llm_started_event(4, "capability-open"),
+      event(5, "run-stopped", %{"outcome" => "timeout"})
+    ]
+
+    assert {:ok, %{"llm_usage" => [%{"calls" => 1, "missing_usage_calls" => 1}]}} =
              LLMUsageSummary.terminal(events)
   end
 

--- a/test/ptc_runner/kernel/llm_usage_summary_test.exs
+++ b/test/ptc_runner/kernel/llm_usage_summary_test.exs
@@ -438,6 +438,12 @@ defmodule PtcRunner.Kernel.LLMUsageSummaryTest do
       ],
       [
         started,
+        llm_started_event(2, "capability-mission", %{"mission_name" => "alpha"}),
+        llm_stopped_event(3, "capability-mission", %{"input" => 1}, %{"mission_name" => "beta"}),
+        stopped
+      ],
+      [
+        started,
         event(2, "capability-started", %{
           "environment" => "workflow",
           "name" => "http-request",

--- a/test/ptc_runner/kernel/llm_usage_summary_test.exs
+++ b/test/ptc_runner/kernel/llm_usage_summary_test.exs
@@ -9,28 +9,38 @@ defmodule PtcRunner.Kernel.LLMUsageSummaryTest do
 
     decoded = [
       event(1, "run-started", %{"missions" => %{}, "connector_snapshots" => [snapshot]}),
-      event(2, "capability-stopped", %{
+      llm_started_event(2, "capability-1"),
+      event(3, "capability-stopped", %{
         "environment" => "workflow",
         "name" => "llm-request",
+        "capability_id" => "capability-1",
         "alias" => "writer",
         "installation_revision" => "stable-v1",
         "status" => "ok",
         "usage" => %{"input" => 3}
       }),
-      event(3, "run-stopped", %{"outcome" => "ok"})
+      event(4, "run-stopped", %{"outcome" => "ok"})
     ]
 
     in_memory = [
       memory_event(1, "run-started", %{missions: %{}, connector_snapshots: [snapshot]}),
-      memory_event(2, "capability-stopped", %{
+      memory_event(2, "capability-started", %{
         environment: :workflow,
         name: "llm-request",
+        capability_id: "capability-1",
+        alias: "writer",
+        installation_revision: "stable-v1"
+      }),
+      memory_event(3, "capability-stopped", %{
+        environment: :workflow,
+        name: "llm-request",
+        capability_id: "capability-1",
         alias: "writer",
         installation_revision: "stable-v1",
         status: :ok,
         usage: %{input: 3}
       }),
-      memory_event(3, "run-stopped", %{outcome: :ok})
+      memory_event(4, "run-stopped", %{outcome: :ok})
     ]
 
     assert {:ok, summary} = LLMUsageSummary.terminal(decoded)
@@ -67,18 +77,19 @@ defmodule PtcRunner.Kernel.LLMUsageSummaryTest do
 
     calls =
       for index <- 1..129 do
-        event(index + 1, "capability-stopped", %{
-          "environment" => "workflow",
-          "name" => "llm-request",
-          "alias" => "a#{String.pad_leading(Integer.to_string(index), 3, "0")}",
-          "installation_revision" => "stable-v1",
-          "status" => "error"
-        })
+        alias_name = "a#{String.pad_leading(Integer.to_string(index), 3, "0")}"
+        capability_id = "capability-#{index}"
+        extra = %{"alias" => alias_name}
+
+        [
+          llm_started_event(index * 2, capability_id, extra),
+          llm_failed_event(index * 2 + 1, capability_id, extra)
+        ]
       end
 
     events =
       [event(1, "run-started", %{"missions" => %{}})] ++
-        calls ++ [event(131, "run-stopped", %{"outcome" => "error"})]
+        List.flatten(calls) ++ [event(260, "run-stopped", %{"outcome" => "error"})]
 
     assert {:error, :invalid_event_batch} = LLMUsageSummary.terminal(events)
   end
@@ -91,15 +102,9 @@ defmodule PtcRunner.Kernel.LLMUsageSummaryTest do
         "missions" => %{},
         "connector_snapshots" => [snapshot, snapshot]
       }),
-      event(2, "capability-stopped", %{
-        "environment" => "workflow",
-        "name" => "llm-request",
-        "alias" => "writer",
-        "installation_revision" => "stable-v1",
-        "status" => "ok",
-        "usage" => %{"input" => 1}
-      }),
-      event(3, "run-stopped", %{"outcome" => "ok"})
+      llm_started_event(2, "capability-ambiguous"),
+      llm_stopped_event(3, "capability-ambiguous", %{"input" => 1}),
+      event(4, "run-stopped", %{"outcome" => "ok"})
     ]
 
     assert {:ok,
@@ -115,9 +120,11 @@ defmodule PtcRunner.Kernel.LLMUsageSummaryTest do
 
     events = [
       event(1, "run-started", %{"missions" => %{}, "connector_snapshots" => [snapshot]}),
-      llm_stopped_event(2, %{"input" => 3, "total_cost" => 0.25}),
-      llm_stopped_event(3, %{"input" => 5}),
-      event(4, "run-stopped", %{"outcome" => "ok"})
+      llm_started_event(2, "capability-priced"),
+      llm_stopped_event(3, "capability-priced", %{"input" => 3, "total_cost" => 0.25}),
+      llm_started_event(4, "capability-unpriced"),
+      llm_stopped_event(5, "capability-unpriced", %{"input" => 5}),
+      event(6, "run-stopped", %{"outcome" => "ok"})
     ]
 
     assert {:ok, summary} = LLMUsageSummary.terminal(events)
@@ -244,6 +251,190 @@ defmodule PtcRunner.Kernel.LLMUsageSummaryTest do
     assert LLMUsageSummary.spend(mixed) == %{"state" => "incomplete"}
   end
 
+  test "an unmatched LLM start is an observed call with unknown usage" do
+    snapshot = TestHelpers.llm_snapshot("writer", "stable-v1", "openrouter:writer/model")
+
+    events = [
+      event(1, "run-started", %{"missions" => %{}, "connector_snapshots" => [snapshot]}),
+      llm_started_event(2, "capability-open"),
+      event(3, "run-stopped", %{"outcome" => "timeout"})
+    ]
+
+    assert {:ok, summary} = LLMUsageSummary.terminal(events)
+    assert summary["unattributed_model_calls"] == 0
+
+    for rows <- [summary["llm_usage"], summary["llm_usage_by_model"]] do
+      assert [
+               %{
+                 "calls" => 1,
+                 "successful_calls" => 0,
+                 "usage_calls" => 0,
+                 "missing_usage_calls" => 1,
+                 "usage" => %{}
+               } = row
+             ] = rows
+
+      refute Map.has_key?(row["usage"], "total_cost")
+    end
+
+    assert hd(summary["llm_usage"])["alias"] == "writer"
+    assert hd(summary["llm_usage"])["installation_revision"] == "stable-v1"
+    assert hd(summary["llm_usage_by_model"])["resolved_model"] == "openrouter:writer/model"
+  end
+
+  test "matched successful and failed LLM calls keep their current counters" do
+    snapshot = TestHelpers.llm_snapshot("writer", "stable-v1", "openrouter:writer/model")
+
+    events = [
+      event(1, "run-started", %{"missions" => %{}, "connector_snapshots" => [snapshot]}),
+      llm_started_event(2, "capability-ok"),
+      llm_stopped_event(3, "capability-ok", %{"input" => 4, "output" => 2, "total_cost" => 0.1}),
+      llm_started_event(4, "capability-error"),
+      llm_failed_event(5, "capability-error"),
+      event(6, "run-stopped", %{"outcome" => "error"})
+    ]
+
+    assert {:ok, summary} = LLMUsageSummary.terminal(events)
+
+    for rows <- [summary["llm_usage"], summary["llm_usage_by_model"]] do
+      assert [
+               %{
+                 "calls" => 2,
+                 "successful_calls" => 1,
+                 "usage_calls" => 1,
+                 "missing_usage_calls" => 0,
+                 "usage" => %{"input" => 4, "output" => 2, "total_cost" => 0.1}
+               }
+             ] = rows
+    end
+  end
+
+  test "mixed measured and unmatched calls retain tokens and omit total_cost" do
+    snapshot = TestHelpers.llm_snapshot("writer", "stable-v1", "openrouter:writer/model")
+
+    events = [
+      event(1, "run-started", %{"missions" => %{}, "connector_snapshots" => [snapshot]}),
+      llm_started_event(2, "capability-measured"),
+      llm_stopped_event(3, "capability-measured", %{
+        "input" => 6,
+        "output" => 1,
+        "total_cost" => 0.4
+      }),
+      llm_started_event(4, "capability-open"),
+      event(5, "run-stopped", %{"outcome" => "timeout"})
+    ]
+
+    assert {:ok, summary} = LLMUsageSummary.terminal(events)
+
+    for rows <- [summary["llm_usage"], summary["llm_usage_by_model"]] do
+      assert [
+               %{
+                 "calls" => 2,
+                 "successful_calls" => 1,
+                 "usage_calls" => 1,
+                 "missing_usage_calls" => 1,
+                 "usage" => usage
+               }
+             ] = rows
+
+      assert usage == %{"input" => 6, "output" => 1}
+      refute Map.has_key?(usage, "total_cost")
+    end
+  end
+
+  test "an unmatched start with ambiguous model attribution keeps the alias row" do
+    snapshot = TestHelpers.llm_snapshot("writer", "stable-v1", "openrouter:writer/model")
+
+    events = [
+      event(1, "run-started", %{
+        "missions" => %{},
+        "connector_snapshots" => [snapshot, snapshot]
+      }),
+      llm_started_event(2, "capability-open"),
+      event(3, "run-stopped", %{"outcome" => "timeout"})
+    ]
+
+    assert {:ok,
+            %{
+              "llm_usage" => [
+                %{
+                  "alias" => "writer",
+                  "calls" => 1,
+                  "successful_calls" => 0,
+                  "usage_calls" => 0,
+                  "missing_usage_calls" => 1
+                }
+              ],
+              "llm_usage_by_model" => [],
+              "unattributed_model_calls" => 1
+            }} = LLMUsageSummary.terminal(events)
+  end
+
+  test "duplicate, reordered, mismatched, or dropped LLM events fail closed" do
+    snapshot = TestHelpers.llm_snapshot("writer", "stable-v1", "openrouter:writer/model")
+    started = event(1, "run-started", %{"missions" => %{}, "connector_snapshots" => [snapshot]})
+    stopped = event(4, "run-stopped", %{"outcome" => "ok"})
+
+    invalid = [
+      [
+        started,
+        llm_started_event(2, "capability-dup"),
+        llm_started_event(3, "capability-dup"),
+        stopped
+      ],
+      [
+        started,
+        llm_stopped_event(2, "capability-early", %{"input" => 1}),
+        llm_started_event(3, "capability-early"),
+        stopped
+      ],
+      [
+        started,
+        llm_started_event(2, "capability-mismatch"),
+        llm_stopped_event(3, "capability-mismatch", %{"input" => 1}, %{"alias" => "other"}),
+        stopped
+      ],
+      [
+        started,
+        llm_started_event(2, "capability-dup-stop"),
+        llm_stopped_event(3, "capability-dup-stop", %{"input" => 1}),
+        llm_stopped_event(4, "capability-dup-stop", %{"input" => 2}),
+        event(5, "run-stopped", %{"outcome" => "ok"})
+      ],
+      [
+        started,
+        llm_started_event(2, "capability-open"),
+        event(3, "events-dropped", %{"counts" => %{"capability-started" => 1}}),
+        event(4, "run-stopped", %{"outcome" => "timeout"})
+      ],
+      [
+        started,
+        llm_started_event(2, "capability-open"),
+        event(3, "events-dropped", %{"counts" => %{"capability-stopped" => 1}}),
+        event(4, "run-stopped", %{"outcome" => "timeout"})
+      ]
+    ]
+
+    for events <- invalid do
+      assert {:error, :invalid_event_batch} = LLMUsageSummary.terminal(events)
+    end
+  end
+
+  test "dropping unrelated event types leaves LLM accounting available" do
+    snapshot = TestHelpers.llm_snapshot("writer", "stable-v1", "openrouter:writer/model")
+
+    events = [
+      event(1, "run-started", %{"missions" => %{}, "connector_snapshots" => [snapshot]}),
+      llm_started_event(2, "capability-ok"),
+      llm_stopped_event(3, "capability-ok", %{"input" => 2}),
+      event(4, "events-dropped", %{"counts" => %{"print" => 1}}),
+      event(5, "run-stopped", %{"outcome" => "ok"})
+    ]
+
+    assert {:ok, %{"llm_usage" => [%{"calls" => 1, "usage_calls" => 1}]}} =
+             LLMUsageSummary.terminal(events)
+  end
+
   defp event(sequence, type, data) do
     %{
       "schema_version" => 2,
@@ -268,7 +459,24 @@ defmodule PtcRunner.Kernel.LLMUsageSummaryTest do
     }
   end
 
-  defp llm_stopped_event(sequence, usage) do
+  defp llm_started_event(sequence, capability_id, extra \\ %{}) do
+    event(
+      sequence,
+      "capability-started",
+      Map.merge(
+        %{
+          "environment" => "workflow",
+          "name" => "llm-request",
+          "capability_id" => capability_id,
+          "alias" => "writer",
+          "installation_revision" => "stable-v1"
+        },
+        extra
+      )
+    )
+  end
+
+  defp llm_stopped_event(sequence, usage) when is_map(usage) do
     event(sequence, "capability-stopped", %{
       "environment" => "workflow",
       "name" => "llm-request",
@@ -277,5 +485,42 @@ defmodule PtcRunner.Kernel.LLMUsageSummaryTest do
       "status" => "ok",
       "usage" => usage
     })
+  end
+
+  defp llm_stopped_event(sequence, capability_id, usage, extra \\ %{})
+       when is_binary(capability_id) do
+    data =
+      Map.merge(
+        %{
+          "environment" => "workflow",
+          "name" => "llm-request",
+          "capability_id" => capability_id,
+          "alias" => "writer",
+          "installation_revision" => "stable-v1",
+          "status" => "ok",
+          "usage" => usage
+        },
+        extra
+      )
+
+    event(sequence, "capability-stopped", data)
+  end
+
+  defp llm_failed_event(sequence, capability_id, extra \\ %{}) do
+    event(
+      sequence,
+      "capability-stopped",
+      Map.merge(
+        %{
+          "environment" => "workflow",
+          "name" => "llm-request",
+          "capability_id" => capability_id,
+          "alias" => "writer",
+          "installation_revision" => "stable-v1",
+          "status" => "error"
+        },
+        extra
+      )
+    )
   end
 end

--- a/test/support/host_llm_adapter.ex
+++ b/test/support/host_llm_adapter.ex
@@ -17,6 +17,12 @@ defmodule PtcRunner.TestSupport.HostLLMAdapter do
       raise ArgumentError, "unknown registry: FakeAdapter.Finch"
     end
 
+    if Application.get_env(:ptc_runner, :host_llm_test_block, false) do
+      receive do
+        :host_llm_test_unblock -> :ok
+      end
+    end
+
     Application.get_env(
       :ptc_runner,
       :host_llm_test_result,

--- a/test/support/memory_soak.ex
+++ b/test/support/memory_soak.ex
@@ -68,6 +68,11 @@ defmodule PtcRunner.TestSupport.MemorySoak do
   Crank `PTC_SOAK_ITERATIONS` to ~10k+ for real soak runs locally.
   """
 
+  # `:recon` is a `runtime: false` test/dev dependency. Mix does not load it
+  # into the compiler, so the optional calls below warn without this.
+  @compile {:no_warn_undefined,
+            [{:recon, :proc_count, 2}, {:recon, :bin_leak, 1}, {:recon_alloc, :memory, 1}]}
+
   @type snapshot :: %{
           mem: keyword(),
           atoms: non_neg_integer(),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #1579.

When a run stops while an LLM request is still in flight, terminal accounting previously counted only `capability-stopped` events. An unmatched `llm-request` start therefore showed `calls: 1` with `missing_usage_calls: 0`, so a consumer following the documented cost pattern treated a potentially billed request as a complete zero-cost total.

## Change

`LLMUsageSummary.terminal/1` now pairs `llm-request` start and stop events by `capability_id`:

- An unmatched start is one observed call with unknown usage (`missing_usage_calls` increments; `successful_calls` does not).
- No synthetic `capability-stopped` event is emitted.
- `llm_usage_state` stays `"available"` when the batch is valid; availability is not completeness.
- Mixed measured and unmatched rows keep known token totals and omit `total_cost`.
- Alias and installation revision come from the start event. Ambiguous model attribution keeps the alias row and increments `unattributed_model_calls`.
- Duplicate IDs, stop-before-start, contradictory identities (name, environment, mission, alias, or revision), dropped `capability-started`/`capability-stopped`, or drop `$overflow` fail closed to unavailable accounting.
- Matched failed completions without usage keep the previous counters.

Doctor/schema coherence no longer requires `successful_calls == calls`. Live spend (`summarize/2`, `accumulate/5`) and timeout classification are unchanged.

## Tests

- Terminal batch cases for unmatched starts, mixed rows, attribution, and fail-closed pairing.
- Credential-free command test: blocking local adapter, sync on the in-flight request, evaluation killed by `workflow_timeout_ms` so the dispatcher cannot emit a matched failed stop.

## Verification

- `mix precommit`
- `scripts/ci/core-tests.sh` (6952 passed)
- Focused tests: `llm_usage_summary_test.exs`, `command_doctor_test.exs`, in-flight timeout case in `command_engine_global_state_test.exs`

## Reviews

Three independent reviews of this slice. Incremental review requested fail-closed pairing for same-id non-LLM stops and `$overflow` drops; those are in the second commit. Cumulative review requested `mission_name` identity; that is in the third commit. No further review cycle.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a029e3-3f83-7c8c-aeb4-f2104a00d54b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a029e3-3f83-7c8c-aeb4-f2104a00d54b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

