### PR TITLE
feat(release): publish multi-architecture container

### DIFF
--- a/.github/workflows/container-release.yml
+++ b/.github/workflows/container-release.yml
@@ -1,0 +1,295 @@
+name: PtcRunner Container Release
+
+on:
+  workflow_call:
+    inputs:
+      publish:
+        description: Publish the exact release tag after verification
+        required: false
+        type: boolean
+        default: false
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: container-release
+  cancel-in-progress: false
+
+env:
+  IMAGE: ghcr.io/${{ github.repository }}
+
+jobs:
+  preflight:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Require a main commit
+        run: |
+          git fetch --no-tags origin main:refs/remotes/origin/main
+          if [ "$GITHUB_REF_TYPE" = "branch" ] && [ "$GITHUB_REF_NAME" != "main" ]; then
+            echo "Container release verification may be dispatched only from main." >&2
+            exit 1
+          fi
+          git merge-base --is-ancestor "$GITHUB_SHA" origin/main
+
+      - name: Read and verify the release version
+        id: version
+        env:
+          PUBLISH: ${{ inputs.publish || false }}
+        run: |
+          version="$(grep -m1 -E '^ +version: "' mix.exs | sed -E 's/.*"(.+)".*/\1/')"
+          test -n "$version"
+          printf '%s\n' "$version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+          if [ "$PUBLISH" = "true" ]; then
+            test "$GITHUB_REF_TYPE" = "tag"
+            test "$GITHUB_REF_NAME" = "v$version"
+          fi
+
+  verify-targets:
+    needs: preflight
+    name: Verify ${{ matrix.platform }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 45
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-22.04
+            artifact: linux-amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            artifact: linux-arm64
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GitHub Container Registry
+        if: inputs.publish
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      # This builds the default `released` target, so the standalone release
+      # gate runs inside the image. The script then drives the finished image
+      # on its native runner, including the host-published Viewer boundary.
+      - name: Build and verify the finished image
+        env:
+          PLATFORM: ${{ matrix.platform }}
+          PUBLISH: ${{ inputs.publish || false }}
+          VERSION: ${{ needs.preflight.outputs.version }}
+        run: |
+          local_image="ptc:release-$VERSION"
+          build_args=(
+            --builder "${{ steps.buildx.outputs.name }}"
+            --platform "$PLATFORM"
+            --label "org.opencontainers.image.description=Bounded BEAM-native runtime for PTC-Lisp workflows"
+            --label "org.opencontainers.image.licenses=MIT"
+            --label "org.opencontainers.image.revision=$GITHUB_SHA"
+            --label "org.opencontainers.image.source=https://github.com/$GITHUB_REPOSITORY"
+            --label "org.opencontainers.image.version=$VERSION"
+          )
+
+          if [ "$PUBLISH" = "true" ]; then
+            build_args+=(
+              --metadata-file "$RUNNER_TEMP/build-metadata.json"
+              --output "type=image,name=$IMAGE,push-by-digest=true,name-canonical=true,push=true"
+            )
+          fi
+
+          scripts/build_container_image.sh "$local_image" "${build_args[@]}"
+
+          if [ "$PUBLISH" = "true" ]; then
+            digest="$(jq -er '."containerimage.digest"' "$RUNNER_TEMP/build-metadata.json")"
+            printf '%s\n' "$digest" | grep -Eq '^sha256:[0-9a-f]{64}$'
+            mkdir -p "$RUNNER_TEMP/digests"
+            touch "$RUNNER_TEMP/digests/${digest#sha256:}"
+          fi
+
+      - name: Retain the verified image digest
+        if: inputs.publish
+        uses: actions/upload-artifact@v6
+        with:
+          name: container-digest-${{ matrix.artifact }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  publish:
+    needs: [preflight, verify-targets]
+    if: inputs.publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      artifact-metadata: write
+      attestations: write
+      contents: read
+      id-token: write
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Reuse or reject an existing version tag
+        id: existing
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.preflight.outputs.version }}
+        run: |
+          set +e
+          inspection="$(docker buildx imagetools inspect "$IMAGE:$VERSION" 2>&1)"
+          status=$?
+          set -e
+
+          if [ "$status" -eq 0 ]; then
+            manifest="$(docker buildx imagetools inspect "$IMAGE:$VERSION" \
+              --format '{{json .Manifest}}')"
+            jq -e '
+              [.manifests[].platform
+                | select(.os != "unknown")
+                | {os, architecture}]
+              | sort_by(.architecture)
+              == [
+                {"architecture":"amd64","os":"linux"},
+                {"architecture":"arm64","os":"linux"}
+              ]
+            ' <<< "$manifest" > /dev/null
+
+            gh attestation verify "oci://$IMAGE:$VERSION" \
+              --repo "$GITHUB_REPOSITORY" \
+              --signer-workflow \
+                "$GITHUB_REPOSITORY/.github/workflows/container-release.yml" \
+              --source-digest "$GITHUB_SHA" \
+              --source-ref "$GITHUB_REF" \
+              --deny-self-hosted-runners
+            echo "published=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          final_line="$(printf '%s\n' "$inspection" | sed '/^[[:space:]]*$/d' | tail -1)"
+          if ! grep -Eqi 'manifest unknown|: not found$' <<< "$final_line"; then
+            printf '%s\n' "$inspection" >&2
+            echo "could not establish that $IMAGE:$VERSION is absent" >&2
+            exit 1
+          fi
+
+      - name: Collect verified image digests
+        if: steps.existing.outputs.published != 'true'
+        uses: actions/download-artifact@v7
+        with:
+          pattern: container-digest-*
+          path: ${{ runner.temp }}/digests
+          merge-multiple: true
+
+      - name: Assemble the verified multi-platform manifest
+        if: steps.existing.outputs.published != 'true'
+        id: manifest
+        run: |
+          mapfile -t digest_files < <(find "$RUNNER_TEMP/digests" -maxdepth 1 -type f -print | sort)
+          test "${#digest_files[@]}" -eq 2
+
+          sources=()
+          for digest_file in "${digest_files[@]}"; do
+            digest="$(basename "$digest_file")"
+            printf '%s\n' "$digest" | grep -Eq '^[0-9a-f]{64}$'
+            sources+=("$IMAGE@sha256:$digest")
+          done
+
+          staging="$IMAGE:staging-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT"
+          metadata="$RUNNER_TEMP/manifest-metadata.json"
+          docker buildx imagetools create \
+            --tag "$staging" \
+            --metadata-file "$metadata" \
+            "${sources[@]}"
+          digest="$(jq -er '."containerimage.descriptor".digest' "$metadata")"
+          printf '%s\n' "$digest" | grep -Eq '^sha256:[0-9a-f]{64}$'
+
+          # Resolve only the content-addressed result captured by the create
+          # operation. The staging tag is mutable registry state and must not
+          # decide which bytes this trusted workflow attests.
+          manifest="$(docker buildx imagetools inspect "$IMAGE@$digest" \
+            --format '{{json .Manifest}}')"
+          jq -e '
+            [.manifests[].platform
+              | select(.os != "unknown")
+              | {os, architecture}]
+            | sort_by(.architecture)
+            == [
+              {"architecture":"amd64","os":"linux"},
+              {"architecture":"arm64","os":"linux"}
+            ]
+          ' <<< "$manifest" > /dev/null
+
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
+
+      - name: Attest the published image
+        if: steps.existing.outputs.published != 'true'
+        uses: actions/attest@v4
+        with:
+          subject-name: ${{ env.IMAGE }}
+          subject-digest: ${{ steps.manifest.outputs.digest }}
+          push-to-registry: true
+
+      - name: Verify staged provenance
+        if: steps.existing.outputs.published != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh attestation verify "oci://$IMAGE@${{ steps.manifest.outputs.digest }}" \
+            --repo "$GITHUB_REPOSITORY" \
+            --signer-workflow \
+              "$GITHUB_REPOSITORY/.github/workflows/container-release.yml" \
+            --source-digest "$GITHUB_SHA" \
+            --source-ref "$GITHUB_REF" \
+            --deny-self-hosted-runners
+
+      # The exact public name is created only after both native images and the
+      # signed manifest have passed every check above. GHCR tags are mutable;
+      # refusing an existing name is this workflow's non-moving-tag policy.
+      - name: Publish the exact version tag
+        if: steps.existing.outputs.published != 'true'
+        env:
+          VERSION: ${{ needs.preflight.outputs.version }}
+        run: |
+          digest="${{ steps.manifest.outputs.digest }}"
+          docker buildx imagetools create --tag "$IMAGE:$VERSION" "$IMAGE@$digest"
+          published="$(docker buildx imagetools inspect "$IMAGE:$VERSION" \
+            --format '{{json .Manifest}}' | jq -er .digest)"
+          test "$published" = "$digest"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,8 +101,20 @@ jobs:
           path: ${{ runner.temp }}/artifacts/*
           if-no-files-found: error
 
+  container:
+    needs: verify
+    uses: ./.github/workflows/container-release.yml
+    permissions:
+      artifact-metadata: write
+      attestations: write
+      contents: read
+      id-token: write
+      packages: write
+    with:
+      publish: ${{ github.ref_type == 'tag' }}
+
   draft-release:
-    needs: macos-artifact
+    needs: [macos-artifact, container]
     if: github.ref_type == 'tag'
     runs-on: ubuntu-latest
     name: Attach standalone artifacts to a draft release

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,11 @@
 # syntax=docker/dockerfile:1
 #
-# Local container scaffolding for the standalone `ptc` command.
+# Linux container image for the standalone `ptc` command.
 #
-# This image is NOT a published distribution route: the container contract in
-# `docs/plans/lisp-kernel/stable-cli-contract.md` also requires the launcher
-# companion and per-architecture evidence, and neither is in place. Build it to
-# exercise the assembled release on Linux; do not tag, push, or document it as
-# an install path until that contract is met.
+# The tag-triggered container-release workflow verifies the finished image on
+# native AMD64 and ARM64 runners before publishing a multi-platform manifest.
+# `scripts/build_container_image.sh` provides the same finished-image probes
+# for a local single-platform build.
 #
 # Both bases are pinned by digest, so a rebuild resolves the same runtime
 # library set rather than whatever the tag points at today.

--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ to stand up.
 
 Download the self-contained macOS arm64 archive and its checksum from [GitHub
 Releases](https://github.com/andreasronge/ptc_runner/releases), then follow the
-[standalone installation](docs/installation/standalone.md). The published
-container image is still planned; the Docker page documents the verified local
-image available today.
+[standalone installation](docs/installation/standalone.md). Starting with the
+next root release, Linux AMD64 and ARM64 users can instead use the image
+described in [Docker installation](docs/installation/docker.md).
 
 Once `ptc` is installed, create and run a project that needs no API key:
 

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -4,9 +4,10 @@ Install `ptc`, verify it without an API key, then run a model-authored program
 without writing PTC-Lisp yourself.
 
 Download the executable as described under
-[Standalone installation](../installation/standalone.md). For the local image,
-use the complete commands in [Docker installation](../installation/docker.md),
-which account for mounted-file ownership.
+[Standalone installation](../installation/standalone.md). Starting with the
+next root release, the [Docker image](../installation/docker.md) provides the
+same command interface; its installation page gives the complete mounted-file
+and ownership form.
 
 ## Run without a credential
 

--- a/docs/installation/docker.md
+++ b/docs/installation/docker.md
@@ -1,47 +1,109 @@
 # Docker installation
 
-Build and run the self-contained PtcRunner container image.
+Install the self-contained Linux AMD64 or ARM64 image and run the PtcRunner CLI,
+Viewer, and stdio launcher without a build toolchain.
 
-Linux is currently
-verified through a local container scaffold. A public image
-and multi-architecture publication contract are still pending, so there is no
-registry name that the documentation can truthfully present as an installation
-today.
+Images are published as `ghcr.io/andreasronge/ptc_runner` starting with the
+first root release after the container publication workflow lands. Older
+releases are not backfilled. The image does not contain runtimes used by
+external MCP servers.
 
-Build and verify the local image from a source checkout:
+## Pull and verify the image
+
+Use an exact version tag for deployments:
 
 ```console
-scripts/build_container_image.sh
+version=VERSION
+image="ghcr.io/andreasronge/ptc_runner:$version"
+docker pull "$image"
+docker run --rm "$image" --version
 ```
 
-The script produces `ptc:dev`, runs the standalone verification inside the
-finished image, probes that image without adding packages, and confirms it runs
-as a non-root user.
+Replace `VERSION` with a three-part release version such as `0.14.0`. The release
+workflow creates each exact version tag once and refuses to replace one. GHCR
+does not enforce that policy as registry-level tag immutability, so pin the
+pulled repository digest and verify its attestation in automated deployments.
+There are no moving `latest` or `MAJOR.MINOR` tags; PtcRunner is 0.x and breaking
+changes are expected.
 
-Run an application through an explicit mount. Match the container process to
-the host user so owner-only credentials remain readable and project artifacts
-remain writable; use a writable container home for runtime-local files:
+Each image has signed GitHub build provenance. Verification requires GitHub CLI
+authentication and a registry login, including for a public image:
+
+```console
+gh auth refresh --scopes read:packages
+gh auth token | docker login ghcr.io \
+  --username "$(gh api user --jq .login)" --password-stdin
+gh attestation verify "oci://$image" \
+  --repo andreasronge/ptc_runner \
+  --signer-workflow \
+    andreasronge/ptc_runner/.github/workflows/container-release.yml \
+  --source-ref "refs/tags/v$version" \
+  --deny-self-hosted-runners
+```
+
+The added `read:packages` scope allows Docker to authenticate to GHCR. A classic
+personal access token carrying `read:packages` can be used instead.
+
+## Run a project
+
+Map the container process to the host user so owner-only credentials remain
+readable and project artifacts remain writable. Supply a writable home for
+runtime-local files:
 
 ```console
 docker run --rm \
   --user "$(id -u):$(id -g)" \
   --env HOME=/tmp \
   --volume "$PWD:/work" \
-  ptc:dev run /work/ptc-project.json
+  "$image" init /work/hello-ptc
+
+docker run --rm \
+  --user "$(id -u):$(id -g)" \
+  --env HOME=/tmp \
+  --volume "$PWD:/work" \
+  "$image" run /work/hello-ptc/ptc-project.json
 ```
 
-Do not run this form from a root shell. A root host UID would also select root
-inside the container and discard the image's non-root default.
+The generated project keeps traces and command envelopes under its mounted
+`.ptc` directory, so `--rm` does not discard them. Do not run this form from a
+root shell: a root host UID would also select root inside the container and
+discard the image's non-root default. Without `--user`, the image runs as its
+built-in `ptc` user with UID and GID 10001.
 
-Open an interactive REPL:
+Mount host configuration and dotenv files only where the project expects them.
+PTC's `--env-file` appears after the image name and is distinct from Docker's
+option of the same name:
+
+```console
+docker run --rm \
+  --user "$(id -u):$(id -g)" \
+  --env HOME=/tmp \
+  --volume "$PWD:/work" \
+  "$image" run /work/hello-ptc/ptc-project.json \
+    --env-file /work/hello-ptc/.env
+```
+
+Remote model and credential-based MCP providers work normally. A stdio MCP
+server runs inside the container namespace: its executable and runtime must be
+Linux-compatible and present in the image or an explicit mount. In particular,
+the published image does not add Node.js or `npx`. Build a derived image when a
+local MCP server needs another runtime. The runtime-included frontend also does
+not initiate interactive MCP OAuth authorization; authorize through a
+supported embedding host or use a provider that can execute non-interactively.
+
+## Open a REPL
+
+Allocate a terminal for interactive editing and history:
 
 ```console
 docker run --rm -it \
   --user "$(id -u):$(id -g)" \
   --env HOME=/tmp \
   --volume "$PWD:/work" \
-  ptc:dev repl
+  "$image" repl
 ```
+
+## Open the Viewer
 
 The Viewer binds to the container's loopback unless explicitly told otherwise,
 which a published port cannot reach. Bind the wildcard only inside the
@@ -55,15 +117,25 @@ docker run --rm \
   --env PTC_VIEWER_TOKEN="$viewer_token" \
   -p 127.0.0.1:4123:4123 \
   -v "$PWD:/work" \
-  ptc:dev viewer /work/ptc-project.json --listen 0.0.0.0
+  "$image" viewer /work/hello-ptc/ptc-project.json \
+    --listen 0.0.0.0 --port 4123
 ```
 
 Open `http://localhost:4123/?live_token=$viewer_token#/live`. The page removes
-the token from the visible URL after bootstrapping and uses it for Live
-mutations. The Runs trace browser itself remains unauthenticated.
+the token from the visible URL after bootstrapping and uses it for Live reads
+and mutations. The Runs trace browser itself remains unauthenticated.
 
-Writing `-p 4123:4123` instead exposes an unauthenticated trace browser to the
+Writing `-p 4123:4123` instead exposes that unauthenticated trace browser to the
 network. The `127.0.0.1:` prefix is the host-side security decision.
 
-The published-image route will become the default only after the target matrix
-and immutable image tags have release evidence.
+## Build from a checkout
+
+Maintainers can build and verify one local platform without publishing it:
+
+```console
+scripts/build_container_image.sh
+```
+
+The script produces `ptc:dev`, runs the standalone verification inside the
+image, probes the finished image without adding packages, and confirms it runs
+as a non-root user.

--- a/docs/maintainers/releasing.md
+++ b/docs/maintainers/releasing.md
@@ -27,6 +27,40 @@ artifact and attaches it, with its `.sha256`, to a draft GitHub release. That
 release stays a draft until a maintainer publishes it, exactly as the launcher
 release does.
 
+After the canonical verification job passes, the root release workflow calls
+`.github/workflows/container-release.yml`. That reusable workflow builds and
+drives the finished image on native Linux AMD64 and ARM64 runners. For a root
+`vX.Y.Z` tag, each runner pushes its tested image by digest. The workflow
+assembles those exact digests into one multi-platform manifest, attests and
+verifies it, and only then creates the exact version tag under
+`ghcr.io/andreasronge/ptc_runner`. It adds signed GitHub build provenance for
+the manifest digest. A direct manual dispatch runs both native verification
+jobs without logging in or publishing.
+
+Only three-part release versions are accepted, and the only supported image
+tag is the exact version. The workflow treats that tag as non-moving, refuses
+to replace one, and creates no moving aliases. GHCR does not enforce this as
+registry-level tag immutability, so deployments should pin the repository digest
+and verify its attestation. Run-scoped `staging-*` references are publication
+internals, not release names, and consumers must not use them. The first package
+publication under the repository owner defaults to private in GHCR; before
+publishing the GitHub release, change that package to public once and confirm
+an unauthenticated pull. Public visibility cannot later be reversed.
+
+After the container workflow is green, verify the signed subject from an
+authenticated GitHub CLI and GHCR session:
+
+```bash
+release_tag=vX.Y.Z
+image="ghcr.io/andreasronge/ptc_runner:${release_tag#v}"
+gh attestation verify "oci://$image" \
+  --repo andreasronge/ptc_runner \
+  --signer-workflow \
+    andreasronge/ptc_runner/.github/workflows/container-release.yml \
+  --source-ref "refs/tags/$release_tag" \
+  --deny-self-hosted-runners
+```
+
 The assembled release and the container image carry the `ptc_viewer`
 companion, so the packaged `ptc viewer` command works from an extracted tarball
 with no toolchain beside it. The Hex package does not: `ptc_viewer` is
@@ -38,11 +72,11 @@ sources still compile at `prod` with the companion absent. Do not turn that
 into an optional Hex requirement without publishing the package first; Hex
 cannot resolve a requirement naming a package that does not exist.
 
-Those artifacts are ad-hoc signed — not Developer ID signed, not notarized —
+The macOS artifacts are ad-hoc signed — not Developer ID signed, not notarized —
 and the installation documentation must say so in those words. macOS arm64 is
-the only published target: macOS x86_64 and the Linux container images require
-their own target evidence first, and publishing one without it is out of
-contract.
+the only standalone target; the published Linux container covers AMD64 and
+ARM64. macOS x86_64 still requires its own target evidence, and publishing it
+without that evidence is out of contract.
 
 Hex and HexDocs publication is a separate, explicit maintainer action performed
 from the tagged `main` commit. Publish the package with

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -21,7 +21,7 @@ belongs in guides or retained specifications.
   closes the loop from model-authored runtime source to an attested component:
   host-side materialization, descriptor provenance, and a promotion gate.
 - [`lisp-kernel/stable-cli-contract.md`](lisp-kernel/stable-cli-contract.md)
-  retains only the unfinished macOS/container distribution and final
+  retains only the first GHCR publication, macOS x86_64 evidence, and final
   acceptance work for the completed standalone command.
 - [`lisp-kernel/product-readiness.md`](lisp-kernel/product-readiness.md)
   tracks the remaining command-line, diagnostics, model-boundary,

--- a/docs/plans/documentation-product-onboarding.md
+++ b/docs/plans/documentation-product-onboarding.md
@@ -6,12 +6,11 @@ Active implementation plan. Remove this file after the approved slices land and
 their durable contracts have moved into the documentation guidelines, retained
 references, schemas, module documentation, and executable examples.
 
-This branch implements the layer-owned paths, reference extraction, README and
-guide rewrite, package usage rules, terminology policy, and focused
-documentation checks. As approved for the imminent release, the documentation
-assumes a verified macOS arm64 archive is available from GitHub Releases. The
-published container image and generated first-agent scaffold remain
-distribution/product prerequisites and are not presented as available.
+The layer-owned paths, reference extraction, README and guide rewrite, package
+usage rules, terminology policy, and focused documentation checks are
+implemented. A verified macOS arm64 archive is available from GitHub Releases,
+and the next root tag owns the first GHCR publication. The generated first-agent
+scaffold remains a product prerequisite.
 
 ## Objective
 
@@ -45,9 +44,9 @@ blurred:
   contract is JSON, PTC-Lisp, a process command, or an immutable artifact;
 - model-selection guidance is mixed with adapter and source maintenance
   concerns;
-- the standalone artifact and local container scaffold exist, but the
-  one-command installer and published container route required by the desired
-  README journey are not complete public installation paths; and
+- the standalone archive and container publication workflow exist, but the
+  one-command installer and generated first-agent path required by the desired
+  README journey are not complete; and
 - the shipped package does not yet provide its own concise `usage-rules.md` for
   coding models integrating the public package API.
 
@@ -179,15 +178,10 @@ and release documentation.
 
 ### Published container image
 
-- Publish the verified runtime image to the chosen registry and target matrix.
-- Define immutable version tags and the policy for any moving convenience tag.
-- Verify the standalone command inside the final runtime image.
-- Run the exact README `docker run` commands in CI.
-- Keep volume, credential, user, result, trace, and Viewer exposure behavior
-  explicit in the Docker installation reference.
-
-Until publication is complete, documentation may show how maintainers build
-the local `ptc:dev` image but must not present it as an end-user installation.
+- Execute the first tag-triggered GHCR publication for Linux AMD64 and ARM64.
+- Make the linked package public and prove an unauthenticated pull.
+- Verify the signed provenance for the published multi-platform digest.
+- Keep the release commands under native target evidence as tags advance.
 
 ### Self-contained first-agent scaffold
 

--- a/docs/plans/lisp-kernel/product-readiness.md
+++ b/docs/plans/lisp-kernel/product-readiness.md
@@ -18,7 +18,7 @@ expertise.
 | --- | --- | --- | --- |
 | P1 | Model protocol | Host-installed LLMs freeze bounded sampling options, but structured-output schema, reasoning controls, an explicit provider timeout, and enforceable token or cost ceilings remain outside the public configuration surface. | Deployments cannot yet express richer model contracts or complete operational budgets. |
 | P1 | Trace operation | A malformed, duplicate, or oversized trace can make a directory source fail as a whole, and trace persistence remains post-run. | One damaged file can hide healthy runs and a crash can lose buffered events. |
-| P1 | Distribution | The assembled standalone release is verified locally and now carries the Viewer, but macOS artifacts and multi-architecture container images are not published. | Installation and deployment still require local release assembly or a source checkout. |
+| P1 | Distribution | macOS ARM64 is published and Linux AMD64/ARM64 publication is automated, but the first public container release and macOS x86_64 evidence remain. | Container users still need the next root release tag; Intel Mac users have no artifact. |
 | P1 | End-to-end evidence | Packaged-install, private-sink/loss, real multi-page Viewer, and complete shell-driven application journeys remain absent. | Large-artifact, packaging, and cross-command regressions can escape normal gates. |
 | P2 | Viewer pagination | Cursor APIs, accumulation, and partial labeling have focused tests, but no valid run above 100 events has been exercised through repeated browser pagination. | Ordering, duplication, or final-cursor defects can remain despite API coverage. |
 | P2 | Source diagnostics | Parser, compiler, and runtime failures do not consistently retain precise source spans across every boundary. | Larger bundles take longer to repair. |
@@ -33,10 +33,9 @@ The remaining target and acceptance work is tracked in
 The shared parser, command engine, Mix frontend, standalone release, REPL,
 human rendering, caller-named V2 envelope publication, exit statuses, and
 package verification are implemented. Retain one contract across those
-frontends while adding target-native evidence for:
-
-- macOS arm64 and x86_64 artifacts; and
-- Linux amd64 and arm64 container images.
+frontends while adding the remaining macOS x86_64 target evidence. macOS ARM64
+and the native Linux AMD64/ARM64 container gates are implemented; the first
+container tag still has to prove the public-registry boundary.
 
 **Exit gate:** all four architectures build and run the packaged verification
 journey, documentation states the unsigned macOS limitation, and no packaging

--- a/docs/plans/lisp-kernel/stable-cli-contract.md
+++ b/docs/plans/lisp-kernel/stable-cli-contract.md
@@ -1,8 +1,8 @@
 # Standalone CLI distribution
 
-**Status:** active; the shared command engine, Mix frontend, assembled release,
-standalone REPL, envelope publication, human rendering, and package verification
-are complete. This plan retains only distribution work that has not landed.
+**Status:** active; macOS ARM64 packaging and the Linux AMD64/ARM64 publication
+machinery are complete. This plan retains the first container publication and
+macOS x86_64 evidence that have not landed.
 
 Implemented architecture belongs in the
 [Kernel maintainer guide](../../maintainers/kernel.md), current behavior in
@@ -86,47 +86,17 @@ The image is packaging, not an extra security or compatibility layer. It must
 not introduce wrapper-only option aliases, environment inference, or alternate
 machine output.
 
-## First increment
+## Remaining distribution work
 
-The four targets do not have to arrive together, and the macOS artifact is the
-one a local maintainer can produce and verify today. This increment delivers
-the machinery; later increments add the remaining architectures to the same
-machinery.
+The next root release tag must execute the container publication workflow,
+make the linked GHCR package public, and prove an unauthenticated pull plus
+signed-provenance verification for the published multi-platform digest. The
+workflow already builds the launcher-bearing finished image on native Linux
+AMD64 and ARM64 runners before it publishes that manifest.
 
-**Published in this increment — macOS arm64 only.**
-
-- A repository-owned packaging script that builds the release, closes its
-  runtime library set under the contract above, runs the existing standalone
-  verification against the *packaged* tree, and emits a compressed artifact
-  with an adjacent SHA-256 file. The same script runs locally and in CI, so a
-  maintainer can reproduce what CI published from the same commit and
-  toolchain. This increment makes no reproducible-build claim beyond that.
-- A tag-workflow job that runs that script on macOS arm64, records build
-  provenance for the artifact as the launcher workflow already does, and
-  attaches it to the draft release.
-- Installation documentation for that artifact, naming the minimum macOS
-  version and the ad-hoc signing status precisely.
-
-**Built but not published in this increment — the container.** The image
-contract above requires the launcher companion and per-architecture evidence,
-and neither is in this increment. A container definition therefore lands as
-local scaffolding: it builds the assembled release into a pinned base image,
-runs as a non-root user, sets a UTF-8 locale explicitly because the Erlang
-runtime needs one for terminal and filename handling, and is exercised by the
-existing standalone verification inside the container. It is not tagged, not
-pushed, and not attached to a release, and the documentation must not offer it
-as an installation route.
-
-Publication of that image requires its own increment, which must first fix
-what "publish" means for it: registry and image name, tag and immutable-digest
-scheme, the base image pinned by digest, the relationship between build and
-runtime architecture, and how provenance is attached and verified — the same
-questions `docs/maintainers/releasing.md` already answers for launcher assets.
-
-Remaining after this increment: macOS x86_64, both Linux architectures as
-published images, the launcher companion inside the image, and the
-per-architecture evidence matrix below. Publishing any of those without its
-own target evidence is out of contract.
+macOS x86_64 remains a separate target. It still needs its own packaging run,
+runtime-library closure evidence, standalone verification, and release asset.
+Publishing it without that target evidence is out of contract.
 
 ## Distribution evidence
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -719,12 +719,13 @@ mapping reachable, and the host-side exposure decision moves to the publish
 rule:
 
 ```console
+image=ghcr.io/andreasronge/ptc_runner:VERSION
 docker run --rm \
   --user "$(id -u):$(id -g)" \
   --env HOME=/tmp \
   -p 127.0.0.1:4123:4123 \
   -v "$PWD:/work" \
-  ptc:dev viewer /work/ptc-project.json --listen 0.0.0.0
+  "$image" viewer /work/ptc-project.json --listen 0.0.0.0 --port 4123
 ```
 
 The `127.0.0.1:` prefix on `-p` is what keeps this equivalent to a loopback

--- a/scripts/build_container_image.sh
+++ b/scripts/build_container_image.sh
@@ -1,14 +1,11 @@
 #!/usr/bin/env bash
 #
-# Builds the local Linux container scaffolding and proves the release inside it.
+# Builds a local Linux container image and proves the release inside it.
 #
 #   scripts/build_container_image.sh [IMAGE_TAG]
 #
-# This is not a publication path. The container contract in
-# `docs/plans/lisp-kernel/stable-cli-contract.md` also requires the launcher
-# companion and per-architecture evidence; until those exist the image is a way
-# to exercise the assembled release on Linux, and nothing here tags, pushes, or
-# documents it as an install route.
+# This remains a local single-platform path. The container-release workflow
+# owns multi-platform publication, immutable version tags, and provenance.
 #
 # The build runs the standalone verification inside the image, so a failure
 # here is a failure of the release, not of the packaging.
@@ -20,7 +17,7 @@ image_tag="${1:-ptc:dev}"
 [ "$#" -gt 0 ] && shift
 
 command -v docker > /dev/null || {
-  echo 'docker is required to build the container scaffolding' >&2
+  echo 'docker is required to build the container image' >&2
   exit 69
 }
 
@@ -51,12 +48,13 @@ for argument in "$@"; do
   esac
 done
 
-# `--load` keeps the result in the local daemon, which only works for one
-# platform at a time. Multi-architecture manifests belong to the publication
-# increment, not to local scaffolding.
+# The explicit Docker exporter keeps this tag local to the daemon. Using the
+# global `--tag` option would also apply it to any extra registry exporter and
+# make a push-by-digest release build try to publish the local probe tag.
+# Loading still limits this helper to one platform at a time; the publication
+# workflow assembles the independently verified native results afterward.
 docker buildx build \
-  --tag "$image_tag" \
-  --load \
+  --output "type=docker,name=$image_tag" \
   "$@" \
   --target released \
   .
@@ -68,6 +66,11 @@ docker buildx build \
 # missing runtime library shows up as the broken output it would really be.
 probe_dir="$(mktemp -d "${TMPDIR:-/tmp}/ptc-image-probe.XXXXXX")"
 viewer_containers=()
+mounted_run=(
+  --user "$(id -u):$(id -g)"
+  --env HOME=/tmp
+  --volume "$probe_dir:/work"
+)
 
 probe_cleanup() {
   if [ "${#viewer_containers[@]}" -gt 0 ]; then
@@ -96,12 +99,54 @@ cat > "$probe_dir/ptc.json" <<'EOF'
 }
 EOF
 
-docker run --rm --volume "$probe_dir:/work" "$image_tag" --version > "$probe_dir/version.stdout"
+cp test/support/mcp_stdio_source_fixture.sh "$probe_dir/mcp_stdio_source_fixture.sh"
+chmod 0755 "$probe_dir/mcp_stdio_source_fixture.sh"
+
+docker run --rm "${mounted_run[@]}" "$image_tag" --version > "$probe_dir/version.stdout"
 grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$' "$probe_dir/version.stdout"
+
+# Exercise the target-native C launcher through the release's real stdio
+# transport. Finding the optional application in the release is not enough:
+# this proves its executable can start a child, frame an MCP exchange, and
+# close cleanly on the architecture being verified.
+docker run --rm "${mounted_run[@]}" \
+  --entrypoint /opt/ptc/bin/ptc_runner \
+  "$image_tag" eval '
+    alias PtcRunner.Kernel.MCPStdioTransport
+
+    [fixture, marker] = System.argv()
+    {:ok, launcher} = PtcRunnerLauncher.executable_path()
+    executable = "/bin/sh"
+
+    {:ok, transport} =
+      MCPStdioTransport.start(
+        launcher: launcher,
+        launcher_protocol_version: PtcRunnerLauncher.protocol_version(),
+        executable: executable,
+        executable_sha256: executable |> File.read!() |> then(&:crypto.hash(:sha256, &1)),
+        cwd: "/work",
+        args: [fixture, marker],
+        env: %{"HOME" => "/tmp", "PATH" => "/usr/bin:/bin"},
+        grace_ms: 50,
+        start_timeout_ms: 5_000
+      )
+
+    metadata = %{
+      "io.modelcontextprotocol/protocolVersion" => "2026-07-28",
+      "io.modelcontextprotocol/clientInfo" => %{"name" => "ptc_runner", "version" => "0.x"},
+      "io.modelcontextprotocol/clientCapabilities" => %{}
+    }
+
+    {:ok, %{"result" => %{"supportedVersions" => ["2026-07-28"]}}} =
+      MCPStdioTransport.request(transport, "server/discover", %{}, metadata, 8_192, 5_000)
+
+    :ok = MCPStdioTransport.close(transport)
+  ' /work/mcp_stdio_source_fixture.sh /work/launcher.marker
+grep -Eq '^[1-9][0-9]*:server/discover$' "$probe_dir/launcher.marker"
 
 # Standard output carries a machine contract: a runtime that writes a startup
 # warning there corrupts it, and only an untouched image can prove it does not.
-docker run --rm --volume "$probe_dir:/work" "$image_tag" run /work/ptc.json \
+docker run --rm "${mounted_run[@]}" "$image_tag" run /work/ptc.json \
   > "$probe_dir/run.stdout" 2> /dev/null
 printf '%s\n' '{"city":"Malmö"}' > "$probe_dir/run.expected"
 cmp "$probe_dir/run.expected" "$probe_dir/run.stdout"
@@ -112,8 +157,8 @@ test "$(docker run --rm --entrypoint id "$image_tag" --user)" != "0"
 # cannot check: it binds inside the container's own network namespace, and the
 # whole question is whether a published port reaches it from the host. Prove
 # both directions here, on the finished image.
-docker run --rm --volume "$probe_dir:/work" "$image_tag" init /work/app > /dev/null
-docker run --rm --volume "$probe_dir:/work" "$image_tag" run /work/app/ptc-project.json \
+docker run --rm "${mounted_run[@]}" "$image_tag" init /work/app > /dev/null
+docker run --rm "${mounted_run[@]}" "$image_tag" run /work/app/ptc-project.json \
   > /dev/null 2> /dev/null
 
 probe_run_ref="$(basename "$(find "$probe_dir/app/.ptc/traces" -maxdepth 1 -type f -name 'cmd-*.jsonl' -print -quit)" .jsonl)"
@@ -129,7 +174,7 @@ test -n "$probe_run_ref"
 # `viewer_containers` is lost and the EXIT trap has nothing to clean up after a
 # mid-probe failure.
 start_viewer() {
-  viewer_container="$(docker run --detach --volume "$probe_dir:/work" \
+  viewer_container="$(docker run --detach "${mounted_run[@]}" \
     --publish 127.0.0.1::4123 "$image_tag" viewer /work/app/ptc-project.json --port 4123 "$@")"
   viewer_containers+=("$viewer_container")
 }
@@ -191,6 +236,8 @@ viewer_containers=()
 echo
 echo "built $image_tag; the standalone verification passed inside it,"
 echo "and the finished image answers correctly with nothing added to it"
-echo "try: docker run --rm -it -v \"\$PWD:/work\" $image_tag repl"
-echo "     docker run --rm -p 127.0.0.1:4123:4123 -v \"\$PWD:/work\" $image_tag \\"
-echo "       viewer /work/ptc-project.json --listen 0.0.0.0"
+echo "try: docker run --rm -it --user \"\$(id -u):\$(id -g)\" --env HOME=/tmp \\"
+echo "       -v \"\$PWD:/work\" $image_tag repl"
+echo "     docker run --rm --user \"\$(id -u):\$(id -g)\" --env HOME=/tmp \\"
+echo "       -p 127.0.0.1:4123:4123 -v \"\$PWD:/work\" $image_tag \\"
+echo "       viewer /work/ptc-project.json --listen 0.0.0.0 --port 4123"

--- a/scripts/ci/classify-changes.sh
+++ b/scripts/ci/classify-changes.sh
@@ -171,7 +171,7 @@ while IFS= read -r path || [ -n "$path" ]; do
       launcher=true
       ;;
 
-    .github/workflows/release.yml)
+    .github/workflows/release.yml|.github/workflows/container-release.yml)
       core=true
       ;;
 

--- a/scripts/verify_core_package.sh
+++ b/scripts/verify_core_package.sh
@@ -3,9 +3,14 @@ set -euo pipefail
 
 project_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 package_tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/ptc-runner-core-package.XXXXXX")"
+dependency_build=""
 
 cleanup() {
   rm -rf "$package_tmp_dir"
+
+  if [[ -n "$dependency_build" ]]; then
+    rm -rf "$dependency_build"
+  fi
 }
 trap cleanup EXIT
 
@@ -94,18 +99,17 @@ done
 cp "$project_root/mix.lock" "$package_tmp_dir/source/mix.lock"
 mkdir -p "$package_tmp_dir/build/lib"
 
-# The packaged source is compiled at `prod` below, so its dependency beams
-# must come from the project's own `prod` build — and this script has to build
-# that itself. Ambient MIX_ENV must not choose it: `mix precommit` runs at
-# `test` and `mix cmd` exports no MIX_ENV, so `_build/${MIX_ENV:-dev}` checked
-# whichever environment the caller's shell happened to have compiled, and in a
-# worktree that had only ever run the gate it failed with no diagnosis.
-# `verify_standalone_release.sh` builds the same tree next, so this is paid
-# once.
+# The packaged source is compiled at `prod` below, so this script builds its
+# dependency beams in an isolated path. Reusing `_build/prod` is incorrect: an
+# earlier `mix release` activates the local Viewer and leaves Plug there, while
+# an ordinary production dependency graph excludes both. Req can then observe
+# Plug during conditional compilation just before Mix removes the stale app,
+# producing a checkout-history-dependent compile failure.
 build_env=prod
-MIX_ENV="$build_env" mix deps.compile
+dependency_build="$(mktemp -d "$project_root/_build/ptc-core-package-deps.XXXXXX")"
+MIX_ENV="$build_env" MIX_BUILD_PATH="$dependency_build" mix deps.compile
 
-active_build_lib="$project_root/_build/$build_env/lib"
+active_build_lib="$dependency_build/lib"
 
 if [[ ! -d "$active_build_lib/jason" ]]; then
   echo "no compiled $build_env dependencies at $active_build_lib" >&2

--- a/site/guides/index.html
+++ b/site/guides/index.html
@@ -196,7 +196,8 @@ deciding whether to promote it.</span></li>
   <span class="desc">Install the self-contained ptc executable from GitHub Releases.</span></li>
 
 <li><a href="/installation/docker/">Docker installation</a>
-  <span class="desc">Build and run the self-contained PtcRunner container image.</span></li>
+  <span class="desc">Install the self-contained Linux AMD64 or ARM64 image and run the PtcRunner CLI,
+Viewer, and stdio launcher without a build toolchain.</span></li>
 
 <li><a href="/installation/source/">Source installation</a>
   <span class="desc">Build PtcRunner from a repository checkout when changing the runtime,

--- a/site/guides/quickstart/index.html
+++ b/site/guides/quickstart/index.html
@@ -99,9 +99,10 @@ without writing PTC-Lisp yourself.">
 <article>
 <h1 id="quickstart">Quickstart</h1><p>Install <code class="inline">ptc</code>, verify it without an API key, then run a model-authored program
 without writing PTC-Lisp yourself.</p><p>Download the executable as described under
-<a href="/installation/standalone/">Standalone installation</a>. For the local image,
-use the complete commands in <a href="/installation/docker/">Docker installation</a>,
-which account for mounted-file ownership.</p><h2 id="run-without-a-credential">Run without a credential</h2><p>Create and run a project that needs no API key:</p><pre><code class="console language-console">ptc init hello-ptc
+<a href="/installation/standalone/">Standalone installation</a>. Starting with the
+next root release, the <a href="/installation/docker/">Docker image</a> provides the
+same command interface; its installation page gives the complete mounted-file
+and ownership form.</p><h2 id="run-without-a-credential">Run without a credential</h2><p>Create and run a project that needs no API key:</p><pre><code class="console language-console">ptc init hello-ptc
 ptc run hello-ptc/ptc-project.json</code></pre><pre><code class="json language-json">{&quot;greeting&quot;:&quot;hello world&quot;}</code></pre><p><code class="inline">init</code> creates an application, a project document with local artifact settings,
 and ignore rules for public and private run artifacts. The first run contacts no
 model or external tool and records a trace and command envelope under

--- a/site/installation/docker/index.html
+++ b/site/installation/docker/index.html
@@ -4,10 +4,12 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Docker installation · PtcRunner</title>
-<meta name="description" content="Build and run the self-contained PtcRunner container image.">
+<meta name="description" content="Install the self-contained Linux AMD64 or ARM64 image and run the PtcRunner CLI,
+Viewer, and stdio launcher without a build toolchain.">
 <link rel="canonical" href="https://ptc-runner.dev/installation/docker/">
 <meta property="og:title" content="Docker installation · PtcRunner">
-<meta property="og:description" content="Build and run the self-contained PtcRunner container image.">
+<meta property="og:description" content="Install the self-contained Linux AMD64 or ARM64 image and run the PtcRunner CLI,
+Viewer, and stdio launcher without a build toolchain.">
 <meta property="og:url" content="https://ptc-runner.dev/installation/docker/">
 <meta property="og:type" content="article">
 <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#9883;</text></svg>">
@@ -95,24 +97,62 @@
 <main class="guide-main">
 <p class="crumb mobile-crumb"><a href="/guides/">&larr; All documentation</a></p>
 <article>
-<h1 id="docker-installation">Docker installation</h1><p>Build and run the self-contained PtcRunner container image.</p><p>Linux is currently
-verified through a local container scaffold. A public image
-and multi-architecture publication contract are still pending, so there is no
-registry name that the documentation can truthfully present as an installation
-today.</p><p>Build and verify the local image from a source checkout:</p><pre><code class="console language-console">scripts/build_container_image.sh</code></pre><p>The script produces <code class="inline">ptc:dev</code>, runs the standalone verification inside the
-finished image, probes that image without adding packages, and confirms it runs
-as a non-root user.</p><p>Run an application through an explicit mount. Match the container process to
-the host user so owner-only credentials remain readable and project artifacts
-remain writable; use a writable container home for runtime-local files:</p><pre><code class="console language-console">docker run --rm \
+<h1 id="docker-installation">Docker installation</h1><p>Install the self-contained Linux AMD64 or ARM64 image and run the PtcRunner CLI,
+Viewer, and stdio launcher without a build toolchain.</p><p>Images are published as <code class="inline">ghcr.io/andreasronge/ptc_runner</code> starting with the
+first root release after the container publication workflow lands. Older
+releases are not backfilled. The image does not contain runtimes used by
+external MCP servers.</p><h2 id="pull-and-verify-the-image">Pull and verify the image</h2><p>Use an exact version tag for deployments:</p><pre><code class="console language-console">version=VERSION
+image=&quot;ghcr.io/andreasronge/ptc_runner:$version&quot;
+docker pull &quot;$image&quot;
+docker run --rm &quot;$image&quot; --version</code></pre><p>Replace <code class="inline">VERSION</code> with a three-part release version such as <code class="inline">0.14.0</code>. The release
+workflow creates each exact version tag once and refuses to replace one. GHCR
+does not enforce that policy as registry-level tag immutability, so pin the
+pulled repository digest and verify its attestation in automated deployments.
+There are no moving <code class="inline">latest</code> or <code class="inline">MAJOR.MINOR</code> tags; PtcRunner is 0.x and breaking
+changes are expected.</p><p>Each image has signed GitHub build provenance. Verification requires GitHub CLI
+authentication and a registry login, including for a public image:</p><pre><code class="console language-console">gh auth refresh --scopes read:packages
+gh auth token | docker login ghcr.io \
+  --username &quot;$(gh api user --jq .login)&quot; --password-stdin
+gh attestation verify &quot;oci://$image&quot; \
+  --repo andreasronge/ptc_runner \
+  --signer-workflow \
+    andreasronge/ptc_runner/.github/workflows/container-release.yml \
+  --source-ref &quot;refs/tags/v$version&quot; \
+  --deny-self-hosted-runners</code></pre><p>The added <code class="inline">read:packages</code> scope allows Docker to authenticate to GHCR. A classic
+personal access token carrying <code class="inline">read:packages</code> can be used instead.</p><h2 id="run-a-project">Run a project</h2><p>Map the container process to the host user so owner-only credentials remain
+readable and project artifacts remain writable. Supply a writable home for
+runtime-local files:</p><pre><code class="console language-console">docker run --rm \
   --user &quot;$(id -u):$(id -g)&quot; \
   --env HOME=/tmp \
   --volume &quot;$PWD:/work&quot; \
-  ptc:dev run /work/ptc-project.json</code></pre><p>Do not run this form from a root shell. A root host UID would also select root
-inside the container and discard the image's non-root default.</p><p>Open an interactive REPL:</p><pre><code class="console language-console">docker run --rm -it \
+  &quot;$image&quot; init /work/hello-ptc
+
+docker run --rm \
   --user &quot;$(id -u):$(id -g)&quot; \
   --env HOME=/tmp \
   --volume &quot;$PWD:/work&quot; \
-  ptc:dev repl</code></pre><p>The Viewer binds to the container's loopback unless explicitly told otherwise,
+  &quot;$image&quot; run /work/hello-ptc/ptc-project.json</code></pre><p>The generated project keeps traces and command envelopes under its mounted
+<code class="inline">.ptc</code> directory, so <code class="inline">--rm</code> does not discard them. Do not run this form from a
+root shell: a root host UID would also select root inside the container and
+discard the image's non-root default. Without <code class="inline">--user</code>, the image runs as its
+built-in <code class="inline">ptc</code> user with UID and GID 10001.</p><p>Mount host configuration and dotenv files only where the project expects them.
+PTC's <code class="inline">--env-file</code> appears after the image name and is distinct from Docker's
+option of the same name:</p><pre><code class="console language-console">docker run --rm \
+  --user &quot;$(id -u):$(id -g)&quot; \
+  --env HOME=/tmp \
+  --volume &quot;$PWD:/work&quot; \
+  &quot;$image&quot; run /work/hello-ptc/ptc-project.json \
+    --env-file /work/hello-ptc/.env</code></pre><p>Remote model and credential-based MCP providers work normally. A stdio MCP
+server runs inside the container namespace: its executable and runtime must be
+Linux-compatible and present in the image or an explicit mount. In particular,
+the published image does not add Node.js or <code class="inline">npx</code>. Build a derived image when a
+local MCP server needs another runtime. The runtime-included frontend also does
+not initiate interactive MCP OAuth authorization; authorize through a
+supported embedding host or use a provider that can execute non-interactively.</p><h2 id="open-a-repl">Open a REPL</h2><p>Allocate a terminal for interactive editing and history:</p><pre><code class="console language-console">docker run --rm -it \
+  --user &quot;$(id -u):$(id -g)&quot; \
+  --env HOME=/tmp \
+  --volume &quot;$PWD:/work&quot; \
+  &quot;$image&quot; repl</code></pre><h2 id="open-the-viewer">Open the Viewer</h2><p>The Viewer binds to the container's loopback unless explicitly told otherwise,
 which a published port cannot reach. Bind the wildcard only inside the
 container and keep the host publication on loopback:</p><pre><code class="console language-console">viewer_token=&quot;$(openssl rand -hex 32)&quot;
 docker run --rm \
@@ -121,11 +161,13 @@ docker run --rm \
   --env PTC_VIEWER_TOKEN=&quot;$viewer_token&quot; \
   -p 127.0.0.1:4123:4123 \
   -v &quot;$PWD:/work&quot; \
-  ptc:dev viewer /work/ptc-project.json --listen 0.0.0.0</code></pre><p>Open <code class="inline">http://localhost:4123/?live_token=$viewer_token#/live</code>. The page removes
-the token from the visible URL after bootstrapping and uses it for Live
-mutations. The Runs trace browser itself remains unauthenticated.</p><p>Writing <code class="inline">-p 4123:4123</code> instead exposes an unauthenticated trace browser to the
-network. The <code class="inline">127.0.0.1:</code> prefix is the host-side security decision.</p><p>The published-image route will become the default only after the target matrix
-and immutable image tags have release evidence.</p>
+  &quot;$image&quot; viewer /work/hello-ptc/ptc-project.json \
+    --listen 0.0.0.0 --port 4123</code></pre><p>Open <code class="inline">http://localhost:4123/?live_token=$viewer_token#/live</code>. The page removes
+the token from the visible URL after bootstrapping and uses it for Live reads
+and mutations. The Runs trace browser itself remains unauthenticated.</p><p>Writing <code class="inline">-p 4123:4123</code> instead exposes that unauthenticated trace browser to the
+network. The <code class="inline">127.0.0.1:</code> prefix is the host-side security decision.</p><h2 id="build-from-a-checkout">Build from a checkout</h2><p>Maintainers can build and verify one local platform without publishing it:</p><pre><code class="console language-console">scripts/build_container_image.sh</code></pre><p>The script produces <code class="inline">ptc:dev</code>, runs the standalone verification inside the
+image, probes the finished image without adding packages, and confirms it runs
+as a non-root user.</p>
 </article>
 <nav class="pager" aria-label="Reading order"><a class="pager-previous" href="/installation/standalone/">&larr; Standalone installation</a><a class="pager-next" href="/installation/source/">Source installation &rarr;</a></nav>
 <footer>

--- a/site/reference/cli/index.html
+++ b/site/reference/cli/index.html
@@ -396,12 +396,13 @@ loopback, while a published port forwards to the container's external
 interface, so a loopback bind refuses every connection a <code class="inline">-p</code> mapping delivers.
 Binding <code class="inline">0.0.0.0</code> <em>inside the container's network namespace</em> is what makes the
 mapping reachable, and the host-side exposure decision moves to the publish
-rule:</p><pre><code class="console language-console">docker run --rm \
+rule:</p><pre><code class="console language-console">image=ghcr.io/andreasronge/ptc_runner:VERSION
+docker run --rm \
   --user &quot;$(id -u):$(id -g)&quot; \
   --env HOME=/tmp \
   -p 127.0.0.1:4123:4123 \
   -v &quot;$PWD:/work&quot; \
-  ptc:dev viewer /work/ptc-project.json --listen 0.0.0.0</code></pre><p>The <code class="inline">127.0.0.1:</code> prefix on <code class="inline">-p</code> is what keeps this equivalent to a loopback
+  &quot;$image&quot; viewer /work/ptc-project.json --listen 0.0.0.0 --port 4123</code></pre><p>The <code class="inline">127.0.0.1:</code> prefix on <code class="inline">-p</code> is what keeps this equivalent to a loopback
 bind. Writing <code class="inline">-p 4123:4123</code> instead publishes an unauthenticated trace browser
 to every host that can reach the machine. The command cannot enforce that
 prefix; you must write it. The user mapping preserves access to the

--- a/test/mix/tasks/ptc_materialize_test.exs
+++ b/test/mix/tasks/ptc_materialize_test.exs
@@ -386,7 +386,8 @@ defmodule Mix.Tasks.Ptc.MaterializeTest do
     assert output =~ "candidate passed 2 host-owned validation cases"
     # The checkout path may contain an issue number such as 1542; only a
     # standalone expected value would be a leaked validation answer.
-    refute output =~ ~r/(?<!\d)42(?!\d)/
+    output_without_tmp_dir = String.replace(output, dir, "<tmp_dir>")
+    refute output_without_tmp_dir =~ ~r/(?<!\d)42(?!\d)/
     assert File.read!(Path.join(out, "candidate.clj")) == @authored
 
     assert %{

--- a/test/scripts/ci_gates_test.exs
+++ b/test/scripts/ci_gates_test.exs
@@ -155,6 +155,25 @@ defmodule PtcRunner.Scripts.CIGatesTest do
     assert launcher =~ ~s(bash ptc_runner_launcher/scripts/verify_precompiled.sh)
   end
 
+  test "container publication is downstream of the canonical release gate" do
+    release = File.read!(Path.join(@root, ".github/workflows/release.yml"))
+    container = File.read!(Path.join(@root, ".github/workflows/container-release.yml"))
+
+    assert release =~
+             ~r/container:\n\s+needs: verify\n\s+uses: \.\/\.github\/workflows\/container-release\.yml/
+
+    assert release =~ "needs: [macos-artifact, container]"
+    assert container =~ "workflow_call:"
+    refute container =~ ~r/^  push:/m
+    assert container =~ "push-by-digest=true"
+    assert container =~ "--metadata-file \"$metadata\""
+    assert container =~ ~s(."containerimage.descriptor".digest)
+    assert container =~ ~s({"architecture":"amd64","os":"linux"})
+    assert container =~ ~s({"architecture":"arm64","os":"linux"})
+    assert container =~ "Publish the exact version tag"
+    refute container =~ "docker/build-push-action"
+  end
+
   test "the interactive REPL PTY check is a Nightly gate, not a PR core-release gate" do
     workflow = File.read!(Path.join(@root, ".github/workflows/test.yml"))
     nightly = File.read!(Path.join(@root, ".github/workflows/nightly.yml"))

--- a/test/scripts/classify_changes_test.exs
+++ b/test/scripts/classify_changes_test.exs
@@ -93,6 +93,7 @@ defmodule PtcRunner.Scripts.ClassifyChangesTest do
           {".github/workflows/pages.yml", all_false()},
           {".github/dependabot.yml", all_false()},
           {".github/workflows/launcher-release.yml", only(["launcher"])},
+          {".github/workflows/container-release.yml", core},
           {".github/workflows/release.yml", core},
           {"scripts/ci/docs.sh", docs},
           {"scripts/build_site.sh", docs},


### PR DESCRIPTION
## Summary

- publish exact-version GHCR images for native Linux AMD64 and ARM64 after canonical release verification
- assemble the manifest from the exact tested digests, verify its platform set, attest it, and create the non-moving version tag last
- document Docker installation and runtime boundaries for readers who already know Docker
- harden finished-image probes and isolate the packaged-release dependency build

## Verification

- native ARM64 finished-image build and probes, including the stdio launcher and Viewer boundary
- one-build local Docker load plus registry push-by-digest verified against a temporary registry
- `mix precommit`
- `MIX_ENV=dev mix docs --warnings-as-errors`
- `scripts/ci/core-release.sh`
- full pre-push gate: 6,953 core checks, static analysis, Dialyzer, package/release, Viewer, and launcher validation
- independent cumulative Codex review, clean after follow-up

## Release note

The first root `vX.Y.Z` release after merge publishes `ghcr.io/andreasronge/ptc_runner:X.Y.Z`. Historical versions are not backfilled. Before publishing that first GitHub release, make the new GHCR package public and verify an unauthenticated pull. GHCR tags are mutable registry pointers; the workflow treats exact version tags as non-moving, while deployments should pin the repository digest and verify its attestation.