### PR TITLE
fix(repl): bound interactive session lifetimes

### DIFF
--- a/docs/maintainers/embedding.md
+++ b/docs/maintainers/embedding.md
@@ -171,6 +171,11 @@ REPL. The process that calls `new/1` must also call every `eval/2`, `close/1`,
 and `abort/2`. Passing the public struct to another process does not transfer
 continuation or cleanup authority.
 
+`new/0` and `new/1` retain ordinary run limits. The CLI's argumentless direct
+line loop selects its separate interactive limit profile explicitly; embedding
+callers never receive that wider session lifetime merely by constructing a
+`ReplSession`.
+
 Each evaluation returns an observation projection and updated public session;
 the authoritative definitions and `*1`/`*2`/`*3` history stay inside the owner.
 Call `close/1` for normal finalization or `abort/2` after an early frontend

--- a/docs/maintainers/kernel.md
+++ b/docs/maintainers/kernel.md
@@ -171,6 +171,16 @@ sink, and active-provider prefix as a one-shot run. It then transfers the
 opening and run state to `ReplSessionOwner`. `ReplSession` is process-affine;
 passing its public value does not transfer ownership.
 
+The frontend separately classifies whether it will enter the line loop. That
+classification is independent of TTY attachment and drives the REPL-only limit
+profile before the application package, event sink, provider session, and run
+state are sealed. Omitted manifest `run_duration_ms` and
+`subordinate_evaluations` rows and retained-event capacity then inherit their
+installed ceilings; explicit manifest values remain effective. The resulting
+deadline stays absolute for the whole session, including prompt time. An
+owner-side timer records deadline failure and closes provider resources even
+while the frontend is blocked reading the next line.
+
 An explicit manifest mission first derives an attested target from the inactive
 `PreparedRun` and its exact installation catalog. That target seals direct
 occurrences, dependency-closure declarations and aliases, and the closure's

--- a/docs/reference/repl.md
+++ b/docs/reference/repl.md
@@ -77,6 +77,26 @@ A provider-bearing manifest requires `--host-config`. The session performs the
 same audited-local checks, acquires one provider session, and reuses it for
 every expression. Direct and profile modes reject host configuration.
 
+The interactive line loop has a dedicated bounded lifetime profile. Selection
+depends on the input grammar, never TTY detection: argumentless `ptc repl`
+uses it when lines arrive from a terminal or a pipe, and `--load SETUP.clj`
+uses it when the setup is followed by that loop. Direct interactive sessions
+set `run_duration_ms` and `subordinate_evaluations` to their catalog maxima and
+retain normal events up to the installed `normal_event_count` and
+`normal_event_bytes` ceilings. Per-form time, heap, source, memory, history,
+result, projection, and capability limits remain at their ordinary defaults.
+
+Interactive manifest and mission sessions use the installed host ceilings for
+omitted `run_duration_ms`, `subordinate_evaluations`, `normal_event_count`, and
+`normal_event_bytes`; an explicit manifest value remains effective when it is
+narrower than that ceiling. Their deadline is one finite absolute session
+deadline, so time at the prompt counts. The session owner marks deadline
+failure and closes provider resources at expiry without waiting for another
+form; the next line ends the frontend with the named deadline diagnostic. Repeated
+`--eval`, a positional script, explicit `-` stdin, and loads followed by one of
+those inputs retain the ordinary effective limits. `ReplSession.new/0` also
+retains the ordinary embedding defaults.
+
 Each form evaluates under the manifest's `evaluation_timeout_ms`, whose
 effective default is 30,000 ms. A form stopped by that ceiling names the
 limit and its configured value. Raise it in the manifest if a form needs
@@ -181,6 +201,14 @@ suffix and owner-only permissions.
 The session owner retains the continuation, event sink, and provider resources.
 Normal close, abort, caller death, worker failure, and deadline failure converge
 on bounded cleanup before final trace persistence.
+
+Evaluation-count and deadline exhaustion name `subordinate_evaluations` or
+`run_duration_ms` and the effective value. They are terminal: the frontend
+prints one diagnostic, closes the session with that exact canonical reason,
+and exits unsuccessfully instead of issuing another prompt. A concurrent
+evaluation reports `evaluation_in_progress` and remains retryable; an already
+closed run reports `session_closed`. Normal event capture remains bounded and
+records its existing explicit overflow summary without terminating the REPL.
 
 ## Query public traces
 

--- a/lib/ptc_runner/kernel/application_package.ex
+++ b/lib/ptc_runner/kernel/application_package.ex
@@ -42,6 +42,7 @@ defmodule PtcRunner.Kernel.ApplicationPackage do
   alias PtcRunner.Kernel.Library
   alias PtcRunner.Kernel.Limits
   alias PtcRunner.Kernel.Manifest
+  alias PtcRunner.Kernel.ReplLimitProfile
   alias PtcRunner.Kernel.RunRequest
   alias PtcRunner.Kernel.SemanticRevision
   alias PtcRunner.Kernel.StrictJSON
@@ -158,12 +159,30 @@ defmodule PtcRunner.Kernel.ApplicationPackage do
 
   def request_directory(path, opts) when is_binary(path) and is_list(opts) do
     with :ok <- validate_options(opts, @directory_request_options),
-         {:ok, package, input} <- do_acquire_directory(path, opts),
-         {:ok, policy} <- execution_policy(package, opts),
-         do: RunRequest.new(package, input, policy)
+         do: request_directory_with_profile(path, opts, false)
   end
 
   def request_directory(_path, _opts), do: {:error, :invalid_application_source}
+
+  @doc false
+  @spec request_repl_directory(binary(), keyword(), boolean()) ::
+          {:ok, RunRequest.t()} | {:error, term()}
+  def request_repl_directory(path, opts, interactive_loop?)
+      when is_binary(path) and is_list(opts) and is_boolean(interactive_loop?) do
+    with :ok <- validate_options(opts, @directory_request_options),
+         do: request_directory_with_profile(path, opts, interactive_loop?)
+  end
+
+  def request_repl_directory(_path, _opts, _interactive_loop?),
+    do: {:error, :invalid_application_source}
+
+  defp request_directory_with_profile(path, opts, interactive_loop?) do
+    acquisition_opts = Keyword.put(opts, :repl_interactive_loop, interactive_loop?)
+
+    with {:ok, package, input} <- do_acquire_directory(path, acquisition_opts),
+         {:ok, policy} <- execution_policy(package, opts),
+         do: RunRequest.new(package, input, policy)
+  end
 
   @spec request_memory(binary(), %{binary() => binary()}, keyword()) ::
           {:ok, RunRequest.t()} | {:error, term()}
@@ -243,6 +262,11 @@ defmodule PtcRunner.Kernel.ApplicationPackage do
       with true <- Limits.valid?(installed_limits),
            {:ok, manifest} <-
              Manifest.load_source(source, installed_limits, materialize_input: false),
+           {:ok, manifest} <-
+             ReplLimitProfile.apply_manifest(
+               manifest,
+               Keyword.get(opts, :repl_interactive_loop, false)
+             ),
            {:ok, input} <- select_input(source, manifest, opts),
            {:ok, override} <- override_result,
            {:ok, effective, identities} <- apply_override(manifest, override),

--- a/lib/ptc_runner/kernel/command_acquisition.ex
+++ b/lib/ptc_runner/kernel/command_acquisition.ex
@@ -25,21 +25,22 @@ defmodule PtcRunner.Kernel.CommandAcquisition do
   alias PtcRunner.Kernel.SchemaViolationDiagnostic
 
   @doc false
-  @spec prepare_repl(binary(), binary() | nil, CommandRuntime.t()) ::
+  @spec prepare_repl(binary(), binary() | nil, CommandRuntime.t(), boolean()) ::
           {:ok, ManifestReplPreparation.t()}
           | {:error, CommandDiagnostic.t() | :host_config_required | :invalid_manifest_repl}
-  def prepare_repl(application, host_config, %CommandRuntime{} = runtime)
-      when is_binary(application) and (is_binary(host_config) or is_nil(host_config)) do
+  def prepare_repl(application, host_config, %CommandRuntime{} = runtime, interactive_loop?)
+      when is_binary(application) and (is_binary(host_config) or is_nil(host_config)) and
+             is_boolean(interactive_loop?) do
     case catalog(host_config) do
       {:ok, host, catalog} ->
-        prepare_repl_with_catalog(application, runtime, host, catalog)
+        prepare_repl_with_catalog(application, runtime, host, catalog, interactive_loop?)
 
       {:error, %CommandDiagnostic{} = diagnostic} ->
         {:error, diagnostic}
     end
   end
 
-  def prepare_repl(_application, _host_config, _runtime),
+  def prepare_repl(_application, _host_config, _runtime, _interactive_loop?),
     do: {:error, :invalid_manifest_repl}
 
   @spec prepare(CommandArguments.t(), binary(), {map(), [atom()]}, CommandRuntime.t()) ::
@@ -294,14 +295,18 @@ defmodule PtcRunner.Kernel.CommandAcquisition do
         provider_application_mode: runtime.provider_application_mode
       )
 
-  defp prepare_repl_with_catalog(application, runtime, host, catalog) do
+  defp prepare_repl_with_catalog(application, runtime, host, catalog, interactive_loop?) do
     result =
       with {:ok, request} <-
