### PR TITLE
fix(repl): preserve classified setup diagnostics

### DIFF
--- a/lib/ptc_runner/kernel/command_diagnostic_renderer.ex
+++ b/lib/ptc_runner/kernel/command_diagnostic_renderer.ex
@@ -1,0 +1,191 @@
+defmodule PtcRunner.Kernel.CommandDiagnosticRenderer do
+  @moduledoc false
+
+  alias PtcRunner.Kernel.CommandDiagnostic
+  alias PtcRunner.Kernel.CommandOutcome
+  alias PtcRunner.Kernel.CommandRunRef
+
+  @pointer_pattern ~r/\A\/[A-Za-z0-9._~\/-]+\z/
+  @source_name_pattern ~r/\A[A-Za-z0-9._~-][A-Za-z0-9._~\/-]*\z/
+
+  @spec render(CommandDiagnostic.t()) :: {:ok, binary()} | {:error, :invalid_command_diagnostic}
+  def render(%CommandDiagnostic{} = diagnostic) do
+    if CommandDiagnostic.valid?(diagnostic),
+      do: {:ok, render_map(CommandDiagnostic.to_map(diagnostic), nil)},
+      else: {:error, :invalid_command_diagnostic}
+  end
+
+  def render(_diagnostic), do: {:error, :invalid_command_diagnostic}
+
+  @doc false
+  @spec render_with_run_ref(CommandDiagnostic.t() | CommandOutcome.t(), binary()) ::
+          {:ok, binary()} | {:error, :invalid_command_diagnostic}
+  def render_with_run_ref(%CommandDiagnostic{} = diagnostic, run_ref) do
+    if CommandDiagnostic.valid?(diagnostic) and CommandRunRef.valid?(run_ref),
+      do: {:ok, render_map(CommandDiagnostic.to_map(diagnostic), run_ref)},
+      else: {:error, :invalid_command_diagnostic}
+  end
+
+  def render_with_run_ref(%CommandOutcome{} = outcome, run_ref) do
+    with true <- CommandOutcome.valid?(outcome),
+         true <- CommandRunRef.valid?(run_ref),
+         %{"error" => error} <- CommandOutcome.to_map(outcome) do
+      {:ok, render_map(error, run_ref)}
+    else
+      _invalid -> {:error, :invalid_command_diagnostic}
+    end
+  end
+
+  def render_with_run_ref(_diagnostic, _run_ref),
+    do: {:error, :invalid_command_diagnostic}
+
+  defp render_map(error, run_ref) do
+    base =
+      "#{error["phase"]}/#{error["code"]}: " <>
+        subject_prefix(error["subject"]) <>
+        error["message"] <>
+        location_suffix(error)
+
+    run_ref_suffix = if run_ref, do: " (run_ref: #{run_ref})", else: ""
+    base <> run_ref_suffix <> diagnostic_suffix(error)
+  end
+
+  defp diagnostic_suffix(%{
+         "phase" => "active_preflight",
+         "code" => "credential_unavailable",
+         "subject" => %{"operation" => "credentials"}
+       }),
+       do: "; export it, pass --env-file PATH, or use a host file credential"
+
+  defp diagnostic_suffix(_error), do: ""
+
+  defp location_suffix(%{
+         "phase" => "project",
+         "code" => "project_schema_invalid",
+         "source" => %{"kind" => "project"},
+         "path" => path
+       })
+       when is_binary(path) and path != "",
+       do: " at " <> path
+
+  defp location_suffix(%{
+         "phase" => "project",
+         "code" => "project_schema_invalid",
+         "source" => %{"kind" => "project"},
+         "path" => ""
+       }),
+       do: " at document root"
+
+  defp location_suffix(%{
+         "phase" => "application",
+         "code" => code,
+         "source" => %{"kind" => "application"},
+         "path" => path
+       })
+       when code in ["schema_violation", "required_property_missing"] and is_binary(path) and
+              path != "",
+       do: " at " <> path
+
+  defp location_suffix(%{
+         "phase" => "application",
+         "code" => code,
+         "source" => %{"kind" => "application"},
+         "path" => ""
+       })
+       when code in ["schema_violation", "required_property_missing"],
+       do: " at document root"
+
+  defp location_suffix(%{
+         "phase" => "host",
+         "code" => "host_schema_invalid",
+         "source" => %{"kind" => "host"},
+         "path" => path
+       })
+       when is_binary(path) and path != "",
+       do: " at " <> path
+
+  defp location_suffix(%{
+         "phase" => "host",
+         "code" => "host_schema_invalid",
+         "source" => %{"kind" => "host"},
+         "path" => ""
+       }),
+       do: " at document root"
+
+  defp location_suffix(%{
+         "phase" => "bundle",
+         "source" => %{"kind" => "component", "name" => name},
+         "span" => %{"start_byte" => start_byte, "end_byte" => end_byte}
+       })
+       when is_binary(name) and is_integer(start_byte) and is_integer(end_byte),
+       do: " at #{name} bytes [#{start_byte},#{end_byte})"
+
+  defp location_suffix(%{
+         "phase" => "application",
+         "code" => "input_contract_failed",
+         "source" => %{"kind" => kind},
+         "path" => path
+       })
+       when kind in ["application", "external_input", "input_contract"] and
+              is_binary(path) and path != "",
+       do: " at " <> terminal_contract_path(path)
+
+  defp location_suffix(%{
+         "phase" => "result_cleanup",
+         "code" => "result_contract_failed",
+         "source" => %{"kind" => "result_contract"},
+         "path" => path
+       })
+       when is_binary(path) and path != "",
+       do: " at " <> terminal_contract_path(path)
+
+  defp location_suffix(%{
+         "phase" => "application",
+         "code" => "contract_invalid",
+         "source" => %{"kind" => kind, "name" => name},
+         "path" => path
+       })
+       when kind in ["input_contract", "result_contract"] and is_binary(name) and
+              is_binary(path) and path != "",
+       do: " at #{terminal_contract_path(path)} in #{terminal_source_name(name)}"
+
+  defp location_suffix(%{
+         "phase" => "application",
+         "code" => "override_invalid",
+         "source" => %{"kind" => "component_override"},
+         "path" => path
+       })
+       when is_binary(path) and path != "",
+       do: " at " <> path
+
+  defp location_suffix(_error), do: ""
+
+  defp terminal_contract_path(path), do: terminal_literal(path, @pointer_pattern)
+
+  defp terminal_source_name(name), do: terminal_literal(name, @source_name_pattern)
+
+  defp terminal_literal(text, pattern) do
+    case text =~ pattern do
+      true -> text
+      false -> inspect(text, binaries: :as_strings, limit: :infinity, printable_limit: :infinity)
+    end
+  end
+
+  defp subject_prefix(%{
+         "kind" => "provider",
+         "name" => name,
+         "operation" => operation,
+         "occurrence" => nil
+       }),
+       do: "provider/#{name}/#{operation}: "
+
+  defp subject_prefix(%{
+         "kind" => "provider",
+         "name" => name,
+         "operation" => operation,
+         "occurrence" => %{"destination" => destination, "index" => index}
+       }),
+       do: "provider/#{name}/#{operation} at #{destination}[#{index}]: "
+
+  defp subject_prefix(nil), do: ""
+end

