### PR TITLE
docs(site): answer "why not a coding agent?" on the landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,28 @@
 **Build AI agents that are bounded in what they can do, easy to change,
 observable in operation, and designed to improve from evidence.**
 
+- **A language for agents** — small, typed, and limited to the tools you
+  approved, discovered in a REPL rather than listed in the prompt.
+- **A runtime for agent services** — built for bounded, traceable jobs and many
+  concurrent requests, without a desktop, workspace, or container for every
+  agent.
+
+## Why not a coding agent?
+
+An agent's results come from the model *and* the harness around it, in roughly
+equal measure. The best harnesses anyone ships today are coding agents, so that
+is what non-coding work gets run on, whether or not it fits.
+
+Capability is not what decides it. How does it run behind your own interface,
+inside a service you already have? What happens when a thousand requests arrive
+at once, and what stops any one of them spending an hour, or a gigabyte? What do
+you show someone who asks, three weeks later, why it did that?
+
+Here those are properties of the runtime, not a project: ceilings on time,
+memory, and tool calls enforced by the VM, a structured trace from every run,
+and thousands of runs on one machine. You call it from your own code, or run it
+as a command and read back JSON.
+
 ## The loop is a library, not the runtime
 
 A system that improves itself has to be able to change itself. In most

--- a/site/index.html
+++ b/site/index.html
@@ -103,6 +103,28 @@
 <p class="lead"><strong>Build AI agents that are bounded in what they can do, easy to
 change, observable in operation, and designed to improve from evidence.</strong></p>
 
+<ul>
+<li><strong>A language for agents</strong> — small, typed, and limited to the tools you
+approved, discovered in a REPL rather than listed in the prompt.</li>
+<li><strong>A runtime for agent services</strong> — built for bounded, traceable jobs and
+many concurrent requests, without a desktop, workspace, or container for every agent.</li>
+</ul>
+
+<h2>Why not a coding agent?</h2>
+
+<p>An agent's results come from the model <em>and</em> the harness around it, in roughly
+equal measure. The best harnesses anyone ships today are coding agents, so that is what
+non-coding work gets run on, whether or not it fits.</p>
+
+<p>Capability is not what decides it. How does it run behind your own interface, inside a
+service you already have? What happens when a thousand requests arrive at once, and what
+stops any one of them spending an hour, or a gigabyte? What do you show someone who asks,
+three weeks later, why it did that?</p>
+
+<p>Here those are properties of the runtime, not a project: ceilings on time, memory, and
+tool calls enforced by the VM, a structured trace from every run, and thousands of runs on
+one machine. You call it from your own code, or run it as a command and read back JSON.</p>
+
 <h2>The loop is a library, not the runtime</h2>
 
 <p>A system that improves itself has to be able to change itself. In most frameworks the


### PR DESCRIPTION
## What

The landing page said what PtcRunner is but never what it is *instead of*. A reader weighing it against a coding agent got no answer, so this adds one.

Two bullets under the lead naming the two halves of the product:

> - **A language for agents** — small, typed, and limited to the tools you approved, with clear feedback so the model can fix mistakes and retry instead of crashing.
> - **A runtime for agent services** — built for bounded, traceable jobs and many concurrent requests, without a desktop, workspace, or container for every agent.

Then a `Why not a coding agent?` section that concedes the comparison before answering it: results come from the model *and* the harness in roughly equal measure, the best harnesses shipping today are coding agents, and so non-coding work gets run on them whether or not it fits. The answer is three operational questions — running inside a service you already have, a thousand concurrent requests, per-run ceilings, and explaining a run three weeks later — and a short paragraph pointing at properties the runtime already has.

## Why operations rather than security

An earlier draft drew the line at what each can touch ("files and commands" vs. "tools and data"). That line does not hold: coding agents call MCP tools too, and their shell and filesystem access can be gated by policy. Deployment, concurrency, per-run limits, tracing, and integration are not answered by restricting a coding agent, so the section argues there instead.

Two claims were deliberately left out for the same reason. "No filesystem" is refutable by `ptc-fs-mcp` — grant that tool and a program reads files — so the bullet says *limited to the tools you approved*, which is the accurate ambient-vs-granted claim. And the deployment jab is left to the Install section, which already discloses that the released archive is macOS arm64 with the published container still planned.

## Notes

- Site-only. `README.md` carries this prose in parallel and is now out of sync by exactly this addition; mirroring it is a follow-up if wanted.
- The section sits above `The loop is a library, not the runtime`. Moving it down to just before `Built on the BEAM`, where the following section substantiates the answer, is a one-block move.

## Verification

`scripts/build_site.sh` assembles cleanly; page and assets served and read locally. Pre-push documentation gate passed (108s).