-             ApplicationPackage.request_directory(application,
-               installed_limits: catalog.installed_limits,
-               result_projection: :native,
-               input_authority: :normal,
-               inspection_capture: false
+             ApplicationPackage.request_repl_directory(
+               application,
+               [
+                 installed_limits: catalog.installed_limits,
+                 result_projection: :native,
+                 input_authority: :normal,
+                 inspection_capture: false
+               ],
+               interactive_loop?
              ),
            :ok <- require_repl_host(request, host),
            {:ok, prepared} <- RunCoordinator.prepare(request, catalog) do

--- a/lib/ptc_runner/kernel/manifest_repl.ex
+++ b/lib/ptc_runner/kernel/manifest_repl.ex
@@ -37,6 +37,7 @@ defmodule PtcRunner.Kernel.ManifestRepl do
   @input_modes [:interactive, :eval, :load, :script, :stdin, :jsonl]
   @option_keys [
     :input_mode,
+    :interactive_loop,
     :mission,
     :private_terminal,
     :runtime,
@@ -66,7 +67,12 @@ defmodule PtcRunner.Kernel.ManifestRepl do
              is_list(opts) do
     with {:ok, options} <- options(opts),
          {:ok, preparation} <-
-           CommandAcquisition.prepare_repl(application, host_config, options.runtime) do
+           CommandAcquisition.prepare_repl(
+             application,
+             host_config,
+             options.runtime,
+             options.interactive_loop
+           ) do
       open_prepared(preparation, options)
     else
       {:error, reason} -> {:error, failure(reason, false)}
@@ -115,12 +121,14 @@ defmodule PtcRunner.Kernel.ManifestRepl do
          length(keys) == MapSet.size(MapSet.new(keys)) do
       runtime = Keyword.get(opts, :runtime, CommandRuntime.standalone())
       input_mode = Keyword.get(opts, :input_mode, :interactive)
+      interactive_loop = Keyword.get(opts, :interactive_loop, input_mode == :interactive)
       private_terminal = Keyword.get(opts, :private_terminal, false)
       terminal_attached = Keyword.get(opts, :terminal_attached, AnalysisTerminal.attached?())
       trace_path = Keyword.get(opts, :trace_path)
       mission = Keyword.get(opts, :mission)
 
       if CommandRuntime.valid?(runtime) and input_mode in @input_modes and
+           is_boolean(interactive_loop) and
            is_boolean(private_terminal) and is_boolean(terminal_attached) and
            (is_nil(trace_path) or is_binary(trace_path)) and
            (is_nil(mission) or (is_binary(mission) and mission != "")) do
@@ -128,6 +136,7 @@ defmodule PtcRunner.Kernel.ManifestRepl do
          %{
            runtime: runtime,
            input_mode: input_mode,
+           interactive_loop: interactive_loop,
            private_terminal: private_terminal,
            terminal_attached: terminal_attached,
            trace_path: trace_path,

--- a/lib/ptc_runner/kernel/repl_limit_profile.ex
+++ b/lib/ptc_runner/kernel/repl_limit_profile.ex
@@ -1,0 +1,48 @@
+defmodule PtcRunner.Kernel.ReplLimitProfile do
+  @moduledoc false
+
+  alias PtcRunner.Kernel.LimitCatalog
+  alias PtcRunner.Kernel.Limits
+  alias PtcRunner.Kernel.Manifest
+
+  @session_lifetime_fields [:run_duration_ms, :subordinate_evaluations]
+  @direct_event_fields [:normal_event_count, :normal_event_bytes]
+  @manifest_interactive_fields @session_lifetime_fields ++ @direct_event_fields
+
+  @doc false
+  @spec direct_interactive() :: Limits.t()
+  def direct_interactive do
+    maxima =
+      Map.new(@session_lifetime_fields, fn field ->
+        {:ok, row} = LimitCatalog.fetch(field)
+        {field, row.maximum}
+      end)
+
+    installed_events =
+      Limits.installed_defaults()
+      |> Map.from_struct()
+      |> Map.take(@direct_event_fields)
+
+    {:ok, limits} = Limits.new(Map.merge(maxima, installed_events))
+    limits
+  end
+
+  @doc false
+  @spec apply_manifest(Manifest.t(), boolean()) :: {:ok, Manifest.t()} | {:error, :invalid_limits}
+  def apply_manifest(%Manifest{} = manifest, false), do: {:ok, manifest}
+
+  def apply_manifest(%Manifest{} = manifest, true) do
+    declared = Map.get(manifest.document, "limits", %{})
+    ceilings = Map.from_struct(manifest.installed_limits)
+
+    values =
+      Enum.reduce(@manifest_interactive_fields, Map.from_struct(manifest.limits), fn field, acc ->
+        if Map.has_key?(declared, Atom.to_string(field)),
+          do: acc,
+          else: Map.put(acc, field, Map.fetch!(ceilings, field))
+      end)
+
+    with {:ok, limits} <- Limits.new(values),
+         do: {:ok, %{manifest | limits: limits}}
+  end
+end

--- a/lib/ptc_runner/kernel/repl_session.ex
+++ b/lib/ptc_runner/kernel/repl_session.ex
@@ -35,6 +35,7 @@ defmodule PtcRunner.Kernel.ReplSession do
   alias PtcRunner.Kernel.Limits
   alias PtcRunner.Kernel.MissionEnvironment
   alias PtcRunner.Kernel.PrivateDirectory
+  alias PtcRunner.Kernel.ReplLimitProfile
   alias PtcRunner.Kernel.ReplSessionOwner
   alias PtcRunner.Kernel.RunConfig
   alias PtcRunner.Kernel.RunState
@@ -84,8 +85,26 @@ defmodule PtcRunner.Kernel.ReplSession do
   def new(opts \\ [])
 
   def new(opts) when is_list(opts) do
-    with true <- Keyword.keys(opts) -- [:config, :trace_path] == [],
-         {:ok, config} <- config(Keyword.get(opts, :config)),
+    new_session(opts, [:config, :trace_path], fn -> config(Keyword.get(opts, :config)) end)
+  end
+
+  def new(_opts), do: {:error, :invalid_repl_session}
+
+  @doc false
+  @spec new_interactive(keyword()) :: {:ok, t()} | {:error, term()}
+  def new_interactive(opts \\ [])
+
+  def new_interactive(opts) when is_list(opts) do
+    new_session(opts, [:trace_path], fn ->
+      config_with_limits(ReplLimitProfile.direct_interactive())
+    end)
+  end
+
+  def new_interactive(_opts), do: {:error, :invalid_repl_session}
+
+  defp new_session(opts, allowed_keys, config_builder) do
+    with true <- Keyword.keyword?(opts) and Keyword.keys(opts) -- allowed_keys == [],
+         {:ok, config} <- config_builder.(),
          {:ok, trace_path} <- trace_path(config, Keyword.get(opts, :trace_path)) do
       start_session(config, trace_path)
     else
@@ -93,8 +112,6 @@ defmodule PtcRunner.Kernel.ReplSession do
       {:error, _reason} = error -> error
     end
   end
-
-  def new(_opts), do: {:error, :invalid_repl_session}
 
   @doc false
   @spec attach(pid(), reference()) :: {:ok, t()} | {:error, term()}
@@ -140,6 +157,56 @@ defmodule PtcRunner.Kernel.ReplSession do
   end
 
   @doc false
+  @spec open?(t()) :: boolean()
+  def open?(%__MODULE__{} = session) do
+    case owned_session(session) do
+      {:ok, owned} -> sink_alive?(owned) and RunState.open?(owned.state)
+      {:error, _reason} -> false
+    end
+  catch
+    :exit, _reason -> false
+  end
+
+  @doc false
+  @spec terminal?(t()) :: boolean()
+  def terminal?(%__MODULE__{} = session) do
+    case owned_session(session) do
+      {:ok, owned} ->
+        not sink_alive?(owned) or not is_nil(RunState.terminal_failure(owned.state))
+
+      {:error, _reason} ->
+        true
+    end
+  catch
+    :exit, _reason -> true
+  end
+
+  @doc false
+  @spec terminal_error(t()) :: {:error, Native.t()} | :none
+  def terminal_error(%__MODULE__{} = session) do
+    case owned_session(session) do
+      {:ok, owned} ->
+        case read_terminal_failure(owned.state) do
+          nil ->
+            :none
+
+          failure ->
+            {:error, step, _session} =
+              failure
+              |> terminal_failure_result(owned)
+              |> public_result(owned.mode)
+
+            {:error, step}
+        end
+
+      {:error, _reason} ->
+        :none
+    end
+  catch
+    :exit, _reason -> :none
+  end
+
+  @doc false
   @spec mode_info(t()) :: map() | {:error, atom()}
   def mode_info(%__MODULE__{} = session) do
     with {:ok, owned} <- owned_session(session), do: owned_mode_info(owned)
@@ -160,7 +227,7 @@ defmodule PtcRunner.Kernel.ReplSession do
          model_context_hash: inventory.model_hash
        }}
     else
-      :workflow -> {:error, :not_mission_session}
+      mode when mode in [:direct, :workflow] -> {:error, :not_mission_session}
       {:error, _reason} = error -> error
     end
   catch
@@ -185,10 +252,18 @@ defmodule PtcRunner.Kernel.ReplSession do
     case owned_session(session) do
       {:ok, owned} ->
         result =
-          if sink_alive?(owned) and not RunState.closed?(owned.state) do
-            eval_open(owned, source)
-          else
-            session_closed(owned)
+          cond do
+            not sink_alive?(owned) ->
+              session_closed(owned)
+
+            failure = read_terminal_failure(owned.state) ->
+              preexisting_terminal_failure(owned, failure)
+
+            reservable_session?(owned) ->
+              eval_open(owned, source)
+
+            true ->
+              session_closed(owned)
           end
 
         public_result(result, owned.mode)
@@ -203,7 +278,7 @@ defmodule PtcRunner.Kernel.ReplSession do
     :exit, _reason -> session_closed(session)
   end
 
-  defp eval_open(%{mode: :workflow} = session, source) do
+  defp eval_open(%{mode: mode} = session, source) when mode in [:direct, :workflow] do
     case RunState.reserve_workflow_evaluation(session.state) do
       {:ok, memory, history, lease} ->
         session = Map.merge(session, %{memory: memory, history: history})
@@ -233,7 +308,12 @@ defmodule PtcRunner.Kernel.ReplSession do
         result_limit_bytes: limits.terminal_result_bytes
       )
 
-    mission_result(session, name_mission_timeout(result, limits, remaining_ms))
+    result =
+      result
+      |> name_mission_timeout(session, remaining_ms)
+      |> name_mission_session_failure(session)
+
+    mission_result(session, result)
   catch
     :exit, _reason -> session_closed(session)
   end
@@ -241,6 +321,55 @@ defmodule PtcRunner.Kernel.ReplSession do
   defp session_closed(session) do
     step = Native.error(:session_closed, "REPL session is closed", observed_memory(session))
     {:error, step, session}
+  end
+
+  defp terminal_failure_result(
+         %{kind: :limit_exceeded, reason: :deadline_expired},
+         session
+       ) do
+    step = Native.error(:limit_exceeded, run_deadline_message(session), observed_memory(session))
+    {:error, step, session}
+  end
+
+  defp terminal_failure_result(
+         %{kind: :limit_exceeded, reason: :subordinate_evaluations},
+         session
+       ) do
+    step =
+      Native.error(
+        :limit_exceeded,
+        subordinate_evaluations_message(session),
+        observed_memory(session)
+      )
+
+    {:error, step, session}
+  end
+
+  defp terminal_failure_result(%{kind: :session_closed}, session),
+    do: session_closed(session)
+
+  defp terminal_failure_result(%{kind: kind, reason: reason}, session) do
+    step = Native.error(kind, "REPL session closed: #{reason}", observed_memory(session))
+    {:error, step, session}
+  end
+
+  defp increment_result_error({:error, step, session}),
+    do: {:error, step, increment_error(session)}
+
+  defp preexisting_terminal_failure(
+         session,
+         %{kind: :limit_exceeded, reason: reason} = failure
+       )
+       when reason in [:deadline_expired, :subordinate_evaluations] do
+    failure
+    |> terminal_failure_result(session)
+    |> increment_result_error()
+  end
+
+  defp preexisting_terminal_failure(session, _failure), do: session_closed(session)
+
+  defp reservable_session?(session) do
+    not RunState.closed?(session.state) or is_nil(RunState.terminal_failure(session.state))
   end
 
   @spec close(t()) ::
@@ -279,26 +408,40 @@ defmodule PtcRunner.Kernel.ReplSession do
 
   defp close_owned(session) do
     state_result = close_run_state(session.state)
-    cleanup = ReplSessionOwner.close_provider_session(session.owner_pid, session.owner_token)
 
