### PR TITLE
docs(example): budget multi-turn tutorial clocks

### DIFF
--- a/docs/guides/building-agents.md
+++ b/docs/guides/building-agents.md
@@ -41,6 +41,20 @@ each mission program the model produces. Configure the loop
 through its documented options and keep the mission tool surface smaller than
 the workflow surface.
 
+## Budget turns and time separately
+
+`max_turns` bounds the agent protocol: it limits how many model-and-program
+turns the loop may attempt. It does not reserve enough elapsed time to finish
+those turns. The complete run, including active preflight, every provider wait,
+and the loop, must fit inside `limits.run_duration_ms`; the workflow evaluation
+that owns the loop must also fit inside `limits.workflow_timeout_ms`.
+
+For a live agent, request explicit values for both Kernel clocks based on the
+expected turn count and model latency. Raising only `run_duration_ms` leaves
+the workflow clock as a separate boundary. The multi-turn tutorial requests
+120 seconds for each clock as a bounded teaching allowance, not a guarantee
+that the provider will complete in that time.
+
 ## Replace policy without replacing enforcement
 
 The Kernel owns capabilities, limits, evaluation, cleanup, and evidence. Agent

--- a/examples/kernel-tutorial/04-multi-turn-agent/ptc.json
+++ b/examples/kernel-tutorial/04-multi-turn-agent/ptc.json
@@ -12,6 +12,10 @@
       "task": "Complete this task in exactly two run_ptc_lisp calls. First call run_ptc_lisp with the program (defn answer [] 42) and do not call return or fail. After the success observation, call run_ptc_lisp with the program (return (answer))."
     }
   },
