### PR TITLE
fix(lisp): honour the configured default sandbox timeout and heap

### DIFF
--- a/lib/ptc_runner/lisp.ex
+++ b/lib/ptc_runner/lisp.ex
@@ -243,7 +243,8 @@ defmodule PtcRunner.Lisp do
     - `:tools` - Map of tool names to functions (default: %{})
     - `:signature` - Optional signature string for return value validation
     - `:float_precision` - Number of decimal places for floats in result (default: nil = full precision)
-    - `:timeout` - Timeout in milliseconds for entire sandbox execution (default: 1000)
+    - `:timeout` - Timeout in milliseconds for entire sandbox execution (default:
+      1000, configurable via `config :ptc_runner, :default_timeout`)
     - `:compile_timeout` - Timeout in milliseconds for the compile phase (parse + analyze) (default: 5000)
     - `:compile_max_heap` - Compile-worker heap ceiling in words (default: the
       `:max_heap` value). No ambient application default is consulted, so a
@@ -257,7 +258,8 @@ defmodule PtcRunner.Lisp do
       operation started late in a run therefore cannot outlive the run.
     - `:pmap_max_concurrency` - Local pmap/pcalls scheduling window — max tasks one call keeps in flight (default: the build-time `System.schedulers_online() * 2`, frozen into the semantic revision). Reduce to avoid overflowing connection pools. The HARD aggregate cap is `:max_parallel_workers`.
     - `:max_heap` - Program heap budget in words ABOVE the measured
-      environment baseline (default: 1_250_000). Host-provided data
+      environment baseline (default: 1_250_000, configurable via
+      `config :ptc_runner, :default_max_heap`). Host-provided data
       (context, `:memory`, tool closures, the parsed program) is measured
       after spawn and excluded from this budget — see
       `PtcRunner.Sandbox` for the re-baseline semantics.
@@ -750,7 +752,7 @@ defmodule PtcRunner.Lisp do
 
   # Bundle the per-run options map consumed by the rest of the run pipeline.
   defp run_params(opts) do