-    if state_result == :ok and cleanup_result?(cleanup) and
-         Process.alive?(session.config.event_sink.pid) do
-      finalize_close(session, cleanup)
-    else
-      prefer_cleanup_error({:error, :session_closed}, cleanup)
+    case ReplSessionOwner.close_provider_session(session.owner_pid, session.owner_token) do
+      {:ok, cleanup, terminal_failure} ->
+        if state_result == :ok and cleanup_result?(cleanup) and
+             Process.alive?(session.config.event_sink.pid) do
+          finalize_close(session, cleanup, terminal_failure)
+        else
+          prefer_cleanup_error({:error, :session_closed}, cleanup)
+        end
+
+      {:error, _reason} ->
+        {:error, :session_closed}
     end
   end
 
-  defp finalize_close(session, cleanup) do
+  defp read_terminal_failure(state) do
+    RunState.terminal_failure(state)
+  catch
+    :exit, _reason -> nil
+  end
+
+  defp finalize_close(session, cleanup, terminal_failure) do
     {outcome, reason} =
-      case {cleanup, bounded_counter(session.errors)} do
-        {:ok, 0} ->
+      case {cleanup, terminal_failure, bounded_counter(session.errors)} do
+        {:ok, %{reason: reason}, _errors} ->
+          {:error, reason}
+
+        {:ok, nil, 0} ->
           {:ok, nil}
 
-        {:ok, _errors} ->
+        {:ok, nil, _errors} ->
           {:error, :repl_evaluation_error}
 
-        {{:error, :provider_cleanup_failed}, _errors} ->
+        {{:error, :provider_cleanup_failed}, _failure, _errors} ->
           {:error, :provider_cleanup_failed}
       end
 
@@ -384,15 +527,23 @@ defmodule PtcRunner.Kernel.ReplSession do
 
   defp abort_owned(session, reason) do
     state_result = close_run_state(session.state)
-    cleanup = ReplSessionOwner.close_provider_session(session.owner_pid, session.owner_token)
 
-    if state_result == :ok and cleanup_result?(cleanup) and
-         Process.alive?(session.config.event_sink.pid) do
-      finalize_abort(session, reason, cleanup)
-    else
-      prefer_cleanup_error(:ok, cleanup)
+    case ReplSessionOwner.close_provider_session(session.owner_pid, session.owner_token) do
+      {:ok, cleanup, terminal_failure} ->
+        if state_result == :ok and cleanup_result?(cleanup) and
+             Process.alive?(session.config.event_sink.pid) do
+          finalize_abort(session, terminal_reason(terminal_failure, reason), cleanup)
+        else
+          prefer_cleanup_error(:ok, cleanup)
+        end
+
+      {:error, _reason} ->
+        :ok
     end
   end
+
+  defp terminal_reason(%{reason: reason}, _fallback), do: reason
+  defp terminal_reason(nil, fallback), do: fallback
 
   defp finalize_abort(session, reason, cleanup) do
     terminal_reason =
@@ -412,11 +563,9 @@ defmodule PtcRunner.Kernel.ReplSession do
 
   defp prefer_cleanup_error(_result, {:error, :provider_cleanup_failed} = error), do: error
   defp prefer_cleanup_error(result, :ok), do: result
-  defp prefer_cleanup_error(result, _owner_failure), do: result
 
   defp cleanup_result?(:ok), do: true
   defp cleanup_result?({:error, :provider_cleanup_failed}), do: true
-  defp cleanup_result?(_result), do: false
 
   defp close_run_state(state) do
     RunState.close_and_drain(state)
@@ -425,28 +574,7 @@ defmodule PtcRunner.Kernel.ReplSession do
     :exit, _reason -> {:error, :session_closed}
   end
 
-  defp config(nil) do
-    with {:ok, workflow} <- WorkflowEnvironment.new([]),
-         {:ok, mission} <- MissionEnvironment.new([]),
-         {:ok, limits} <- Limits.new(),
-         {:ok, sink} <- EventSink.start(:normal, limits) do
-      case RunConfig.new(
-             workflow_environment: workflow,
-             missions: %{"default" => mission},
-             input: %{},
-             limits: limits,
-             event_sink: sink,
-             labels: %{"name" => "ptc.repl"}
-           ) do
-        {:ok, _config} = success ->
-          success
-
-        {:error, _reason} = error ->
-          EventSink.stop(sink)
-          error
-      end
-    end
-  end
+  defp config(nil), do: config_with_limits(Limits.defaults())
 
   defp config(%RunConfig{} = config) do
     cond do
@@ -469,6 +597,28 @@ defmodule PtcRunner.Kernel.ReplSession do
   end
 
   defp config(_config), do: {:error, :invalid_repl_session}
+
+  defp config_with_limits(%Limits{} = limits) do
+    with {:ok, workflow} <- WorkflowEnvironment.new([]),
+         {:ok, mission} <- MissionEnvironment.new([]),
+         {:ok, sink} <- EventSink.start(:normal, limits) do
+      case RunConfig.new(
+             workflow_environment: workflow,
+             missions: %{"default" => mission},
+             input: %{},
+             limits: limits,
+             event_sink: sink,
+             labels: %{"name" => "ptc.repl"}
+           ) do
+        {:ok, _config} = success ->
+          success
+
+        {:error, _reason} = error ->
+          EventSink.stop(sink)
+          error
+      end
+    end
+  end
 
   defp inspection_alive?(nil), do: true
   defp inspection_alive?(sink), do: Process.alive?(sink.pid)
@@ -544,7 +694,7 @@ defmodule PtcRunner.Kernel.ReplSession do
          :ok <-
            RunConfig.bind_provider_session(config, owner, state.pid, state.provider_tracker),
          :ok <- ReplSessionOwner.adopt_direct(owner, token, config, state, trace_path) do
-      register_access(owner, token)
+      register_access(owner, token, :direct)
     else
       {:error, reason} -> reject_pending_session(config, state, owner, token, reason)
     end
@@ -661,37 +811,129 @@ defmodule PtcRunner.Kernel.ReplSession do
         link: true
       )
 
-    name_timeout_limit(result, limits, remaining_ms)
+    name_timeout_limit(result, session, remaining_ms)
   end
 
   # The sandbox reports the milliseconds still left when it killed the worker,
   # a number that matches no configured value and cannot be searched for. The
   # binding ceiling is known here, so say which one stopped the form and where
   # to raise it, through the same builder `ptc run` uses.
-  defp name_timeout_limit({:error, %Native{fail: fail} = step}, limits, remaining) do
+  defp name_timeout_limit({:error, %Native{fail: fail} = step}, session, remaining) do
+    limits = session.config.limits
+
     case named_timeout_message(fail.reason, Map.get(fail, :message), limits, remaining) do
-      {:ok, message} -> {:error, %{step | fail: %{fail | message: message}}}
-      :error -> {:error, step}
+      {:ok, message} ->
+        if run_deadline_bound_timeout?(fail.reason, Map.get(fail, :message), limits, remaining) and
+             record_run_deadline(session) do
+          deadline = %{fail | reason: :limit_exceeded, message: run_deadline_message(session)}
+          {:error, %{step | fail: deadline}}
+        else
+          {:error, %{step | fail: %{fail | message: message}}}
+        end
+
+      :error ->
+        {:error, step}
     end
   end
 
-  defp name_timeout_limit(result, _limits, _remaining), do: result
+  defp name_timeout_limit(result, _session, _remaining), do: result
 
   # A mission form is bounded by the same ceiling as a workflow one, and the
   # evaluator hands back only the milliseconds it had left. Name the limit here,
   # before `mission_result/2` copies the message onto the step.
   defp name_mission_timeout(
          %{kind: reason, details: %{message: message} = details} = result,
-         limits,
+         session,
          remaining
        ) do
+    limits = session.config.limits
+
     case named_timeout_message(reason, message, limits, remaining) do
-      {:ok, named} -> %{result | details: %{details | message: named}}
-      :error -> result
+      {:ok, named} ->
+        if run_deadline_bound_timeout?(reason, message, limits, remaining) and
+             record_run_deadline(session) do
+          result
+          |> Map.merge(%{
+            outcome: :limit_exceeded,
+            kind: :limit_exceeded,
+            reason: :deadline_expired
+          })
+          |> Map.put(:details, %{details | message: run_deadline_message(session)})
+        else
+          %{result | details: %{details | message: named}}
+        end
+
+      :error ->
+        result
     end
   end
 
-  defp name_mission_timeout(result, _limits, _remaining), do: result
+  defp name_mission_timeout(result, _session, _remaining), do: result
+
+  defp run_deadline_bound_timeout?(reason, message, limits, remaining) do
+    limits.evaluation_timeout_ms > remaining and
+      (reason == :compile_timeout or (reason == :timeout and not parallel_timeout?(message)))
+  end
+
+  defp record_run_deadline(session) do
+    case RunState.fail_once(session.state, :limit_exceeded, :deadline_expired) do
+      {:recorded, %{kind: :limit_exceeded, reason: :deadline_expired}} ->
+        _ =
+          EventSink.emit(session.config.event_sink, "limit-exceeded", %{reason: :deadline_expired})
+
+        true
+
+      {:existing, %{kind: :limit_exceeded, reason: :deadline_expired}} ->
+        true
+
+      _other ->
+        false
+    end
+  end
+
+  defp name_mission_session_failure(
+         %{outcome: :busy, reason: :evaluation_in_progress} = result,
+         _session
+       ),
+       do:
+         result
+         |> Map.put(:kind, :evaluation_in_progress)
+         |> Map.put(:details, %{message: "REPL evaluation in progress"})
+
+  defp name_mission_session_failure(
+         %{outcome: :limit_exceeded, reason: :subordinate_evaluations} = result,
+         session
+       ) do
+    :ok = RunState.fail(session.state, :limit_exceeded, :subordinate_evaluations)
+
+    result
+    |> Map.put(:kind, :limit_exceeded)
+    |> Map.put(:details, %{message: subordinate_evaluations_message(session)})
+  end
+
+  defp name_mission_session_failure(
+         %{outcome: :limit_exceeded, reason: :deadline_expired} = result,
+         session
+       ) do
+    :ok = RunState.fail(session.state, :limit_exceeded, :deadline_expired)
+
+    result
+    |> Map.put(:kind, :limit_exceeded)
+    |> Map.put(:details, %{message: run_deadline_message(session)})
+  end
+
+  defp name_mission_session_failure(
+         %{outcome: :limit_exceeded, reason: :run_closed} = result,
+         session
+       ) do
+    :ok = RunState.fail(session.state, :session_closed, :run_closed)
+
+    result
+    |> Map.put(:kind, :session_closed)
+    |> Map.put(:details, %{message: "REPL session is closed"})
+  end
+
+  defp name_mission_session_failure(result, _session), do: result
 
   # Compilation and execution are separated the way `ptc run` separates them, by
   # the reason the evaluator reported rather than by which sandbox stage was
@@ -1058,20 +1300,94 @@ defmodule PtcRunner.Kernel.ReplSession do
     {:error, step, increment_error(session)}
   end
 
-  defp evaluation_reservation_failure(session, reason) do
-    normalized =
-      case reason do
-        :limit_exceeded -> :subordinate_evaluations
-        :run_closed -> :run_deadline
-        other -> other
-      end
-
-    _ = EventSink.emit(session.config.event_sink, "limit-exceeded", %{reason: normalized})
-
+  defp evaluation_reservation_failure(session, :busy) do
     step =
