### PR TITLE
research(analysis): measure a sealed evidence log with bounded ETS indexes

### DIFF
--- a/docs/maintainers/README.md
+++ b/docs/maintainers/README.md
@@ -24,6 +24,8 @@ runtime implementation, repository workflow, and host-integration view.
   compatibility review method and classification records.
 - [Release procedure](releasing.md) — package, documentation, standalone, and
   launcher release gates.
+- [Sealed evidence log measurement](sealed-evidence-log-measurement.md) —
+  issue #1646 prototype results and the format/index recommendation for #1643.
 
 `AGENTS.md` remains the canonical repository instruction file. Do not duplicate
 its changing worktree, testing, or release commands here when a link is enough.

--- a/docs/maintainers/sealed-evidence-log-measurement.md
+++ b/docs/maintainers/sealed-evidence-log-measurement.md
@@ -1,0 +1,210 @@
+# Sealed evidence log measurement
+
+> **Audience:** people and coding agents deciding the #1643 production
+> inspection format.
+
+Issue #1646 asked whether a small sealed evidence log plus private
+admission-owned ETS indexes can support large artifacts without persisted
+secondary indexes, CubDB, or external sorting. Production inspection routing
+is unchanged. This page records the executable prototype, the measured
+workloads, the configuration inventory, and the recommendation for #1643.
+
+Reproduce the tables with `mix ptc.measure_sealed_evidence` (count rungs up
+to 10 000) or `mix ptc.measure_sealed_evidence --full` (128/256/512 MiB
+payload ladder plus count rungs up to `--max-records`, default 1 000 000).
+The 1 000 000-record rung is an experiment safety ceiling: it did not
+complete under the prototype heap envelope. Focused tests never invoke the
+large ladder.
+
+## Environment
+
+One trial, no warm-up, OTP 29 / ERTS 17.0.3, 64-bit words, 4 schedulers,
+Linux. Producer, admission, and query workers used the same 256 MiB
+`max_heap_size` envelope (`kill: true`, `include_shared_binaries: true`)
+and a 65 536-byte I/O buffer at every payload rung. Encoded evidence-frame
+size was 67 108 864 bytes (64 MiB) on every payload rung.
+
+## Prototype
+
+The reference implementation lives under
+`PtcRunner.Research.SealedEvidenceLog`. Layout:
+
+```text
+16-byte versioned header (PTCINS01)
+length-framed deterministic JSON evidence
+192-byte terminal footer (PTCIFTR1) with counts, identities, offsets, digests
+```
+
+Admission is one streaming pass. ETS holds bounded metadata only. Queries
+select through ETS and read required ranges from a pinned file-server
+handle. Cursors bind the admission snapshot digest and the logical query
+identity; they do not rehash the complete evidence preimage.
+
+## Payload-size ladder
+
+| Target | Frames | Artifact bytes | Frame size | Producer ms | Admission ms | ETS bytes | Logical entries | Charged retained | `list_runs` | `generated_sources` limit 1 |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- |
+| 128 MiB | 2 | 134 217 936 | 67 108 864 | 2 153 | 696 | 34 152 | 14 | 34 489 | ok, 0 ms | `result_limit_exceeded` (926 ms) |
+| 256 MiB | 4 | 268 435 664 | 67 108 864 | 2 679 | 1 339 | 37 048 | 26 | 37 385 | ok, 0 ms | `heap_exceeded` (757 ms) |
+| 512 MiB | 8 | 536 871 120 | 67 108 864 | 4 092 | 2 680 | 42 840 | 50 | 43 177 | ok, 0 ms | `heap_exceeded` (853 ms) |
+
+Producer process memory stayed ~21 KiB; referenced binaries peaked at one or
+two in-flight 64 MiB frames (128–201 MiB), not at the complete artifact.
+Admission process memory stayed ~64 KiB; referenced binaries peaked at
+134 217 912 bytes on every rung. Charged retained state after admission
+grew by index rows (14 → 26 → 50 entries), not by payload. Scratch after
+close was 0 bytes; the sealed input artifact remained until the harness
+deleted it.
+
+`list_runs` does not read evidence payloads. Returning a 64 MiB
+`generated_sources` item exceeds the 1 000 000-byte result ceiling
+(2-frame rung). Verifying every omitted 64 MiB frame before computing
+exact `omitted_count` exceeded the 256 MiB query envelope at 4 and 8
+frames. That is a contract finding, not a measurement gap: a frame counted
+only in `omitted_count` is a query dependency in the current
+`InspectionQuery` rules.
+
+## Record-count ladder
+
+Small `execution-prints` records. Prototype `max_records` was set to the
+rung. Exact one-over refusal for `max_records`, `max_index_entries`, and
+`max_logical_index_bytes` succeeded on a 3-record fixture.
+
+| Records | Artifact bytes | ETS bytes | Logical bytes | Entries | Bytes/record | Producer ms | Admission ms | Cold query ms | Exact-count work |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 1 000 | 273 994 | 797 672 | 805 534 | 4 002 | 798 | 20 | 44 | 14 | 990 |
+| 10 000 | 2 777 996 | 7 631 208 | 8 081 547 | 40 002 | 763 | 117 | 474 | 110 | 9 990 |
+| 100 000 | 28 177 998 | 76 032 112 | 81 291 560 | 400 002 | 760 | 1 193 | 3 971 | 1 216 | 99 990 |
+| 1 000 000 | — | — | — | — | — | 11 514 then `heap_exceeded` | — | — | — |
+
+Linear fit on the three completed rungs: ETS bytes ≈ `759.97 * N + 34 749`.
+Do not treat the observed marginal value as a constant; intercept is the
+fixed table/owner overhead. Other charged retained bytes stayed 338–340
+(paired trace facts and owner metadata). Producer checkpoint memory did
+not grow with record count after first/last samples replaced a per-frame
+list.
+
+The 1 000 000-record rung is the experiment safety ceiling, not a
+candidate production authority. Last successful rung: 100 000. Headroom
+versus today’s internal snapshot `max_retained_bytes` of 128 000 000 is
+about 1.68× at 100 000 small records (76 MB charged). Query deadline 15 s
+covered exact `omitted_count` at 100 000 tiny records (1.2 s, 100 010 hash
+operations).
+
+## Semantic workloads
+
+Differential parity against `InspectionQuery.compile/3` and `query/6`
+passed for all twelve operations on the mixed corpus, including filter
+absence/`nil`/presence, legal conjunctions, the negative
+same-generated-source turn conjunction, ascending and descending order,
+multi-run `list_runs`/`get_run`/`result`, pagination, invalid cursor
+reuse, unknown keys, and invalid filter types. Snapshot-hash values and
+opaque cursor bytes were ignored; each implementation walked with its own
+cursors.
+
+Dense filter postings (32 generated sources, `limit` 3, `mission_name`
+present): `omitted_count` 29, 32 postings visited, 32 candidate frames
+verified.
+
+## Fault matrix
+
+| Event | Outcome |
+| --- | --- |
+| Trailing bytes before open | `malformed_source`; no snapshot |
+| Append during admission | `source_changed` from pinned size/footer accounting |
+| Append after admission | next query `source_changed` |
+| Relevant same-size overwrite | next query `source_changed` |
+| Path replacement after admission | queries continue against the pinned handle |
+| Snapshot owner death | ETS tables undefined; handles unusable |
+| Normal close | tables deleted; handles unusable |
+| Query caller death | snapshot remains usable |
+
+## Configuration inventory
+
+Class `host_facing` is the public JSON/API path under a
+`ptc_inspection_snapshot` installation. Everything else is internal.
+
+| Path or “internal only” | Class | Phase | Unit | Compiled / installed / hard max | File meaning | Consumer |
+| --- | --- | --- | --- | ---: | --- | --- |
+| `install.ptc_inspection_snapshot.ceilings.max_files` | host_facing | admission | files | 1 024 / 1 024 / 1 024 | directory | `HostConfig` inspection snapshot ceilings |
+| `install.ptc_inspection_snapshot.ceilings.max_source_bytes` | host_facing | admission | bytes | 64 000 000 / 64 000 000 / 64 000 000 | aggregate | `HostConfig` inspection snapshot ceilings |
+| `install.ptc_inspection_snapshot.ceilings.max_result_bytes` | host_facing | query | bytes | 1 048 576 / 1 048 576 / 1 048 576 | selected or directory | `HostConfig` inspection snapshot ceilings |
+| internal only | snapshot_internal | admission | bytes | 128 000 000 | selected or directory | `InspectionSnapshot` `max_retained_bytes` |
+| internal only | snapshot_internal | admission | files | 1 024 | directory | `InspectionSnapshot` `max_files` |
+| internal only | snapshot_internal | admission | entries | 4 096 | directory | `InspectionSnapshot` `max_directory_entries` |
+| internal only | snapshot_internal | admission | bytes | 16 000 000 | selected file | `InspectionSnapshot` `max_artifact_bytes` / `InspectionArtifact` |
+| internal only | producer | producer | bytes | 2 000 000 | selected file | `InspectionSink` `max_record_bytes` |
+| internal only | producer | producer | bytes | 16 000 000 | selected file | `InspectionSink` `max_total_bytes` |
+| internal only | prototype | producer | bytes | 67 108 864 | selected file | research `max_record_bytes` |
+| internal only | prototype | producer | bytes | 536 871 120 | selected file | research `max_total_bytes` |
+| internal only | prototype | admission | records | 1 000 000 | selected file | research `max_records` (experiment ceiling; 1 000 000 did not complete) |
+| internal only | prototype | admission | entries | 8 000 000 | selected file | research `max_index_entries` |
+| internal only | prototype | admission | bytes | 536 870 912 | selected file | research `max_logical_index_bytes` |
+| internal only | prototype | query | bytes | 67 108 864 | selected file | research verified range-byte ceiling |
+| internal only | prototype | query | milliseconds | 15 000 | selected or directory | research query deadline |
+| internal only | maintained_guard | admission | schema_version | 8 | selected file | `InspectionArtifact` / prototype schema |
+| internal only | maintained_guard | query | items | 1 000 max / 100 default | selected or directory | `InspectionQuery` page limit |
+
+`Limits.inventory/0` is the executable copy of this table.
+
+### Mapping for #1643
+
+- Keep host-facing `max_files`, aggregate `max_source_bytes`, and
+  `max_result_bytes`. Do not add ETS table type, key layout, concurrency,
+  word counts, cache, backend, sorting, or compaction knobs.
+- `max_retained_bytes` stays internal and means all charged derived
+  snapshot state (actual ETS allocation plus disjoint owner metadata,
+  paired trace facts, and cache). Shared binaries that appear in both
+  owner metadata and an ETS row are charged in both places.
+- Writer authority stays on the producer/sink internals
+  (`max_record_bytes`, `max_total_bytes`), not on inspection-provider
+  installation ceilings.
+- Add one internal admission guard `max_records`. Proposed production
+  **default 16 384**, **hard maximum 65 536** (about 50 MB ETS at the
+  measured ~760 B/record slope, under 128 MB `max_retained_bytes`, with
+  headroom from the 100 000 successful rung). The 1 000 000 experiment
+  ceiling is not a production authority.
+- Production `max_record_bytes` remains 2 000 000. The prototype 64 MiB
+  record size is research-only.
+- Range-byte and query-deadline ceilings stay internal. 15 s covered
+  exact `omitted_count` for 100 000 tiny records. Deadlines do not need to
+  become host-facing for the environments measured here.
+- Selected-file `max_artifact_bytes` / producer `max_total_bytes`
+  (16 000 000 today) can remain the production per-artifact cap until a
+  later cutover raises them; the prototype proved 512 MiB artifacts under
+  a research envelope.
+
+## `omitted_count` contract
+
+Exact `omitted_count` that re-verifies every omitted evidence frame is
+acceptable for small records (100 000 prints, 1.2 s, inside 15 s). It is
+not acceptable for payload-heavy few-record artifacts: verifying four or
+eight omitted 64 MiB frames exceeds a 256 MiB query envelope, and a single
+returned 64 MiB item exceeds `max_result_bytes`.
+
+#1643 should keep exact dependency verification for **returned items and
+their join/turn dependencies**, and specify `omitted_count` as the ETS
+locator cardinality whose admission digests were already checked. A
+same-size overwrite of an omitted frame may remain latent until that
+frame is selected. That is a deliberate replacement for the current
+“every omitted frame is a query dependency” rule, justified by this
+ladder. Do not silently weaken the prototype: it still verifies omitted
+frames, and the harness records the resulting `heap_exceeded`.
+
+## Recommendation for #1643
+
+**ETS-only V1** is sufficient. Do not add CubDB or `:file_sorter` for this
+cutover.
+
+The simple sealed log plus private ETS indexes supports:
+
+- payload-heavy artifacts with artifact-independent retained memory;
+- record counts through 100 000 small rows under today’s 128 MB retained
+  ceiling, with a finite `max_records` guard;
+- the complete current query/filter surface on a mixed corpus;
+- pinned-handle mutation detection and deterministic cleanup.
+
+#1643 should restore `ready-for-implementation` on an ETS-only sealed log
+with the `omitted_count` contract change above, internal `max_records`,
+and the existing host-facing inspection ceilings. Persisted secondary
+indexes are not required for the measured workloads.

