### PR TITLE
feat(site): add PtcRunner brand mark

### DIFF
--- a/dev/mix/tasks/ptc.gen_site_guides.ex
+++ b/dev/mix/tasks/ptc.gen_site_guides.ex
@@ -374,7 +374,7 @@ defmodule Mix.Tasks.Ptc.GenSiteGuides do
     <meta property="og:description" content="#{MarkdownHTML.escape(description)}">
     <meta property="og:url" content="#{canonical}">
     <meta property="og:type" content="article">
-    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#9883;</text></svg>">
+    <link rel="icon" href="/ptc-runner-mark.svg" type="image/svg+xml">
     <link rel="stylesheet" href="/style.css">
     <link rel="stylesheet" href="/guides.css">
     <script type="module" src="/docs.js"></script>

--- a/site/guides.css
+++ b/site/guides.css
@@ -63,6 +63,16 @@
 
 /* The landing page shares the shell; keep its measure comfortable. */
 .guide-main.landing { max-width: 48rem; }
+.landing-header {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+.landing-header .landing-mark {
+  width: 3.5rem;
+  height: 3.5rem;
+  flex: 0 0 auto;
+}
 
 .mobile-crumb { display: none; }
 

--- a/site/guides/agent-cli-usage/index.html
+++ b/site/guides/agent-cli-usage/index.html
@@ -12,7 +12,7 @@ drives ptc.">
 drives ptc.">
 <meta property="og:url" content="https://ptc-runner.dev/guides/agent-cli-usage/">
 <meta property="og:type" content="article">
-<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#9883;</text></svg>">
+<link rel="icon" href="/ptc-runner-mark.svg" type="image/svg+xml">
 <link rel="stylesheet" href="/style.css">
 <link rel="stylesheet" href="/guides.css">
 <script type="module" src="/docs.js"></script>

--- a/site/guides/agent-workflow-patterns/index.html
+++ b/site/guides/agent-workflow-patterns/index.html
@@ -12,7 +12,7 @@ code.">
 code.">
 <meta property="og:url" content="https://ptc-runner.dev/guides/agent-workflow-patterns/">
 <meta property="og:type" content="article">
-<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#9883;</text></svg>">
+<link rel="icon" href="/ptc-runner-mark.svg" type="image/svg+xml">
 <link rel="stylesheet" href="/style.css">
 <link rel="stylesheet" href="/guides.css">
 <script type="module" src="/docs.js"></script>

--- a/site/guides/building-agents/index.html
+++ b/site/guides/building-agents/index.html
@@ -12,7 +12,7 @@ composition, or complete implementation.">
 composition, or complete implementation.">
 <meta property="og:url" content="https://ptc-runner.dev/guides/building-agents/">
 <meta property="og:type" content="article">
-<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#9883;</text></svg>">
+<link rel="icon" href="/ptc-runner-mark.svg" type="image/svg+xml">
 <link rel="stylesheet" href="/style.css">
 <link rel="stylesheet" href="/guides.css">
 <script type="module" src="/docs.js"></script>

--- a/site/guides/components-and-preludes/index.html
+++ b/site/guides/components-and-preludes/index.html
@@ -12,7 +12,7 @@ shipped behavior no longer fits.">
 shipped behavior no longer fits.">
 <meta property="og:url" content="https://ptc-runner.dev/guides/components-and-preludes/">
 <meta property="og:type" content="article">
-<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#9883;</text></svg>">
+<link rel="icon" href="/ptc-runner-mark.svg" type="image/svg+xml">
 <link rel="stylesheet" href="/style.css">
 <link rel="stylesheet" href="/guides.css">
 <script type="module" src="/docs.js"></script>

--- a/site/guides/concepts/index.html
+++ b/site/guides/concepts/index.html
@@ -12,7 +12,7 @@ commands, and results. You can run the Quickstart without reading it first.">
 commands, and results. You can run the Quickstart without reading it first.">
 <meta property="og:url" content="https://ptc-runner.dev/guides/concepts/">
 <meta property="og:type" content="article">
-<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#9883;</text></svg>">
+<link rel="icon" href="/ptc-runner-mark.svg" type="image/svg+xml">
 <link rel="stylesheet" href="/style.css">
 <link rel="stylesheet" href="/guides.css">
 <script type="module" src="/docs.js"></script>

--- a/site/guides/connecting-tools-with-mcp/index.html
+++ b/site/guides/connecting-tools-with-mcp/index.html
@@ -10,7 +10,7 @@
 <meta property="og:description" content="Connect one MCP server while exposing only the tools a mission needs.">
 <meta property="og:url" content="https://ptc-runner.dev/guides/connecting-tools-with-mcp/">
 <meta property="og:type" content="article">
-<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#9883;</text></svg>">
+<link rel="icon" href="/ptc-runner-mark.svg" type="image/svg+xml">
 <link rel="stylesheet" href="/style.css">
 <link rel="stylesheet" href="/guides.css">
 <script type="module" src="/docs.js"></script>

--- a/site/guides/debugging-a-failed-run/index.html
+++ b/site/guides/debugging-a-failed-run/index.html
@@ -12,7 +12,7 @@ the trace cannot answer the question.">
 the trace cannot answer the question.">
 <meta property="og:url" content="https://ptc-runner.dev/guides/debugging-a-failed-run/">
 <meta property="og:type" content="article">
-<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#9883;</text></svg>">
+<link rel="icon" href="/ptc-runner-mark.svg" type="image/svg+xml">
 <link rel="stylesheet" href="/style.css">
 <link rel="stylesheet" href="/guides.css">
 <script type="module" src="/docs.js"></script>

--- a/site/guides/designing-agent-workflows/index.html
+++ b/site/guides/designing-agent-workflows/index.html
@@ -12,7 +12,7 @@ move the rules into code, then split the work between specialists.">
 move the rules into code, then split the work between specialists.">
 <meta property="og:url" content="https://ptc-runner.dev/guides/designing-agent-workflows/">
 <meta property="og:type" content="article">
-<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#9883;</text></svg>">
+<link rel="icon" href="/ptc-runner-mark.svg" type="image/svg+xml">
 <link rel="stylesheet" href="/style.css">
 <link rel="stylesheet" href="/guides.css">
 <script type="module" src="/docs.js"></script>

--- a/site/guides/evaluating-with-replay/index.html
+++ b/site/guides/evaluating-with-replay/index.html
@@ -12,7 +12,7 @@ deciding whether to promote it.">
 deciding whether to promote it.">
 <meta property="og:url" content="https://ptc-runner.dev/guides/evaluating-with-replay/">
 <meta property="og:type" content="article">
-<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#9883;</text></svg>">
+<link rel="icon" href="/ptc-runner-mark.svg" type="image/svg+xml">
 <link rel="stylesheet" href="/style.css">
 <link rel="stylesheet" href="/guides.css">
 <script type="module" src="/docs.js"></script>

--- a/site/guides/getting-started/index.html
+++ b/site/guides/getting-started/index.html
@@ -12,7 +12,7 @@ an agent loop.">
 an agent loop.">
 <meta property="og:url" content="https://ptc-runner.dev/guides/getting-started/">
 <meta property="og:type" content="article">
-<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#9883;</text></svg>">
+<link rel="icon" href="/ptc-runner-mark.svg" type="image/svg+xml">
 <link rel="stylesheet" href="/style.css">
 <link rel="stylesheet" href="/guides.css">
 <script type="module" src="/docs.js"></script>

--- a/site/guides/host-configuration/index.html
+++ b/site/guides/host-configuration/index.html
@@ -12,7 +12,7 @@ limits separately from an application.">
 limits separately from an application.">
 <meta property="og:url" content="https://ptc-runner.dev/guides/host-configuration/">
 <meta property="og:type" content="article">
-<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#9883;</text></svg>">
+<link rel="icon" href="/ptc-runner-mark.svg" type="image/svg+xml">
 <link rel="stylesheet" href="/style.css">
 <link rel="stylesheet" href="/guides.css">
 <script type="module" src="/docs.js"></script>

--- a/site/guides/index.html
+++ b/site/guides/index.html
@@ -10,7 +10,7 @@
 <meta property="og:description" content="Task-focused guides, installation routes, and the reference documentation for PtcRunner.">
 <meta property="og:url" content="https://ptc-runner.dev/guides/">
 <meta property="og:type" content="article">
-<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#9883;</text></svg>">
+<link rel="icon" href="/ptc-runner-mark.svg" type="image/svg+xml">
 <link rel="stylesheet" href="/style.css">
 <link rel="stylesheet" href="/guides.css">
 <script type="module" src="/docs.js"></script>

--- a/site/guides/kernel-repl/index.html
+++ b/site/guides/kernel-repl/index.html
@@ -12,7 +12,7 @@ unattended REPL session.">
 unattended REPL session.">
 <meta property="og:url" content="https://ptc-runner.dev/guides/kernel-repl/">
 <meta property="og:type" content="article">
-<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#9883;</text></svg>">
+<link rel="icon" href="/ptc-runner-mark.svg" type="image/svg+xml">
 <link rel="stylesheet" href="/style.css">
 <link rel="stylesheet" href="/guides.css">
 <script type="module" src="/docs.js"></script>

--- a/site/guides/manifests-and-capabilities/index.html
+++ b/site/guides/manifests-and-capabilities/index.html
@@ -10,7 +10,7 @@
 <meta property="og:description" content="Use ptc.json to declare code, input, selected providers, missions, and limits.">
 <meta property="og:url" content="https://ptc-runner.dev/guides/manifests-and-capabilities/">
 <meta property="og:type" content="article">
-<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#9883;</text></svg>">
+<link rel="icon" href="/ptc-runner-mark.svg" type="image/svg+xml">
 <link rel="stylesheet" href="/style.css">
 <link rel="stylesheet" href="/guides.css">
 <script type="module" src="/docs.js"></script>

--- a/site/guides/project-configuration/index.html
+++ b/site/guides/project-configuration/index.html
@@ -12,7 +12,7 @@ results, and the Viewer.">
 results, and the Viewer.">
 <meta property="og:url" content="https://ptc-runner.dev/guides/project-configuration/">
 <meta property="og:type" content="article">
-<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#9883;</text></svg>">
+<link rel="icon" href="/ptc-runner-mark.svg" type="image/svg+xml">
 <link rel="stylesheet" href="/style.css">
 <link rel="stylesheet" href="/guides.css">
 <script type="module" src="/docs.js"></script>

--- a/site/guides/ptc-lisp-basics/index.html
+++ b/site/guides/ptc-lisp-basics/index.html
@@ -12,7 +12,7 @@ anything.">
 anything.">
 <meta property="og:url" content="https://ptc-runner.dev/guides/ptc-lisp-basics/">
 <meta property="og:type" content="article">
-<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#9883;</text></svg>">
+<link rel="icon" href="/ptc-runner-mark.svg" type="image/svg+xml">
 <link rel="stylesheet" href="/style.css">
 <link rel="stylesheet" href="/guides.css">
 <script type="module" src="/docs.js"></script>

--- a/site/guides/quickstart/index.html
+++ b/site/guides/quickstart/index.html
@@ -12,7 +12,7 @@ without writing PTC-Lisp yourself.">
 without writing PTC-Lisp yourself.">
 <meta property="og:url" content="https://ptc-runner.dev/guides/quickstart/">
 <meta property="og:type" content="article">
-<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#9883;</text></svg>">
+<link rel="icon" href="/ptc-runner-mark.svg" type="image/svg+xml">
 <link rel="stylesheet" href="/style.css">
 <link rel="stylesheet" href="/guides.css">
 <script type="module" src="/docs.js"></script>

--- a/site/guides/running-and-debugging/index.html
+++ b/site/guides/running-and-debugging/index.html
@@ -10,7 +10,7 @@
 <meta property="og:description" content="Run, validate, and inspect a PtcRunner project through the ptc executable.">
 <meta property="og:url" content="https://ptc-runner.dev/guides/running-and-debugging/">
 <meta property="og:type" content="article">
-<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#9883;</text></svg>">
+<link rel="icon" href="/ptc-runner-mark.svg" type="image/svg+xml">
 <link rel="stylesheet" href="/style.css">
 <link rel="stylesheet" href="/guides.css">
 <script type="module" src="/docs.js"></script>

--- a/site/guides/using-models/index.html
+++ b/site/guides/using-models/index.html
@@ -12,7 +12,7 @@ implementation.">
 implementation.">
 <meta property="og:url" content="https://ptc-runner.dev/guides/using-models/">
 <meta property="og:type" content="article">
-<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#9883;</text></svg>">
+<link rel="icon" href="/ptc-runner-mark.svg" type="image/svg+xml">
 <link rel="stylesheet" href="/style.css">
 <link rel="stylesheet" href="/guides.css">
 <script type="module" src="/docs.js"></script>

--- a/site/index.html
+++ b/site/index.html
@@ -10,7 +10,7 @@
 <meta property="og:description" content="A runtime for Code Mode agents. Bounded programs, explicit limits, recorded evidence.">
 <meta property="og:url" content="https://ptc-runner.dev/">
 <meta property="og:type" content="website">
-<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#9883;</text></svg>">
+<link rel="icon" href="/ptc-runner-mark.svg" type="image/svg+xml">
 <link rel="stylesheet" href="/style.css">
 <link rel="stylesheet" href="/guides.css">
 <script type="module" src="/docs.js"></script>
@@ -95,9 +95,13 @@
 <!-- END GENERATED: site sidebar -->
 <main class="guide-main landing">
 
-<header>
-  <h1>PtcRunner</h1>
-  <p class="kicker">A runtime for self-improving agents</p>
+<header class="landing-header">
+  <img class="landing-mark" src="/ptc-runner-mark.svg" width="100" height="100"
+       alt="" aria-hidden="true">
+  <div>
+    <h1>PtcRunner</h1>
+    <p class="kicker">A runtime for self-improving agents</p>
+  </div>
 </header>
 
 <p class="lead"><strong>Build AI agents that are bounded in what they can do, easy to

--- a/site/installation/docker/index.html
+++ b/site/installation/docker/index.html
@@ -12,7 +12,7 @@ Viewer, and stdio launcher without a build toolchain.">
 Viewer, and stdio launcher without a build toolchain.">
 <meta property="og:url" content="https://ptc-runner.dev/installation/docker/">
 <meta property="og:type" content="article">
-<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#9883;</text></svg>">
+<link rel="icon" href="/ptc-runner-mark.svg" type="image/svg+xml">
 <link rel="stylesheet" href="/style.css">
 <link rel="stylesheet" href="/guides.css">
 <script type="module" src="/docs.js"></script>

--- a/site/installation/source/index.html
+++ b/site/installation/source/index.html
@@ -12,7 +12,7 @@ validating an unreleased revision, or producing a standalone artifact.">
 validating an unreleased revision, or producing a standalone artifact.">
 <meta property="og:url" content="https://ptc-runner.dev/installation/source/">
 <meta property="og:type" content="article">
-<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#9883;</text></svg>">
+<link rel="icon" href="/ptc-runner-mark.svg" type="image/svg+xml">
 <link rel="stylesheet" href="/style.css">
 <link rel="stylesheet" href="/guides.css">
 <script type="module" src="/docs.js"></script>

--- a/site/installation/standalone/index.html
+++ b/site/installation/standalone/index.html
@@ -10,7 +10,7 @@
 <meta property="og:description" content="Install the self-contained ptc executable from GitHub Releases.">
 <meta property="og:url" content="https://ptc-runner.dev/installation/standalone/">
 <meta property="og:type" content="article">
-<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#9883;</text></svg>">
+<link rel="icon" href="/ptc-runner-mark.svg" type="image/svg+xml">
 <link rel="stylesheet" href="/style.css">
 <link rel="stylesheet" href="/guides.css">
 <script type="module" src="/docs.js"></script>

--- a/site/ptc-runner-mark.svg
+++ b/site/ptc-runner-mark.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <style>
+    .parenthesis {
+      fill: none;
+      stroke: #1c1a17;
+      stroke-linecap: round;
+      stroke-width: 10;
+    }
+
+    .arrow {
+      fill: none;
+      stroke: #9a4a1e;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-width: 9;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      .parenthesis { stroke: #fbfaf8; }
+      .arrow { stroke: #e08a55; }
+    }
+  </style>
+  <path class="parenthesis" d="M34 16C23 25 18 37 18 50s5 25 16 34"/>
+  <path class="parenthesis" d="M66 16c11 9 16 21 16 34s-5 25-16 34"/>
+  <path class="arrow" d="M35 50h33M58 40l10 10-10 10"/>
+</svg>

--- a/site/reference/agent-library-reference/index.html
+++ b/site/reference/agent-library-reference/index.html
@@ -14,7 +14,7 @@ interfaces. For a guided workflow, see
 Building agents.">
 <meta property="og:url" content="https://ptc-runner.dev/reference/agent-library-reference/">
 <meta property="og:type" content="article">
-<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#9883;</text></svg>">
+<link rel="icon" href="/ptc-runner-mark.svg" type="image/svg+xml">
 <link rel="stylesheet" href="/style.css">
 <link rel="stylesheet" href="/guides.css">
 <script type="module" src="/docs.js"></script>

--- a/site/reference/application-manifest/index.html
+++ b/site/reference/application-manifest/index.html
@@ -10,7 +10,7 @@
 <meta property="og:description" content="This is the complete contract for ptc.json.">
 <meta property="og:url" content="https://ptc-runner.dev/reference/application-manifest/">
 <meta property="og:type" content="article">
-<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#9883;</text></svg>">
+<link rel="icon" href="/ptc-runner-mark.svg" type="image/svg+xml">
 <link rel="stylesheet" href="/style.css">
 <link rel="stylesheet" href="/guides.css">
 <script type="module" src="/docs.js"></script>

--- a/site/reference/cli/index.html
+++ b/site/reference/cli/index.html
@@ -10,7 +10,7 @@
 <meta property="og:description" content="This is the complete ptc command and process contract.">
 <meta property="og:url" content="https://ptc-runner.dev/reference/cli/">
 <meta property="og:type" content="article">
-<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#9883;</text></svg>">
+<link rel="icon" href="/ptc-runner-mark.svg" type="image/svg+xml">
 <link rel="stylesheet" href="/style.css">
 <link rel="stylesheet" href="/guides.css">
 <script type="module" src="/docs.js"></script>

--- a/site/reference/clojure-conformance-gaps/index.html
+++ b/site/reference/clojure-conformance-gaps/index.html
@@ -10,7 +10,7 @@
 <meta property="og:description" content="Tracked differences between PTC-Lisp and Clojure semantics, discovered via conformance testing against SCI, Babashka, Joker, and manual investigation.">
 <meta property="og:url" content="https://ptc-runner.dev/reference/clojure-conformance-gaps/">
 <meta property="og:type" content="article">
-<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#9883;</text></svg>">
+<link rel="icon" href="/ptc-runner-mark.svg" type="image/svg+xml">
 <link rel="stylesheet" href="/style.css">
 <link rel="stylesheet" href="/guides.css">
 <script type="module" src="/docs.js"></script>

--- a/site/reference/component-contracts/index.html
+++ b/site/reference/component-contracts/index.html
@@ -12,7 +12,7 @@ contract.">
 contract.">
 <meta property="og:url" content="https://ptc-runner.dev/reference/component-contracts/">
 <meta property="og:type" content="article">
-<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#9883;</text></svg>">
+<link rel="icon" href="/ptc-runner-mark.svg" type="image/svg+xml">
 <link rel="stylesheet" href="/style.css">
 <link rel="stylesheet" href="/guides.css">
 <script type="module" src="/docs.js"></script>

--- a/site/reference/debug-navigation/index.html
+++ b/site/reference/debug-navigation/index.html
@@ -10,7 +10,7 @@
 <meta property="og:description" content="This is the complete frozen-evidence graph and debug.nav contract.">
 <meta property="og:url" content="https://ptc-runner.dev/reference/debug-navigation/">
 <meta property="og:type" content="article">
-<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#9883;</text></svg>">
+<link rel="icon" href="/ptc-runner-mark.svg" type="image/svg+xml">
 <link rel="stylesheet" href="/style.css">
 <link rel="stylesheet" href="/guides.css">
 <script type="module" src="/docs.js"></script>

--- a/site/reference/host-installation/index.html
+++ b/site/reference/host-installation/index.html
@@ -12,7 +12,7 @@ data classes, and outer limits.">
 data classes, and outer limits.">
 <meta property="og:url" content="https://ptc-runner.dev/reference/host-installation/">
 <meta property="og:type" content="article">
-<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#9883;</text></svg>">
+<link rel="icon" href="/ptc-runner-mark.svg" type="image/svg+xml">
 <link rel="stylesheet" href="/style.css">
 <link rel="stylesheet" href="/guides.css">
 <script type="module" src="/docs.js"></script>

--- a/site/reference/java-interop/index.html
+++ b/site/reference/java-interop/index.html
@@ -10,7 +10,7 @@
 <meta property="og:description" content="PTC-Lisp emulates a subset of Java interop for LLM compatibility. These are not real JVM calls — they are BEAM-native implementations that mirror the Java API …">
 <meta property="og:url" content="https://ptc-runner.dev/reference/java-interop/">
 <meta property="og:type" content="article">
-<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#9883;</text></svg>">
+<link rel="icon" href="/ptc-runner-mark.svg" type="image/svg+xml">
 <link rel="stylesheet" href="/style.css">
 <link rel="stylesheet" href="/guides.css">
 <script type="module" src="/docs.js"></script>

--- a/site/reference/kernel-limits-reference/index.html
+++ b/site/reference/kernel-limits-reference/index.html
@@ -10,7 +10,7 @@
 <meta property="og:description" content="Every limit is a positive enforced ceiling; there is no disabled or infinite form. Two documents decide one number. The host document installs the outer ceilin…">
 <meta property="og:url" content="https://ptc-runner.dev/reference/kernel-limits-reference/">
 <meta property="og:type" content="article">
-<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#9883;</text></svg>">
+<link rel="icon" href="/ptc-runner-mark.svg" type="image/svg+xml">
 <link rel="stylesheet" href="/style.css">
 <link rel="stylesheet" href="/guides.css">
 <script type="module" src="/docs.js"></script>

--- a/site/reference/mcp/index.html
+++ b/site/reference/mcp/index.html
@@ -12,7 +12,7 @@ lifecycle contract.">
 lifecycle contract.">
 <meta property="og:url" content="https://ptc-runner.dev/reference/mcp/">
 <meta property="og:type" content="article">
-<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#9883;</text></svg>">
+<link rel="icon" href="/ptc-runner-mark.svg" type="image/svg+xml">
 <link rel="stylesheet" href="/style.css">
 <link rel="stylesheet" href="/guides.css">
 <script type="module" src="/docs.js"></script>

--- a/site/reference/prelude-reference/index.html
+++ b/site/reference/prelude-reference/index.html
@@ -10,7 +10,7 @@
 <meta property="og:description" content="PtcRunner ships 14 reusable PTC-Lisp components with 48 public exports. A component is one named source module with one namespace. A prelude is the immutable c…">
 <meta property="og:url" content="https://ptc-runner.dev/reference/prelude-reference/">
 <meta property="og:type" content="article">
-<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#9883;</text></svg>">
+<link rel="icon" href="/ptc-runner-mark.svg" type="image/svg+xml">
 <link rel="stylesheet" href="/style.css">
 <link rel="stylesheet" href="/guides.css">
 <script type="module" src="/docs.js"></script>

--- a/site/reference/project-files/index.html
+++ b/site/reference/project-files/index.html
@@ -12,7 +12,7 @@ contract.">
 contract.">
 <meta property="og:url" content="https://ptc-runner.dev/reference/project-files/">
 <meta property="og:type" content="article">
-<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#9883;</text></svg>">
+<link rel="icon" href="/ptc-runner-mark.svg" type="image/svg+xml">
 <link rel="stylesheet" href="/style.css">
 <link rel="stylesheet" href="/guides.css">
 <script type="module" src="/docs.js"></script>

--- a/site/reference/ptc-lisp-specification/index.html
+++ b/site/reference/ptc-lisp-specification/index.html
@@ -12,7 +12,7 @@ calling through explicitly granted capabilities.">
 calling through explicitly granted capabilities.">
 <meta property="og:url" content="https://ptc-runner.dev/reference/ptc-lisp-specification/">
 <meta property="og:type" content="article">
-<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#9883;</text></svg>">
+<link rel="icon" href="/ptc-runner-mark.svg" type="image/svg+xml">
 <link rel="stylesheet" href="/style.css">
 <link rel="stylesheet" href="/guides.css">
 <script type="module" src="/docs.js"></script>

--- a/site/reference/repl/index.html
+++ b/site/reference/repl/index.html
@@ -12,7 +12,7 @@ private-session contract.">
 private-session contract.">
 <meta property="og:url" content="https://ptc-runner.dev/reference/repl/">
 <meta property="og:type" content="article">
-<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#9883;</text></svg>">
+<link rel="icon" href="/ptc-runner-mark.svg" type="image/svg+xml">
 <link rel="stylesheet" href="/style.css">
 <link rel="stylesheet" href="/guides.css">
 <script type="module" src="/docs.js"></script>

--- a/site/reference/signature-syntax/index.html
+++ b/site/reference/signature-syntax/index.html
@@ -12,7 +12,7 @@ then validate both sides of each call.">
 then validate both sides of each call.">
 <meta property="og:url" content="https://ptc-runner.dev/reference/signature-syntax/">
 <meta property="og:type" content="article">
-<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#9883;</text></svg>">
+<link rel="icon" href="/ptc-runner-mark.svg" type="image/svg+xml">
 <link rel="stylesheet" href="/style.css">
 <link rel="stylesheet" href="/guides.css">
 <script type="module" src="/docs.js"></script>

--- a/site/schemas/index.html
+++ b/site/schemas/index.html
@@ -6,7 +6,7 @@
 <title>JSON Schemas — PtcRunner</title>
 <meta name="description" content="Stable $id URLs for the PtcRunner project, application, host, and command-envelope JSON Schemas.">
 <link rel="canonical" href="https://ptc-runner.dev/schemas/">
-<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>&#9883;</text></svg>">
+<link rel="icon" href="/ptc-runner-mark.svg" type="image/svg+xml">
 <link rel="stylesheet" href="/style.css">
 </head>
 <body>


### PR DESCRIPTION
## Summary

- add a crisp `(→)` PtcRunner vector mark to the landing-page title
- adapt the parentheses and arrow colors to light and dark color schemes
- replace the atom favicon across all generated documentation pages
- keep generated site output aligned with its owning generator

## Verification

- `mix test test/documentation_guidelines_test.exs`
- `mix ptc.gen_docs --check`
- `scripts/build_site.sh`
- `mix precommit`
- `MIX_ENV=dev mix docs --warnings-as-errors`
- independent cumulative review: no actionable findings
- repository pre-push documentation gate