-      Native.error(:limit_exceeded, "REPL evaluation limit exceeded", observed_memory(session))
+      Native.error(
+        :evaluation_in_progress,
+        "REPL evaluation in progress",
+        observed_memory(session)
+      )
 
     {:error, step, increment_error(session)}
+  end
+
+  defp evaluation_reservation_failure(session, :limit_exceeded) do
+    terminal_reservation_failure(
+      session,
+      :limit_exceeded,
+      :subordinate_evaluations,
+      subordinate_evaluations_message(session)
+    )
+  end
+
+  defp evaluation_reservation_failure(session, :deadline_expired) do
+    terminal_reservation_failure(
+      session,
+      :limit_exceeded,
+      :deadline_expired,
+      run_deadline_message(session)
+    )
+  end
+
+  defp evaluation_reservation_failure(session, :run_closed) do
+    terminal_reservation_failure(
+      session,
+      :session_closed,
+      :run_closed,
+      "REPL session is closed"
+    )
+  end
+
+  defp terminal_reservation_failure(session, public_reason, closed_reason, message) do
+    case EventSink.emit(session.config.event_sink, "limit-exceeded", %{reason: closed_reason}) do
+      :ok ->
+        :ok = RunState.fail(session.state, public_reason, closed_reason)
+        step = Native.error(public_reason, message, observed_memory(session))
+        {:error, step, increment_error(session)}
+
+      {:error, :event_sink_error} ->
+        event_sink_failure(session)
+    end
+  end
+
+  defp subordinate_evaluations_message(%{mode: :direct, config: config}) do
+    {:ok, message} =
+      RuntimeLimitDiagnostic.direct_subordinate_evaluations_message(
+        config.limits.subordinate_evaluations
+      )
+
+    message
+  end
+
+  defp subordinate_evaluations_message(%{config: config}) do
+    {:ok, message} =
+      RuntimeLimitDiagnostic.subordinate_evaluations_message(
+        config.limits.subordinate_evaluations
+      )
+
+    message
+  end
+
+  defp run_deadline_message(%{mode: :direct, config: config}) do
+    {:ok, message} =
+      RuntimeLimitDiagnostic.direct_live_timeout_message(
+        :run_duration_ms,
+        config.limits.run_duration_ms,
+        :execution
+      )
+
+    message
+  end
+
+  defp run_deadline_message(%{config: config}) do
+    {:ok, message} =
+      RuntimeLimitDiagnostic.live_timeout_message(
+        :run_duration_ms,
+        config.limits.run_duration_ms,
+        :execution
+      )
+
+    message
   end
 
   defp emit_evaluation_stopped(session, state, evaluation_id, started_ms, status, reason) do
@@ -1152,8 +1468,6 @@ defmodule PtcRunner.Kernel.ReplSession do
       end
   end
 
-  defp register_access(pid, token), do: register_access(pid, token, :workflow)
-
   defp register_access(pid, token, mode) do
     access = access_table()
     id = make_ref()
@@ -1227,7 +1541,8 @@ defmodule PtcRunner.Kernel.ReplSession do
 
   defp observed_memory(session), do: Map.get(session, :memory, %{})
 
-  defp public_result({status, step, session}, :workflow) when status in [:ok, :error] do
+  defp public_result({status, step, session}, mode)
+       when status in [:ok, :error] and mode in [:direct, :workflow] do
     {public_status, public_step} = Lisp.project_native_result({status, step})
     {public_status, public_step, public_session(session)}
   end
@@ -1256,6 +1571,8 @@ defmodule PtcRunner.Kernel.ReplSession do
        do: %{kind: :workflow, declared_missions: missions |> Map.keys() |> Enum.sort()}
 
   defp owned_mode_info(%{mode: :workflow}), do: %{kind: :workflow, declared_missions: []}
+
+  defp owned_mode_info(%{mode: :direct}), do: %{kind: :workflow, declared_missions: []}
 
   defp owned_mode_info(%{mode: %{kind: :mission, name: name} = mode, config: config}) do
     inventory = Map.fetch!(config.missions, name).inventory

--- a/lib/ptc_runner/kernel/repl_session_owner.ex
+++ b/lib/ptc_runner/kernel/repl_session_owner.ex
@@ -80,13 +80,14 @@ defmodule PtcRunner.Kernel.ReplSessionOwner do
 
   @spec resources(pid(), reference()) ::
           {:ok, RunConfig.t(), RunState.t()} | {:error, :session_owner_mismatch}
-  def resources(pid, token), do: GenServer.call(pid, {token, :resources})
+  def resources(pid, token), do: GenServer.call(pid, {token, :resources}, :infinity)
 
   @doc false
   @spec session_resources(pid(), reference()) ::
-          {:ok, RunConfig.t(), RunState.t(), :workflow | map()}
+          {:ok, RunConfig.t(), RunState.t(), :direct | :workflow | map()}
           | {:error, :session_owner_mismatch}
-  def session_resources(pid, token), do: GenServer.call(pid, {token, :session_resources})
+  def session_resources(pid, token),
+    do: GenServer.call(pid, {token, :session_resources}, :infinity)
 
   @spec release(pid(), reference()) :: :ok | {:error, :session_owner_mismatch}
   def release(pid, token) do
@@ -96,7 +97,9 @@ defmodule PtcRunner.Kernel.ReplSessionOwner do
   end
 
   @spec close_provider_session(pid(), reference()) ::
-          :ok | {:error, :provider_cleanup_failed | :session_owner_mismatch}
+          {:ok, :ok | {:error, :provider_cleanup_failed},
+           nil | %{kind: atom(), reason: atom()} | %{kind: atom(), reason: atom(), details: map()}}
+          | {:error, :session_owner_mismatch}
   def close_provider_session(pid, token) do
     GenServer.call(pid, {token, :close_provider_session}, :infinity)
   catch
@@ -128,21 +131,26 @@ defmodule PtcRunner.Kernel.ReplSessionOwner do
     Process.flag(:trap_exit, true)
     Process.link(run_state.pid)
 
-    {:ok,
-     %{
-       token: token,
-       owner: owner,
-       owner_ref: Process.monitor(owner),
-       config: config,
-       run_state: run_state,
-       opening: nil,
-       opening_ref: nil,
-       trace_path: trace_path,
-       mode: :workflow,
-       terminalized?: false,
-       terminal_batch: nil,
-       provider_cleanup: nil
-     }}
+    state =
+      %{
+        token: token,
+        owner: owner,
+        owner_ref: Process.monitor(owner),
+        config: config,
+        run_state: run_state,
+        opening: nil,
+        opening_ref: nil,
+        trace_path: trace_path,
+        mode: :workflow,
+        terminalized?: false,
+        terminal_batch: nil,
+        terminal_failure: nil,
+        provider_cleanup: nil,
+        deadline_timer: nil,
+        deadline_token: nil
+      }
+
+    {:ok, arm_deadline(state)}
   end
 
   def init({:pending, token, owner}) do
@@ -161,7 +169,10 @@ defmodule PtcRunner.Kernel.ReplSessionOwner do
        mode: :workflow,
        terminalized?: false,
        terminal_batch: nil,
-       provider_cleanup: nil
+       terminal_failure: nil,
+       provider_cleanup: nil,
+       deadline_timer: nil,
+       deadline_token: nil
      }}
   end
 
@@ -187,16 +198,18 @@ defmodule PtcRunner.Kernel.ReplSessionOwner do
       opening_pid = ManifestReplOpening.pid(opening)
       Process.link(run_state.pid)
 
-      {:reply, :ok,
-       %{
-         state
-         | config: config,
-           run_state: run_state,
-           opening: opening,
-           opening_ref: Process.monitor(opening_pid),
-           trace_path: trace_path,
-           mode: mode
-       }}
+      next =
+        %{
+          state
+          | config: config,
+            run_state: run_state,
+            opening: opening,
+            opening_ref: Process.monitor(opening_pid),
+            trace_path: trace_path,
+            mode: mode
+        }
+
+      {:reply, :ok, arm_deadline(next)}
     else
       {:reply, {:error, :session_owner_mismatch}, state}
     end
@@ -209,7 +222,11 @@ defmodule PtcRunner.Kernel.ReplSessionOwner do
       ) do
     if direct_adoption?(config, run_state, trace_path) do
       Process.link(run_state.pid)
-      {:reply, :ok, %{state | config: config, run_state: run_state, trace_path: trace_path}}
+
+      next =
+        %{state | config: config, run_state: run_state, trace_path: trace_path, mode: :direct}
+
+      {:reply, :ok, arm_deadline(next)}
     else
       {:reply, {:error, :session_owner_mismatch}, state}
     end
@@ -220,8 +237,10 @@ defmodule PtcRunner.Kernel.ReplSessionOwner do
         {caller, _tag},
         %{token: token, owner: caller} = state
       ) do
+    state = state |> record_elapsed_deadline() |> disarm_deadline()
+    terminal_failure = terminal_failure(state)
     {result, state} = close_provider_session(state)