+  "limits": {
+    "run_duration_ms": 120000,
+    "workflow_timeout_ms": 120000
+  },
   "providers": {
     "workflow": [
       {"name": "deepseek"}

--- a/examples/kernel-tutorial/README.md
+++ b/examples/kernel-tutorial/README.md
@@ -31,6 +31,13 @@ model alias. Follow `ptc docs quickstart` once before running them. Example 03
 launches `ptc-fs-mcp@0.1.0` through `npx`; the first run may download that
 package. Node.js and `npx` are required.
 
+Example 04 requests explicit 120-second `run_duration_ms` and
+`workflow_timeout_ms` limits for its live, two-turn model loop. Its
+`max_turns` setting bounds the agent protocol; it is not a time allowance.
+Every turn and provider wait must also finish within both Kernel clocks.
+Applications should choose an explicit bounded allowance for their expected
+turn count and model latency; this tutorial value is not a completion guarantee.
+
 Direct manifest invocation with explicit `--env-file` and `--host-config`
 switches remains available as the low-level automation form.
 

--- a/site/guides/building-agents/index.html
+++ b/site/guides/building-agents/index.html
@@ -111,7 +111,15 @@ access to it.</p><h2 id="start-with-the-shipped-loop">Start with the shipped loo
   (agent.core/run (get input &quot;task&quot;) {&quot;max_turns&quot; 6}))</code></pre><p>Normally, generate this scaffold or start from an example. You do not write
 each mission program the model produces. Configure the loop
 through its documented options and keep the mission tool surface smaller than
-the workflow surface.</p><h2 id="replace-policy-without-replacing-enforcement">Replace policy without replacing enforcement</h2><p>The Kernel owns capabilities, limits, evaluation, cleanup, and evidence. Agent
+the workflow surface.</p><h2 id="budget-turns-and-time-separately">Budget turns and time separately</h2><p><code class="inline">max_turns</code> bounds the agent protocol: it limits how many model-and-program
+turns the loop may attempt. It does not reserve enough elapsed time to finish
+those turns. The complete run, including active preflight, every provider wait,
+and the loop, must fit inside <code class="inline">limits.run_duration_ms</code>; the workflow evaluation
+that owns the loop must also fit inside <code class="inline">limits.workflow_timeout_ms</code>.</p><p>For a live agent, request explicit values for both Kernel clocks based on the
+expected turn count and model latency. Raising only <code class="inline">run_duration_ms</code> leaves
+the workflow clock as a separate boundary. The multi-turn tutorial requests
+120 seconds for each clock as a bounded teaching allowance, not a guarantee
+that the provider will complete in that time.</p><h2 id="replace-policy-without-replacing-enforcement">Replace policy without replacing enforcement</h2><p>The Kernel owns capabilities, limits, evaluation, cleanup, and evidence. Agent
 behavior lives in ordinary replaceable components. After the default loop works,
 an application may introduce new component IDs for:</p><ul><li>system and correction prompts;</li><li>feedback formatting;</li><li>retry and continuation policy;</li><li>completion and failure rules;</li><li>specialist routing; or</li><li>a complete alternative loop.</li></ul><p>Changing those components cannot grant a new model, tool, credential, endpoint,
 or higher limit. <code class="inline">ptc.json</code> can still select only what <code class="inline">ptc-host.json</code> makes

--- a/test/ptc_runner/kernel/example_library_test.exs
+++ b/test/ptc_runner/kernel/example_library_test.exs
@@ -23,6 +23,17 @@ defmodule PtcRunner.Kernel.ExampleLibraryTest do
     end
   end
 
+  test "the materializable multi-turn tutorial carries its explicit run clocks" do
+    assert {:ok, files} = ExampleLibrary.fetch("kernel-tutorial")
+
+    manifest = files["04-multi-turn-agent/ptc.json"] |> Jason.decode!()
+
+    assert manifest["limits"] == %{
+             "run_duration_ms" => 120_000,
+             "workflow_timeout_ms" => 120_000
+           }
+  end
+
   test "run artifacts are not embedded and local .env files are not copied from the source tree" do
     for name <- ExampleLibrary.names(),
         {:ok, files} = ExampleLibrary.fetch(name),

--- a/test/ptc_runner/kernel/tutorial_examples_contract_test.exs
+++ b/test/ptc_runner/kernel/tutorial_examples_contract_test.exs
@@ -30,6 +30,15 @@ defmodule PtcRunner.Kernel.TutorialExamplesContractTest do
     end
   end
 
+  test "the multi-turn tutorial declares both Kernel run clocks" do
+    manifest = decode!(Path.join([@examples, "04-multi-turn-agent", "ptc.json"]))
+
+    assert manifest["limits"] == %{
+             "run_duration_ms" => 120_000,
+             "workflow_timeout_ms" => 120_000
+           }
+  end
+
   test "support-triage labels report the model installed by the host" do
     model =
       @support_triage

--- a/test/ptc_runner/kernel/tutorial_examples_test.exs
+++ b/test/ptc_runner/kernel/tutorial_examples_test.exs
@@ -40,6 +40,13 @@ defmodule PtcRunner.Kernel.TutorialExamplesTest do
     for example <- ["02-deepseek-extract", "03-file-agent", "04-multi-turn-agent"] do
       assert {:ok, manifest} = Manifest.load(path(example))
       assert manifest.entry =~ "/"
+
+      if example == "04-multi-turn-agent" do
+        assert manifest.limits.run_duration_ms == 120_000
+        assert manifest.limits.workflow_timeout_ms == 120_000
+        assert manifest.limits.run_duration_ms < manifest.installed_limits.run_duration_ms
+        assert manifest.limits.workflow_timeout_ms < manifest.installed_limits.workflow_timeout_ms
+      end
     end
   end
 


### PR DESCRIPTION
## Summary

- give the live multi-turn tutorial explicit 120-second run and workflow clocks
- explain that `max_turns` is a protocol bound rather than a time allowance
- pin checked-in, parsed-effective, and materialized example contracts

## Verification

- focused example and docs tests: 39 passed
- root core suite: 6,993 tests passed
- ExDoc, generated-doc staleness, precommit, static/Dialyzer, release, and Viewer gates passed
- independent Codex review: 1 clean pass (maximum allowed: 2)

Closes #1610