### PR TITLE
fix(kernel): make workflow data lookup strict (#1602)

### DIFF
--- a/docs/ptc-lisp-specification.md
+++ b/docs/ptc-lisp-specification.md
@@ -1355,9 +1355,11 @@ is distinct from an evaluator error returned under the outer `:error` tag.
 
 ```clojure
 ;; Signal failure when a required condition isn't met.
-;; Valid at the workflow boundary and in `PtcRunner.Lisp.run/2`, where a
-;; missing `data/<name>` is `nil`. Mission-scoped evaluation is strict: name
-;; the granted keys or let a missing grant fail instead of testing `nil?`.
+;; This tests whether the granted value is `nil`, which is a different question
+;; from whether the name was granted at all. Under the Kernel -- a workflow
+;; entry, a mission run, or either REPL -- an ungranted `data/<name>` is a
+;; runtime error, not `nil`, so `nil?` cannot be used to probe for one.
+;; `PtcRunner.Lisp.run/2` stays permissive and answers `nil` for both.
 (if (nil? data/input)
   (fail "No input data provided")
   (process data/input))
@@ -3306,13 +3308,17 @@ Context is **per-request** data passed by the host. It does not persist across t
      (sum-by :amount))
 ```
 
-At the generic `PtcRunner.Lisp.run/2` embedding API and at the Kernel workflow
-boundary, a missing `data/<name>` evaluates to `nil`. Mission-scoped evaluation
-— a normal mission run and `ptc repl --mission` — is strict: a missing grant is
-a `:runtime_error` that names the rejected symbol and lists the mission's
-granted `data/<name>` forms. Calling a granted data value, as in
-`(data/tickets)`, is `:not_callable` and names the symbol rather than rendering
-the value.
+Every Kernel boundary looks up `data/<name>` strictly — a workflow entry, a
+normal mission run, and both `ptc repl` session kinds. A missing grant is a
+`:runtime_error` that names the rejected symbol and lists the granted
+`data/<name>` forms available at that boundary. Calling a granted data value,
+as in `(data/tickets)`, is `:not_callable` and names the symbol rather than
+rendering the value. Only the generic `PtcRunner.Lisp.run/2` embedding API is
+permissive, where a missing `data/<name>` still evaluates to `nil`.
+
+A manifest binds exactly one workflow name, `data/input`, from its `input`
+declaration, so a misspelled workflow reference is rejected against that single
+granted form.
 
 `data/params` is injected only by `kernel/eval-with` and
 `kernel/eval-source-with`. Referencing it when this evaluation supplied no

--- a/docs/reference/repl.md
+++ b/docs/reference/repl.md
@@ -123,8 +123,10 @@ application, host configuration, and lazy environment-file paths, while
 duplicated in `ptc-project.json`. The manifest form is the equivalent low-level
 command. Omitting `--mission` keeps the workflow REPL behavior — which carries
 no mission namespaces, so a mission's own namespace is rejected as unknown.
-Calling `data/<name>` in that session is `not_callable` rather than an unknown
-namespace, because `data/` is a language namespace. Both answers name
+A `data/<name>` form in that session answers from the language rather than as
+an unknown namespace, because `data/` is a language namespace the workflow
+environment carries: an ungranted name is a missing-grant runtime error, and
+calling the granted `data/input` is `not_callable`. All three answers name
 `--mission` and list the missions the manifest declares.
 
 A mission session starts with a fresh continuation and evaluates through the

--- a/docs/reference/repl.md
+++ b/docs/reference/repl.md
@@ -136,12 +136,13 @@ start applications, request authorization or credentials, or acquire
 resources. Dependency-only providers support the session without contributing
 task capabilities.
 
-A mission session looks up `data/<name>` strictly: a granted name resolves to
+Both session kinds look up `data/<name>` strictly: a granted name resolves to
 its value, a missing name is a runtime error that lists the granted
 `data/<name>` forms, and calling a granted value as in `(data/tickets)` is
-`not_callable` naming the symbol. Discover those names with `:context`. The
-workflow session and the generic embedding API keep the permissive `nil`
-default.
+`not_callable` naming the symbol. A mission session grants the mission's data;
+discover those names with `:context`. A workflow session grants the single
+`data/input` the manifest declares. Only the generic embedding API,
+`PtcRunner.Lisp.run/2`, keeps the permissive `nil` default.
 
 The interactive banner names the selected mission, components, and direct
 provider aliases. Mission sessions add one meta-command:

--- a/lib/ptc_runner/kernel/evaluation.ex
+++ b/lib/ptc_runner/kernel/evaluation.ex
@@ -28,21 +28,21 @@ defmodule PtcRunner.Kernel.Evaluation do
   observation rather than returning JSON to workflow Lisp.
 
   Mission-scoped evaluation is strict for `data/<name>`: a missing grant is a
-  runtime error that lists the names `PtcRunner.Kernel.MissionInventory` would
-  publish, calling a granted value is `not_callable` naming the symbol, and
+  runtime error that lists the same granted names the mission inventory
+  publishes, calling a granted value is `not_callable` naming the symbol, and
   `data/params` without a supplied params map names `kernel/eval-with` and
   `kernel/eval-source-with`. `PtcRunner.Lisp.run/2` stays permissive.
   """
 
   alias PtcRunner.Kernel.Events
   alias PtcRunner.Kernel.InspectionSink
-  alias PtcRunner.Kernel.MissionInventory
   alias PtcRunner.Kernel.ProjectionError
   alias PtcRunner.Kernel.RunState
   alias PtcRunner.Kernel.RuntimeTools
   alias PtcRunner.Kernel.TerminalResultLimit
   alias PtcRunner.Kernel.ToolGrant
   alias PtcRunner.Lisp
+  alias PtcRunner.Lisp.DataKeys
   alias PtcRunner.Lisp.TrustedTool
 
   @missing_data_params_message "data/params is not available because this evaluation supplied no params. " <>
@@ -395,7 +395,7 @@ defmodule PtcRunner.Kernel.Evaluation do
       preserve_runtime_callables: true,
       link: true,
       strict_data: true,
-      data_grants: MissionInventory.source_referenceable_forms(environment.data),
+      data_grants: DataKeys.source_referenceable_forms(environment.data),
       missing_data_params_message: @missing_data_params_message
     ]
 

--- a/lib/ptc_runner/kernel/mission_inventory.ex
+++ b/lib/ptc_runner/kernel/mission_inventory.ex
@@ -28,7 +28,7 @@ defmodule PtcRunner.Kernel.MissionInventory do
   alias PtcRunner.Kernel.Limits
   alias PtcRunner.Kernel.MissionEnvironment
   alias PtcRunner.Kernel.ModelContract
-  alias PtcRunner.Lisp.Parser
+  alias PtcRunner.Lisp.DataKeys
   alias PtcRunner.Lisp.Prelude
   alias PtcRunner.Lisp.Prelude.Export
 
@@ -105,32 +105,10 @@ defmodule PtcRunner.Kernel.MissionInventory do
   def grant_summary(data, bundle, provider_names)
       when is_map(data) and not is_struct(data) and is_list(provider_names) do
     %{
-      "data" => source_referenceable_forms(data),
+      "data" => DataKeys.source_referenceable_forms(data),
       "exports" => public_export_refs(bundle),
       "providers" => provider_names
     }
-  end
-
-  @doc """
-  Returns the sorted `data/<name>` source forms for keys that can be written as
-  a `data/<name>` reference.
-
-  Names that cannot be parsed as that form are omitted. Inventory data entries
-  and missing-grant diagnostics both consume this list rather than selecting
-  forms independently. The Kernel mission evaluator prints it rather than
-  deriving names from the evaluation context.
-  """
-  @spec source_referenceable_forms(map()) :: [binary()]
-  def source_referenceable_forms(data) when is_map(data) and not is_struct(data) do
-    data
-    |> Map.keys()
-    |> Enum.sort()
-    |> Enum.flat_map(fn name ->
-      case source_referenceable_form(name) do
-        {:ok, form} -> [form]
-        :skip -> []
-      end
-    end)
   end
 
   defp public_export_refs(nil), do: []
@@ -231,7 +209,7 @@ defmodule PtcRunner.Kernel.MissionInventory do
   defp data_entries(%{data: data}) when is_map(data) and not is_struct(data) do
     if JSONValue.map?(data) do
       data
-      |> source_referenceable_forms()
+      |> DataKeys.source_referenceable_forms()
       |> Enum.reduce_while({:ok, []}, fn form, {:ok, entries} ->
         "data/" <> name = form
         value = Map.fetch!(data, name)
@@ -258,18 +236,6 @@ defmodule PtcRunner.Kernel.MissionInventory do
       "Mission data supplied by the application manifest."
     )
   end
-
-  defp source_referenceable_form(name) when is_binary(name) do
-    case Parser.parse("data/" <> name) do
-      {:ok, {:ns_symbol, :data, parsed}} ->
-        if to_string(parsed) == name, do: {:ok, "data/" <> name}, else: :skip
-
-      _not_a_source_reference ->
-        :skip
-    end
-  end
-
-  defp source_referenceable_form(_name), do: :skip
 
   defp model_exports(%{bundle: %{prelude: prelude}} = mission) do
     prelude

--- a/lib/ptc_runner/kernel/repl_session.ex
+++ b/lib/ptc_runner/kernel/repl_session.ex
@@ -45,6 +45,7 @@ defmodule PtcRunner.Kernel.ReplSession do
   alias PtcRunner.Kernel.TraceLog
   alias PtcRunner.Kernel.WorkflowEnvironment
   alias PtcRunner.Lisp
+  alias PtcRunner.Lisp.DataKeys
   alias PtcRunner.Lisp.Eval.Helpers
   alias PtcRunner.Lisp.Result, as: Native
   alias PtcRunner.Lisp.RetainedSize
@@ -808,7 +809,9 @@ defmodule PtcRunner.Kernel.ReplSession do
         max_tool_call_result_bytes: limits.capability_result_bytes,
         preserve_runtime_callables: true,
         filter_context: false,
-        link: true
+        link: true,
+        strict_data: true,
+        data_grants: DataKeys.source_referenceable_forms(session.config.input)
       )
 
     name_timeout_limit(result, session, remaining_ms)

--- a/lib/ptc_runner/kernel/runner.ex
+++ b/lib/ptc_runner/kernel/runner.ex
@@ -27,6 +27,7 @@ defmodule PtcRunner.Kernel.Runner do
   alias PtcRunner.Kernel.TerminalResultLimit
   alias PtcRunner.Kernel.ToolGrant
   alias PtcRunner.Lisp
+  alias PtcRunner.Lisp.DataKeys
   alias PtcRunner.Lisp.Eval.Helpers
   alias PtcRunner.Lisp.Result, as: LispResult
   alias PtcRunner.Lisp.RetainedSize
@@ -237,7 +238,9 @@ defmodule PtcRunner.Kernel.Runner do
       max_program_bytes: config.limits.entry_source_bytes,
       filter_context: false,
       caller: :kernel,
-      telemetry_run: state.pid
+      telemetry_run: state.pid,
+      strict_data: true,
+      data_grants: DataKeys.source_referenceable_forms(config.input)
     ]
 
     case Lisp.run_native(entry_source, opts) do

--- a/lib/ptc_runner/lisp.ex
+++ b/lib/ptc_runner/lisp.ex
@@ -275,13 +275,15 @@ defmodule PtcRunner.Lisp do
     - `:max_print_length` - Max characters per `println` call (default: 2000)
     - `:filter_context` - Filter context to only include accessed data keys (default: true)
     - `:strict_data` - When true, a missing `data/<name>` is a runtime error
-      instead of `nil` (default: false). The Kernel enables this at the mission
-      boundary; `run/2` stays permissive.
+      instead of `nil` (default: false). The Kernel enables this at every one of
+      its boundaries -- the workflow entry, a mission evaluation, and both REPL
+      session kinds; `run/2` stays permissive.
     - `:data_grants` - Optional sorted `data/<name>` forms included in the
-      missing-grant diagnostic under `:strict_data`. The Kernel passes the same
-      list the mission inventory publishes rather than deriving it from context
-      keys. When omitted, the diagnostic names the missing key without a grant
-      list.
+      missing-grant diagnostic under `:strict_data`. The Kernel passes the list
+      `PtcRunner.Lisp.DataKeys.source_referenceable_forms/1` derives from the
+      granted data, the same one the mission inventory publishes, rather than
+      deriving it from context keys. When omitted, the diagnostic names the
+      missing key without a grant list.
     - `:missing_data_params_message` - Optional diagnostic used when `data/params`
       is missing under `:strict_data`. The Kernel sets this so a no-params
       evaluation is not reported as a missing grant.

--- a/lib/ptc_runner/lisp/data_keys.ex
+++ b/lib/ptc_runner/lisp/data_keys.ex
@@ -19,6 +19,7 @@ defmodule PtcRunner.Lisp.DataKeys do
 
   alias PtcRunner.Lisp.Format.SymbolRef
   alias PtcRunner.Lisp.Keyword, as: LispKeyword
+  alias PtcRunner.Lisp.Parser
 
   @doc """
   Extracts all data keys accessed by a program.
@@ -202,6 +203,50 @@ defmodule PtcRunner.Lisp.DataKeys do
 
   # Primitives and structs - no data access
   defp do_extract(_other, acc), do: acc
+
+  @doc """
+  Returns the sorted `data/<name>` source forms for the keys of `data` that can
+  be written as a `data/<name>` reference.
+
+  Names that cannot be parsed as that form are omitted. Every granted-name list
+  the runtime publishes or prints comes from here: mission inventory entries and
+  the mission and workflow missing-grant diagnostics all consume this rather
+  than selecting forms independently, so the list a user is shown always matches
+  the list that resolves.
+
+  ## Examples
+
+      iex> PtcRunner.Lisp.DataKeys.source_referenceable_forms(%{"b" => 1, "a" => 2})
+      ["data/a", "data/b"]
+
+      iex> PtcRunner.Lisp.DataKeys.source_referenceable_forms(%{"not a symbol" => 1})
+      []
+
+  """
+  @spec source_referenceable_forms(map()) :: [binary()]
+  def source_referenceable_forms(data) when is_map(data) and not is_struct(data) do
+    data
+    |> Map.keys()
+    |> Enum.sort()
+    |> Enum.flat_map(fn name ->
+      case source_referenceable_form(name) do
+        {:ok, form} -> [form]
+        :skip -> []
+      end
+    end)
+  end
+
+  defp source_referenceable_form(name) when is_binary(name) do
+    case Parser.parse("data/" <> name) do
+      {:ok, {:ns_symbol, :data, parsed}} ->
+        if to_string(parsed) == name, do: {:ok, "data/" <> name}, else: :skip
+
+      _not_a_source_reference ->
+        :skip
+    end
+  end
+
+  defp source_referenceable_form(_name), do: :skip
 
   defp existing_atom_or(key) do
     String.to_existing_atom(key)

--- a/lib/ptc_runner/lisp/eval.ex
+++ b/lib/ptc_runner/lisp/eval.ex
@@ -71,6 +71,7 @@ defmodule PtcRunner.Lisp.Eval do
   alias PtcRunner.Lisp.KeyNormalizer
   alias PtcRunner.Lisp.Keyword, as: LispKeyword
   alias PtcRunner.Lisp.Metadata
+  alias PtcRunner.Lisp.NamespaceDiagnostic
   alias PtcRunner.Lisp.PreludeClosure
   alias PtcRunner.Lisp.RuntimeCallable
   alias PtcRunner.Lisp.UntrustedRenderer
@@ -1772,8 +1773,6 @@ defmodule PtcRunner.Lisp.Eval do
   # Strict-data lookup helpers (used by `do_eval({:data, key}, ...)`)
   # ============================================================
 
-  @max_granted_data_names 32
-
   # Public SymbolRef context keys internalize to `{:symbol_ref, name}` while
   # `data/'name` carries the display spelling. Preserve normal flexible lookup
   # precedence, then bridge that display spelling to the internal key.
@@ -1815,23 +1814,8 @@ defmodule PtcRunner.Lisp.Eval do
 
   defp params_key?(key), do: data_key_name(key) == "params"
 
-  defp missing_grant_error(key, grants) do
-    data_symbol(key) <>
-      " is not a granted data name. Granted: " <> format_granted_names(grants)
-  end
-
-  defp format_granted_names([]), do: "(none)"
-
-  defp format_granted_names(names) do
-    shown = Enum.take(names, @max_granted_data_names)
-    formatted = Enum.join(shown, ", ")
-
-    if length(names) > @max_granted_data_names do
-      formatted <> ", …"
-    else
-      formatted
-    end
-  end
+  defp missing_grant_error(key, grants),
+    do: NamespaceDiagnostic.missing_data_grant_message(data_symbol(key), grants)
 
   # ============================================================
   # Sequential evaluation helpers

--- a/lib/ptc_runner/lisp/namespace_diagnostic.ex
+++ b/lib/ptc_runner/lisp/namespace_diagnostic.ex
@@ -60,6 +60,7 @@ defmodule PtcRunner.Lisp.NamespaceDiagnostic do
 
   @data_not_callable_prefix "not callable: data/"
   @missing_data_grant_infix " is not a granted data name. Granted: "
+  @rejected_data_symbol ~r{\A(?:[a-z_]+: )?data/\S+\z}
   @max_granted_data_names 32
 
   @doc """
@@ -90,23 +91,20 @@ defmodule PtcRunner.Lisp.NamespaceDiagnostic do
 
   It shares a home with the message it recognizes so the two cannot drift; the
   REPL frontend reads it to decide whether a workflow session should be told
-  which switch opens a mission. The message is matched wherever it starts,
-  because callers render it both bare and behind a `reason: ` prefix.
+  which switch opens a mission. The rejected half must be the entire prefix --
+  a bare `data/<name>`, optionally behind one `reason: ` tag -- so another
+  diagnostic that merely quotes this text, such as `not callable: "data/x is
+  not a granted data name. …"`, is not mistaken for it.
   """
   @spec missing_data_grant?(binary()) :: boolean()
   def missing_data_grant?(message) when is_binary(message) do
     case String.split(message, @missing_data_grant_infix, parts: 2) do
-      [rejected, _granted] -> data_symbol?(rejected |> String.split() |> List.last())
+      [rejected, _granted] -> Regex.match?(@rejected_data_symbol, rejected)
       _no_infix -> false
     end
   end
 
   def missing_data_grant?(_message), do: false
-
-  defp data_symbol?(token) when is_binary(token),
-    do: String.starts_with?(token, "data/") and byte_size(token) > byte_size("data/")
-
-  defp data_symbol?(_token), do: false
 
   defp format_granted_names([]), do: "(none)"
 

--- a/lib/ptc_runner/lisp/namespace_diagnostic.ex
+++ b/lib/ptc_runner/lisp/namespace_diagnostic.ex
@@ -59,6 +59,8 @@ defmodule PtcRunner.Lisp.NamespaceDiagnostic do
   def unknown_namespace?(_message), do: false
 
   @data_not_callable_prefix "not callable: data/"
+  @missing_data_grant_infix " is not a granted data name. Granted: "
+  @max_granted_data_names 32
 
   @doc """
   Answers whether a rendered message is a `not_callable` diagnostic for a
@@ -69,6 +71,55 @@ defmodule PtcRunner.Lisp.NamespaceDiagnostic do
     do: String.starts_with?(message, @data_not_callable_prefix)
 
   def data_not_callable?(_message), do: false
+
+  @doc """
+  Builds the strict missing-grant diagnostic for `symbol`, listing `granted`.
+
+  The list is sorted by the caller and truncated here at #{@max_granted_data_names}
+  names, so a large grant set cannot push the rejected symbol out of a bounded
+  renderer.
+  """
+  @spec missing_data_grant_message(binary(), [binary()]) :: binary()
+  def missing_data_grant_message(symbol, granted)
+      when is_binary(symbol) and is_list(granted) do
+    symbol <> @missing_data_grant_infix <> format_granted_names(granted)
+  end
+
+  @doc """
+  Answers whether a rendered message is the strict missing-grant diagnostic.
+
+  It shares a home with the message it recognizes so the two cannot drift; the
+  REPL frontend reads it to decide whether a workflow session should be told
+  which switch opens a mission. The message is matched wherever it starts,
+  because callers render it both bare and behind a `reason: ` prefix.
+  """
+  @spec missing_data_grant?(binary()) :: boolean()
+  def missing_data_grant?(message) when is_binary(message) do
+    case String.split(message, @missing_data_grant_infix, parts: 2) do
+      [rejected, _granted] -> data_symbol?(rejected |> String.split() |> List.last())
+      _no_infix -> false
+    end
+  end
+
+  def missing_data_grant?(_message), do: false
+
+  defp data_symbol?(token) when is_binary(token),
+    do: String.starts_with?(token, "data/") and byte_size(token) > byte_size("data/")
+
+  defp data_symbol?(_token), do: false
+
+  defp format_granted_names([]), do: "(none)"
+
+  defp format_granted_names(names) do
+    shown = Enum.take(names, @max_granted_data_names)
+    formatted = Enum.join(shown, ", ")
+
+    if length(names) > @max_granted_data_names do
+      formatted <> ", …"
+    else
+      formatted
+    end
+  end
 
   @doc false
   @spec rejected_namespace(binary()) :: {:ok, binary()} | :error

--- a/lib/ptc_runner/repl_frontend.ex
+++ b/lib/ptc_runner/repl_frontend.ex
@@ -1599,11 +1599,13 @@ defmodule PtcRunner.ReplFrontend do
 
   # The analyzer answers an unknown namespace with the language's own list,
   # thirty-odd entries that name no mission, because a workflow session cannot
-  # reach one. Calling `data/<name>` is `not_callable` rather than unknown
-  # namespace, because `data/` is a language namespace. Which switch would add
-  # mission names is a REPL fact rather than a language fact, so it is said
-  # here instead of in the shared diagnostic -- whose exact text is also
-  # reverse-parsed by `NamespaceDiagnostic.rejected_namespace/1`.
+  # reach one. A `data/<name>` form answers from the language instead: an
+  # ungranted name is the strict missing-grant error and a granted one called
+  # as a function is `not_callable`, because `data/` is a language namespace
+  # the workflow environment does carry. Which switch would add mission names
+  # is a REPL fact rather than a language fact, so it is said here instead of
+  # in the shared diagnostic -- whose exact text is also reverse-parsed by
+  # `NamespaceDiagnostic.rejected_namespace/1`.
   #
   # It leads, because the enumeration that follows is long enough to be
   # truncated by the one-shot renderer and is the least actionable part of the
@@ -1625,7 +1627,8 @@ defmodule PtcRunner.ReplFrontend do
 
   defp workflow_mission_hint?(message) do
     NamespaceDiagnostic.unknown_namespace?(message) or
-      NamespaceDiagnostic.data_not_callable?(message)
+      NamespaceDiagnostic.data_not_callable?(message) or
+      NamespaceDiagnostic.missing_data_grant?(message)
   end
 
   defp finish({:ok, session}, _render) do

--- a/site/reference/ptc-lisp-specification/index.html
+++ b/site/reference/ptc-lisp-specification/index.html
@@ -548,9 +548,11 @@ roll back a multi-turn run. Direct <code class="inline">PtcRunner.Lisp.run/2</co
 successful evaluation whose <code class="inline">Result.return</code> is <code class="inline">{:__ptc_fail__, value}</code>; this
 is distinct from an evaluator error returned under the outer <code class="inline">:error</code> tag.</p><p><strong>Syntax:</strong></p><pre><code class="clojure language-clojure">(fail error)</code></pre><p><strong>Semantics:</strong></p><ul><li>Immediately terminates the current program execution</li><li>The outer call to <code class="inline">PtcRunner.Lisp.run/2</code> succeeds and <code class="inline">Result.return</code> contains
 <code class="inline">{:__ptc_fail__, value}</code></li><li>Cannot be used inside <code class="inline">pmap</code> or <code class="inline">pcalls</code> (raises an error)</li></ul><pre><code class="clojure language-clojure">;; Signal failure when a required condition isn't met.
-;; Valid at the workflow boundary and in `PtcRunner.Lisp.run/2`, where a
-;; missing `data/&lt;name&gt;` is `nil`. Mission-scoped evaluation is strict: name
-;; the granted keys or let a missing grant fail instead of testing `nil?`.
+;; This tests whether the granted value is `nil`, which is a different question
+;; from whether the name was granted at all. Under the Kernel -- a workflow
+;; entry, a mission run, or either REPL -- an ungranted `data/&lt;name&gt;` is a
+;; runtime error, not `nil`, so `nil?` cannot be used to probe for one.
+;; `PtcRunner.Lisp.run/2` stays permissive and answers `nil` for both.
 (if (nil? data/input)
   (fail &quot;No input data provided&quot;)
   (process data/input))</code></pre><hr class="thin"><h2 id="6-threading-macros">6. Threading Macros</h2><p>Threading macros transform nested function calls into linear pipelines.</p><h3 id="6-1-thread-last">6.1 <code class="inline">-&gt;&gt;</code> — Thread Last</h3><p>Threads the value as the <strong>last argument</strong> to each form:</p><pre><code class="clojure language-clojure">(-&gt;&gt; value
@@ -1311,13 +1313,15 @@ query-count</code></pre><h3 id="9-3-context-access-data">9.3 Context Access — 
 data/user-id              ; get :user-id from context
 data/request-id           ; get :request-id from context</code></pre><p>Context is <strong>per-request</strong> data passed by the host. It does not persist across turns.</p><pre><code class="clojure language-clojure">(-&gt;&gt; data/expenses
      (filter (fn [e] (= (:category e) &quot;travel&quot;)))
-     (sum-by :amount))</code></pre><p>At the generic <code class="inline">PtcRunner.Lisp.run/2</code> embedding API and at the Kernel workflow
-boundary, a missing <code class="inline">data/&lt;name&gt;</code> evaluates to <code class="inline">nil</code>. Mission-scoped evaluation
-— a normal mission run and <code class="inline">ptc repl --mission</code> — is strict: a missing grant is
-a <code class="inline">:runtime_error</code> that names the rejected symbol and lists the mission's
-granted <code class="inline">data/&lt;name&gt;</code> forms. Calling a granted data value, as in
-<code class="inline">(data/tickets)</code>, is <code class="inline">:not_callable</code> and names the symbol rather than rendering
-the value.</p><p><code class="inline">data/params</code> is injected only by <code class="inline">kernel/eval-with</code> and
+     (sum-by :amount))</code></pre><p>Every Kernel boundary looks up <code class="inline">data/&lt;name&gt;</code> strictly — a workflow entry, a
+normal mission run, and both <code class="inline">ptc repl</code> session kinds. A missing grant is a
+<code class="inline">:runtime_error</code> that names the rejected symbol and lists the granted
+<code class="inline">data/&lt;name&gt;</code> forms available at that boundary. Calling a granted data value,
+as in <code class="inline">(data/tickets)</code>, is <code class="inline">:not_callable</code> and names the symbol rather than
+rendering the value. Only the generic <code class="inline">PtcRunner.Lisp.run/2</code> embedding API is
+permissive, where a missing <code class="inline">data/&lt;name&gt;</code> still evaluates to <code class="inline">nil</code>.</p><p>A manifest binds exactly one workflow name, <code class="inline">data/input</code>, from its <code class="inline">input</code>
+declaration, so a misspelled workflow reference is rejected against that single
+granted form.</p><p><code class="inline">data/params</code> is injected only by <code class="inline">kernel/eval-with</code> and
 <code class="inline">kernel/eval-source-with</code>. Referencing it when this evaluation supplied no
 params is a distinct error, not a missing-grant diagnostic. Discover granted
 names from the mission inventory (<code class="inline">:context</code> in a mission REPL), not from

--- a/site/reference/repl/index.html
+++ b/site/reference/repl/index.html
@@ -156,8 +156,10 @@ application, host configuration, and lazy environment-file paths, while
 duplicated in <code class="inline">ptc-project.json</code>. The manifest form is the equivalent low-level
 command. Omitting <code class="inline">--mission</code> keeps the workflow REPL behavior — which carries
 no mission namespaces, so a mission's own namespace is rejected as unknown.
-Calling <code class="inline">data/&lt;name&gt;</code> in that session is <code class="inline">not_callable</code> rather than an unknown
-namespace, because <code class="inline">data/</code> is a language namespace. Both answers name
+A <code class="inline">data/&lt;name&gt;</code> form in that session answers from the language rather than as
+an unknown namespace, because <code class="inline">data/</code> is a language namespace the workflow
+environment carries: an ungranted name is a missing-grant runtime error, and
+calling the granted <code class="inline">data/input</code> is <code class="inline">not_callable</code>. All three answers name
 <code class="inline">--mission</code> and list the missions the manifest declares.</p><p>A mission session starts with a fresh continuation and evaluates through the
 same strict JSON boundary as ordinary mission execution. It exposes that
 mission's components and data, but no workflow bundle, workflow capabilities,

--- a/site/reference/repl/index.html
+++ b/site/reference/repl/index.html
@@ -165,12 +165,13 @@ model route, or other missions. Only the mission's direct providers and their
 dependency closure are opened; unrelated providers do not run local checks,
 start applications, request authorization or credentials, or acquire
 resources. Dependency-only providers support the session without contributing
-task capabilities.</p><p>A mission session looks up <code class="inline">data/&lt;name&gt;</code> strictly: a granted name resolves to
+task capabilities.</p><p>Both session kinds look up <code class="inline">data/&lt;name&gt;</code> strictly: a granted name resolves to
 its value, a missing name is a runtime error that lists the granted
 <code class="inline">data/&lt;name&gt;</code> forms, and calling a granted value as in <code class="inline">(data/tickets)</code> is
-<code class="inline">not_callable</code> naming the symbol. Discover those names with <code class="inline">:context</code>. The
-workflow session and the generic embedding API keep the permissive <code class="inline">nil</code>
-default.</p><p>The interactive banner names the selected mission, components, and direct
+<code class="inline">not_callable</code> naming the symbol. A mission session grants the mission's data;
+discover those names with <code class="inline">:context</code>. A workflow session grants the single
+<code class="inline">data/input</code> the manifest declares. Only the generic embedding API,
+<code class="inline">PtcRunner.Lisp.run/2</code>, keeps the permissive <code class="inline">nil</code> default.</p><p>The interactive banner names the selected mission, components, and direct
 provider aliases. Mission sessions add one meta-command:</p><pre><code class="text language-text">:context          Show the exact frozen model context and its SHA-256 hash</code></pre><p><code class="inline">--mission</code> requires a manifest (directly or after project expansion) and
 cannot be combined with <code class="inline">--profile</code> or <code class="inline">--describe-profile</code>. An unknown name
 lists declared missions in sorted order before sinks or provider activity.</p><p>Interactive meta-commands are deliberately small:</p><pre><code class="text language-text">:help             List session commands

--- a/test/mix/tasks/ptc_repl_test.exs
+++ b/test/mix/tasks/ptc_repl_test.exs
@@ -417,6 +417,25 @@ defmodule PtcRunner.ReplFrontendTest do
   end
 
   @tag :tmp_dir
+  test "a workflow session does not hint --mission for an error that merely quotes the grant diagnostic",
+       %{tmp_dir: directory} do
+    manifest_path = write_workflow_repl_manifest(directory)
+
+    error =
+      assert_raise Mix.Error, fn ->
+        run_repl([
+          "--manifest",
+          manifest_path,
+          "-e",
+          ~S|(let [x "data/foo is not a granted data name. Granted: x"] (x))|
+        ])
+      end
+
+    assert error.message =~ "not callable:"
+    refute error.message =~ "--mission NAME"
+  end
+
+  @tag :tmp_dir
   test "a bare misspelled data name in a workflow session is rejected instead of answering nil",
        %{
          tmp_dir: directory

--- a/test/mix/tasks/ptc_repl_test.exs
+++ b/test/mix/tasks/ptc_repl_test.exs
@@ -384,19 +384,52 @@ defmodule PtcRunner.ReplFrontendTest do
   end
 
   @tag :tmp_dir
-  test "calling data/ in a workflow session still names the switch that opens a mission", %{
-    tmp_dir: directory
-  } do
+  test "calling the granted workflow input in a workflow session still names the switch that opens a mission",
+       %{tmp_dir: directory} do
     manifest_path = write_workflow_repl_manifest(directory)
 
+    error =
+      assert_raise Mix.Error, fn ->
+        run_repl(["--manifest", manifest_path, "-e", "(data/input)"])
+      end
+
+    assert error.message =~ "not callable: data/input"
+    assert error.message =~ "--mission NAME"
+    assert error.message =~ "declared: review, writing"
+  end
+
+  @tag :tmp_dir
+  test "an ungranted data name in a workflow session is rejected and still names the switch",
+       %{tmp_dir: directory} do
+    manifest_path = write_workflow_repl_manifest(directory)
+
+    # Strict workflow lookup answers before callability, so the miss -- not
+    # `not_callable` -- is what has to carry the hint.
     error =
       assert_raise Mix.Error, fn ->
         run_repl(["--manifest", manifest_path, "-e", "(data/tickets)"])
       end
 
-    assert error.message =~ "not callable: data/tickets"
+    assert error.message =~ "data/tickets is not a granted data name"
+    assert error.message =~ "Granted: data/input"
     assert error.message =~ "--mission NAME"
     assert error.message =~ "declared: review, writing"
+  end
+
+  @tag :tmp_dir
+  test "a bare misspelled data name in a workflow session is rejected instead of answering nil",
+       %{
+         tmp_dir: directory
+       } do
+    manifest_path = write_workflow_repl_manifest(directory)
+
+    error =
+      assert_raise Mix.Error, fn ->
+        run_repl(["--manifest", manifest_path, "-e", "data/inupt"])
+      end
+
+    assert error.message =~ "data/inupt is not a granted data name"
+    assert error.message =~ "Granted: data/input"
   end
 
   @tag :tmp_dir

--- a/test/ptc_runner/kernel/mission_data_resolution_test.exs
+++ b/test/ptc_runner/kernel/mission_data_resolution_test.exs
@@ -11,6 +11,7 @@ defmodule PtcRunner.Kernel.MissionDataResolutionTest do
   alias PtcRunner.Kernel.RunConfig
   alias PtcRunner.Kernel.RunState
   alias PtcRunner.Kernel.WorkflowEnvironment
+  alias PtcRunner.Lisp.DataKeys
 
   @sentinel "SECRET_TICKET_SENTINEL"
 
@@ -19,7 +20,7 @@ defmodule PtcRunner.Kernel.MissionDataResolutionTest do
     {:ok, mission} = MissionEnvironment.new(data: data)
     {:ok, inventory} = MissionInventory.build(mission, Limits.defaults())
 
-    forms = MissionInventory.source_referenceable_forms(data)
+    forms = DataKeys.source_referenceable_forms(data)
 
     rendered_forms =
       inventory.rendered |> Jason.decode!() |> Map.fetch!("data") |> Enum.map(& &1["form"])

--- a/test/ptc_runner/kernel/named_missions_diagnosis_test.exs
+++ b/test/ptc_runner/kernel/named_missions_diagnosis_test.exs
@@ -71,7 +71,7 @@ defmodule PtcRunner.Kernel.NamedMissionsDiagnosisTest do
       RunConfig.new(
         workflow_environment: workflow,
         missions: %{"default" => default_mission, "work" => work},
-        input: %{},
+        input: %{"input" => %{}},
         limits: limits,
         event_sink: sink
       )

--- a/test/ptc_runner/kernel/named_missions_e2e_test.exs
+++ b/test/ptc_runner/kernel/named_missions_e2e_test.exs
@@ -99,20 +99,8 @@ defmodule PtcRunner.Kernel.NamedMissionsE2ETest do
 
     {:ok, bundle} = shipped_loop_bundle()
 
-    {:ok, workflow} = WorkflowEnvironment.new(bundle: bundle, capabilities: [llm_capability])
-    {:ok, default_mission} = MissionEnvironment.new([])
-    {:ok, research} = MissionEnvironment.new(bundle: mission_bundle("res", @research_source))
-    {:ok, review} = MissionEnvironment.new(bundle: mission_bundle("rev", @review_source))
-    {:ok, sink} = EventSink.start(:normal, limits, run_id: "named-missions-shipped")
-
-    {:ok, config} =
-      RunConfig.new(
-        workflow_environment: workflow,
-        missions: %{"default" => default_mission, "research" => research, "review" => review},
-        input: %{},
-        limits: limits,
-        event_sink: sink
-      )
+    {:ok, config, sink} =
+      research_review_config(bundle, llm_capability, limits, "named-missions-shipped")
 
     assert {:ok, %{value: value}} = Kernel.run("(spike.shipped/run data/input)", config)
 
@@ -170,20 +158,8 @@ defmodule PtcRunner.Kernel.NamedMissionsE2ETest do
     {:ok, components} = Library.resolve_components([par, {:library, "agent.core"}])
     {:ok, bundle} = Kernel.compile_bundle(components)
 
-    {:ok, workflow} = WorkflowEnvironment.new(bundle: bundle, capabilities: [llm_capability])
-    {:ok, default_mission} = MissionEnvironment.new([])
-    {:ok, research} = MissionEnvironment.new(bundle: mission_bundle("res", @research_source))
-    {:ok, review} = MissionEnvironment.new(bundle: mission_bundle("rev", @review_source))
-    {:ok, sink} = EventSink.start(:normal, limits, run_id: "named-missions-parallel")
-
-    {:ok, config} =
-      RunConfig.new(
-        workflow_environment: workflow,
-        missions: %{"default" => default_mission, "research" => research, "review" => review},
-        input: %{},
-        limits: limits,
-        event_sink: sink
-      )
+    {:ok, config, sink} =
+      research_review_config(bundle, llm_capability, limits, "named-missions-parallel")
 
     assert {:ok, %{value: values}} = Kernel.run("(spike.par/run data/input)", config)
     assert length(values) == 4
@@ -252,5 +228,27 @@ defmodule PtcRunner.Kernel.NamedMissionsE2ETest do
       limits: limits,
       installed_limits: host.limits
     })
+  end
+
+  # Both live walks stand up the same three-mission run over their own bundle.
+  # The entry call is `(entry data/input)`, exactly what `RunBuilder` emits, so
+  # the context must bind `data/input` the way a manifest run does.
+  defp research_review_config(bundle, llm_capability, limits, run_id) do
+    {:ok, workflow} = WorkflowEnvironment.new(bundle: bundle, capabilities: [llm_capability])
+    {:ok, default_mission} = MissionEnvironment.new([])
+    {:ok, research} = MissionEnvironment.new(bundle: mission_bundle("res", @research_source))
+    {:ok, review} = MissionEnvironment.new(bundle: mission_bundle("rev", @review_source))
+    {:ok, sink} = EventSink.start(:normal, limits, run_id: run_id)
+
+    {:ok, config} =
+      RunConfig.new(
+        workflow_environment: workflow,
+        missions: %{"default" => default_mission, "research" => research, "review" => review},
+        input: %{"input" => %{}},
+        limits: limits,
+        event_sink: sink
+      )
+
+    {:ok, config, sink}
   end
 end

--- a/test/ptc_runner/kernel/named_missions_parallel_test.exs
+++ b/test/ptc_runner/kernel/named_missions_parallel_test.exs
@@ -85,7 +85,7 @@ defmodule PtcRunner.Kernel.NamedMissionsParallelTest do
       RunConfig.new(
         workflow_environment: workflow,
         missions: %{"default" => default_mission, "one" => one, "two" => two},
-        input: %{},
+        input: %{"input" => %{}},
         limits: limits,
         event_sink: sink
       )

--- a/test/ptc_runner/kernel/workflow_data_resolution_test.exs
+++ b/test/ptc_runner/kernel/workflow_data_resolution_test.exs
@@ -1,0 +1,64 @@
+defmodule PtcRunner.Kernel.WorkflowDataResolutionTest do
+  use ExUnit.Case, async: true
+
+  alias PtcRunner.Kernel
+  alias PtcRunner.Kernel.EventSink
+  alias PtcRunner.Kernel.Limits
+  alias PtcRunner.Kernel.RunConfig
+  alias PtcRunner.Kernel.WorkflowEnvironment
+  alias PtcRunner.Lisp
+
+  @sentinel "SECRET_INPUT_SENTINEL"
+
+  test "a workflow entry resolves granted input, rejects misses, and does not render called values" do
+    input = %{"tickets" => [%{"id" => @sentinel}], "orders" => []}
+
+    assert {:ok, %{value: [%{"id" => @sentinel}]}} = run_entry("(return data/tickets)", input)
+
+    assert {:error,
+            %{kind: :workflow_failed, reason: :runtime_error, details: %{message: missing}}} =
+             run_entry("(return data/nosuch)", input)
+
+    assert missing =~ "data/nosuch is not a granted data name"
+    assert missing =~ "data/orders"
+    assert missing =~ "data/tickets"
+    refute missing =~ @sentinel
+
+    assert {:error,
+            %{kind: :workflow_failed, reason: :not_callable, details: %{message: not_callable}}} =
+             run_entry("(return (data/tickets))", input)
+
+    assert not_callable =~ "not callable: data/tickets"
+    refute not_callable =~ @sentinel
+  end
+
+  test "a workflow entry names no params entry point in its missing-grant diagnostic" do
+    assert {:error, %{details: %{message: message}}} =
+             run_entry("(return data/params)", %{"tickets" => []})
+
+    assert message =~ "data/params is not a granted data name"
+    refute message =~ "kernel/eval-with"
+    refute message =~ "supplied no params"
+  end
+
+  test "the generic embedding API stays permissive" do
+    assert {:ok, %{return: nil}} = Lisp.run("data/missing")
+  end
+
+  defp run_entry(source, input) do
+    {:ok, workflow} = WorkflowEnvironment.new(bundle: nil)
+    {:ok, limits} = Limits.new()
+    {:ok, sink} = EventSink.start(:normal, limits, run_id: "workflow-data-resolution")
+
+    {:ok, config} =
+      RunConfig.new(
+        workflow_environment: workflow,
+        missions: %{},
+        input: input,
+        limits: limits,
+        event_sink: sink
+      )
+
+    Kernel.run(source, config)
+  end
+end


### PR DESCRIPTION
Closes #1602. Follows #1599, which did the same for the mission boundary.

## The bug

`ptc run`'s workflow entry and a workflow REPL session both resolved an
ungranted `data/<name>` to a silent `nil`. A workflow program reading
`data/inupt` proceeded on empty data with no diagnostic anywhere — in a paid
run. #1584 fixed this for missions and deliberately left the workflow boundary
open; this closes it.

## What changed

Strict lookup at both workflow call sites (`runner.ex`, `repl_session.ex`),
reusing what #1599 built — `:strict_data`, `:data_grants`, and the
`{:not_callable, {:data_ref, _}}` payload — unchanged.

Two consolidations, because each would otherwise have become a second copy:

- `source_referenceable_forms/1` moves `MissionInventory` → `Lisp.DataKeys`.
  It already fed both the published inventory and the mission diagnostic; the
  workflow boundary is the third consumer, and `Runner` should not reach into a
  mission-named module for workflow data.
- The missing-grant message builder moves `Eval` → `NamespaceDiagnostic`, next
  to the predicate that recognizes it, matching how that module already pairs
  `message/2` with `unknown_namespace?/1`.

A manifest binds exactly one workflow name, `data/input`
(`run_builder.ex:1118`), so a misspelled workflow reference is now rejected
against that single granted form.

## The hint regressed a second time

The workflow REPL's `--mission NAME` hint was keyed on `data_not_callable?/1`,
which only matched because a workflow session resolved `data/<name>`
permissively *before* reporting callability. Strict lookup answers first, so
the hint silently disappeared — the same navigational dead end #1584 was about,
relocated one surface over. An existing test caught it. The hint now also fires
on the missing-grant diagnostic.

## Not changed

`PtcRunner.Lisp.run/2` stays permissive. Both pins on that default still pass
(`lisp_test.exs:154`, `strict_data_test.exs:8`).

## Fixtures this surfaced

Six cases across three files paired the production entry call
`(entry data/input)` with `input: %{}`, which `RunBuilder` never does. Under
permissive lookup that mismatch was invisible. They now mirror the real
contract. Two were in `named_missions_e2e_test.exs`, which `mix test` excludes
— found by review, not by the suite.

## Verification

- Full suite: 6991 passed
- `named_missions_e2e_test.exs --include e2e`: 3 passed with a key; confirmed
  2 fail without this change
- `mix precommit` clean; duplication baseline unchanged at 43
- Pre-push: ExDoc, Dialyzer, release verification, Viewer, core tests all green

One `codex review` round was run and its three findings addressed in cc590af9.
Those fixes were verified by tests but not re-submitted for a second cold
review.

https://claude.ai/code/session_01WB1btMPazUyea9dYuVU8k4