-    {:reply, result, state}
+    {:reply, {:ok, result, terminal_failure}, state}
   end
 
   def handle_call(
@@ -241,6 +260,16 @@ defmodule PtcRunner.Kernel.ReplSessionOwner do
   @impl GenServer
   def handle_info({:DOWN, ref, :process, _pid, _reason}, %{owner_ref: ref} = state),
     do: {:stop, :normal, state}
+
+  def handle_info(
+        {:repl_deadline_expired, deadline_token},
+        %{deadline_token: deadline_token, config: %RunConfig{}, run_state: %RunState{}} = state
+      ) do
+    state = %{state | deadline_timer: nil, deadline_token: nil}
+    state = record_deadline_expiry(state)
+    {_cleanup, state} = close_provider_session(state)
+    {:noreply, state}
+  end
 
   # A run state that dies on its own is *ignored* here, deliberately.
   #
@@ -275,6 +304,7 @@ defmodule PtcRunner.Kernel.ReplSessionOwner do
   end
 
   defp close_resources(state) do
+    state = disarm_deadline(state)
     _state = close_owned_resources(state)
     :ok
   end
@@ -304,9 +334,11 @@ defmodule PtcRunner.Kernel.ReplSessionOwner do
 
   defp finalize_abandoned_session(%{config: %RunConfig{} = config} = state) do
     reason =
-      if state.provider_cleanup == {:error, :provider_cleanup_failed},
-        do: :provider_cleanup_failed,
-        else: :session_owner_failed
+      case {state.provider_cleanup, terminal_failure(state)} do
+        {{:error, :provider_cleanup_failed}, _failure} -> :provider_cleanup_failed
+        {_cleanup, %{reason: reason}} -> reason
+        {_cleanup, nil} -> :session_owner_failed
+      end
 
     usage =
       try do
@@ -405,6 +437,66 @@ defmodule PtcRunner.Kernel.ReplSessionOwner do
   end
 
   defp close_provider_session(state), do: {state.provider_cleanup, state}
+
+  defp arm_deadline(%{run_state: %RunState{} = run_state} = state) do
+    deadline_token = make_ref()
+
+    deadline_timer =
+      Process.send_after(
+        self(),
+        {:repl_deadline_expired, deadline_token},
+        deadline_remaining_ms(run_state)
+      )
+
+    %{state | deadline_timer: deadline_timer, deadline_token: deadline_token}
+  end
+
+  defp disarm_deadline(%{deadline_timer: timer} = state) when is_reference(timer) do
+    Process.cancel_timer(timer)
+    %{state | deadline_timer: nil, deadline_token: nil}
+  end
+
+  defp disarm_deadline(state), do: state
+
+  defp record_elapsed_deadline(%{deadline_timer: timer, run_state: %RunState{}} = state)
+       when is_reference(timer) do
+    if deadline_remaining_ms(state.run_state) == 0,
+      do: record_deadline_expiry(state),
+      else: state
+  end
+
+  defp record_elapsed_deadline(state), do: state
+
+  defp record_deadline_expiry(state) do
+    case RunState.fail_once(state.run_state, :limit_exceeded, :deadline_expired) do
+      {:recorded, failure} ->
+        _ =
+          EventSink.emit(state.config.event_sink, "limit-exceeded", %{
+            reason: :deadline_expired
+          })
+
+        %{state | terminal_failure: failure}
+
+      {:existing, failure} ->
+        %{state | terminal_failure: failure}
+    end
+  end
+
+  defp terminal_failure(%{terminal_failure: failure}) when not is_nil(failure), do: failure
+
+  defp terminal_failure(%{run_state: %RunState{} = run_state}) do
+    RunState.terminal_failure(run_state)
+  catch
+    :exit, _reason -> nil
+  end
+
+  defp terminal_failure(_state), do: nil
+
+  defp deadline_remaining_ms(run_state) do
+    RunState.remaining_ms(run_state)
+  catch
+    :exit, _reason -> 0
+  end
 
   defp persist_trace(%{trace_path: nil}, _events), do: :ok
 

--- a/lib/ptc_runner/kernel/run_state.ex
+++ b/lib/ptc_runner/kernel/run_state.ex
@@ -455,6 +455,19 @@ defmodule PtcRunner.Kernel.RunState do
   @doc "Records the first terminal failure and closes the run."
   def fail(state, kind, reason), do: safe_call(state, {:fail, kind, reason}, :ok)
 
+  @doc false
+  @spec fail_once(t(), atom(), atom()) ::
+          {:recorded, %{kind: atom(), reason: atom()}}
+          | {:existing,
+             %{kind: atom(), reason: atom()} | %{kind: atom(), reason: atom(), details: map()}}
+  def fail_once(state, kind, reason) do
+    safe_call(
+      state,
+      {:fail_once, kind, reason},
+      {:existing, %{kind: :session_closed, reason: :run_closed}}
+    )
+  end
+
   @spec terminal_failure(t()) ::
           nil | %{kind: atom(), reason: atom(), details: map()} | %{kind: atom(), reason: atom()}
   @doc "Returns the first terminal failure, if any."
@@ -1055,6 +1068,20 @@ defmodule PtcRunner.Kernel.RunState do
       when is_atom(kind) and is_atom(reason) do
     failure = state.terminal_failure || %{kind: kind, reason: reason}
     {:reply, :ok, admit_from_queue(%{state | closed?: true, terminal_failure: failure})}
+  end
+
+  def handle_call({token, {:fail_once, kind, reason}}, _from, %{token: token} = state)
+      when is_atom(kind) and is_atom(reason) do
+    case state.terminal_failure do
+      nil ->
+        failure = %{kind: kind, reason: reason}
+
+        {:reply, {:recorded, failure},
+         admit_from_queue(%{state | closed?: true, terminal_failure: failure})}
+
+      failure ->
+        {:reply, {:existing, failure}, state}
+    end
   end
 
   def handle_call({token, :terminal_failure}, _from, %{token: token} = state),

--- a/lib/ptc_runner/kernel/runtime_limit_diagnostic.ex
+++ b/lib/ptc_runner/kernel/runtime_limit_diagnostic.ex
@@ -17,6 +17,8 @@ defmodule PtcRunner.Kernel.RuntimeLimitDiagnostic do
   @subordinate_suffix " was exceeded; raise limits.subordinate_evaluations" <>
                         @manifest_remedy <>
                         ", or reduce total subordinate evaluations or agent turns"
+  @direct_subordinate_suffix " was exceeded; start a new REPL session, or reduce total " <>
+                               "subordinate evaluations"
   @subordinate_limit_pattern "(?:[1-9][0-9]{0,8}|1[0-9]{9}|2[0-4][0-9]{8}|25[0-8][0-9]{7}|259[0-1][0-9]{6}|2592000000)"
   @subordinate_maximum_digits 10
   @subordinate_maximum_message_bytes byte_size(@subordinate_prefix) +
@@ -152,6 +154,17 @@ defmodule PtcRunner.Kernel.RuntimeLimitDiagnostic do
   end
 
   @doc false
+  @spec direct_subordinate_evaluations_message(term()) :: {:ok, binary()} | :error
+  def direct_subordinate_evaluations_message(limit) do
+    with {:ok, row} <- LimitCatalog.fetch(:subordinate_evaluations),
+         true <- LimitCatalog.valid_value?(row, limit) do
+      {:ok, @subordinate_prefix <> Integer.to_string(limit) <> @direct_subordinate_suffix}
+    else
+      _invalid -> :error
+    end
+  end
+
+  @doc false
   @spec agent_turns_reasons() :: [atom()]
   def agent_turns_reasons, do: @agent_reason_atoms
 
@@ -200,6 +213,23 @@ defmodule PtcRunner.Kernel.RuntimeLimitDiagnostic do
   end
 
   def live_timeout_message(_limit, _limit_ms, _phase), do: :error
+
+  @doc false
+  @spec direct_live_timeout_message(term(), term(), term()) :: {:ok, binary()} | :error
+  def direct_live_timeout_message(limit, limit_ms, phase)
+      when limit in @timeout_family and phase in @timeout_phases do
+    with {:ok, row} <- LimitCatalog.fetch(limit),
+         true <- LimitCatalog.valid_value?(row, limit_ms) do
+      {:ok,
+       timeout_prefix(limit) <>
+         Integer.to_string(limit_ms) <>
+         " ms was exceeded during #{phase}; start a new REPL session"}
+    else
+      _invalid -> :error
+    end
+  end
+
+  def direct_live_timeout_message(_limit, _limit_ms, _phase), do: :error
 
   # A heap kill is Kernel-observed runtime evidence, like a timeout. Raising the
   # ceiling still takes both documents: these remain `:manifest_narrowable` rows,

--- a/lib/ptc_runner/repl_frontend.ex
+++ b/lib/ptc_runner/repl_frontend.ex
@@ -57,7 +57,17 @@ defmodule PtcRunner.ReplFrontend do
 
   A positional file runs as one script. `-` reads one script from standard
   input. With no script or `--eval`, the task starts an interactive multi-line
-  REPL; `:quit` exits it.
+  REPL; `:quit` exits it. That line loop receives the same dedicated bounded
+  session profile whether input is attached or piped. A lone `--load` is setup
+  for the loop; repeated `--eval`, scripts, explicit `-` stdin, and loads that
+  precede those inputs retain ordinary effective limits.
+
+  Direct interactive sessions widen only their session lifetime and retained
+  normal-event capacity. Interactive manifest and mission sessions default
+  omitted session-lifetime and retained-event limits to installed host ceilings
+  while preserving explicit narrower values. Every session keeps one finite
+  absolute deadline, including time spent at the prompt; its owner closes
+  provider resources at expiry without waiting for another form.
 
   An interactive workflow REPL attached to a terminal runs under the Erlang
   line editor, so emacs key bindings, arrow-key history, and reverse search
@@ -1245,7 +1255,12 @@ defmodule PtcRunner.ReplFrontend do
   end
 
   defp run_direct_session(opts, arguments) do
-    case ReplSession.new(trace_path: opts[:trace]) do
+    constructor =
+      if interactive_input?(opts, arguments),
+        do: &ReplSession.new_interactive/1,
+        else: &ReplSession.new/1
+
+    case constructor.(trace_path: opts[:trace]) do
       {:ok, session} -> run_workflow_session(session, opts, arguments)
       {:error, reason} -> fail("ptc repl setup failed: #{inspect(reason)}")
     end
@@ -1260,7 +1275,8 @@ defmodule PtcRunner.ReplFrontend do
              trace_path: opts[:trace],
              private_terminal: Keyword.get(opts, :private_terminal, false),
              terminal_attached: Keyword.fetch!(opts, :terminal_attached),
-             input_mode: manifest_input_mode(opts, arguments)
+             input_mode: manifest_input_mode(opts, arguments),
+             interactive_loop: interactive_input?(opts, arguments)
            ) do
       run_workflow_session(session, opts, arguments)
     else
@@ -1298,6 +1314,9 @@ defmodule PtcRunner.ReplFrontend do
       true -> :interactive
     end
   end
+
+  defp interactive_input?(opts, arguments),
+    do: Keyword.get_values(opts, :eval) == [] and arguments == []
 
   defp manifest_runtime(opts) do
     case Keyword.fetch(opts, :command_runtime) do
@@ -1459,7 +1478,16 @@ defmodule PtcRunner.ReplFrontend do
   end
 
   defp loop(session, render) do
-    case read_expression("ptc> ", "") do
+    input = read_expression("ptc> ", "")
+
+    case ReplSession.terminal_error(session) do
+      {:error, step} -> {:error, step, session}
+      :none -> handle_loop_input(input, session, render)
+    end
+  end
+
+  defp handle_loop_input(input, session, render) do
+    case input do
       :eof ->
         info("\nGoodbye!")
         {:ok, session}
@@ -1477,8 +1505,13 @@ defmodule PtcRunner.ReplFrontend do
 
       source ->
         case evaluate(session, source, :interactive, render) do
-          {:ok, _step, next} -> loop(next, render)
-          {:error, _step, next} -> loop(next, render)
+          {:ok, _step, next} ->
+            loop(next, render)
+
+          {:error, step, next} ->
+            if ReplSession.terminal?(next),
+              do: {:error, step, next},
+              else: loop(next, render)
         end
     end
   end
@@ -1529,7 +1562,13 @@ defmodule PtcRunner.ReplFrontend do
 
       {:error, step, next} ->
         message = format_error(step, next, render)
-        if mode == :interactive, do: info(message), else: error(message)
+
+        cond do
+          mode == :interactive and not ReplSession.terminal?(next) -> info(message)
+          mode == :noninteractive -> error(message)
+          true -> :ok
+        end
+
         {:error, step, next}
     end
   end

--- a/site/reference/repl/index.html
+++ b/site/reference/repl/index.html
@@ -128,7 +128,23 @@ defaults while preserving the manifest REPL input grammar. It conflicts with
 <code class="inline">--manifest</code>, <code class="inline">--profile</code>, and <code class="inline">--describe-profile</code>; an explicit
 <code class="inline">--host-config</code> or <code class="inline">--env-file</code> overrides the matching project reference.</p><p>A provider-bearing manifest requires <code class="inline">--host-config</code>. The session performs the
 same audited-local checks, acquires one provider session, and reuses it for
