### PR TITLE
fix(viewer): reject unknown browser routes

### DIFF
--- a/ptc_viewer/lib/ptc_viewer/router.ex
+++ b/ptc_viewer/lib/ptc_viewer/router.ex
@@ -268,8 +268,27 @@ defmodule PtcViewer.Router do
     end
   end
 
-  match _ do
+  get "/" do
     send_entry_document(conn)
+  end
+
+  get "/run/:run_id" do
+    if valid_browser_run_id?(run_id) do
+      encoded = URI.encode(run_id, &URI.char_unreserved?/1)
+
+      conn
+      |> security_headers()
+      |> put_resp_header("cache-control", "no-store")
+      |> put_resp_header("location", "/#/run/" <> encoded)
+      |> send_resp(302, "")
+      |> scrub_bandit_response()
+    else
+      send_resp(conn, 404, "Not found")
+    end
+  end
+
+  match _ do
+    send_resp(conn, 404, "Not found")
   end
 
   defp repl_store(conn) do
@@ -626,6 +645,9 @@ defmodule PtcViewer.Router do
         send_resp(conn, 404, "Not found")
     end
   end
+
+  defp valid_browser_run_id?(run_id),
+    do: is_binary(run_id) and String.valid?(run_id) and byte_size(run_id) in 1..512
 
   defp security_headers(conn) do
     conn

--- a/ptc_viewer/test/ptc_viewer/repl_router_test.exs
+++ b/ptc_viewer/test/ptc_viewer/repl_router_test.exs
@@ -184,7 +184,7 @@ defmodule PtcViewer.ReplRouterTest do
 
   test "enabled entry documents contain only the public bootstrap configuration" do
     %{opts: opts} = start_repl()
-    html = conn(:get, "/anything") |> call_router(opts)
+    html = conn(:get, "/") |> call_router(opts)
 
     assert html.status == 200
     assert html.resp_body =~ "ptc-viewer-config"

--- a/ptc_viewer/test/ptc_viewer/router_test.exs
+++ b/ptc_viewer/test/ptc_viewer/router_test.exs
@@ -23,6 +23,39 @@ defmodule PtcViewer.RouterTest do
     assert conn.resp_body =~ "Canonical Kernel TraceLog transcript view"
   end
 
+  test "entry, run handoff, and unknown browser paths have distinct HTTP semantics", %{
+    router_opts: router_opts
+  } do
+    entry = conn(:get, "/") |> call_router(router_opts)
+    assert entry.status == 200
+    assert entry.resp_body =~ "ptc-viewer-config"
+
+    handoff = conn(:get, "/run/run%3Aone") |> call_router(router_opts)
+    assert handoff.status == 302
+    assert get_resp_header(handoff, "location") == ["/#/run/run%3Aone"]
+    refute handoff.resp_body =~ "ptc-viewer-config"
+
+    for request <- [
+          conn(:get, "/runs"),
+          conn(:get, "/runs/does-not-exist"),
+          conn(:get, "/totally/made/up"),
+          conn(:post, "/totally/made/up", "")
+        ] do
+      response = call_router(request, router_opts)
+      assert response.status == 404
+      assert response.resp_body == "Not found"
+      refute response.resp_body =~ "ptc-viewer-config"
+    end
+  end
+
+  test "path-form run handoff enforces the Viewer run ID bound", %{router_opts: router_opts} do
+    oversized = String.duplicate("a", 513)
+    response = conn(:get, "/run/#{oversized}") |> call_router(router_opts)
+
+    assert response.status == 404
+    assert response.resp_body == "Not found"
+  end
+
   test "GET /api/kernel/runs uses the shared host query adapter", %{trace_dir: trace_dir} do
     adapter = fn _source, operation, arguments ->
       {:ok, %{"operation" => Atom.to_string(operation), "arguments" => arguments}}


### PR DESCRIPTION
## Summary

- serve the Viewer SPA entry document only at `GET /`
- redirect `GET /run/:run_id` to the fragment route with bounded UTF-8 validation and percent-encoding
- return a fixed 404 for unknown browser paths and methods

## Verification

- Viewer suite: 117 tests passed
- root core suite: 6,991 tests passed
- warnings-as-errors, precommit, Dialyzer, docs, release, and Viewer pre-push gates passed
- independent Codex review: 1 clean pass (maximum allowed: 2)

Closes #1611