--- a/lib/ptc_runner/kernel/command_renderer.ex
+++ b/lib/ptc_runner/kernel/command_renderer.ex
@@ -18,14 +18,13 @@ defmodule PtcRunner.Kernel.CommandRenderer do
   """
 
   alias PtcRunner.Kernel.CommandDeclaration
+  alias PtcRunner.Kernel.CommandDiagnostic
+  alias PtcRunner.Kernel.CommandDiagnosticRenderer
   alias PtcRunner.Kernel.CommandOutcome
   alias PtcRunner.Kernel.CommandRejection
   alias PtcRunner.Kernel.CommandRunRef
   alias PtcRunner.Kernel.DeterministicJSON
   alias PtcRunner.Kernel.DiagnosticCatalog
-
-  @pointer_pattern ~r/\A\/[A-Za-z0-9._~\/-]+\z/
-  @source_name_pattern ~r/\A[A-Za-z0-9._~-][A-Za-z0-9._~\/-]*\z/
 
   @spec render(CommandOutcome.t(), CommandRejection.t() | nil) ::
           {:stdout | :stderr, binary()}
@@ -68,8 +67,8 @@ defmodule PtcRunner.Kernel.CommandRenderer do
       } ->
         {:stdout, json_line(result)}
 
-      %{"status" => "error", "error" => error, "run_ref" => run_ref} ->
-        {:stderr, failure_line(error, run_ref, rejection)}
+      %{"status" => "error", "run_ref" => run_ref} ->
+        {:stderr, failure_line(outcome, run_ref, rejection)}
     end
   rescue
     _exception ->
@@ -112,170 +111,14 @@ defmodule PtcRunner.Kernel.CommandRenderer do
   @spec rejection(binary(), CommandRejection.t()) :: binary()
   def rejection(run_ref, %CommandRejection{} = rejection) do
     row = DiagnosticCatalog.fetch!(:arguments, rejection.code)
-
-    failure_line(
-      %{
-        "phase" => "arguments",
-        "code" => Atom.to_string(rejection.code),
-        "message" => row.message
-      },
-      run_ref,
-      rejection
-    )
+    diagnostic = CommandDiagnostic.new!(:arguments, rejection.code, message: row.message)
+    failure_line(diagnostic, run_ref, rejection)
   end
 
-  defp failure_line(error, run_ref, rejection) do
-    base =
-      "error: #{error["phase"]}/#{error["code"]}: " <>
-        subject_prefix(error["subject"]) <>
-        error["message"] <>
-        location_suffix(error) <>
-        "(run_ref: #{run_ref})"
-
-    base <> diagnostic_suffix(error) <> rejection_suffix(rejection) <> "\n"
+  defp failure_line(diagnostic, run_ref, rejection) do
+    {:ok, rendered} = CommandDiagnosticRenderer.render_with_run_ref(diagnostic, run_ref)
+    "error: " <> rendered <> rejection_suffix(rejection) <> "\n"
   end
-
-  defp diagnostic_suffix(%{
-         "phase" => "active_preflight",
-         "code" => "credential_unavailable",
-         "subject" => %{"operation" => "credentials"}
-       }),
-       do: "; export it, pass --env-file PATH, or use a host file credential"
-
-  defp diagnostic_suffix(_error), do: ""
-
-  defp location_suffix(%{
-         "phase" => "project",
-         "code" => "project_schema_invalid",
-         "source" => %{"kind" => "project"},
-         "path" => path
-       })
-       when is_binary(path) and path != "",
-       do: " at " <> path <> " "
-
-  defp location_suffix(%{
-         "phase" => "project",
-         "code" => "project_schema_invalid",
-         "source" => %{"kind" => "project"},
-         "path" => ""
-       }),
-       do: " at document root "
-
-  defp location_suffix(%{
-         "phase" => "application",
-         "code" => code,
-         "source" => %{"kind" => "application"},
-         "path" => path
-       })
-       when code in ["schema_violation", "required_property_missing"] and is_binary(path) and
-              path != "",
-       do: " at " <> path <> " "
-
-  defp location_suffix(%{
-         "phase" => "application",
-         "code" => code,
-         "source" => %{"kind" => "application"},
-         "path" => ""
-       })
-       when code in ["schema_violation", "required_property_missing"],
-       do: " at document root "
-
-  defp location_suffix(%{
-         "phase" => "host",
-         "code" => "host_schema_invalid",
-         "source" => %{"kind" => "host"},
-         "path" => path
-       })
-       when is_binary(path) and path != "",
-       do: " at " <> path <> " "
-
-  defp location_suffix(%{
-         "phase" => "host",
-         "code" => "host_schema_invalid",
-         "source" => %{"kind" => "host"},
-         "path" => ""
-       }),
-       do: " at document root "
-
-  defp location_suffix(%{
-         "phase" => "bundle",
-         "source" => %{"kind" => "component", "name" => name},
-         "span" => %{"start_byte" => start_byte, "end_byte" => end_byte}
-       })
-       when is_binary(name) and is_integer(start_byte) and is_integer(end_byte),
-       do: " at #{name} bytes [#{start_byte},#{end_byte}) "
-
-  defp location_suffix(%{
-         "phase" => "application",
-         "code" => "input_contract_failed",
-         "source" => %{"kind" => kind},
-         "path" => path
-       })
-       when kind in ["application", "external_input", "input_contract"] and
-              is_binary(path) and path != "",
-       do: " at " <> terminal_contract_path(path) <> " "
-
-  defp location_suffix(%{
-         "phase" => "result_cleanup",
-         "code" => "result_contract_failed",
-         "source" => %{"kind" => "result_contract"},
-         "path" => path
-       })
-       when is_binary(path) and path != "",
-       do: " at " <> terminal_contract_path(path) <> " "
-
-  # A rejected contract schema is located inside a document the author opens,
-  # and a manifest may carry two of them, so the pointer is meaningless without
-  # the file it indexes.
-  defp location_suffix(%{
-         "phase" => "application",
-         "code" => "contract_invalid",
-         "source" => %{"kind" => kind, "name" => name},
-         "path" => path
-       })
-       when kind in ["input_contract", "result_contract"] and is_binary(name) and
-              is_binary(path) and path != "",
-       do: " at #{terminal_contract_path(path)} in #{terminal_source_name(name)} "
-
-  defp location_suffix(%{
-         "phase" => "application",
-         "code" => "override_invalid",
-         "source" => %{"kind" => "component_override"},
-         "path" => path
-       })
-       when is_binary(path) and path != "",
-       do: " at " <> path <> " "
-
-  defp location_suffix(_error), do: " "
-
-  defp terminal_contract_path(path), do: terminal_literal(path, @pointer_pattern)
-
-  defp terminal_source_name(name), do: terminal_literal(name, @source_name_pattern)
-
-  defp terminal_literal(text, pattern) do
-    case text =~ pattern do
-      true -> text
-      false -> inspect(text, binaries: :as_strings, limit: :infinity, printable_limit: :infinity)
-    end
-  end
-
-  defp subject_prefix(%{
-         "kind" => "provider",
-         "name" => name,
-         "operation" => operation,
-         "occurrence" => nil
-       }),
-       do: "provider/#{name}/#{operation}: "
-
-  defp subject_prefix(%{
-         "kind" => "provider",
-         "name" => name,
-         "operation" => operation,
-         "occurrence" => %{"destination" => destination, "index" => index}
-       }),
-       do: "provider/#{name}/#{operation} at #{destination}[#{index}]: "
-
-  defp subject_prefix(nil), do: ""
 
   defp rejection_suffix(%CommandRejection{kind: :unknown_switch, accepted: accepted}),
     do: "; unknown switch; accepted: " <> Enum.join(accepted, ", ")

--- a/lib/ptc_runner/kernel/manifest_repl.ex
+++ b/lib/ptc_runner/kernel/manifest_repl.ex
@@ -48,6 +48,7 @@ defmodule PtcRunner.Kernel.ManifestRepl do
   @type failure :: %{
           required(:code) => atom(),
           required(:provider_activity) => boolean(),
+          optional(:diagnostic) => CommandDiagnostic.t(),
           optional(:declared) => [binary()]
         }
 
@@ -208,7 +209,7 @@ defmodule PtcRunner.Kernel.ManifestRepl do
   end
 
   defp maybe_setup_environment(%{environment_setup_required: true}, runtime, :workflow),
-    do: CommandRuntime.setup_environment(runtime)
+    do: CommandRuntime.setup_environment_diagnostic(runtime)
 
   defp maybe_setup_environment(
          %{environment_setup_aliases: aliases},
@@ -216,14 +217,23 @@ defmodule PtcRunner.Kernel.ManifestRepl do
          %MissionReplTarget{} = target
        ) do
     if Enum.any?(target.aliases, &(&1 in aliases)),
-      do: CommandRuntime.setup_environment(runtime),
+      do: CommandRuntime.setup_environment_diagnostic(runtime),
       else: :ok
   end
 
   defp maybe_setup_environment(_preparation, _runtime, _target), do: :ok
 
-  defp failure(%CommandDiagnostic{} = diagnostic, _activity),
-    do: %{code: diagnostic.code, provider_activity: diagnostic.provider_activity}
+  defp failure(%CommandDiagnostic{} = diagnostic, activity) do
+    if CommandDiagnostic.valid?(diagnostic) do
+      %{
+        code: diagnostic.code,
+        diagnostic: diagnostic,
+        provider_activity: diagnostic.provider_activity
+      }
+    else
+      %{code: :invalid_manifest_repl, provider_activity: activity == true}
+    end
+  end
 
   defp failure(reason, activity) when is_atom(reason),
     do: %{code: reason, provider_activity: activity == true}

--- a/lib/ptc_runner/repl_frontend.ex
+++ b/lib/ptc_runner/repl_frontend.ex
@@ -101,6 +101,7 @@ defmodule PtcRunner.ReplFrontend do
   alias PtcRunner.Kernel.AnalysisSessionBuilder
   alias PtcRunner.Kernel.AnalysisTerminal
   alias PtcRunner.Kernel.CommandArguments
+  alias PtcRunner.Kernel.CommandDiagnosticRenderer
   alias PtcRunner.Kernel.CommandRuntime
   alias PtcRunner.Kernel.DeterministicJSON
   alias PtcRunner.Kernel.DirectorySeparation
@@ -1282,6 +1283,12 @@ defmodule PtcRunner.ReplFrontend do
     else
       {:error, %{code: :unknown_mission, declared: declared}} ->
         fail("unknown mission #{inspect(opts[:mission])}; declared: #{Enum.join(declared, ", ")}")
+
+      {:error, %{code: code, diagnostic: diagnostic}} ->
+        case CommandDiagnosticRenderer.render(diagnostic) do
+          {:ok, rendered} -> fail(rendered)
+          {:error, :invalid_command_diagnostic} -> fail(manifest_repl_error(code))
+        end
 
       {:error, %{code: code}} ->
         fail(manifest_repl_error(code))

--- a/test/mix/tasks/ptc_repl_test.exs
+++ b/test/mix/tasks/ptc_repl_test.exs
@@ -698,6 +698,39 @@ defmodule PtcRunner.ReplFrontendTest do
   end
 
   @tag :tmp_dir
+  test "a missing provider credential retains the run diagnostic and remedy", %{
+    tmp_dir: directory
+  } do
+    {manifest_path, host_path} = write_missing_credential_repl(directory)
+
+    for {mission_args, expected_subject} <- [
+          {[], "alpha"},
+          {["--mission", "review"], "workspace-alpha"}
+        ] do
+      error =
+        assert_raise Mix.Error, fn ->
+          run_repl(
+            [
+              "--manifest",
+              manifest_path,
+              "--host-config",
+              host_path,
+              "-e",
+              "(+ 1 2)"
+            ] ++ mission_args
+          )
+        end
+
+      assert error.message =~
+               "error: repl/command_failed: active_preflight/credential_unavailable: " <>
+                 "provider/#{expected_subject}/credentials: a required provider credential is unavailable; " <>
+                 "export it, pass --env-file PATH, or use a host file credential"
+
+      refute error.message =~ "PTC_REPL_ABSENT"
+    end
+  end
+
+  @tag :tmp_dir
   test "a private manifest rejects eval before authorizing its trace", %{tmp_dir: directory} do
     component_path = Path.join(directory, "helpers.clj")
     manifest_path = Path.join(directory, "private.json")
@@ -1883,6 +1916,85 @@ defmodule PtcRunner.ReplFrontendTest do
     )
 
     manifest_path
+  end
+
+  defp write_missing_credential_repl(directory) do
+    File.write!(Path.join(directory, "credential-main.clj"), "(ns app) (defn run [x] (return x))")
+    File.write!(Path.join(directory, "credential-review.clj"), "(ns review)")
+    manifest_path = Path.join(directory, "credential-repl.json")
+    host_path = Path.join(directory, "credential-repl-host.json")
+
+    workflow_declarations = [
+      %{"name" => "alpha"},
+      %{"name" => "omega"}
+    ]
+
+    mission_declarations = [
+      %{"name" => "workspace-alpha"},
+      %{"name" => "workspace-omega"}
+    ]
+
+    File.write!(
+      manifest_path,
+      Jason.encode!(%{
+        "version" => 1,
+        "workflow" => %{
+          "components" => [%{"id" => "app", "path" => "credential-main.clj"}],
+          "entry" => "app/run"
+        },
+        "missions" => %{
+          "review" => %{
+            "components" => [%{"id" => "review", "path" => "credential-review.clj"}],
+            "providers" => ["workspace-alpha", "workspace-omega"]
+          }
+        },
+        "input" => %{"value" => %{}},
+        "providers" => %{
+          "workflow" => workflow_declarations,
+          "mission" => mission_declarations
+        }
+      })
+    )
+
+    File.write!(
+      host_path,
+      Jason.encode!(%{
+        "credentials" => %{
+          "alpha-key" => %{"env" => "PTC_REPL_ABSENT_ALPHA_KEY"},
+          "omega-key" => %{"env" => "PTC_REPL_ABSENT_OMEGA_KEY"}
+        },
+        "install" => %{
+          "alpha" => repl_llm_installation("alpha-key"),
+          "omega" => repl_llm_installation("omega-key"),
+          "workspace-alpha" => repl_mcp_installation("alpha-key"),
+          "workspace-omega" => repl_mcp_installation("omega-key")
+        }
+      })
+    )
+
+    {manifest_path, host_path}
+  end
+
+  defp repl_llm_installation(credential) do
+    %{
+      "source" => "llm",
+      "installation_revision" => "repl-missing-credential-v1",
+      "model" => "openrouter:test/model",
+      "credential" => credential
+    }
+  end
+
+  defp repl_mcp_installation(credential) do
+    %{
+      "source" => "mcp",
+      "installation_revision" => "repl-missing-credential-v1",
+      "transport" => %{
+        "type" => "stdio",
+        "command" => System.find_executable("sh"),
+        "env" => %{"TOKEN" => %{"binding" => credential}}
+      },
+      "tools" => %{"read" => %{"as" => "#{credential}.read", "effect" => "read"}}
+    }
   end
 
   # ex_dna:disable-for-next-line — boundary test keeps its trace fixture local and explicit

--- a/test/ptc_runner/kernel/command_frontend_test.exs
+++ b/test/ptc_runner/kernel/command_frontend_test.exs
@@ -3,6 +3,7 @@ defmodule PtcRunner.Kernel.CommandFrontendTest do
 
   alias PtcRunner.Kernel.CommandContract
   alias PtcRunner.Kernel.CommandDiagnostic
+  alias PtcRunner.Kernel.CommandDiagnosticRenderer
   alias PtcRunner.Kernel.CommandEngine
   alias PtcRunner.Kernel.CommandEntry
   alias PtcRunner.Kernel.CommandFrontend
@@ -949,6 +950,27 @@ defmodule PtcRunner.Kernel.CommandFrontendTest do
               "error: active_preflight/credential_unavailable: " <>
                 "provider/deepseek/credentials: a required provider credential is unavailable " <>
                 "(run_ref: #{@run_ref}); export it, pass --env-file PATH, or use a host file credential\n"}
+
+    assert CommandDiagnosticRenderer.render(credential_outcome.envelope["error"]) ==
+             {:error, :invalid_command_diagnostic}
+
+    credential_diagnostic =
+      CommandDiagnostic.new!(:active_preflight, :credential_unavailable,
+        subject: credential_subject
+      )
+
+    assert CommandDiagnosticRenderer.render(credential_diagnostic) ==
+             {:ok,
+              "active_preflight/credential_unavailable: " <>
+                "provider/deepseek/credentials: a required provider credential is unavailable; " <>
+                "export it, pass --env-file PATH, or use a host file credential"}
+
+    refute CommandDiagnostic.valid?(%{credential_diagnostic | message: "PRIVATE credential name"})
+
+    assert CommandDiagnosticRenderer.render(%{
+             credential_diagnostic
+             | message: "PRIVATE credential name"
+           }) == {:error, :invalid_command_diagnostic}
 
     {:ok, selection_subject} =
       CommandSubject.provider("workspace", :selection, %{destination: :mission, index: 2})

--- a/test/ptc_runner/kernel/manifest_repl_test.exs
+++ b/test/ptc_runner/kernel/manifest_repl_test.exs
@@ -545,6 +545,47 @@ defmodule PtcRunner.Kernel.ManifestReplTest do
   end
 
   @tag :tmp_dir
+  test "workflow and mission openings retain the sealed credential diagnostic", %{
+    tmp_dir: directory
+  } do
+    configure_host_llm()
+
+    for {policy, private_opts} <- [
+          {:normal, []},
+          {:private, [private_terminal: true]}
+        ],
+        target <- [:workflow, {:mission, "review"}] do
+      {manifest, host} = write_missing_credential_application(directory, policy, target)
+      mission_opts = if target == :workflow, do: [], else: [mission: elem(target, 1)]
+      owners_before = provider_activity_owners()
+
+      assert {:error,
+              %{
+                code: :credential_unavailable,
+                diagnostic: %CommandDiagnostic{} = diagnostic,
+                provider_activity: false
+              }} =
+               ManifestRepl.open(
+                 manifest,
+                 host,
+                 [input_mode: :interactive, terminal_attached: true] ++
+                   private_opts ++ mission_opts
+               )
+
+      assert CommandDiagnostic.valid?(diagnostic)
+      assert diagnostic.phase == :active_preflight
+      assert diagnostic.subject.name == "alpha"
+      assert diagnostic.subject.operation == :credentials
+      refute_received {:host_llm_ensure_ready, _worker}
+      refute_received {:host_llm_request, _model, _request}
+
+      assert_eventually(fn ->
+        MapSet.difference(provider_activity_owners(), owners_before) == MapSet.new()
+      end)
+    end
+  end
+
+  @tag :tmp_dir
   test "killing an adopted session owner also terminates its run state", %{tmp_dir: directory} do
     manifest = write_provider_free_application(directory, :normal)
     trace_path = Path.join(directory, "killed-owner.jsonl")
@@ -652,9 +693,10 @@ defmodule PtcRunner.Kernel.ManifestReplTest do
 
     assert_receive {:manifest_repl_result, {:error, failure}}, 5_000
 
-    assert %{provider_activity: true, code: code} = failure
+    assert %{provider_activity: true, code: code, diagnostic: diagnostic} = failure
     assert is_atom(code)
-    assert Enum.sort(Map.keys(failure)) == [:code, :provider_activity]
+    assert CommandDiagnostic.valid?(diagnostic)
+    assert Enum.sort(Map.keys(failure)) == [:code, :diagnostic, :provider_activity]
     refute Process.alive?(opener)
 
     assert_eventually(fn -> File.exists?(trace_path) end)
@@ -819,6 +861,78 @@ defmodule PtcRunner.Kernel.ManifestReplTest do
     )
 
     {manifest, host}
+  end
+
+  defp write_missing_credential_application(directory, policy, target) do
+    suffix = "#{policy}-#{System.unique_integer([:positive])}"
+    write_component(directory)
+    File.write!(Path.join(directory, "review.clj"), "(ns review)")
+    manifest = Path.join(directory, "missing-credential-#{suffix}.json")
+    host = Path.join(directory, "missing-credential-host-#{suffix}.json")
+
+    declarations = [%{"name" => "alpha", "config" => %{}}, %{"name" => "omega", "config" => %{}}]
+
+    providers =
+      if target == :workflow,
+        do: %{"workflow" => declarations, "mission" => []},
+        else: %{"workflow" => [], "mission" => declarations}
+
+    mission_providers = if target == :workflow, do: [], else: ["alpha", "omega"]
+
+    document =
+      manifest_document(policy, providers)
+      |> Map.put("missions", %{
+        "review" => %{
+          "components" => [%{"id" => "review", "path" => "review.clj"}],
+          "data" => %{},
+          "providers" => mission_providers
+        }
+      })
+
+    File.write!(manifest, Jason.encode!(document))
+
+    installations =
+      if target == :workflow,
+        do: %{"alpha" => llm_installation("alpha-key"), "omega" => llm_installation("omega-key")},
+        else: %{
+          "alpha" => mcp_installation("alpha-key"),
+          "omega" => mcp_installation("omega-key")
+        }
+
+    File.write!(
+      host,
+      Jason.encode!(%{
+        "credentials" => %{
+          "alpha-key" => %{"env" => "PTC_REPL_ABSENT_ALPHA_KEY"},
+          "omega-key" => %{"env" => "PTC_REPL_ABSENT_OMEGA_KEY"}
+        },
+        "install" => installations
+      })
+    )
+
+    {manifest, host}
+  end
+
+  defp llm_installation(credential) do
+    %{
+      "source" => "llm",
+      "installation_revision" => "manifest-repl-missing-credential-v1",
+      "model" => "openrouter:test/model",
+      "credential" => credential
+    }
+  end
+
+  defp mcp_installation(credential) do
+    %{
+      "source" => "mcp",
+      "installation_revision" => "manifest-repl-missing-credential-v1",
+      "transport" => %{
+        "type" => "stdio",
+        "command" => System.find_executable("sh"),
+        "env" => %{"TOKEN" => %{"binding" => credential}}
+      },
+      "tools" => %{"read" => %{"as" => "#{credential}.read", "effect" => "read"}}
+    }
   end
 
   defp write_mcp_mission_application(directory, marker) do


### PR DESCRIPTION
## Summary

- retain sealed `CommandDiagnostic` evidence through manifest REPL setup failures
- share the validated diagnostic text projection between one-shot commands and the REPL
- preserve workflow/mission scope while showing the provider subject and credential remedies

## Verification

- focused renderer, manifest REPL, and Mix REPL tests: 120 passed
- full core suite: 6,993 tests passed
- precommit, Dialyzer, ExDoc, generated-doc staleness, release, and Viewer gates passed
- independent Codex review: 1 clean pass (maximum allowed: 2)

Closes #1608