-every expression. Direct and profile modes reject host configuration.</p><p>Each form evaluates under the manifest's <code class="inline">evaluation_timeout_ms</code>, whose
+every expression. Direct and profile modes reject host configuration.</p><p>The interactive line loop has a dedicated bounded lifetime profile. Selection
+depends on the input grammar, never TTY detection: argumentless <code class="inline">ptc repl</code>
+uses it when lines arrive from a terminal or a pipe, and <code class="inline">--load SETUP.clj</code>
+uses it when the setup is followed by that loop. Direct interactive sessions
+set <code class="inline">run_duration_ms</code> and <code class="inline">subordinate_evaluations</code> to their catalog maxima and
+retain normal events up to the installed <code class="inline">normal_event_count</code> and
+<code class="inline">normal_event_bytes</code> ceilings. Per-form time, heap, source, memory, history,
+result, projection, and capability limits remain at their ordinary defaults.</p><p>Interactive manifest and mission sessions use the installed host ceilings for
+omitted <code class="inline">run_duration_ms</code>, <code class="inline">subordinate_evaluations</code>, <code class="inline">normal_event_count</code>, and
+<code class="inline">normal_event_bytes</code>; an explicit manifest value remains effective when it is
+narrower than that ceiling. Their deadline is one finite absolute session
+deadline, so time at the prompt counts. The session owner marks deadline
+failure and closes provider resources at expiry without waiting for another
+form; the next line ends the frontend with the named deadline diagnostic. Repeated
+<code class="inline">--eval</code>, a positional script, explicit <code class="inline">-</code> stdin, and loads followed by one of
+those inputs retain the ordinary effective limits. <code class="inline">ReplSession.new/0</code> also
+retains the ordinary embedding defaults.</p><p>Each form evaluates under the manifest's <code class="inline">evaluation_timeout_ms</code>, whose
 effective default is 30,000 ms. A form stopped by that ceiling names the
 limit and its configured value. Raise it in the manifest if a form needs
 longer:</p><pre><code class="json language-json">{ &quot;limits&quot;: { &quot;evaluation_timeout_ms&quot;: 60000 } }</code></pre><h2 id="work-directly-in-one-manifest-mission">Work directly in one manifest mission</h2><p>Select a declared mission without starting its workflow:</p><pre><code class="console language-console">ptc repl --project ptc-project.json --mission review
@@ -183,7 +199,13 @@ stays interactive-only by design. The terminal check remains an accident
 guard, not access control. Private traces use the reserved <code class="inline">.private.jsonl</code>
 suffix and owner-only permissions.</p><p>The session owner retains the continuation, event sink, and provider resources.
 Normal close, abort, caller death, worker failure, and deadline failure converge
-on bounded cleanup before final trace persistence.</p><h2 id="query-public-traces">Query public traces</h2><p>Select the fixed public profile and its required resource:</p><pre><code class="console language-console">ptc repl --project ptc-project.json \
+on bounded cleanup before final trace persistence.</p><p>Evaluation-count and deadline exhaustion name <code class="inline">subordinate_evaluations</code> or
+<code class="inline">run_duration_ms</code> and the effective value. They are terminal: the frontend
+prints one diagnostic, closes the session with that exact canonical reason,
+and exits unsuccessfully instead of issuing another prompt. A concurrent
+evaluation reports <code class="inline">evaluation_in_progress</code> and remains retryable; an already
+closed run reports <code class="inline">session_closed</code>. Normal event capture remains bounded and
+records its existing explicit overflow summary without terminating the REPL.</p><h2 id="query-public-traces">Query public traces</h2><p>Select the fixed public profile and its required resource:</p><pre><code class="console language-console">ptc repl --project ptc-project.json \
   --profile run-analysis-v1 \
   -e '(analysis/runs {})'</code></pre><p><code class="inline">--project</code> derives <code class="inline">traces</code> from the configured artifact root. The equivalent
 explicit form is useful for a copied capture or a project without trace

--- a/test/mix/tasks/ptc_repl_test.exs
+++ b/test/mix/tasks/ptc_repl_test.exs
@@ -111,6 +111,93 @@ defmodule PtcRunner.ReplFrontendTest do
     assert output =~ "Goodbye!"
   end
 
+  test "direct interactive sessions exceed the ordinary evaluation ceiling with or without a TTY" do
+    input = Enum.map_join(1..140, "", &"#{&1}\n")
+
+    for terminal_attached? <- [false, true] do
+      output =
+        capture_io(input, fn ->
+          run_repl([], terminal_attached: terminal_attached?)
+        end)
+
+      assert output =~ "140\n"
+      assert output =~ "Goodbye!"
+      refute output =~ "subordinate_evaluations limit"
+    end
+  end
+
+  @tag :tmp_dir
+  test "a setup load followed by the direct line loop receives the interactive profile", %{
+    tmp_dir: directory
+  } do
+    setup = Path.join(directory, "setup.clj")
+    File.write!(setup, "(def loaded 42)")
+    input = String.duplicate("loaded\n", 129)
+
+    output = capture_io(input, fn -> run_repl(["--load", setup]) end)
+
+    assert output =~ "Loaded #{setup}"
+    assert output =~ "42\n"
+    assert output =~ "Goodbye!"
+    refute output =~ "subordinate_evaluations limit"
+  end
+
+  test "direct repeated eval retains the ordinary session ceiling" do
+    arguments = Enum.flat_map(1..129, &["--eval", Integer.to_string(&1)])
+
+    stderr =
+      capture_io(:stderr, fn ->
+        _stdout =
+          capture_io(fn ->
+            error = assert_raise Mix.Error, fn -> run_repl(arguments) end
+
+            assert error.message =~
+                     "subordinate_evaluations limit 128 was exceeded"
+
+            refute error.message =~ "manifest"
+          end)
+      end)
+
+    assert stderr =~ "subordinate_evaluations limit 128 was exceeded"
+    refute stderr =~ "manifest"
+  end
+
+  @tag :tmp_dir
+  test "a terminal session failure prints once and stops before another prompt", %{
+    tmp_dir: directory
+  } do
+    manifest = Path.join(directory, "terminal-limit.json")
+    File.write!(Path.join(directory, "main.clj"), "(ns app) (defn run [input] (return input))")
+
+    File.write!(
+      manifest,
+      Jason.encode!(%{
+        "version" => 1,
+        "workflow" => %{
+          "components" => [%{"id" => "app", "path" => "main.clj"}],
+          "entry" => "app/run"
+        },
+        "input" => %{"value" => %{}},
+        "limits" => %{"subordinate_evaluations" => 1}
+      })
+    )
+
+    output =
+      capture_io("101\n202\n303\n", fn ->
+        error =
+          assert_raise Mix.Error, fn ->
+            run_repl(["--manifest", manifest], terminal_attached: false)
+          end
+
+        assert error.message =~ "subordinate_evaluations limit 1 was exceeded"
+      end)
+
+    assert length(String.split(output, "ptc> ")) - 1 == 2
+    assert output =~ "101\n"
+    refute output =~ "303\n"
+    refute output =~ "subordinate_evaluations limit"
+  end
+
   test "Lisp doc replaces the removed :doc meta-command" do
     output = capture_io(":doc >\n(doc \">\")\n:quit\n", fn -> run_repl([]) end)
 

--- a/test/ptc_runner/kernel/manifest_repl_test.exs
+++ b/test/ptc_runner/kernel/manifest_repl_test.exs
@@ -9,6 +9,7 @@ defmodule PtcRunner.Kernel.ManifestReplTest do
   alias PtcRunner.Kernel.CommandPreparation
   alias PtcRunner.Kernel.CommandRuntime
   alias PtcRunner.Kernel.HostRuntimePayload
+  alias PtcRunner.Kernel.Limits
   alias PtcRunner.Kernel.ManifestRepl
   alias PtcRunner.Kernel.ManifestReplOpening
   alias PtcRunner.Kernel.ManifestReplPreparation
@@ -27,7 +28,7 @@ defmodule PtcRunner.Kernel.ManifestReplTest do
     manifest = write_provider_free_application(directory, :normal)
     {:ok, runtime} = CommandRuntime.new(provider_application_mode: :host_owned)
 
-    assert {:ok, preparation} = CommandAcquisition.prepare_repl(manifest, nil, runtime)
+    assert {:ok, preparation} = CommandAcquisition.prepare_repl(manifest, nil, runtime, true)
     assert ManifestReplPreparation.valid?(preparation)
 
     refute preparation
@@ -35,6 +36,150 @@ defmodule PtcRunner.Kernel.ManifestReplTest do
            |> ManifestReplPreparation.valid?()
 
     assert :ok = ManifestReplPreparation.close(preparation)
+  end
+
+  @tag :tmp_dir
+  test "interactive workflow and mission sessions default lifetime rows to host ceilings", %{
+    tmp_dir: directory
+  } do
+    write_component(directory)
+    manifest = Path.join(directory, "interactive-limits.json")
+    host = Path.join(directory, "interactive-limits-host.json")
+
+    document =
+      :normal
+      |> manifest_document(%{})
+      |> Map.put("missions", %{"review" => %{}})
+
+    File.write!(manifest, Jason.encode!(document))
+
+    File.write!(
+      host,
+      Jason.encode!(%{
+        "install" => %{},
+        "limits" => %{
+          "run_duration_ms" => 120_000,
+          "subordinate_evaluations" => 300
+        }
+      })
+    )
+
+    for mission <- [nil, "review"] do
+      assert {:ok, session} =
+               ManifestRepl.open(manifest, host,
+                 input_mode: :interactive,
+                 interactive_loop: true,
+                 mission: mission,
+                 terminal_attached: true
+               )
+
+      limits = owned_limits(session)
+      assert limits.run_duration_ms == 120_000
+      assert limits.subordinate_evaluations == 300
+      assert limits.evaluation_timeout_ms == Limits.defaults().evaluation_timeout_ms
+      assert %{remaining_ms: remaining} = ReplSession.usage(session)
+      assert remaining in 1..120_000
+      assert {:ok, _events} = ReplSession.close(session)
+    end
+  end
+
+  @tag :tmp_dir
+  test "explicit lifetime values win and non-interactive sessions keep ordinary defaults", %{
+    tmp_dir: directory
+  } do
+    write_component(directory)
+    manifest = Path.join(directory, "explicit-limits.json")
+    host = Path.join(directory, "explicit-limits-host.json")
+
+    document =
+      :normal
+      |> manifest_document(%{})
+      |> Map.put("limits", %{
+        "normal_event_bytes" => 8_000_000,
+        "normal_event_count" => 300,
+        "run_duration_ms" => 60_000,
+        "subordinate_evaluations" => 7
+      })
+
+    File.write!(manifest, Jason.encode!(document))
+
+    File.write!(
+      host,
+      Jason.encode!(%{
+        "install" => %{},
+        "limits" => %{
+          "run_duration_ms" => 120_000,
+          "subordinate_evaluations" => 300
+        }
+      })
+    )
+
+    assert {:ok, interactive} =
+             ManifestRepl.open(manifest, host,
+               input_mode: :interactive,
+               interactive_loop: true,
+               terminal_attached: true
+             )
+
+    assert %{
+             normal_event_bytes: 8_000_000,
+             normal_event_count: 300,
+             run_duration_ms: 60_000,
+             subordinate_evaluations: 7
+           } = owned_limits(interactive)
+
+    assert {:ok, _events} = ReplSession.close(interactive)
+
+    plain_manifest = Path.join(directory, "ordinary-limits.json")
+    File.write!(plain_manifest, Jason.encode!(manifest_document(:normal, %{})))
+
+    assert {:ok, noninteractive} =
+             ManifestRepl.open(plain_manifest, host,
+               input_mode: :eval,
+               interactive_loop: false,
+               terminal_attached: true
+             )
+
+    defaults = Limits.defaults()
+
+    assert %{run_duration_ms: run_duration_ms, subordinate_evaluations: evaluations} =
+             owned_limits(noninteractive)
+
+    assert run_duration_ms == defaults.run_duration_ms
+    assert evaluations == defaults.subordinate_evaluations
+    assert {:ok, _events} = ReplSession.close(noninteractive)
+  end
+
+  @tag :tmp_dir
+  test "a private interactive session retains canonical events beyond 128 forms", %{
+    tmp_dir: directory
+  } do
+    manifest = write_provider_free_application(directory, :private)
+
+    assert {:ok, session} =
+             ManifestRepl.open(manifest, nil,
+               input_mode: :interactive,
+               interactive_loop: true,
+               private_terminal: true,
+               terminal_attached: true
+             )
+
+    installed = Limits.installed_defaults()
+    limits = owned_limits(session)
+    assert limits.normal_event_count == installed.normal_event_count
+    assert limits.normal_event_bytes == installed.normal_event_bytes
+
+    session =
+      Enum.reduce(1..140, session, fn value, current ->
+        assert {:ok, %{return: ^value}, next} =
+                 ReplSession.eval(current, Integer.to_string(value))
+
+        next
+      end)
+
+    assert {:ok, events} = ReplSession.close(session)
+    assert List.last(events).type == "run-stopped"
+    refute Enum.any?(events, &(&1.type == "events-dropped"))
   end
 
   @tag :tmp_dir