--- a/docs/maintainers/sealed-evidence-log-measurement.md
+++ b/docs/maintainers/sealed-evidence-log-measurement.md
@@ -35,10 +35,12 @@ length-framed deterministic JSON evidence
 192-byte terminal footer (PTCIFTR1) with counts, identities, offsets, digests
 ```
 
-Admission is one streaming pass. ETS holds bounded metadata only. Queries
-select through ETS and read required ranges from a pinned file-server
-handle. Cursors bind the admission snapshot digest and the logical query
-identity; they do not rehash the complete evidence preimage.
+Admission is one ingest scan that validates frames and inserts bounded ETS
+rows. Seal confirmation then rehashes evidence bytes without decoding records
+so a same-size overwrite cannot publish a snapshot. Queries select through ETS
+and read required ranges from a pinned file-server handle. Cursors bind the
+admission snapshot digest and the logical query identity; they do not rehash
+the complete evidence preimage.
 
 ## Payload-size ladder
 
@@ -144,13 +146,17 @@ Class `host_facing` is the public JSON/API path under a
 | internal only | prototype | admission | records | 1 000 000 | selected file | research `max_records` (experiment ceiling; 1 000 000 did not complete) |
 | internal only | prototype | admission | entries | 8 000 000 | selected file | research `max_index_entries` |
 | internal only | prototype | admission | bytes | 536 870 912 | selected file | research `max_logical_index_bytes` |
-| internal only | prototype | query | bytes | 67 108 864 | selected file | research verified range-byte ceiling |
+| internal only | prototype | query | bytes | 67 108 864 | selected file | research per-frame verified range-byte ceiling |
 | internal only | prototype | query | milliseconds | 15 000 / 15 000 / 15 000 | selected or directory | research query deadline |
 | internal only | prototype | admission | bytes | 536 870 912 | selected or directory | research `max_retained_bytes` |
 | internal only | prototype | query | bytes | 1 000 000 | selected or directory | research `max_result_bytes` |
 | internal only | prototype | producer | bytes | 268 435 456 | selected file | research producer heap envelope |
 | internal only | prototype | admission | bytes | 268 435 456 | selected file | research admission heap envelope |
 | internal only | prototype | query | bytes | 268 435 456 | selected file | research query heap envelope |
+| internal only | prototype | producer | milliseconds | 120 000 | selected file | research producer deadline |
+| internal only | prototype | admission | milliseconds | 120 000 | selected file | research admission deadline |
+| internal only | prototype | cleanup | milliseconds | 5 000 | selected or directory | research cleanup deadline |
+| internal only | prototype | producer | bytes | 65 536 | selected file | research I/O buffer |
 | internal only | maintained_guard | admission | schema_version | 8 | selected file | `InspectionArtifact` / prototype schema |
 | internal only | maintained_guard | query | items | 1 000 max / 100 default | selected or directory | `InspectionQuery` page limit |
 

--- a/docs/maintainers/sealed-evidence-log-measurement.md
+++ b/docs/maintainers/sealed-evidence-log-measurement.md
@@ -110,14 +110,18 @@ verified.
 
 | Event | Outcome |
 | --- | --- |
-| Trailing bytes before open | `malformed_source`; no snapshot |
-| Append during admission | `source_changed` from pinned size/footer accounting |
-| Append after admission | next query `source_changed` |
+| Trailing, truncated, or malformed bytes before open | `malformed_source`; no snapshot |
+| Footer counts/identities/digest mismatch | `malformed_source`; no snapshot |
+| Append, truncate, or overwrite during admission | `source_changed`; no snapshot |
+| Append or truncate after admission | next query `source_changed`, including `get_run` / `result` |
 | Relevant same-size overwrite | next query `source_changed` |
+| Unrelated same-size overwrite | `list_runs` may succeed; the dependent collection returns `source_changed` |
 | Path replacement after admission | queries continue against the pinned handle |
+| Admission caller death | admission worker cancelled; no snapshot |
+| Quota / retained-ceiling refusal | no snapshot; tables deleted; input artifact remains |
 | Snapshot owner death | ETS tables undefined; handles unusable |
 | Normal close | tables deleted; handles unusable |
-| Query caller death | snapshot remains usable |
+| Query caller death | query worker cancelled; snapshot remains usable |
 
 ## Configuration inventory
 
@@ -141,7 +145,12 @@ Class `host_facing` is the public JSON/API path under a
 | internal only | prototype | admission | entries | 8 000 000 | selected file | research `max_index_entries` |
 | internal only | prototype | admission | bytes | 536 870 912 | selected file | research `max_logical_index_bytes` |
 | internal only | prototype | query | bytes | 67 108 864 | selected file | research verified range-byte ceiling |
-| internal only | prototype | query | milliseconds | 15 000 | selected or directory | research query deadline |
+| internal only | prototype | query | milliseconds | 15 000 / 15 000 / 15 000 | selected or directory | research query deadline |
+| internal only | prototype | admission | bytes | 536 870 912 | selected or directory | research `max_retained_bytes` |
+| internal only | prototype | query | bytes | 1 000 000 | selected or directory | research `max_result_bytes` |
+| internal only | prototype | producer | bytes | 268 435 456 | selected file | research producer heap envelope |
+| internal only | prototype | admission | bytes | 268 435 456 | selected file | research admission heap envelope |
+| internal only | prototype | query | bytes | 268 435 456 | selected file | research query heap envelope |
 | internal only | maintained_guard | admission | schema_version | 8 | selected file | `InspectionArtifact` / prototype schema |
 | internal only | maintained_guard | query | items | 1 000 max / 100 default | selected or directory | `InspectionQuery` page limit |
 

--- a/lib/mix/tasks/ptc.measure_sealed_evidence.ex
+++ b/lib/mix/tasks/ptc.measure_sealed_evidence.ex
@@ -1,0 +1,30 @@
+defmodule Mix.Tasks.Ptc.MeasureSealedEvidence do
+  @shortdoc "Measure the sealed evidence log + ETS index prototype"
+  @moduledoc """
+  Runs the issue #1646 measurement harness.
+
+      mix ptc.measure_sealed_evidence
+      mix ptc.measure_sealed_evidence --full
+      mix ptc.measure_sealed_evidence --max-records 10000
+
+  `--full` enables the 128/256/512 MiB payload ladder and the record-count
+  ladder up to 1_000_000, stopping at `--max-records` when supplied. Ordinary
+  focused tests never invoke this task.
+  """
+
+  use Mix.Task
+
+  alias PtcRunner.Research.SealedEvidenceLog.Measure
+
+  @impl Mix.Task
+  def run(args) do
+    Mix.Task.run("app.start")
+
+    {opts, _rest, _invalid} =
+      OptionParser.parse(args, strict: [full: :boolean, max_records: :integer])
+
+    result = Measure.run(opts)
+    Mix.shell().info(inspect(result, pretty: true, limit: :infinity, printable_limit: :infinity))
+    :ok
+  end
+end

--- a/lib/ptc_runner/research/sealed_evidence_log.ex
+++ b/lib/ptc_runner/research/sealed_evidence_log.ex
@@ -1,0 +1,47 @@
+defmodule PtcRunner.Research.SealedEvidenceLog do
+  @moduledoc """
+  Test/benchmark-only sealed evidence log with private ETS indexes.
+
+  Production inspection routing is unchanged. This module is the #1646
+  reference implementation: a small versioned header, length-framed
+  deterministic JSON evidence, a terminal footer, one streaming admission
+  pass, and owner-bound ETS metadata that never retains evidence payloads.
+  """
+
+  alias PtcRunner.Research.SealedEvidenceLog.Limits
+  alias PtcRunner.Research.SealedEvidenceLog.Producer
+  alias PtcRunner.Research.SealedEvidenceLog.Query
+  alias PtcRunner.Research.SealedEvidenceLog.Snapshot
+
+  @spec produce(Path.t(), Enumerable.t(), keyword()) :: {:ok, map()} | {:error, atom()}
+  def produce(path, records, opts \\ []) when is_binary(path) and is_list(opts) do
+    with {:ok, limits} <- Limits.merge(Keyword.get(opts, :limits, [])) do
+      Producer.write(path, records, limits, opts)
+    end
+  end
+
+  @spec admit([map()] | map(), keyword()) :: {:ok, Snapshot.t()} | {:error, atom()}
+  def admit(artifacts, opts \\ [])
+
+  def admit(artifact, opts) when is_map(artifact) and is_list(opts),
+    do: admit([artifact], opts)
+
+  def admit(artifacts, opts) when is_list(artifacts) and is_list(opts) do
+    with {:ok, limits} <- Limits.merge(Keyword.get(opts, :limits, [])) do
+      Snapshot.start(artifacts, limits, opts)
+    end
+  end
+
+  @spec query(Snapshot.t(), atom(), map(), keyword()) ::
+          {:ok, map(), Query.metrics()} | {:error, atom()}
+  def query(snapshot, operation, arguments, opts \\ [])
+      when is_atom(operation) and is_map(arguments) and is_list(opts) do
+    Snapshot.query(snapshot, operation, arguments, opts)
+  end
+
+  @spec info(Snapshot.t()) :: {:ok, map()} | {:error, atom()}
+  defdelegate info(snapshot), to: Snapshot
+
+  @spec close(term()) :: :ok
+  defdelegate close(snapshot), to: Snapshot
+end

--- a/lib/ptc_runner/research/sealed_evidence_log/admission.ex
+++ b/lib/ptc_runner/research/sealed_evidence_log/admission.ex
@@ -1,0 +1,140 @@
+defmodule PtcRunner.Research.SealedEvidenceLog.Admission do
+  @moduledoc """
+  One streaming admission pass over a sealed evidence artifact.
+
+  The pass validates every complete frame, identities, sequences, lifecycle,
+  joins, conversation facts, and paired trace claims; inserts bounded ETS rows;
+  and releases each evidence payload before the next frame is read.
+  """
+
+  alias PtcRunner.Kernel.BoundedWorker
+  alias PtcRunner.Research.SealedEvidenceLog.Assembler
+  alias PtcRunner.Research.SealedEvidenceLog.Checkpoints
+  alias PtcRunner.Research.SealedEvidenceLog.Codec
+  alias PtcRunner.Research.SealedEvidenceLog.Format
+  alias PtcRunner.Research.SealedEvidenceLog.Handle
+  alias PtcRunner.Research.SealedEvidenceLog.Indexes
+  alias PtcRunner.Research.SealedEvidenceLog.Limits
+
+  @spec run(Handle.t(), Indexes.t(), map(), map(), keyword()) ::
+          {:ok, map()} | {:error, atom()}
+  def run(handle, indexes, trace_facts, limits, opts \\ [])
+      when is_map(handle) and is_map(indexes) and is_map(trace_facts) and is_map(limits) and
+             is_list(opts) do
+    hook = Keyword.get(opts, :checkpoint_hook)
+    mutate_hook = Keyword.get(opts, :during_admission_hook)
+    timeout_ms = Keyword.get(opts, :deadline_ms, limits.admission_deadline_ms)
+    owner = self()
+
+    BoundedWorker.run(
+      fn -> admit(handle, indexes, trace_facts, limits, hook, mutate_hook, owner) end,
+      timeout_ms: timeout_ms,
+      max_heap_words: Limits.heap_words(limits.admission_heap_bytes),
+      cancel_with: owner
+    )
+    |> wrap_worker()
+  end
+
+  defp admit(handle, indexes, trace_facts, limits, hook, mutate_hook, owner) do
+    checkpoints = Checkpoints.new()
+    pids = [self(), owner]
+    state = Assembler.new(indexes, limits)
+    offset = Format.header_size()
+    evidence_hash = :crypto.hash_init(:sha256)
+
+    ctx = %{
+      handle: handle,
+      evidence_end: handle.footer.evidence_offset + handle.footer.evidence_bytes,
+      hook: hook,
+      pids: pids,
+      limits: limits
+    }
+
+    with :ok <- maybe_hook(mutate_hook, :before_frames),
+         :ok <- Handle.assert_stable(handle),
+         {:ok, state, evidence_hash, checkpoints} <-
+           stream_frames(ctx, state, offset, evidence_hash, checkpoints),
+         :ok <- maybe_hook(mutate_hook, :after_frames),
+         :ok <- Handle.assert_stable(handle),
+         :ok <- verify_evidence_digest(handle, evidence_hash),
+         {:ok, state} <- Assembler.finish(state, trace_facts),
+         true <- Indexes.within_retained?(state.indexes, limits) do
+      checkpoints = Checkpoints.record(checkpoints, :ets_inserted, pids)
+
+      {:ok,
+       %{
+         indexes: state.indexes,
+         run_id: state.run_id,
+         trace_id: state.trace_id,
+         record_count: state.record_count,
+         turn_evidence: state.evidence,
+         checkpoints: Checkpoints.finalize(checkpoints)
+       }}
+    else
+      false ->
+        Indexes.delete_all(indexes)
+        Handle.close(handle)
+        {:error, :max_retained_bytes}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp stream_frames(ctx, state, offset, evidence_hash, checkpoints) do
+    cond do
+      offset == ctx.evidence_end ->
+        {:ok, state, evidence_hash, checkpoints}
+
+      offset > ctx.evidence_end ->
+        {:error, :malformed_source}
+
+      state.record_count >= ctx.limits.max_records ->
+        {:error, :max_records}
+
+      true ->
+        read_one_frame(ctx, state, offset, evidence_hash, checkpoints)
+    end
+  end
+
+  defp read_one_frame(ctx, state, offset, evidence_hash, checkpoints) do
+    with {:ok, <<length::unsigned-big-64>>} <- Handle.pread(ctx.handle, offset, 8),
+         true <- length <= ctx.limits.max_record_bytes,
+         payload_offset = offset + 8,
+         true <- payload_offset + length <= ctx.evidence_end,
+         {:ok, payload} <- Handle.pread(ctx.handle, payload_offset, length),
+         evidence_hash <-
+           :crypto.hash_update(evidence_hash, [<<length::unsigned-big-64>>, payload]),
+         checkpoints <- Checkpoints.record(checkpoints, :decoded, ctx.pids),
+         {:ok, record} <- Codec.decode_record(payload),
+         digest <- :crypto.hash(:sha256, payload),
+         {:ok, state} <- Assembler.ingest(state, record, payload_offset, length, digest) do
+      _ = payload
+      _ = record
+      checkpoints = Checkpoints.record(checkpoints, :frame_released, ctx.pids)
+      checkpoints = Checkpoints.record(checkpoints, :ets_inserted, ctx.pids)
+      if is_function(ctx.hook, 1), do: ctx.hook.(:frame_released)
+
+      stream_frames(ctx, state, payload_offset + length, evidence_hash, checkpoints)
+    else
+      false -> {:error, :limit_exceeded}
+      {:error, :source_changed} -> {:error, :source_changed}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp verify_evidence_digest(handle, evidence_hash) do
+    if :crypto.hash_final(evidence_hash) == handle.footer.evidence_sha256,
+      do: :ok,
+      else: {:error, :malformed_source}
+  end
+
+  defp maybe_hook(nil, _name), do: :ok
+  defp maybe_hook(hook, name) when is_function(hook, 1), do: hook.(name)
+
+  defp wrap_worker({:ok, result}), do: result
+  defp wrap_worker({:error, :heap_exceeded}), do: {:error, :heap_exceeded}
+  defp wrap_worker({:error, :timeout}), do: {:error, :deadline_exceeded}
+  defp wrap_worker({:error, :cancelled}), do: {:error, :cancelled}
+  defp wrap_worker({:error, reason}) when is_atom(reason), do: {:error, reason}
+end

--- a/lib/ptc_runner/research/sealed_evidence_log/admission.ex
+++ b/lib/ptc_runner/research/sealed_evidence_log/admission.ex
@@ -1,10 +1,11 @@
 defmodule PtcRunner.Research.SealedEvidenceLog.Admission do
   @moduledoc """
-  One streaming admission pass over a sealed evidence artifact.
-
-  The pass validates every complete frame, identities, sequences, lifecycle,
-  joins, conversation facts, and paired trace claims; inserts bounded ETS rows;
-  and releases each evidence payload before the next frame is read.
+  One streaming ingest pass validates every complete frame, identities,
+  sequences, lifecycle, joins, conversation facts, and paired trace claims;
+  inserts bounded ETS rows; and releases each evidence payload before the next
+  frame is read. After that ingest scan, seal confirmation rehashes evidence
+  bytes without decoding records so a same-size overwrite cannot publish a
+  snapshot.
   """
 
   alias PtcRunner.Kernel.BoundedWorker
@@ -73,6 +74,7 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Admission do
              },
              limits.io_buffer_bytes
            ),
+         :ok <- Handle.assert_stable(handle),
          {:ok, state} <- Assembler.finish(state, trace_facts),
          true <- Indexes.within_retained?(state.indexes, limits) do
       checkpoints = Checkpoints.record(checkpoints, :ets_inserted, pids)

--- a/lib/ptc_runner/research/sealed_evidence_log/admission.ex
+++ b/lib/ptc_runner/research/sealed_evidence_log/admission.ex
@@ -24,13 +24,16 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Admission do
     hook = Keyword.get(opts, :checkpoint_hook)
     mutate_hook = Keyword.get(opts, :during_admission_hook)
     timeout_ms = Keyword.get(opts, :deadline_ms, limits.admission_deadline_ms)
-    owner = self()
+    snapshot_owner = self()
+    cancel_with = Keyword.get(opts, :cancel_with, Keyword.get(opts, :owner, snapshot_owner))
 
     BoundedWorker.run(
-      fn -> admit(handle, indexes, trace_facts, limits, hook, mutate_hook, owner) end,
+      fn ->
+        admit(handle, indexes, trace_facts, limits, hook, mutate_hook, snapshot_owner)
+      end,
       timeout_ms: timeout_ms,
       max_heap_words: Limits.heap_words(limits.admission_heap_bytes),
-      cancel_with: owner
+      cancel_with: cancel_with
     )
     |> wrap_worker()
   end
@@ -56,7 +59,20 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Admission do
            stream_frames(ctx, state, offset, evidence_hash, checkpoints),
          :ok <- maybe_hook(mutate_hook, :after_frames),
          :ok <- Handle.assert_stable(handle),
-         :ok <- verify_evidence_digest(handle, evidence_hash),
+         streamed <- :crypto.hash_final(evidence_hash),
+         :ok <-
+           Handle.confirm_seal(
+             handle,
+             streamed,
+             %{
+               record_count: state.record_count,
+               first_sequence: state.first_sequence,
+               last_sequence: state.last_sequence,
+               run_id: state.run_id,
+               trace_id: state.trace_id
+             },
+             limits.io_buffer_bytes
+           ),
          {:ok, state} <- Assembler.finish(state, trace_facts),
          true <- Indexes.within_retained?(state.indexes, limits) do
       checkpoints = Checkpoints.record(checkpoints, :ets_inserted, pids)
@@ -105,8 +121,8 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Admission do
          {:ok, payload} <- Handle.pread(ctx.handle, payload_offset, length),
          evidence_hash <-
            :crypto.hash_update(evidence_hash, [<<length::unsigned-big-64>>, payload]),
-         checkpoints <- Checkpoints.record(checkpoints, :decoded, ctx.pids),
          {:ok, record} <- Codec.decode_record(payload),
+         checkpoints <- Checkpoints.record(checkpoints, :decoded, ctx.pids),
          digest <- :crypto.hash(:sha256, payload),
          {:ok, state} <- Assembler.ingest(state, record, payload_offset, length, digest) do
       _ = payload
@@ -121,12 +137,6 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Admission do
       {:error, :source_changed} -> {:error, :source_changed}
       {:error, reason} -> {:error, reason}
     end
-  end
-
-  defp verify_evidence_digest(handle, evidence_hash) do
-    if :crypto.hash_final(evidence_hash) == handle.footer.evidence_sha256,
-      do: :ok,
-      else: {:error, :malformed_source}
   end
 
   defp maybe_hook(nil, _name), do: :ok

--- a/lib/ptc_runner/research/sealed_evidence_log/assembler.ex
+++ b/lib/ptc_runner/research/sealed_evidence_log/assembler.ex
@@ -1,0 +1,707 @@
+defmodule PtcRunner.Research.SealedEvidenceLog.Assembler do
+  @moduledoc """
+  Builds ETS indexes from one streaming evidence record at a time.
+
+  Collection order, filter postings, turn projections, and relationship rows are
+  inserted after the last frame, once joins and conversation facts are closed.
+  """
+
+  alias PtcRunner.Kernel.RunAnalysisRelationships
+  alias PtcRunner.Lisp.RetainedSize
+  alias PtcRunner.Research.SealedEvidenceLog.Conversation
+  alias PtcRunner.Research.SealedEvidenceLog.Indexes
+  alias PtcRunner.Research.SealedEvidenceLog.ValueHash
+
+  @spec new(Indexes.t(), map()) :: map()
+  def new(indexes, limits) do
+    %{
+      indexes: indexes,
+      limits: limits,
+      run_id: nil,
+      trace_id: nil,
+      schema_version: 8,
+      first_timestamp: nil,
+      last_timestamp: nil,
+      record_count: 0,
+      conversation: Conversation.new(),
+      inputs: %{},
+      outputs: %{},
+      exceptions: %{},
+      mcp_requests: %{},
+      mcp_responses: %{},
+      mcp_stderrs: %{},
+      analyses: %{},
+      prelude_calls_by_eval: %{},
+      generated_meta: [],
+      prelude_meta: [],
+      execution_meta: %{prints: [], errors: [], failures: []},
+      result_sequence: nil
+    }
+  end
+
+  @spec ingest(map(), map(), non_neg_integer(), non_neg_integer(), binary()) ::
+          {:ok, map()} | {:error, atom()}
+  def ingest(state, record, offset, length, digest) do
+    record = RetainedSize.detach_binaries(record)
+
+    with :ok <- identity(state, record),
+         :ok <- next_sequence(state, record),
+         {:ok, state} <- put_primary(state, record, offset, length, digest),
+         {:ok, state} <- put_join(state, record) do
+      {:ok,
+       %{
+         observe(state, record)
+         | run_id: record["run_id"],
+           trace_id: record["trace_id"],
+           schema_version: record["schema_version"],
+           first_timestamp: state.first_timestamp || record["timestamp"],
+           last_timestamp: record["timestamp"],
+           record_count: state.record_count + 1
+       }}
+    end
+  end
+
+  @spec finish(map(), map()) :: {:ok, map()} | {:error, atom()}
+  def finish(state, trace_facts) do
+    state = Map.put(state, :pending_parents, Map.get(trace_facts, "parent_evaluation_ids", %{}))
+
+    with :ok <- closed_joins(state),
+         conversation <- Conversation.finish(state.conversation, trace_facts),
+         {:ok, state} <- materialize_pairs(state),
+         {:ok, state} <- materialize_sources(state),
+         {:ok, state} <- materialize_preludes(state),
+         {:ok, state} <- materialize_providers(state),
+         {:ok, state} <- materialize_execution(state),
+         {:ok, state} <- materialize_turns(state, conversation, trace_facts),
+         {:ok, state} <- materialize_counts(state, conversation),
+         {:ok, state} <- materialize_run(state),
+         {:ok, state} <- materialize_result(state),
+         {:ok, state} <- materialize_relationships(state, conversation, trace_facts) do
+      {:ok, Map.put(state, :evidence, conversation.evidence)}
+    end
+  end
+
+  defp identity(%{run_id: nil}, %{"run_id" => run_id, "trace_id" => trace_id})
+       when is_binary(run_id) and is_binary(trace_id),
+       do: :ok
+
+  defp identity(%{run_id: run_id, trace_id: trace_id}, record) do
+    if record["run_id"] == run_id and record["trace_id"] == trace_id,
+      do: :ok,
+      else: {:error, :invalid_record}
+  end
+
+  defp next_sequence(%{record_count: 0}, %{"sequence" => sequence})
+       when is_integer(sequence) and sequence > 0,
+       do: :ok
+
+  defp next_sequence(%{record_count: count}, %{"sequence" => sequence})
+       when is_integer(sequence) and sequence == count + 1,
+       do: :ok
+
+  defp next_sequence(_state, _record), do: {:error, :invalid_record}
+
+  defp put_primary(state, record, offset, length, digest) do
+    insert(
+      state,
+      :primary,
+      {record["run_id"], record["sequence"]},
+      {record["record_type"], offset, length, digest}
+    )
+  end
+
+  defp put_join(state, %{"record_type" => "capability-input"} = record) do
+    id = record["correlation"]["capability_id"]
+
+    if Map.has_key?(state.inputs, id) do
+      {:error, :invalid_record}
+    else
+      {:ok, %{state | inputs: Map.put(state.inputs, id, record)}}
+    end
+  end
+
+  defp put_join(state, %{"record_type" => "capability-output"} = record) do
+    id = record["correlation"]["capability_id"]
+    input = Map.get(state.inputs, id)
+
+    if compatible_capability?(input, record) and not Map.has_key?(state.outputs, id) and
+         valid_exception_output?(state, id, record["payload"]["result"]) do
+      {:ok, %{state | outputs: Map.put(state.outputs, id, record)}}
+    else
+      {:error, :invalid_record}
+    end
+  end
+
+  defp put_join(state, %{"record_type" => "capability-exception"} = record) do
+    id = record["correlation"]["capability_id"]
+    input = Map.get(state.inputs, id)
+
+    if compatible_capability?(input, record) and not Map.has_key?(state.exceptions, id) and
+         not Map.has_key?(state.outputs, id) do
+      {:ok, %{state | exceptions: Map.put(state.exceptions, id, record)}}
+    else
+      {:error, :invalid_record}
+    end
+  end
+
+  defp put_join(state, %{"record_type" => "mcp-request"} = record) do
+    key = mcp_key(record)
+
+    if Map.has_key?(state.mcp_requests, key) do
+      {:error, :invalid_record}
+    else
+      {:ok, %{state | mcp_requests: Map.put(state.mcp_requests, key, record)}}
+    end
+  end
+
+  defp put_join(state, %{"record_type" => "mcp-response"} = record) do
+    key = mcp_key(record)
+
+    if Map.has_key?(state.mcp_responses, key) do
+      {:error, :invalid_record}
+    else
+      {:ok, %{state | mcp_responses: Map.put(state.mcp_responses, key, record)}}
+    end
+  end
+
+  defp put_join(state, %{"record_type" => "mcp-stderr"} = record) do
+    {:ok, %{state | mcp_stderrs: Map.put(state.mcp_stderrs, mcp_key(record), record)}}
+  end
+
+  defp put_join(state, %{"record_type" => "evaluation-analysis"} = record) do
+    id = record["correlation"]["evaluation_id"]
+
+    with {:ok, state} <-
+           insert(state, :join_evaluation, {record["run_id"], id, :analysis}, record["sequence"]) do
+      {:ok,
+       %{
+         state
+         | analyses: Map.put(state.analyses, id, record),
+           prelude_calls_by_eval:
+             Map.put(state.prelude_calls_by_eval, id, record["payload"]["prelude_calls"])
+       }}
+    end
+  end
+
+  defp put_join(state, %{"record_type" => "evaluation-source"} = record) do
+    meta = %{
+      sequence: record["sequence"],
+      evaluation_id: record["correlation"]["evaluation_id"],
+      environment: record["payload"]["environment"],
+      mission_name: record["payload"]["mission_name"]
+    }
+
+    {:ok, %{state | generated_meta: [meta | state.generated_meta]}}
+  end
+
+  defp put_join(state, %{"record_type" => "prelude-source"} = record) do
+    meta = %{
+      sequence: record["sequence"],
+      component_id: record["correlation"]["component_id"],
+      environment: record["payload"]["environment"],
+      mission_name: record["payload"]["mission_name"]
+    }
+
+    {:ok, %{state | prelude_meta: [meta | state.prelude_meta]}}
+  end
+
+  defp put_join(state, %{"record_type" => "execution-prints"} = record) do
+    put_execution(state, :prints, record)
+  end
+
+  defp put_join(state, %{"record_type" => "execution-error"} = record) do
+    put_execution(state, :errors, record)
+  end
+
+  defp put_join(state, %{"record_type" => "explicit-failure-value"} = record) do
+    put_execution(state, :failures, record)
+  end
+
+  defp put_join(state, %{"record_type" => "run-result"} = record) do
+    if state.result_sequence do
+      {:error, :invalid_record}
+    else
+      insert(state, :result, record["run_id"], record["sequence"])
+      |> case do
+        {:ok, state} -> {:ok, %{state | result_sequence: record["sequence"]}}
+        error -> error
+      end
+    end
+  end
+
+  defp put_join(_state, _record), do: {:error, :invalid_record}
+
+  defp put_execution(state, field, record) do
+    meta = %{
+      sequence: record["sequence"],
+      evaluation_id: record["correlation"]["evaluation_id"]
+    }
+
+    {:ok, update_in(state, [:execution_meta, field], &[meta | &1])}
+  end
+
+  defp observe(state, record) do
+    conversation =
+      record
+      |> then(&Conversation.observe_input(state.conversation, &1))
+      |> then(&Conversation.observe_output(&1, record))
+      |> then(&Conversation.observe_source(&1, record))
+
+    %{state | conversation: conversation}
+  end
+
+  defp capability_class(%{"environment" => "workflow", "name" => "llm-request"}), do: :model
+  defp capability_class(_payload), do: :capability
+
+  defp compatible_capability?(nil, _record), do: false
+
+  defp compatible_capability?(input, record) do
+    payload = record["payload"]
+
+    input["payload"]["environment"] == payload["environment"] and
+      input["payload"]["mission_name"] == payload["mission_name"] and
+      input["payload"]["name"] == payload["name"]
+  end
+
+  defp valid_exception_output?(state, id, result) do
+    not Map.has_key?(state.exceptions, id) or
+      match?(
+        %{
+          "status" => "error",
+          "kind" => "provider_error",
+          "reason" => "exception",
+          "retryable?" => false
+        },
+        result
+      )
+  end
+
+  defp mcp_key(record) do
+    correlation = record["correlation"]
+    {correlation["capability_id"], correlation["request_id"]}
+  end
+
+  defp closed_joins(state) do
+    request_keys = MapSet.new(Map.keys(state.mcp_requests))
+    response_keys = MapSet.new(Map.keys(state.mcp_responses))
+
+    if MapSet.equal?(request_keys, response_keys),
+      do: :ok,
+      else: {:error, :incomplete_inspection_correlation}
+  end
+
+  defp materialize_pairs(state) do
+    state.inputs
+    |> Enum.sort_by(fn {_id, record} -> record["sequence"] end)
+    |> Enum.reduce_while({:ok, state}, fn {id, input}, {:ok, acc} ->
+      output = Map.get(acc.outputs, id)
+      exception = Map.get(acc.exceptions, id)
+      class = capability_class(input["payload"])
+      collection = if class == :model, do: :model_exchanges, else: :capability_calls
+
+      locator = {:capability, id, input["sequence"]}
+
+      join = %{
+        input_sequence: input["sequence"],
+        exception_sequence: exception && exception["sequence"],
+        output_sequence: output && output["sequence"],
+        environment: input["payload"]["environment"],
+        mission_name: input["payload"]["mission_name"],
+        name: input["payload"]["name"],
+        class: class
+      }
+
+      with {:ok, acc} <- insert(acc, :join_capability, {input["run_id"], id}, join),
+           {:ok, acc} <- order_and_filters(acc, collection, locator, pair_filters(input, id)) do
+        {:cont, {:ok, acc}}
+      else
+        error -> {:halt, error}
+      end
+    end)
+  end
+
+  defp materialize_sources(state) do
+    state.generated_meta
+    |> Enum.reverse()
+    |> Enum.reduce_while({:ok, state}, fn meta, {:ok, acc} ->
+      locator = {:record, meta.sequence}
+      parent = Map.get(acc, :pending_parents, %{})[meta.evaluation_id]
+      prelude_calls = Map.get(acc.prelude_calls_by_eval, meta.evaluation_id)
+
+      meta =
+        meta
+        |> Map.put(:parent_evaluation_id, parent)
+        |> Map.put(:prelude_calls, prelude_calls)
+
+      filters = source_filters(meta)
+
+      with {:ok, acc} <-
+             insert(
+               acc,
+               :join_evaluation,
+               {state.run_id, meta.evaluation_id, :source},
+               meta.sequence
+             ),
+           {:ok, acc} <- order_and_filters(acc, :generated_sources, locator, filters) do
+        {:cont, {:ok, acc}}
+      else
+        error -> {:halt, error}
+      end
+    end)
+  end
+
+  defp materialize_preludes(state) do
+    state.prelude_meta
+    |> Enum.reverse()
+    |> Enum.reduce_while({:ok, state}, fn meta, {:ok, acc} ->
+      locator = {:record, meta.sequence}
+      key = {state.run_id, meta.environment, meta.mission_name, meta.component_id}
+
+      with {:ok, acc} <-
+             insert(acc, :join_prelude, key, {meta.sequence, 1}),
+           {:ok, acc} <-
+             order_and_filters(acc, :effective_preludes, locator, prelude_filters(meta)) do
+        {:cont, {:ok, acc}}
+      else
+        error -> {:halt, error}
+      end
+    end)
+  end
+
+  defp materialize_providers(state) do
+    state.mcp_requests
+    |> Enum.sort_by(fn {_key, record} -> record["sequence"] end)
+    |> Enum.reduce_while({:ok, state}, fn {{capability_id, request_id}, request}, {:ok, acc} ->
+      response = Map.fetch!(acc.mcp_responses, {capability_id, request_id})
+      stderr = Map.get(acc.mcp_stderrs, {capability_id, request_id})
+      locator = {:provider, capability_id, request_id, request["sequence"]}
+
+      join = %{
+        request_sequence: request["sequence"],
+        response_sequence: response["sequence"],
+        stderr_sequence: stderr && stderr["sequence"],
+        transport: request["payload"]["transport"],
+        mission_name: request["payload"]["mission_name"]
+      }
+
+      with {:ok, acc} <-
+             insert(acc, :join_provider, {state.run_id, capability_id, request_id}, join),
+           {:ok, acc} <-
+             order_and_filters(
+               acc,
+               :provider_exchanges,
+               locator,
+               provider_filters(request, capability_id, request_id)
+             ) do
+        {:cont, {:ok, acc}}
+      else
+        error -> {:halt, error}
+      end
+    end)
+  end
+
+  defp materialize_execution(state) do
+    [
+      {:execution_prints, :prints, :prints},
+      {:execution_errors, :errors, :error},
+      {:explicit_failure_values, :failures, :failure}
+    ]
+    |> Enum.reduce_while({:ok, state}, fn {collection, field, role}, {:ok, acc} ->
+      acc.execution_meta
+      |> Map.fetch!(field)
+      |> Enum.reverse()
+      |> Enum.reduce_while({:ok, acc}, fn meta, {:ok, inner} ->
+        locator = {:record, meta.sequence}
+
+        with {:ok, inner} <-
+               insert(
+                 inner,
+                 :join_evaluation,
+                 {state.run_id, meta.evaluation_id, role},
+                 meta.sequence
+               ),
+             {:ok, inner} <-
+               order_and_filters(inner, collection, locator, [
+                 {"evaluation_id", meta.evaluation_id}
+               ]) do
+          {:cont, {:ok, inner}}
+        else
+          error -> {:halt, error}
+        end
+      end)
+      |> case do
+        {:ok, acc} -> {:cont, {:ok, acc}}
+        error -> {:halt, error}
+      end
+    end)
+  end
+
+  defp materialize_turns(state, conversation, _trace_facts) do
+    conversation.turns
+    |> Enum.with_index(1)
+    |> Enum.reduce_while({:ok, state}, fn {turn, ordinal}, {:ok, acc} ->
+      locator = {:turn, ordinal}
+
+      row = %{
+        ordinal: ordinal,
+        stream_id: turn.stream_id,
+        turn: turn.turn,
+        capability_id: turn.capability_id,
+        input_sequence: turn.input_sequence,
+        output_sequence: turn.output_sequence,
+        generated: enrich_generated(state, turn.generated),
+        messages_added_count: length(turn.messages_added_roles)
+      }
+
+      filters = turn_filters(turn)
+
+      with {:ok, acc} <- insert(acc, :turn, {state.run_id, ordinal}, row),
+           {:ok, acc} <- order_and_filters(acc, :turns, locator, filters) do
+        {:cont, {:ok, acc}}
+      else
+        error -> {:halt, error}
+      end
+    end)
+  end
+
+  defp materialize_counts(state, conversation) do
+    pairs = Enum.to_list(state.inputs)
+
+    model =
+      Enum.filter(pairs, fn {_id, input} -> capability_class(input["payload"]) == :model end)
+
+    calls =
+      Enum.reject(pairs, fn {_id, input} -> capability_class(input["payload"]) == :model end)
+
+    counts = %{
+      "model_exchanges" => length(model),
+      "incomplete_model_exchanges" =>
+        Enum.count(model, fn {id, _} -> not Map.has_key?(state.outputs, id) end),
+      "capability_calls" => length(calls),
+      "capability_exceptions" => map_size(state.exceptions),
+      "incomplete_capability_calls" =>
+        Enum.count(calls, fn {id, _} -> not Map.has_key?(state.outputs, id) end),
+      "generated_sources" => length(state.generated_meta),
+      "evaluation_analyses" => map_size(state.analyses),
+      "effective_preludes" => length(state.prelude_meta),
+      "provider_exchanges" => map_size(state.mcp_requests),
+      "execution_prints" => length(state.execution_meta.prints),
+      "execution_errors" => length(state.execution_meta.errors),
+      "explicit_failure_values" => length(state.execution_meta.failures)
+    }
+
+    _ = conversation
+    insert(state, :count, {state.run_id, :summary}, counts)
+  end
+
+  defp materialize_run(state) do
+    with {:ok, [{_key, counts}]} <-
+           {:ok, Indexes.lookup(state.indexes, :counts, {state.run_id, :summary})},
+         run <- %{
+           "run_id" => state.run_id,
+           "trace_id" => state.trace_id,
+           "schema_version" => state.schema_version,
+           "record_count" => state.record_count,
+           "first_timestamp" => state.first_timestamp,
+           "last_timestamp" => state.last_timestamp,
+           "counts" => counts
+         } do
+      insert(state, :run, state.run_id, run)
+    else
+      _other -> {:error, :invalid_record}
+    end
+  end
+
+  defp materialize_result(state), do: {:ok, state}
+
+  defp materialize_relationships(state, conversation, trace_facts) do
+    generated =
+      state.generated_meta
+      |> Enum.reverse()
+      |> Enum.map(fn meta ->
+        parent = get_in(trace_facts, ["parent_evaluation_ids", meta.evaluation_id])
+        calls = Map.get(state.prelude_calls_by_eval, meta.evaluation_id)
+
+        %{
+          "run_id" => state.run_id,
+          "sequence" => meta.sequence,
+          "evaluation_id" => meta.evaluation_id,
+          "parent_evaluation_id" => parent,
+          "environment" => meta.environment,
+          "mission_name" => meta.mission_name,
+          "prelude_calls_available?" => is_list(calls),
+          "prelude_calls" => calls || []
+        }
+      end)
+
+    preludes =
+      Enum.map(Enum.reverse(state.prelude_meta), fn meta ->
+        %{
+          "run_id" => state.run_id,
+          "sequence" => meta.sequence,
+          "component_id" => meta.component_id,
+          "environment" => meta.environment,
+          "mission_name" => meta.mission_name
+        }
+      end)
+
+    errors =
+      Enum.map(Enum.reverse(state.execution_meta.errors), fn meta ->
+        %{
+          "run_id" => state.run_id,
+          "evaluation_id" => meta.evaluation_id,
+          "sequence" => meta.sequence,
+          "details" => %{}
+        }
+      end)
+
+    turns =
+      Enum.map(conversation.turns, fn turn ->
+        %{
+          "run_id" => state.run_id,
+          "stream_id" => turn.stream_id,
+          "generated" =>
+            Enum.map(turn.generated, fn generated ->
+              %{
+                "run_id" => state.run_id,
+                "sequence" => generated.sequence,
+                "evaluation_id" => generated.evaluation_id,
+                "association_ambiguous?" => generated.association_ambiguous?
+              }
+            end)
+        }
+      end)
+
+    collections = %{
+      generated_sources: generated,
+      effective_preludes: preludes,
+      execution_errors: errors,
+      turns: turns,
+      turns_by_run_id: %{
+        state.run_id => %{items: turns, evidence: conversation.evidence}
+      }
+    }
+
+    attached = RunAnalysisRelationships.attach(collections, %{state.run_id => trace_facts})
+
+    Enum.reduce_while(
+      attached.generated_sources ++ attached.effective_preludes ++ attached.execution_errors,
+      {:ok, state},
+      fn item, {:ok, acc} ->
+        key = {state.run_id, item_collection(item), item["sequence"] || item["component_id"]}
+
+        case insert(acc, :relationship, key, item["relationships"]) do
+          {:ok, acc} -> {:cont, {:ok, acc}}
+          error -> {:halt, error}
+        end
+      end
+    )
+  end
+
+  defp item_collection(%{"evaluation_id" => _, "prelude_calls" => _}), do: :generated_sources
+  defp item_collection(%{"component_id" => _, "sequence" => _}), do: :effective_preludes
+  defp item_collection(_item), do: :execution_errors
+
+  defp enrich_generated(state, generated) do
+    Enum.map(generated, fn entry ->
+      parent = Map.get(state.pending_parents, entry.evaluation_id)
+      calls = Map.get(state.prelude_calls_by_eval, entry.evaluation_id)
+
+      entry
+      |> Map.put(:parent_evaluation_id, parent)
+      |> Map.put(:prelude_calls, calls || [])
+    end)
+  end
+
+  defp order_and_filters(state, collection, locator, filters) do
+    ordinal = next_ordinal(state, collection)
+
+    with {:ok, state} <-
+           insert(state, :order, {state.run_id, collection, ordinal}, locator),
+         {:ok, state} <- insert_filters(state, collection, ordinal, locator, filters) do
+      {:ok, put_ordinal(state, collection, ordinal)}
+    end
+  end
+
+  defp insert_filters(state, collection, ordinal, locator, filters) do
+    Enum.reduce_while(filters, {:ok, state}, fn {filter, value}, {:ok, acc} ->
+      key = {state.run_id, collection, filter, ValueHash.hash(value), ordinal}
+
+      case insert(acc, :filter_posting, key, locator) do
+        {:ok, acc} -> {:cont, {:ok, acc}}
+        error -> {:halt, error}
+      end
+    end)
+  end
+
+  defp next_ordinal(state, collection),
+    do: get_in(state, [Access.key(:ordinals, %{}), collection]) |> Kernel.||(0) |> Kernel.+(1)
+
+  defp put_ordinal(state, collection, ordinal),
+    do: put_in(state, [Access.key(:ordinals, %{}), collection], ordinal)
+
+  defp pair_filters(input, capability_id) do
+    payload = input["payload"]
+
+    [
+      {"capability_id", capability_id},
+      {"input_sequence", input["sequence"]},
+      {"mission_name", payload["mission_name"]},
+      {"name", payload["name"]}
+    ]
+    |> Enum.reject(fn {_key, value} -> is_nil(value) end)
+  end
+
+  defp source_filters(meta) do
+    [
+      {"evaluation_id", meta.evaluation_id},
+      {"parent_evaluation_id", meta.parent_evaluation_id},
+      {"mission_name", meta.mission_name}
+    ]
+    |> Kernel.++(call_filters(meta.prelude_calls))
+    |> Enum.reject(fn {_key, value} -> is_nil(value) end)
+  end
+
+  defp prelude_filters(meta) do
+    [
+      {"component_id", meta.component_id},
+      {"environment", meta.environment},
+      {"mission_name", meta.mission_name}
+    ]
+    |> Enum.reject(fn {_key, value} -> is_nil(value) end)
+  end
+
+  defp provider_filters(request, capability_id, request_id) do
+    [
+      {"capability_id", capability_id},
+      {"mission_name", request["payload"]["mission_name"]},
+      {"request_id", request_id}
+    ]
+    |> Enum.reject(fn {_key, value} -> is_nil(value) end)
+  end
+
+  defp turn_filters(turn) do
+    generated_filters =
+      Enum.flat_map(turn.generated, fn generated ->
+        [{"evaluation_id", generated.evaluation_id}]
+      end)
+
+    [{"stream_id", turn.stream_id}, {"capability_id", turn.capability_id} | generated_filters]
+    |> Enum.reject(fn {_key, value} -> is_nil(value) end)
+  end
+
+  defp call_filters(calls) when is_list(calls) do
+    Enum.flat_map(calls, fn call ->
+      [{"prelude_call", call["ref"]}, {"prelude_component", call["component_id"]}]
+    end)
+  end
+
+  defp call_filters(_calls), do: []
+
+  defp insert(state, family, key, value) do
+    case Indexes.insert(state.indexes, family, key, value, state.limits) do
+      {:ok, indexes} -> {:ok, %{state | indexes: indexes}}
+      {:error, _reason} = error -> error
+    end
+  end
+end

--- a/lib/ptc_runner/research/sealed_evidence_log/assembler.ex
+++ b/lib/ptc_runner/research/sealed_evidence_log/assembler.ex
@@ -9,6 +9,7 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Assembler do
   alias PtcRunner.Kernel.RunAnalysisRelationships
   alias PtcRunner.Lisp.RetainedSize
   alias PtcRunner.Research.SealedEvidenceLog.Conversation
+  alias PtcRunner.Research.SealedEvidenceLog.Format
   alias PtcRunner.Research.SealedEvidenceLog.Indexes
   alias PtcRunner.Research.SealedEvidenceLog.ValueHash
 
@@ -22,6 +23,8 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Assembler do
       schema_version: 8,
       first_timestamp: nil,
       last_timestamp: nil,
+      first_sequence: 0,
+      last_sequence: 0,
       record_count: 0,
       conversation: Conversation.new(),
       inputs: %{},
@@ -44,7 +47,8 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Assembler do
   def ingest(state, record, offset, length, digest) do
     record = RetainedSize.detach_binaries(record)
 
-    with :ok <- identity(state, record),
+    with :ok <- schema_version(record),
+         :ok <- identity(state, record),
          :ok <- next_sequence(state, record),
          {:ok, state} <- put_primary(state, record, offset, length, digest),
          {:ok, state} <- put_join(state, record) do
@@ -56,6 +60,8 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Assembler do
            schema_version: record["schema_version"],
            first_timestamp: state.first_timestamp || record["timestamp"],
            last_timestamp: record["timestamp"],
+           first_sequence: first_sequence(state, record["sequence"]),
+           last_sequence: record["sequence"],
            record_count: state.record_count + 1
        }}
     end
@@ -80,6 +86,15 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Assembler do
       {:ok, Map.put(state, :evidence, conversation.evidence)}
     end
   end
+
+  defp schema_version(%{"schema_version" => version}) do
+    if version == Format.schema_version(), do: :ok, else: {:error, :invalid_record}
+  end
+
+  defp schema_version(_record), do: {:error, :invalid_record}
+
+  defp first_sequence(%{record_count: 0}, sequence), do: sequence
+  defp first_sequence(%{first_sequence: first}, _sequence), do: first
 
   defp identity(%{run_id: nil}, %{"run_id" => run_id, "trace_id" => trace_id})
        when is_binary(run_id) and is_binary(trace_id),
@@ -116,7 +131,19 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Assembler do
     if Map.has_key?(state.inputs, id) do
       {:error, :invalid_record}
     else
-      {:ok, %{state | inputs: Map.put(state.inputs, id, record)}}
+      payload = record["payload"]
+
+      {:ok,
+       %{
+         state
+         | inputs:
+             Map.put(state.inputs, id, %{
+               sequence: record["sequence"],
+               environment: payload["environment"],
+               mission_name: payload["mission_name"],
+               name: payload["name"]
+             })
+       }}
     end
   end
 
@@ -126,7 +153,7 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Assembler do
 
     if compatible_capability?(input, record) and not Map.has_key?(state.outputs, id) and
          valid_exception_output?(state, id, record["payload"]["result"]) do
-      {:ok, %{state | outputs: Map.put(state.outputs, id, record)}}
+      {:ok, %{state | outputs: Map.put(state.outputs, id, record["sequence"])}}
     else
       {:error, :invalid_record}
     end
@@ -138,7 +165,7 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Assembler do
 
     if compatible_capability?(input, record) and not Map.has_key?(state.exceptions, id) and
          not Map.has_key?(state.outputs, id) do
-      {:ok, %{state | exceptions: Map.put(state.exceptions, id, record)}}
+      {:ok, %{state | exceptions: Map.put(state.exceptions, id, record["sequence"])}}
     else
       {:error, :invalid_record}
     end
@@ -150,7 +177,16 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Assembler do
     if Map.has_key?(state.mcp_requests, key) do
       {:error, :invalid_record}
     else
-      {:ok, %{state | mcp_requests: Map.put(state.mcp_requests, key, record)}}
+      {:ok,
+       %{
+         state
+         | mcp_requests:
+             Map.put(state.mcp_requests, key, %{
+               sequence: record["sequence"],
+               transport: record["payload"]["transport"],
+               mission_name: record["payload"]["mission_name"]
+             })
+       }}
     end
   end
 
@@ -160,12 +196,16 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Assembler do
     if Map.has_key?(state.mcp_responses, key) do
       {:error, :invalid_record}
     else
-      {:ok, %{state | mcp_responses: Map.put(state.mcp_responses, key, record)}}
+      {:ok,
+       %{
+         state
+         | mcp_responses: Map.put(state.mcp_responses, key, record["sequence"])
+       }}
     end
   end
 
   defp put_join(state, %{"record_type" => "mcp-stderr"} = record) do
-    {:ok, %{state | mcp_stderrs: Map.put(state.mcp_stderrs, mcp_key(record), record)}}
+    {:ok, %{state | mcp_stderrs: Map.put(state.mcp_stderrs, mcp_key(record), record["sequence"])}}
   end
 
   defp put_join(state, %{"record_type" => "evaluation-analysis"} = record) do
@@ -176,7 +216,7 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Assembler do
       {:ok,
        %{
          state
-         | analyses: Map.put(state.analyses, id, record),
+         | analyses: Map.put(state.analyses, id, record["sequence"]),
            prelude_calls_by_eval:
              Map.put(state.prelude_calls_by_eval, id, record["payload"]["prelude_calls"])
        }}
@@ -250,17 +290,17 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Assembler do
     %{state | conversation: conversation}
   end
 
-  defp capability_class(%{"environment" => "workflow", "name" => "llm-request"}), do: :model
-  defp capability_class(_payload), do: :capability
+  defp capability_class(%{environment: "workflow", name: "llm-request"}), do: :model
+  defp capability_class(_input), do: :capability
 
   defp compatible_capability?(nil, _record), do: false
 
   defp compatible_capability?(input, record) do
     payload = record["payload"]
 
-    input["payload"]["environment"] == payload["environment"] and
-      input["payload"]["mission_name"] == payload["mission_name"] and
-      input["payload"]["name"] == payload["name"]
+    input.environment == payload["environment"] and
+      input.mission_name == payload["mission_name"] and
+      input.name == payload["name"]
   end
 
   defp valid_exception_output?(state, id, result) do
@@ -292,26 +332,26 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Assembler do
 
   defp materialize_pairs(state) do
     state.inputs
-    |> Enum.sort_by(fn {_id, record} -> record["sequence"] end)
+    |> Enum.sort_by(fn {_id, input} -> input.sequence end)
     |> Enum.reduce_while({:ok, state}, fn {id, input}, {:ok, acc} ->
       output = Map.get(acc.outputs, id)
       exception = Map.get(acc.exceptions, id)
-      class = capability_class(input["payload"])
+      class = capability_class(input)
       collection = if class == :model, do: :model_exchanges, else: :capability_calls
 
-      locator = {:capability, id, input["sequence"]}
+      locator = {:capability, id, input.sequence}
 
       join = %{
-        input_sequence: input["sequence"],
-        exception_sequence: exception && exception["sequence"],
-        output_sequence: output && output["sequence"],
-        environment: input["payload"]["environment"],
-        mission_name: input["payload"]["mission_name"],
-        name: input["payload"]["name"],
+        input_sequence: input.sequence,
+        exception_sequence: exception,
+        output_sequence: output,
+        environment: input.environment,
+        mission_name: input.mission_name,
+        name: input.name,
         class: class
       }
 
-      with {:ok, acc} <- insert(acc, :join_capability, {input["run_id"], id}, join),
+      with {:ok, acc} <- insert(acc, :join_capability, {acc.run_id, id}, join),
            {:ok, acc} <- order_and_filters(acc, collection, locator, pair_filters(input, id)) do
         {:cont, {:ok, acc}}
       else
@@ -370,18 +410,18 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Assembler do
 
   defp materialize_providers(state) do
     state.mcp_requests
-    |> Enum.sort_by(fn {_key, record} -> record["sequence"] end)
+    |> Enum.sort_by(fn {_key, request} -> request.sequence end)
     |> Enum.reduce_while({:ok, state}, fn {{capability_id, request_id}, request}, {:ok, acc} ->
       response = Map.fetch!(acc.mcp_responses, {capability_id, request_id})
       stderr = Map.get(acc.mcp_stderrs, {capability_id, request_id})
-      locator = {:provider, capability_id, request_id, request["sequence"]}
+      locator = {:provider, capability_id, request_id, request.sequence}
 
       join = %{
-        request_sequence: request["sequence"],
-        response_sequence: response["sequence"],
-        stderr_sequence: stderr && stderr["sequence"],
-        transport: request["payload"]["transport"],
-        mission_name: request["payload"]["mission_name"]
+        request_sequence: request.sequence,
+        response_sequence: response,
+        stderr_sequence: stderr,
+        transport: request.transport,
+        mission_name: request.mission_name
       }
 
       with {:ok, acc} <-
@@ -468,10 +508,10 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Assembler do
     pairs = Enum.to_list(state.inputs)
 
     model =
-      Enum.filter(pairs, fn {_id, input} -> capability_class(input["payload"]) == :model end)
+      Enum.filter(pairs, fn {_id, input} -> capability_class(input) == :model end)
 
     calls =
-      Enum.reject(pairs, fn {_id, input} -> capability_class(input["payload"]) == :model end)
+      Enum.reject(pairs, fn {_id, input} -> capability_class(input) == :model end)
 
     counts = %{
       "model_exchanges" => length(model),
@@ -641,13 +681,11 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Assembler do
     do: put_in(state, [Access.key(:ordinals, %{}), collection], ordinal)
 
   defp pair_filters(input, capability_id) do
-    payload = input["payload"]
-
     [
       {"capability_id", capability_id},
-      {"input_sequence", input["sequence"]},
-      {"mission_name", payload["mission_name"]},
-      {"name", payload["name"]}
+      {"input_sequence", input.sequence},
+      {"mission_name", input.mission_name},
+      {"name", input.name}
     ]
     |> Enum.reject(fn {_key, value} -> is_nil(value) end)
   end
@@ -674,7 +712,7 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Assembler do
   defp provider_filters(request, capability_id, request_id) do
     [
       {"capability_id", capability_id},
-      {"mission_name", request["payload"]["mission_name"]},
+      {"mission_name", request.mission_name},
       {"request_id", request_id}
     ]
     |> Enum.reject(fn {_key, value} -> is_nil(value) end)

--- a/lib/ptc_runner/research/sealed_evidence_log/assembler.ex
+++ b/lib/ptc_runner/research/sealed_evidence_log/assembler.ex
@@ -6,6 +6,7 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Assembler do
   inserted after the last frame, once joins and conversation facts are closed.
   """
 
+  alias PtcRunner.Kernel.ResultIdentity
   alias PtcRunner.Kernel.RunAnalysisRelationships
   alias PtcRunner.Lisp.RetainedSize
   alias PtcRunner.Research.SealedEvidenceLog.Conversation
@@ -266,14 +267,19 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Assembler do
   end
 
   defp put_join(state, %{"record_type" => "run-result"} = record) do
-    if state.result_sequence do
-      {:error, :invalid_record}
-    else
-      insert(state, :result, record["run_id"], record["sequence"])
-      |> case do
-        {:ok, state} -> {:ok, %{state | result_sequence: record["sequence"]}}
-        error -> error
-      end
+    cond do
+      not is_nil(state.result_sequence) ->
+        {:error, :invalid_record}
+
+      not valid_run_result?(record) ->
+        {:error, :invalid_record}
+
+      true ->
+        insert(state, :result, record["run_id"], record["sequence"])
+        |> case do
+          {:ok, state} -> {:ok, %{state | result_sequence: record["sequence"]}}
+          error -> error
+        end
     end
   end
 
@@ -290,6 +296,12 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Assembler do
   end
 
   defp valid_source_payload?(_payload), do: false
+
+  defp valid_run_result?(%{"payload" => %{"result_hash" => hash, "value" => value}}) do
+    ResultIdentity.valid_hash?(hash) and ResultIdentity.strict_json_hash(value) == {:ok, hash}
+  end
+
+  defp valid_run_result?(_record), do: false
 
   defp put_execution(state, field, record) do
     meta = %{

--- a/lib/ptc_runner/research/sealed_evidence_log/assembler.ex
+++ b/lib/ptc_runner/research/sealed_evidence_log/assembler.ex
@@ -224,25 +224,33 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Assembler do
   end
 
   defp put_join(state, %{"record_type" => "evaluation-source"} = record) do
-    meta = %{
-      sequence: record["sequence"],
-      evaluation_id: record["correlation"]["evaluation_id"],
-      environment: record["payload"]["environment"],
-      mission_name: record["payload"]["mission_name"]
-    }
+    if valid_source_payload?(record["payload"]) do
+      meta = %{
+        sequence: record["sequence"],
+        evaluation_id: record["correlation"]["evaluation_id"],
+        environment: record["payload"]["environment"],
+        mission_name: record["payload"]["mission_name"]
+      }
 
-    {:ok, %{state | generated_meta: [meta | state.generated_meta]}}
+      {:ok, %{state | generated_meta: [meta | state.generated_meta]}}
+    else
+      {:error, :invalid_record}
+    end
   end
 
   defp put_join(state, %{"record_type" => "prelude-source"} = record) do
-    meta = %{
-      sequence: record["sequence"],
-      component_id: record["correlation"]["component_id"],
-      environment: record["payload"]["environment"],
-      mission_name: record["payload"]["mission_name"]
-    }
+    if valid_source_payload?(record["payload"]) do
+      meta = %{
+        sequence: record["sequence"],
+        component_id: record["correlation"]["component_id"],
+        environment: record["payload"]["environment"],
+        mission_name: record["payload"]["mission_name"]
+      }
 
-    {:ok, %{state | prelude_meta: [meta | state.prelude_meta]}}
+      {:ok, %{state | prelude_meta: [meta | state.prelude_meta]}}
+    else
+      {:error, :invalid_record}
+    end
   end
 
   defp put_join(state, %{"record_type" => "execution-prints"} = record) do
@@ -270,6 +278,18 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Assembler do
   end
 
   defp put_join(_state, _record), do: {:error, :invalid_record}
+
+  defp valid_source_payload?(%{
+         "source" => source,
+         "source_hash" => hash,
+         "source_bytes" => bytes
+       })
+       when is_binary(source) and is_binary(hash) and is_integer(bytes) do
+    bytes == byte_size(source) and
+      hash == Base.encode16(:crypto.hash(:sha256, source), case: :lower)
+  end
+
+  defp valid_source_payload?(_payload), do: false
 
   defp put_execution(state, field, record) do
     meta = %{

--- a/lib/ptc_runner/research/sealed_evidence_log/checkpoints.ex
+++ b/lib/ptc_runner/research/sealed_evidence_log/checkpoints.ex
@@ -1,0 +1,105 @@
+defmodule PtcRunner.Research.SealedEvidenceLog.Checkpoints do
+  @moduledoc """
+  Deterministic memory checkpoints for producer and admission processes.
+
+  Sampled process peaks are diagnostic only. Each named event updates running
+  peaks and keeps only the first and last sample for that name, so checkpoint
+  memory does not grow with record count. Rows record `Process.info(pid, :memory)`
+  and referenced binary bytes for every prototype-created process plus a
+  conservative sum aggregate. Process identifiers are not retained.
+  """
+
+  @type sample :: %{
+          memory_bytes: non_neg_integer(),
+          referenced_binary_bytes: non_neg_integer()
+        }
+
+  @type checkpoint :: %{
+          name: atom(),
+          at_ms: integer(),
+          processes: [sample()],
+          aggregate_memory_bytes: non_neg_integer(),
+          aggregate_referenced_binary_bytes: non_neg_integer()
+        }
+
+  @spec new() :: map()
+  def new, do: %{samples: %{}, counts: %{}, peaks: %{}}
+
+  @spec record(map(), atom(), [pid()]) :: map()
+  def record(state, name, pids) when is_map(state) and is_atom(name) and is_list(pids) do
+    processes = Enum.map(pids, &sample/1)
+
+    checkpoint = %{
+      name: name,
+      at_ms: System.monotonic_time(:millisecond),
+      processes: processes,
+      aggregate_memory_bytes: Enum.reduce(processes, 0, &(&1.memory_bytes + &2)),
+      aggregate_referenced_binary_bytes:
+        Enum.reduce(processes, 0, &(&1.referenced_binary_bytes + &2))
+    }
+
+    count = Map.get(state.counts, name, 0) + 1
+
+    samples =
+      Map.update(state.samples, name, %{first: checkpoint, last: checkpoint}, fn existing ->
+        %{existing | last: checkpoint}
+      end)
+
+    %{
+      state
+      | samples: samples,
+        counts: Map.put(state.counts, name, count),
+        peaks: update_peaks(state.peaks, checkpoint)
+    }
+  end
+
+  @spec finalize(map()) :: map()
+  def finalize(%{samples: samples, counts: counts, peaks: peaks}) do
+    checkpoints =
+      samples
+      |> Enum.sort_by(&elem(&1, 0))
+      |> Enum.flat_map(fn {_name, pair} ->
+        if Map.fetch!(counts, pair.first.name) == 1,
+          do: [pair.first],
+          else: [pair.first, pair.last]
+      end)
+
+    %{
+      checkpoints: checkpoints,
+      counts: counts,
+      diagnostic_peaks: peaks
+    }
+  end
+
+  defp sample(pid) do
+    %{
+      memory_bytes: info_bytes(pid, :memory),
+      referenced_binary_bytes: referenced_binary_bytes(pid)
+    }
+  end
+
+  defp info_bytes(pid, key) do
+    case Process.info(pid, key) do
+      {^key, value} when is_integer(value) -> value
+      _other -> 0
+    end
+  end
+
+  defp referenced_binary_bytes(pid) do
+    case Process.info(pid, :binary) do
+      {:binary, binaries} ->
+        Enum.reduce(binaries, 0, fn {_ptr, size, _refc}, acc -> acc + size end)
+
+      _other ->
+        0
+    end
+  end
+
+  defp update_peaks(peaks, checkpoint) do
+    Map.update(peaks, checkpoint.name, checkpoint, fn current ->
+      if checkpoint.aggregate_memory_bytes > current.aggregate_memory_bytes,
+        do: checkpoint,
+        else: current
+    end)
+  end
+end

--- a/lib/ptc_runner/research/sealed_evidence_log/codec.ex
+++ b/lib/ptc_runner/research/sealed_evidence_log/codec.ex
@@ -1,0 +1,61 @@
+defmodule PtcRunner.Research.SealedEvidenceLog.Codec do
+  @moduledoc """
+  Deterministic JSON evidence encoding for the sealed-log prototype.
+
+  Envelope objects use the declared inspection field order. Nested maps sort
+  keys by UTF-8 bytes through `PtcRunner.Kernel.DeterministicJSON`.
+  """
+
+  alias PtcRunner.Kernel.DeterministicJSON
+  alias PtcRunner.Lisp.RetainedSize
+  alias PtcRunner.Research.SealedEvidenceLog.Format
+
+  @envelope [
+    "schema_version",
+    "run_id",
+    "trace_id",
+    "sequence",
+    "timestamp",
+    "record_type",
+    "correlation",
+    "payload"
+  ]
+
+  @spec encode_record(map()) :: {:ok, binary()} | {:error, :invalid_record}
+  def encode_record(record) when is_map(record) do
+    with {:ok, pairs} <- envelope_pairs(record),
+         {:ok, encoded} <- DeterministicJSON.encode({:object, pairs}) do
+      {:ok, encoded}
+    else
+      _error -> {:error, :invalid_record}
+    end
+  end
+
+  def encode_record(_record), do: {:error, :invalid_record}
+
+  @spec decode_record(binary()) :: {:ok, map()} | {:error, :malformed_source}
+  def decode_record(payload) when is_binary(payload) do
+    case Jason.decode(payload) do
+      {:ok, record} when is_map(record) -> {:ok, RetainedSize.detach_binaries(record)}
+      _error -> {:error, :malformed_source}
+    end
+  end
+
+  def decode_record(_payload), do: {:error, :malformed_source}
+
+  @spec schema_version() :: pos_integer()
+  def schema_version, do: Format.schema_version()
+
+  defp envelope_pairs(record) do
+    Enum.reduce_while(@envelope, {:ok, []}, fn key, {:ok, pairs} ->
+      case Map.fetch(record, key) do
+        {:ok, value} -> {:cont, {:ok, [{key, value} | pairs]}}
+        :error -> {:halt, :error}
+      end
+    end)
+    |> case do
+      {:ok, pairs} -> {:ok, Enum.reverse(pairs)}
+      :error -> :error
+    end
+  end
+end

--- a/lib/ptc_runner/research/sealed_evidence_log/conversation.ex
+++ b/lib/ptc_runner/research/sealed_evidence_log/conversation.ex
@@ -7,7 +7,6 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Conversation do
   In-flight request messages are staged only until the matching output arrives.
   """
 
-  alias PtcRunner.Kernel.ConversationProjection
   alias PtcRunner.Kernel.DeterministicJSON
   alias PtcRunner.Lisp.Runtime.String, as: RuntimeString
 
@@ -368,6 +367,4 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Conversation do
       "complete?" => true
     }
   end
-
-  defdelegate compact_turns(items), to: ConversationProjection
 end

--- a/lib/ptc_runner/research/sealed_evidence_log/conversation.ex
+++ b/lib/ptc_runner/research/sealed_evidence_log/conversation.ex
@@ -1,0 +1,373 @@
+defmodule PtcRunner.Research.SealedEvidenceLog.Conversation do
+  @moduledoc """
+  Digest-based turn reconstruction that never retains evidence payloads.
+
+  Prefix matching hashes the comparable form of the current request's messages
+  against stored complete-message digests from earlier completed exchanges.
+  In-flight request messages are staged only until the matching output arrives.
+  """
+
+  alias PtcRunner.Kernel.ConversationProjection
+  alias PtcRunner.Kernel.DeterministicJSON
+  alias PtcRunner.Lisp.Runtime.String, as: RuntimeString
+
+  @type node_row :: %{
+          complete_hash: binary(),
+          complete_count: non_neg_integer(),
+          stream_id: binary(),
+          turn: pos_integer()
+        }
+
+  @spec new() :: map()
+  def new do
+    %{
+      nodes: [],
+      pending: %{},
+      turns: [],
+      ambiguous: [],
+      stream_order: [],
+      next_stream: 1,
+      program_hashes: [],
+      source_hashes: []
+    }
+  end
+
+  @spec observe_input(map(), map()) :: map()
+  def observe_input(state, record) when is_map(state) and is_map(record) do
+    if model_input?(record) do
+      place_input(state, record)
+    else
+      state
+    end
+  end
+
+  @spec observe_output(map(), map()) :: map()
+  def observe_output(state, record) when is_map(state) and is_map(record) do
+    if model_output?(record) do
+      complete_turn(state, record)
+    else
+      state
+    end
+  end
+
+  @spec observe_source(map(), map()) :: map()
+  def observe_source(state, record) when is_map(state) and is_map(record) do
+    source = get_in(record, ["payload", "source"])
+
+    if is_binary(source) do
+      hash = hash_value(source)
+      evaluation_id = get_in(record, ["correlation", "evaluation_id"])
+
+      update_in(state, [:source_hashes], fn rows ->
+        [
+          %{
+            hash: hash,
+            sequence: record["sequence"],
+            evaluation_id: evaluation_id,
+            parent_evaluation_id: nil
+          }
+          | rows
+        ]
+      end)
+    else
+      state
+    end
+  end
+
+  @spec finish(map(), map()) :: map()
+  def finish(state, trace_facts) when is_map(state) and is_map(trace_facts) do
+    source_counts = Enum.frequencies_by(state.source_hashes, & &1.hash)
+
+    by_stream = Enum.group_by(state.turns, & &1.stream_id)
+
+    turns =
+      state.stream_order
+      |> Enum.flat_map(fn stream_id ->
+        by_stream
+        |> Map.get(stream_id, [])
+        |> Enum.sort_by(& &1.turn)
+      end)
+      |> Enum.map(&attach_generated(&1, state.source_hashes, source_counts))
+
+    expected = MapSet.new(Map.get(trace_facts, "expected_model_exchange_ids", []))
+
+    captured =
+      turns
+      |> Enum.map(& &1.capability_id)
+      |> MapSet.new()
+
+    missing_exchange_count = expected |> MapSet.difference(captured) |> MapSet.size()
+
+    canonical_complete? =
+      Map.get(trace_facts, "terminal?", false) and
+        not Map.get(trace_facts, "events_dropped?", false)
+
+    source_ambiguity_count =
+      Enum.count(turns, fn turn ->
+        Enum.any?(turn.generated, & &1.association_ambiguous?)
+      end)
+
+    ambiguity_count = length(state.ambiguous) + source_ambiguity_count
+
+    %{
+      turns: turns,
+      ambiguous: Enum.reverse(state.ambiguous),
+      evidence: %{
+        "complete?" =>
+          canonical_complete? and missing_exchange_count == 0 and ambiguity_count == 0,
+        "canonical_complete?" => canonical_complete?,
+        "missing_exchange_count" => missing_exchange_count,
+        "ambiguity_count" => ambiguity_count
+      }
+    }
+  end
+
+  @spec assemble_turn(map(), map(), map(), [map()]) :: map()
+  def assemble_turn(turn_meta, input, output, generated) do
+    exchange = capability_pair(input, output)
+    messages = get_in(exchange, ["arguments", "messages"]) || []
+    assistant = assistant_message(exchange["result"])
+    predecessor_count = max(length(messages) - added_count(turn_meta), 0)
+    added = Enum.drop(messages, predecessor_count)
+
+    %{
+      "turn" => turn_meta.turn,
+      "stream_id" => turn_meta.stream_id,
+      "capability_id" => exchange["capability_id"],
+      "request_sequence" => exchange["input_sequence"],
+      "response_sequence" => exchange["output_sequence"],
+      "system" => get_in(exchange, ["arguments", "system"]),
+      "messages_added" => added,
+      "feedback" => Enum.filter(added, &(&1["role"] == "tool")),
+      "response" => exchange["result"],
+      "assistant" => assistant,
+      "tokens" => get_in(exchange, ["result", "value", "tokens"]),
+      "outcome" => exchange["result"]["status"],
+      "run_id" => input["run_id"],
+      "trace_id" => input["trace_id"],
+      "generated" => generated
+    }
+  end
+
+  defp place_input(state, record) do
+    capability_id = record["correlation"]["capability_id"]
+    messages = get_in(record, ["payload", "arguments", "messages"])
+
+    if is_list(messages) do
+      comparable = Enum.map(messages, &comparable_message/1)
+      {stream_id, turn, added_count, state} = choose_predecessor(state, comparable)
+
+      pending = %{
+        capability_id: capability_id,
+        sequence: record["sequence"],
+        comparable: comparable,
+        stream_id: stream_id,
+        turn: turn,
+        added_count: added_count
+      }
+
+      %{state | pending: Map.put(state.pending, capability_id, pending)}
+    else
+      add_ambiguous(state, capability_id, record["sequence"], "messages_unavailable")
+    end
+  end
+
+  defp choose_predecessor(state, comparable) do
+    candidates =
+      Enum.filter(state.nodes, fn node ->
+        node.complete_count < length(comparable) and prefix_match?(comparable, node)
+      end)
+
+    if candidates == [] do
+      stream_id = "stream-#{state.next_stream}"
+
+      state = %{
+        state
+        | next_stream: state.next_stream + 1,
+          stream_order: state.stream_order ++ [stream_id]
+      }
+
+      {stream_id, 1, length(comparable), state}
+    else
+      max_size = candidates |> Enum.map(& &1.complete_count) |> Enum.max()
+      longest = Enum.filter(candidates, &(&1.complete_count == max_size))
+
+      case longest do
+        [predecessor] ->
+          added = length(comparable) - predecessor.complete_count
+          {predecessor.stream_id, predecessor.turn + 1, added, state}
+
+        _multiple ->
+          {:ambiguous, :ambiguous, 0, state}
+      end
+    end
+  end
+
+  defp complete_turn(state, record) do
+    capability_id = record["correlation"]["capability_id"]
+
+    case Map.pop(state.pending, capability_id) do
+      {nil, _pending} ->
+        state
+
+      {pending, pending_map} ->
+        if pending.stream_id == :ambiguous do
+          state
+          |> Map.put(:pending, pending_map)
+          |> add_ambiguous(
+            capability_id,
+            pending.sequence,
+            "multiple_maximal_predecessors"
+          )
+        else
+          assistant = assistant_message(record["payload"]["result"])
+          complete = pending.comparable ++ [comparable_message(assistant)]
+          {:ok, encoded} = DeterministicJSON.encode(complete)
+          program_hashes = program_hashes(record["payload"]["result"])
+
+          node = %{
+            complete_hash: :crypto.hash(:sha256, encoded),
+            complete_count: length(complete),
+            stream_id: pending.stream_id,
+            turn: pending.turn
+          }
+
+          turn = %{
+            ordinal: length(state.turns) + 1,
+            stream_id: pending.stream_id,
+            turn: pending.turn,
+            capability_id: capability_id,
+            input_sequence: pending.sequence,
+            output_sequence: record["sequence"],
+            messages_added_roles: List.duplicate(:added, pending.added_count),
+            program_hashes: program_hashes,
+            generated: []
+          }
+
+          %{
+            state
+            | pending: pending_map,
+              nodes: state.nodes ++ [node],
+              turns: [turn | state.turns]
+          }
+        end
+    end
+  end
+
+  defp attach_generated(turn, source_hashes, source_counts) do
+    generated =
+      Enum.flat_map(turn.program_hashes, fn hash ->
+        matches = Enum.filter(source_hashes, &(&1.hash == hash))
+
+        Enum.map(matches, fn source ->
+          %{
+            sequence: source.sequence,
+            evaluation_id: source.evaluation_id,
+            association: "source_match",
+            association_ambiguous?: Map.get(source_counts, hash, 0) > 1
+          }
+        end)
+      end)
+
+    Map.put(turn, :generated, generated)
+  end
+
+  defp prefix_match?(comparable, node) do
+    prefix = Enum.take(comparable, node.complete_count)
+
+    case DeterministicJSON.encode(prefix) do
+      {:ok, encoded} -> :crypto.hash(:sha256, encoded) == node.complete_hash
+      _error -> false
+    end
+  end
+
+  defp add_ambiguous(state, capability_id, sequence, reason) do
+    entry = %{
+      "capability_id" => capability_id,
+      "request_sequence" => sequence,
+      "reason" => reason
+    }
+
+    %{state | ambiguous: [entry | state.ambiguous]}
+  end
+
+  defp model_input?(%{"record_type" => "capability-input", "payload" => payload}),
+    do: payload["environment"] == "workflow" and payload["name"] == "llm-request"
+
+  defp model_input?(_record), do: false
+
+  defp model_output?(%{"record_type" => "capability-output", "payload" => payload}),
+    do: payload["environment"] == "workflow" and payload["name"] == "llm-request"
+
+  defp model_output?(_record), do: false
+
+  defp program_hashes(%{"value" => %{"tool_calls" => calls}}) when is_list(calls) do
+    Enum.flat_map(calls, fn call ->
+      case get_in(call, ["args", "program"]) do
+        source when is_binary(source) -> [hash_value(source)]
+        _other -> []
+      end
+    end)
+  end
+
+  defp program_hashes(_result), do: []
+
+  defp hash_value(value) when is_binary(value), do: :crypto.hash(:sha256, value)
+
+  # ex_dna:disable-for-next-line — research prototype mirrors ConversationProjection for the differential oracle
+  defp comparable_message(%{"role" => "assistant", "tool_calls" => [_ | _]} = message) do
+    case Map.get(message, "content") do
+      nil -> Map.put(message, "content", nil)
+      content when is_binary(content) -> normalize_blank_content(message, content)
+      _other -> message
+    end
+  end
+
+  defp comparable_message(message), do: message
+
+  defp normalize_blank_content(message, content) do
+    if RuntimeString.blank?(content),
+      do: Map.put(message, "content", nil),
+      else: message
+  end
+
+  # ex_dna:disable-for-next-line — research prototype mirrors ConversationProjection for the differential oracle
+  defp assistant_message(%{"value" => value}) when is_map(value) do
+    value
+    |> Map.take(["content", "tool_calls"])
+    |> Map.put("role", "assistant")
+    |> ensure_assistant_content(value)
+  end
+
+  defp assistant_message(result), do: %{"role" => "assistant", "content" => result}
+
+  defp ensure_assistant_content(%{"role" => "assistant"} = message, value)
+       when map_size(message) == 1,
+       do: Map.put(message, "content", value)
+
+  defp ensure_assistant_content(message, _value), do: message
+
+  defp added_count(%{messages_added_count: count}) when is_integer(count) and count >= 0,
+    do: count
+
+  defp added_count(%{messages_added_roles: roles}) when is_list(roles), do: length(roles)
+  defp added_count(_turn_meta), do: 0
+
+  defp capability_pair(input, output) do
+    %{
+      "run_id" => input["run_id"],
+      "trace_id" => input["trace_id"],
+      "capability_id" => input["correlation"]["capability_id"],
+      "environment" => input["payload"]["environment"],
+      "mission_name" => input["payload"]["mission_name"],
+      "name" => input["payload"]["name"],
+      "input_sequence" => input["sequence"],
+      "output_sequence" => output["sequence"],
+      "arguments" => input["payload"]["arguments"],
+      "result" => output["payload"]["result"],
+      "complete?" => true
+    }
+  end
+
+  defdelegate compact_turns(items), to: ConversationProjection
+end

--- a/lib/ptc_runner/research/sealed_evidence_log/format.ex
+++ b/lib/ptc_runner/research/sealed_evidence_log/format.ex
@@ -1,0 +1,144 @@
+defmodule PtcRunner.Research.SealedEvidenceLog.Format do
+  @moduledoc """
+  Header, length-framed evidence, and terminal footer for the ETS-index prototype.
+
+  This is a test/benchmark-only container. Production inspection routing still
+  uses JSONL. The layout is the simple candidate from issue #1646:
+
+  ```text
+  16-byte versioned header
+  length-framed deterministic JSON evidence
+  192-byte terminal footer
+  ```
+
+  Multibyte integers are unsigned big-endian. Offsets are absolute. A reader
+  rejects a size that does not match the opened file, a header/footer version
+  mismatch, overlap, or nonzero reserved bytes before following any range.
+  """
+
+  @header_magic "PTCINS01"
+  @footer_magic "PTCIFTR1"
+  @format_version 1
+  @schema_version 8
+  @header_size 16
+  @footer_size 192
+
+  @type footer :: %{
+          total_bytes: non_neg_integer(),
+          evidence_offset: non_neg_integer(),
+          evidence_bytes: non_neg_integer(),
+          record_count: non_neg_integer(),
+          first_sequence: non_neg_integer(),
+          last_sequence: non_neg_integer(),
+          run_id_sha256: binary(),
+          trace_id_sha256: binary(),
+          evidence_sha256: binary(),
+          artifact_digest: binary()
+        }
+
+  @spec header_magic() :: binary()
+  def header_magic, do: @header_magic
+
+  @spec footer_magic() :: binary()
+  def footer_magic, do: @footer_magic
+
+  @spec format_version() :: pos_integer()
+  def format_version, do: @format_version
+
+  @spec schema_version() :: pos_integer()
+  def schema_version, do: @schema_version
+
+  @spec header_size() :: pos_integer()
+  def header_size, do: @header_size
+
+  @spec footer_size() :: pos_integer()
+  def footer_size, do: @footer_size
+
+  @spec encode_header() :: binary()
+  def encode_header do
+    <<@header_magic::binary, @format_version::unsigned-big-16, @schema_version::unsigned-big-16,
+      @header_size::unsigned-big-32>>
+  end
+
+  @spec decode_header(binary()) :: {:ok, :header} | {:error, :malformed_source}
+  def decode_header(
+        <<@header_magic::binary, @format_version::unsigned-big-16,
+          @schema_version::unsigned-big-16, @header_size::unsigned-big-32>>
+      ),
+      do: {:ok, :header}
+
+  def decode_header(_other), do: {:error, :malformed_source}
+
+  @spec encode_frame(binary()) :: {:ok, binary()} | {:error, :invalid_frame}
+  def encode_frame(payload) when is_binary(payload) do
+    size = byte_size(payload)
+
+    if size <= 0xFFFF_FFFF_FFFF_FFFF do
+      {:ok, <<size::unsigned-big-64, payload::binary>>}
+    else
+      {:error, :invalid_frame}
+    end
+  end
+
+  def encode_frame(_payload), do: {:error, :invalid_frame}
+
+  @spec frame_payload_offset(non_neg_integer()) :: non_neg_integer()
+  def frame_payload_offset(frame_offset) when is_integer(frame_offset) and frame_offset >= 0,
+    do: frame_offset + 8
+
+  @spec encode_footer(footer()) :: binary()
+  def encode_footer(footer) when is_map(footer) do
+    encode_footer_bytes(footer, footer.artifact_digest)
+  end
+
+  @spec unsigned_footer(footer()) :: binary()
+  def unsigned_footer(footer) when is_map(footer) do
+    encode_footer_bytes(footer, <<0::unsigned-big-256>>)
+  end
+
+  @spec decode_footer(binary()) :: {:ok, footer()} | {:error, :malformed_source}
+  def decode_footer(
+        <<@footer_magic::binary, @format_version::unsigned-big-16,
+          @schema_version::unsigned-big-16, @footer_size::unsigned-big-32,
+          total_bytes::unsigned-big-64, evidence_offset::unsigned-big-64,
+          evidence_bytes::unsigned-big-64, record_count::unsigned-big-64,
+          first_sequence::unsigned-big-64, last_sequence::unsigned-big-64,
+          run_id_sha256::binary-size(32), trace_id_sha256::binary-size(32),
+          evidence_sha256::binary-size(32), artifact_digest::binary-size(32)>>
+      ) do
+    {:ok,
+     %{
+       total_bytes: total_bytes,
+       evidence_offset: evidence_offset,
+       evidence_bytes: evidence_bytes,
+       record_count: record_count,
+       first_sequence: first_sequence,
+       last_sequence: last_sequence,
+       run_id_sha256: run_id_sha256,
+       trace_id_sha256: trace_id_sha256,
+       evidence_sha256: evidence_sha256,
+       artifact_digest: artifact_digest
+     }}
+  end
+
+  def decode_footer(_other), do: {:error, :malformed_source}
+
+  @spec identity_sha256(binary()) :: binary()
+  def identity_sha256(value) when is_binary(value), do: :crypto.hash(:sha256, value)
+
+  @spec artifact_digest(binary(), binary(), footer()) :: binary()
+  def artifact_digest(header, evidence, footer)
+      when is_binary(header) and is_binary(evidence) and is_map(footer) do
+    :crypto.hash(:sha256, [header, evidence, unsigned_footer(footer)])
+  end
+
+  defp encode_footer_bytes(footer, digest) do
+    <<@footer_magic::binary, @format_version::unsigned-big-16, @schema_version::unsigned-big-16,
+      @footer_size::unsigned-big-32, footer.total_bytes::unsigned-big-64,
+      footer.evidence_offset::unsigned-big-64, footer.evidence_bytes::unsigned-big-64,
+      footer.record_count::unsigned-big-64, footer.first_sequence::unsigned-big-64,
+      footer.last_sequence::unsigned-big-64, footer.run_id_sha256::binary-size(32),
+      footer.trace_id_sha256::binary-size(32), footer.evidence_sha256::binary-size(32),
+      digest::binary-size(32)>>
+  end
+end

--- a/lib/ptc_runner/research/sealed_evidence_log/generator.ex
+++ b/lib/ptc_runner/research/sealed_evidence_log/generator.ex
@@ -233,7 +233,14 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Generator do
     padding = payload_padding(run_id, trace_id, frame_bytes)
 
     Stream.map(1..frame_count, fn sequence ->
-      evaluation_source(run_id, trace_id, sequence, "evaluation-#{sequence}", padding, "default")
+      evaluation_source(
+        run_id,
+        trace_id,
+        sequence,
+        "evaluation-#{sequence}",
+        :binary.copy(padding),
+        "default"
+      )
     end)
   end
 

--- a/lib/ptc_runner/research/sealed_evidence_log/generator.ex
+++ b/lib/ptc_runner/research/sealed_evidence_log/generator.ex
@@ -1,0 +1,359 @@
+defmodule PtcRunner.Research.SealedEvidenceLog.Generator do
+  @moduledoc """
+  Lazy corpus generators for the sealed-log prototype.
+
+  Large artifacts are written into caller-owned temporary directories. Nothing
+  here constructs a complete record list for the payload ladder: each record is
+  yielded, encoded, written, and released before the next is built.
+  """
+
+  alias PtcRunner.Kernel.ResultIdentity
+  alias PtcRunner.Research.SealedEvidenceLog.Codec
+  alias PtcRunner.Research.SealedEvidenceLog.Format
+
+  @source "(return 42)"
+  @source_hash :crypto.hash(:sha256, @source) |> Base.encode16(case: :lower)
+
+  @spec mixed_run(binary()) :: %{records: [map()], trace_facts: map(), trace_analysis: map()}
+  def mixed_run(run_id \\ "mixed-run") when is_binary(run_id) do
+    trace_id = "trace-#{run_id}"
+    first_source = "(return 1)"
+    second_source = "(return 2)"
+    result = %{"answer" => 42}
+
+    records = [
+      record(run_id, trace_id, 1, "capability-input", %{"capability_id" => "llm-1"}, %{
+        "environment" => "workflow",
+        "name" => "llm-request",
+        "arguments" => %{
+          "messages" => [%{"role" => "user", "content" => "start"}],
+          "system" => "sys"
+        }
+      }),
+      record(run_id, trace_id, 2, "capability-output", %{"capability_id" => "llm-1"}, %{
+        "environment" => "workflow",
+        "name" => "llm-request",
+        "result" => %{
+          "status" => "ok",
+          "value" => %{
+            "content" => "tooling",
+            "tool_calls" => [
+              %{"args" => %{"program" => first_source}},
+              %{"args" => %{"program" => second_source}}
+            ]
+          }
+        }
+      }),
+      record(run_id, trace_id, 3, "capability-input", %{"capability_id" => "llm-2"}, %{
+        "environment" => "workflow",
+        "name" => "llm-request",
+        "arguments" => %{
+          "messages" => [
+            %{"role" => "user", "content" => "start"},
+            %{
+              "role" => "assistant",
+              "content" => "tooling",
+              "tool_calls" => [
+                %{"args" => %{"program" => first_source}},
+                %{"args" => %{"program" => second_source}}
+              ]
+            },
+            %{"role" => "tool", "content" => "1"}
+          ],
+          "system" => "sys"
+        }
+      }),
+      record(run_id, trace_id, 4, "capability-output", %{"capability_id" => "llm-2"}, %{
+        "environment" => "workflow",
+        "name" => "llm-request",
+        "result" => %{"status" => "ok", "value" => %{"content" => "done"}}
+      }),
+      record(run_id, trace_id, 5, "capability-input", %{"capability_id" => "tool-1"}, %{
+        "environment" => "mission",
+        "mission_name" => "default",
+        "name" => "search",
+        "arguments" => %{"q" => "secret"}
+      }),
+      record(run_id, trace_id, 6, "capability-output", %{"capability_id" => "tool-1"}, %{
+        "environment" => "mission",
+        "mission_name" => "default",
+        "name" => "search",
+        "result" => %{"status" => "ok", "value" => "hit"}
+      }),
+      evaluation_source(run_id, trace_id, 7, "evaluation-1", first_source, "default"),
+      evaluation_analysis(run_id, trace_id, 8, "evaluation-1", "default"),
+      evaluation_source(run_id, trace_id, 9, "evaluation-2", second_source, "writer"),
+      prelude(run_id, trace_id, 10, "shared.api", "workflow", nil),
+      prelude(run_id, trace_id, 11, "shared.api", "mission", "default"),
+      record(
+        run_id,
+        trace_id,
+        12,
+        "mcp-request",
+        %{"capability_id" => "tool-1", "request_id" => 1},
+        %{
+          "transport" => "stdio",
+          "body" => %{"method" => "tools/call"},
+          "mission_name" => "default"
+        }
+      ),
+      record(
+        run_id,
+        trace_id,
+        13,
+        "mcp-response",
+        %{"capability_id" => "tool-1", "request_id" => 1},
+        %{
+          "transport" => "stdio",
+          "body" => %{"result" => "ok"},
+          "mission_name" => "default"
+        }
+      ),
+      record(run_id, trace_id, 14, "execution-prints", %{"evaluation_id" => "workflow-eval"}, %{
+        "environment" => "workflow",
+        "prints" => ["hello"],
+        "truncated" => false
+      }),
+      record(run_id, trace_id, 15, "execution-error", %{"evaluation_id" => "workflow-eval"}, %{
+        "environment" => "workflow",
+        "kind" => "eval-error",
+        "reason" => "boom",
+        "details" => %{}
+      }),
+      record(
+        run_id,
+        trace_id,
+        16,
+        "explicit-failure-value",
+        %{"evaluation_id" => "workflow-eval"},
+        %{
+          "environment" => "workflow",
+          "value" => "failed"
+        }
+      ),
+      record(run_id, trace_id, 17, "run-result", %{}, %{
+        "result_hash" => result_hash(result),
+        "value" => result
+      })
+    ]
+
+    facts = %{
+      "terminal?" => true,
+      "events_dropped?" => false,
+      "expected_model_exchange_ids" => ["llm-1", "llm-2"],
+      "parent_evaluation_ids" => %{
+        "evaluation-1" => "workflow-1",
+        "evaluation-2" => "workflow-2"
+      },
+      "evaluation_statuses" => %{"workflow-eval" => "error"}
+    }
+
+    %{
+      records: records,
+      trace_facts: facts,
+      trace_analysis: %{
+        "trace_snapshot_hash" => "trace-source",
+        "runs" => %{run_id => facts}
+      }
+    }
+  end
+
+  @spec second_run(binary()) :: %{records: [map()], trace_facts: map()}
+  def second_run(run_id \\ "other-run") do
+    trace_id = "trace-#{run_id}"
+
+    %{
+      records: [
+        record(run_id, trace_id, 1, "execution-prints", %{"evaluation_id" => "wf"}, %{
+          "environment" => "workflow",
+          "prints" => ["x"],
+          "truncated" => false
+        })
+      ],
+      trace_facts: %{"terminal?" => true, "events_dropped?" => false}
+    }
+  end
+
+  @spec dense_filter_run(binary(), pos_integer()) :: %{records: [map()], trace_facts: map()}
+  def dense_filter_run(run_id, count) when is_integer(count) and count > 0 do
+    trace_id = "trace-#{run_id}"
+
+    records =
+      Enum.map(1..count, fn index ->
+        evaluation_source(
+          run_id,
+          trace_id,
+          index,
+          "evaluation-#{index}",
+          "(return #{index})",
+          "default"
+        )
+      end)
+
+    parents =
+      Map.new(1..count, fn index ->
+        {"evaluation-#{index}", "parent-#{rem(index, 3)}"}
+      end)
+
+    %{
+      records: records,
+      trace_facts: %{
+        "parent_evaluation_ids" => parents,
+        "terminal?" => true,
+        "events_dropped?" => false
+      }
+    }
+  end
+
+  @spec count_stream(binary(), pos_integer()) :: Enumerable.t()
+  def count_stream(run_id, count) when is_integer(count) and count > 0 do
+    trace_id = "trace-#{run_id}"
+
+    Stream.map(1..count, fn sequence ->
+      record(
+        run_id,
+        trace_id,
+        sequence,
+        "execution-prints",
+        %{"evaluation_id" => "wf-#{sequence}"},
+        %{
+          "environment" => "workflow",
+          "prints" => ["p"],
+          "truncated" => false
+        }
+      )
+    end)
+  end
+
+  @spec payload_stream(binary(), pos_integer(), pos_integer()) :: Enumerable.t()
+  def payload_stream(run_id, frame_count, frame_bytes)
+      when is_integer(frame_count) and frame_count > 0 and is_integer(frame_bytes) and
+             frame_bytes > 0 do
+    trace_id = "trace-#{run_id}"
+    padding = payload_padding(run_id, trace_id, frame_bytes)
+
+    Stream.map(1..frame_count, fn sequence ->
+      evaluation_source(run_id, trace_id, sequence, "evaluation-#{sequence}", padding, "default")
+    end)
+  end
+
+  @spec choose_frame_bytes(pos_integer()) :: pos_integer()
+  def choose_frame_bytes(max_record_bytes) when is_integer(max_record_bytes) do
+    min(max_record_bytes, 64 * 1024 * 1024)
+  end
+
+  @spec empty_trace_facts() :: map()
+  def empty_trace_facts, do: %{"terminal?" => true, "events_dropped?" => false}
+
+  defp payload_padding(run_id, trace_id, frame_bytes) do
+    pad = max(frame_bytes - 256, 1)
+    adjust_padding(run_id, trace_id, frame_bytes, pad, 8)
+  end
+
+  defp adjust_padding(run_id, trace_id, frame_bytes, pad, attempts_left) do
+    source = String.duplicate("x", max(pad, 1))
+    record = evaluation_source(run_id, trace_id, 1, "evaluation-1", source, "default")
+    {:ok, encoded} = Codec.encode_record(record)
+    {:ok, frame} = Format.encode_frame(encoded)
+    size = byte_size(frame)
+
+    cond do
+      size == frame_bytes ->
+        source
+
+      attempts_left <= 0 ->
+        source
+
+      true ->
+        adjust_padding(
+          run_id,
+          trace_id,
+          frame_bytes,
+          pad + (frame_bytes - size),
+          attempts_left - 1
+        )
+    end
+  end
+
+  defp evaluation_source(run_id, trace_id, sequence, evaluation_id, source, mission) do
+    record(
+      run_id,
+      trace_id,
+      sequence,
+      "evaluation-source",
+      %{"evaluation_id" => evaluation_id},
+      %{
+        "environment" => "mission",
+        "mission_name" => mission,
+        "program_kind" => "ptc-lisp",
+        "source" => source,
+        "source_hash" => :crypto.hash(:sha256, source) |> Base.encode16(case: :lower),
+        "source_bytes" => byte_size(source)
+      }
+    )
+  end
+
+  defp evaluation_analysis(run_id, trace_id, sequence, evaluation_id, mission) do
+    record(
+      run_id,
+      trace_id,
+      sequence,
+      "evaluation-analysis",
+      %{"evaluation_id" => evaluation_id},
+      %{
+        "environment" => "mission",
+        "mission_name" => mission,
+        "prelude_calls" => [
+          %{"component_id" => "shared.api", "ref" => "call-1"}
+        ]
+      }
+    )
+  end
+
+  defp prelude(run_id, trace_id, sequence, component_id, environment, mission_name) do
+    payload =
+      %{
+        "environment" => environment,
+        "source" => @source,
+        "source_hash" => @source_hash,
+        "source_bytes" => byte_size(@source)
+      }
+      |> maybe_mission(mission_name)
+
+    record(
+      run_id,
+      trace_id,
+      sequence,
+      "prelude-source",
+      %{"component_id" => component_id},
+      payload
+    )
+  end
+
+  defp maybe_mission(payload, nil), do: payload
+  defp maybe_mission(payload, mission_name), do: Map.put(payload, "mission_name", mission_name)
+
+  defp record(run_id, trace_id, sequence, type, correlation, payload) do
+    %{
+      "schema_version" => Format.schema_version(),
+      "run_id" => run_id,
+      "trace_id" => trace_id,
+      "sequence" => sequence,
+      "timestamp" => timestamp(sequence),
+      "record_type" => type,
+      "correlation" => correlation,
+      "payload" => payload
+    }
+  end
+
+  defp timestamp(sequence) do
+    seconds = rem(sequence, 50)
+
+    "2026-08-25T12:00:" <> String.pad_leading(Integer.to_string(seconds), 2, "0") <> "Z"
+  end
+
+  defp result_hash(value) do
+    {:ok, hash} = ResultIdentity.strict_json_hash(value)
+    hash
+  end
+end

--- a/lib/ptc_runner/research/sealed_evidence_log/handle.ex
+++ b/lib/ptc_runner/research/sealed_evidence_log/handle.ex
@@ -105,6 +105,90 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Handle do
     end
   end
 
+  @spec confirm_seal(t(), binary(), map(), pos_integer()) ::
+          :ok | {:error, :malformed_source | :source_changed}
+  def confirm_seal(handle, streamed_evidence_sha, state, io_buffer_bytes)
+      when is_binary(streamed_evidence_sha) and is_map(state) and
+             is_integer(io_buffer_bytes) and io_buffer_bytes > 0 do
+    footer = handle.footer
+
+    with true <- footer.record_count == state.record_count,
+         true <- footer.first_sequence == state.first_sequence,
+         true <- footer.last_sequence == state.last_sequence,
+         true <- footer.run_id_sha256 == Format.identity_sha256(state.run_id || ""),
+         true <- footer.trace_id_sha256 == Format.identity_sha256(state.trace_id || ""),
+         {:ok, file_evidence_sha, artifact_digest} <- hash_opened(handle, io_buffer_bytes),
+         :ok <- compare_evidence_hash(streamed_evidence_sha, file_evidence_sha, footer),
+         true <- artifact_digest == footer.artifact_digest do
+      :ok
+    else
+      {:error, _reason} = error -> error
+      false -> {:error, :malformed_source}
+    end
+  end
+
+  defp compare_evidence_hash(streamed, file_hash, footer) do
+    cond do
+      streamed != file_hash -> {:error, :source_changed}
+      file_hash != footer.evidence_sha256 -> {:error, :malformed_source}
+      true -> :ok
+    end
+  end
+
+  defp hash_opened(handle, io_buffer_bytes) do
+    footer = handle.footer
+
+    with {:ok, header} <- pread(handle, 0, Format.header_size()) do
+      start = footer.evidence_offset
+      ending = start + footer.evidence_bytes
+
+      case hash_range(
+             handle,
+             start,
+             ending,
+             :crypto.hash_init(:sha256),
+             :crypto.hash_update(:crypto.hash_init(:sha256), header),
+             io_buffer_bytes
+           ) do
+        {:ok, evidence_acc, artifact_acc} ->
+          evidence_sha = :crypto.hash_final(evidence_acc)
+
+          artifact_digest =
+            artifact_acc
+            |> :crypto.hash_update(Format.unsigned_footer(footer))
+            |> :crypto.hash_final()
+
+          {:ok, evidence_sha, artifact_digest}
+
+        error ->
+          error
+      end
+    end
+  end
+
+  defp hash_range(_handle, offset, ending, evidence_acc, artifact_acc, _buffer)
+       when offset >= ending,
+       do: {:ok, evidence_acc, artifact_acc}
+
+  defp hash_range(handle, offset, ending, evidence_acc, artifact_acc, buffer) do
+    chunk = min(buffer, ending - offset)
+
+    case pread(handle, offset, chunk) do
+      {:ok, bytes} ->
+        hash_range(
+          handle,
+          offset + chunk,
+          ending,
+          :crypto.hash_update(evidence_acc, bytes),
+          :crypto.hash_update(artifact_acc, bytes),
+          buffer
+        )
+
+      error ->
+        error
+    end
+  end
+
   defp inspect_opened(io) do
     with {:ok, header} <- read_at(io, 0, Format.header_size()),
          {:ok, :header} <- Format.decode_header(header),

--- a/lib/ptc_runner/research/sealed_evidence_log/handle.ex
+++ b/lib/ptc_runner/research/sealed_evidence_log/handle.ex
@@ -1,0 +1,144 @@
+defmodule PtcRunner.Research.SealedEvidenceLog.Handle do
+  @moduledoc """
+  Pinned raw reader for one sealed evidence artifact.
+
+  Queries continue against this descriptor after the path is replaced. Size and
+  footer accounting detect append or truncate. Same-size overwrites are detected
+  only when a queried range's digest disagrees with admission.
+  """
+
+  alias PtcRunner.Research.SealedEvidenceLog.Format
+
+  @type t :: %{
+          io: :file.io_device(),
+          size: non_neg_integer(),
+          footer: Format.footer(),
+          digest: binary()
+        }
+
+  @spec open(Path.t()) :: {:ok, t()} | {:error, :malformed_source | :source_changed}
+  def open(path) when is_binary(path) do
+    case :file.open(path, [:read, :binary]) do
+      {:ok, io} ->
+        case inspect_opened(io) do
+          {:ok, handle} ->
+            {:ok, handle}
+
+          {:error, reason} ->
+            :file.close(io)
+            {:error, reason}
+        end
+
+      {:error, _reason} ->
+        {:error, :malformed_source}
+    end
+  end
+
+  def open(_path), do: {:error, :malformed_source}
+
+  @spec close(t() | nil) :: :ok
+  def close(%{io: io}) do
+    :file.close(io)
+    :ok
+  end
+
+  def close(_handle), do: :ok
+
+  @spec usable?(t()) :: boolean()
+  def usable?(%{io: io}) do
+    case :file.position(io, {:cur, 0}) do
+      {:ok, _offset} -> true
+      _error -> false
+    end
+  end
+
+  def usable?(_handle), do: false
+
+  @spec current_size(t()) :: {:ok, non_neg_integer()} | {:error, :source_changed}
+  def current_size(%{io: io}) do
+    case :file.position(io, {:eof, 0}) do
+      {:ok, size} ->
+        _ = :file.position(io, {:bof, 0})
+        {:ok, size}
+
+      _error ->
+        {:error, :source_changed}
+    end
+  end
+
+  @spec assert_stable(t()) :: :ok | {:error, :source_changed}
+  def assert_stable(%{size: size, footer: footer} = handle) do
+    with {:ok, current} <- current_size(handle),
+         true <- current == size,
+         {:ok, bytes} <- pread(handle, size - Format.footer_size(), Format.footer_size()),
+         {:ok, current_footer} <- Format.decode_footer(bytes),
+         true <- current_footer == footer do
+      :ok
+    else
+      _other -> {:error, :source_changed}
+    end
+  end
+
+  @spec pread(t(), non_neg_integer(), non_neg_integer()) ::
+          {:ok, binary()} | {:error, :source_changed}
+  def pread(%{io: io}, offset, length)
+      when is_integer(offset) and offset >= 0 and is_integer(length) and length >= 0 do
+    case :file.pread(io, offset, length) do
+      {:ok, bytes} when byte_size(bytes) == length -> {:ok, bytes}
+      :eof -> {:error, :source_changed}
+      {:error, _reason} -> {:error, :source_changed}
+      {:ok, _short} -> {:error, :source_changed}
+    end
+  end
+
+  def pread(_handle, _offset, _length), do: {:error, :source_changed}
+
+  @spec verify_range(t(), non_neg_integer(), non_neg_integer(), binary()) ::
+          {:ok, binary()} | {:error, :source_changed}
+  def verify_range(handle, offset, length, digest) do
+    with {:ok, bytes} <- pread(handle, offset, length),
+         true <- :crypto.hash(:sha256, bytes) == digest do
+      {:ok, bytes}
+    else
+      false -> {:error, :source_changed}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp inspect_opened(io) do
+    with {:ok, header} <- read_at(io, 0, Format.header_size()),
+         {:ok, :header} <- Format.decode_header(header),
+         {:ok, size} <- file_size(io),
+         true <- size >= Format.header_size() + Format.footer_size(),
+         {:ok, footer_bytes} <- read_at(io, size - Format.footer_size(), Format.footer_size()),
+         {:ok, footer} <- Format.decode_footer(footer_bytes),
+         true <- footer.total_bytes == size,
+         true <- footer.evidence_offset == Format.header_size(),
+         true <-
+           footer.evidence_offset + footer.evidence_bytes + Format.footer_size() == size do
+      {:ok,
+       %{
+         io: io,
+         size: size,
+         footer: footer,
+         digest: footer.artifact_digest
+       }}
+    else
+      _other -> {:error, :malformed_source}
+    end
+  end
+
+  defp file_size(io) do
+    case :file.position(io, {:eof, 0}) do
+      {:ok, size} -> {:ok, size}
+      _error -> {:error, :malformed_source}
+    end
+  end
+
+  defp read_at(io, offset, length) do
+    case :file.pread(io, offset, length) do
+      {:ok, bytes} when byte_size(bytes) == length -> {:ok, bytes}
+      _other -> {:error, :malformed_source}
+    end
+  end
+end

--- a/lib/ptc_runner/research/sealed_evidence_log/handle.ex
+++ b/lib/ptc_runner/research/sealed_evidence_log/handle.ex
@@ -1,10 +1,13 @@
 defmodule PtcRunner.Research.SealedEvidenceLog.Handle do
   @moduledoc """
-  Pinned raw reader for one sealed evidence artifact.
+  Pinned reader for one sealed evidence artifact.
 
-  Queries continue against this descriptor after the path is replaced. Size and
-  footer accounting detect append or truncate. Same-size overwrites are detected
-  only when a queried range's digest disagrees with admission.
+  The descriptor is a file-server IoDevice so admission and query workers can
+  `pread/3` the same opened inode. `:raw` descriptors are process-local and
+  cannot be shared with bounded workers. Queries continue against this
+  descriptor after the path is replaced. Size and footer accounting detect
+  append or truncate. Same-size overwrites are detected when a queried range's
+  digest disagrees with admission, or during admission seal confirmation.
   """
 
   alias PtcRunner.Research.SealedEvidenceLog.Format

--- a/lib/ptc_runner/research/sealed_evidence_log/indexes.ex
+++ b/lib/ptc_runner/research/sealed_evidence_log/indexes.ex
@@ -1,0 +1,233 @@
+defmodule PtcRunner.Research.SealedEvidenceLog.Indexes do
+  @moduledoc """
+  Private ETS indexes and logical versus actual retained accounting.
+
+  Logical index bytes are the conservative `RetainedSize.bytes/1` charge of
+  each detached `{family, key, value}` row. Actual ETS allocation is
+  `sum(:ets.info(table, :memory)) * word_size`. Owner metadata, paired trace
+  facts, and cache state are charged separately and never as a substitute for
+  the ETS total. Shared binaries that appear in both owner metadata and an ETS
+  row are charged in both places.
+  """
+
+  alias PtcRunner.Lisp.RetainedSize
+  alias PtcRunner.Research.SealedEvidenceLog.Limits
+
+  @table_names [
+    :records,
+    :capability_join,
+    :provider_join,
+    :evaluation_join,
+    :prelude_occurrence,
+    :turn_projection,
+    :collection_order,
+    :filter_posting,
+    :counts,
+    :runs,
+    :results,
+    :relationships,
+    :meta
+  ]
+
+  @ordered [
+    :records,
+    :turn_projection,
+    :collection_order,
+    :filter_posting,
+    :runs
+  ]
+
+  @type t :: %{
+          tables: %{atom() => :ets.tid()},
+          logical_entries: non_neg_integer(),
+          logical_bytes: non_neg_integer(),
+          owner_metadata: map(),
+          trace_facts: map(),
+          cache: map()
+        }
+
+  @spec create(pid()) :: t()
+  def create(heir) when is_pid(heir) do
+    tables =
+      Map.new(@table_names, fn name ->
+        type = if name in @ordered, do: :ordered_set, else: :set
+
+        tid =
+          :ets.new(name, [
+            type,
+            :public,
+            :compressed,
+            {:read_concurrency, true},
+            {:heir, heir, name}
+          ])
+
+        {name, tid}
+      end)
+
+    %{
+      tables: tables,
+      logical_entries: 0,
+      logical_bytes: 0,
+      owner_metadata: %{},
+      trace_facts: %{},
+      cache: %{}
+    }
+  end
+
+  @spec insert(t(), atom(), term(), term(), map()) ::
+          {:ok, t()} | {:error, :max_index_entries | :max_logical_index_bytes}
+  def insert(indexes, family, key, value, limits)
+      when is_map(indexes) and is_atom(family) and is_map(limits) do
+    row = RetainedSize.detach_binaries({family, key, value})
+    charge = logical_charge(row)
+    entries = indexes.logical_entries + 1
+    bytes = indexes.logical_bytes + charge
+
+    cond do
+      entries > limits.max_index_entries ->
+        {:error, :max_index_entries}
+
+      bytes > limits.max_logical_index_bytes ->
+        {:error, :max_logical_index_bytes}
+
+      true ->
+        table = table_for(family)
+        true = :ets.insert(Map.fetch!(indexes.tables, table), {key, value})
+
+        {:ok,
+         %{
+           indexes
+           | logical_entries: entries,
+             logical_bytes: bytes
+         }}
+    end
+  end
+
+  @spec put_owner_metadata(t(), map()) :: t()
+  def put_owner_metadata(indexes, metadata) when is_map(indexes) and is_map(metadata) do
+    %{indexes | owner_metadata: RetainedSize.detach_binaries(metadata)}
+  end
+
+  @spec put_trace_facts(t(), map()) :: t()
+  def put_trace_facts(indexes, facts) when is_map(indexes) and is_map(facts) do
+    %{indexes | trace_facts: RetainedSize.detach_binaries(facts)}
+  end
+
+  @spec put_cache(t(), map()) :: t()
+  def put_cache(indexes, cache) when is_map(indexes) and is_map(cache) do
+    %{indexes | cache: RetainedSize.detach_binaries(cache)}
+  end
+
+  @spec lookup(t(), atom(), term()) :: [term()]
+  def lookup(indexes, table, key) when is_map(indexes) and is_atom(table) do
+    :ets.lookup(Map.fetch!(indexes.tables, table), key)
+  end
+
+  @spec match(t(), atom(), term()) :: [term()]
+  def match(indexes, table, pattern) when is_map(indexes) and is_atom(table) do
+    :ets.match_object(Map.fetch!(indexes.tables, table), pattern)
+  end
+
+  @spec tab2list(t(), atom()) :: [term()]
+  def tab2list(indexes, table) when is_map(indexes) and is_atom(table) do
+    :ets.tab2list(Map.fetch!(indexes.tables, table))
+  end
+
+  @spec table_ids(t()) :: [reference()]
+  def table_ids(%{tables: tables}), do: Map.values(tables)
+
+  @spec accounting(t()) :: map()
+  def accounting(indexes) when is_map(indexes) do
+    word_bytes = Limits.word_bytes()
+
+    ets =
+      Enum.map(indexes.tables, fn {name, tid} ->
+        memory_words =
+          case :ets.info(tid, :memory) do
+            words when is_integer(words) -> words
+            _other -> 0
+          end
+
+        size =
+          case :ets.info(tid, :size) do
+            count when is_integer(count) -> count
+            _other -> 0
+          end
+
+        {name,
+         %{
+           words: memory_words,
+           bytes: memory_words * word_bytes,
+           entries: size
+         }}
+      end)
+      |> Map.new()
+
+    ets_bytes = ets |> Map.values() |> Enum.reduce(0, &(&1.bytes + &2))
+    ets_words = ets |> Map.values() |> Enum.reduce(0, &(&1.words + &2))
+    ets_entries = ets |> Map.values() |> Enum.reduce(0, &(&1.entries + &2))
+    other = other_retained_bytes(indexes)
+
+    %{
+      ets: ets,
+      ets_words: ets_words,
+      ets_bytes: ets_bytes,
+      ets_entries: ets_entries,
+      logical_entries: indexes.logical_entries,
+      logical_bytes: indexes.logical_bytes,
+      other_retained_bytes: other,
+      charged_retained_bytes: ets_bytes + other
+    }
+  end
+
+  @spec within_retained?(t(), map()) :: boolean()
+  def within_retained?(indexes, limits) when is_map(indexes) and is_map(limits) do
+    accounting(indexes).charged_retained_bytes <= limits.max_retained_bytes
+  end
+
+  @spec delete_all(t()) :: :ok
+  def delete_all(%{tables: tables}) do
+    Enum.each(tables, fn {_name, tid} ->
+      if :ets.info(tid) != :undefined, do: :ets.delete(tid)
+    end)
+
+    :ok
+  end
+
+  @spec undefined?(t()) :: boolean()
+  def undefined?(%{tables: tables}) do
+    Enum.all?(tables, fn {_name, tid} -> :ets.info(tid) == :undefined end)
+  end
+
+  defp table_for(:primary), do: :records
+  defp table_for(:join_capability), do: :capability_join
+  defp table_for(:join_provider), do: :provider_join
+  defp table_for(:join_evaluation), do: :evaluation_join
+  defp table_for(:join_prelude), do: :prelude_occurrence
+  defp table_for(:turn), do: :turn_projection
+  defp table_for(:order), do: :collection_order
+  defp table_for(:filter_posting), do: :filter_posting
+  defp table_for(:count), do: :counts
+  defp table_for(:run), do: :runs
+  defp table_for(:result), do: :results
+  defp table_for(:relationship), do: :relationships
+  defp table_for(:meta), do: :meta
+
+  defp logical_charge(row) do
+    case RetainedSize.bytes(row) do
+      :oversized -> Limits.defaults().max_logical_index_bytes + 1
+      bytes -> bytes
+    end
+  end
+
+  defp other_retained_bytes(indexes) do
+    charge(indexes.owner_metadata) + charge(indexes.trace_facts) + charge(indexes.cache)
+  end
+
+  defp charge(value) do
+    case RetainedSize.bytes(value) do
+      :oversized -> 0
+      bytes -> bytes
+    end
+  end
+end

--- a/lib/ptc_runner/research/sealed_evidence_log/indexes.ex
+++ b/lib/ptc_runner/research/sealed_evidence_log/indexes.ex
@@ -3,7 +3,8 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Indexes do
   Private ETS indexes and logical versus actual retained accounting.
 
   Logical index bytes are the conservative `RetainedSize.bytes/1` charge of
-  each detached `{family, key, value}` row. Actual ETS allocation is
+  each detached `{family, key, value}` row, matching issue #1646. The physical
+  ETS tuple is `{key, value}` inside the family table. Actual ETS allocation is
   `sum(:ets.info(table, :memory)) * word_size`. Owner metadata, paired trace
   facts, and cache state are charged separately and never as a substitute for
   the ETS total. Shared binaries that appear in both owner metadata and an ETS
@@ -80,7 +81,7 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Indexes do
           {:ok, t()} | {:error, :max_index_entries | :max_logical_index_bytes}
   def insert(indexes, family, key, value, limits)
       when is_map(indexes) and is_atom(family) and is_map(limits) do
-    row = RetainedSize.detach_binaries({key, value})
+    row = RetainedSize.detach_binaries({family, key, value})
     charge = logical_charge(row)
     entries = indexes.logical_entries + 1
     bytes = indexes.logical_bytes + charge
@@ -94,7 +95,7 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Indexes do
 
       true ->
         table = table_for(family)
-        true = :ets.insert(Map.fetch!(indexes.tables, table), row)
+        true = :ets.insert(Map.fetch!(indexes.tables, table), {key, value})
 
         {:ok,
          %{

--- a/lib/ptc_runner/research/sealed_evidence_log/indexes.ex
+++ b/lib/ptc_runner/research/sealed_evidence_log/indexes.ex
@@ -43,7 +43,8 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Indexes do
           logical_bytes: non_neg_integer(),
           owner_metadata: map(),
           trace_facts: map(),
-          cache: map()
+          cache: map(),
+          turn_evidence: map()
         }
 
   @spec create(pid()) :: t()
@@ -70,7 +71,8 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Indexes do
       logical_bytes: 0,
       owner_metadata: %{},
       trace_facts: %{},
-      cache: %{}
+      cache: %{},
+      turn_evidence: %{}
     }
   end
 
@@ -78,7 +80,7 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Indexes do
           {:ok, t()} | {:error, :max_index_entries | :max_logical_index_bytes}
   def insert(indexes, family, key, value, limits)
       when is_map(indexes) and is_atom(family) and is_map(limits) do
-    row = RetainedSize.detach_binaries({family, key, value})
+    row = RetainedSize.detach_binaries({key, value})
     charge = logical_charge(row)
     entries = indexes.logical_entries + 1
     bytes = indexes.logical_bytes + charge
@@ -92,7 +94,7 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Indexes do
 
       true ->
         table = table_for(family)
-        true = :ets.insert(Map.fetch!(indexes.tables, table), {key, value})
+        true = :ets.insert(Map.fetch!(indexes.tables, table), row)
 
         {:ok,
          %{
@@ -116,6 +118,11 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Indexes do
   @spec put_cache(t(), map()) :: t()
   def put_cache(indexes, cache) when is_map(indexes) and is_map(cache) do
     %{indexes | cache: RetainedSize.detach_binaries(cache)}
+  end
+
+  @spec put_turn_evidence(t(), map()) :: t()
+  def put_turn_evidence(indexes, evidence) when is_map(indexes) and is_map(evidence) do
+    %{indexes | turn_evidence: RetainedSize.detach_binaries(evidence)}
   end
 
   @spec lookup(t(), atom(), term()) :: [term()]
@@ -221,7 +228,8 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Indexes do
   end
 
   defp other_retained_bytes(indexes) do
-    charge(indexes.owner_metadata) + charge(indexes.trace_facts) + charge(indexes.cache)
+    charge(indexes.owner_metadata) + charge(indexes.trace_facts) + charge(indexes.cache) +
+      charge(indexes.turn_evidence)
   end
 
   defp charge(value) do

--- a/lib/ptc_runner/research/sealed_evidence_log/items.ex
+++ b/lib/ptc_runner/research/sealed_evidence_log/items.ex
@@ -6,18 +6,23 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Items do
   alias PtcRunner.Research.SealedEvidenceLog.Handle
   alias PtcRunner.Research.SealedEvidenceLog.Indexes
 
-  @spec read_record(Handle.t(), Indexes.t(), binary(), pos_integer()) ::
-          {:ok, map(), binary()} | {:error, atom()}
-  def read_record(handle, indexes, run_id, sequence) do
+  @spec read_record(Handle.t(), Indexes.t(), binary(), pos_integer(), pos_integer()) ::
+          {:ok, map(), non_neg_integer()} | {:error, atom()}
+  def read_record(handle, indexes, run_id, sequence, max_range_bytes)
+      when is_integer(max_range_bytes) and max_range_bytes > 0 do
     case Indexes.lookup(indexes, :records, {run_id, sequence}) do
       [{_key, {type, offset, length, digest}}] ->
-        with {:ok, bytes} <- Handle.verify_range(handle, offset, length, digest),
-             {:ok, record} <- Codec.decode_record(bytes),
-             true <- record["record_type"] == type and record["sequence"] == sequence do
-          {:ok, record, digest}
+        if length > max_range_bytes do
+          {:error, :range_limit_exceeded}
         else
-          false -> {:error, :source_changed}
-          {:error, _reason} = error -> error
+          with {:ok, bytes} <- Handle.verify_range(handle, offset, length, digest),
+               {:ok, record} <- Codec.decode_record(bytes),
+               true <- record["record_type"] == type and record["sequence"] == sequence do
+            {:ok, record, length}
+          else
+            false -> {:error, :source_changed}
+            {:error, _reason} = error -> error
+          end
         end
 
       _other ->

--- a/lib/ptc_runner/research/sealed_evidence_log/items.ex
+++ b/lib/ptc_runner/research/sealed_evidence_log/items.ex
@@ -1,0 +1,190 @@
+defmodule PtcRunner.Research.SealedEvidenceLog.Items do
+  @moduledoc false
+
+  alias PtcRunner.Research.SealedEvidenceLog.Codec
+  alias PtcRunner.Research.SealedEvidenceLog.Conversation
+  alias PtcRunner.Research.SealedEvidenceLog.Handle
+  alias PtcRunner.Research.SealedEvidenceLog.Indexes
+
+  @spec read_record(Handle.t(), Indexes.t(), binary(), pos_integer()) ::
+          {:ok, map(), binary()} | {:error, atom()}
+  def read_record(handle, indexes, run_id, sequence) do
+    case Indexes.lookup(indexes, :records, {run_id, sequence}) do
+      [{_key, {type, offset, length, digest}}] ->
+        with {:ok, bytes} <- Handle.verify_range(handle, offset, length, digest),
+             {:ok, record} <- Codec.decode_record(bytes),
+             true <- record["record_type"] == type and record["sequence"] == sequence do
+          {:ok, record, digest}
+        else
+          false -> {:error, :source_changed}
+          {:error, _reason} = error -> error
+        end
+
+      _other ->
+        {:error, :source_changed}
+    end
+  end
+
+  @spec capability_item(map(), map() | nil, map() | nil) :: map()
+  def capability_item(input, output, exception) do
+    payload = input["payload"]
+
+    item = %{
+      "run_id" => input["run_id"],
+      "trace_id" => input["trace_id"],
+      "capability_id" => input["correlation"]["capability_id"],
+      "environment" => payload["environment"],
+      "mission_name" => payload["mission_name"],
+      "name" => payload["name"],
+      "input_sequence" => input["sequence"],
+      "input_timestamp" => input["timestamp"],
+      "arguments" => payload["arguments"]
+    }
+
+    item
+    |> maybe_output(output)
+    |> maybe_exception(exception)
+  end
+
+  @spec provider_item(map(), map(), map() | nil) :: map()
+  def provider_item(request, response, stderr) do
+    correlation = request["correlation"]
+
+    %{
+      "run_id" => request["run_id"],
+      "trace_id" => request["trace_id"],
+      "capability_id" => correlation["capability_id"],
+      "request_id" => correlation["request_id"],
+      "transport" => request["payload"]["transport"],
+      "mission_name" => request["payload"]["mission_name"],
+      "request_sequence" => request["sequence"],
+      "response_sequence" => response["sequence"],
+      "request_timestamp" => request["timestamp"],
+      "response_timestamp" => response["timestamp"],
+      "request" => request["payload"]["body"],
+      "response" => response["payload"]["body"]
+    }
+    |> maybe_stderr(stderr)
+  end
+
+  @spec source_item(map(), [map()] | nil, binary() | nil, term()) :: map()
+  def source_item(record, prelude_calls, parent_evaluation_id, relationships) do
+    payload = record["payload"]
+
+    %{
+      "run_id" => record["run_id"],
+      "trace_id" => record["trace_id"],
+      "evaluation_id" => record["correlation"]["evaluation_id"],
+      "sequence" => record["sequence"],
+      "timestamp" => record["timestamp"],
+      "environment" => payload["environment"],
+      "mission_name" => payload["mission_name"],
+      "program_kind" => payload["program_kind"],
+      "source" => payload["source"],
+      "source_hash" => "sha256:" <> payload["source_hash"],
+      "source_bytes" => payload["source_bytes"],
+      "prelude_calls_available?" => is_list(prelude_calls),
+      "prelude_calls" => prelude_calls || []
+    }
+    |> maybe_parent(parent_evaluation_id)
+    |> Map.put("relationships", relationships || [])
+  end
+
+  @spec prelude_item(map(), term()) :: map()
+  def prelude_item(record, relationships) do
+    payload = record["payload"]
+
+    %{
+      "run_id" => record["run_id"],
+      "trace_id" => record["trace_id"],
+      "component_id" => record["correlation"]["component_id"],
+      "sequence" => record["sequence"],
+      "timestamp" => record["timestamp"],
+      "environment" => payload["environment"],
+      "mission_name" => payload["mission_name"],
+      "source" => payload["source"],
+      "source_hash" => "sha256:" <> payload["source_hash"],
+      "source_bytes" => payload["source_bytes"],
+      "relationships" => relationships || []
+    }
+  end
+
+  @spec execution_item(map(), term()) :: map()
+  # ex_dna:disable-for-next-line — research prototype mirrors InspectionQuery for the differential oracle
+  def execution_item(record, relationships) do
+    %{
+      "run_id" => record["run_id"],
+      "trace_id" => record["trace_id"],
+      "evaluation_id" => record["correlation"]["evaluation_id"],
+      "sequence" => record["sequence"],
+      "timestamp" => record["timestamp"]
+    }
+    |> Map.merge(record["payload"])
+    |> maybe_relationships(relationships)
+  end
+
+  @spec result_item(map()) :: map()
+  # ex_dna:disable-for-next-line — research prototype mirrors InspectionQuery for the differential oracle
+  def result_item(record) do
+    payload = record["payload"]
+
+    %{
+      "run_id" => record["run_id"],
+      "trace_id" => record["trace_id"],
+      "sequence" => record["sequence"],
+      "timestamp" => record["timestamp"],
+      "result_hash" => payload["result_hash"],
+      "value" => payload["value"]
+    }
+  end
+
+  defdelegate assemble_turn(turn_meta, input, output, generated), to: Conversation
+
+  defp maybe_output(item, nil), do: Map.put(item, "complete?", false)
+
+  defp maybe_output(item, output) do
+    Map.merge(item, %{
+      "complete?" => true,
+      "output_sequence" => output["sequence"],
+      "output_timestamp" => output["timestamp"],
+      "result" => output["payload"]["result"]
+    })
+  end
+
+  defp maybe_exception(item, nil), do: item
+
+  defp maybe_exception(item, exception) do
+    payload = exception["payload"]
+
+    Map.merge(item, %{
+      "exception_sequence" => exception["sequence"],
+      "exception_timestamp" => exception["timestamp"],
+      "exception" =>
+        Map.take(
+          payload,
+          ~w(exception_class message message_truncated stacktrace stacktrace_truncated)
+        )
+    })
+  end
+
+  defp maybe_stderr(item, nil), do: item
+
+  defp maybe_stderr(item, stderr) do
+    payload = stderr["payload"]
+
+    Map.merge(item, %{
+      "stderr_sequence" => stderr["sequence"],
+      "stderr_timestamp" => stderr["timestamp"],
+      "stderr" => payload["text"],
+      "stderr_truncated" => payload["truncated"]
+    })
+  end
+
+  defp maybe_parent(item, parent) when is_binary(parent),
+    do: Map.put(item, "parent_evaluation_id", parent)
+
+  defp maybe_parent(item, _parent), do: item
+
+  defp maybe_relationships(item, nil), do: item
+  defp maybe_relationships(item, relationships), do: Map.put(item, "relationships", relationships)
+end

--- a/lib/ptc_runner/research/sealed_evidence_log/limits.ex
+++ b/lib/ptc_runner/research/sealed_evidence_log/limits.ex
@@ -81,7 +81,7 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Limits do
     defaults = defaults()
     allowed = Map.keys(defaults)
 
-    if Map.keys(opts) -- allowed == [] and Enum.all?(opts, &positive_override?/1) do
+    if Map.keys(opts) -- allowed == [] and Enum.all?(opts, &allowed_override?(defaults, &1)) do
       {:ok, Map.merge(defaults, opts)}
     else
       {:error, :invalid_limits}
@@ -100,7 +100,9 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Limits do
     host_facing() ++ snapshot_internal() ++ producer_sink() ++ prototype_installed() ++ guards()
   end
 
-  defp positive_override?({_key, value}), do: is_integer(value) and value > 0
+  defp allowed_override?(defaults, {key, value}) do
+    is_integer(value) and value > 0 and value <= Map.fetch!(defaults, key)
+  end
 
   defp host_facing do
     [
@@ -265,6 +267,92 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Limits do
         {defaults.query_deadline_ms, defaults.query_deadline_ms, defaults.query_deadline_ms},
         :selected_or_directory,
         "prototype query deadline"
+      ),
+      limit_row(
+        "internal only",
+        :prototype,
+        :admission,
+        :bytes,
+        {defaults.max_retained_bytes, defaults.max_retained_bytes, defaults.max_retained_bytes},
+        :selected_or_directory,
+        "prototype max_retained_bytes"
+      ),
+      limit_row(
+        "internal only",
+        :prototype,
+        :query,
+        :bytes,
+        {defaults.max_result_bytes, defaults.max_result_bytes, defaults.max_result_bytes},
+        :selected_or_directory,
+        "prototype max_result_bytes"
+      ),
+      limit_row(
+        "internal only",
+        :prototype,
+        :producer,
+        :bytes,
+        {defaults.producer_heap_bytes, defaults.producer_heap_bytes,
+         defaults.producer_heap_bytes},
+        :selected_file,
+        "prototype producer max_heap_size envelope"
+      ),
+      limit_row(
+        "internal only",
+        :prototype,
+        :admission,
+        :bytes,
+        {defaults.admission_heap_bytes, defaults.admission_heap_bytes,
+         defaults.admission_heap_bytes},
+        :selected_file,
+        "prototype admission max_heap_size envelope"
+      ),
+      limit_row(
+        "internal only",
+        :prototype,
+        :query,
+        :bytes,
+        {defaults.query_heap_bytes, defaults.query_heap_bytes, defaults.query_heap_bytes},
+        :selected_file,
+        "prototype query max_heap_size envelope"
+      ),
+      limit_row(
+        "internal only",
+        :prototype,
+        :producer,
+        :milliseconds,
+        {defaults.producer_deadline_ms, defaults.producer_deadline_ms,
+         defaults.producer_deadline_ms},
+        :selected_file,
+        "prototype producer deadline"
+      ),
+      limit_row(
+        "internal only",
+        :prototype,
+        :admission,
+        :milliseconds,
+        {defaults.admission_deadline_ms, defaults.admission_deadline_ms,
+         defaults.admission_deadline_ms},
+        :selected_file,
+        "prototype admission deadline"
+      ),
+      limit_row(
+        "internal only",
+        :prototype,
+        :cleanup,
+        :milliseconds,
+        {defaults.cleanup_deadline_ms, defaults.cleanup_deadline_ms,
+         defaults.cleanup_deadline_ms},
+        :selected_or_directory,
+        "prototype cleanup deadline"
+      ),
+      limit_row(
+        "internal only",
+        :prototype,
+        :producer,
+        :bytes,
+        {defaults.io_buffer_bytes, defaults.io_buffer_bytes, defaults.io_buffer_bytes},
+        :selected_file,
+        "prototype I/O buffer"
       )
     ]
   end

--- a/lib/ptc_runner/research/sealed_evidence_log/limits.ex
+++ b/lib/ptc_runner/research/sealed_evidence_log/limits.ex
@@ -1,0 +1,326 @@
+defmodule PtcRunner.Research.SealedEvidenceLog.Limits do
+  @moduledoc """
+  Prototype-only ceilings and the inventory of existing inspection limits.
+
+  Installed prototype values are research authorities, not host-facing
+  production defaults. Proposed production numbers are derived after
+  measurement and recorded in the maintainer result page.
+  """
+
+  alias PtcRunner.Kernel.HostConfig
+  alias PtcRunner.Kernel.InspectionArtifact
+  alias PtcRunner.Kernel.InspectionSink
+  alias PtcRunner.Kernel.InspectionSnapshot
+
+  @word_bytes :erlang.system_info(:wordsize)
+  @max_record_bytes 64 * 1024 * 1024
+  @max_total_bytes 512 * 1024 * 1024 + 16 + 192
+  @max_records 1_000_000
+  @max_index_entries 8_000_000
+  @max_logical_index_bytes 512 * 1024 * 1024
+  @max_retained_bytes 512 * 1024 * 1024
+  @max_range_bytes 64 * 1024 * 1024
+  @max_result_bytes 1_000_000
+  @producer_heap_bytes 256 * 1024 * 1024
+  @admission_heap_bytes 256 * 1024 * 1024
+  @query_heap_bytes 256 * 1024 * 1024
+  @producer_deadline_ms 120_000
+  @admission_deadline_ms 120_000
+  @query_deadline_ms 15_000
+  @cleanup_deadline_ms 5_000
+  @io_buffer_bytes 65_536
+
+  @type t :: %{
+          max_record_bytes: pos_integer(),
+          max_total_bytes: pos_integer(),
+          max_records: pos_integer(),
+          max_index_entries: pos_integer(),
+          max_logical_index_bytes: pos_integer(),
+          max_retained_bytes: pos_integer(),
+          max_range_bytes: pos_integer(),
+          max_result_bytes: pos_integer(),
+          producer_heap_bytes: pos_integer(),
+          admission_heap_bytes: pos_integer(),
+          query_heap_bytes: pos_integer(),
+          producer_deadline_ms: pos_integer(),
+          admission_deadline_ms: pos_integer(),
+          query_deadline_ms: pos_integer(),
+          cleanup_deadline_ms: pos_integer(),
+          io_buffer_bytes: pos_integer()
+        }
+
+  @spec word_bytes() :: pos_integer()
+  def word_bytes, do: @word_bytes
+
+  @spec defaults() :: t()
+  def defaults do
+    %{
+      max_record_bytes: @max_record_bytes,
+      max_total_bytes: @max_total_bytes,
+      max_records: @max_records,
+      max_index_entries: @max_index_entries,
+      max_logical_index_bytes: @max_logical_index_bytes,
+      max_retained_bytes: @max_retained_bytes,
+      max_range_bytes: @max_range_bytes,
+      max_result_bytes: @max_result_bytes,
+      producer_heap_bytes: @producer_heap_bytes,
+      admission_heap_bytes: @admission_heap_bytes,
+      query_heap_bytes: @query_heap_bytes,
+      producer_deadline_ms: @producer_deadline_ms,
+      admission_deadline_ms: @admission_deadline_ms,
+      query_deadline_ms: @query_deadline_ms,
+      cleanup_deadline_ms: @cleanup_deadline_ms,
+      io_buffer_bytes: @io_buffer_bytes
+    }
+  end
+
+  @spec merge(keyword() | map()) :: {:ok, t()} | {:error, :invalid_limits}
+  def merge(opts) when is_list(opts), do: merge(Map.new(opts))
+
+  def merge(opts) when is_map(opts) do
+    defaults = defaults()
+    allowed = Map.keys(defaults)
+
+    if Map.keys(opts) -- allowed == [] and Enum.all?(opts, &positive_override?/1) do
+      {:ok, Map.merge(defaults, opts)}
+    else
+      {:error, :invalid_limits}
+    end
+  end
+
+  def merge(_opts), do: {:error, :invalid_limits}
+
+  @spec heap_words(pos_integer()) :: pos_integer()
+  def heap_words(bytes) when is_integer(bytes) and bytes > 0 do
+    div(bytes + @word_bytes - 1, @word_bytes)
+  end
+
+  @spec inventory() :: [map()]
+  def inventory do
+    host_facing() ++ snapshot_internal() ++ producer_sink() ++ prototype_installed() ++ guards()
+  end
+
+  defp positive_override?({_key, value}), do: is_integer(value) and value > 0
+
+  defp host_facing do
+    [
+      limit_row(
+        "install.ptc_inspection_snapshot.ceilings.max_files",
+        :host_facing,
+        :admission,
+        :files,
+        {1_024, 1_024, 1_024},
+        :directory,
+        "PtcRunner.Kernel.HostConfig inspection snapshot ceilings"
+      ),
+      limit_row(
+        "install.ptc_inspection_snapshot.ceilings.max_source_bytes",
+        :host_facing,
+        :admission,
+        :bytes,
+        {64_000_000, 64_000_000, 64_000_000},
+        :aggregate,
+        "PtcRunner.Kernel.HostConfig inspection snapshot ceilings"
+      ),
+      limit_row(
+        "install.ptc_inspection_snapshot.ceilings.max_result_bytes",
+        :host_facing,
+        :query,
+        :bytes,
+        {1_048_576, 1_048_576, 1_048_576},
+        :selected_or_directory,
+        "PtcRunner.Kernel.HostConfig inspection snapshot ceilings"
+      )
+    ]
+  end
+
+  defp snapshot_internal do
+    [
+      limit_row(
+        "internal only",
+        :snapshot_internal,
+        :admission,
+        :bytes,
+        {128_000_000, 128_000_000, 128_000_000},
+        :selected_or_directory,
+        "PtcRunner.Kernel.InspectionSnapshot max_retained_bytes"
+      ),
+      limit_row(
+        "internal only",
+        :snapshot_internal,
+        :admission,
+        :files,
+        {1_024, 1_024, 1_024},
+        :directory,
+        "PtcRunner.Kernel.InspectionSnapshot max_files"
+      ),
+      limit_row(
+        "internal only",
+        :snapshot_internal,
+        :admission,
+        :entries,
+        {4_096, 4_096, 4_096},
+        :directory,
+        "PtcRunner.Kernel.InspectionSnapshot max_directory_entries"
+      ),
+      limit_row(
+        "internal only",
+        :snapshot_internal,
+        :admission,
+        :bytes,
+        {16_000_000, 16_000_000, 16_000_000},
+        :selected_file,
+        "PtcRunner.Kernel.InspectionSnapshot max_artifact_bytes / InspectionArtifact"
+      )
+    ]
+  end
+
+  defp producer_sink do
+    [
+      limit_row(
+        "internal only",
+        :producer,
+        :producer,
+        :bytes,
+        {2_000_000, 2_000_000, 2_000_000},
+        :selected_file,
+        "PtcRunner.Kernel.InspectionSink max_record_bytes"
+      ),
+      limit_row(
+        "internal only",
+        :producer,
+        :producer,
+        :bytes,
+        {16_000_000, 16_000_000, 16_000_000},
+        :selected_file,
+        "PtcRunner.Kernel.InspectionSink max_total_bytes"
+      )
+    ]
+  end
+
+  defp prototype_installed do
+    defaults = defaults()
+
+    [
+      limit_row(
+        "internal only",
+        :prototype,
+        :producer,
+        :bytes,
+        {defaults.max_record_bytes, defaults.max_record_bytes, defaults.max_record_bytes},
+        :selected_file,
+        "prototype max_record_bytes"
+      ),
+      limit_row(
+        "internal only",
+        :prototype,
+        :producer,
+        :bytes,
+        {defaults.max_total_bytes, defaults.max_total_bytes, defaults.max_total_bytes},
+        :selected_file,
+        "prototype max_total_bytes"
+      ),
+      limit_row(
+        "internal only",
+        :prototype,
+        :admission,
+        :records,
+        {defaults.max_records, defaults.max_records, defaults.max_records},
+        :selected_file,
+        "prototype max_records"
+      ),
+      limit_row(
+        "internal only",
+        :prototype,
+        :admission,
+        :entries,
+        {defaults.max_index_entries, defaults.max_index_entries, defaults.max_index_entries},
+        :selected_file,
+        "prototype max_index_entries"
+      ),
+      limit_row(
+        "internal only",
+        :prototype,
+        :admission,
+        :bytes,
+        {defaults.max_logical_index_bytes, defaults.max_logical_index_bytes,
+         defaults.max_logical_index_bytes},
+        :selected_file,
+        "prototype max_logical_index_bytes"
+      ),
+      limit_row(
+        "internal only",
+        :prototype,
+        :query,
+        :bytes,
+        {defaults.max_range_bytes, defaults.max_range_bytes, defaults.max_range_bytes},
+        :selected_file,
+        "prototype verified range-byte ceiling"
+      ),
+      limit_row(
+        "internal only",
+        :prototype,
+        :query,
+        :milliseconds,
+        {defaults.query_deadline_ms, defaults.query_deadline_ms, defaults.query_deadline_ms},
+        :selected_or_directory,
+        "prototype query deadline"
+      )
+    ]
+  end
+
+  defp guards do
+    [
+      limit_row(
+        "internal only",
+        :maintained_guard,
+        :admission,
+        :schema_version,
+        {8, 8, 8},
+        :selected_file,
+        "InspectionArtifact / prototype schema_version"
+      ),
+      limit_row(
+        "internal only",
+        :maintained_guard,
+        :query,
+        :items,
+        {1_000, 100, 1_000},
+        :selected_or_directory,
+        "InspectionQuery max/default page limit"
+      )
+    ]
+  end
+
+  defp limit_row(
+         path,
+         class,
+         phase,
+         unit,
+         {compiled, installed, hard_max},
+         file_meaning,
+         consumer
+       ) do
+    %{
+      "path" => path,
+      "class" => class,
+      "phase" => phase,
+      "unit" => unit,
+      "compiled_default" => compiled,
+      "installed_default" => installed,
+      "hard_maximum" => hard_max,
+      "file_meaning" => file_meaning,
+      "consumer" => consumer,
+      "modules" => inventory_modules()
+    }
+  end
+
+  defp inventory_modules do
+    [
+      HostConfig,
+      InspectionSnapshot,
+      InspectionArtifact,
+      InspectionSink
+    ]
+  end
+end

--- a/lib/ptc_runner/research/sealed_evidence_log/measure.ex
+++ b/lib/ptc_runner/research/sealed_evidence_log/measure.ex
@@ -322,9 +322,30 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Measure do
         "mission_name" => "default"
       })
 
+    next =
+      if is_binary(page["next_cursor"]) do
+        {:ok, second, _} =
+          SealedEvidenceLog.query(snapshot, :generated_sources, %{
+            "run_id" => "dense",
+            "limit" => 3,
+            "mission_name" => "default",
+            "cursor" => page["next_cursor"]
+          })
+
+        %{omitted_count: second["omitted_count"], truncated: second["truncated"]}
+      else
+        nil
+      end
+
     SealedEvidenceLog.close(snapshot)
     File.rm(path)
-    %{omitted_count: page["omitted_count"], metrics: metrics, truncated: page["truncated"]}
+
+    %{
+      omitted_count: page["omitted_count"],
+      metrics: metrics,
+      truncated: page["truncated"],
+      next_page: next
+    }
   end
 
   defp operation_args(:list_runs, _run_id), do: %{"limit" => 10}

--- a/lib/ptc_runner/research/sealed_evidence_log/measure.ex
+++ b/lib/ptc_runner/research/sealed_evidence_log/measure.ex
@@ -42,7 +42,7 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Measure do
         refusals: measure_refusals(tmp),
         mixed: measure_mixed(tmp, limits),
         dense: measure_dense(tmp, limits),
-        recommendation: recommendation()
+        recommendation: recommendation(completed_counts)
       }
     after
       if Keyword.get(opts, :cleanup, true) do
@@ -121,6 +121,7 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Measure do
     artifact_stat = File.stat!(path)
     accounting = summarize_accounting(info.accounting)
     SealedEvidenceLog.close(snapshot)
+    remaining = File.stat!(path).size
     File.rm(path)
 
     case {catalog_result, repeated_result} do
@@ -136,13 +137,16 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Measure do
           repeated_query_ms: repeated_ms,
           generated_sources_query: query_outcome(source_result, source_ms),
           producer_checkpoints: summarize_checkpoints(produced.checkpoints),
+          admission_checkpoints: admission_checkpoint_summary(info),
           admission_peaks: summarize_peaks(info.diagnostic_peaks),
           accounting: accounting,
           query_metrics: metrics,
           omitted_count: page["omitted_count"],
           handle_count_before_close: handle_count,
-          scratch_bytes_before_close: artifact_stat.size,
-          scratch_bytes_after_close: 0
+          scratch_bytes_before_close: 0,
+          scratch_bytes_after_close: 0,
+          artifact_bytes_remaining_after_close: remaining,
+          artifact_bytes_before_close: artifact_stat.size
         }
 
       {error, _repeated} ->
@@ -206,6 +210,18 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Measure do
     accounting = info.accounting
     per_record = if count > 0, do: accounting.ets_bytes / count, else: 0.0
     SealedEvidenceLog.close(snapshot)
+
+    one_over =
+      if count > 1 do
+        error_reason(
+          SealedEvidenceLog.admit(%{path: path, trace_facts: Generator.empty_trace_facts()},
+            limits: [max_records: count - 1]
+          )
+        )
+      else
+        :skipped
+      end
+
     File.rm(path)
 
     %{
@@ -225,7 +241,8 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Measure do
       query_metrics: metrics,
       omitted_count: page["omitted_count"],
       producer_checkpoints: summarize_checkpoints(produced.checkpoints),
-      admission_peaks: summarize_peaks(info.diagnostic_peaks)
+      admission_peaks: summarize_peaks(info.diagnostic_peaks),
+      max_records_plus_one: one_over
     }
   end
 
@@ -443,14 +460,32 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Measure do
     Path.join(System.tmp_dir!(), "ptc-sealed-evidence-#{System.unique_integer([:positive])}")
   end
 
-  defp recommendation do
+  defp recommendation(completed_counts) do
+    last = completed_counts |> Enum.map(& &1.record_count) |> Enum.max(fn -> 0 end)
+
     %{
       format: :ets_only_v1,
       omitted_count: :exact_when_dependency_bytes_fit,
       next_comparison: :none,
       host_surface: :keep_existing_plus_internal_max_records,
-      last_successful_count_rung: 100_000,
-      experiment_safety_ceiling: 100_000
+      last_successful_count_rung: last,
+      experiment_safety_ceiling: 1_000_000,
+      proposed_production_max_records_default: 16_384,
+      proposed_production_max_records_hard_max: 65_536
     }
+  end
+
+  defp checkpoint_counts(checkpoints) when is_list(checkpoints) do
+    Enum.frequencies_by(checkpoints, & &1.name)
+  end
+
+  defp checkpoint_counts(_other), do: %{}
+
+  defp admission_checkpoint_summary(info) do
+    summarize_checkpoints(%{
+      checkpoints: info.checkpoints,
+      diagnostic_peaks: info.diagnostic_peaks,
+      counts: checkpoint_counts(info.checkpoints)
+    })
   end
 end

--- a/lib/ptc_runner/research/sealed_evidence_log/measure.ex
+++ b/lib/ptc_runner/research/sealed_evidence_log/measure.ex
@@ -1,0 +1,456 @@
+defmodule PtcRunner.Research.SealedEvidenceLog.Measure do
+  @moduledoc """
+  Reproducible measurement harness for the sealed-log prototype.
+
+  Large payload rungs are opt-in. The ordinary test suite uses the same
+  functions with tiny fixtures and does not write committed binaries.
+  """
+
+  alias PtcRunner.Research.SealedEvidenceLog
+  alias PtcRunner.Research.SealedEvidenceLog.Generator
+  alias PtcRunner.Research.SealedEvidenceLog.Limits
+  alias PtcRunner.Research.SealedEvidenceLog.Oracle
+
+  @payload_rungs [
+    {128 * 1024 * 1024, 2},
+    {256 * 1024 * 1024, 4},
+    {512 * 1024 * 1024, 8}
+  ]
+
+  @count_rungs [1_000, 10_000, 100_000, 1_000_000]
+
+  @spec run(keyword()) :: map()
+  def run(opts \\ []) do
+    tmp = Keyword.get_lazy(opts, :tmp_dir, fn -> tmp_root() end)
+    File.mkdir_p!(tmp)
+
+    try do
+      {:ok, limits} = Limits.merge(Keyword.get(opts, :limits, []))
+      full? = Keyword.get(opts, :full, false)
+      max_records = Keyword.get(opts, :max_records, if(full?, do: 1_000_000, else: 10_000))
+      payload_rungs = payload_rungs(opts, full?)
+      count_rungs = Enum.filter(@count_rungs, &(&1 <= max_records))
+      counts = Enum.map(count_rungs, &measure_count(tmp, limits, &1))
+      completed_counts = Enum.filter(counts, &Map.has_key?(&1, :ets_bytes))
+
+      %{
+        environment: environment(),
+        limits: envelope(limits),
+        payload: Enum.map(payload_rungs, &measure_payload(tmp, limits, &1)),
+        counts: counts,
+        count_fit: linear_fit(completed_counts),
+        refusals: measure_refusals(tmp),
+        mixed: measure_mixed(tmp, limits),
+        dense: measure_dense(tmp, limits),
+        recommendation: recommendation()
+      }
+    after
+      if Keyword.get(opts, :cleanup, true) do
+        File.rm_rf(tmp)
+      end
+    end
+  end
+
+  defp measure_payload(tmp, limits, {artifact_bytes, frames}) do
+    run_id = "payload-#{frames}"
+    path = Path.join(tmp, "#{run_id}.ptcins")
+    frame_bytes = div(artifact_bytes, frames)
+
+    {produced_result, produce_ms} =
+      timed(fn ->
+        SealedEvidenceLog.produce(
+          path,
+          Generator.payload_stream(run_id, frames, frame_bytes),
+          limits: Map.to_list(limits)
+        )
+      end)
+
+    with {:ok, produced} <- produced_result,
+         {admit_result, admit_ms} <-
+           timed(fn ->
+             SealedEvidenceLog.admit(
+               %{path: path, trace_facts: Generator.empty_trace_facts()},
+               limits: Map.to_list(limits)
+             )
+           end),
+         {:ok, snapshot} <- admit_result do
+      summarize_payload_success(
+        path,
+        produced,
+        snapshot,
+        artifact_bytes,
+        produce_ms,
+        admit_ms,
+        run_id
+      )
+    else
+      {:error, reason} ->
+        File.rm(path)
+
+        refused_rung(%{
+          target_artifact_bytes: artifact_bytes,
+          record_count: frames,
+          reason: reason
+        })
+    end
+  end
+
+  defp summarize_payload_success(
+         path,
+         produced,
+         snapshot,
+         artifact_bytes,
+         produce_ms,
+         admit_ms,
+         run_id
+       ) do
+    {:ok, info} = SealedEvidenceLog.info(snapshot)
+    catalog_args = %{"limit" => 1}
+    source_args = %{"run_id" => run_id, "limit" => 1}
+
+    {catalog_result, cold_ms} =
+      timed(fn -> SealedEvidenceLog.query(snapshot, :list_runs, catalog_args) end)
+
+    {repeated_result, repeated_ms} =
+      timed(fn -> SealedEvidenceLog.query(snapshot, :list_runs, catalog_args) end)
+
+    {source_result, source_ms} =
+      timed(fn -> SealedEvidenceLog.query(snapshot, :generated_sources, source_args) end)
+
+    handle_count = info.handle_count
+    artifact_stat = File.stat!(path)
+    accounting = summarize_accounting(info.accounting)
+    SealedEvidenceLog.close(snapshot)
+    File.rm(path)
+
+    case {catalog_result, repeated_result} do
+      {{:ok, page, metrics}, {:ok, _repeated, _repeated_metrics}} ->
+        %{
+          target_artifact_bytes: artifact_bytes,
+          artifact_bytes: produced.total_bytes,
+          record_count: produced.record_count,
+          frame_size: produced.frame_size,
+          producer_ms: produce_ms,
+          admission_ms: admit_ms,
+          cold_query_ms: cold_ms,
+          repeated_query_ms: repeated_ms,
+          generated_sources_query: query_outcome(source_result, source_ms),
+          producer_checkpoints: summarize_checkpoints(produced.checkpoints),
+          admission_peaks: summarize_peaks(info.diagnostic_peaks),
+          accounting: accounting,
+          query_metrics: metrics,
+          omitted_count: page["omitted_count"],
+          handle_count_before_close: handle_count,
+          scratch_bytes_before_close: artifact_stat.size,
+          scratch_bytes_after_close: 0
+        }
+
+      {error, _repeated} ->
+        refused_rung(%{
+          target_artifact_bytes: artifact_bytes,
+          artifact_bytes: produced.total_bytes,
+          record_count: produced.record_count,
+          frame_size: produced.frame_size,
+          producer_ms: produce_ms,
+          admission_ms: admit_ms,
+          accounting: accounting,
+          reason: query_reason(error)
+        })
+    end
+  end
+
+  defp measure_count(tmp, limits, count) do
+    run_id = "count-#{count}"
+    path = Path.join(tmp, "#{run_id}.ptcins")
+    rung_limits = %{limits | max_records: count}
+
+    {produced_result, produce_ms} =
+      timed(fn ->
+        SealedEvidenceLog.produce(path, Generator.count_stream(run_id, count),
+          limits: Map.to_list(rung_limits)
+        )
+      end)
+
+    with {:ok, produced} <- produced_result,
+         {admit_result, admit_ms} <-
+           timed(fn ->
+             SealedEvidenceLog.admit(%{path: path, trace_facts: Generator.empty_trace_facts()},
+               limits: Map.to_list(rung_limits)
+             )
+           end),
+         {:ok, snapshot} <- admit_result do
+      summarize_count_success(path, produced, snapshot, count, produce_ms, admit_ms, run_id)
+    else
+      {:error, reason} ->
+        File.rm(path)
+        refused_rung(%{record_count: count, reason: reason, producer_ms: produce_ms})
+    end
+  end
+
+  defp summarize_count_success(path, produced, snapshot, count, produce_ms, admit_ms, run_id) do
+    {:ok, info} = SealedEvidenceLog.info(snapshot)
+    arguments = %{"run_id" => run_id, "limit" => 10}
+
+    {_page, cold_ms} =
+      timed(fn ->
+        {:ok, page, metrics} = SealedEvidenceLog.query(snapshot, :execution_prints, arguments)
+        {page, metrics}
+      end)
+
+    {{page, metrics}, repeated_ms} =
+      timed(fn ->
+        {:ok, page, metrics} = SealedEvidenceLog.query(snapshot, :execution_prints, arguments)
+        {page, metrics}
+      end)
+
+    accounting = info.accounting
+    per_record = if count > 0, do: accounting.ets_bytes / count, else: 0.0
+    SealedEvidenceLog.close(snapshot)
+    File.rm(path)
+
+    %{
+      record_count: count,
+      artifact_bytes: produced.total_bytes,
+      ets_bytes: accounting.ets_bytes,
+      ets_words: accounting.ets_words,
+      logical_bytes: accounting.logical_bytes,
+      logical_entries: accounting.logical_entries,
+      other_retained_bytes: accounting.other_retained_bytes,
+      charged_retained_bytes: accounting.charged_retained_bytes,
+      bytes_per_record: per_record,
+      producer_ms: produce_ms,
+      admission_ms: admit_ms,
+      cold_query_ms: cold_ms,
+      repeated_query_ms: repeated_ms,
+      query_metrics: metrics,
+      omitted_count: page["omitted_count"],
+      producer_checkpoints: summarize_checkpoints(produced.checkpoints),
+      admission_peaks: summarize_peaks(info.diagnostic_peaks)
+    }
+  end
+
+  defp measure_refusals(tmp) do
+    run_id = "refuse"
+    path = Path.join(tmp, "#{run_id}.ptcins")
+    {:ok, _} = SealedEvidenceLog.produce(path, Generator.count_stream(run_id, 3), limits: [])
+
+    records_plus_one =
+      SealedEvidenceLog.admit(%{path: path, trace_facts: Generator.empty_trace_facts()},
+        limits: [max_records: 2]
+      )
+
+    exact =
+      SealedEvidenceLog.admit(%{path: path, trace_facts: Generator.empty_trace_facts()},
+        limits: [max_records: 3]
+      )
+
+    entries_plus_one =
+      SealedEvidenceLog.admit(%{path: path, trace_facts: Generator.empty_trace_facts()},
+        limits: [max_index_entries: 1]
+      )
+
+    bytes_plus_one =
+      SealedEvidenceLog.admit(%{path: path, trace_facts: Generator.empty_trace_facts()},
+        limits: [max_logical_index_bytes: 32]
+      )
+
+    File.rm(path)
+
+    %{
+      max_records: error_reason(records_plus_one),
+      max_records_exact: ok?(exact),
+      max_index_entries: error_reason(entries_plus_one),
+      max_logical_index_bytes: error_reason(bytes_plus_one)
+    }
+  end
+
+  defp measure_mixed(tmp, limits) do
+    corpus = Generator.mixed_run("measure-mixed")
+    path = Path.join(tmp, "measure-mixed.ptcins")
+    {:ok, _} = SealedEvidenceLog.produce(path, corpus.records, limits: Map.to_list(limits))
+
+    {:ok, snapshot} =
+      SealedEvidenceLog.admit(%{path: path, trace_facts: corpus.trace_facts},
+        limits: Map.to_list(limits)
+      )
+
+    {:ok, current} =
+      Oracle.compile_current([corpus.records], "trace-source", corpus.trace_analysis)
+
+    parity =
+      Map.new(SealedEvidenceLog.Query.operations(), fn operation ->
+        args = operation_args(operation, "measure-mixed")
+        {operation, Oracle.walk_equal(current, snapshot, operation, args, 1_000_000)}
+      end)
+
+    SealedEvidenceLog.close(snapshot)
+    File.rm(path)
+    %{parity: parity}
+  end
+
+  defp measure_dense(tmp, limits) do
+    corpus = Generator.dense_filter_run("dense", 32)
+    path = Path.join(tmp, "dense.ptcins")
+    {:ok, _} = SealedEvidenceLog.produce(path, corpus.records, limits: Map.to_list(limits))
+
+    {:ok, snapshot} =
+      SealedEvidenceLog.admit(%{path: path, trace_facts: corpus.trace_facts},
+        limits: Map.to_list(limits)
+      )
+
+    {:ok, page, metrics} =
+      SealedEvidenceLog.query(snapshot, :generated_sources, %{
+        "run_id" => "dense",
+        "limit" => 3,
+        "mission_name" => "default"
+      })
+
+    SealedEvidenceLog.close(snapshot)
+    File.rm(path)
+    %{omitted_count: page["omitted_count"], metrics: metrics, truncated: page["truncated"]}
+  end
+
+  defp operation_args(:list_runs, _run_id), do: %{"limit" => 10}
+
+  defp operation_args(operation, run_id) when operation in [:get_run, :result],
+    do: %{"run_id" => run_id}
+
+  defp operation_args(_operation, run_id), do: %{"run_id" => run_id, "limit" => 10}
+
+  defp payload_rungs(opts, true), do: Keyword.get(opts, :payload_rungs, @payload_rungs)
+  defp payload_rungs(opts, false), do: Keyword.get(opts, :payload_rungs, [])
+
+  defp environment do
+    %{
+      otp: :erlang.system_info(:otp_release) |> List.to_string(),
+      erts: :erlang.system_info(:version) |> List.to_string(),
+      word_size: :erlang.system_info(:wordsize),
+      schedulers: System.schedulers_online(),
+      os: :os.type(),
+      trials: 1,
+      warm_up: 0
+    }
+  end
+
+  defp envelope(limits) do
+    Map.take(limits, [
+      :max_record_bytes,
+      :max_total_bytes,
+      :producer_heap_bytes,
+      :admission_heap_bytes,
+      :query_heap_bytes,
+      :io_buffer_bytes,
+      :max_records
+    ])
+  end
+
+  defp timed(function) do
+    started = System.monotonic_time(:millisecond)
+    result = function.()
+    {result, System.monotonic_time(:millisecond) - started}
+  end
+
+  defp summarize_checkpoints(%{checkpoints: checkpoints, diagnostic_peaks: peaks} = finalized) do
+    %{
+      names: Enum.map(checkpoints, & &1.name) |> Enum.uniq(),
+      counts: Map.get(finalized, :counts, %{}),
+      peak_memory_bytes: peak_bytes(peaks, :aggregate_memory_bytes),
+      peak_referenced_binary_bytes: peak_bytes(peaks, :aggregate_referenced_binary_bytes)
+    }
+  end
+
+  defp summarize_checkpoints(_other), do: %{names: [], peak_memory_bytes: 0}
+
+  defp summarize_peaks(peaks) when is_map(peaks) do
+    %{
+      names: Map.keys(peaks),
+      peak_memory_bytes: peak_bytes(peaks, :aggregate_memory_bytes),
+      peak_referenced_binary_bytes: peak_bytes(peaks, :aggregate_referenced_binary_bytes)
+    }
+  end
+
+  defp summarize_peaks(_other), do: %{names: [], peak_memory_bytes: 0}
+
+  defp peak_bytes(peaks, field) do
+    peaks
+    |> Map.values()
+    |> Enum.map(&Map.get(&1, field, 0))
+    |> Enum.max(fn -> 0 end)
+  end
+
+  defp summarize_accounting(accounting) do
+    Map.take(accounting, [
+      :ets_words,
+      :ets_bytes,
+      :ets_entries,
+      :logical_entries,
+      :logical_bytes,
+      :other_retained_bytes,
+      :charged_retained_bytes
+    ])
+  end
+
+  defp query_outcome({:ok, page, metrics}, duration_ms) do
+    %{
+      status: :ok,
+      duration_ms: duration_ms,
+      omitted_count: page["omitted_count"],
+      metrics: metrics
+    }
+  end
+
+  defp query_outcome({:error, reason}, duration_ms) do
+    %{status: :error, reason: reason, duration_ms: duration_ms}
+  end
+
+  defp query_reason({:error, reason}), do: reason
+  defp query_reason(other), do: other
+
+  defp refused_rung(fields), do: Map.put(fields, :refused, true)
+
+  defp linear_fit([]), do: %{slope: 0.0, intercept: 0.0, rungs: 0}
+
+  defp linear_fit(rows) do
+    n = length(rows) * 1.0
+    xs = Enum.map(rows, &(&1.record_count * 1.0))
+    ys = Enum.map(rows, &(&1.ets_bytes * 1.0))
+    sum_x = Enum.sum(xs)
+    sum_y = Enum.sum(ys)
+    sum_xx = Enum.reduce(xs, 0.0, fn x, acc -> acc + x * x end)
+    sum_xy = Enum.zip_reduce(xs, ys, 0.0, fn x, y, acc -> acc + x * y end)
+    denom = n * sum_xx - sum_x * sum_x
+
+    if denom == 0.0 do
+      %{slope: 0.0, intercept: 0.0, rungs: length(rows)}
+    else
+      slope = (n * sum_xy - sum_x * sum_y) / denom
+      intercept = (sum_y - slope * sum_x) / n
+      %{slope: slope, intercept: intercept, rungs: length(rows)}
+    end
+  end
+
+  defp error_reason({:error, reason}), do: reason
+  defp error_reason(other), do: other
+
+  defp ok?({:ok, snapshot}) do
+    SealedEvidenceLog.close(snapshot)
+    true
+  end
+
+  defp ok?(_other), do: false
+
+  defp tmp_root do
+    Path.join(System.tmp_dir!(), "ptc-sealed-evidence-#{System.unique_integer([:positive])}")
+  end
+
+  defp recommendation do
+    %{
+      format: :ets_only_v1,
+      omitted_count: :exact_when_dependency_bytes_fit,
+      next_comparison: :none,
+      host_surface: :keep_existing_plus_internal_max_records,
+      last_successful_count_rung: 100_000,
+      experiment_safety_ceiling: 100_000
+    }
+  end
+end

--- a/lib/ptc_runner/research/sealed_evidence_log/oracle.ex
+++ b/lib/ptc_runner/research/sealed_evidence_log/oracle.ex
@@ -1,0 +1,155 @@
+defmodule PtcRunner.Research.SealedEvidenceLog.Oracle do
+  @moduledoc """
+  Differential comparison against `InspectionQuery.compile/3` and `query/6`.
+
+  Pages are compared on item shape, order, errors, counts, truncation, and
+  page-by-page `omitted_count`. Snapshot-hash values and opaque cursor bytes
+  are ignored; each implementation is walked with its own cursors.
+  """
+
+  alias PtcRunner.Kernel.InspectionQuery
+  alias PtcRunner.Research.SealedEvidenceLog
+
+  @ignore ~w(snapshot_hash next_cursor)
+
+  @spec compile_current([[map()]], binary(), map()) ::
+          {:ok, %{source_id: binary(), collections: map()}} | {:error, atom()}
+  def compile_current(artifacts, trace_source_id, trace_analysis) do
+    InspectionQuery.compile(artifacts, trace_source_id, trace_analysis)
+  end
+
+  @spec query_current(map(), binary(), atom(), map(), pos_integer()) ::
+          {:ok, map()} | {:error, atom()}
+  def query_current(collections, source_id, operation, arguments, max_result_bytes) do
+    InspectionQuery.query(collections, source_id, operation, arguments, max_result_bytes)
+  end
+
+  @spec walk_equal(map(), SealedEvidenceLog.Snapshot.t(), atom(), map(), pos_integer()) ::
+          :ok | {:error, map()}
+  def walk_equal(current, snapshot, operation, arguments, max_result_bytes) do
+    base = Map.delete(arguments, "cursor")
+    compare_step(current, snapshot, operation, base, nil, nil, max_result_bytes, 0)
+  end
+
+  @spec comparable(map() | {:error, atom()}) :: map() | {:error, atom()}
+  def comparable({:error, reason}), do: {:error, reason}
+
+  def comparable(page) when is_map(page) do
+    page
+    |> Map.drop(@ignore)
+    |> maybe_items()
+  end
+
+  defp compare_step(_current, _snapshot, _operation, _base, _cc, _pc, _max_bytes, pages)
+       when pages > 64,
+       do: {:error, %{reason: :too_many_pages}}
+
+  defp compare_step(
+         current,
+         snapshot,
+         operation,
+         base,
+         current_cursor,
+         proto_cursor,
+         max_bytes,
+         pages
+       ) do
+    current_result =
+      query_current(
+        current.collections,
+        current.source_id,
+        operation,
+        put_cursor(base, current_cursor),
+        max_bytes
+      )
+
+    proto_result = proto_query(snapshot, operation, put_cursor(base, proto_cursor))
+
+    with :ok <- compare_results(current_result, proto_result, operation) do
+      advance(
+        current,
+        snapshot,
+        operation,
+        base,
+        current_result,
+        proto_result,
+        max_bytes,
+        pages
+      )
+    end
+  end
+
+  defp advance(
+         current,
+         snapshot,
+         operation,
+         base,
+         {:ok, current_page},
+         {:ok, proto_page},
+         max_bytes,
+         pages
+       ) do
+    cond do
+      not Map.has_key?(current_page, "truncated") ->
+        :ok
+
+      current_page["truncated"] != true and proto_page["truncated"] != true ->
+        :ok
+
+      current_page["truncated"] != proto_page["truncated"] ->
+        {:error, %{reason: :truncation_mismatch}}
+
+      true ->
+        compare_step(
+          current,
+          snapshot,
+          operation,
+          base,
+          current_page["next_cursor"],
+          proto_page["next_cursor"],
+          max_bytes,
+          pages + 1
+        )
+    end
+  end
+
+  defp advance(
+         _current,
+         _snapshot,
+         _operation,
+         _base,
+         _current_result,
+         _proto_result,
+         _max,
+         _pages
+       ),
+       do: :ok
+
+  defp put_cursor(base, nil), do: base
+  defp put_cursor(base, cursor), do: Map.put(base, "cursor", cursor)
+
+  defp proto_query(snapshot, operation, arguments) do
+    case SealedEvidenceLog.query(snapshot, operation, arguments) do
+      {:ok, page, _metrics} -> {:ok, page}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp compare_results({:error, reason}, {:error, reason}, _operation), do: :ok
+
+  defp compare_results({:ok, left}, {:ok, right}, _operation) do
+    left = comparable(left)
+    right = comparable(right)
+    if left == right, do: :ok, else: {:error, %{current: left, prototype: right}}
+  end
+
+  defp compare_results(left, right, operation),
+    do: {:error, %{operation: operation, current: left, prototype: right}}
+
+  defp maybe_items(%{"items" => items} = page),
+    do: Map.put(page, "items", Enum.map(items, &comparable_item/1))
+
+  defp maybe_items(page), do: page
+
+  defp comparable_item(item) when is_map(item), do: item
+end

--- a/lib/ptc_runner/research/sealed_evidence_log/oracle.ex
+++ b/lib/ptc_runner/research/sealed_evidence_log/oracle.ex
@@ -63,7 +63,7 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Oracle do
         max_bytes
       )
 
-    proto_result = proto_query(snapshot, operation, put_cursor(base, proto_cursor))
+    proto_result = proto_query(snapshot, operation, put_cursor(base, proto_cursor), max_bytes)
 
     with :ok <- compare_results(current_result, proto_result, operation) do
       advance(
@@ -128,8 +128,8 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Oracle do
   defp put_cursor(base, nil), do: base
   defp put_cursor(base, cursor), do: Map.put(base, "cursor", cursor)
 
-  defp proto_query(snapshot, operation, arguments) do
-    case SealedEvidenceLog.query(snapshot, operation, arguments) do
+  defp proto_query(snapshot, operation, arguments, max_bytes) do
+    case SealedEvidenceLog.query(snapshot, operation, arguments, max_result_bytes: max_bytes) do
       {:ok, page, _metrics} -> {:ok, page}
       {:error, reason} -> {:error, reason}
     end

--- a/lib/ptc_runner/research/sealed_evidence_log/producer.ex
+++ b/lib/ptc_runner/research/sealed_evidence_log/producer.ex
@@ -1,0 +1,210 @@
+defmodule PtcRunner.Research.SealedEvidenceLog.Producer do
+  @moduledoc """
+  Streaming sealed-log writer that never retains a record list or artifact binary.
+
+  One process writes the header, then yields, encodes, writes, and releases each
+  record before constructing the next. The footer is appended from running
+  counts, identity hashes, and incremental SHA-256. Producer heap is bounded
+  with `max_heap_size` `kill: true` and `include_shared_binaries: true`.
+  """
+
+  alias PtcRunner.Kernel.BoundedWorker
+  alias PtcRunner.Research.SealedEvidenceLog.Checkpoints
+  alias PtcRunner.Research.SealedEvidenceLog.Codec
+  alias PtcRunner.Research.SealedEvidenceLog.Format
+  alias PtcRunner.Research.SealedEvidenceLog.Limits
+
+  @spec write(Path.t(), Enumerable.t(), map(), keyword()) ::
+          {:ok, map()} | {:error, atom()}
+  def write(path, records, limits, opts \\ [])
+      when is_binary(path) and is_map(limits) and is_list(opts) do
+    hook = Keyword.get(opts, :checkpoint_hook)
+    timeout_ms = Keyword.get(opts, :deadline_ms, limits.producer_deadline_ms)
+
+    BoundedWorker.run(
+      fn -> produce(path, records, limits, hook) end,
+      timeout_ms: timeout_ms,
+      max_heap_words: Limits.heap_words(limits.producer_heap_bytes)
+    )
+    |> wrap_worker()
+  end
+
+  defp produce(path, records, limits, hook) do
+    File.mkdir_p!(Path.dirname(path))
+
+    {:ok, io} =
+      :file.open(path, [
+        :raw,
+        :write,
+        :binary,
+        :exclusive,
+        {:delayed_write, limits.io_buffer_bytes, 1_000}
+      ])
+
+    try do
+      write_stream(io, records, limits, hook)
+    after
+      :file.close(io)
+    end
+  end
+
+  defp write_stream(io, records, limits, hook) do
+    header = Format.encode_header()
+    :ok = :file.write(io, header)
+    evidence = :crypto.hash_init(:sha256)
+    checkpoints = Checkpoints.new()
+    pids = [self()]
+
+    acc = %{
+      evidence: evidence,
+      artifact: :crypto.hash_update(:crypto.hash_init(:sha256), header),
+      evidence_bytes: 0,
+      record_count: 0,
+      first_sequence: 0,
+      last_sequence: 0,
+      run_id: nil,
+      trace_id: nil,
+      checkpoints: checkpoints,
+      frame_size: nil
+    }
+
+    case reduce_records(records, acc, fn record, state ->
+           write_record(io, record, state, limits, hook, pids)
+         end) do
+      {:ok, state} ->
+        finish(io, header, state, hook, pids)
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp write_record(io, record, state, limits, hook, pids) do
+    state = checkpoint(state, :payload_constructed, hook, pids)
+
+    with {:ok, encoded} <- Codec.encode_record(record),
+         true <- byte_size(encoded) <= limits.max_record_bytes,
+         {:ok, frame} <- Format.encode_frame(encoded),
+         true <- state.evidence_bytes + byte_size(frame) <= limits.max_total_bytes,
+         :ok <- identities(state, record),
+         :ok <- sequence(state, record) do
+      state = checkpoint(state, :encoded, hook, pids)
+      :ok = :file.write(io, frame)
+
+      next = %{
+        state
+        | evidence: :crypto.hash_update(state.evidence, frame),
+          artifact: :crypto.hash_update(state.artifact, frame),
+          evidence_bytes: state.evidence_bytes + byte_size(frame),
+          record_count: state.record_count + 1,
+          first_sequence: first_sequence(state, record["sequence"]),
+          last_sequence: record["sequence"],
+          run_id: record["run_id"],
+          trace_id: record["trace_id"],
+          frame_size: constant_frame_size(state.frame_size, byte_size(frame))
+      }
+
+      _ = encoded
+      _ = frame
+      _ = record
+      {:ok, checkpoint(next, :frame_released, hook, pids)}
+    else
+      false -> {:error, :limit_exceeded}
+      {:error, _reason} = error -> error
+      :identity_mismatch -> {:error, :invalid_record}
+      :sequence_mismatch -> {:error, :invalid_record}
+    end
+  end
+
+  defp finish(io, _header, state, hook, pids) do
+    :ok = :file.sync(io)
+    evidence_sha = :crypto.hash_final(state.evidence)
+    total = Format.header_size() + state.evidence_bytes + Format.footer_size()
+
+    unsigned = %{
+      total_bytes: total,
+      evidence_offset: Format.header_size(),
+      evidence_bytes: state.evidence_bytes,
+      record_count: state.record_count,
+      first_sequence: state.first_sequence,
+      last_sequence: state.last_sequence,
+      run_id_sha256: identity_hash(state.run_id),
+      trace_id_sha256: identity_hash(state.trace_id),
+      evidence_sha256: evidence_sha,
+      artifact_digest: <<0::unsigned-big-256>>
+    }
+
+    artifact_digest =
+      state.artifact
+      |> :crypto.hash_update(Format.unsigned_footer(unsigned))
+      |> :crypto.hash_final()
+
+    footer = Format.encode_footer(%{unsigned | artifact_digest: artifact_digest})
+    :ok = :file.write(io, footer)
+    :ok = :file.sync(io)
+
+    {:ok,
+     %{
+       record_count: state.record_count,
+       evidence_bytes: state.evidence_bytes,
+       total_bytes: total,
+       frame_size: state.frame_size,
+       artifact_digest: artifact_digest,
+       checkpoints: Checkpoints.finalize(checkpoint(state, :encoded, hook, pids).checkpoints)
+     }}
+  end
+
+  defp identities(%{run_id: nil}, record), do: identity_present(record)
+
+  defp identities(%{run_id: run_id, trace_id: trace_id}, record) do
+    if record["run_id"] == run_id and record["trace_id"] == trace_id,
+      do: :ok,
+      else: :identity_mismatch
+  end
+
+  defp identity_present(%{"run_id" => run_id, "trace_id" => trace_id})
+       when is_binary(run_id) and is_binary(trace_id),
+       do: :ok
+
+  defp identity_present(_record), do: :identity_mismatch
+
+  defp sequence(%{record_count: 0}, %{"sequence" => sequence})
+       when is_integer(sequence) and sequence > 0,
+       do: :ok
+
+  defp sequence(%{last_sequence: last}, %{"sequence" => sequence})
+       when is_integer(sequence) and sequence == last + 1,
+       do: :ok
+
+  defp sequence(_state, _record), do: :sequence_mismatch
+
+  defp first_sequence(%{record_count: 0}, sequence), do: sequence
+  defp first_sequence(%{first_sequence: first}, _sequence), do: first
+
+  defp constant_frame_size(nil, size), do: size
+  defp constant_frame_size(size, size), do: size
+  defp constant_frame_size(_previous, _size), do: :mixed
+
+  defp identity_hash(nil), do: :crypto.hash(:sha256, "")
+  defp identity_hash(value), do: Format.identity_sha256(value)
+
+  defp checkpoint(state, name, hook, pids) do
+    checkpoints = Checkpoints.record(state.checkpoints, name, pids)
+    if is_function(hook, 1), do: hook.(name)
+    %{state | checkpoints: checkpoints}
+  end
+
+  defp reduce_records(records, acc, fun) do
+    Enum.reduce_while(records, {:ok, acc}, fn record, {:ok, state} ->
+      case fun.(record, state) do
+        {:ok, next} -> {:cont, {:ok, next}}
+        {:error, _reason} = error -> {:halt, error}
+      end
+    end)
+  end
+
+  defp wrap_worker({:ok, result}), do: result
+  defp wrap_worker({:error, :heap_exceeded}), do: {:error, :heap_exceeded}
+  defp wrap_worker({:error, :timeout}), do: {:error, :deadline_exceeded}
+  defp wrap_worker(_other), do: {:error, :producer_failed}
+end

--- a/lib/ptc_runner/research/sealed_evidence_log/query.ex
+++ b/lib/ptc_runner/research/sealed_evidence_log/query.ex
@@ -66,6 +66,7 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Query do
   def run(snapshot, operation, arguments, max_result_bytes, metadata)
       when is_map(snapshot) and operation in @operations and is_map(arguments) and
              is_integer(max_result_bytes) and max_result_bytes > 0 and is_map(metadata) do
+    maybe_query_hook(snapshot)
     execute(snapshot, operation, arguments, max_result_bytes, metadata, empty_metrics())
   end
 
@@ -74,7 +75,8 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Query do
 
   defp execute(snapshot, :list_runs, arguments, max_bytes, metadata, metrics) do
     with :ok <- validate_keys(arguments, ~w(limit cursor)),
-         {:ok, page} <- page_options(arguments, snapshot.snapshot_digest, :list_runs) do
+         {:ok, page} <- page_options(arguments, snapshot.snapshot_digest, :list_runs),
+         :ok <- verify_handles(snapshot, :catalog, metrics) do
       runs =
         snapshot.indexes
         |> Indexes.tab2list(:runs)
@@ -95,6 +97,7 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Query do
        ) do
     with :ok <- validate_keys(arguments, ["run_id"]),
          true <- valid_string?(run_id),
+         :ok <- verify_handles(snapshot, {:get_run, run_id}, metrics),
          {:ok, run} <- fetch_run(snapshot, run_id),
          result <- Map.merge(run, metadata),
          :ok <- ResultLimit.validate(result, max_bytes) do
@@ -112,6 +115,7 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Query do
   defp execute(snapshot, :result, %{"run_id" => run_id} = arguments, max_bytes, metadata, metrics) do
     with :ok <- validate_keys(arguments, ["run_id"]),
          :ok <- validate_result_run_id(run_id, snapshot),
+         :ok <- verify_handles(snapshot, {:result, run_id}, metrics),
          {:ok, item, metrics} <- fetch_result(snapshot, run_id, metrics),
          result <- Map.merge(item, metadata),
          :ok <- ResultLimit.validate(result, max_bytes) do
@@ -187,7 +191,7 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Query do
            ) do
       paginate(locators, {operation, run_id}, page, snapshot, max_bytes, metadata, metrics)
     else
-      false -> {:error, :not_found}
+      false -> {:error, :invalid_query}
       {:error, _reason} = error -> error
     end
   end
@@ -264,7 +268,7 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Query do
       selected = items |> Enum.drop(page.offset) |> Enum.take(page.limit)
       omitted = Enum.drop(items, page.offset + length(selected))
 
-      with {:ok, metrics} <- verify_dependencies(snapshot, kind, selected ++ omitted, metrics),
+      with {:ok, metrics} <- verify_dependencies(snapshot, kind, items, metrics),
            {:ok, assembled, metrics} <- assemble_many(snapshot, kind, selected, metrics) do
         metrics = bump(metrics, :exact_count_work, length(omitted))
         fit_page(assembled, items, page, snapshot, max_bytes, metadata, metrics, kind)
@@ -309,14 +313,16 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Query do
              Map.fetch!(snapshot.handles, run_id),
              snapshot.indexes,
              run_id,
-             sequence
+             sequence,
+             range_ceiling(snapshot)
            ) do
-        {:ok, _record, _digest} ->
+        {:ok, _record, bytes_read} ->
           acc =
             acc
             |> bump(:candidate_frames_verified, 1)
             |> bump(:hash_operations, 1)
             |> bump(:ranges, 1)
+            |> bump(:bytes_read, bytes_read)
 
           {:cont, {:ok, acc}}
 
@@ -399,10 +405,10 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Query do
   defp assemble_one(snapshot, {:generated_sources, run_id}, {:record, sequence}, metrics) do
     handle = Map.fetch!(snapshot.handles, run_id)
 
-    with {:ok, record, metrics} <- read(handle, snapshot, run_id, sequence, metrics) do
-      evaluation_id = record["correlation"]["evaluation_id"]
+    with {:ok, record, metrics} <- read(handle, snapshot, run_id, sequence, metrics),
+         evaluation_id = record["correlation"]["evaluation_id"],
+         {:ok, calls, metrics} <- analysis_calls(snapshot, run_id, evaluation_id, metrics) do
       parent = get_in(snapshot.trace_facts, [run_id, "parent_evaluation_ids", evaluation_id])
-      calls = analysis_calls(snapshot, run_id, evaluation_id)
       relationships = relationships(snapshot, run_id, :generated_sources, sequence)
       {:ok, Items.source_item(record, calls, parent, relationships), metrics}
     end
@@ -502,13 +508,19 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Query do
   defp compact_turn_page(result), do: result
 
   defp read(handle, snapshot, run_id, sequence, metrics) do
-    case Items.read_record(handle, snapshot.indexes, run_id, sequence) do
-      {:ok, record, _digest} ->
+    case Items.read_record(
+           handle,
+           snapshot.indexes,
+           run_id,
+           sequence,
+           range_ceiling(snapshot)
+         ) do
+      {:ok, record, bytes_read} ->
         metrics =
           metrics
           |> bump(:ranges, 1)
           |> bump(:hash_operations, 1)
-          |> bump(:bytes_read, byte_size_of(record))
+          |> bump(:bytes_read, bytes_read)
 
         {:ok, record, metrics}
 
@@ -596,21 +608,41 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Query do
     end
   end
 
+  defp locator_sequences(snapshot, :generated_sources, run_id, {:record, sequence}) do
+    [sequence | analysis_sequences(snapshot, run_id, sequence)]
+  end
+
   defp locator_sequences(_snapshot, _operation, _run_id, {:record, sequence}), do: [sequence]
   defp locator_sequences(_snapshot, _operation, _run_id, _locator), do: []
 
-  defp analysis_calls(snapshot, run_id, evaluation_id) do
+  defp analysis_sequences(snapshot, run_id, sequence) do
+    case Indexes.match(snapshot.indexes, :evaluation_join, {{run_id, :_, :source}, sequence}) do
+      [{{^run_id, evaluation_id, :source}, ^sequence}] ->
+        case Indexes.lookup(
+               snapshot.indexes,
+               :evaluation_join,
+               {run_id, evaluation_id, :analysis}
+             ) do
+          [{_key, analysis_seq}] -> [analysis_seq]
+          _other -> []
+        end
+
+      _other ->
+        []
+    end
+  end
+
+  defp analysis_calls(snapshot, run_id, evaluation_id, metrics) do
     case Indexes.lookup(snapshot.indexes, :evaluation_join, {run_id, evaluation_id, :analysis}) do
       [{_key, sequence}] ->
         handle = Map.fetch!(snapshot.handles, run_id)
 
-        case Items.read_record(handle, snapshot.indexes, run_id, sequence) do
-          {:ok, record, _digest} -> record["payload"]["prelude_calls"]
-          _error -> nil
+        with {:ok, record, metrics} <- read(handle, snapshot, run_id, sequence, metrics) do
+          {:ok, record["payload"]["prelude_calls"], metrics}
         end
 
       _other ->
-        nil
+        {:ok, nil, metrics}
     end
   end
 
@@ -749,10 +781,13 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Query do
 
   defp bump(metrics, key, amount), do: Map.update!(metrics, key, &(&1 + amount))
 
-  defp byte_size_of(record) do
-    case Jason.encode(record) do
-      {:ok, encoded} -> byte_size(encoded)
-      _error -> 0
+  defp range_ceiling(snapshot) do
+    case snapshot do
+      %{limits: %{max_range_bytes: bytes}} when is_integer(bytes) and bytes > 0 -> bytes
+      _other -> 64 * 1024 * 1024
     end
   end
+
+  defp maybe_query_hook(%{query_hook: hook}) when is_function(hook, 1), do: hook.(:before_query)
+  defp maybe_query_hook(_snapshot), do: :ok
 end

--- a/lib/ptc_runner/research/sealed_evidence_log/query.ex
+++ b/lib/ptc_runner/research/sealed_evidence_log/query.ex
@@ -476,7 +476,7 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Query do
   end
 
   defp shrink(selected, all_items, page, snapshot, max_bytes, metadata, metrics, _kind) do
-    Enum.reduce_while(length(selected)..1, {:error, :result_limit_exceeded}, fn count, acc ->
+    Enum.reduce_while(length(selected)..1//-1, {:error, :result_limit_exceeded}, fn count, acc ->
       result = page_result(Enum.take(selected, count), all_items, page, snapshot, metadata)
 
       if ResultLimit.within?(result, max_bytes),
@@ -573,7 +573,14 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Query do
   defp locator_sequences(snapshot, :turns, run_id, {:turn, ordinal}) do
     case Indexes.lookup(snapshot.indexes, :turn_projection, {run_id, ordinal}) do
       [{_key, turn}] ->
-        [turn.input_sequence, turn.output_sequence | Enum.map(turn.generated, & &1.sequence)]
+        generated = Enum.map(turn.generated, & &1.sequence)
+
+        analysis =
+          Enum.flat_map(generated, fn sequence ->
+            analysis_sequences(snapshot, run_id, sequence)
+          end)
+
+        [turn.input_sequence, turn.output_sequence | generated ++ analysis]
 
       _other ->
         []

--- a/lib/ptc_runner/research/sealed_evidence_log/query.ex
+++ b/lib/ptc_runner/research/sealed_evidence_log/query.ex
@@ -1,0 +1,757 @@
+defmodule PtcRunner.Research.SealedEvidenceLog.Query do
+  @moduledoc """
+  ETS-selected queries that verify dependency frames before returning a page.
+
+  Cursors bind the admission snapshot digest and the logical query identity.
+  They do not rehash the complete evidence preimage. Every frame that affects
+  membership, ordering, returned items, exact `omitted_count`, or the logical
+  cursor position is verified against its admission digest.
+  """
+
+  alias PtcRunner.Kernel.ResultLimit
+  alias PtcRunner.Research.SealedEvidenceLog.Conversation
+  alias PtcRunner.Research.SealedEvidenceLog.Handle
+  alias PtcRunner.Research.SealedEvidenceLog.Indexes
+  alias PtcRunner.Research.SealedEvidenceLog.Items
+  alias PtcRunner.Research.SealedEvidenceLog.ValueHash
+
+  @default_limit 100
+  @max_limit 1_000
+  @max_cursor_bytes 2_048
+
+  @operations [
+    :list_runs,
+    :get_run,
+    :turns,
+    :model_exchanges,
+    :capability_calls,
+    :generated_sources,
+    :effective_preludes,
+    :provider_exchanges,
+    :execution_prints,
+    :execution_errors,
+    :explicit_failure_values,
+    :result
+  ]
+
+  @type metrics :: %{
+          postings_visited: non_neg_integer(),
+          candidate_frames_verified: non_neg_integer(),
+          hash_operations: non_neg_integer(),
+          ranges: non_neg_integer(),
+          bytes_read: non_neg_integer(),
+          exact_count_work: non_neg_integer()
+        }
+
+  @spec operations() :: [atom()]
+  def operations, do: @operations
+
+  @spec empty_metrics() :: metrics()
+  def empty_metrics do
+    %{
+      postings_visited: 0,
+      candidate_frames_verified: 0,
+      hash_operations: 0,
+      ranges: 0,
+      bytes_read: 0,
+      exact_count_work: 0
+    }
+  end
+
+  @spec run(map(), atom(), map(), pos_integer(), map()) ::
+          {:ok, map(), metrics()} | {:error, atom()}
+  def run(snapshot, operation, arguments, max_result_bytes, metadata \\ %{})
+
+  def run(snapshot, operation, arguments, max_result_bytes, metadata)
+      when is_map(snapshot) and operation in @operations and is_map(arguments) and
+             is_integer(max_result_bytes) and max_result_bytes > 0 and is_map(metadata) do
+    execute(snapshot, operation, arguments, max_result_bytes, metadata, empty_metrics())
+  end
+
+  def run(_snapshot, _operation, _arguments, _max_result_bytes, _metadata),
+    do: {:error, :invalid_query}
+
+  defp execute(snapshot, :list_runs, arguments, max_bytes, metadata, metrics) do
+    with :ok <- validate_keys(arguments, ~w(limit cursor)),
+         {:ok, page} <- page_options(arguments, snapshot.snapshot_digest, :list_runs) do
+      runs =
+        snapshot.indexes
+        |> Indexes.tab2list(:runs)
+        |> Enum.sort_by(&elem(&1, 0))
+        |> Enum.map(&elem(&1, 1))
+
+      paginate(runs, :catalog, page, snapshot, max_bytes, metadata, metrics)
+    end
+  end
+
+  defp execute(
+         snapshot,
+         :get_run,
+         %{"run_id" => run_id} = arguments,
+         max_bytes,
+         metadata,
+         metrics
+       ) do
+    with :ok <- validate_keys(arguments, ["run_id"]),
+         true <- valid_string?(run_id),
+         {:ok, run} <- fetch_run(snapshot, run_id),
+         result <- Map.merge(run, metadata),
+         :ok <- ResultLimit.validate(result, max_bytes) do
+      {:ok, result, metrics}
+    else
+      false -> {:error, :invalid_query}
+      :error -> {:error, :not_found}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp execute(_snapshot, :get_run, _arguments, _max_bytes, _metadata, _metrics),
+    do: {:error, :invalid_query}
+
+  defp execute(snapshot, :result, %{"run_id" => run_id} = arguments, max_bytes, metadata, metrics) do
+    with :ok <- validate_keys(arguments, ["run_id"]),
+         :ok <- validate_result_run_id(run_id, snapshot),
+         {:ok, item, metrics} <- fetch_result(snapshot, run_id, metrics),
+         result <- Map.merge(item, metadata),
+         :ok <- ResultLimit.validate(result, max_bytes) do
+      {:ok, result, metrics}
+    end
+  end
+
+  defp execute(_snapshot, :result, _arguments, _max_bytes, _metadata, _metrics),
+    do: {:error, :invalid_query}
+
+  defp execute(snapshot, :turns, %{"run_id" => run_id} = arguments, max_bytes, metadata, metrics) do
+    allowed =
+      ~w(run_id limit cursor stream_id capability_id evaluation_id parent_evaluation_id prelude_call prelude_component)
+
+    with :ok <- validate_keys(arguments, allowed),
+         true <- valid_string?(run_id),
+         :ok <- validate_filter_values(arguments, allowed -- ~w(run_id limit cursor)),
+         :ok <- run_present(snapshot, run_id),
+         {:ok, page} <- page_options(arguments, snapshot.snapshot_digest, :turns),
+         {:ok, locators, metrics} <- select(snapshot, run_id, :turns, arguments, "asc", metrics),
+         {:ok, locators, metrics} <- filter_turns(snapshot, run_id, locators, arguments, metrics) do
+      metadata =
+        Map.merge(metadata, %{
+          "evidence" => turn_evidence(snapshot, run_id),
+          "trace_snapshot_hash" => snapshot.trace_snapshot_hash
+        })
+
+      paginate(locators, {:turns, run_id}, page, snapshot, max_bytes, metadata, metrics)
+      |> compact_turn_page()
+    else
+      false -> {:error, :invalid_query}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp execute(_snapshot, :turns, _arguments, _max_bytes, _metadata, _metrics),
+    do: {:error, :invalid_query}
+
+  defp execute(
+         snapshot,
+         operation,
+         %{"run_id" => run_id} = arguments,
+         max_bytes,
+         metadata,
+         metrics
+       )
+       when operation in [
+              :model_exchanges,
+              :capability_calls,
+              :generated_sources,
+              :effective_preludes,
+              :provider_exchanges,
+              :execution_prints,
+              :execution_errors,
+              :explicit_failure_values
+            ] do
+    allowed = ~w(run_id limit cursor order) ++ collection_filters(operation)
+
+    with :ok <- validate_keys(arguments, allowed),
+         true <- valid_string?(run_id),
+         :ok <- validate_order(arguments),
+         :ok <- validate_filter_values(arguments, collection_filters(operation)),
+         :ok <- run_present(snapshot, run_id),
+         {:ok, page} <- page_options(arguments, snapshot.snapshot_digest, operation),
+         {:ok, locators, metrics} <-
+           select(
+             snapshot,
+             run_id,
+             operation,
+             arguments,
+             Map.get(arguments, "order", "asc"),
+             metrics
+           ) do
+      paginate(locators, {operation, run_id}, page, snapshot, max_bytes, metadata, metrics)
+    else
+      false -> {:error, :not_found}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp execute(_snapshot, _operation, _arguments, _max_bytes, _metadata, _metrics),
+    do: {:error, :invalid_query}
+
+  defp select(snapshot, run_id, collection, arguments, order, metrics) do
+    ordered =
+      snapshot.indexes
+      |> Indexes.match(:collection_order, {{run_id, collection, :_}, :_})
+      |> Enum.sort_by(fn {{_run, _collection, ordinal}, _locator} -> ordinal end)
+
+    filters =
+      arguments
+      |> Map.take(collection_filters(collection) ++ turn_filters())
+      |> Enum.reject(fn {_key, value} -> is_nil(value) end)
+
+    {ordinals, metrics} =
+      Enum.reduce(filters, {MapSet.new(Enum.map(ordered, &ordinal/1)), metrics}, fn {filter,
+                                                                                     value},
+                                                                                    {set, metrics} ->
+        postings =
+          Indexes.match(
+            snapshot.indexes,
+            :filter_posting,
+            {{run_id, collection, filter, ValueHash.hash(value), :_}, :_}
+          )
+
+        posting_ordinals = MapSet.new(Enum.map(postings, &posting_ordinal/1))
+        metrics = bump(metrics, :postings_visited, length(postings))
+        {MapSet.intersection(set, posting_ordinals), metrics}
+      end)
+
+    locators =
+      ordered
+      |> Enum.filter(fn row -> MapSet.member?(ordinals, ordinal(row)) end)
+      |> Enum.map(&elem(&1, 1))
+      |> order(order)
+
+    {:ok, locators, metrics}
+  end
+
+  defp filter_turns(snapshot, run_id, locators, arguments, metrics) do
+    filters =
+      Map.take(arguments, ~w(evaluation_id parent_evaluation_id prelude_call prelude_component))
+
+    if Enum.all?(filters, fn {_key, value} -> is_nil(value) end) do
+      {:ok, locators, metrics}
+    else
+      kept =
+        Enum.filter(locators, fn {:turn, ordinal} ->
+          case Indexes.lookup(snapshot.indexes, :turn_projection, {run_id, ordinal}) do
+            [{_key, turn}] -> generated_source_match?(turn, arguments, snapshot, run_id)
+            _other -> false
+          end
+        end)
+
+      {:ok, kept, metrics}
+    end
+  end
+
+  defp generated_source_match?(turn, arguments, _snapshot, _run_id) do
+    Enum.any?(turn.generated, fn generated ->
+      equal_filter?(generated.evaluation_id, arguments["evaluation_id"]) and
+        equal_filter?(generated.parent_evaluation_id, arguments["parent_evaluation_id"]) and
+        call_match?(generated, arguments["prelude_call"], "ref") and
+        call_match?(generated, arguments["prelude_component"], "component_id")
+    end)
+  end
+
+  defp paginate(items, kind, page, snapshot, max_bytes, metadata, metrics) do
+    with :ok <- verify_handles(snapshot, kind, metrics) do
+      selected = items |> Enum.drop(page.offset) |> Enum.take(page.limit)
+      omitted = Enum.drop(items, page.offset + length(selected))
+
+      with {:ok, metrics} <- verify_dependencies(snapshot, kind, selected ++ omitted, metrics),
+           {:ok, assembled, metrics} <- assemble_many(snapshot, kind, selected, metrics) do
+        metrics = bump(metrics, :exact_count_work, length(omitted))
+        fit_page(assembled, items, page, snapshot, max_bytes, metadata, metrics, kind)
+      end
+    end
+  end
+
+  defp verify_handles(snapshot, :catalog, _metrics) do
+    snapshot.handles
+    |> Map.values()
+    |> Enum.reduce_while(:ok, fn handle, :ok ->
+      case Handle.assert_stable(handle) do
+        :ok -> {:cont, :ok}
+        error -> {:halt, error}
+      end
+    end)
+  end
+
+  defp verify_handles(snapshot, {_operation, run_id}, _metrics) do
+    case Map.fetch(snapshot.handles, run_id) do
+      {:ok, handle} -> Handle.assert_stable(handle)
+      :error -> {:error, :not_found}
+    end
+  end
+
+  defp verify_dependencies(_snapshot, :catalog, _items, metrics), do: {:ok, metrics}
+
+  defp verify_dependencies(snapshot, kind, locators, metrics) do
+    Enum.reduce_while(locators, {:ok, metrics}, fn locator, {:ok, acc} ->
+      case verify_locator(snapshot, kind, locator, acc) do
+        {:ok, acc} -> {:cont, {:ok, acc}}
+        error -> {:halt, error}
+      end
+    end)
+  end
+
+  defp verify_locator(snapshot, {operation, run_id}, locator, metrics) do
+    sequences = locator_sequences(snapshot, operation, run_id, locator)
+
+    Enum.reduce_while(sequences, {:ok, metrics}, fn sequence, {:ok, acc} ->
+      case Items.read_record(
+             Map.fetch!(snapshot.handles, run_id),
+             snapshot.indexes,
+             run_id,
+             sequence
+           ) do
+        {:ok, _record, _digest} ->
+          acc =
+            acc
+            |> bump(:candidate_frames_verified, 1)
+            |> bump(:hash_operations, 1)
+            |> bump(:ranges, 1)
+
+          {:cont, {:ok, acc}}
+
+        {:error, _reason} = error ->
+          {:halt, error}
+      end
+    end)
+  end
+
+  defp assemble_many(_snapshot, :catalog, items, metrics), do: {:ok, items, metrics}
+
+  defp assemble_many(snapshot, kind, locators, metrics) do
+    Enum.reduce_while(locators, {:ok, [], metrics}, fn locator, {:ok, items, acc} ->
+      case assemble_one(snapshot, kind, locator, acc) do
+        {:ok, item, acc} -> {:cont, {:ok, items ++ [item], acc}}
+        error -> {:halt, error}
+      end
+    end)
+    |> case do
+      {:ok, items, metrics} -> {:ok, items, metrics}
+      error -> error
+    end
+  end
+
+  defp assemble_one(snapshot, {:turns, run_id}, {:turn, ordinal}, metrics) do
+    case Indexes.lookup(snapshot.indexes, :turn_projection, {run_id, ordinal}) do
+      [{_key, turn}] ->
+        handle = Map.fetch!(snapshot.handles, run_id)
+
+        with {:ok, input, metrics} <- read(handle, snapshot, run_id, turn.input_sequence, metrics),
+             {:ok, output, metrics} <-
+               read(handle, snapshot, run_id, turn.output_sequence, metrics),
+             {:ok, generated, metrics} <-
+               assemble_generated(snapshot, run_id, turn.generated, metrics) do
+          item =
+            turn
+            |> Conversation.assemble_turn(input, output, generated)
+            |> Map.put("run_id", run_id)
+
+          {:ok, item, metrics}
+        end
+
+      _other ->
+        {:error, :source_changed}
+    end
+  end
+
+  defp assemble_one(snapshot, {operation, run_id}, locator, metrics)
+       when operation in [:model_exchanges, :capability_calls] do
+    {:capability, id, _sequence} = locator
+    [{_key, join}] = Indexes.lookup(snapshot.indexes, :capability_join, {run_id, id})
+    handle = Map.fetch!(snapshot.handles, run_id)
+
+    with {:ok, input, metrics} <- read(handle, snapshot, run_id, join.input_sequence, metrics),
+         {:ok, output, metrics} <-
+           maybe_read(handle, snapshot, run_id, join.output_sequence, metrics),
+         {:ok, exception, metrics} <-
+           maybe_read(handle, snapshot, run_id, join.exception_sequence, metrics) do
+      {:ok, Items.capability_item(input, output, exception), metrics}
+    end
+  end
+
+  defp assemble_one(snapshot, {:provider_exchanges, run_id}, locator, metrics) do
+    {:provider, capability_id, request_id, _sequence} = locator
+
+    [{_key, join}] =
+      Indexes.lookup(snapshot.indexes, :provider_join, {run_id, capability_id, request_id})
+
+    handle = Map.fetch!(snapshot.handles, run_id)
+
+    with {:ok, request, metrics} <- read(handle, snapshot, run_id, join.request_sequence, metrics),
+         {:ok, response, metrics} <-
+           read(handle, snapshot, run_id, join.response_sequence, metrics),
+         {:ok, stderr, metrics} <-
+           maybe_read(handle, snapshot, run_id, join.stderr_sequence, metrics) do
+      {:ok, Items.provider_item(request, response, stderr), metrics}
+    end
+  end
+
+  defp assemble_one(snapshot, {:generated_sources, run_id}, {:record, sequence}, metrics) do
+    handle = Map.fetch!(snapshot.handles, run_id)
+
+    with {:ok, record, metrics} <- read(handle, snapshot, run_id, sequence, metrics) do
+      evaluation_id = record["correlation"]["evaluation_id"]
+      parent = get_in(snapshot.trace_facts, [run_id, "parent_evaluation_ids", evaluation_id])
+      calls = analysis_calls(snapshot, run_id, evaluation_id)
+      relationships = relationships(snapshot, run_id, :generated_sources, sequence)
+      {:ok, Items.source_item(record, calls, parent, relationships), metrics}
+    end
+  end
+
+  defp assemble_one(snapshot, {:effective_preludes, run_id}, {:record, sequence}, metrics) do
+    handle = Map.fetch!(snapshot.handles, run_id)
+
+    with {:ok, record, metrics} <- read(handle, snapshot, run_id, sequence, metrics) do
+      relationships = relationships(snapshot, run_id, :effective_preludes, sequence)
+      {:ok, Items.prelude_item(record, relationships), metrics}
+    end
+  end
+
+  defp assemble_one(snapshot, {operation, run_id}, {:record, sequence}, metrics)
+       when operation in [:execution_prints, :execution_errors, :explicit_failure_values] do
+    handle = Map.fetch!(snapshot.handles, run_id)
+
+    with {:ok, record, metrics} <- read(handle, snapshot, run_id, sequence, metrics) do
+      relationships =
+        if operation == :execution_errors,
+          do: relationships(snapshot, run_id, :execution_errors, sequence),
+          else: nil
+
+      {:ok, Items.execution_item(record, relationships), metrics}
+    end
+  end
+
+  defp assemble_generated(snapshot, run_id, generated, metrics) do
+    Enum.reduce_while(generated, {:ok, [], metrics}, fn entry, {:ok, items, acc} ->
+      locator = {:record, entry.sequence}
+
+      case assemble_one(snapshot, {:generated_sources, run_id}, locator, acc) do
+        {:ok, item, acc} ->
+          item =
+            item
+            |> Map.put("association", entry.association)
+            |> Map.put("association_ambiguous?", entry.association_ambiguous?)
+
+          {:cont, {:ok, items ++ [item], acc}}
+
+        error ->
+          {:halt, error}
+      end
+    end)
+    |> case do
+      {:ok, items, metrics} -> {:ok, items, metrics}
+      error -> error
+    end
+  end
+
+  defp fit_page(selected, all_items, page, snapshot, max_bytes, metadata, metrics, kind) do
+    result = page_result(selected, all_items, page, snapshot, metadata)
+
+    cond do
+      ResultLimit.within?(result, max_bytes) ->
+        {:ok, result, metrics}
+
+      selected == [] ->
+        {:error, :result_limit_exceeded}
+
+      true ->
+        shrink(selected, all_items, page, snapshot, max_bytes, metadata, metrics, kind)
+    end
+  end
+
+  defp shrink(selected, all_items, page, snapshot, max_bytes, metadata, metrics, _kind) do
+    Enum.reduce_while(length(selected)..1, {:error, :result_limit_exceeded}, fn count, acc ->
+      result = page_result(Enum.take(selected, count), all_items, page, snapshot, metadata)
+
+      if ResultLimit.within?(result, max_bytes),
+        do: {:halt, {:ok, result, metrics}},
+        else: {:cont, acc}
+    end)
+  end
+
+  defp page_result(selected, all_items, page, snapshot, metadata) do
+    next_offset = page.offset + length(selected)
+    more? = next_offset < length(all_items)
+
+    Map.merge(metadata, %{
+      "items" => selected,
+      "next_cursor" =>
+        if(more?,
+          do: encode_cursor(next_offset, snapshot.snapshot_digest, page.query_id),
+          else: nil
+        ),
+      "truncated" => more?,
+      "omitted_count" => max(length(all_items) - next_offset, 0)
+    })
+  end
+
+  defp compact_turn_page({:ok, %{"items" => items} = page, metrics}) do
+    {:ok, Map.put(page, "items", Conversation.compact_turns(items)), metrics}
+  end
+
+  defp compact_turn_page(result), do: result
+
+  defp read(handle, snapshot, run_id, sequence, metrics) do
+    case Items.read_record(handle, snapshot.indexes, run_id, sequence) do
+      {:ok, record, _digest} ->
+        metrics =
+          metrics
+          |> bump(:ranges, 1)
+          |> bump(:hash_operations, 1)
+          |> bump(:bytes_read, byte_size_of(record))
+
+        {:ok, record, metrics}
+
+      error ->
+        error
+    end
+  end
+
+  defp maybe_read(_handle, _snapshot, _run_id, nil, metrics), do: {:ok, nil, metrics}
+
+  defp maybe_read(handle, snapshot, run_id, sequence, metrics),
+    do: read(handle, snapshot, run_id, sequence, metrics)
+
+  defp fetch_run(snapshot, run_id) do
+    case Indexes.lookup(snapshot.indexes, :runs, run_id) do
+      [{^run_id, run}] -> {:ok, run}
+      _other -> :error
+    end
+  end
+
+  defp fetch_result(snapshot, run_id, metrics) do
+    case Indexes.lookup(snapshot.indexes, :results, run_id) do
+      [{^run_id, sequence}] ->
+        handle = Map.fetch!(snapshot.handles, run_id)
+
+        with {:ok, record, metrics} <- read(handle, snapshot, run_id, sequence, metrics) do
+          {:ok, Items.result_item(record), metrics}
+        end
+
+      _other ->
+        {:error, :result_not_found}
+    end
+  end
+
+  defp validate_result_run_id(run_id, snapshot) do
+    cond do
+      not valid_string?(run_id) -> {:error, :invalid_query}
+      match?({:ok, _}, fetch_run(snapshot, run_id)) -> :ok
+      true -> {:error, :not_found}
+    end
+  end
+
+  defp run_present(snapshot, run_id) do
+    case fetch_run(snapshot, run_id) do
+      {:ok, _run} -> :ok
+      :error -> {:error, :not_found}
+    end
+  end
+
+  defp locator_sequences(snapshot, :turns, run_id, {:turn, ordinal}) do
+    case Indexes.lookup(snapshot.indexes, :turn_projection, {run_id, ordinal}) do
+      [{_key, turn}] ->
+        [turn.input_sequence, turn.output_sequence | Enum.map(turn.generated, & &1.sequence)]
+
+      _other ->
+        []
+    end
+  end
+
+  defp locator_sequences(snapshot, operation, run_id, {:capability, id, _sequence})
+       when operation in [:model_exchanges, :capability_calls] do
+    case Indexes.lookup(snapshot.indexes, :capability_join, {run_id, id}) do
+      [{_key, join}] ->
+        [join.input_sequence, join.output_sequence, join.exception_sequence]
+        |> Enum.reject(&is_nil/1)
+
+      _other ->
+        []
+    end
+  end
+
+  defp locator_sequences(
+         snapshot,
+         :provider_exchanges,
+         run_id,
+         {:provider, capability_id, request_id, _}
+       ) do
+    case Indexes.lookup(snapshot.indexes, :provider_join, {run_id, capability_id, request_id}) do
+      [{_key, join}] ->
+        [join.request_sequence, join.response_sequence, join.stderr_sequence]
+        |> Enum.reject(&is_nil/1)
+
+      _other ->
+        []
+    end
+  end
+
+  defp locator_sequences(_snapshot, _operation, _run_id, {:record, sequence}), do: [sequence]
+  defp locator_sequences(_snapshot, _operation, _run_id, _locator), do: []
+
+  defp analysis_calls(snapshot, run_id, evaluation_id) do
+    case Indexes.lookup(snapshot.indexes, :evaluation_join, {run_id, evaluation_id, :analysis}) do
+      [{_key, sequence}] ->
+        handle = Map.fetch!(snapshot.handles, run_id)
+
+        case Items.read_record(handle, snapshot.indexes, run_id, sequence) do
+          {:ok, record, _digest} -> record["payload"]["prelude_calls"]
+          _error -> nil
+        end
+
+      _other ->
+        nil
+    end
+  end
+
+  defp relationships(snapshot, run_id, collection, key) do
+    case Indexes.lookup(snapshot.indexes, :relationships, {run_id, collection, key}) do
+      [{_key, relations}] -> relations
+      _other -> []
+    end
+  end
+
+  defp turn_evidence(snapshot, run_id) do
+    get_in(snapshot, [:turn_evidence, run_id]) ||
+      %{
+        "complete?" => false,
+        "canonical_complete?" => false,
+        "missing_exchange_count" => 0,
+        "ambiguity_count" => 0
+      }
+  end
+
+  defp page_options(arguments, source_id, operation) do
+    limit = Map.get(arguments, "limit", @default_limit)
+    query_id = digest({operation, Map.drop(arguments, ["cursor", "limit"])})
+
+    with true <- is_integer(limit) and limit in 1..@max_limit,
+         {:ok, offset} <- cursor_offset(Map.get(arguments, "cursor"), source_id, query_id) do
+      {:ok, %{limit: limit, offset: offset, query_id: query_id}}
+    else
+      {:error, _reason} = error -> error
+      _invalid -> {:error, :invalid_query}
+    end
+  end
+
+  defp cursor_offset(nil, _source_id, _query_id), do: {:ok, 0}
+
+  defp cursor_offset(cursor, source_id, query_id)
+       when is_binary(cursor) and byte_size(cursor) <= @max_cursor_bytes do
+    with {:ok, encoded} <- Base.url_decode64(cursor, padding: false),
+         {:ok,
+          %{"offset" => offset, "source" => cursor_source, "query" => cursor_query} = payload} <-
+           Jason.decode(encoded),
+         true <- map_size(payload) == 3,
+         true <- is_integer(offset) and offset >= 0,
+         true <- is_binary(cursor_source) and is_binary(cursor_query) do
+      cond do
+        cursor_source != source_id -> {:error, :source_changed}
+        cursor_query != query_id -> {:error, :invalid_query}
+        true -> {:ok, offset}
+      end
+    else
+      _invalid -> {:error, :invalid_query}
+    end
+  end
+
+  defp cursor_offset(_cursor, _source_id, _query_id), do: {:error, :invalid_query}
+
+  # ex_dna:disable-for-next-line — research prototype mirrors InspectionQuery for the differential oracle
+  defp encode_cursor(offset, source_id, query_id) do
+    %{"offset" => offset, "source" => source_id, "query" => query_id}
+    |> Jason.encode!()
+    |> Base.url_encode64(padding: false)
+  end
+
+  defp digest(value) do
+    value
+    |> :erlang.term_to_binary([:deterministic])
+    |> then(&:crypto.hash(:sha256, &1))
+    |> Base.url_encode64(padding: false)
+  end
+
+  # ex_dna:disable-for-next-line — research prototype mirrors InspectionQuery for the differential oracle
+  defp validate_keys(arguments, allowed) do
+    if Map.keys(arguments) -- allowed == [], do: :ok, else: {:error, :invalid_query}
+  end
+
+  # ex_dna:disable-for-next-line — research prototype mirrors InspectionQuery for the differential oracle
+  defp valid_string?(value),
+    do: is_binary(value) and byte_size(value) in 1..4_096 and String.valid?(value)
+
+  # ex_dna:disable-for-next-line — research prototype mirrors InspectionQuery for the differential oracle
+  defp validate_order(%{"order" => order}) when order in ["asc", "desc"], do: :ok
+  defp validate_order(arguments) when not is_map_key(arguments, "order"), do: :ok
+  defp validate_order(_arguments), do: {:error, :invalid_query}
+
+  defp collection_filters(:model_exchanges), do: ~w(capability_id input_sequence)
+  defp collection_filters(:capability_calls), do: ~w(capability_id mission_name name)
+  defp collection_filters(:provider_exchanges), do: ~w(capability_id mission_name request_id)
+
+  defp collection_filters(:generated_sources),
+    do: ~w(evaluation_id parent_evaluation_id mission_name prelude_call prelude_component)
+
+  defp collection_filters(:effective_preludes), do: ~w(component_id environment mission_name)
+
+  defp collection_filters(operation)
+       when operation in [:execution_prints, :execution_errors, :explicit_failure_values, :turns],
+       do: ["evaluation_id"]
+
+  defp collection_filters(_operation), do: []
+
+  defp turn_filters, do: ~w(stream_id capability_id)
+
+  # ex_dna:disable-for-next-line — research prototype mirrors InspectionQuery for the differential oracle
+  defp validate_filter_values(arguments, filters) do
+    valid? =
+      Enum.all?(filters, fn
+        filter when filter in ["input_sequence", "request_id"] ->
+          is_nil(arguments[filter]) or (is_integer(arguments[filter]) and arguments[filter] > 0)
+
+        filter ->
+          is_nil(arguments[filter]) or valid_string?(arguments[filter])
+      end)
+
+    if valid?, do: :ok, else: {:error, :invalid_query}
+  end
+
+  defp order(items, "asc"), do: items
+  defp order(items, "desc"), do: Enum.reverse(items)
+
+  defp ordinal({{_run, _collection, ordinal}, _locator}), do: ordinal
+  defp posting_ordinal({{_run, _collection, _filter, _hash, ordinal}, _locator}), do: ordinal
+
+  defp equal_filter?(_actual, nil), do: true
+  defp equal_filter?(actual, expected), do: actual == expected
+
+  defp call_match?(_item, nil, _key), do: true
+
+  defp call_match?(item, expected, key) do
+    item
+    |> prelude_calls()
+    |> Enum.any?(&(&1[key] == expected))
+  end
+
+  defp prelude_calls(%{prelude_calls: calls}) when is_list(calls), do: calls
+  defp prelude_calls(item) when is_map(item), do: Map.get(item, "prelude_calls", [])
+  defp prelude_calls(_item), do: []
+
+  defp bump(metrics, key, amount), do: Map.update!(metrics, key, &(&1 + amount))
+
+  defp byte_size_of(record) do
+    case Jason.encode(record) do
+      {:ok, encoded} -> byte_size(encoded)
+      _error -> 0
+    end
+  end
+end

--- a/lib/ptc_runner/research/sealed_evidence_log/query.ex
+++ b/lib/ptc_runner/research/sealed_evidence_log/query.ex
@@ -8,6 +8,7 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Query do
   cursor position is verified against its admission digest.
   """
 
+  alias PtcRunner.Kernel.ConversationProjection
   alias PtcRunner.Kernel.ResultLimit
   alias PtcRunner.Research.SealedEvidenceLog.Conversation
   alias PtcRunner.Research.SealedEvidenceLog.Handle
@@ -495,7 +496,7 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Query do
   end
 
   defp compact_turn_page({:ok, %{"items" => items} = page, metrics}) do
-    {:ok, Map.put(page, "items", Conversation.compact_turns(items)), metrics}
+    {:ok, Map.put(page, "items", ConversationProjection.compact_turns(items)), metrics}
   end
 
   defp compact_turn_page(result), do: result

--- a/lib/ptc_runner/research/sealed_evidence_log/snapshot.ex
+++ b/lib/ptc_runner/research/sealed_evidence_log/snapshot.ex
@@ -1,0 +1,329 @@
+defmodule PtcRunner.Research.SealedEvidenceLog.Snapshot do
+  @moduledoc """
+  Owner process for admitted ETS indexes and pinned sealed-log readers.
+
+  The owner creates the tables, runs admission in a bounded worker, and remains
+  the sole mutator of retained state. Owner death deletes every table and closes
+  every handle. Query workers cancel with the caller; the snapshot stays usable.
+  """
+
+  use GenServer
+
+  alias PtcRunner.Kernel.BoundedWorker
+  alias PtcRunner.Research.SealedEvidenceLog.Admission
+  alias PtcRunner.Research.SealedEvidenceLog.Handle
+  alias PtcRunner.Research.SealedEvidenceLog.Indexes
+  alias PtcRunner.Research.SealedEvidenceLog.Limits
+  alias PtcRunner.Research.SealedEvidenceLog.Query
+
+  @enforce_keys [:pid, :token]
+  defstruct [:pid, :token]
+
+  @type t :: %__MODULE__{pid: pid(), token: reference()}
+
+  @spec start([map()], map(), keyword()) :: {:ok, t()} | {:error, atom()}
+  def start(artifacts, limits, opts \\ [])
+      when is_list(artifacts) and is_map(limits) and is_list(opts) do
+    owner = Keyword.get(opts, :owner, self())
+    token = make_ref()
+
+    case GenServer.start(__MODULE__, {artifacts, limits, owner, token, opts}) do
+      {:ok, pid} -> {:ok, %__MODULE__{pid: pid, token: token}}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @spec query(t(), atom(), map(), keyword()) ::
+          {:ok, map(), Query.metrics()} | {:error, atom()}
+  def query(snapshot, operation, arguments, opts \\ [])
+
+  def query(%__MODULE__{} = snapshot, operation, arguments, opts)
+      when is_atom(operation) and is_map(arguments) and is_list(opts) do
+    call(snapshot, {:query, operation, arguments, opts})
+  end
+
+  def query(_snapshot, _operation, _arguments, _opts), do: {:error, :invalid_query}
+
+  @spec info(t()) :: {:ok, map()} | {:error, atom()}
+  def info(%__MODULE__{} = snapshot), do: call(snapshot, :info)
+  def info(_snapshot), do: {:error, :invalid_snapshot}
+
+  @spec close(term()) :: :ok
+  def close(%__MODULE__{} = snapshot) do
+    case call(snapshot, :stop) do
+      :ok -> :ok
+      {:error, _reason} -> :ok
+    end
+  end
+
+  def close(_snapshot), do: :ok
+
+  @spec alive?(t()) :: boolean()
+  def alive?(%__MODULE__{pid: pid}), do: Process.alive?(pid)
+
+  @spec table_ids(t()) :: [reference()] | {:error, atom()}
+  def table_ids(%__MODULE__{} = snapshot), do: call(snapshot, :table_ids)
+
+  @spec handles(t()) :: {:ok, [Handle.t()]} | {:error, atom()}
+  def handles(%__MODULE__{} = snapshot), do: call(snapshot, :handles)
+
+  @impl GenServer
+  def init({artifacts, limits, owner, token, opts}) do
+    Process.flag(:trap_exit, true)
+    owner_ref = Process.monitor(owner)
+    indexes = Indexes.create(self())
+
+    case admit_all(artifacts, indexes, limits, opts) do
+      {:ok, state} ->
+        {:ok,
+         Map.merge(state, %{
+           token: token,
+           owner_ref: owner_ref,
+           limits: limits,
+           indexes: Indexes.put_owner_metadata(state.indexes, %{token: token})
+         })}
+
+      {:error, reason} ->
+        Indexes.delete_all(indexes)
+        {:stop, reason}
+    end
+  end
+
+  @impl GenServer
+  def handle_call({:query, operation, arguments, opts}, {caller, _ref} = from, state) do
+    if valid_token?(state, opts) do
+      run_query(state, operation, arguments, caller, from)
+    else
+      {:reply, {:error, :invalid_snapshot}, state}
+    end
+  end
+
+  def handle_call(:info, _from, state) do
+    accounting = Indexes.accounting(state.indexes)
+
+    {:reply,
+     {:ok,
+      %{
+        snapshot_digest: state.snapshot_digest,
+        run_count: map_size(state.handles),
+        accounting: accounting,
+        record_count: state.record_count,
+        checkpoints: state.checkpoints,
+        diagnostic_peaks: state.peaks,
+        handle_count: map_size(state.handles)
+      }}, state}
+  end
+
+  def handle_call(:table_ids, _from, state),
+    do: {:reply, Indexes.table_ids(state.indexes), state}
+
+  def handle_call(:handles, _from, state),
+    do: {:reply, {:ok, Map.values(state.handles)}, state}
+
+  def handle_call(:stop, _from, state) do
+    {:stop, :normal, :ok, state}
+  end
+
+  def handle_call(_message, _from, state), do: {:reply, {:error, :invalid_query}, state}
+
+  @impl GenServer
+  # ex_dna:disable-for-next-line — GenServer callback, intentionally per-module
+  def handle_info({:DOWN, ref, :process, _pid, _reason}, %{owner_ref: ref} = state) do
+    {:stop, :normal, state}
+  end
+
+  def handle_info(_message, state), do: {:noreply, state}
+
+  @impl GenServer
+  def terminate(_reason, state) do
+    if Map.has_key?(state, :indexes), do: Indexes.delete_all(state.indexes)
+    state |> Map.get(:handles, %{}) |> Map.values() |> Enum.each(&Handle.close/1)
+    :ok
+  end
+
+  @impl GenServer
+  def format_status(status), do: redact_status(status)
+
+  defp admit_all(artifacts, indexes, limits, opts) do
+    Enum.reduce_while(artifacts, {:ok, empty_state(indexes)}, fn artifact, {:ok, acc} ->
+      case admit_one(artifact, acc.indexes, limits, opts) do
+        {:ok, admitted} ->
+          handles = Map.put(acc.handles, admitted.run_id, admitted.handle)
+
+          {:cont,
+           {:ok,
+            %{
+              acc
+              | indexes: admitted.indexes,
+                handles: handles,
+                trace_facts: Map.put(acc.trace_facts, admitted.run_id, artifact.trace_facts),
+                turn_evidence:
+                  Map.put(acc.turn_evidence, admitted.run_id, admitted.turn_evidence),
+                record_count: acc.record_count + admitted.record_count,
+                checkpoints: acc.checkpoints ++ admitted.checkpoints.checkpoints,
+                peaks: merge_peaks(acc.peaks, admitted.checkpoints.diagnostic_peaks),
+                digests: Map.put(acc.digests, admitted.run_id, admitted.handle.digest)
+            }}}
+
+        {:error, reason} ->
+          {:halt, {:error, reason}}
+      end
+    end)
+    |> case do
+      {:ok, state} ->
+        {:ok,
+         %{
+           state
+           | snapshot_digest: snapshot_digest(state, opts),
+             trace_snapshot_hash: Keyword.get(opts, :trace_snapshot_hash, "trace-source"),
+             indexes: Indexes.put_trace_facts(state.indexes, state.trace_facts)
+         }}
+
+      error ->
+        error
+    end
+  end
+
+  defp admit_one(artifact, indexes, limits, opts) do
+    path = artifact.path
+    trace_facts = artifact.trace_facts
+
+    with {:ok, handle} <- Handle.open(path),
+         {:ok, admitted} <- Admission.run(handle, indexes, trace_facts, limits, opts) do
+      {:ok,
+       %{
+         handle: handle,
+         indexes: admitted.indexes,
+         run_id: admitted.run_id,
+         record_count: admitted.record_count,
+         checkpoints: admitted.checkpoints,
+         turn_evidence: turn_evidence(admitted)
+       }}
+    end
+  end
+
+  defp run_query(state, operation, arguments, caller, from) do
+    snapshot = query_state(state)
+    max_bytes = state.limits.max_result_bytes
+    metadata = %{"snapshot_hash" => snapshot_hash(state.snapshot_digest)}
+    limits = state.limits
+
+    {:noreply, state,
+     {:continue,
+      {:dispatch_query, operation, arguments, caller, from, snapshot, max_bytes, metadata, limits}}}
+  end
+
+  @impl GenServer
+  def handle_continue(
+        {:dispatch_query, operation, arguments, caller, from, snapshot, max_bytes, metadata,
+         limits},
+        state
+      ) do
+    result =
+      BoundedWorker.run(
+        fn -> Query.run(snapshot, operation, arguments, max_bytes, metadata) end,
+        timeout_ms: limits.query_deadline_ms,
+        max_heap_words: Limits.heap_words(limits.query_heap_bytes),
+        cancel_with: caller
+      )
+
+    GenServer.reply(from, wrap_query(result))
+    {:noreply, state}
+  end
+
+  defp wrap_query({:ok, {:ok, page, metrics}}), do: {:ok, page, metrics}
+  defp wrap_query({:ok, {:error, reason}}) when is_atom(reason), do: {:error, reason}
+  defp wrap_query({:error, :timeout}), do: {:error, :deadline_exceeded}
+  defp wrap_query({:error, :cancelled}), do: {:error, :cancelled}
+  defp wrap_query({:error, :heap_exceeded}), do: {:error, :heap_exceeded}
+  defp wrap_query({:error, :worker_failed}), do: {:error, :query_failed}
+  defp wrap_query(_other), do: {:error, :query_failed}
+
+  defp query_state(state) do
+    %{
+      indexes: state.indexes,
+      handles: state.handles,
+      snapshot_digest: state.snapshot_digest,
+      trace_facts: state.trace_facts,
+      trace_snapshot_hash: state.trace_snapshot_hash,
+      turn_evidence: state.turn_evidence
+    }
+  end
+
+  defp empty_state(indexes) do
+    %{
+      indexes: indexes,
+      handles: %{},
+      trace_facts: %{},
+      turn_evidence: %{},
+      record_count: 0,
+      checkpoints: [],
+      peaks: %{},
+      digests: %{},
+      snapshot_digest: "",
+      trace_snapshot_hash: "trace-source"
+    }
+  end
+
+  defp snapshot_digest(state, opts) do
+    capture =
+      opts
+      |> Keyword.get(:trace_capture_sha256, :crypto.hash(:sha256, "prototype-trace"))
+      |> capture_bytes()
+
+    pairs =
+      state.digests
+      |> Enum.sort_by(&elem(&1, 0))
+      |> Enum.map(fn {run_id, digest} ->
+        [<<byte_size(run_id)::unsigned-big-64>>, run_id, digest]
+      end)
+
+    :crypto.hash(
+      :sha256,
+      [
+        "ptc-inspection-snapshot-v1\0",
+        capture,
+        <<map_size(state.digests)::unsigned-big-64>>,
+        pairs
+      ]
+    )
+    |> Base.url_encode64(padding: false)
+  end
+
+  defp capture_bytes(value) when is_binary(value) and byte_size(value) == 32, do: value
+  defp capture_bytes(value) when is_binary(value), do: :crypto.hash(:sha256, value)
+
+  defp merge_peaks(left, right) when is_map(left) and is_map(right) do
+    Map.merge(left, right, fn _name, current, incoming ->
+      if incoming.aggregate_memory_bytes > current.aggregate_memory_bytes,
+        do: incoming,
+        else: current
+    end)
+  end
+
+  defp snapshot_hash(digest) when is_binary(digest) do
+    "sha256:" <> Base.encode16(:crypto.hash(:sha256, digest), case: :lower)
+  end
+
+  defp turn_evidence(admitted), do: admitted.turn_evidence
+
+  defp valid_token?(state, _opts), do: is_reference(state.token)
+
+  defp call(%__MODULE__{pid: pid}, message) do
+    GenServer.call(pid, message, 30_000)
+  catch
+    :exit, _reason -> {:error, :invalid_snapshot}
+  end
+
+  # The token is stored on the handle; calls go to the pid. The struct token is
+  # checked by the public functions that pattern-match `%__MODULE__{}`.
+  defp redact_status(status) when is_map(status) do
+    Map.new(status, fn
+      {key, _value} when key in [:state, :message, :reason] -> {key, :redacted}
+      {:log, _value} -> {:log, []}
+      key_value -> key_value
+    end)
+  end
+
+  defp redact_status(status), do: status
+end

--- a/lib/ptc_runner/research/sealed_evidence_log/snapshot.ex
+++ b/lib/ptc_runner/research/sealed_evidence_log/snapshot.ex
@@ -26,8 +26,10 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Snapshot do
   @spec start([map()], map(), keyword()) :: {:ok, t()} | {:error, atom()}
   def start(artifacts, limits, opts \\ [])
       when is_list(artifacts) and is_map(limits) and is_list(opts) do
-    owner = Keyword.get(opts, :owner, self())
+    caller = self()
+    owner = Keyword.get(opts, :owner, caller)
     token = make_ref()
+    opts = opts |> Keyword.put(:owner, owner) |> Keyword.put(:cancel_with, caller)
 
     case GenServer.start(__MODULE__, {artifacts, limits, owner, token, opts}) do
       {:ok, pid} -> {:ok, %__MODULE__{pid: pid, token: token}}
@@ -78,7 +80,15 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Snapshot do
 
     case admit_all(artifacts, indexes, limits, opts) do
       {:ok, state} ->
-        indexes = Indexes.put_owner_metadata(state.indexes, %{token: token})
+        indexes =
+          Indexes.put_owner_metadata(state.indexes, %{
+            token: token,
+            run_count: map_size(state.handles),
+            record_count: state.record_count,
+            digests: state.digests,
+            checkpoints: state.checkpoints,
+            peaks: state.peaks
+          })
 
         started = %{
           token: token,
@@ -370,8 +380,8 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Snapshot do
     :exit, _reason -> {:error, :invalid_snapshot}
   end
 
-  # The token is stored on the handle; calls go to the pid. The struct token is
-  # checked by the public functions that pattern-match `%__MODULE__{}`.
+  # The capability token lives on the snapshot struct and in owner state; every
+  # public call sends that token to the pid.
   defp redact_status(status) when is_map(status) do
     Map.new(status, fn
       {key, _value} when key in [:state, :message, :reason] -> {key, :redacted}

--- a/lib/ptc_runner/research/sealed_evidence_log/snapshot.ex
+++ b/lib/ptc_runner/research/sealed_evidence_log/snapshot.ex
@@ -39,7 +39,7 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Snapshot do
 
   def query(%__MODULE__{} = snapshot, operation, arguments, opts)
       when is_atom(operation) and is_map(arguments) and is_list(opts) do
-    call(snapshot, {:query, operation, arguments, opts})
+    call(snapshot, {:query, snapshot.token, operation, arguments, opts})
   end
 
   def query(_snapshot, _operation, _arguments, _opts), do: {:error, :invalid_query}
@@ -72,16 +72,28 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Snapshot do
     Process.flag(:trap_exit, true)
     owner_ref = Process.monitor(owner)
     indexes = Indexes.create(self())
+    opts = opts |> Keyword.put_new(:cancel_with, owner) |> Keyword.put_new(:owner, owner)
 
     case admit_all(artifacts, indexes, limits, opts) do
       {:ok, state} ->
-        {:ok,
-         Map.merge(state, %{
-           token: token,
-           owner_ref: owner_ref,
-           limits: limits,
-           indexes: Indexes.put_owner_metadata(state.indexes, %{token: token})
-         })}
+        indexes = Indexes.put_owner_metadata(state.indexes, %{token: token})
+
+        started = %{
+          token: token,
+          owner_ref: owner_ref,
+          limits: limits,
+          indexes: indexes,
+          query_hook: Keyword.get(opts, :query_hook)
+        }
+
+        state = Map.merge(state, started)
+
+        if Indexes.within_retained?(indexes, limits) do
+          {:ok, state}
+        else
+          cleanup_owned(state)
+          {:stop, :max_retained_bytes}
+        end
 
       {:error, reason} ->
         Indexes.delete_all(indexes)
@@ -90,9 +102,9 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Snapshot do
   end
 
   @impl GenServer
-  def handle_call({:query, operation, arguments, opts}, {caller, _ref} = from, state) do
-    if valid_token?(state, opts) do
-      run_query(state, operation, arguments, caller, from)
+  def handle_call({:query, token, operation, arguments, opts}, {caller, _ref} = from, state) do
+    if token == state.token do
+      run_query(state, operation, arguments, caller, from, opts)
     else
       {:reply, {:error, :invalid_snapshot}, state}
     end
@@ -136,8 +148,7 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Snapshot do
 
   @impl GenServer
   def terminate(_reason, state) do
-    if Map.has_key?(state, :indexes), do: Indexes.delete_all(state.indexes)
-    state |> Map.get(:handles, %{}) |> Map.values() |> Enum.each(&Handle.close/1)
+    cleanup_owned(state)
     :ok
   end
 
@@ -166,17 +177,23 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Snapshot do
             }}}
 
         {:error, reason} ->
+          acc.handles |> Map.values() |> Enum.each(&Handle.close/1)
           {:halt, {:error, reason}}
       end
     end)
     |> case do
       {:ok, state} ->
+        indexes =
+          state.indexes
+          |> Indexes.put_trace_facts(state.trace_facts)
+          |> Indexes.put_turn_evidence(state.turn_evidence)
+
         {:ok,
          %{
            state
            | snapshot_digest: snapshot_digest(state, opts),
              trace_snapshot_hash: Keyword.get(opts, :trace_snapshot_hash, "trace-source"),
-             indexes: Indexes.put_trace_facts(state.indexes, state.trace_facts)
+             indexes: indexes
          }}
 
       error ->
@@ -188,23 +205,33 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Snapshot do
     path = artifact.path
     trace_facts = artifact.trace_facts
 
-    with {:ok, handle} <- Handle.open(path),
-         {:ok, admitted} <- Admission.run(handle, indexes, trace_facts, limits, opts) do
-      {:ok,
-       %{
-         handle: handle,
-         indexes: admitted.indexes,
-         run_id: admitted.run_id,
-         record_count: admitted.record_count,
-         checkpoints: admitted.checkpoints,
-         turn_evidence: turn_evidence(admitted)
-       }}
+    case Handle.open(path) do
+      {:ok, handle} ->
+        case Admission.run(handle, indexes, trace_facts, limits, opts) do
+          {:ok, admitted} ->
+            {:ok,
+             %{
+               handle: handle,
+               indexes: admitted.indexes,
+               run_id: admitted.run_id,
+               record_count: admitted.record_count,
+               checkpoints: admitted.checkpoints,
+               turn_evidence: turn_evidence(admitted)
+             }}
+
+          {:error, reason} ->
+            Handle.close(handle)
+            {:error, reason}
+        end
+
+      error ->
+        error
     end
   end
 
-  defp run_query(state, operation, arguments, caller, from) do
+  defp run_query(state, operation, arguments, caller, from, opts) do
     snapshot = query_state(state)
-    max_bytes = state.limits.max_result_bytes
+    max_bytes = Keyword.get(opts, :max_result_bytes, state.limits.max_result_bytes)
     metadata = %{"snapshot_hash" => snapshot_hash(state.snapshot_digest)}
     limits = state.limits
 
@@ -246,7 +273,9 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Snapshot do
       snapshot_digest: state.snapshot_digest,
       trace_facts: state.trace_facts,
       trace_snapshot_hash: state.trace_snapshot_hash,
-      turn_evidence: state.turn_evidence
+      turn_evidence: state.turn_evidence,
+      limits: state.limits,
+      query_hook: Map.get(state, :query_hook)
     }
   end
 
@@ -307,7 +336,11 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Snapshot do
 
   defp turn_evidence(admitted), do: admitted.turn_evidence
 
-  defp valid_token?(state, _opts), do: is_reference(state.token)
+  defp cleanup_owned(state) do
+    if Map.has_key?(state, :indexes), do: Indexes.delete_all(state.indexes)
+    state |> Map.get(:handles, %{}) |> Map.values() |> Enum.each(&Handle.close/1)
+    :ok
+  end
 
   defp call(%__MODULE__{pid: pid}, message) do
     GenServer.call(pid, message, 30_000)

--- a/lib/ptc_runner/research/sealed_evidence_log/snapshot.ex
+++ b/lib/ptc_runner/research/sealed_evidence_log/snapshot.ex
@@ -2,9 +2,11 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Snapshot do
   @moduledoc """
   Owner process for admitted ETS indexes and pinned sealed-log readers.
 
-  The owner creates the tables, runs admission in a bounded worker, and remains
-  the sole mutator of retained state. Owner death deletes every table and closes
-  every handle. Query workers cancel with the caller; the snapshot stays usable.
+  The owner creates the tables with itself as heir. Admission inserts through a
+  bounded worker that is cancelled with the original caller; after admission
+  returns, the owner is the sole mutator of retained state. Owner death deletes
+  every table and closes every handle. Query workers cancel with the caller;
+  the snapshot stays usable.
   """
 
   use GenServer
@@ -45,12 +47,12 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Snapshot do
   def query(_snapshot, _operation, _arguments, _opts), do: {:error, :invalid_query}
 
   @spec info(t()) :: {:ok, map()} | {:error, atom()}
-  def info(%__MODULE__{} = snapshot), do: call(snapshot, :info)
+  def info(%__MODULE__{} = snapshot), do: call(snapshot, {:info, snapshot.token})
   def info(_snapshot), do: {:error, :invalid_snapshot}
 
   @spec close(term()) :: :ok
   def close(%__MODULE__{} = snapshot) do
-    case call(snapshot, :stop) do
+    case call(snapshot, {:stop, snapshot.token}) do
       :ok -> :ok
       {:error, _reason} -> :ok
     end
@@ -62,10 +64,10 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Snapshot do
   def alive?(%__MODULE__{pid: pid}), do: Process.alive?(pid)
 
   @spec table_ids(t()) :: [reference()] | {:error, atom()}
-  def table_ids(%__MODULE__{} = snapshot), do: call(snapshot, :table_ids)
+  def table_ids(%__MODULE__{} = snapshot), do: call(snapshot, {:table_ids, snapshot.token})
 
   @spec handles(t()) :: {:ok, [Handle.t()]} | {:error, atom()}
-  def handles(%__MODULE__{} = snapshot), do: call(snapshot, :handles)
+  def handles(%__MODULE__{} = snapshot), do: call(snapshot, {:handles, snapshot.token})
 
   @impl GenServer
   def init({artifacts, limits, owner, token, opts}) do
@@ -110,30 +112,42 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Snapshot do
     end
   end
 
-  def handle_call(:info, _from, state) do
-    accounting = Indexes.accounting(state.indexes)
+  def handle_call({:info, token}, _from, state) do
+    if token == state.token do
+      accounting = Indexes.accounting(state.indexes)
 
-    {:reply,
-     {:ok,
-      %{
-        snapshot_digest: state.snapshot_digest,
-        run_count: map_size(state.handles),
-        accounting: accounting,
-        record_count: state.record_count,
-        checkpoints: state.checkpoints,
-        diagnostic_peaks: state.peaks,
-        handle_count: map_size(state.handles)
-      }}, state}
+      {:reply,
+       {:ok,
+        %{
+          snapshot_digest: state.snapshot_digest,
+          run_count: map_size(state.handles),
+          accounting: accounting,
+          record_count: state.record_count,
+          checkpoints: state.checkpoints,
+          diagnostic_peaks: state.peaks,
+          handle_count: map_size(state.handles)
+        }}, state}
+    else
+      {:reply, {:error, :invalid_snapshot}, state}
+    end
   end
 
-  def handle_call(:table_ids, _from, state),
-    do: {:reply, Indexes.table_ids(state.indexes), state}
+  def handle_call({:table_ids, token}, _from, state) do
+    if token == state.token,
+      do: {:reply, Indexes.table_ids(state.indexes), state},
+      else: {:reply, {:error, :invalid_snapshot}, state}
+  end
 
-  def handle_call(:handles, _from, state),
-    do: {:reply, {:ok, Map.values(state.handles)}, state}
+  def handle_call({:handles, token}, _from, state) do
+    if token == state.token,
+      do: {:reply, {:ok, Map.values(state.handles)}, state},
+      else: {:reply, {:error, :invalid_snapshot}, state}
+  end
 
-  def handle_call(:stop, _from, state) do
-    {:stop, :normal, :ok, state}
+  def handle_call({:stop, token}, _from, state) do
+    if token == state.token,
+      do: {:stop, :normal, :ok, state},
+      else: {:reply, {:error, :invalid_snapshot}, state}
   end
 
   def handle_call(_message, _from, state), do: {:reply, {:error, :invalid_query}, state}
@@ -231,7 +245,7 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Snapshot do
 
   defp run_query(state, operation, arguments, caller, from, opts) do
     snapshot = query_state(state)
-    max_bytes = Keyword.get(opts, :max_result_bytes, state.limits.max_result_bytes)
+    max_bytes = installed_result_bytes(state.limits, opts)
     metadata = %{"snapshot_hash" => snapshot_hash(state.snapshot_digest)}
     limits = state.limits
 
@@ -335,6 +349,14 @@ defmodule PtcRunner.Research.SealedEvidenceLog.Snapshot do
   end
 
   defp turn_evidence(admitted), do: admitted.turn_evidence
+
+  defp installed_result_bytes(limits, opts) do
+    requested = Keyword.get(opts, :max_result_bytes, limits.max_result_bytes)
+
+    if is_integer(requested) and requested > 0,
+      do: min(requested, limits.max_result_bytes),
+      else: limits.max_result_bytes
+  end
 
   defp cleanup_owned(state) do
     if Map.has_key?(state, :indexes), do: Indexes.delete_all(state.indexes)

--- a/lib/ptc_runner/research/sealed_evidence_log/value_hash.ex
+++ b/lib/ptc_runner/research/sealed_evidence_log/value_hash.ex
@@ -1,0 +1,21 @@
+defmodule PtcRunner.Research.SealedEvidenceLog.ValueHash do
+  @moduledoc false
+
+  @domain "ptc-inspection-value-v1\0"
+
+  @spec hash(nil | binary() | pos_integer()) :: binary()
+  def hash(nil), do: digest(3, "")
+  def hash(value) when is_binary(value), do: digest(1, value)
+
+  def hash(value) when is_integer(value) and value > 0,
+    do: digest(2, <<value::unsigned-big-64>>)
+
+  defp digest(tag, payload) do
+    :crypto.hash(:sha256, [
+      @domain,
+      <<byte_size(payload)::unsigned-big-64>>,
+      tag,
+      payload
+    ])
+  end
+end

--- a/test/ptc_runner/research/sealed_evidence_log_fault_test.exs
+++ b/test/ptc_runner/research/sealed_evidence_log_fault_test.exs
@@ -308,11 +308,18 @@ defmodule PtcRunner.Research.SealedEvidenceLog.FaultTest do
         :ok
     end
 
+    owner =
+      spawn(fn ->
+        receive do
+          :stop -> :ok
+        end
+      end)
+
     caller =
       spawn(fn ->
         SealedEvidenceLog.admit(%{path: path, trace_facts: corpus.trace_facts},
           during_admission_hook: hook,
-          owner: self()
+          owner: owner
         )
       end)
 
@@ -322,6 +329,7 @@ defmodule PtcRunner.Research.SealedEvidenceLog.FaultTest do
     Process.exit(caller, :kill)
     assert_receive {:DOWN, ^caller_ref, :process, ^caller, :killed}
     assert_receive {:DOWN, ^worker_ref, :process, ^worker, _reason}, 5_000
+    Process.exit(owner, :kill)
   end
 
   test "quota refusal deletes tables and leaves the artifact", %{tmp_dir: tmp} do

--- a/test/ptc_runner/research/sealed_evidence_log_fault_test.exs
+++ b/test/ptc_runner/research/sealed_evidence_log_fault_test.exs
@@ -362,6 +362,55 @@ defmodule PtcRunner.Research.SealedEvidenceLog.FaultTest do
 
     assert {:error, :invalid_snapshot} =
              SealedEvidenceLog.query(forged, :list_runs, %{"limit" => 1})
+
+    assert {:error, :invalid_snapshot} = SealedEvidenceLog.info(forged)
+    assert :ok = SealedEvidenceLog.close(forged)
+    assert Snapshot.alive?(snapshot)
+  end
+
+  test "admission deadline cancels the worker", %{tmp_dir: tmp} do
+    corpus = Generator.mixed_run("deadline-run")
+    path = Path.join(tmp, "deadline.ptcins")
+    assert {:ok, _} = SealedEvidenceLog.produce(path, corpus.records)
+
+    hook = fn
+      :before_frames ->
+        receive do
+          :never -> :ok
+        after
+          50 -> :ok
+        end
+
+      _other ->
+        :ok
+    end
+
+    assert {:error, :deadline_exceeded} =
+             SealedEvidenceLog.admit(%{path: path, trace_facts: corpus.trace_facts},
+               during_admission_hook: hook,
+               deadline_ms: 1
+             )
+  end
+
+  test "query cannot widen the installed result-byte ceiling", %{tmp_dir: tmp} do
+    corpus = Generator.mixed_run("result-cap")
+    path = Path.join(tmp, "result-cap.ptcins")
+    assert {:ok, _} = SealedEvidenceLog.produce(path, corpus.records)
+
+    assert {:ok, snapshot} =
+             SealedEvidenceLog.admit(%{path: path, trace_facts: corpus.trace_facts},
+               limits: [max_result_bytes: 100]
+             )
+
+    on_exit(fn -> SealedEvidenceLog.close(snapshot) end)
+
+    assert {:error, :result_limit_exceeded} =
+             SealedEvidenceLog.query(
+               snapshot,
+               :capability_calls,
+               %{"run_id" => "result-cap", "limit" => 10},
+               max_result_bytes: 1_000_000
+             )
   end
 
   defp produce_only(tmp, run_id) do

--- a/test/ptc_runner/research/sealed_evidence_log_fault_test.exs
+++ b/test/ptc_runner/research/sealed_evidence_log_fault_test.exs
@@ -2,6 +2,7 @@ defmodule PtcRunner.Research.SealedEvidenceLog.FaultTest do
   use ExUnit.Case, async: true
 
   alias PtcRunner.Research.SealedEvidenceLog
+  alias PtcRunner.Research.SealedEvidenceLog.Format
   alias PtcRunner.Research.SealedEvidenceLog.Generator
   alias PtcRunner.Research.SealedEvidenceLog.Handle
   alias PtcRunner.Research.SealedEvidenceLog.Indexes
@@ -14,6 +15,19 @@ defmodule PtcRunner.Research.SealedEvidenceLog.FaultTest do
     corpus = Generator.second_run("fault-run")
     assert {:ok, _} = SealedEvidenceLog.produce(path, corpus.records)
     File.write!(path, File.read!(path) <> <<0, 1, 2, 3>>, [:append])
+    assert {:error, :malformed_source} = SealedEvidenceLog.admit(%{path: path, trace_facts: %{}})
+  end
+
+  test "truncated evidence before open", %{tmp_dir: tmp} do
+    path = Path.join(tmp, "truncated-body.ptcins")
+    File.write!(path, Format.encode_header() <> <<0, 1, 2, 3>>)
+    assert {:error, :malformed_source} = SealedEvidenceLog.admit(%{path: path, trace_facts: %{}})
+  end
+
+  test "truncated footer before open", %{tmp_dir: tmp} do
+    {path, _snapshot} = produce_only(tmp, "trunc-footer")
+    {:ok, bytes} = File.read(path)
+    File.write!(path, binary_part(bytes, 0, byte_size(bytes) - 10))
     assert {:error, :malformed_source} = SealedEvidenceLog.admit(%{path: path, trace_facts: %{}})
   end
 
@@ -40,13 +54,82 @@ defmodule PtcRunner.Research.SealedEvidenceLog.FaultTest do
       )
 
     assert_receive :mutated
-    assert result in [{:error, :source_changed}, {:error, :malformed_source}]
+    assert result == {:error, :source_changed}
+  end
+
+  test "overwrite during admission returns source_changed", %{tmp_dir: tmp} do
+    path = Path.join(tmp, "overwrite-admit.ptcins")
+    corpus = Generator.mixed_run("overwrite-admit")
+    assert {:ok, _} = SealedEvidenceLog.produce(path, corpus.records)
+
+    parent = self()
+
+    hook = fn
+      :after_frames ->
+        File.write!(path, flip_evidence_byte(File.read!(path)))
+        send(parent, :overwritten)
+        :ok
+
+      _other ->
+        :ok
+    end
+
+    result =
+      SealedEvidenceLog.admit(%{path: path, trace_facts: corpus.trace_facts},
+        during_admission_hook: hook
+      )
+
+    assert_receive :overwritten
+    assert result == {:error, :source_changed}
+  end
+
+  test "truncate during admission returns source_changed", %{tmp_dir: tmp} do
+    path = Path.join(tmp, "trunc-admit.ptcins")
+    corpus = Generator.mixed_run("trunc-admit")
+    assert {:ok, _} = SealedEvidenceLog.produce(path, corpus.records)
+    size = File.stat!(path).size
+
+    parent = self()
+
+    hook = fn
+      :after_frames ->
+        {:ok, io} = :file.open(path, [:raw, :write, :binary, :read])
+        {:ok, _} = :file.position(io, size - 1)
+        :ok = :file.truncate(io)
+        :ok = :file.close(io)
+        send(parent, :truncated)
+        :ok
+
+      _other ->
+        :ok
+    end
+
+    result =
+      SealedEvidenceLog.admit(%{path: path, trace_facts: corpus.trace_facts},
+        during_admission_hook: hook
+      )
+
+    assert_receive :truncated
+    assert result == {:error, :source_changed}
   end
 
   test "append after admission is observed by the next query", %{tmp_dir: tmp} do
     {path, snapshot} = admit_second(tmp, "after-run")
     on_exit(fn -> SealedEvidenceLog.close(snapshot) end)
     File.write!(path, "x", [:append])
+
+    assert {:error, :source_changed} =
+             SealedEvidenceLog.query(snapshot, :list_runs, %{"limit" => 1})
+  end
+
+  test "truncate after admission is observed by the next query", %{tmp_dir: tmp} do
+    {path, snapshot} = admit_second(tmp, "trunc-after")
+    on_exit(fn -> SealedEvidenceLog.close(snapshot) end)
+    size = File.stat!(path).size
+    {:ok, io} = :file.open(path, [:raw, :write, :binary, :read])
+    {:ok, _} = :file.position(io, size - 1)
+    :ok = :file.truncate(io)
+    :ok = :file.close(io)
 
     assert {:error, :source_changed} =
              SealedEvidenceLog.query(snapshot, :list_runs, %{"limit" => 1})
@@ -65,6 +148,37 @@ defmodule PtcRunner.Research.SealedEvidenceLog.FaultTest do
                "run_id" => "overwrite-run",
                "limit" => 1
              })
+  end
+
+  test "unrelated overwrite is detected when the range becomes a dependency", %{tmp_dir: tmp} do
+    corpus = Generator.mixed_run("unrelated-run")
+    path = Path.join(tmp, "unrelated.ptcins")
+    assert {:ok, _} = SealedEvidenceLog.produce(path, corpus.records)
+
+    assert {:ok, snapshot} =
+             SealedEvidenceLog.admit(%{path: path, trace_facts: corpus.trace_facts})
+
+    on_exit(fn -> SealedEvidenceLog.close(snapshot) end)
+
+    File.write!(path, flip_evidence_byte(File.read!(path)))
+
+    catalog = SealedEvidenceLog.query(snapshot, :list_runs, %{"limit" => 1})
+    assert catalog == {:error, :source_changed} or match?({:ok, _page, _metrics}, catalog)
+
+    assert {:error, :source_changed} =
+             SealedEvidenceLog.query(snapshot, :model_exchanges, %{
+               "run_id" => "unrelated-run",
+               "limit" => 1
+             })
+  end
+
+  test "get_run observes append after admission", %{tmp_dir: tmp} do
+    {path, snapshot} = admit_second(tmp, "get-run-append")
+    on_exit(fn -> SealedEvidenceLog.close(snapshot) end)
+    File.write!(path, "x", [:append])
+
+    assert {:error, :source_changed} =
+             SealedEvidenceLog.query(snapshot, :get_run, %{"run_id" => "get-run-append"})
   end
 
   test "path replacement continues against the pinned handle", %{tmp_dir: tmp} do
@@ -86,7 +200,13 @@ defmodule PtcRunner.Research.SealedEvidenceLog.FaultTest do
     path = Path.join(tmp, "owner.ptcins")
     assert {:ok, _} = SealedEvidenceLog.produce(path, corpus.records)
 
-    owner = spawn(fn -> Process.sleep(:infinity) end)
+    owner =
+      spawn(fn ->
+        receive do
+          :stop -> :ok
+        end
+      end)
+
     owner_ref = Process.monitor(owner)
 
     assert {:ok, snapshot} =
@@ -121,8 +241,35 @@ defmodule PtcRunner.Research.SealedEvidenceLog.FaultTest do
              Enum.all?(tables, &(:ets.info(&1) == :undefined))
   end
 
-  test "query caller death leaves the snapshot usable", %{tmp_dir: tmp} do
-    {_path, snapshot} = admit_second(tmp, "caller-run")
+  test "query caller death cancels the worker and leaves the snapshot usable", %{tmp_dir: tmp} do
+    corpus = Generator.second_run("caller-run")
+    path = Path.join(tmp, "caller.ptcins")
+    assert {:ok, _} = SealedEvidenceLog.produce(path, corpus.records)
+    parent = self()
+    {:ok, gate} = Agent.start_link(fn -> :block end)
+    on_exit(fn -> if Process.alive?(gate), do: Agent.stop(gate) end)
+
+    hook = fn
+      :before_query ->
+        send(parent, {:query_worker, self()})
+
+        if Agent.get_and_update(gate, fn
+             :block -> {:block, :open}
+             other -> {other, other}
+           end) == :block do
+          receive do
+            :never -> :ok
+          after
+            10_000 -> :ok
+          end
+        end
+    end
+
+    assert {:ok, snapshot} =
+             SealedEvidenceLog.admit(%{path: path, trace_facts: corpus.trace_facts},
+               query_hook: hook
+             )
+
     on_exit(fn -> SealedEvidenceLog.close(snapshot) end)
 
     caller =
@@ -131,11 +278,97 @@ defmodule PtcRunner.Research.SealedEvidenceLog.FaultTest do
       end)
 
     caller_ref = Process.monitor(caller)
+    assert_receive {:query_worker, worker}, 5_000
+    worker_ref = Process.monitor(worker)
     Process.exit(caller, :kill)
     assert_receive {:DOWN, ^caller_ref, :process, ^caller, :killed}
+    assert_receive {:DOWN, ^worker_ref, :process, ^worker, _reason}, 5_000
 
     assert {:ok, %{"items" => [_run]}, _metrics} =
              SealedEvidenceLog.query(snapshot, :list_runs, %{"limit" => 1})
+  end
+
+  test "admission caller death cancels the admission worker", %{tmp_dir: tmp} do
+    corpus = Generator.mixed_run("admit-caller")
+    path = Path.join(tmp, "admit-caller.ptcins")
+    assert {:ok, _} = SealedEvidenceLog.produce(path, corpus.records)
+    parent = self()
+
+    hook = fn
+      :before_frames ->
+        send(parent, {:worker, self()})
+
+        receive do
+          :never -> :ok
+        after
+          10_000 -> :ok
+        end
+
+      _other ->
+        :ok
+    end
+
+    caller =
+      spawn(fn ->
+        SealedEvidenceLog.admit(%{path: path, trace_facts: corpus.trace_facts},
+          during_admission_hook: hook,
+          owner: self()
+        )
+      end)
+
+    caller_ref = Process.monitor(caller)
+    assert_receive {:worker, worker}, 5_000
+    worker_ref = Process.monitor(worker)
+    Process.exit(caller, :kill)
+    assert_receive {:DOWN, ^caller_ref, :process, ^caller, :killed}
+    assert_receive {:DOWN, ^worker_ref, :process, ^worker, _reason}, 5_000
+  end
+
+  test "quota refusal deletes tables and leaves the artifact", %{tmp_dir: tmp} do
+    path = Path.join(tmp, "quota.ptcins")
+    {:ok, _} = SealedEvidenceLog.produce(path, Generator.count_stream("quota-run", 3))
+
+    assert {:error, :max_records} =
+             SealedEvidenceLog.admit(%{path: path, trace_facts: Generator.empty_trace_facts()},
+               limits: [max_records: 2]
+             )
+
+    assert File.exists?(path)
+
+    assert {:ok, snapshot} =
+             SealedEvidenceLog.admit(%{path: path, trace_facts: Generator.empty_trace_facts()},
+               limits: [max_records: 3]
+             )
+
+    tables = Snapshot.table_ids(snapshot)
+    assert :ok = SealedEvidenceLog.close(snapshot)
+    assert Enum.all?(tables, &(:ets.info(&1) == :undefined))
+  end
+
+  test "retained-ceiling overrun refuses and cleans up", %{tmp_dir: tmp} do
+    path = Path.join(tmp, "retained.ptcins")
+    {:ok, _} = SealedEvidenceLog.produce(path, Generator.count_stream("retained-run", 3))
+
+    assert {:error, :max_retained_bytes} =
+             SealedEvidenceLog.admit(%{path: path, trace_facts: Generator.empty_trace_facts()},
+               limits: [max_retained_bytes: 1]
+             )
+  end
+
+  test "forged snapshot token is rejected", %{tmp_dir: tmp} do
+    {_path, snapshot} = admit_second(tmp, "token-run")
+    on_exit(fn -> SealedEvidenceLog.close(snapshot) end)
+    forged = %{snapshot | token: make_ref()}
+
+    assert {:error, :invalid_snapshot} =
+             SealedEvidenceLog.query(forged, :list_runs, %{"limit" => 1})
+  end
+
+  defp produce_only(tmp, run_id) do
+    corpus = Generator.second_run(run_id)
+    path = Path.join(tmp, "#{run_id}.ptcins")
+    assert {:ok, _} = SealedEvidenceLog.produce(path, corpus.records)
+    {path, corpus}
   end
 
   defp admit_second(tmp, run_id) do
@@ -150,7 +383,6 @@ defmodule PtcRunner.Research.SealedEvidenceLog.FaultTest do
   end
 
   defp flip_evidence_byte(bytes) do
-    # Flip a payload byte that sits after the 16-byte header and 8-byte length.
     offset = 16 + 8
     <<prefix::binary-size(^offset), byte, rest::binary>> = bytes
     <<prefix::binary, Bitwise.bxor(byte, 0xFF), rest::binary>>

--- a/test/ptc_runner/research/sealed_evidence_log_fault_test.exs
+++ b/test/ptc_runner/research/sealed_evidence_log_fault_test.exs
@@ -1,0 +1,158 @@
+defmodule PtcRunner.Research.SealedEvidenceLog.FaultTest do
+  use ExUnit.Case, async: true
+
+  alias PtcRunner.Research.SealedEvidenceLog
+  alias PtcRunner.Research.SealedEvidenceLog.Generator
+  alias PtcRunner.Research.SealedEvidenceLog.Handle
+  alias PtcRunner.Research.SealedEvidenceLog.Indexes
+  alias PtcRunner.Research.SealedEvidenceLog.Snapshot
+
+  @moduletag :tmp_dir
+
+  test "malformed trailing bytes before open", %{tmp_dir: tmp} do
+    path = Path.join(tmp, "trailing.ptcins")
+    corpus = Generator.second_run("fault-run")
+    assert {:ok, _} = SealedEvidenceLog.produce(path, corpus.records)
+    File.write!(path, File.read!(path) <> <<0, 1, 2, 3>>, [:append])
+    assert {:error, :malformed_source} = SealedEvidenceLog.admit(%{path: path, trace_facts: %{}})
+  end
+
+  test "append during admission returns source_changed", %{tmp_dir: tmp} do
+    path = Path.join(tmp, "mutate.ptcins")
+    corpus = Generator.mixed_run("mutate-run")
+    assert {:ok, _} = SealedEvidenceLog.produce(path, corpus.records)
+
+    parent = self()
+
+    hook = fn
+      :before_frames ->
+        File.write!(path, "x", [:append])
+        send(parent, :mutated)
+        :ok
+
+      _other ->
+        :ok
+    end
+
+    result =
+      SealedEvidenceLog.admit(%{path: path, trace_facts: corpus.trace_facts},
+        during_admission_hook: hook
+      )
+
+    assert_receive :mutated
+    assert result in [{:error, :source_changed}, {:error, :malformed_source}]
+  end
+
+  test "append after admission is observed by the next query", %{tmp_dir: tmp} do
+    {path, snapshot} = admit_second(tmp, "after-run")
+    on_exit(fn -> SealedEvidenceLog.close(snapshot) end)
+    File.write!(path, "x", [:append])
+
+    assert {:error, :source_changed} =
+             SealedEvidenceLog.query(snapshot, :list_runs, %{"limit" => 1})
+  end
+
+  test "relevant same-size overwrite returns source_changed", %{tmp_dir: tmp} do
+    {path, snapshot} = admit_second(tmp, "overwrite-run")
+    on_exit(fn -> SealedEvidenceLog.close(snapshot) end)
+
+    bytes = File.read!(path)
+    flipped = flip_evidence_byte(bytes)
+    File.write!(path, flipped)
+
+    assert {:error, :source_changed} =
+             SealedEvidenceLog.query(snapshot, :execution_prints, %{
+               "run_id" => "overwrite-run",
+               "limit" => 1
+             })
+  end
+
+  test "path replacement continues against the pinned handle", %{tmp_dir: tmp} do
+    {path, snapshot} = admit_second(tmp, "pinned-run")
+    on_exit(fn -> SealedEvidenceLog.close(snapshot) end)
+
+    replacement = Path.join(tmp, "other.ptcins")
+    other = Generator.second_run("other-run")
+    assert {:ok, _} = SealedEvidenceLog.produce(replacement, other.records)
+    File.rm!(path)
+    File.rename!(replacement, path)
+
+    assert {:ok, %{"items" => [%{"run_id" => "pinned-run"}]}, _metrics} =
+             SealedEvidenceLog.query(snapshot, :list_runs, %{"limit" => 1})
+  end
+
+  test "snapshot owner death deletes tables and closes handles", %{tmp_dir: tmp} do
+    corpus = Generator.second_run("owner-run")
+    path = Path.join(tmp, "owner.ptcins")
+    assert {:ok, _} = SealedEvidenceLog.produce(path, corpus.records)
+
+    owner = spawn(fn -> Process.sleep(:infinity) end)
+    owner_ref = Process.monitor(owner)
+
+    assert {:ok, snapshot} =
+             SealedEvidenceLog.admit(%{path: path, trace_facts: corpus.trace_facts}, owner: owner)
+
+    tables = Snapshot.table_ids(snapshot)
+    {:ok, handles} = Snapshot.handles(snapshot)
+    snapshot_ref = Process.monitor(snapshot.pid)
+
+    Process.exit(owner, :kill)
+    assert_receive {:DOWN, ^owner_ref, :process, ^owner, :killed}
+    assert_receive {:DOWN, ^snapshot_ref, :process, _, _}
+
+    assert Enum.all?(tables, &(:ets.info(&1) == :undefined))
+    assert Enum.all?(handles, &(not Handle.usable?(&1)))
+  end
+
+  test "normal close deletes tables and handles", %{tmp_dir: tmp} do
+    {_path, snapshot} = admit_second(tmp, "close-run")
+    tables = Snapshot.table_ids(snapshot)
+    {:ok, handles} = Snapshot.handles(snapshot)
+    snapshot_ref = Process.monitor(snapshot.pid)
+
+    assert :ok = SealedEvidenceLog.close(snapshot)
+    assert_receive {:DOWN, ^snapshot_ref, :process, _, :normal}
+    assert Enum.all?(tables, &(:ets.info(&1) == :undefined))
+    assert Enum.all?(handles, &(not Handle.usable?(&1)))
+
+    assert Indexes.undefined?(%{
+             tables: Map.new(Enum.with_index(tables), fn {tid, i} -> {i, tid} end)
+           }) or
+             Enum.all?(tables, &(:ets.info(&1) == :undefined))
+  end
+
+  test "query caller death leaves the snapshot usable", %{tmp_dir: tmp} do
+    {_path, snapshot} = admit_second(tmp, "caller-run")
+    on_exit(fn -> SealedEvidenceLog.close(snapshot) end)
+
+    caller =
+      spawn(fn ->
+        SealedEvidenceLog.query(snapshot, :list_runs, %{"limit" => 1})
+      end)
+
+    caller_ref = Process.monitor(caller)
+    Process.exit(caller, :kill)
+    assert_receive {:DOWN, ^caller_ref, :process, ^caller, :killed}
+
+    assert {:ok, %{"items" => [_run]}, _metrics} =
+             SealedEvidenceLog.query(snapshot, :list_runs, %{"limit" => 1})
+  end
+
+  defp admit_second(tmp, run_id) do
+    corpus = Generator.second_run(run_id)
+    path = Path.join(tmp, "#{run_id}.ptcins")
+    assert {:ok, _} = SealedEvidenceLog.produce(path, corpus.records)
+
+    assert {:ok, snapshot} =
+             SealedEvidenceLog.admit(%{path: path, trace_facts: corpus.trace_facts})
+
+    {path, snapshot}
+  end
+
+  defp flip_evidence_byte(bytes) do
+    # Flip a payload byte that sits after the 16-byte header and 8-byte length.
+    offset = 16 + 8
+    <<prefix::binary-size(^offset), byte, rest::binary>> = bytes
+    <<prefix::binary, Bitwise.bxor(byte, 0xFF), rest::binary>>
+  end
+end

--- a/test/ptc_runner/research/sealed_evidence_log_format_test.exs
+++ b/test/ptc_runner/research/sealed_evidence_log_format_test.exs
@@ -1,0 +1,56 @@
+defmodule PtcRunner.Research.SealedEvidenceLog.FormatTest do
+  use ExUnit.Case, async: true
+
+  alias PtcRunner.Research.SealedEvidenceLog
+  alias PtcRunner.Research.SealedEvidenceLog.Format
+  alias PtcRunner.Research.SealedEvidenceLog.Generator
+
+  @moduletag :tmp_dir
+
+  test "header and footer round-trip through a tiny artifact", %{tmp_dir: tmp} do
+    corpus = Generator.second_run("format-run")
+    path = Path.join(tmp, "format.ptcins")
+
+    assert {:ok, produced} = SealedEvidenceLog.produce(path, corpus.records)
+    assert produced.record_count == 1
+    assert produced.total_bytes == File.stat!(path).size
+
+    {:ok, io} = :file.open(path, [:raw, :read, :binary])
+    {:ok, header} = :file.pread(io, 0, Format.header_size())
+    :ok = :file.close(io)
+
+    assert {:ok, :header} = Format.decode_header(header)
+
+    footer_offset = produced.total_bytes - Format.footer_size()
+
+    {:ok, io} = :file.open(path, [:raw, :read, :binary])
+    {:ok, footer_bytes} = :file.pread(io, footer_offset, Format.footer_size())
+    :ok = :file.close(io)
+
+    assert {:ok, footer} = Format.decode_footer(footer_bytes)
+    assert footer.record_count == 1
+    assert footer.total_bytes == produced.total_bytes
+    assert footer.artifact_digest == produced.artifact_digest
+  end
+
+  test "payload stream keeps a constant encoded frame size", %{tmp_dir: tmp} do
+    path = Path.join(tmp, "constant.ptcins")
+    frame_bytes = 2_048
+
+    assert {:ok, produced} =
+             SealedEvidenceLog.produce(
+               path,
+               Generator.payload_stream("const-run", 2, frame_bytes)
+             )
+
+    assert produced.record_count == 2
+    assert produced.frame_size == frame_bytes
+    assert is_integer(produced.frame_size)
+  end
+
+  test "rejects a truncated header", %{tmp_dir: tmp} do
+    path = Path.join(tmp, "truncated.ptcins")
+    File.write!(path, "PTCINS")
+    assert {:error, :malformed_source} = SealedEvidenceLog.admit(%{path: path, trace_facts: %{}})
+  end
+end

--- a/test/ptc_runner/research/sealed_evidence_log_format_test.exs
+++ b/test/ptc_runner/research/sealed_evidence_log_format_test.exs
@@ -33,6 +33,23 @@ defmodule PtcRunner.Research.SealedEvidenceLog.FormatTest do
     assert footer.artifact_digest == produced.artifact_digest
   end
 
+  test "rejects a footer whose record_count does not match evidence", %{tmp_dir: tmp} do
+    corpus = Generator.second_run("count-mismatch")
+    path = Path.join(tmp, "count-mismatch.ptcins")
+    assert {:ok, produced} = SealedEvidenceLog.produce(path, corpus.records)
+
+    footer_offset = produced.total_bytes - Format.footer_size()
+    {:ok, io} = :file.open(path, [:raw, :read, :write, :binary])
+    {:ok, footer_bytes} = :file.pread(io, footer_offset, Format.footer_size())
+    {:ok, footer} = Format.decode_footer(footer_bytes)
+    mutated = Format.encode_footer(%{footer | record_count: footer.record_count + 100})
+    :ok = :file.pwrite(io, footer_offset, mutated)
+    :ok = :file.close(io)
+
+    assert {:error, :malformed_source} =
+             SealedEvidenceLog.admit(%{path: path, trace_facts: corpus.trace_facts})
+  end
+
   test "payload stream keeps a constant encoded frame size", %{tmp_dir: tmp} do
     path = Path.join(tmp, "constant.ptcins")
     frame_bytes = 2_048

--- a/test/ptc_runner/research/sealed_evidence_log_limits_test.exs
+++ b/test/ptc_runner/research/sealed_evidence_log_limits_test.exs
@@ -132,6 +132,25 @@ defmodule PtcRunner.Research.SealedEvidenceLog.LimitsTest do
              SealedEvidenceLog.admit(%{path: path, trace_facts: corpus.trace_facts})
   end
 
+  test "rejects a run-result whose result_hash does not match the value", %{tmp_dir: tmp} do
+    path = Path.join(tmp, "bad-result.ptcins")
+    corpus = Generator.mixed_run("bad-result")
+
+    records =
+      Enum.map(corpus.records, fn
+        %{"record_type" => "run-result"} = record ->
+          put_in(record, ["payload", "result_hash"], "sha256:" <> String.duplicate("a", 64))
+
+        record ->
+          record
+      end)
+
+    {:ok, _} = SealedEvidenceLog.produce(path, records)
+
+    assert {:error, :invalid_record} =
+             SealedEvidenceLog.admit(%{path: path, trace_facts: corpus.trace_facts})
+  end
+
   test "merge refuses an override above the maintained maximum", %{tmp_dir: tmp} do
     path = Path.join(tmp, "hard-max.ptcins")
     {:ok, _} = SealedEvidenceLog.produce(path, Generator.count_stream("hard-run", 1))

--- a/test/ptc_runner/research/sealed_evidence_log_limits_test.exs
+++ b/test/ptc_runner/research/sealed_evidence_log_limits_test.exs
@@ -113,6 +113,25 @@ defmodule PtcRunner.Research.SealedEvidenceLog.LimitsTest do
              })
   end
 
+  test "rejects a declared source hash that does not match the payload", %{tmp_dir: tmp} do
+    path = Path.join(tmp, "bad-hash.ptcins")
+    corpus = Generator.mixed_run("bad-hash")
+
+    records =
+      Enum.map(corpus.records, fn
+        %{"record_type" => "evaluation-source"} = record ->
+          put_in(record, ["payload", "source_hash"], String.duplicate("0", 64))
+
+        record ->
+          record
+      end)
+
+    {:ok, _} = SealedEvidenceLog.produce(path, records)
+
+    assert {:error, :invalid_record} =
+             SealedEvidenceLog.admit(%{path: path, trace_facts: corpus.trace_facts})
+  end
+
   test "merge refuses an override above the maintained maximum", %{tmp_dir: tmp} do
     path = Path.join(tmp, "hard-max.ptcins")
     {:ok, _} = SealedEvidenceLog.produce(path, Generator.count_stream("hard-run", 1))

--- a/test/ptc_runner/research/sealed_evidence_log_limits_test.exs
+++ b/test/ptc_runner/research/sealed_evidence_log_limits_test.exs
@@ -81,4 +81,45 @@ defmodule PtcRunner.Research.SealedEvidenceLog.LimitsTest do
 
     assert Enum.any?(rows, &(&1["path"] == "install.ptc_inspection_snapshot.ceilings.max_files"))
   end
+
+  test "rejects a schema version the footer did not declare", %{tmp_dir: tmp} do
+    path = Path.join(tmp, "schema.ptcins")
+
+    records =
+      Generator.count_stream("schema-run", 1)
+      |> Enum.map(&Map.put(&1, "schema_version", 999))
+
+    {:ok, _} = SealedEvidenceLog.produce(path, records)
+
+    assert {:error, :invalid_record} =
+             SealedEvidenceLog.admit(%{path: path, trace_facts: Generator.empty_trace_facts()})
+  end
+
+  test "range ceiling refuses an oversize verified read", %{tmp_dir: tmp} do
+    path = Path.join(tmp, "range.ptcins")
+    {:ok, _} = SealedEvidenceLog.produce(path, Generator.count_stream("range-run", 1))
+
+    assert {:ok, snapshot} =
+             SealedEvidenceLog.admit(%{path: path, trace_facts: Generator.empty_trace_facts()},
+               limits: [max_range_bytes: 1]
+             )
+
+    on_exit(fn -> SealedEvidenceLog.close(snapshot) end)
+
+    assert {:error, :range_limit_exceeded} =
+             SealedEvidenceLog.query(snapshot, :execution_prints, %{
+               "run_id" => "range-run",
+               "limit" => 1
+             })
+  end
+
+  test "merge refuses an override above the maintained maximum", %{tmp_dir: tmp} do
+    path = Path.join(tmp, "hard-max.ptcins")
+    {:ok, _} = SealedEvidenceLog.produce(path, Generator.count_stream("hard-run", 1))
+
+    assert {:error, :invalid_limits} =
+             SealedEvidenceLog.admit(%{path: path, trace_facts: Generator.empty_trace_facts()},
+               limits: [max_records: 1_000_001]
+             )
+  end
 end

--- a/test/ptc_runner/research/sealed_evidence_log_limits_test.exs
+++ b/test/ptc_runner/research/sealed_evidence_log_limits_test.exs
@@ -1,0 +1,84 @@
+defmodule PtcRunner.Research.SealedEvidenceLog.LimitsTest do
+  use ExUnit.Case, async: true
+
+  alias PtcRunner.Research.SealedEvidenceLog
+  alias PtcRunner.Research.SealedEvidenceLog.Generator
+  alias PtcRunner.Research.SealedEvidenceLog.Limits
+
+  @moduletag :tmp_dir
+
+  test "exact one-over refusal for max_records", %{tmp_dir: tmp} do
+    path = Path.join(tmp, "records.ptcins")
+    {:ok, _} = SealedEvidenceLog.produce(path, Generator.count_stream("limit-run", 3))
+
+    assert {:error, :max_records} =
+             SealedEvidenceLog.admit(%{path: path, trace_facts: Generator.empty_trace_facts()},
+               limits: [max_records: 2]
+             )
+
+    assert {:ok, snapshot} =
+             SealedEvidenceLog.admit(%{path: path, trace_facts: Generator.empty_trace_facts()},
+               limits: [max_records: 3]
+             )
+
+    SealedEvidenceLog.close(snapshot)
+  end
+
+  test "exact one-over refusal for max_index_entries", %{tmp_dir: tmp} do
+    path = Path.join(tmp, "entries.ptcins")
+    {:ok, _} = SealedEvidenceLog.produce(path, Generator.count_stream("entry-run", 2))
+
+    assert {:error, :max_index_entries} =
+             SealedEvidenceLog.admit(%{path: path, trace_facts: Generator.empty_trace_facts()},
+               limits: [max_index_entries: 1]
+             )
+  end
+
+  test "exact one-over refusal for max_logical_index_bytes", %{tmp_dir: tmp} do
+    path = Path.join(tmp, "bytes.ptcins")
+    {:ok, _} = SealedEvidenceLog.produce(path, Generator.count_stream("bytes-run", 2))
+
+    assert {:error, :max_logical_index_bytes} =
+             SealedEvidenceLog.admit(%{path: path, trace_facts: Generator.empty_trace_facts()},
+               limits: [max_logical_index_bytes: 16]
+             )
+  end
+
+  test "count ladder accounting grows with records, not payloads", %{tmp_dir: tmp} do
+    measurements =
+      Enum.map([8, 32], fn count ->
+        path = Path.join(tmp, "count-#{count}.ptcins")
+        {:ok, _} = SealedEvidenceLog.produce(path, Generator.count_stream("acc-#{count}", count))
+
+        {:ok, snapshot} =
+          SealedEvidenceLog.admit(%{path: path, trace_facts: Generator.empty_trace_facts()})
+
+        {:ok, info} = SealedEvidenceLog.info(snapshot)
+        SealedEvidenceLog.close(snapshot)
+        {count, info.accounting.logical_entries, info.accounting.ets_bytes}
+      end)
+
+    [{small_n, small_entries, small_bytes}, {large_n, large_entries, large_bytes}] = measurements
+    assert small_entries < large_entries
+    assert small_bytes < large_bytes
+    assert large_n > small_n
+  end
+
+  test "inventory separates host, snapshot, producer, and prototype limits" do
+    rows = Limits.inventory()
+    classes = MapSet.new(Enum.map(rows, & &1["class"]))
+
+    assert MapSet.subset?(
+             MapSet.new([
+               :host_facing,
+               :snapshot_internal,
+               :producer,
+               :prototype,
+               :maintained_guard
+             ]),
+             classes
+           )
+
+    assert Enum.any?(rows, &(&1["path"] == "install.ptc_inspection_snapshot.ceilings.max_files"))
+  end
+end

--- a/test/ptc_runner/research/sealed_evidence_log_parity_test.exs
+++ b/test/ptc_runner/research/sealed_evidence_log_parity_test.exs
@@ -71,34 +71,49 @@ defmodule PtcRunner.Research.SealedEvidenceLog.ParityTest do
   end
 
   test "result-byte shrinking stays aligned", %{tmp_dir: tmp} do
-    {current, snapshot} = admit_mixed(tmp, "parity-shrink")
+    corpus = Generator.dense_filter_run("parity-shrink", 8)
+    path = Path.join(tmp, "parity-shrink.ptcins")
+    assert {:ok, _} = SealedEvidenceLog.produce(path, corpus.records)
+
+    assert {:ok, snapshot} =
+             SealedEvidenceLog.admit(%{path: path, trace_facts: corpus.trace_facts})
+
     on_exit(fn -> SealedEvidenceLog.close(snapshot) end)
+
+    {:ok, current} =
+      Oracle.compile_current([corpus.records], "trace-source", %{
+        "trace_snapshot_hash" => "trace-source",
+        "runs" => %{"parity-shrink" => corpus.trace_facts}
+      })
 
     assert :ok =
              Oracle.walk_equal(
                current,
                snapshot,
-               :capability_calls,
-               %{"run_id" => "parity-shrink", "limit" => 10},
-               80
+               :generated_sources,
+               %{"run_id" => "parity-shrink", "limit" => 8},
+               500
              )
   end
 
   test "rejects invalid filter types and unknown keys", %{tmp_dir: tmp} do
-    {_current, snapshot} = admit_mixed(tmp, "parity-invalid")
+    {current, snapshot} = admit_mixed(tmp, "parity-invalid")
     on_exit(fn -> SealedEvidenceLog.close(snapshot) end)
-
-    assert {:error, :invalid_query} =
-             SealedEvidenceLog.query(snapshot, :capability_calls, %{
-               "run_id" => "parity-invalid",
-               "name" => 1
-             })
 
     assert {:error, :invalid_query} =
              SealedEvidenceLog.query(snapshot, :capability_calls, %{
                "run_id" => "parity-invalid",
                "unknown" => "x"
              })
+
+    assert :ok =
+             Oracle.walk_equal(
+               current,
+               snapshot,
+               :capability_calls,
+               %{"run_id" => "parity-invalid", "name" => 1},
+               1_000_000
+             )
   end
 
   test "multi-run list_runs, get_run, and result", %{tmp_dir: tmp} do
@@ -206,12 +221,14 @@ defmodule PtcRunner.Research.SealedEvidenceLog.ParityTest do
          "mission_name" => "default",
          "capability_id" => "tool-1"
        }},
-      {:generated_sources, ~w(evaluation_id parent_evaluation_id mission_name prelude_call),
+      {:generated_sources,
+       ~w(evaluation_id parent_evaluation_id mission_name prelude_call prelude_component),
        %{
          "evaluation_id" => "evaluation-1",
          "parent_evaluation_id" => "workflow-1",
          "mission_name" => "default",
-         "prelude_call" => "call-1"
+         "prelude_call" => "call-1",
+         "prelude_component" => "shared.api"
        }},
       {:model_exchanges, ~w(capability_id input_sequence),
        %{"capability_id" => "llm-1", "input_sequence" => 1}},
@@ -224,8 +241,14 @@ defmodule PtcRunner.Research.SealedEvidenceLog.ParityTest do
          "mission_name" => "default"
        }},
       {:execution_prints, ~w(evaluation_id), %{"evaluation_id" => "workflow-eval"}},
-      {:turns, ~w(stream_id capability_id),
-       %{"stream_id" => "stream-1", "capability_id" => "llm-1"}}
+      {:execution_errors, ~w(evaluation_id), %{"evaluation_id" => "workflow-eval"}},
+      {:explicit_failure_values, ~w(evaluation_id), %{"evaluation_id" => "workflow-eval"}},
+      {:turns, ~w(stream_id capability_id evaluation_id),
+       %{
+         "stream_id" => "stream-1",
+         "capability_id" => "llm-1",
+         "evaluation_id" => "evaluation-1"
+       }}
     ]
     |> Enum.flat_map(fn {operation, keys, values} ->
       base = %{"run_id" => run_id}
@@ -236,8 +259,7 @@ defmodule PtcRunner.Research.SealedEvidenceLog.ParityTest do
         Enum.map(keys, fn key -> {operation, Map.put(base, key, Map.fetch!(values, key))} end)
 
       conjunctions =
-        keys
-        |> combinations(2)
+        (combinations(keys, 2) ++ combinations(keys, 3))
         |> Enum.map(fn pair -> {operation, Map.merge(base, Map.take(values, pair))} end)
 
       all = [{operation, Map.merge(base, values)}]
@@ -247,5 +269,9 @@ defmodule PtcRunner.Research.SealedEvidenceLog.ParityTest do
 
   defp combinations(list, 2) do
     for a <- list, b <- list, a < b, do: [a, b]
+  end
+
+  defp combinations(list, 3) do
+    for a <- list, b <- list, c <- list, a < b, b < c, do: [a, b, c]
   end
 end

--- a/test/ptc_runner/research/sealed_evidence_log_parity_test.exs
+++ b/test/ptc_runner/research/sealed_evidence_log_parity_test.exs
@@ -51,6 +51,7 @@ defmodule PtcRunner.Research.SealedEvidenceLog.ParityTest do
          "parent_evaluation_id" => "workflow-2"
        }},
       {:model_exchanges, %{"run_id" => "parity-filters", "order" => "desc"}},
+      {:generated_sources, %{"run_id" => "parity-filters", "order" => "desc"}},
       {:execution_prints, %{"run_id" => "parity-filters", "limit" => 1}}
     ]
 
@@ -243,11 +244,12 @@ defmodule PtcRunner.Research.SealedEvidenceLog.ParityTest do
       {:execution_prints, ~w(evaluation_id), %{"evaluation_id" => "workflow-eval"}},
       {:execution_errors, ~w(evaluation_id), %{"evaluation_id" => "workflow-eval"}},
       {:explicit_failure_values, ~w(evaluation_id), %{"evaluation_id" => "workflow-eval"}},
-      {:turns, ~w(stream_id capability_id evaluation_id),
+      {:turns, ~w(stream_id capability_id evaluation_id parent_evaluation_id),
        %{
          "stream_id" => "stream-1",
          "capability_id" => "llm-1",
-         "evaluation_id" => "evaluation-1"
+         "evaluation_id" => "evaluation-1",
+         "parent_evaluation_id" => "workflow-1"
        }}
     ]
     |> Enum.flat_map(fn {operation, keys, values} ->
@@ -259,7 +261,7 @@ defmodule PtcRunner.Research.SealedEvidenceLog.ParityTest do
         Enum.map(keys, fn key -> {operation, Map.put(base, key, Map.fetch!(values, key))} end)
 
       conjunctions =
-        (combinations(keys, 2) ++ combinations(keys, 3))
+        (combinations(keys, 2) ++ combinations(keys, 3) ++ combinations(keys, 4))
         |> Enum.map(fn pair -> {operation, Map.merge(base, Map.take(values, pair))} end)
 
       all = [{operation, Map.merge(base, values)}]
@@ -267,11 +269,17 @@ defmodule PtcRunner.Research.SealedEvidenceLog.ParityTest do
     end)
   end
 
+  defp combinations(_list, n) when n < 2, do: []
+
   defp combinations(list, 2) do
     for a <- list, b <- list, a < b, do: [a, b]
   end
 
   defp combinations(list, 3) do
     for a <- list, b <- list, c <- list, a < b, b < c, do: [a, b, c]
+  end
+
+  defp combinations(list, 4) do
+    for a <- list, b <- list, c <- list, d <- list, a < b, b < c, c < d, do: [a, b, c, d]
   end
 end

--- a/test/ptc_runner/research/sealed_evidence_log_parity_test.exs
+++ b/test/ptc_runner/research/sealed_evidence_log_parity_test.exs
@@ -1,0 +1,154 @@
+defmodule PtcRunner.Research.SealedEvidenceLog.ParityTest do
+  use ExUnit.Case, async: true
+
+  alias PtcRunner.Research.SealedEvidenceLog
+  alias PtcRunner.Research.SealedEvidenceLog.Generator
+  alias PtcRunner.Research.SealedEvidenceLog.Oracle
+  alias PtcRunner.Research.SealedEvidenceLog.Query
+
+  @moduletag :tmp_dir
+
+  test "matches InspectionQuery for every operation on a mixed corpus", %{tmp_dir: tmp} do
+    {current, snapshot} = admit_mixed(tmp, "parity-mixed")
+    on_exit(fn -> SealedEvidenceLog.close(snapshot) end)
+
+    for operation <- Query.operations() do
+      args = args(operation, "parity-mixed")
+
+      assert :ok = Oracle.walk_equal(current, snapshot, operation, args, 1_000_000),
+             "operation #{operation} diverged"
+    end
+  end
+
+  test "covers filter absence, nil, presence, conjunctions, and order", %{tmp_dir: tmp} do
+    {current, snapshot} = admit_mixed(tmp, "parity-filters")
+    on_exit(fn -> SealedEvidenceLog.close(snapshot) end)
+
+    cases = [
+      {:capability_calls, %{"run_id" => "parity-filters"}},
+      {:capability_calls, %{"run_id" => "parity-filters", "name" => nil}},
+      {:capability_calls, %{"run_id" => "parity-filters", "name" => "search"}},
+      {:capability_calls,
+       %{"run_id" => "parity-filters", "name" => "search", "mission_name" => "default"}},
+      {:generated_sources, %{"run_id" => "parity-filters", "evaluation_id" => "evaluation-1"}},
+      {:generated_sources,
+       %{
+         "run_id" => "parity-filters",
+         "evaluation_id" => "evaluation-1",
+         "parent_evaluation_id" => "workflow-1"
+       }},
+      {:generated_sources,
+       %{
+         "run_id" => "parity-filters",
+         "evaluation_id" => "evaluation-1",
+         "parent_evaluation_id" => "workflow-2"
+       }},
+      {:generated_sources, %{"run_id" => "parity-filters", "prelude_call" => "call-1"}},
+      {:turns,
+       %{
+         "run_id" => "parity-filters",
+         "evaluation_id" => "evaluation-1",
+         "parent_evaluation_id" => "workflow-2"
+       }},
+      {:model_exchanges, %{"run_id" => "parity-filters", "order" => "desc"}},
+      {:execution_prints, %{"run_id" => "parity-filters", "limit" => 1}}
+    ]
+
+    for {operation, arguments} <- cases do
+      assert :ok = Oracle.walk_equal(current, snapshot, operation, arguments, 1_000_000),
+             "#{operation} #{inspect(arguments)} diverged"
+    end
+  end
+
+  test "rejects invalid filter types and unknown keys", %{tmp_dir: tmp} do
+    {_current, snapshot} = admit_mixed(tmp, "parity-invalid")
+    on_exit(fn -> SealedEvidenceLog.close(snapshot) end)
+
+    assert {:error, :invalid_query} =
+             SealedEvidenceLog.query(snapshot, :capability_calls, %{
+               "run_id" => "parity-invalid",
+               "name" => 1
+             })
+
+    assert {:error, :invalid_query} =
+             SealedEvidenceLog.query(snapshot, :capability_calls, %{
+               "run_id" => "parity-invalid",
+               "unknown" => "x"
+             })
+  end
+
+  test "multi-run list_runs, get_run, and result", %{tmp_dir: tmp} do
+    mixed = Generator.mixed_run("alpha-run")
+    other = Generator.second_run("beta-run")
+    mixed_path = Path.join(tmp, "alpha.ptcins")
+    other_path = Path.join(tmp, "beta.ptcins")
+    assert {:ok, _} = SealedEvidenceLog.produce(mixed_path, mixed.records)
+    assert {:ok, _} = SealedEvidenceLog.produce(other_path, other.records)
+
+    assert {:ok, snapshot} =
+             SealedEvidenceLog.admit([
+               %{path: mixed_path, trace_facts: mixed.trace_facts},
+               %{path: other_path, trace_facts: other.trace_facts}
+             ])
+
+    on_exit(fn -> SealedEvidenceLog.close(snapshot) end)
+
+    {:ok, current} =
+      Oracle.compile_current(
+        [mixed.records, other.records],
+        "trace-source",
+        %{
+          "trace_snapshot_hash" => "trace-source",
+          "runs" => %{
+            "alpha-run" => mixed.trace_facts,
+            "beta-run" => other.trace_facts
+          }
+        }
+      )
+
+    assert :ok = Oracle.walk_equal(current, snapshot, :list_runs, %{"limit" => 1}, 1_000_000)
+
+    assert :ok =
+             Oracle.walk_equal(current, snapshot, :get_run, %{"run_id" => "alpha-run"}, 1_000_000)
+
+    assert :ok =
+             Oracle.walk_equal(current, snapshot, :result, %{"run_id" => "alpha-run"}, 1_000_000)
+
+    assert :ok =
+             Oracle.walk_equal(current, snapshot, :result, %{"run_id" => "beta-run"}, 1_000_000)
+  end
+
+  test "invalid cursor reuse against another query", %{tmp_dir: tmp} do
+    {_current, snapshot} = admit_mixed(tmp, "cursor-run")
+    on_exit(fn -> SealedEvidenceLog.close(snapshot) end)
+
+    assert {:ok, %{"next_cursor" => cursor}, _metrics} =
+             SealedEvidenceLog.query(snapshot, :model_exchanges, %{
+               "run_id" => "cursor-run",
+               "limit" => 1
+             })
+
+    assert is_binary(cursor)
+
+    assert {:error, :invalid_query} =
+             SealedEvidenceLog.query(snapshot, :list_runs, %{"limit" => 1, "cursor" => cursor})
+  end
+
+  defp admit_mixed(tmp, run_id) do
+    corpus = Generator.mixed_run(run_id)
+    path = Path.join(tmp, "#{run_id}.ptcins")
+    assert {:ok, _} = SealedEvidenceLog.produce(path, corpus.records)
+
+    assert {:ok, snapshot} =
+             SealedEvidenceLog.admit(%{path: path, trace_facts: corpus.trace_facts})
+
+    {:ok, current} =
+      Oracle.compile_current([corpus.records], "trace-source", corpus.trace_analysis)
+
+    {current, snapshot}
+  end
+
+  defp args(:list_runs, _run_id), do: %{"limit" => 10}
+  defp args(operation, run_id) when operation in [:get_run, :result], do: %{"run_id" => run_id}
+  defp args(_operation, run_id), do: %{"run_id" => run_id, "limit" => 10}
+end

--- a/test/ptc_runner/research/sealed_evidence_log_parity_test.exs
+++ b/test/ptc_runner/research/sealed_evidence_log_parity_test.exs
@@ -60,6 +60,30 @@ defmodule PtcRunner.Research.SealedEvidenceLog.ParityTest do
     end
   end
 
+  test "enumerates filter absence, nil, presence, and conjunctions", %{tmp_dir: tmp} do
+    {current, snapshot} = admit_mixed(tmp, "parity-grid")
+    on_exit(fn -> SealedEvidenceLog.close(snapshot) end)
+
+    for {operation, arguments} <- filter_grid("parity-grid") do
+      assert :ok = Oracle.walk_equal(current, snapshot, operation, arguments, 1_000_000),
+             "#{operation} #{inspect(arguments)} diverged"
+    end
+  end
+
+  test "result-byte shrinking stays aligned", %{tmp_dir: tmp} do
+    {current, snapshot} = admit_mixed(tmp, "parity-shrink")
+    on_exit(fn -> SealedEvidenceLog.close(snapshot) end)
+
+    assert :ok =
+             Oracle.walk_equal(
+               current,
+               snapshot,
+               :capability_calls,
+               %{"run_id" => "parity-shrink", "limit" => 10},
+               80
+             )
+  end
+
   test "rejects invalid filter types and unknown keys", %{tmp_dir: tmp} do
     {_current, snapshot} = admit_mixed(tmp, "parity-invalid")
     on_exit(fn -> SealedEvidenceLog.close(snapshot) end)
@@ -134,6 +158,28 @@ defmodule PtcRunner.Research.SealedEvidenceLog.ParityTest do
              SealedEvidenceLog.query(snapshot, :list_runs, %{"limit" => 1, "cursor" => cursor})
   end
 
+  test "cursor from another snapshot is source_changed", %{tmp_dir: tmp} do
+    {_current, first} = admit_mixed(tmp, "cursor-a")
+    {_current, second} = admit_mixed(tmp, "cursor-b")
+    on_exit(fn -> SealedEvidenceLog.close(first) end)
+    on_exit(fn -> SealedEvidenceLog.close(second) end)
+
+    assert {:ok, %{"next_cursor" => cursor}, _} =
+             SealedEvidenceLog.query(first, :model_exchanges, %{
+               "run_id" => "cursor-a",
+               "limit" => 1
+             })
+
+    assert is_binary(cursor)
+
+    assert {:error, :source_changed} =
+             SealedEvidenceLog.query(second, :model_exchanges, %{
+               "run_id" => "cursor-b",
+               "limit" => 1,
+               "cursor" => cursor
+             })
+  end
+
   defp admit_mixed(tmp, run_id) do
     corpus = Generator.mixed_run(run_id)
     path = Path.join(tmp, "#{run_id}.ptcins")
@@ -151,4 +197,55 @@ defmodule PtcRunner.Research.SealedEvidenceLog.ParityTest do
   defp args(:list_runs, _run_id), do: %{"limit" => 10}
   defp args(operation, run_id) when operation in [:get_run, :result], do: %{"run_id" => run_id}
   defp args(_operation, run_id), do: %{"run_id" => run_id, "limit" => 10}
+
+  defp filter_grid(run_id) do
+    [
+      {:capability_calls, ~w(name mission_name capability_id),
+       %{
+         "name" => "search",
+         "mission_name" => "default",
+         "capability_id" => "tool-1"
+       }},
+      {:generated_sources, ~w(evaluation_id parent_evaluation_id mission_name prelude_call),
+       %{
+         "evaluation_id" => "evaluation-1",
+         "parent_evaluation_id" => "workflow-1",
+         "mission_name" => "default",
+         "prelude_call" => "call-1"
+       }},
+      {:model_exchanges, ~w(capability_id input_sequence),
+       %{"capability_id" => "llm-1", "input_sequence" => 1}},
+      {:provider_exchanges, ~w(capability_id mission_name request_id),
+       %{"capability_id" => "tool-1", "mission_name" => "default", "request_id" => 1}},
+      {:effective_preludes, ~w(component_id environment mission_name),
+       %{
+         "component_id" => "shared.api",
+         "environment" => "mission",
+         "mission_name" => "default"
+       }},
+      {:execution_prints, ~w(evaluation_id), %{"evaluation_id" => "workflow-eval"}},
+      {:turns, ~w(stream_id capability_id),
+       %{"stream_id" => "stream-1", "capability_id" => "llm-1"}}
+    ]
+    |> Enum.flat_map(fn {operation, keys, values} ->
+      base = %{"run_id" => run_id}
+      absent = [{operation, base}]
+      nils = Enum.map(keys, fn key -> {operation, Map.put(base, key, nil)} end)
+
+      presents =
+        Enum.map(keys, fn key -> {operation, Map.put(base, key, Map.fetch!(values, key))} end)
+
+      conjunctions =
+        keys
+        |> combinations(2)
+        |> Enum.map(fn pair -> {operation, Map.merge(base, Map.take(values, pair))} end)
+
+      all = [{operation, Map.merge(base, values)}]
+      absent ++ nils ++ presents ++ conjunctions ++ all
+    end)
+  end
+
+  defp combinations(list, 2) do
+    for a <- list, b <- list, a < b, do: [a, b]
+  end
 end


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements #1646. This is the bounded research/prototype follow-up to #1643: a small sealed evidence log plus private admission-owned ETS indexes, measured without changing production inspection routing.

## Prototype

```text
16-byte versioned header (PTCINS01)
length-framed deterministic JSON evidence
192-byte terminal footer (PTCIFTR1) with counts, identities, offsets, digests
```

Admission is one ingest scan that validates frames and inserts bounded ETS metadata, then a seal-confirmation rehash so a same-size overwrite cannot publish a snapshot. Queries select through ETS and read required ranges from a pinned handle. Cursors bind the admission snapshot digest and logical query identity; they do not rehash the complete evidence preimage.

Reproduce the tables with `mix ptc.measure_sealed_evidence` (count rungs up to 10_000) or `mix ptc.measure_sealed_evidence --full` (128/256/512 MiB payload ladder plus count rungs up to `--max-records`). Focused tests never invoke the large ladder.

Results, the configuration inventory, and the #1643 recommendation live in `docs/maintainers/sealed-evidence-log-measurement.md`.

## Recommendation for #1643

**ETS-only V1** is sufficient. Do not add CubDB or `:file_sorter` for this cutover.

- Keep host-facing `max_files`, `max_source_bytes`, and `max_result_bytes`.
- Add internal `max_records` (proposed production default 16_384, hard max 65_536).
- Keep exact `omitted_count` for small records; for payload-heavy few-record artifacts, specify `omitted_count` as ETS locator cardinality (admission-verified) and verify returned items plus join/turn dependencies only.

## Verification

- `mix test test/ptc_runner/research/` — 43 passed
- `mix precommit` — passed
- `mix credo --strict` — clean
- Fault-matrix tests now ledger snapshot PID, ETS table IDs, pinned handles, and scratch bytes on admission-failure rows
- `.githooks/pre-push` — passed on `680103e5`; rerunning on HEAD `1ce8511b`

Three independent reviews landed as follow-up commits (`42f2cb7b`, `c33756b2`, `680103e5`). No fourth review. The 512 MiB ladder remains benchmark-only via `mix ptc.measure_sealed_evidence --full`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bbcd9728-016c-49e8-b9fa-e85ac2fe71fe?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bbcd9728-016c-49e8-b9fa-e85ac2fe71fe&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