-    max_heap = Keyword.get(opts, :max_heap, 1_250_000)
+    max_heap = Keyword.get(opts, :max_heap, PtcRunner.Sandbox.default_max_heap())
 
     %{
       ctx: Keyword.get(opts, :context, %{}),
@@ -759,7 +761,7 @@ defmodule PtcRunner.Lisp do
       signature_str: Keyword.get(opts, :signature),
       float_precision: Keyword.get(opts, :float_precision),
       preserve_runtime_callables: Keyword.get(opts, :preserve_runtime_callables, false),
-      timeout: Keyword.get(opts, :timeout, 1000),
+      timeout: Keyword.get(opts, :timeout, PtcRunner.Sandbox.default_timeout()),
       max_heap: max_heap,
       setup_max_heap: Keyword.get(opts, :setup_max_heap),
       # Security H1: every pmap/pcalls worker runs under this FIXED heap cap

--- a/lib/ptc_runner/sandbox.ex
+++ b/lib/ptc_runner/sandbox.ex
@@ -141,6 +141,29 @@ defmodule PtcRunner.Sandbox do
   @type failure_snapshot_fn :: (term() -> term())
 
   @doc """
+  The default wall-clock ceiling, in milliseconds, for one sandbox execution.
+
+  Configurable as `config :ptc_runner, :default_timeout`, so a host whose
+  machine is contended can raise the floor for every entry point at once
+  rather than per call site. An explicit `:timeout` option always wins.
+  """
+  @spec default_timeout() :: pos_integer()
+  def default_timeout do
+    Application.get_env(:ptc_runner, :default_timeout, @default_timeout)
+  end
+
+  @doc """
+  The default sandbox heap ceiling, in words.
+
+  Configurable as `config :ptc_runner, :default_max_heap`. An explicit
+  `:max_heap` option always wins.
+  """
+  @spec default_max_heap() :: non_neg_integer()
+  def default_max_heap do
+    Application.get_env(:ptc_runner, :default_max_heap, @default_max_heap)
+  end
+
+  @doc """
   Executes an AST in an isolated sandbox process.
 
   ## Arguments
@@ -172,11 +195,8 @@ defmodule PtcRunner.Sandbox do
   @spec execute(term(), term(), keyword()) :: execute_result()
 
   def execute(ast, context, opts \\ []) do
-    default_timeout = Application.get_env(:ptc_runner, :default_timeout, @default_timeout)
-    default_max_heap = Application.get_env(:ptc_runner, :default_max_heap, @default_max_heap)
-
-    timeout = Keyword.get(opts, :timeout, default_timeout)
-    max_heap = Keyword.get(opts, :max_heap, default_max_heap)
+    timeout = Keyword.get(opts, :timeout, default_timeout())
+    max_heap = Keyword.get(opts, :max_heap, default_max_heap())
 
     validate_limit!(:timeout, timeout)
     validate_limit!(:max_heap, max_heap)
@@ -537,11 +557,8 @@ defmodule PtcRunner.Sandbox do
              | {:memory_exceeded, non_neg_integer()}
              | {:execution_error, String.t()}}
   def run_bounded(fun, opts \\ []) when is_function(fun, 0) do
-    default_timeout = Application.get_env(:ptc_runner, :default_timeout, @default_timeout)
-    default_max_heap = Application.get_env(:ptc_runner, :default_max_heap, @default_max_heap)
-
-    timeout = Keyword.get(opts, :timeout, default_timeout)
-    max_heap = Keyword.get(opts, :max_heap, default_max_heap)
+    timeout = Keyword.get(opts, :timeout, default_timeout())
+    max_heap = Keyword.get(opts, :max_heap, default_max_heap())
     link? = Keyword.get(opts, :link, false)
 
     validate_limit!(:timeout, timeout)

--- a/test/ptc_runner/lisp/default_limits_test.exs
+++ b/test/ptc_runner/lisp/default_limits_test.exs
@@ -1,0 +1,36 @@
+defmodule PtcRunner.Lisp.DefaultLimitsTest do
+  # Mutates the global `:ptc_runner` application environment that every sandbox
+  # on the node reads, so this case cannot share the scheduler with concurrent
+  # ones.
+  use ExUnit.Case, async: false
+
+  alias PtcRunner.Lisp
+
+  setup do
+    original = Application.fetch_env(:ptc_runner, :default_timeout)
+
+    on_exit(fn ->
+      case original do
+        {:ok, value} -> Application.put_env(:ptc_runner, :default_timeout, value)
+        :error -> Application.delete_env(:ptc_runner, :default_timeout)
+      end
+    end)
+
+    :ok
+  end
+
+  test "run/2 takes its default sandbox timeout from the application environment" do
+    Application.put_env(:ptc_runner, :default_timeout, 1)
+
+    assert {:error, result} = Lisp.run("(reduce + (range 20000))")
+    assert result.fail.reason == :timeout
+    assert result.fail.details.timeout_ms == 1
+  end
+
+  test "an explicit :timeout still overrides the configured default" do
+    Application.put_env(:ptc_runner, :default_timeout, 1)
+
+    assert {:ok, result} = Lisp.run("(+ 1 2)", timeout: 5_000)
+    assert result.return == 3
+  end
+end


### PR DESCRIPTION
## The bug

`PtcRunner.Sandbox`'s moduledoc documents `:default_timeout` and `:default_max_heap` as application-level defaults — and uses `PtcRunner.Lisp.run/2` as its own worked example of setting them. `Sandbox` honours both. `Lisp.run/2` hardcoded `1000` and `1_250_000` in `run_params/1` and silently ignored the configuration.

`config/test.exs:16` has set `default_timeout: 10_000` all along. Because `Lisp.run/2` never read it, **every `Lisp.run/2` in the suite has really been executing under a 1 s wall-clock budget** on a machine running `System.schedulers_online()` cases concurrently.

## Why it shows up as random flakes

Roughly 800 `Lisp.run/2` call sites under `test/ptc_runner/lisp/` inherit that default. Only two files pass an explicit `:timeout` — `pmap_heap_cap_test.exs` and `integration/parallel_limits_test.exs` — and those are the two whose subject *is* timing, so they had to.

When any one of the other 800 loses a scheduler race, the sandbox is killed mid-eval and the test sees `{:error, %Result{}}` with every counter at zero. That is exactly what `ToolCacheBoundaryTest` did during a pre-push on a **docs-only** branch, which is what prompted this.

Confirmed by fingerprint: forcing the deadline reproduces the observed failure down to `memory_bytes: 24` with every counter zero, and `fail` = `%{reason: :timeout, details: %{phase: :eval}}`.

## The change

Both defaults now come from `Sandbox.default_timeout/0` and `Sandbox.default_max_heap/0`. Routing `Sandbox`'s own two call sites through the new accessors also removes the duplicated `Application.get_env` pair it carried.

`validate/2` deliberately keeps its literal: compile ceilings are documented as not movable by ambient configuration, so a sealed Kernel run cannot have its compile budget raised from outside the sealed request.

The shipped default is unchanged at 1000 ms — only the ability to configure it is restored.

## Not covered

This does **not** fix #1472 (`ToolGrantTest` validation deadline). That test sets `validation_deadline_ms` explicitly at line 161 and never goes through `Lisp.run/2`, so no default reaches it. It is the same family — an absolute wall-clock deadline in a test — but the opposite direction: it fails when validation is *warm and fast* and beats the deadline the test expects to win.

## Verification

- New test fails before the change (the configured 1 ms default is ignored and the program completes) and passes after.
- `test/ptc_runner/lisp/`, `lisp_test.exs`, `sandbox_test.exs`: 4254 passed.
- Full suite: 6955 passed in 274 s, no slowdown.
- Pre-push gate passed in 405 s including Dialyzer (the push itself then lost the GitHub connection twice, so the branch was pushed with `--no-verify` after the gate had already gone green).