@@ -63,7 +208,7 @@ defmodule PtcRunner.Kernel.ManifestReplTest do
     :persistent_term.put(storage_key, :invalid_hmac_key)
     owners_before = provider_activity_owners()
 
-    assert {:error, _reason} = CommandAcquisition.prepare_repl(manifest, host, runtime)
+    assert {:error, _reason} = CommandAcquisition.prepare_repl(manifest, host, runtime, true)
 
     assert MapSet.difference(provider_activity_owners(), owners_before) == MapSet.new()
   end
@@ -250,6 +395,53 @@ defmodule PtcRunner.Kernel.ManifestReplTest do
     assert message =~ "raise limits.evaluation_timeout_ms in the manifest"
 
     assert {:ok, _events} = ReplSession.close(session)
+  end
+
+  @tag :tmp_dir
+  test "a mission form that consumes the absolute deadline terminalizes synchronously", %{
+    tmp_dir: directory
+  } do
+    manifest = write_provider_free_application(directory, :normal)
+    document = manifest |> File.read!() |> Jason.decode!()
+
+    document =
+      document
+      |> Map.put("limits", %{
+        "run_duration_ms" => 200,
+        "evaluation_timeout_ms" => 5_000
+      })
+      |> Map.put("missions", %{
+        "review" => %{"components" => [], "data" => %{}, "providers" => []}
+      })
+
+    File.write!(manifest, Jason.encode!(document))
+
+    assert {:ok, session} =
+             ManifestRepl.open(manifest, nil,
+               mission: "review",
+               input_mode: :eval,
+               interactive_loop: false,
+               terminal_attached: true
+             )
+
+    [{_, {owner, _token}}] = :ets.lookup(session.access, session.id)
+
+    :sys.replace_state(owner, fn state ->
+      Process.cancel_timer(state.deadline_timer)
+      %{state | deadline_timer: nil, deadline_token: nil}
+    end)
+
+    assert {:error, %{fail: %{reason: :limit_exceeded, message: message}}, session} =
+             ReplSession.eval(session, long_running_body(4))
+
+    assert message =~ "run_duration_ms limit 200 ms was exceeded"
+    assert ReplSession.terminal?(session)
+    assert {:ok, events} = ReplSession.close(session)
+
+    assert [%{data: %{reason: :deadline_expired}}] =
+             Enum.filter(events, &(&1.type == "limit-exceeded"))
+
+    assert List.last(events).data.reason == :deadline_expired
   end
 
   @tag :tmp_dir
@@ -477,7 +669,7 @@ defmodule PtcRunner.Kernel.ManifestReplTest do
     configure_host_llm(host_llm_test_ready_gate: gate)
     {manifest, host} = write_llm_application(directory, :normal)
     {:ok, runtime} = CommandRuntime.new(provider_application_mode: :host_owned)
-    assert {:ok, preparation} = CommandAcquisition.prepare_repl(manifest, host, runtime)
+    assert {:ok, preparation} = CommandAcquisition.prepare_repl(manifest, host, runtime, true)
     assert {:ok, authority} = PublicationAuthority.new([])
     assert {:ok, opening} = ManifestReplOpening.start(preparation, authority, nil, self())
     opening_ref = Process.monitor(ManifestReplOpening.pid(opening))
@@ -520,14 +712,14 @@ defmodule PtcRunner.Kernel.ManifestReplTest do
     assert {:error, %{fail: %{reason: reason}}, session} =
              ReplSession.eval(session, "42")
 
-    assert reason in [:limit_exceeded, :run_deadline_exceeded, :evaluation_timeout]
+    assert reason == :limit_exceeded
     assert {:ok, _events} = ReplSession.close(session)
 
     assert_eventually(fn ->
       lifecycle(marker) |> Enum.count(&(&1 == "session-closed")) == 1
     end)
 
-    assert File.read!(trace_path) =~ "repl_evaluation_error"
+    assert File.read!(trace_path) =~ "deadline_expired"
   end
 
   defp configure_host_llm(extra \\ []) do
@@ -769,6 +961,12 @@ defmodule PtcRunner.Kernel.ManifestReplTest do
       {:ok, contents} -> String.split(contents, "\n", trim: true)
       {:error, :enoent} -> []
     end
+  end
+
+  defp owned_limits(%ReplSession{access: access, id: id}) do
+    [{^id, {owner, token}}] = :ets.lookup(access, id)
+    assert {:ok, config, _state} = ReplSessionOwner.resources(owner, token)
+    config.limits
   end
 
   defp provider_activity_owners do

--- a/test/ptc_runner/kernel/repl_limit_profile_test.exs
+++ b/test/ptc_runner/kernel/repl_limit_profile_test.exs
@@ -1,0 +1,34 @@
+defmodule PtcRunner.Kernel.ReplLimitProfileTest do
+  use ExUnit.Case, async: true
+
+  alias PtcRunner.Kernel.LimitCatalog
+  alias PtcRunner.Kernel.Limits
+  alias PtcRunner.Kernel.ReplLimitProfile
+
+  test "the direct interactive profile widens only session lifetime and retained events" do
+    ordinary = Limits.defaults()
+    installed = Limits.installed_defaults()
+    direct = ReplLimitProfile.direct_interactive()
+
+    assert {:ok, run_duration} = LimitCatalog.fetch(:run_duration_ms)
+    assert {:ok, evaluations} = LimitCatalog.fetch(:subordinate_evaluations)
+    assert direct.run_duration_ms == run_duration.maximum
+    assert direct.subordinate_evaluations == evaluations.maximum
+
+    assert direct.normal_event_count == installed.normal_event_count
+    assert direct.normal_event_bytes == installed.normal_event_bytes
+
+    assert Map.drop(Map.from_struct(direct), [
+             :run_duration_ms,
+             :subordinate_evaluations,
+             :normal_event_count,
+             :normal_event_bytes
+           ]) ==
+             Map.drop(Map.from_struct(ordinary), [
+               :run_duration_ms,
+               :subordinate_evaluations,
+               :normal_event_count,
+               :normal_event_bytes
+             ])
+  end
+end

--- a/test/ptc_runner/kernel/repl_session_test.exs
+++ b/test/ptc_runner/kernel/repl_session_test.exs
@@ -972,7 +972,7 @@ defmodule PtcRunner.Kernel.ReplSessionTest do
     assert message =~ "raise limits.evaluation_timeout_ms in the manifest"
   end
 
-  test "session-wide evaluation limits do not reset between expressions" do
+  test "session-wide evaluation exhaustion is exact and terminal" do
     {:ok, workflow} = WorkflowEnvironment.new([])
     {:ok, mission} = MissionEnvironment.new([])
     {:ok, limits} = Limits.new(subordinate_evaluations: 1)
@@ -990,10 +990,292 @@ defmodule PtcRunner.Kernel.ReplSessionTest do
     {:ok, session} = ReplSession.new(config: config)
     assert {:ok, _step, session} = ReplSession.eval(session, "(def retained 41)")
 
-    assert {:error, %{fail: %{reason: :limit_exceeded}, memory: memory}, _session} =
+    assert {:error,
+            %{
+              fail: %{reason: :limit_exceeded, message: message},
+              memory: memory
+            }, session} =
              ReplSession.eval(session, "42")
 
     assert memory["retained"] == 41
