### PR TITLE
test(kernel): remove the timing race from the validation-deadline test

### DIFF
--- a/test/ptc_runner/kernel/tool_grant_test.exs
+++ b/test/ptc_runner/kernel/tool_grant_test.exs
@@ -158,17 +158,29 @@ defmodule PtcRunner.Kernel.ToolGrantTest do
         dispatch_context(
           validation_heap_words: 100_000_000,
           evaluation_lease: lease,
-          validation_deadline_ms: System.monotonic_time(:millisecond) + 30
+          # The dispatcher reserves a fixed handoff window (25 ms) out of the
+          # deadline so a refusal can still persist terminal host provenance.
+          # A deadline inside that window therefore leaves a non-positive
+          # validation budget and is refused before the validator is entered.
+          # The deadline is still in the FUTURE: what is being asserted is the
+          # reserve, not expiry. Do not raise this past the handoff window -
+          # a deadline of +30 ms grants validation the ~5 ms difference and
+          # turns the assertion into a race against how fast the validator
+          # happens to be on the machine (issue #1472).
+          validation_deadline_ms: System.monotonic_time(:millisecond) + 5
         ),
         nil,
         nil
       )
 
+    # Every row violates `minimum: 1`, so a validator that ran at all would
+    # report `:invalid_arguments`. Getting `:input_validation_unavailable`
+    # is what proves it was never entered.
     assert %{
              status: :error,
              kind: :capability_unavailable,
              reason: :input_validation_unavailable
-           } = grant["checked"].(%{"rows" => List.duplicate(0, 10_000)})
+           } = grant["checked"].(%{"rows" => [0, 0, 0]})
 
     assert {:ok, %{terminal_host_failure?: true}} =
              RunState.release_evaluation_status(state, lease)


### PR DESCRIPTION
Closes #1472.

## The race, quantified

`tool_grant_test.exs:132` set `validation_deadline_ms` 30 ms out. The dispatcher reserves `@validation_handoff_ms` (25 ms) of every deadline so a refusal can still persist terminal host provenance — so the test granted validation the **5 ms difference** and asserted that 5 ms was not enough.

Measured on this machine, warm validation of the 10,000-row payload takes **7.5 ms median** (min 7.5, max 17.8) against that ~5 ms budget. A 1.5× cushion is the whole margin: fast enough on a warm path and the validator wins, returning the equally-correct `:invalid_arguments` that the issue reports. This is also why it passes in isolation and failed under full-suite load — warm beats busy, exactly as #1472 called out.

## The change

Move the deadline *inside* the handoff window rather than widening a margin:

```
validation_worker_timeout_ms/2:  deadline - now - 25
```

At `+5 ms` that is non-positive for any `elapsed >= 0`, so `validate/7` short-circuits to `:input_validation_unavailable` before the validator is entered. The refusal is now arithmetic, not a race. The deadline is still in the **future** — the subject is the reserve, not expiry.

The payload shrinks to three rows because it no longer has to outrun anything. Every row still violates `minimum: 1`, so a validator that ran at all would report `:invalid_arguments` — which is what makes `:input_validation_unavailable` evidence that it was never entered.

## What this does not pin

This asserts refusal plus provenance persistence. It does **not** pin the value of the handoff constant: zeroing `@validation_handoff_ms` still passes, because a 5 ms budget is too short for the validator spawn as well. I checked this by mutation rather than assuming it. Pinning the constant would require a boundary assertion that is timing-sensitive all over again, which is the thing being removed.

## Verification

- 40 repeat runs of the file (`--repeat-until-failure 40`).
- Kernel directory: 2259 tests.
- Full suite: 6953 tests.

All green. No `lib/` change — the production behaviour under test is unchanged, and the issue found no production defect either.

## Related

Separate from #1597, which fixes a different flake in the same family (`Lisp.run/2` ignoring the configured `:default_timeout`, leaving ~800 call sites on a 1 s budget). That one fails when a run is too *slow*; this one failed when validation was too *fast*.