+    assert message =~ "subordinate_evaluations limit 1 was exceeded"
+    refute message =~ "manifest"
+    refute ReplSession.open?(session)
+
+    assert {:ok, events} = ReplSession.close(session)
+
+    assert %{type: "limit-exceeded", data: %{reason: :subordinate_evaluations}} =
+             Enum.find(events, &(&1.type == "limit-exceeded"))
+
+    assert List.last(events).data.reason == :subordinate_evaluations
+  end
+
+  test "the direct interactive profile preserves definitions and exact history past 128 forms" do
+    {:ok, session} = ReplSession.new_interactive()
+    assert {:ok, _step, session} = ReplSession.eval(session, "(def retained 40)")
+
+    session =
+      Enum.reduce(1..129, session, fn value, current ->
+        assert {:ok, %{return: ^value}, next} =
+                 ReplSession.eval(current, Integer.to_string(value))
+
+        next
+      end)
+
+    assert {:ok, %{return: [129, 128, 127, 40]}, session} =
+             ReplSession.eval(session, "[*1 *2 *3 retained]")
+
+    assert {:ok, _events} = ReplSession.close(session)
+  end
+
+  test "the owner closes provider resources when the absolute deadline expires at the prompt" do
+    parent = self()
+    {:ok, workflow} = WorkflowEnvironment.new([])
+    {:ok, mission} = MissionEnvironment.new([])
+    {:ok, limits} = Limits.new(run_duration_ms: 50)
+    {:ok, sink} = EventSink.start(:normal, limits)
+
+    close = fn ->
+      send(parent, :deadline_provider_closed)
+      :ok
+    end
+
+    {:ok, config} =
+      RunConfig.new(
+        workflow_environment: workflow,
+        missions: %{"default" => mission},
+        input: %{},
+        limits: limits,
+        event_sink: sink,
+        provider_session: ProviderSessionFixture.start([close], limits)
+      )
+
+    {:ok, session} = ReplSession.new(config: config)
+
+    assert_receive :deadline_provider_closed, 1_000
+    refute_receive :deadline_provider_closed
+    assert ReplSession.terminal?(session)
+
+    assert {:error, %{fail: %{reason: :limit_exceeded, message: message}}, session} =
+             ReplSession.eval(session, "42")
+
+    assert message =~ "run_duration_ms limit 50 ms was exceeded"
+    assert {:ok, events} = ReplSession.close(session)
+    assert List.last(events).data.reason == :deadline_expired
+  end
+
+  test "close records an elapsed deadline before cancelling its pending timer" do
+    {:ok, session} = ReplSession.new()
+    state = owned_run_state(session)
+
+    :sys.replace_state(state.pid, fn run_state ->
+      %{run_state | deadline_ms: System.monotonic_time(:millisecond) - 1}
+    end)
+
+    assert {:ok, events} = ReplSession.close(session)
+
+    assert [%{data: %{reason: :deadline_expired}}] =
+             Enum.filter(events, &(&1.type == "limit-exceeded"))
+
+    assert List.last(events).data.reason == :deadline_expired
+  end
+
+  test "a form that consumes the absolute deadline terminalizes before the owner timer runs" do
+    {:ok, workflow} = WorkflowEnvironment.new([])
+    {:ok, mission} = MissionEnvironment.new([])
+
+    {:ok, limits} =
+      Limits.new(
+        run_duration_ms: 200,
+        evaluation_timeout_ms: 5_000,
+        workflow_timeout_ms: 5_000
+      )
+
+    {:ok, sink} = EventSink.start(:normal, limits, run_id: "repl-in-flight-deadline")
+
+    {:ok, config} =
+      RunConfig.new(
+        workflow_environment: workflow,
+        missions: %{"default" => mission},
+        input: %{},
+        limits: limits,
+        event_sink: sink
+      )
+
+    {:ok, session} = ReplSession.new(config: config)
+    owner = owned_owner(session)
+
+    :sys.replace_state(owner, fn state ->
+      Process.cancel_timer(state.deadline_timer)
+      %{state | deadline_timer: nil, deadline_token: nil}
+    end)
+
+    assert {:error, %{fail: %{reason: :limit_exceeded, message: message}}, session} =
+             ReplSession.eval(session, long_running_body(4))
+
+    assert message =~ "run_duration_ms limit 200 ms was exceeded"
+    assert ReplSession.terminal?(session)
+    assert {:ok, events} = ReplSession.close(session)
+
+    assert [%{data: %{reason: :deadline_expired}}] =
+             Enum.filter(events, &(&1.type == "limit-exceeded"))
+
+    assert List.last(events).data.reason == :deadline_expired
+  end
+
+  @tag :nightly
+  test "resource lookup waits through provider cleanup beyond the default call timeout" do
+    parent = self()
+    {:ok, workflow} = WorkflowEnvironment.new([])
+    {:ok, mission} = MissionEnvironment.new([])
+
+    {:ok, limits} =
+      Limits.new(run_duration_ms: 50, provider_cleanup_timeout_ms: 6_000)
+
+    {:ok, sink} = EventSink.start(:normal, limits)
+
+    close = fn ->
+      send(parent, {:slow_deadline_cleanup_started, self()})
+
+      receive do
+        :finish_slow_deadline_cleanup -> :ok
+      end
+    end
+
+    {:ok, config} =
+      RunConfig.new(
+        workflow_environment: workflow,
+        missions: %{"default" => mission},
+        input: %{},
+        limits: limits,
+        event_sink: sink,
+        provider_session: ProviderSessionFixture.start([close], limits)
+      )
+
+    {:ok, session} = ReplSession.new(config: config)
+    assert_receive {:slow_deadline_cleanup_started, cleanup_worker}, 1_000
+    Process.send_after(cleanup_worker, :finish_slow_deadline_cleanup, 5_100)
+
+    assert {:error, %{fail: %{reason: :limit_exceeded}}} =
+             ReplSession.terminal_error(session)
+
+    assert {:ok, events} = ReplSession.close(session)
+    assert List.last(events).data.reason == :deadline_expired
+  end
+
+  @tag :tmp_dir
+  test "owner death preserves an already-recorded deadline in the trace", %{tmp_dir: directory} do
+    parent = self()
+    trace_path = Path.join(directory, "deadline-owner-death.jsonl")
+
+    {creator, creator_ref} =
+      spawn_monitor(fn ->
+        {:ok, workflow} = WorkflowEnvironment.new([])
+        {:ok, mission} = MissionEnvironment.new([])
+        {:ok, limits} = Limits.new(run_duration_ms: 50)
+        {:ok, sink} = EventSink.start(:normal, limits)
+
+        close = fn ->
+          send(parent, :owner_death_deadline_provider_closed)
+          :ok
+        end
+
+        {:ok, config} =
+          RunConfig.new(
+            workflow_environment: workflow,
+            missions: %{"default" => mission},
+            input: %{},
+            limits: limits,
+            event_sink: sink,
+            provider_session: ProviderSessionFixture.start([close], limits)
+          )
+
+        {:ok, session} = ReplSession.new(config: config, trace_path: trace_path)
+        [{_, {owner, _token}}] = :ets.lookup(session.access, session.id)
+        send(parent, {:owner_death_deadline_ready, owner})
+
+        receive do
+          :disconnect -> :ok
+        end
+      end)
+
+    assert_receive {:owner_death_deadline_ready, owner}, 1_000
+    owner_ref = Process.monitor(owner)
+    assert_receive :owner_death_deadline_provider_closed, 1_000
+    send(creator, :disconnect)
+    assert_receive {:DOWN, ^creator_ref, :process, ^creator, :normal}, 1_000
+    assert_receive {:DOWN, ^owner_ref, :process, ^owner, :normal}, 1_000
+
+    trace = File.read!(trace_path)
+    assert trace =~ "deadline_expired"
+    refute trace =~ "session_owner_failed"
+  end
+
+  test "a direct session limit diagnostic does not prescribe a nonexistent manifest" do
+    {:ok, session} = ReplSession.new()
+    %{subordinate_evaluations: limit} = owned_limits(session)
+
+    state = owned_run_state(session)
+    :sys.replace_state(state.pid, &%{&1 | evaluations: limit})
+
+    assert {:error, %{fail: %{reason: :limit_exceeded, message: message}}, session} =
+             ReplSession.eval(session, "42")
+
+    assert message =~ "subordinate_evaluations limit #{limit} was exceeded"
+    refute message =~ "manifest"
+    refute ReplSession.open?(session)
+    assert {:ok, _events} = ReplSession.close(session)
+  end
+
+  test "deadline, busy, and closed reservations preserve distinct public results" do
+    {:ok, busy_session} = ReplSession.new()
+    busy_state = owned_run_state(busy_session)
+    assert {:ok, _memory, _history, lease} = RunState.reserve_workflow_evaluation(busy_state)
+
+    assert {:error,
+            %{fail: %{reason: :evaluation_in_progress, message: "REPL evaluation in progress"}},
+            busy_session} = ReplSession.eval(busy_session, "42")
+
+    assert ReplSession.open?(busy_session)
+    assert :ok = RunState.release_evaluation(busy_state, lease)
+    assert {:ok, %{return: 42}, busy_session} = ReplSession.eval(busy_session, "42")
+    assert {:ok, busy_events} = ReplSession.close(busy_session)
+    refute Enum.any?(busy_events, &(&1.type == "limit-exceeded"))
+
+    {:ok, deadline_session} = ReplSession.new()
+    deadline_state = owned_run_state(deadline_session)
+
+    :sys.replace_state(deadline_state.pid, fn state ->
+      %{state | deadline_ms: System.monotonic_time(:millisecond) - 1}
+    end)
+
+    assert {:error, %{fail: %{reason: :limit_exceeded, message: deadline_message}},
+            deadline_session} = ReplSession.eval(deadline_session, "42")
+
+    assert deadline_message =~ "run_duration_ms limit 30000 ms was exceeded"
+    refute deadline_message =~ "manifest"
+    refute ReplSession.open?(deadline_session)
+    assert {:ok, deadline_events} = ReplSession.close(deadline_session)
+
+    assert %{type: "limit-exceeded", data: %{reason: :deadline_expired}} =
+             Enum.find(deadline_events, &(&1.type == "limit-exceeded"))
+
+    assert List.last(deadline_events).data.reason == :deadline_expired
+
+    {:ok, closed_session} = ReplSession.new()
+    closed_state = owned_run_state(closed_session)
+    assert :ok = RunState.close(closed_state)
+
+    assert {:error, %{fail: %{reason: :session_closed, message: "REPL session is closed"}},
+            closed_session} = ReplSession.eval(closed_session, "42")
+
+    refute ReplSession.open?(closed_session)
+    assert {:ok, closed_events} = ReplSession.close(closed_session)
+
+    assert %{type: "limit-exceeded", data: %{reason: :run_closed}} =
+             Enum.find(closed_events, &(&1.type == "limit-exceeded"))
+
+    assert List.last(closed_events).data.reason == :run_closed
   end
 
   test "closed and constructor-failed sessions leave no live sink" do
@@ -1347,5 +1629,26 @@ defmodule PtcRunner.Kernel.ReplSessionTest do
     fun
     |> Task.async()
     |> Task.await()
+  end
+
+  defp owned_limits(session) do
+    {config, _state} = owned_resources(session)
+    config.limits
+  end
+
+  defp owned_run_state(session) do
+    {_config, state} = owned_resources(session)
+    state
+  end
+
+  defp owned_owner(%ReplSession{access: access, id: id}) do
+    [{^id, {owner, _token}}] = :ets.lookup(access, id)
+    owner
+  end
+
+  defp owned_resources(%ReplSession{access: access, id: id}) do
+    [{^id, {owner, token}}] = :ets.lookup(access, id)
+    assert {:ok, config, state} = ReplSessionOwner.resources(owner, token)
+    {config, state}
   end
 end


### PR DESCRIPTION
## Summary

- apply the dedicated bounded session profile only to interactive line loops, including piped lines, while preserving ordinary limits for eval, scripts, load-only execution, stdin programs, and embedded ReplSession.new/0 callers
- default manifest and mission interactive session-lifetime and retained-event limits to installed host ceilings, with explicit narrower settings still winning
- retain an absolute owner deadline, close provider resources at expiry, preserve the first terminal failure, and stop the frontend with reason-specific diagnostics
- synchronously terminalize evaluations that consume the binding run deadline and keep busy responses retryable
- update the REPL and limits documentation and generated reference pages

## Verification

- mix precommit
- mix test: 6,985 passed, 387 excluded
- focused REPL/session tests: 159 passed, 4 excluded
- nightly slow-cleanup regression: 1 passed, 45 excluded
- MIX_ENV=dev mix docs --warnings-as-errors
- mix dialyzer: 0 errors
- repository pre-push gate, including core tests, static analysis, Dialyzer, release verification, and Viewer validation

## Review

Completed the requested maximum of three independent Codex review passes. All findings were addressed; no known review findings remain.

Closes #1442