### PR TITLE
feat(trace): isolate damaged directory artifacts

### DIFF
--- a/docs/maintainers/kernel.md
+++ b/docs/maintainers/kernel.md
@@ -401,19 +401,23 @@ fixes whether the directory is ordinary normal-only input or private-authorized
 canonical input; a caller cannot widen an existing handle or relabel it for
 another profile.
 
-Ordinary capture enumerates supported normal `.jsonl` names in canonical sorted
-order, records a pre-read directory and file inventory, opens only regular
-files, compares path and descriptor identity, retains the baseline bytes, and
-performs a second byte-for-byte verification around a final inventory check,
-followed by one last content verification after that inventory. Any name,
-identity, metadata, type, or content change between baseline and final
-verification returns `:source_changed`; a mixed capture is never installed. The
-decoded event set is normalized and validated exactly once before the owner
-becomes queryable. Private `.private.jsonl` and `.ptcins` artifacts
-stay excluded by normal discovery. The private-authorized capture instead
-selects both ordinary and `.private.jsonl` traces, records `sanitized` or
-`private` provenance per run, and still rejects inspection artifacts. A run
-cannot be split across the two trace classes.
+Ordinary capture selects normal `<run-id>.jsonl` names in raw-byte sorted order,
+records a pre-read directory and file inventory, compares path and descriptor
+identity, retains the baseline bytes, and performs repeated byte-for-byte and
+namespace verification before installation. Any selected name, identity,
+metadata, type, or content change between baseline and final verification
+returns `:source_changed`; a mixed capture is never installed. Stable damaged
+members instead enter one deterministic run/trace claim graph. The complete
+connected component is isolated for a malformed file, unsupported version,
+filename/run mismatch, non-regular or unreadable member, repeated identity, or
+sequence/lifecycle failure, while disjoint canonical files remain queryable.
+There is no filename-ordered winner or partial-run merge.
+
+Private `.private.jsonl` and `.ptcins` artifacts stay excluded by normal
+discovery. The private-authorized capture instead selects both ordinary and
+`<run-id>.private.jsonl` traces, records `sanitized` or `private` provenance per
+admitted run, and still excludes inspection artifacts. A run split across
+files or source classes is isolated as one connected component.
 
 The default aggregate encoded-source ceiling is 8,000,000 bytes. Snapshot
 retention independently limits the decoded representation to 32,000,000
@@ -422,12 +426,15 @@ enumerates under a fixed heap and time bound and rejects directories above
 4,096 total entries or 1,024 selected trace files before sorting, stating,
 opening, or verifying any selected file. Hosts may lower the construction
 limits but cannot raise them, and browser or Lisp input cannot select them.
-The owner retains only validated events, their digest, fixed query limits,
-safe capture metadata, and an owner monitor. Its tokenized handle carries only
-a PID and an unforgeable reference; neither owner state, status output,
-capability closures, safe metadata, nor errors retain or expose the directory
-path. Safe capture metadata is the capture digest, UTC capture time, visible
-run count, raw encoded source bytes, and retained decoded bytes. All four
+The owner retains the detached `directory_admission_v1` value: selected source
+proofs and classifications, admitted events and compiled projection, complete
+isolation components, and source identity. Fixed query limits, safe capture
+metadata, and the owner monitor live alongside that admission in owner state.
+Its tokenized handle carries only a PID and an unforgeable reference; neither
+owner state, status output, capability closures, safe metadata, nor errors
+retain or expose the directory path. Safe capture metadata is the capture
+digest, UTC capture time, visible run count, raw encoded source bytes, and
+retained admission bytes. All four
 snapshot queries execute the same `TraceLog` filtering,
 metadata, ordering, pagination, cursor, and result-limit code as ordinary
 sources, and cursors bind to the captured digest so they stay stable when the

--- a/docs/maintainers/kernel.md
+++ b/docs/maintainers/kernel.md
@@ -652,10 +652,13 @@ suites must keep proving, concretely:
   inventory, direct `Evaluation` parity, exact continuation behavior, bounded
   result and accounting projection, terminal-budget lifecycle, and path and
   source redaction;
-- an immutable capture verifies pre/post inventory and content, enforces its
-  encoded and retained ceilings independently, redacts the path from ownership
-  and errors, keeps snapshot cursors stable after the original directory
-  mutates, and cleans up idempotently under owner death;
+- an immutable directory capture verifies the root plus selected raw names,
+  identities, sizes, and bytes around classification; retains one complete
+  `directory_admission_v1` value containing admitted events, provenance,
+  compiled analysis, and all isolation evidence; enforces encoded and retained
+  ceilings independently; redacts paths and unsafe names from public metadata;
+  keeps snapshot cursors stable after the original directory mutates; and
+  cleans up idempotently under owner death;
 - saturating event count and byte capacity still retains one dropped summary
   plus exactly one terminal event through a reloadable persisted batch;
 - atomic publication faulted before, during, and after write and at cleanup

--- a/docs/maintainers/trace-log-contract.md
+++ b/docs/maintainers/trace-log-contract.md
@@ -164,6 +164,25 @@ transiently for every call. Their cursors therefore invalidate when any
 selected admitted or isolated evidence changes; snapshot cursors remain bound
 to the retained value.
 
+Every `list_runs` page and `counters` result reports grant-visible damaged
+components in an `isolation` object, independent of filters and pagination.
+Its exact `component_count`, `source_count`, and `known_run_count` count the
+complete isolated graph; `known_run_count` is the distinct union of valid
+filename and decoded embedded run claims. `reasons` follows the classifier's
+fixed reason order and gives exact component and source counts for each reason,
+with a multi-reason component contributing once to every applicable reason.
+Run-scoped successful answers omit `isolation`.
+
+The diagnostic `examples` list contains at most 16 components in classifier
+order. Each example contains at most eight sorted, canonical UTF-8 basenames,
+while `source_count`, `sources_omitted_count`, and
+`examples_omitted_count` state the exact omissions, including invalid
+basenames that cannot be displayed. Result fitting removes example source
+names and then examples from the deterministic tail, updating those omission
+counts, before shortening a run-item page. The exact counts and reason totals
+are never removed; if those fixed fields plus the counters aggregate or an
+empty page envelope do not fit, the query returns `result_limit_exceeded`.
+
 Normal trace sinks sanitize before persistence. Private canonical event sinks
 use the separate fail-closed policy specified by the event-sink section of the
 `PtcRunner.Kernel.EventSink` module documentation, but retain the same event

--- a/docs/maintainers/trace-log-contract.md
+++ b/docs/maintainers/trace-log-contract.md
@@ -159,6 +159,10 @@ commits to an absolute path, opposite-class basename or bytes, advisory
 exclusion count, capture time, or presentation caps. Snapshots retain that
 complete detached admission value—including the compiled analysis
 projection—and charge it against the 32,000,000-byte retained ceiling.
+Direct directory queries build and charge the byte-identical detached value
+transiently for every call. Their cursors therefore invalidate when any
+selected admitted or isolated evidence changes; snapshot cursors remain bound
+to the retained value.
 
 Normal trace sinks sanitize before persistence. Private canonical event sinks
 use the separate fail-closed policy specified by the event-sink section of the
@@ -1070,11 +1074,14 @@ inspection does not wait for that work and does not change
 
 ## Failure algebra
 
-Trace queries surface two capability-envelope kinds — `:not_found` and
-`:invalid_request` (plus `:internal` for unexpected failures). The specific
-condition is carried in the bounded details string. `:invalid_request` covers
-`:invalid_query`, `:unsupported_version`, `:malformed_source`,
-`:source_limit_exceeded`, `:result_limit_exceeded`, and `:source_changed`.
+Trace queries surface three capability-envelope kinds — `:not_found`,
+`:invalid_request`, and non-retryable `:unavailable` (plus `:internal` for
+unexpected failures). The specific condition is carried in the bounded details
+string. `:unavailable` reports a grant-visible `:run_isolated` claim with the
+exact detail `analysis run is isolated by damaged trace evidence`.
+`:invalid_request` covers `:invalid_query`, `:unsupported_version`,
+`:malformed_source`, `:source_limit_exceeded`, `:result_limit_exceeded`, and
+`:source_changed`.
 
 Details are bounded and sanitized. Host paths are not exposed beyond safe
 grant-relative identifiers.

--- a/docs/maintainers/trace-log-contract.md
+++ b/docs/maintainers/trace-log-contract.md
@@ -117,18 +117,28 @@ The current trace schema supports:
 - explicitly granted directories containing JSONL files;
 - a bounded in-memory sink for REPL, tests, and short-lived runs.
 
-JSONL files are written in canonical sequence order. Directory loading is
-deterministic: discover supported files, normalize paths, sort them, then load
-in sorted order under one aggregate byte cap. Exact selected capture is a
-distinct source variant used by `ptc transcript RUN_ID`: it resolves only
+JSONL files are written in canonical sequence order. A generated trace
+directory is a set of filename-bound canonical files:
+`<run-id>.jsonl` for sanitized evidence and
+`<run-id>.private.jsonl` for private evidence. Each selected directory member
+contains exactly one run ID and trace ID, and its embedded run ID equals the
+filename stem. The stem is 1–256 ASCII bytes matching
+`[A-Za-z0-9][A-Za-z0-9._-]*`. Directory admission bounds and sorts the raw
+selected basenames, inventories every selected member before reading any,
+proves the root/name/file/content selection stable, and classifies a complete
+run/trace claim graph. A damaged component is isolated as a unit while
+disjoint valid files remain admitted; no filename-ordered winner, repair, or
+partial run is selected.
+
+Exact selected capture is a distinct source variant used by
+`ptc transcript RUN_ID`: it resolves only
 `<run-ref>.jsonl` or `<run-ref>.private.jsonl` plus
 `<run-ref>.ptcins`, never lists the granted directory, and does not
 count unrelated members toward `max_directory_entries`, `max_files`, or the
 aggregate source-byte ceiling. Selected snapshot identity commits to the
 requested run reference, trace source class, exact evidence digests, and
-correlated trace ID. Filenames remain routing hints; embedded identities are
-authoritative. Directory snapshots keep their current fail-closed contract and
-still reject malformed or mismatched members.
+correlated trace ID. Explicit single-file sources remain filename-agnostic and
+may contain multiple complete disjoint runs; they never combine with siblings.
 
 One directory holds both sanitized and private trace files, and one source
 grant reads exactly one kind. A run listing and a counters query therefore
@@ -141,14 +151,26 @@ carry the field. The count is advisory evidence about the directory, not part
 of the source identity, so a concurrent write to the kind a grant does not read
 never invalidates the evidence it does read.
 
+The `directory_admission_v1` source identity commits to the grant class; every
+selected raw relative-name byte string, source class, length, and content
+digest; complete filename and embedded claims and reasons; admitted events and
+their per-run provenance; and untruncated isolation components. It never
+commits to an absolute path, opposite-class basename or bytes, advisory
+exclusion count, capture time, or presentation caps. Snapshots retain that
+complete detached admission value—including the compiled analysis
+projection—and charge it against the 32,000,000-byte retained ceiling.
+
 Normal trace sinks sanitize before persistence. Private canonical event sinks
 use the separate fail-closed policy specified by the event-sink section of the
 `PtcRunner.Kernel.EventSink` module documentation, but retain the same event
 vocabulary rather than capturing exact payloads or source.
 
-Malformed or unsupported canonical events fail closed by default. A debugging
-mode may report bounded per-file errors, but it never silently reinterprets
-malformed data as valid runs.
+Malformed or unsupported explicit single-file canonical events fail closed.
+For directory discovery, malformed JSONL, unsupported versions, filename
+mismatch, identity conflicts, sequence conflicts, lifecycle conflicts,
+non-regular members, and stably unreadable members isolate their complete
+connected component. Invalid raw basenames remain in immutable proof and
+counts but are never emitted as source metadata.
 
 ## Source grants and authority
 

--- a/docs/reference/application-manifest.md
+++ b/docs/reference/application-manifest.md
@@ -242,10 +242,14 @@ its required trace snapshot with authorized private records. Set the
 trace dependency's config to `{"expose": false}` when only the aggregate
 inspection namespace should be callable.
 
-Snapshot acquisition is fail closed and immutable: malformed, duplicate,
-orphaned, or oversized evidence rejects the capture rather than exposing a
-partial catalog. Private inspection also requires every selected provider to
-accept the `private_inspection` data class before any directory opens.
+Trace-directory acquisition is immutable: stable malformed, duplicate, or
+identity-conflicting trace files isolate their connected component while
+disjoint valid runs remain available. Namespace mutation and whole-source
+limits reject the capture rather than installing a partial generation.
+Inspection snapshots remain fail closed for malformed, duplicate, orphaned, or
+oversized private inspection records. Private inspection also requires every
+selected provider to accept the `private_inspection` data class before any
+directory opens.
 
 Treat the workflow bundle and manifest as application code. Treat
 model-generated source, mission input, file content, and provider output as

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -690,8 +690,10 @@ remain authoritative, and unrelated directory members are not listed, opened,
 sized, decoded, or counted toward directory or aggregate source limits. The
 selected files still keep their individual source, record, retained-memory,
 heap, deadline, and result ceilings. Whole-directory snapshots used by
-`private-run-analysis-v1` stay a distinct source variant and still fail closed
-on malformed or mismatched members.
+`private-run-analysis-v1` stay a distinct source variant: they admit only
+filename-bound one-run files, isolate a stable damaged connected component,
+and keep disjoint healthy runs queryable. Namespace or selected-file mutation
+still rejects the whole capture.
 
 The parent of `--private-output` must already exist and be reached without a
 symbolic link — on macOS `/tmp` is a symlink, so `/tmp/out.json` is refused.
@@ -731,6 +733,13 @@ probes loopback: another PTC Viewer is reported with its exact project document
 path, while any other listener is reported as an occupied service. The command
 runs in the foreground until `Ctrl+C`, and opens a browser only when the project
 asks for it *and* a terminal is attached.
+
+Directory discovery expects producer-owned `<run-id>.jsonl` and
+`<run-id>.private.jsonl` names, each containing exactly that one run and one
+trace identity. The run list reports bounded damaged-source evidence when a
+stable malformed, mismatched, split, or conflicting component is isolated;
+unrelated valid runs remain available. A selected namespace change during
+capture fails the refresh rather than installing a partial generation.
 
 The Viewer does not search the invocation directory or its parents for a
 `.env` file. Environment-backed provider credentials come from the inherited

--- a/docs/reference/debug-navigation.md
+++ b/docs/reference/debug-navigation.md
@@ -318,6 +318,15 @@ withheld trace files of the other kind reports that separately, as
 `excluded_private_trace_files` or `excluded_sanitized_trace_files` on a run
 listing or counters query.
 
+Damaged evidence is also separate from pagination and policy exclusion.
+`list_runs` and `counters` carry the same bounded `isolation` summary with
+exact component, source, known-run, and reason totals plus capped examples.
+The Viewer renders that object as a damaged-source notice without hiding the
+source-kind exclusion notice. Opening a grant-visible run claim that belongs
+only to an isolated component answers `422 run_isolated`; a direct trace
+capture that exceeds its retained-memory ceiling answers
+`413 Trace source retained size exceeded`.
+
 ### Join on correlation ids, never on sequence numbers
 
 A transcript turn and a trace event live in different sequence

--- a/docs/reference/host-installation.md
+++ b/docs/reference/host-installation.md
@@ -313,6 +313,14 @@ classifies the run as `private_inspection`. An inspection snapshot requires
 exactly one of those trace sources so it can validate every private artifact
 against the captured trace evidence.
 
+Whole-directory trace snapshots admit filename-bound `<run-id>.jsonl` or
+`<run-id>.private.jsonl` members containing exactly one matching run and trace
+identity. Stable malformed, mismatched, split, or conflicting members are
+isolated by connected identity component while disjoint valid runs remain
+queryable. Selected namespace mutation rejects the complete capture; it never
+installs a partial snapshot. Explicit single-file trace sources remain a
+separate filename-agnostic aggregate contract.
+
 Set a trace selection's manifest config to `{"expose": false}` when it exists
 only as the inspection source's dependency. It still supplies the frozen trace
 capture without creating a second analysis namespace. The

--- a/docs/reference/project-files.md
+++ b/docs/reference/project-files.md
@@ -124,6 +124,13 @@ symlinked layout is refused. When a pre-existing directory fails the owner-only
 a bare publication failure. Artifact files retain the normal no-replace and
 privacy rules.
 
+The trace filenames are also the canonical directory-discovery contract. Each
+file contains exactly the run ID named by its stem and one trace identity;
+arbitrary aggregate filenames and split histories remain supported only when a
+caller explicitly selects one file, not when Viewer or run analysis discovers a
+directory. Stable damaged components are isolated without hiding unrelated
+valid runs.
+
 ## Overrides and lazy environment loading
 
 An explicit command value wins over the corresponding project default for host,

--- a/examples/viewer-demo/README.md
+++ b/examples/viewer-demo/README.md
@@ -20,9 +20,11 @@ examples/viewer-demo/run.sh /path/out  # or an explicit directory
 The script regenerates the granted `files/` root, launches
 `ptc-fs-mcp@0.1.0` through `ptc-host.json`, runs each journey with
 `--trace-dir` and `--inspect` into one owner-only project artifact root, writes
+each trace and inspection artifact under its generated run-reference filename,
 the project document beside it, and prints the `mix ptc viewer` command that
 opens it. Node.js and `npx` are required; the first run may download that
-package. That
+package. A rerun removes only the generated artifacts recorded by the prior
+pass, so the Viewer continues to contain exactly the five current journeys. That
 project grants the Viewer the private inspection artifacts, so treat the
 browser tab as a private sink.
 

--- a/examples/viewer-demo/run.sh
+++ b/examples/viewer-demo/run.sh
@@ -23,6 +23,21 @@ for child in envelopes inspection results traces; do
   chmod 700 "$artifacts/$child"
 done
 
+# Generated run-reference filenames cannot be rediscovered from journey names.
+# Journal only names produced by this script, then remove those exact artifacts
+# on the next pass so a rerun still presents exactly five journeys.
+run_refs="$out/.viewer-demo-run-refs"
+if [ -f "$run_refs" ]; then
+  while IFS= read -r previous_run_ref; do
+    if [[ "$previous_run_ref" =~ ^cmd-[A-Za-z0-9._-]+$ ]]; then
+      rm -f \
+        "$artifacts/traces/$previous_run_ref.jsonl" \
+        "$artifacts/inspection/$previous_run_ref.ptcins"
+    fi
+  done < "$run_refs"
+fi
+: > "$run_refs"
+
 cat > "$out/ptc-project.json" <<'PROJECT'
 {
   "$schema": "https://ptc-runner.dev/schemas/ptc-project-config.schema.json",
@@ -68,7 +83,17 @@ run_journey() {
     exit 1
   fi
 
-  mv "$generated_trace" "$artifacts/traces/$journey.jsonl"
+  local run_ref generated_inspection
+  run_ref="$(basename "$generated_trace" .jsonl)"
+  generated_inspection="$artifacts/inspection/$run_ref.ptcins"
+  printf '%s\n' "$run_ref" >> "$run_refs"
+  mv "$artifacts/inspection/$journey.ptcins" "$generated_inspection"
+
+  # Directory admission binds canonical trace and inspection artifacts to the
+  # generated run reference. Keep that producer-owned filename instead of
+  # relabeling the bytes with the human-facing journey name.
+  journey_trace="$generated_trace"
+  journey_inspection="$generated_inspection"
 
   case "$expect" in
     ok)
@@ -86,7 +111,7 @@ run_journey() {
     any) ;;
   esac
 
-  for artifact in "$artifacts/traces/$journey.jsonl" "$artifacts/inspection/$journey.ptcins"; do
+  for artifact in "$journey_trace" "$journey_inspection"; do
     if [ ! -s "$artifact" ]; then
       echo "FAIL: $journey produced no $artifact" >&2
       exit 1
@@ -105,17 +130,17 @@ require_evidence() {
 run_journey 01-recovery ok
 run_journey 02-bulk ok
 run_journey 03-limits any
-require_evidence 03-limits "$artifacts/traces/03-limits.jsonl" '"limit-exceeded"' "limit-exceeded events"
+require_evidence 03-limits "$journey_trace" '"limit-exceeded"' "limit-exceeded events"
 
 # 04/05 must fail for the advertised reason, not from an unrelated
 # provider or runtime error: the canonical trace must end in an error
 # outcome and the private feedback must carry the intended error code.
 run_journey 04-loop-limit error
-require_evidence 04-loop-limit "$artifacts/traces/04-loop-limit.jsonl" '"outcome":"error"' "an error run outcome"
-require_evidence 04-loop-limit "$artifacts/inspection/04-loop-limit.ptcins" 'loop_limit_exceeded' "loop-limit feedback"
+require_evidence 04-loop-limit "$journey_trace" '"outcome":"error"' "an error run outcome"
+require_evidence 04-loop-limit "$journey_inspection" 'loop_limit_exceeded' "loop-limit feedback"
 run_journey 05-memory error
-require_evidence 05-memory "$artifacts/traces/05-memory.jsonl" '"outcome":"error"' "an error run outcome"
-require_evidence 05-memory "$artifacts/inspection/05-memory.ptcins" 'memory_exceeded' "heap-budget feedback"
+require_evidence 05-memory "$journey_trace" '"outcome":"error"' "an error run outcome"
+require_evidence 05-memory "$journey_inspection" 'memory_exceeded' "heap-budget feedback"
 
 # The project document must name an application, and it must be a portable
 # path beneath the document -- so one journey manifest is copied next to it.

--- a/lib/ptc_runner/kernel/bounded_worker.ex
+++ b/lib/ptc_runner/kernel/bounded_worker.ex
@@ -6,9 +6,11 @@ defmodule PtcRunner.Kernel.BoundedWorker do
   late reply before returning to the caller. Callers that are themselves
   disposable workers may opt into `:cancel_with_caller`; the bounded worker is
   then covered by a monitor-based guard so caller death terminates blocked work
-  without changing the caller's exit-trapping semantics. A caller may also
-  supply a `:cancel_with` process; its termination cancels the worker without
-  coupling the two owners.
+  without changing the caller's exit-trapping semantics. The guard retains only
+  process identities; the callback closure enters the heap-limited worker
+  directly, and startup coordination consumes the same absolute deadline as
+  callback execution. A caller may also supply a `:cancel_with` process; its
+  termination cancels the worker without coupling the two owners.
   """
 
   @doc """
@@ -64,6 +66,7 @@ defmodule PtcRunner.Kernel.BoundedWorker do
     cancel_with_caller? = Keyword.get(opts, :cancel_with_caller, false)
     cancel_with = Keyword.get(opts, :cancel_with)
     timeout_cleanup_hook = Keyword.get(opts, :timeout_cleanup_hook)
+    startup_fault_hook = Keyword.get(opts, :startup_fault_hook)
 
     run_worker(
       function,
@@ -71,7 +74,8 @@ defmodule PtcRunner.Kernel.BoundedWorker do
       max_heap_words,
       cancel_with_caller?,
       cancel_with,
-      timeout_cleanup_hook
+      timeout_cleanup_hook,
+      startup_fault_hook
     )
   end
 
@@ -81,18 +85,22 @@ defmodule PtcRunner.Kernel.BoundedWorker do
          max_heap_words,
          cancel_with_caller?,
          cancel_with,
-         timeout_cleanup_hook
+         timeout_cleanup_hook,
+         startup_fault_hook
        ) do
     reply_alias = Process.alias()
     reply_ref = make_ref()
     cancel_monitor = monitor_cancel_target(cancel_with)
+    deadline_ms = System.monotonic_time(:millisecond) + timeout_ms
 
     case start_worker(
            function,
            reply_alias,
            reply_ref,
            max_heap_words,
-           cancel_with_caller?
+           cancel_with_caller?,
+           deadline_ms,
+           startup_fault_hook
          ) do
       {:ok, pid, monitor_ref, caller_guard} ->
         await_worker(
@@ -102,14 +110,15 @@ defmodule PtcRunner.Kernel.BoundedWorker do
           reply_alias,
           reply_ref,
           cancel_monitor,
-          timeout_ms,
+          deadline_ms,
           timeout_cleanup_hook
         )
 
-      {:error, :worker_failed} ->
+      {:error, reason} ->
         demonitor_cancel_target(cancel_monitor)
         Process.unalias(reply_alias)
-        {:error, :worker_failed}
+        if reason == :timeout, do: run_timeout_cleanup_hook(timeout_cleanup_hook)
+        {:error, reason}
     end
   end
 
@@ -120,18 +129,33 @@ defmodule PtcRunner.Kernel.BoundedWorker do
          reply_alias,
          reply_ref,
          cancel_monitor,
-         timeout_ms,
+         deadline_ms,
          timeout_cleanup_hook
        ) do
     {guard, guard_monitor} = caller_guard_identity(caller_guard)
 
     receive do
-      {^reply_ref, result} ->
+      {^reply_ref, completed_at_ms, result} ->
+        if completed_before_deadline?(completed_at_ms, deadline_ms) do
+          demonitor_cancel_target(cancel_monitor)
+          Process.unalias(reply_alias)
+          await_down(pid, monitor_ref)
+          release_caller_guard(caller_guard)
+          {:ok, result}
+        else
+          demonitor_cancel_target(cancel_monitor)
+          run_timeout_cleanup_hook(timeout_cleanup_hook)
+          terminate(pid, monitor_ref, reply_alias, reply_ref)
+          release_caller_guard(caller_guard)
+          {:error, :timeout}
+        end
+
+      {^reply_ref, :deadline_expired} ->
         demonitor_cancel_target(cancel_monitor)
-        Process.unalias(reply_alias)
-        await_down(pid, monitor_ref)
+        run_timeout_cleanup_hook(timeout_cleanup_hook)
+        terminate(pid, monitor_ref, reply_alias, reply_ref)
         release_caller_guard(caller_guard)
-        {:ok, result}
+        {:error, :timeout}
 
       {:DOWN, ^monitor_ref, :process, ^pid, :killed} ->
         demonitor_cancel_target(cancel_monitor)
@@ -157,7 +181,7 @@ defmodule PtcRunner.Kernel.BoundedWorker do
 
         {:error, :cancelled}
     after
-      timeout_ms ->
+      remaining_timeout(deadline_ms) ->
         demonitor_cancel_target(cancel_monitor)
         run_timeout_cleanup_hook(timeout_cleanup_hook)
 
@@ -168,54 +192,118 @@ defmodule PtcRunner.Kernel.BoundedWorker do
     end
   end
 
-  defp start_worker(function, reply_alias, reply_ref, max_heap_words, false) do
-    {pid, monitor_ref} = spawn_worker(function, reply_alias, reply_ref, max_heap_words)
+  defp start_worker(
+         function,
+         reply_alias,
+         reply_ref,
+         max_heap_words,
+         false,
+         deadline_ms,
+         _startup_fault_hook
+       ) do
+    {pid, monitor_ref} =
+      spawn_worker(function, reply_alias, reply_ref, max_heap_words, deadline_ms)
+
     {:ok, pid, monitor_ref, nil}
   end
 
-  defp start_worker(function, reply_alias, reply_ref, max_heap_words, true) do
+  defp start_worker(
+         function,
+         reply_alias,
+         reply_ref,
+         max_heap_words,
+         true,
+         deadline_ms,
+         startup_fault_hook
+       ) do
     caller = self()
     guard_ref = make_ref()
+    start_ref = make_ref()
 
     {guard, guard_monitor} =
-      spawn_monitor(fn ->
-        caller_guard(caller, guard_ref, function, reply_alias, reply_ref, max_heap_words)
-      end)
+      spawn_monitor(fn -> caller_guard(caller, guard_ref) end)
+
+    {worker, worker_monitor} =
+      spawn_guarded_worker(
+        caller,
+        function,
+        reply_alias,
+        reply_ref,
+        max_heap_words,
+        start_ref,
+        deadline_ms
+      )
+
+    run_startup_fault_hook(startup_fault_hook, worker)
+    send(guard, {guard_ref, :watch, worker})
 
     receive do
-      {^guard_ref, pid, start_ref} ->
-        worker_monitor = Process.monitor(pid)
-        send(pid, {start_ref, :run})
-        {:ok, pid, worker_monitor, {guard, guard_monitor, guard_ref}}
+      {^guard_ref, :armed} ->
+        if deadline_live?(deadline_ms) do
+          send(worker, {start_ref, :run})
+          {:ok, worker, worker_monitor, {guard, guard_monitor, guard_ref}}
+        else
+          terminate(worker, worker_monitor, reply_alias, reply_ref)
+          release_caller_guard({guard, guard_monitor, guard_ref})
+          {:error, :timeout}
+        end
+
+      {:DOWN, ^worker_monitor, :process, ^worker, reason} ->
+        release_caller_guard({guard, guard_monitor, guard_ref})
+        {:error, worker_failure(reason)}
 
       {:DOWN, ^guard_monitor, :process, ^guard, _reason} ->
+        terminate(worker, worker_monitor, reply_alias, reply_ref)
         {:error, :worker_failed}
+    after
+      remaining_timeout(deadline_ms) ->
+        terminate(worker, worker_monitor, reply_alias, reply_ref)
+        release_caller_guard({guard, guard_monitor, guard_ref})
+        {:error, :timeout}
     end
   end
 
-  defp spawn_worker(function, reply_alias, reply_ref, max_heap_words) do
+  defp spawn_worker(function, reply_alias, reply_ref, max_heap_words, deadline_ms) do
     Process.spawn(
-      fn -> send(reply_alias, {reply_ref, function.()}) end,
+      fn -> execute_callback(function, reply_alias, reply_ref, deadline_ms) end,
       worker_spawn_options(max_heap_words)
     )
   end
 
-  defp caller_guard(caller, guard_ref, function, reply_alias, reply_ref, max_heap_words) do
+  defp caller_guard(caller, guard_ref) do
     caller_ref = Process.monitor(caller)
-    start_ref = make_ref()
 
-    {worker, worker_ref} =
-      spawn_guarded_worker(function, reply_alias, reply_ref, max_heap_words, start_ref)
+    receive do
+      {^guard_ref, :watch, worker} when is_pid(worker) ->
+        worker_ref = Process.monitor(worker)
+        send(caller, {guard_ref, :armed})
+        guard_worker(caller, caller_ref, guard_ref, worker, worker_ref)
 
-    send(caller, {guard_ref, worker, start_ref})
-    guard_worker(caller, caller_ref, guard_ref, worker, worker_ref)
+      {:DOWN, ^caller_ref, :process, ^caller, _reason} ->
+        :ok
+    end
   end
 
-  defp spawn_guarded_worker(function, reply_alias, reply_ref, max_heap_words, start_ref) do
+  defp spawn_guarded_worker(
+         caller,
+         function,
+         reply_alias,
+         reply_ref,
+         max_heap_words,
+         start_ref,
+         deadline_ms
+       ) do
     Process.spawn(
       fn ->
+        caller_ref = Process.monitor(caller)
+
         receive do
-          {^start_ref, :run} -> send(reply_alias, {reply_ref, function.()})
+          {^start_ref, :run} ->
+            Process.demonitor(caller_ref, [:flush])
+            execute_callback(function, reply_alias, reply_ref, deadline_ms)
+
+          {:DOWN, ^caller_ref, :process, ^caller, _reason} ->
+            :ok
         end
       end,
       worker_spawn_options(max_heap_words)
@@ -267,10 +355,39 @@ defmodule PtcRunner.Kernel.BoundedWorker do
   defp release_caller_guard({guard, guard_monitor, guard_ref}) do
     send(guard, {guard_ref, :release})
     await_down(guard, guard_monitor)
+    drain_guard_acknowledgement(guard_ref)
   end
 
   defp caller_guard_identity(nil), do: {nil, nil}
   defp caller_guard_identity({guard, guard_monitor, _guard_ref}), do: {guard, guard_monitor}
+
+  defp worker_failure(:killed), do: :heap_exceeded
+  defp worker_failure(_reason), do: :worker_failed
+
+  defp enforce_initial_heap_limit do
+    :erlang.garbage_collect()
+  end
+
+  defp execute_callback(function, reply_alias, reply_ref, deadline_ms) do
+    enforce_initial_heap_limit()
+
+    if deadline_live?(deadline_ms) do
+      result = function.()
+      send(reply_alias, {reply_ref, System.monotonic_time(:millisecond), result})
+    else
+      send(reply_alias, {reply_ref, :deadline_expired})
+    end
+  end
+
+  defp deadline_live?(deadline_ms),
+    do: System.monotonic_time(:millisecond) < deadline_ms
+
+  defp completed_before_deadline?(completed_at_ms, deadline_ms),
+    do: completed_at_ms < deadline_ms
+
+  defp remaining_timeout(deadline_ms) do
+    max(deadline_ms - System.monotonic_time(:millisecond), 0)
+  end
 
   defp monitor_cancel_target(nil), do: nil
   defp monitor_cancel_target(pid) when is_pid(pid), do: {pid, Process.monitor(pid)}
@@ -289,9 +406,21 @@ defmodule PtcRunner.Kernel.BoundedWorker do
   defp run_timeout_cleanup_hook(nil), do: :ok
   defp run_timeout_cleanup_hook(hook) when is_function(hook, 0), do: hook.()
 
+  defp run_startup_fault_hook(nil, _worker), do: :ok
+  defp run_startup_fault_hook(hook, worker) when is_function(hook, 1), do: hook.(worker)
+
   defp drain_result(reply_ref) do
     receive do
-      {^reply_ref, _late_result} -> :ok
+      {^reply_ref, _completed_at_ms, _late_result} -> :ok
+      {^reply_ref, :deadline_expired} -> :ok
+    after
+      0 -> :ok
+    end
+  end
+
+  defp drain_guard_acknowledgement(guard_ref) do
+    receive do
+      {^guard_ref, :armed} -> :ok
     after
       0 -> :ok
     end

--- a/lib/ptc_runner/kernel/bounded_worker.ex
+++ b/lib/ptc_runner/kernel/bounded_worker.ex
@@ -5,9 +5,10 @@ defmodule PtcRunner.Kernel.BoundedWorker do
   Results use a process alias so timeout cleanup can invalidate and drain a
   late reply before returning to the caller. Callers that are themselves
   disposable workers may opt into `:cancel_with_caller`; the bounded worker is
-  then linked for the duration of the call so an untrappable caller kill also
-  terminates blocked work. A caller may also supply a `:cancel_with` process;
-  its termination cancels the worker without coupling the two owners.
+  then covered by a monitor-based guard so caller death terminates blocked work
+  without changing the caller's exit-trapping semantics. A caller may also
+  supply a `:cancel_with` process; its termination cancels the worker without
+  coupling the two owners.
   """
 
   @doc """
@@ -64,38 +65,21 @@ defmodule PtcRunner.Kernel.BoundedWorker do
     cancel_with = Keyword.get(opts, :cancel_with)
     timeout_cleanup_hook = Keyword.get(opts, :timeout_cleanup_hook)
 
-    if cancel_with_caller? do
-      previous_trap_exit = Process.flag(:trap_exit, true)
-
-      try do
-        run_worker(
-          function,
-          timeout_ms,
-          max_heap_words,
-          true,
-          cancel_with,
-          timeout_cleanup_hook
-        )
-      after
-        Process.flag(:trap_exit, previous_trap_exit)
-      end
-    else
-      run_worker(
-        function,
-        timeout_ms,
-        max_heap_words,
-        false,
-        cancel_with,
-        timeout_cleanup_hook
-      )
-    end
+    run_worker(
+      function,
+      timeout_ms,
+      max_heap_words,
+      cancel_with_caller?,
+      cancel_with,
+      timeout_cleanup_hook
+    )
   end
 
   defp run_worker(
          function,
          timeout_ms,
          max_heap_words,
-         linked?,
+         cancel_with_caller?,
          cancel_with,
          timeout_cleanup_hook
        ) do
@@ -103,62 +87,73 @@ defmodule PtcRunner.Kernel.BoundedWorker do
     reply_ref = make_ref()
     cancel_monitor = monitor_cancel_target(cancel_with)
 
-    spawn_options =
-      [
-        {:max_heap_size,
-         %{
-           size: max_heap_words,
-           kill: true,
-           error_logger: false,
-           include_shared_binaries: true
-         }},
-        :monitor
-      ] ++ if(linked?, do: [:link], else: [])
+    case start_worker(
+           function,
+           reply_alias,
+           reply_ref,
+           max_heap_words,
+           cancel_with_caller?
+         ) do
+      {:ok, pid, monitor_ref, caller_guard} ->
+        await_worker(
+          pid,
+          monitor_ref,
+          caller_guard,
+          reply_alias,
+          reply_ref,
+          cancel_monitor,
+          timeout_ms,
+          timeout_cleanup_hook
+        )
 
-    {pid, monitor_ref} =
-      Process.spawn(
-        fn -> send(reply_alias, {reply_ref, function.()}) end,
-        spawn_options
-      )
+      {:error, :worker_failed} ->
+        demonitor_cancel_target(cancel_monitor)
+        Process.unalias(reply_alias)
+        {:error, :worker_failed}
+    end
+  end
+
+  defp await_worker(
+         pid,
+         monitor_ref,
+         caller_guard,
+         reply_alias,
+         reply_ref,
+         cancel_monitor,
+         timeout_ms,
+         timeout_cleanup_hook
+       ) do
+    {guard, guard_monitor} = caller_guard_identity(caller_guard)
 
     receive do
       {^reply_ref, result} ->
         demonitor_cancel_target(cancel_monitor)
         Process.unalias(reply_alias)
         await_down(pid, monitor_ref)
-        unlink(pid, linked?)
-        drain_exit(pid, linked?)
+        release_caller_guard(caller_guard)
         {:ok, result}
 
       {:DOWN, ^monitor_ref, :process, ^pid, :killed} ->
         demonitor_cancel_target(cancel_monitor)
         Process.unalias(reply_alias)
-        unlink(pid, linked?)
-        drain_exit(pid, linked?)
+        release_caller_guard(caller_guard)
         {:error, :heap_exceeded}
 
       {:DOWN, ^monitor_ref, :process, ^pid, _reason} ->
         demonitor_cancel_target(cancel_monitor)
         Process.unalias(reply_alias)
-        unlink(pid, linked?)
-        drain_exit(pid, linked?)
+        release_caller_guard(caller_guard)
         {:error, :worker_failed}
 
-      {:EXIT, ^pid, reason} when linked? ->
+      {:DOWN, ^guard_monitor, :process, ^guard, _reason} ->
         demonitor_cancel_target(cancel_monitor)
-        await_down(pid, monitor_ref)
-        Process.unlink(pid)
-        drain_exit(pid, true)
-
-        if reason == :killed,
-          do: {:error, :heap_exceeded},
-          else: {:error, :worker_failed}
+        terminate(pid, monitor_ref, reply_alias, reply_ref)
+        {:error, :worker_failed}
 
       {:DOWN, cancel_ref, :process, cancel_pid, _reason}
       when cancel_monitor == {cancel_pid, cancel_ref} ->
-        if linked?,
-          do: terminate_linked(pid, monitor_ref, reply_alias, reply_ref),
-          else: terminate(pid, monitor_ref, reply_alias, reply_ref)
+        terminate(pid, monitor_ref, reply_alias, reply_ref)
+        release_caller_guard(caller_guard)
 
         {:error, :cancelled}
     after
@@ -166,16 +161,116 @@ defmodule PtcRunner.Kernel.BoundedWorker do
         demonitor_cancel_target(cancel_monitor)
         run_timeout_cleanup_hook(timeout_cleanup_hook)
 
-        if linked?,
-          do: terminate_linked(pid, monitor_ref, reply_alias, reply_ref),
-          else: terminate(pid, monitor_ref, reply_alias, reply_ref)
+        terminate(pid, monitor_ref, reply_alias, reply_ref)
+        release_caller_guard(caller_guard)
 
         {:error, :timeout}
     end
   end
 
-  defp unlink(pid, true), do: Process.unlink(pid)
-  defp unlink(_pid, false), do: true
+  defp start_worker(function, reply_alias, reply_ref, max_heap_words, false) do
+    {pid, monitor_ref} = spawn_worker(function, reply_alias, reply_ref, max_heap_words)
+    {:ok, pid, monitor_ref, nil}
+  end
+
+  defp start_worker(function, reply_alias, reply_ref, max_heap_words, true) do
+    caller = self()
+    guard_ref = make_ref()
+
+    {guard, guard_monitor} =
+      spawn_monitor(fn ->
+        caller_guard(caller, guard_ref, function, reply_alias, reply_ref, max_heap_words)
+      end)
+
+    receive do
+      {^guard_ref, pid, start_ref} ->
+        worker_monitor = Process.monitor(pid)
+        send(pid, {start_ref, :run})
+        {:ok, pid, worker_monitor, {guard, guard_monitor, guard_ref}}
+
+      {:DOWN, ^guard_monitor, :process, ^guard, _reason} ->
+        {:error, :worker_failed}
+    end
+  end
+
+  defp spawn_worker(function, reply_alias, reply_ref, max_heap_words) do
+    Process.spawn(
+      fn -> send(reply_alias, {reply_ref, function.()}) end,
+      worker_spawn_options(max_heap_words)
+    )
+  end
+
+  defp caller_guard(caller, guard_ref, function, reply_alias, reply_ref, max_heap_words) do
+    caller_ref = Process.monitor(caller)
+    start_ref = make_ref()
+
+    {worker, worker_ref} =
+      spawn_guarded_worker(function, reply_alias, reply_ref, max_heap_words, start_ref)
+
+    send(caller, {guard_ref, worker, start_ref})
+    guard_worker(caller, caller_ref, guard_ref, worker, worker_ref)
+  end
+
+  defp spawn_guarded_worker(function, reply_alias, reply_ref, max_heap_words, start_ref) do
+    Process.spawn(
+      fn ->
+        receive do
+          {^start_ref, :run} -> send(reply_alias, {reply_ref, function.()})
+        end
+      end,
+      worker_spawn_options(max_heap_words)
+    )
+  end
+
+  defp worker_spawn_options(max_heap_words) do
+    [
+      {:max_heap_size,
+       %{
+         size: max_heap_words,
+         kill: true,
+         error_logger: false,
+         include_shared_binaries: true
+       }},
+      :monitor
+    ]
+  end
+
+  defp guard_worker(caller, caller_ref, guard_ref, worker, worker_ref) do
+    receive do
+      {^guard_ref, :release} ->
+        Process.demonitor(caller_ref, [:flush])
+        Process.demonitor(worker_ref, [:flush])
+        :ok
+
+      {:DOWN, ^caller_ref, :process, ^caller, _reason} ->
+        Process.exit(worker, :kill)
+        await_down(worker, worker_ref)
+
+      {:DOWN, ^worker_ref, :process, ^worker, _reason} ->
+        guard_after_worker(caller, caller_ref, guard_ref)
+    end
+  end
+
+  defp guard_after_worker(caller, caller_ref, guard_ref) do
+    receive do
+      {^guard_ref, :release} ->
+        Process.demonitor(caller_ref, [:flush])
+        :ok
+
+      {:DOWN, ^caller_ref, :process, ^caller, _reason} ->
+        :ok
+    end
+  end
+
+  defp release_caller_guard(nil), do: :ok
+
+  defp release_caller_guard({guard, guard_monitor, guard_ref}) do
+    send(guard, {guard_ref, :release})
+    await_down(guard, guard_monitor)
+  end
+
+  defp caller_guard_identity(nil), do: {nil, nil}
+  defp caller_guard_identity({guard, guard_monitor, _guard_ref}), do: {guard, guard_monitor}
 
   defp monitor_cancel_target(nil), do: nil
   defp monitor_cancel_target(pid) when is_pid(pid), do: {pid, Process.monitor(pid)}
@@ -189,25 +284,6 @@ defmodule PtcRunner.Kernel.BoundedWorker do
     receive do
       {:DOWN, ^monitor_ref, :process, ^pid, _reason} -> :ok
     end
-  end
-
-  defp drain_exit(pid, true) do
-    receive do
-      {:EXIT, ^pid, _reason} -> :ok
-    after
-      0 -> :ok
-    end
-  end
-
-  defp drain_exit(_pid, false), do: :ok
-
-  defp terminate_linked(pid, monitor_ref, reply_alias, reply_ref) do
-    Process.unalias(reply_alias)
-    Process.exit(pid, :kill)
-    await_down(pid, monitor_ref)
-    Process.unlink(pid)
-    drain_exit(pid, true)
-    drain_result(reply_ref)
   end
 
   defp run_timeout_cleanup_hook(nil), do: :ok

--- a/lib/ptc_runner/kernel/event_sink.ex
+++ b/lib/ptc_runner/kernel/event_sink.ex
@@ -376,9 +376,9 @@ defmodule PtcRunner.Kernel.EventSink do
 
   # Run identifiers must be unique across separate OS processes: traces from
   # independent CLI invocations commonly land in one directory, and
-  # `Kernel.TraceLog` fail-closes the whole directory source when two files
-  # reuse a run/trace identity with restarted sequences. A per-VM counter
-  # collides almost deterministically there, so the default carries entropy.
+  # `Kernel.TraceLog` isolates every connected file when two files reuse a
+  # run/trace identity with restarted sequences. A per-VM counter collides
+  # almost deterministically there, so the default carries entropy.
   defp default_run_id do
     "run-" <> Base.encode16(:crypto.strong_rand_bytes(6), case: :lower)
   end

--- a/lib/ptc_runner/kernel/run_analysis_capability.ex
+++ b/lib/ptc_runner/kernel/run_analysis_capability.ex
@@ -174,6 +174,9 @@ defmodule PtcRunner.Kernel.RunAnalysisCapability do
       {:error, :not_found} ->
         provider_error(:not_found, "analysis run not found")
 
+      {:error, :run_isolated} ->
+        provider_error(:unavailable, "analysis run is isolated by damaged trace evidence")
+
       {:error, :evidence_unavailable} ->
         provider_error(:invalid_request, "private evidence unavailable in this analysis recipe")
 

--- a/lib/ptc_runner/kernel/trace_directory_admission.ex
+++ b/lib/ptc_runner/kernel/trace_directory_admission.ex
@@ -1,0 +1,381 @@
+defmodule PtcRunner.Kernel.TraceDirectoryAdmission do
+  @moduledoc false
+
+  alias PtcRunner.Kernel.TraceLog
+
+  @reason_order [
+    :invalid_filename,
+    :not_regular,
+    :unreadable,
+    :malformed_jsonl,
+    :unsupported_version,
+    :filename_run_mismatch,
+    :run_identity_conflict,
+    :trace_identity_conflict,
+    :sequence_conflict,
+    :lifecycle_conflict,
+    :malformed_event
+  ]
+
+  @reason_rank @reason_order |> Enum.with_index() |> Map.new()
+  @normal_suffix ".jsonl"
+  @private_suffix ".private.jsonl"
+  @max_claim_bytes 256
+
+  @type source_kind :: :sanitized | :private
+  @type reason ::
+          :invalid_filename
+          | :not_regular
+          | :unreadable
+          | :malformed_jsonl
+          | :unsupported_version
+          | :filename_run_mismatch
+          | :run_identity_conflict
+          | :trace_identity_conflict
+          | :sequence_conflict
+          | :lifecycle_conflict
+          | :malformed_event
+
+  @type evidence_status ::
+          :not_regular | :unreadable | :malformed_jsonl | {:decoded, [map()]}
+
+  @type file_evidence :: %{
+          required(:raw_name) => binary(),
+          required(:source_name) => binary() | nil,
+          required(:source_kind) => source_kind(),
+          required(:filename_run_claim) => binary() | nil,
+          required(:embedded_run_claims) => [binary()],
+          required(:embedded_trace_claims) => [binary()],
+          required(:events) => [map()],
+          required(:status) => evidence_status(),
+          required(:reasons) => [reason()]
+        }
+
+  @type component :: %{
+          required(:sources) => [file_evidence()],
+          required(:source_count) => pos_integer(),
+          required(:source_names) => [binary()],
+          required(:sources_omitted_count) => non_neg_integer(),
+          required(:run_claims) => [binary()],
+          required(:trace_claims) => [binary()],
+          required(:reasons) => [reason()],
+          required(:admitted?) => boolean()
+        }
+
+  @type classification :: %{
+          required(:components) => [component()],
+          required(:admitted) => [file_evidence()],
+          required(:isolated) => [component()],
+          required(:known_isolated_run_ids) => MapSet.t(binary())
+        }
+
+  @spec reason_order() :: [reason()]
+  def reason_order, do: @reason_order
+
+  @spec evidence(binary(), source_kind(), evidence_status()) ::
+          {:ok, file_evidence()} | {:error, :invalid_evidence}
+  def evidence(raw_name, source_kind, status)
+      when is_binary(raw_name) and source_kind in [:sanitized, :private] do
+    with ^source_kind <- filename_source_kind(raw_name),
+         {:ok, events, status_reasons} <- status_evidence(status) do
+      filename_run_claim = filename_run_claim(raw_name, source_kind)
+      source_name = if filename_run_claim, do: raw_name
+      embedded_run_claims = claims(events, "run_id")
+      embedded_trace_claims = claims(events, "trace_id")
+
+      reasons =
+        []
+        |> maybe_add(is_nil(filename_run_claim), :invalid_filename)
+        |> Kernel.++(status_reasons)
+        |> Kernel.++(decoded_reasons(status, events, filename_run_claim, embedded_run_claims))
+        |> Kernel.++(semantic_reasons(status, events))
+        |> order_reasons()
+
+      {:ok,
+       %{
+         raw_name: raw_name,
+         source_name: source_name,
+         source_kind: source_kind,
+         filename_run_claim: filename_run_claim,
+         embedded_run_claims: embedded_run_claims,
+         embedded_trace_claims: embedded_trace_claims,
+         events: events,
+         status: status,
+         reasons: reasons
+       }}
+    else
+      _invalid -> {:error, :invalid_evidence}
+    end
+  end
+
+  def evidence(_raw_name, _source_kind, _status), do: {:error, :invalid_evidence}
+
+  @spec classify([file_evidence()]) :: {:ok, classification()} | {:error, :invalid_evidence}
+  def classify(evidence) when is_list(evidence) do
+    if Enum.all?(evidence, &valid_evidence?/1) do
+      classify_valid_evidence(evidence)
+    else
+      {:error, :invalid_evidence}
+    end
+  end
+
+  def classify(_evidence), do: {:error, :invalid_evidence}
+
+  defp classify_valid_evidence(evidence) do
+    indexed = evidence |> Enum.sort_by(& &1.raw_name) |> Enum.with_index()
+
+    components =
+      indexed
+      |> connected_indexes()
+      |> Enum.map(&build_component(&1, indexed))
+      |> Enum.sort_by(&component_sort_key/1)
+
+    isolated = Enum.reject(components, & &1.admitted?)
+
+    {:ok,
+     %{
+       components: components,
+       admitted: components |> Enum.filter(& &1.admitted?) |> Enum.flat_map(& &1.sources),
+       isolated: isolated,
+       known_isolated_run_ids: isolated |> Enum.flat_map(& &1.run_claims) |> MapSet.new()
+     }}
+  end
+
+  defp status_evidence({:decoded, events}) when is_list(events) do
+    if Enum.all?(events, &is_map/1),
+      do: {:ok, events, []},
+      else: {:error, :invalid_evidence}
+  end
+
+  defp status_evidence(:not_regular), do: {:ok, [], [:not_regular]}
+  defp status_evidence(:unreadable), do: {:ok, [], [:unreadable]}
+  defp status_evidence(:malformed_jsonl), do: {:ok, [], [:malformed_jsonl]}
+  defp status_evidence(_status), do: {:error, :invalid_evidence}
+
+  defp decoded_reasons({:decoded, []}, _events, _filename_claim, _run_claims),
+    do: [:malformed_jsonl]
+
+  defp decoded_reasons({:decoded, _decoded}, _events, filename_claim, run_claims) do
+    []
+    |> maybe_add(filename_mismatch?(filename_claim, run_claims), :filename_run_mismatch)
+  end
+
+  defp decoded_reasons(_status, _events, _filename_claim, _run_claims), do: []
+
+  defp semantic_reasons({:decoded, [_ | _]}, events),
+    do: TraceLog.directory_event_reasons(events)
+
+  defp semantic_reasons(_status, _events), do: []
+
+  defp filename_mismatch?(_filename_claim, run_claims) when length(run_claims) != 1, do: true
+  defp filename_mismatch?(nil, [_run_claim]), do: false
+  defp filename_mismatch?(filename_claim, [run_claim]), do: filename_claim != run_claim
+
+  defp claims(events, key) do
+    events
+    |> Enum.reduce(MapSet.new(), fn event, claims ->
+      case Map.get(event, key) do
+        claim when is_binary(claim) ->
+          if bounded_claim?(claim), do: MapSet.put(claims, claim), else: claims
+
+        _other ->
+          claims
+      end
+    end)
+    |> MapSet.to_list()
+    |> Enum.sort()
+  end
+
+  defp bounded_claim?(claim),
+    do: byte_size(claim) in 1..@max_claim_bytes and String.valid?(claim)
+
+  defp filename_run_claim(raw_name, source_kind) do
+    suffix = if source_kind == :private, do: @private_suffix, else: @normal_suffix
+
+    with true <- byte_size(raw_name) > byte_size(suffix),
+         true <-
+           binary_part(raw_name, byte_size(raw_name) - byte_size(suffix), byte_size(suffix)) ==
+             suffix,
+         stem_size = byte_size(raw_name) - byte_size(suffix),
+         stem = binary_part(raw_name, 0, stem_size),
+         true <- canonical_stem?(stem) do
+      stem
+    else
+      _invalid -> nil
+    end
+  end
+
+  defp canonical_stem?(stem) when byte_size(stem) in 1..@max_claim_bytes do
+    <<first, rest::binary>> = stem
+    ascii_alphanumeric?(first) and rest_bytes_valid?(rest)
+  end
+
+  defp canonical_stem?(_stem), do: false
+
+  defp rest_bytes_valid?(<<>>), do: true
+
+  defp rest_bytes_valid?(<<byte, rest::binary>>)
+       when (byte >= ?A and byte <= ?Z) or (byte >= ?a and byte <= ?z) or
+              (byte >= ?0 and byte <= ?9) or byte in [?., ?_, ?-],
+       do: rest_bytes_valid?(rest)
+
+  defp rest_bytes_valid?(_rest), do: false
+
+  defp ascii_alphanumeric?(byte),
+    do:
+      (byte >= ?A and byte <= ?Z) or (byte >= ?a and byte <= ?z) or
+        (byte >= ?0 and byte <= ?9)
+
+  defp filename_source_kind(raw_name) do
+    cond do
+      has_suffix?(raw_name, @private_suffix) -> :private
+      has_suffix?(raw_name, @normal_suffix) -> :sanitized
+      true -> nil
+    end
+  end
+
+  defp has_suffix?(value, suffix) when byte_size(value) >= byte_size(suffix),
+    do: binary_part(value, byte_size(value) - byte_size(suffix), byte_size(suffix)) == suffix
+
+  defp has_suffix?(_value, _suffix), do: false
+
+  defp valid_evidence?(
+         %{raw_name: raw_name, source_kind: source_kind, status: status} = candidate
+       ) do
+    case evidence(raw_name, source_kind, status) do
+      {:ok, expected} -> candidate == expected
+      {:error, :invalid_evidence} -> false
+    end
+  end
+
+  defp valid_evidence?(_evidence), do: false
+
+  defp connected_indexes(indexed) do
+    parents = Map.new(indexed, fn {_evidence, index} -> {index, index} end)
+
+    parents =
+      indexed
+      |> claim_groups()
+      |> Enum.reduce(parents, &union_group/2)
+
+    indexed
+    |> Enum.group_by(fn {_evidence, index} -> find_root(parents, index) end, &elem(&1, 1))
+    |> Map.values()
+  end
+
+  defp claim_groups(indexed) do
+    Enum.reduce(indexed, %{}, fn {evidence, index}, groups ->
+      claims =
+        Enum.map(all_run_claims(evidence), &{:run, &1}) ++
+          Enum.map(evidence.embedded_trace_claims, &{:trace, &1})
+
+      Enum.reduce(claims, groups, fn claim, acc ->
+        Map.update(acc, claim, [index], &[index | &1])
+      end)
+    end)
+    |> Map.values()
+  end
+
+  defp union_group([first | rest], parents),
+    do: Enum.reduce(rest, parents, &union_indexes(first, &1, &2))
+
+  defp union_group([], parents), do: parents
+
+  defp union_indexes(left, right, parents) do
+    left_root = find_root(parents, left)
+    right_root = find_root(parents, right)
+
+    if left_root == right_root,
+      do: parents,
+      else: Map.put(parents, max(left_root, right_root), min(left_root, right_root))
+  end
+
+  defp find_root(parents, index) do
+    case Map.fetch!(parents, index) do
+      ^index -> index
+      parent -> find_root(parents, parent)
+    end
+  end
+
+  defp build_component(indexes, indexed) do
+    by_index = Map.new(indexed, fn {evidence, index} -> {index, evidence} end)
+    sources = indexes |> Enum.map(&Map.fetch!(by_index, &1)) |> Enum.sort_by(& &1.raw_name)
+    run_claims = sources |> Enum.flat_map(&all_run_claims/1) |> Enum.uniq() |> Enum.sort()
+
+    trace_claims =
+      sources |> Enum.flat_map(& &1.embedded_trace_claims) |> Enum.uniq() |> Enum.sort()
+
+    reasons =
+      sources
+      |> Enum.flat_map(& &1.reasons)
+      |> maybe_add(run_claim_conflict?(sources), :run_identity_conflict)
+      |> maybe_add(trace_claim_conflict?(sources), :trace_identity_conflict)
+      |> order_reasons()
+
+    source_names = sources |> Enum.map(& &1.source_name) |> Enum.reject(&is_nil/1)
+
+    %{
+      sources: sources,
+      source_count: length(sources),
+      source_names: source_names,
+      sources_omitted_count: length(sources) - length(source_names),
+      run_claims: run_claims,
+      trace_claims: trace_claims,
+      reasons: reasons,
+      admitted?: admitted?(sources, reasons)
+    }
+  end
+
+  defp all_run_claims(evidence) do
+    [evidence.filename_run_claim | evidence.embedded_run_claims]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.uniq()
+  end
+
+  defp run_claim_conflict?(sources) do
+    repeated_claim?(sources, &all_run_claims/1)
+  end
+
+  defp trace_claim_conflict?(sources) do
+    repeated_claim?(sources, & &1.embedded_trace_claims) or
+      Enum.any?(sources, &(length(&1.embedded_trace_claims) > 1)) or
+      trace_maps_to_multiple_runs?(sources)
+  end
+
+  defp repeated_claim?(sources, claims) do
+    sources
+    |> Enum.flat_map(fn source -> Enum.map(claims.(source), &{&1, source.raw_name}) end)
+    |> Enum.group_by(&elem(&1, 0), &elem(&1, 1))
+    |> Enum.any?(fn {_claim, names} -> names |> Enum.uniq() |> length() > 1 end)
+  end
+
+  defp trace_maps_to_multiple_runs?(sources) do
+    sources
+    |> Enum.flat_map(fn source ->
+      for trace_id <- source.embedded_trace_claims,
+          run_id <- source.embedded_run_claims,
+          do: {trace_id, run_id}
+    end)
+    |> Enum.group_by(&elem(&1, 0), &elem(&1, 1))
+    |> Enum.any?(fn {_trace_id, run_ids} -> run_ids |> Enum.uniq() |> length() > 1 end)
+  end
+
+  defp admitted?([source], []) do
+    source.status != :malformed_jsonl and match?({:decoded, [_ | _]}, source.status) and
+      source.embedded_run_claims == [source.filename_run_claim] and
+      length(source.embedded_trace_claims) == 1
+  end
+
+  defp admitted?(_sources, _reasons), do: false
+
+  defp component_sort_key(component), do: Enum.map(component.sources, & &1.raw_name)
+
+  defp maybe_add(values, true, value), do: [value | values]
+  defp maybe_add(values, false, _value), do: values
+
+  defp order_reasons(reasons) do
+    reasons
+    |> Enum.uniq()
+    |> Enum.sort_by(&Map.fetch!(@reason_rank, &1))
+  end
+end

--- a/lib/ptc_runner/kernel/trace_directory_admission.ex
+++ b/lib/ptc_runner/kernel/trace_directory_admission.ex
@@ -1,7 +1,7 @@
 defmodule PtcRunner.Kernel.TraceDirectoryAdmission do
   @moduledoc false
 
-  alias PtcRunner.Kernel.TraceLog
+  alias PtcRunner.Kernel.TraceEventValidation
 
   @reason_order [
     :invalid_filename,
@@ -48,6 +48,7 @@ defmodule PtcRunner.Kernel.TraceDirectoryAdmission do
           required(:embedded_trace_claims) => [binary()],
           required(:events) => [map()],
           required(:status) => evidence_status(),
+          required(:semantic_reasons) => [reason()],
           required(:reasons) => [reason()]
         }
 
@@ -77,38 +78,20 @@ defmodule PtcRunner.Kernel.TraceDirectoryAdmission do
   def evidence(raw_name, source_kind, status)
       when is_binary(raw_name) and source_kind in [:sanitized, :private] do
     with ^source_kind <- filename_source_kind(raw_name),
-         {:ok, events, status_reasons} <- status_evidence(status) do
-      filename_run_claim = filename_run_claim(raw_name, source_kind)
-      source_name = if filename_run_claim, do: raw_name
-      embedded_run_claims = claims(events, "run_id")
-      embedded_trace_claims = claims(events, "trace_id")
-
-      reasons =
-        []
-        |> maybe_add(is_nil(filename_run_claim), :invalid_filename)
-        |> Kernel.++(status_reasons)
-        |> Kernel.++(decoded_reasons(status, events, filename_run_claim, embedded_run_claims))
-        |> Kernel.++(semantic_reasons(status, events))
-        |> order_reasons()
-
-      {:ok,
-       %{
-         raw_name: raw_name,
-         source_name: source_name,
-         source_kind: source_kind,
-         filename_run_claim: filename_run_claim,
-         embedded_run_claims: embedded_run_claims,
-         embedded_trace_claims: embedded_trace_claims,
-         events: events,
-         status: status,
-         reasons: reasons
-       }}
+         {:ok, events, _status_reasons} <- status_evidence(status),
+         semantic_reasons = validate_semantics(status, events),
+         true <- valid_semantic_reasons?(semantic_reasons) do
+      {:ok, build_evidence(raw_name, source_kind, status, semantic_reasons)}
     else
       _invalid -> {:error, :invalid_evidence}
     end
   end
 
   def evidence(_raw_name, _source_kind, _status), do: {:error, :invalid_evidence}
+
+  @spec source_kind(binary()) :: source_kind() | nil
+  def source_kind(raw_name) when is_binary(raw_name), do: filename_source_kind(raw_name)
+  def source_kind(_raw_name), do: nil
 
   @spec classify([file_evidence()]) :: {:ok, classification()} | {:error, :invalid_evidence}
   def classify(evidence) when is_list(evidence) do
@@ -162,10 +145,46 @@ defmodule PtcRunner.Kernel.TraceDirectoryAdmission do
 
   defp decoded_reasons(_status, _events, _filename_claim, _run_claims), do: []
 
-  defp semantic_reasons({:decoded, [_ | _]}, events),
-    do: TraceLog.directory_event_reasons(events)
+  defp validate_semantics({:decoded, [_ | _]}, events),
+    do: TraceEventValidation.directory_reasons(events)
 
-  defp semantic_reasons(_status, _events), do: []
+  defp validate_semantics(_status, _events), do: []
+
+  defp valid_semantic_reasons?(reasons) when is_list(reasons) do
+    allowed = [:unsupported_version, :sequence_conflict, :lifecycle_conflict, :malformed_event]
+    Enum.all?(reasons, &(&1 in allowed)) and reasons == order_reasons(reasons)
+  end
+
+  defp valid_semantic_reasons?(_reasons), do: false
+
+  defp build_evidence(raw_name, source_kind, status, semantic_reasons) do
+    {:ok, events, status_reasons} = status_evidence(status)
+    filename_run_claim = filename_run_claim(raw_name, source_kind)
+    source_name = if filename_run_claim, do: raw_name
+    embedded_run_claims = claims(events, "run_id")
+    embedded_trace_claims = claims(events, "trace_id")
+
+    reasons =
+      []
+      |> maybe_add(is_nil(filename_run_claim), :invalid_filename)
+      |> Kernel.++(status_reasons)
+      |> Kernel.++(decoded_reasons(status, events, filename_run_claim, embedded_run_claims))
+      |> Kernel.++(semantic_reasons)
+      |> order_reasons()
+
+    %{
+      raw_name: raw_name,
+      source_name: source_name,
+      source_kind: source_kind,
+      filename_run_claim: filename_run_claim,
+      embedded_run_claims: embedded_run_claims,
+      embedded_trace_claims: embedded_trace_claims,
+      events: events,
+      status: status,
+      semantic_reasons: semantic_reasons,
+      reasons: reasons
+    }
+  end
 
   defp filename_mismatch?(_filename_claim, run_claims) when length(run_claims) != 1, do: true
   defp filename_mismatch?(nil, [_run_claim]), do: false
@@ -240,12 +259,19 @@ defmodule PtcRunner.Kernel.TraceDirectoryAdmission do
   defp has_suffix?(_value, _suffix), do: false
 
   defp valid_evidence?(
-         %{raw_name: raw_name, source_kind: source_kind, status: status} = candidate
+         %{
+           raw_name: raw_name,
+           source_kind: source_kind,
+           status: status,
+           events: events,
+           semantic_reasons: semantic_reasons
+         } = candidate
        ) do
-    case evidence(raw_name, source_kind, status) do
-      {:ok, expected} -> candidate == expected
-      {:error, :invalid_evidence} -> false
-    end
+    filename_source_kind(raw_name) == source_kind and valid_semantic_reasons?(semantic_reasons) and
+      candidate ==
+        build_evidence(raw_name, source_kind, status, validate_semantics(status, events))
+  rescue
+    _exception -> false
   end
 
   defp valid_evidence?(_evidence), do: false

--- a/lib/ptc_runner/kernel/trace_event_validation.ex
+++ b/lib/ptc_runner/kernel/trace_event_validation.ex
@@ -1,0 +1,423 @@
+defmodule PtcRunner.Kernel.TraceEventValidation do
+  @moduledoc false
+
+  alias PtcRunner.Kernel.JSONValue
+  alias PtcRunner.Kernel.LLMUsageSummary
+  alias PtcRunner.Kernel.ResultIdentity
+
+  @event_type ~r/\A[a-z][a-z0-9-]{0,127}\z/
+  @bundle_hash ~r/\A[0-9a-f]{64}\z/
+  @event_keys ~w(schema_version run_id trace_id sequence timestamp type data)
+  @max_string_bytes 256
+
+  @spec validate([map()]) :: :ok | {:error, :malformed_source | :unsupported_version}
+  def validate(events) when is_list(events) do
+    initial = %{
+      sequences: %{},
+      run_traces: %{},
+      trace_runs: %{},
+      run_lifecycles: %{},
+      evaluation_lifecycles: %{}
+    }
+
+    Enum.reduce_while(events, {:ok, initial}, fn event, {:ok, state} ->
+      with :ok <- validate_event(event),
+           trace_id = event["trace_id"],
+           run_id = event["run_id"],
+           sequence = event["sequence"],
+           previous = Map.get(state.sequences, trace_id, 0),
+           true <- sequence > previous,
+           :ok <- same_identity(state, run_id, trace_id),
+           {:ok, run_lifecycles} <-
+             advance_run_lifecycle(state.run_lifecycles, run_id, event["type"]),
+           {:ok, evaluation_lifecycles} <-
+             advance_evaluation_lifecycle(state.evaluation_lifecycles, run_id, event) do
+        {:cont,
+         {:ok,
+          %{
+            sequences: Map.put(state.sequences, trace_id, sequence),
+            run_traces: Map.put(state.run_traces, run_id, trace_id),
+            trace_runs: Map.put(state.trace_runs, trace_id, run_id),
+            run_lifecycles: run_lifecycles,
+            evaluation_lifecycles: evaluation_lifecycles
+          }}}
+      else
+        {:error, reason} -> {:halt, {:error, reason}}
+        _invalid -> {:halt, {:error, :malformed_source}}
+      end
+    end)
+    |> case do
+      {:ok, _state} -> :ok
+      {:error, _reason} = error -> error
+    end
+  end
+
+  @spec directory_reasons([map()]) ::
+          [
+            :unsupported_version
+            | :sequence_conflict
+            | :lifecycle_conflict
+            | :malformed_event
+          ]
+  def directory_reasons(events) when is_list(events) do
+    []
+    |> maybe_directory_reason(unsupported_directory_version?(events), :unsupported_version)
+    |> maybe_directory_reason(directory_sequence_conflict?(events), :sequence_conflict)
+    |> maybe_directory_reason(directory_lifecycle_conflict?(events), :lifecycle_conflict)
+    |> maybe_directory_reason(directory_malformed_event?(events), :malformed_event)
+  end
+
+  defp unsupported_directory_version?(events) do
+    Enum.any?(events, fn event ->
+      case Map.fetch(event, "schema_version") do
+        {:ok, version} when is_integer(version) -> version != 2
+        _other -> false
+      end
+    end)
+  end
+
+  defp directory_sequence_conflict?(events) do
+    Enum.reduce_while(events, %{}, fn event, sequences ->
+      case {event["trace_id"], event["sequence"]} do
+        {trace_id, sequence} when is_binary(trace_id) and is_integer(sequence) and sequence > 0 ->
+          cond do
+            valid_event_id(trace_id) != :ok ->
+              {:cont, sequences}
+
+            sequence > Map.get(sequences, trace_id, 0) ->
+              {:cont, Map.put(sequences, trace_id, sequence)}
+
+            true ->
+              {:halt, :conflict}
+          end
+
+        {trace_id, _sequence} when is_binary(trace_id) ->
+          if valid_event_id(trace_id) == :ok,
+            do: {:halt, :conflict},
+            else: {:cont, sequences}
+
+        _invalid_identity ->
+          {:cont, sequences}
+      end
+    end) == :conflict
+  end
+
+  defp directory_lifecycle_conflict?(events) do
+    Enum.reduce_while(events, %{}, &advance_directory_run_lifecycle/2) == :conflict or
+      Enum.reduce_while(events, %{}, &advance_directory_evaluation_lifecycle/2) == :conflict
+  end
+
+  defp advance_directory_run_lifecycle(
+         %{"run_id" => run_id, "type" => type},
+         lifecycles
+       )
+       when is_binary(run_id) and is_binary(type) do
+    if directory_lifecycle_identity?(run_id, type),
+      do: lifecycle_reduction(advance_run_lifecycle(lifecycles, run_id, type)),
+      else: {:cont, lifecycles}
+  end
+
+  defp advance_directory_run_lifecycle(_event, lifecycles), do: {:cont, lifecycles}
+
+  defp advance_directory_evaluation_lifecycle(
+         %{"run_id" => run_id, "type" => type, "data" => data} = event,
+         lifecycles
+       )
+       when is_binary(run_id) and is_binary(type) and is_map(data) do
+    if directory_lifecycle_identity?(run_id, type),
+      do: lifecycle_reduction(advance_evaluation_lifecycle(lifecycles, run_id, event)),
+      else: {:cont, lifecycles}
+  end
+
+  defp advance_directory_evaluation_lifecycle(_event, lifecycles),
+    do: {:cont, lifecycles}
+
+  defp lifecycle_reduction({:ok, advanced}), do: {:cont, advanced}
+  defp lifecycle_reduction({:error, _reason}), do: {:halt, :conflict}
+
+  defp directory_lifecycle_identity?(run_id, type),
+    do: valid_event_id(run_id) == :ok and type =~ @event_type
+
+  defp directory_malformed_event?(events),
+    do: Enum.any?(events, &match?({:error, _reason}, directory_event_shape(&1)))
+
+  defp directory_event_shape(event) when is_map(event) do
+    event
+    |> Map.put("schema_version", normalized_directory_version(event["schema_version"]))
+    |> Map.put("sequence", normalized_directory_sequence(event["sequence"]))
+    |> validate_event()
+    |> case do
+      :ok -> :ok
+      {:error, _reason} -> {:error, :malformed_event}
+    end
+  end
+
+  defp directory_event_shape(_event), do: {:error, :malformed_event}
+
+  defp normalized_directory_version(version) when is_integer(version) and version != 2, do: 2
+  defp normalized_directory_version(version), do: version
+
+  defp normalized_directory_sequence(sequence)
+       when not is_integer(sequence) or sequence <= 0,
+       do: 1
+
+  defp normalized_directory_sequence(sequence), do: sequence
+
+  defp maybe_directory_reason(reasons, true, reason), do: reasons ++ [reason]
+  defp maybe_directory_reason(reasons, false, _reason), do: reasons
+
+  defp advance_run_lifecycle(run_lifecycles, run_id, type) do
+    case {Map.get(run_lifecycles, run_id), type} do
+      {nil, "run-started"} ->
+        {:ok, Map.put(run_lifecycles, run_id, :open)}
+
+      {:open, "run-stopped"} ->
+        {:ok, Map.put(run_lifecycles, run_id, :stopped)}
+
+      {:open, "run-started"} ->
+        {:error, :malformed_source}
+
+      {:open, _type} ->
+        {:ok, run_lifecycles}
+
+      {_lifecycle, _type} ->
+        {:error, :malformed_source}
+    end
+  end
+
+  defp advance_evaluation_lifecycle(evaluations, run_id, %{
+         "type" => "evaluation-started",
+         "data" => data
+       }) do
+    evaluation_id = data["evaluation_id"]
+    environment = stringify(data["environment"])
+    parent_evaluation_id = data["parent_evaluation_id"]
+    key = {run_id, evaluation_id}
+
+    with :ok <- valid_event_id(evaluation_id),
+         false <- Map.has_key?(evaluations, key),
+         :ok <- validate_parent_evaluation(evaluations, run_id, environment, parent_evaluation_id) do
+      {:ok,
+       Map.put(evaluations, key, %{
+         environment: environment,
+         parent_evaluation_id: parent_evaluation_id,
+         lifecycle: :open
+       })}
+    else
+      _invalid -> {:error, :malformed_source}
+    end
+  end
+
+  defp advance_evaluation_lifecycle(evaluations, run_id, %{
+         "type" => "evaluation-stopped",
+         "data" => data
+       }) do
+    evaluation_id = data["evaluation_id"]
+    environment = stringify(data["environment"])
+    parent_evaluation_id = data["parent_evaluation_id"]
+    key = {run_id, evaluation_id}
+
+    with :ok <- valid_event_id(evaluation_id),
+         %{lifecycle: :open} = started <- Map.get(evaluations, key),
+         true <- started.environment == environment,
+         true <- started.parent_evaluation_id == parent_evaluation_id do
+      {:ok, put_in(evaluations, [key, :lifecycle], :stopped)}
+    else
+      nil when is_nil(parent_evaluation_id) -> {:ok, evaluations}
+      _invalid -> {:error, :malformed_source}
+    end
+  end
+
+  defp advance_evaluation_lifecycle(evaluations, _run_id, %{"data" => data}) do
+    if Map.has_key?(data, "parent_evaluation_id"),
+      do: {:error, :malformed_source},
+      else: {:ok, evaluations}
+  end
+
+  defp validate_parent_evaluation(_evaluations, _run_id, _environment, nil), do: :ok
+
+  defp validate_parent_evaluation(evaluations, run_id, "mission", parent_evaluation_id) do
+    with :ok <- valid_event_id(parent_evaluation_id),
+         %{environment: "workflow", lifecycle: :open, parent_evaluation_id: nil} <-
+           Map.get(evaluations, {run_id, parent_evaluation_id}) do
+      :ok
+    else
+      _invalid -> {:error, :malformed_source}
+    end
+  end
+
+  defp validate_parent_evaluation(_evaluations, _run_id, _environment, _parent_evaluation_id),
+    do: {:error, :malformed_source}
+
+  defp valid_event_id(value), do: valid_string(value)
+
+  defp same_identity(state, run_id, trace_id) do
+    with existing_trace when existing_trace in [nil, trace_id] <-
+           Map.get(state.run_traces, run_id),
+         existing_run when existing_run in [nil, run_id] <- Map.get(state.trace_runs, trace_id) do
+      :ok
+    else
+      _other -> {:error, :malformed_source}
+    end
+  end
+
+  defp validate_event(event) when is_map(event) do
+    with true <- Enum.sort(Map.keys(event)) == Enum.sort(@event_keys),
+         2 <- event["schema_version"],
+         :ok <- valid_string(event["run_id"]),
+         :ok <- valid_string(event["trace_id"]),
+         sequence when is_integer(sequence) and sequence > 0 <- event["sequence"],
+         timestamp when is_binary(timestamp) <- event["timestamp"],
+         {:ok, _datetime, 0} <- DateTime.from_iso8601(timestamp),
+         type when is_binary(type) <- event["type"],
+         true <- type =~ @event_type,
+         true <- JSONValue.map?(event["data"]),
+         :ok <- validate_event_data(type, event["data"]) do
+      :ok
+    else
+      version when is_integer(version) and version != 2 -> {:error, :unsupported_version}
+      _invalid -> {:error, :malformed_source}
+    end
+  end
+
+  defp validate_event(_event), do: {:error, :malformed_source}
+
+  defp validate_event_data(type, data) do
+    with :ok <- validate_current_event_data(type, data),
+         :ok <- validate_run_stopped_usage(type, data) do
+      validate_run_stopped_result_hash(type, data)
+    end
+  end
+
+  defp validate_run_stopped_result_hash("run-stopped", data) do
+    case Map.fetch(data, "result_hash") do
+      :error ->
+        :ok
+
+      {:ok, result_hash} ->
+        if stringify(data["outcome"]) == "ok" and ResultIdentity.valid_hash?(result_hash),
+          do: :ok,
+          else: {:error, :malformed_source}
+    end
+  end
+
+  defp validate_run_stopped_result_hash(_type, _data), do: :ok
+
+  defp validate_current_event_data("run-started", data) do
+    singular =
+      ~w(mission_prelude mission_inventory_hash mission_inventory_bytes mission_model_context_hash mission_model_context_bytes)
+
+    if is_map(data["missions"]) and Enum.all?(singular, &(not Map.has_key?(data, &1))) and
+         not Map.has_key?(data, "mission_name") and
+         valid_prelude_projection?(data["workflow_prelude"]) and
+         valid_mission_preludes?(data["missions"]) do
+      :ok
+    else
+      {:error, :malformed_source}
+    end
+  end
+
+  defp validate_current_event_data(type, data) when type in ["run-stopped", "events-dropped"] do
+    if Map.has_key?(data, "mission_name"), do: {:error, :malformed_source}, else: :ok
+  end
+
+  defp validate_current_event_data(_type, data) do
+    case stringify(data["environment"]) do
+      "mission" ->
+        if valid_string(data["mission_name"]) == :ok,
+          do: :ok,
+          else: {:error, :malformed_source}
+
+      "workflow" ->
+        if Map.has_key?(data, "mission_name"), do: {:error, :malformed_source}, else: :ok
+
+      _other ->
+        if Map.has_key?(data, "mission_name"), do: {:error, :malformed_source}, else: :ok
+    end
+  end
+
+  defp valid_mission_preludes?(missions) do
+    Enum.all?(missions, fn {_name, metadata} ->
+      is_map(metadata) and valid_prelude_projection?(metadata["prelude"])
+    end)
+  end
+
+  defp valid_prelude_projection?(nil), do: true
+
+  defp valid_prelude_projection?(prelude) when is_map(prelude) do
+    component_ids = prelude["component_ids"]
+
+    is_list(component_ids) and Enum.all?(component_ids, &(valid_string(&1) == :ok)) and
+      component_ids == Enum.uniq(component_ids) and
+      valid_prelude_hash?(prelude["hash"], component_ids) and
+      valid_dependency_indices?(prelude["dependency_indices"], length(component_ids))
+  end
+
+  defp valid_prelude_projection?(_prelude), do: false
+
+  defp valid_prelude_hash?(nil, component_ids), do: component_ids == []
+  defp valid_prelude_hash?(hash, _component_ids) when is_binary(hash), do: hash =~ @bundle_hash
+  defp valid_prelude_hash?(_hash, _component_ids), do: false
+
+  defp valid_dependency_indices?(dependency_indices, count) when is_list(dependency_indices) do
+    length(dependency_indices) == count and
+      dependency_indices
+      |> Enum.with_index()
+      |> Enum.all?(fn {indices, position} -> valid_dependency_list?(indices, position) end)
+  end
+
+  defp valid_dependency_indices?(_dependency_indices, _count), do: false
+
+  defp valid_dependency_list?(indices, position) when is_list(indices) do
+    Enum.all?(indices, &(is_integer(&1) and &1 >= 0 and &1 < position)) and
+      indices == Enum.sort(indices) and indices == Enum.uniq(indices)
+  end
+
+  defp valid_dependency_list?(_indices, _position), do: false
+
+  defp validate_run_stopped_usage("run-stopped", data) do
+    case Map.fetch(data, "usage") do
+      :error ->
+        :ok
+
+      {:ok, usage} when is_map(usage) ->
+        with :ok <- validate_subordinate_source_checks(usage),
+             do: validate_terminal_llm_spend(usage)
+
+      _invalid_usage ->
+        {:error, :malformed_source}
+    end
+  end
+
+  defp validate_run_stopped_usage(_type, _data), do: :ok
+
+  defp validate_subordinate_source_checks(usage) do
+    case Map.fetch(usage, "subordinate_source_checks") do
+      :error -> :ok
+      {:ok, count} when is_integer(count) and count >= 0 -> :ok
+      _invalid_count -> {:error, :malformed_source}
+    end
+  end
+
+  defp validate_terminal_llm_spend(usage) do
+    case Map.fetch(usage, "llm_spend") do
+      :error ->
+        :ok
+
+      {:ok, spend} ->
+        case LLMUsageSummary.validate_spend(spend) do
+          {:ok, _spend} -> :ok
+          {:error, :invalid_llm_spend} -> {:error, :malformed_source}
+        end
+    end
+  end
+
+  defp valid_string(value)
+       when is_binary(value) and byte_size(value) in 1..@max_string_bytes,
+       do: if(String.valid?(value), do: :ok, else: {:error, :malformed_source})
+
+  defp valid_string(_value), do: {:error, :malformed_source}
+
+  defp stringify(value) when is_atom(value), do: Atom.to_string(value)
+  defp stringify(value), do: value
+end

--- a/lib/ptc_runner/kernel/trace_isolation_presentation.ex
+++ b/lib/ptc_runner/kernel/trace_isolation_presentation.ex
@@ -1,0 +1,87 @@
+defmodule PtcRunner.Kernel.TraceIsolationPresentation do
+  @moduledoc false
+
+  alias PtcRunner.Kernel.TraceDirectoryAdmission
+
+  @max_examples 16
+  @max_example_sources 8
+
+  @spec metadata([TraceDirectoryAdmission.component()], MapSet.t(binary())) :: map()
+  def metadata([], %MapSet{}), do: %{}
+
+  def metadata(components, %MapSet{} = known_run_ids) when is_list(components) do
+    examples = components |> Enum.take(@max_examples) |> Enum.map(&example/1)
+
+    %{
+      "isolation" => %{
+        "component_count" => length(components),
+        "source_count" => total_sources(components),
+        "known_run_count" => MapSet.size(known_run_ids),
+        "reasons" => reason_totals(components),
+        "examples" => examples,
+        "examples_omitted_count" => length(components) - length(examples)
+      }
+    }
+  end
+
+  @spec shrink(map()) :: {:ok, map()} | :exhausted
+  def shrink(%{"isolation" => %{"examples" => []}}), do: :exhausted
+
+  def shrink(%{"isolation" => %{"examples" => examples} = isolation} = metadata)
+      when is_list(examples) do
+    {leading, [last]} = Enum.split(examples, -1)
+
+    next_isolation =
+      case last["sources"] do
+        [] ->
+          isolation
+          |> Map.put("examples", leading)
+          |> Map.update!("examples_omitted_count", &(&1 + 1))
+
+        sources ->
+          next_last =
+            last
+            |> Map.put("sources", Enum.drop(sources, -1))
+            |> Map.update!("sources_omitted_count", &(&1 + 1))
+
+          Map.put(isolation, "examples", leading ++ [next_last])
+      end
+
+    {:ok, Map.put(metadata, "isolation", next_isolation)}
+  end
+
+  def shrink(_metadata), do: :exhausted
+
+  defp example(component) do
+    sources = Enum.take(component.source_names, @max_example_sources)
+
+    %{
+      "sources" => sources,
+      "source_count" => component.source_count,
+      "sources_omitted_count" => component.source_count - length(sources),
+      "reasons" => Enum.map(component.reasons, &Atom.to_string/1)
+    }
+  end
+
+  defp reason_totals(components) do
+    TraceDirectoryAdmission.reason_order()
+    |> Enum.flat_map(fn reason ->
+      matching = Enum.filter(components, &(reason in &1.reasons))
+
+      if matching == [] do
+        []
+      else
+        [
+          %{
+            "reason" => Atom.to_string(reason),
+            "component_count" => length(matching),
+            "source_count" => total_sources(matching)
+          }
+        ]
+      end
+    end)
+  end
+
+  defp total_sources(components),
+    do: Enum.reduce(components, 0, fn component, total -> total + component.source_count end)
+end

--- a/lib/ptc_runner/kernel/trace_log.ex
+++ b/lib/ptc_runner/kernel/trace_log.ex
@@ -3,11 +3,13 @@ defmodule PtcRunner.Kernel.TraceLog do
   Bounded canonical trace loading, validation, filtering, and pagination.
 
   A source is an in-memory `PtcRunner.Kernel.EventSink`, one JSONL file, or a
-  directory of JSONL files. Loading validates the complete event envelope,
-  schema version, JSON-like data, run/trace identity, timestamps, and monotonic
-  sequence before deriving query results. Each run must begin with exactly one
-  `run-started`; it may remain open or end with exactly one final
-  `run-stopped`.
+  directory of JSONL files. Explicit files validate one complete aggregate.
+  Immutable directory capture instead treats each
+  `<run-id>[.private].jsonl` member as one filename-bound run, proves the
+  selected namespace and bytes stable, and isolates a damaged connected
+  identity component without hiding disjoint healthy runs. Each admitted run
+  validates the complete event envelope, schema version, JSON-like data,
+  run/trace identity, timestamps, monotonic sequence, and lifecycle.
 
   Supported query operations are:
 
@@ -25,6 +27,10 @@ defmodule PtcRunner.Kernel.TraceLog do
   suffix; private files require an explicit source.
   Internal immutable capture may use a private authority that admits both
   normal and private trace files while retaining accurate per-run provenance.
+  Its `directory_admission_v1` identity commits to every selected raw name,
+  content digest, classification, admitted event, provenance claim, and full
+  isolation component, but excludes absolute paths, opposite-class names, and
+  advisory exclusion counts.
 
   The internal trace-snapshot owner uses this module's canonical validation and
   query execution against one immutable directory capture or one exact selected
@@ -40,8 +46,9 @@ defmodule PtcRunner.Kernel.TraceLog do
   alias PtcRunner.Kernel.LLMUsageSummary
   alias PtcRunner.Kernel.PrivateDirectory
   alias PtcRunner.Kernel.PublicationHandle
-  alias PtcRunner.Kernel.ResultIdentity
   alias PtcRunner.Kernel.ResultLimit
+  alias PtcRunner.Kernel.TraceDirectoryAdmission
+  alias PtcRunner.Kernel.TraceEventValidation
   alias PtcRunner.Kernel.TracePublication
 
   @default_source_bytes 8_000_000
@@ -54,9 +61,6 @@ defmodule PtcRunner.Kernel.TraceLog do
   @max_limit 100
   @max_cursor_bytes 1_024
   @max_string_bytes 256
-  @event_type ~r/\A[a-z][a-z0-9-]{0,127}\z/
-  @bundle_hash ~r/\A[0-9a-f]{64}\z/
-  @event_keys ~w(schema_version run_id trace_id sequence timestamp type data)
   @append_lock_timeout_ms 30_000
   @append_lock_helper ~S"""
   set -eu
@@ -1877,8 +1881,7 @@ defmodule PtcRunner.Kernel.TraceLog do
     do: trace_file_name?(name) and private_path?(name) == (source_kind == :private)
 
   defp trace_file_name?(name) do
-    Path.basename(name) == name and String.ends_with?(name, ".jsonl") and
-      not inspection_path?(name)
+    TraceDirectoryAdmission.source_kind(name) in [:sanitized, :private]
   end
 
   defp capture_directory_files(
@@ -1891,7 +1894,7 @@ defmodule PtcRunner.Kernel.TraceLog do
          capture_hook,
          listing_hook
        ) do
-    with {:ok, before_inventory, excluded} <-
+    with {:ok, before_inventory, _initial_excluded} <-
            directory_inventory(
              directory,
              source_kind,
@@ -1900,8 +1903,8 @@ defmodule PtcRunner.Kernel.TraceLog do
              include_sanitized,
              listing_hook
            ) do
-      directory
-      |> capture_inventory(
+      capture_directory_inventory(
+        directory,
         before_inventory,
         max_source_bytes,
         capture_hook,
@@ -1914,19 +1917,113 @@ defmodule PtcRunner.Kernel.TraceLog do
             include_sanitized,
             listing_hook
           )
-        end
+        end,
+        directory_grant_class(source_kind, include_sanitized)
       )
-      |> put_excluded_trace_files(excluded)
     end
   end
 
-  # The exclusion count is reported beside the capture, never inside the
-  # inventory the capture re-verifies: a concurrent write to the kind this
-  # capture does not read must not fail it as a changed source.
-  defp put_excluded_trace_files({:ok, capture}, excluded),
-    do: {:ok, %{capture | excluded_trace_files: excluded}}
+  defp directory_grant_class(:sanitized, _include_sanitized), do: :sanitized
+  defp directory_grant_class(:private, false), do: :private
+  defp directory_grant_class(:private, true), do: :mixed_private_authorized
 
-  defp put_excluded_trace_files({:error, _reason} = error, _excluded), do: error
+  defp capture_directory_inventory(
+         directory,
+         before_inventory,
+         max_source_bytes,
+         capture_hook,
+         refresh_inventory,
+         grant_class
+       ) do
+    with {:ok, captured_sources, source_bytes} <-
+           read_directory_inventory(directory, before_inventory.files, max_source_bytes),
+         :ok <- run_capture_hook(capture_hook),
+         {:ok, after_read_inventory, _after_read_excluded} <- refresh_inventory.(),
+         :ok <- same_inventory(before_inventory, after_read_inventory),
+         :ok <- verify_directory_sources(directory, after_read_inventory.files, captured_sources),
+         {:ok, after_verify_inventory, final_excluded} <- refresh_inventory.(),
+         :ok <- same_inventory(after_read_inventory, after_verify_inventory),
+         :ok <-
+           verify_directory_sources(directory, after_verify_inventory.files, captured_sources),
+         {:ok, evidence, source_proofs} <- directory_evidence(captured_sources),
+         {:ok, classification} <- TraceDirectoryAdmission.classify(evidence) do
+      build_directory_admission(
+        grant_class,
+        classification,
+        source_proofs,
+        source_bytes,
+        final_excluded
+      )
+    end
+  end
+
+  defp build_directory_admission(
+         grant_class,
+         classification,
+         source_proofs,
+         source_bytes,
+         excluded_trace_files
+       ) do
+    events = Enum.flat_map(classification.admitted, & &1.events)
+
+    run_sources =
+      Map.new(classification.admitted, fn evidence ->
+        [run_id] = evidence.embedded_run_claims
+        {run_id, evidence.source_kind}
+      end)
+
+    analysis = compile_analysis(events, run_sources)
+
+    identity = %{
+      version: :directory_admission_v1,
+      grant_class: grant_class,
+      sources: directory_identity_sources(source_proofs, classification.components),
+      events: events,
+      run_sources: run_sources,
+      isolated_components: classification.isolated
+    }
+
+    admission = %{
+      version: :directory_admission_v1,
+      grant_class: grant_class,
+      events: events,
+      run_sources: run_sources,
+      analysis: analysis,
+      source_id: digest(identity),
+      source_bytes: source_bytes,
+      file_count: length(source_proofs),
+      excluded_trace_files: excluded_trace_files,
+      source_proofs: source_proofs,
+      components: classification.components,
+      isolated_components: classification.isolated,
+      known_isolated_run_ids: classification.known_isolated_run_ids
+    }
+
+    {:ok, admission}
+  end
+
+  defp directory_identity_sources(source_proofs, components) do
+    classifications =
+      components
+      |> Enum.flat_map(& &1.sources)
+      |> Map.new(&{&1.raw_name, &1})
+
+    Enum.map(source_proofs, fn proof ->
+      evidence = Map.fetch!(classifications, proof.raw_name)
+
+      %{
+        raw_name: proof.raw_name,
+        source_kind: proof.source_kind,
+        byte_length: proof.byte_length,
+        content_digest: proof.content_digest,
+        status: evidence.status,
+        filename_run_claim: evidence.filename_run_claim,
+        embedded_run_claims: evidence.embedded_run_claims,
+        embedded_trace_claims: evidence.embedded_trace_claims,
+        reasons: evidence.reasons
+      }
+    end)
+  end
 
   defp capture_inventory(
          directory,
@@ -1995,7 +2092,7 @@ defmodule PtcRunner.Kernel.TraceLog do
          {:ok, names} <-
            bounded_capture_names(listed, source_kind, include_sanitized, max_trace_files),
          {:ok, files} <- inventory_files(directory, names) do
-      {:ok, %{directory: stat_identity(directory_stat), files: files},
+      {:ok, %{directory: directory_root_identity(directory_stat), files: files},
        excluded_trace_files(listed, names, source_kind)}
     else
       {:ok, %File.Stat{}} -> {:error, :malformed_source}
@@ -2020,7 +2117,8 @@ defmodule PtcRunner.Kernel.TraceLog do
            include_sanitized,
            listing_hook
          ) do
-      {:ok, inventory, _excluded} -> {:ok, inventory}
+      {:ok, inventory, excluded} -> {:ok, inventory, excluded}
+      {:error, :source_limit_exceeded} = error -> error
       {:error, _reason} -> {:error, :source_changed}
     end
   end
@@ -2057,12 +2155,13 @@ defmodule PtcRunner.Kernel.TraceLog do
   end
 
   defp capture_name?(name, :sanitized, _include_sanitized),
-    do: supported_name?(name, :sanitized)
+    do: TraceDirectoryAdmission.source_kind(name) == :sanitized
 
   defp capture_name?(name, :private, true),
-    do: supported_name?(name, :sanitized) or supported_name?(name, :private)
+    do: TraceDirectoryAdmission.source_kind(name) in [:sanitized, :private]
 
-  defp capture_name?(name, :private, false), do: supported_name?(name, :private)
+  defp capture_name?(name, :private, false),
+    do: TraceDirectoryAdmission.source_kind(name) == :private
 
   defp capture_file_name?(name, :sanitized),
     do: Path.basename(name) == name and not reserved_path?(name)
@@ -2072,12 +2171,9 @@ defmodule PtcRunner.Kernel.TraceLog do
 
   defp inventory_files(directory, names) do
     Enum.reduce_while(names, {:ok, []}, fn name, {:ok, files} ->
-      case File.lstat(Path.join(directory, name), time: :posix) do
-        {:ok, %File.Stat{type: :regular} = stat} ->
+      case File.lstat(directory_member_path(directory, name), time: :posix) do
+        {:ok, %File.Stat{} = stat} ->
           {:cont, {:ok, [{name, stat_identity(stat)} | files]}}
-
-        {:ok, %File.Stat{}} ->
-          {:halt, {:error, :malformed_source}}
 
         {:error, _reason} ->
           {:halt, {:error, :source_unavailable}}
@@ -2086,6 +2182,151 @@ defmodule PtcRunner.Kernel.TraceLog do
     |> case do
       {:ok, files} -> {:ok, Enum.reverse(files)}
       {:error, _reason} = error -> error
+    end
+  end
+
+  defp read_directory_inventory(directory, files, max_source_bytes) do
+    source_bytes =
+      Enum.reduce(files, 0, fn
+        {_name, %{type: :regular, size: size}}, bytes -> bytes + size
+        {_name, _identity}, bytes -> bytes
+      end)
+
+    if source_bytes <= max_source_bytes do
+      Enum.reduce_while(files, {:ok, []}, fn {name, expected}, {:ok, sources} ->
+        case read_directory_member(directory, name, expected) do
+          {:ok, status} ->
+            source = %{raw_name: name, stat_identity: expected, read_status: status}
+            {:cont, {:ok, [source | sources]}}
+
+          {:error, _reason} = error ->
+            {:halt, error}
+        end
+      end)
+      |> case do
+        {:ok, sources} -> {:ok, Enum.reverse(sources), source_bytes}
+        {:error, _reason} = error -> error
+      end
+    else
+      {:error, :source_limit_exceeded}
+    end
+  end
+
+  defp read_directory_member(directory, name, %{type: type} = expected) when type != :regular do
+    path = directory_member_path(directory, name)
+
+    with {:ok, %File.Stat{} = current} <- File.lstat(path, time: :posix),
+         :ok <- same_stat_identity(expected, stat_identity(current)) do
+      {:ok, :not_regular}
+    else
+      _changed -> {:error, :source_changed}
+    end
+  end
+
+  defp read_directory_member(directory, name, expected) do
+    path = directory_member_path(directory, name)
+
+    with {:ok, %File.Stat{type: :regular} = current} <- File.lstat(path, time: :posix),
+         :ok <- same_stat_identity(expected, stat_identity(current)) do
+      case :file.open(path, [:read, :binary, :raw]) do
+        {:ok, device} ->
+          try do
+            case read_inventory_device(device, expected) do
+              {:ok, source} -> {:ok, {:read, source}}
+              {:error, _reason} = error -> error
+            end
+          after
+            :file.close(device)
+          end
+
+        {:error, reason} when reason in [:eacces, :eperm] ->
+          confirm_unreadable_member(path, expected)
+
+        {:error, _reason} ->
+          confirm_open_failure(path, expected)
+      end
+    else
+      {:ok, %File.Stat{}} -> {:error, :source_changed}
+      {:error, :source_changed} = error -> error
+      {:error, _reason} -> {:error, :source_changed}
+    end
+  end
+
+  defp confirm_unreadable_member(path, expected) do
+    with {:ok, %File.Stat{type: :regular} = current} <- File.lstat(path, time: :posix),
+         :ok <- same_stat_identity(expected, stat_identity(current)) do
+      {:ok, :unreadable}
+    else
+      _changed -> {:error, :source_changed}
+    end
+  end
+
+  defp confirm_open_failure(path, expected) do
+    with {:ok, %File.Stat{type: :regular} = current} <- File.lstat(path, time: :posix),
+         :ok <- same_stat_identity(expected, stat_identity(current)) do
+      {:error, :source_unavailable}
+    else
+      _changed -> {:error, :source_changed}
+    end
+  end
+
+  defp verify_directory_sources(directory, files, captured_sources) do
+    expected_sources = Map.new(captured_sources, &{&1.raw_name, &1})
+
+    Enum.reduce_while(files, :ok, fn {name, expected}, :ok ->
+      captured = Map.fetch!(expected_sources, name)
+
+      case verify_directory_source(directory, name, expected, captured.read_status) do
+        :ok -> {:cont, :ok}
+        {:error, _reason} = error -> {:halt, error}
+      end
+    end)
+  end
+
+  defp verify_directory_source(directory, name, expected, expected_status) do
+    case read_directory_member(directory, name, expected) do
+      {:ok, ^expected_status} -> :ok
+      {:ok, _changed_status} -> {:error, :source_changed}
+      {:error, :source_unavailable} = error -> error
+      {:error, _reason} -> {:error, :source_changed}
+    end
+  end
+
+  defp directory_evidence(captured_sources) do
+    Enum.reduce_while(captured_sources, {:ok, [], []}, fn source, {:ok, evidence, proofs} ->
+      with {:ok, status, digest} <- directory_evidence_status(source.read_status),
+           source_kind when source_kind in [:sanitized, :private] <-
+             TraceDirectoryAdmission.source_kind(source.raw_name),
+           {:ok, file_evidence} <-
+             TraceDirectoryAdmission.evidence(source.raw_name, source_kind, status) do
+        proof = %{
+          raw_name: source.raw_name,
+          source_kind: source_kind,
+          byte_length: source.stat_identity.size,
+          content_digest: digest,
+          stat_identity: source.stat_identity
+        }
+
+        {:cont, {:ok, [file_evidence | evidence], [proof | proofs]}}
+      else
+        _invalid -> {:halt, {:error, :source_unavailable}}
+      end
+    end)
+    |> case do
+      {:ok, evidence, proofs} -> {:ok, Enum.reverse(evidence), Enum.reverse(proofs)}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp directory_evidence_status(:not_regular), do: {:ok, :not_regular, nil}
+  defp directory_evidence_status(:unreadable), do: {:ok, :unreadable, nil}
+
+  defp directory_evidence_status({:read, source}) do
+    digest = :crypto.hash(:sha256, source)
+
+    case decode_jsonl(source) do
+      {:ok, events} -> {:ok, {:decoded, events}, digest}
+      {:error, :malformed_source} -> {:ok, :malformed_jsonl, digest}
     end
   end
 
@@ -2211,6 +2452,17 @@ defmodule PtcRunner.Kernel.TraceLog do
 
   defp same_stat_identity(identity, identity), do: :ok
   defp same_stat_identity(_expected, _current), do: {:error, :source_changed}
+
+  defp directory_root_identity(%File.Stat{} = stat) do
+    %{
+      major_device: stat.major_device,
+      minor_device: stat.minor_device,
+      inode: stat.inode,
+      type: stat.type
+    }
+  end
+
+  defp directory_member_path(directory, raw_name), do: directory <> "/" <> raw_name
 
   # ex_dna:disable-for-next-line — TraceLog keeps its source identity contract independent from inspection snapshots.
   defp stat_identity(%File.Stat{} = stat) do
@@ -2350,7 +2602,7 @@ defmodule PtcRunner.Kernel.TraceLog do
     encoded_bytes = Enum.reduce(events, 0, &(&2 + byte_size(Jason.encode!(&1))))
 
     with true <- encoded_bytes <= max_bytes,
-         :ok <- validate_events(events) do
+         :ok <- TraceEventValidation.validate(events) do
       source_id = digest(events)
 
       {:ok, events, source_id}
@@ -2360,449 +2612,6 @@ defmodule PtcRunner.Kernel.TraceLog do
     end
   rescue
     Jason.EncodeError -> {:error, :malformed_source}
-  end
-
-  defp validate_events(events) do
-    initial = %{
-      sequences: %{},
-      run_traces: %{},
-      trace_runs: %{},
-      run_lifecycles: %{},
-      evaluation_lifecycles: %{}
-    }
-
-    Enum.reduce_while(events, {:ok, initial}, fn event, {:ok, state} ->
-      with :ok <- validate_event(event),
-           trace_id = event["trace_id"],
-           run_id = event["run_id"],
-           sequence = event["sequence"],
-           previous = Map.get(state.sequences, trace_id, 0),
-           true <- sequence > previous,
-           :ok <- same_identity(state, run_id, trace_id),
-           {:ok, run_lifecycles} <-
-             advance_run_lifecycle(state.run_lifecycles, run_id, event["type"]),
-           {:ok, evaluation_lifecycles} <-
-             advance_evaluation_lifecycle(state.evaluation_lifecycles, run_id, event) do
-        {:cont,
-         {:ok,
-          %{
-            sequences: Map.put(state.sequences, trace_id, sequence),
-            run_traces: Map.put(state.run_traces, run_id, trace_id),
-            trace_runs: Map.put(state.trace_runs, trace_id, run_id),
-            run_lifecycles: run_lifecycles,
-            evaluation_lifecycles: evaluation_lifecycles
-          }}}
-      else
-        {:error, reason} -> {:halt, {:error, reason}}
-        _ -> {:halt, {:error, :malformed_source}}
-      end
-    end)
-    |> case do
-      {:ok, _state} ->
-        :ok
-
-      {:error, _reason} = error ->
-        error
-    end
-  end
-
-  @doc false
-  @spec directory_event_reasons([map()]) ::
-          [
-            :unsupported_version
-            | :sequence_conflict
-            | :lifecycle_conflict
-            | :malformed_event
-          ]
-  def directory_event_reasons(events) when is_list(events) do
-    []
-    |> maybe_directory_reason(unsupported_directory_version?(events), :unsupported_version)
-    |> maybe_directory_reason(directory_sequence_conflict?(events), :sequence_conflict)
-    |> maybe_directory_reason(directory_lifecycle_conflict?(events), :lifecycle_conflict)
-    |> maybe_directory_reason(directory_malformed_event?(events), :malformed_event)
-  end
-
-  defp unsupported_directory_version?(events) do
-    Enum.any?(events, fn event ->
-      case Map.fetch(event, "schema_version") do
-        {:ok, version} when is_integer(version) -> version != 2
-        _other -> false
-      end
-    end)
-  end
-
-  defp directory_sequence_conflict?(events) do
-    Enum.reduce_while(events, %{}, fn event, sequences ->
-      case {event["trace_id"], event["sequence"]} do
-        {trace_id, sequence} when is_binary(trace_id) and is_integer(sequence) and sequence > 0 ->
-          cond do
-            valid_event_id(trace_id) != :ok ->
-              {:cont, sequences}
-
-            sequence > Map.get(sequences, trace_id, 0) ->
-              {:cont, Map.put(sequences, trace_id, sequence)}
-
-            true ->
-              {:halt, :conflict}
-          end
-
-        {trace_id, _sequence} when is_binary(trace_id) ->
-          if valid_event_id(trace_id) == :ok,
-            do: {:halt, :conflict},
-            else: {:cont, sequences}
-
-        _invalid_identity ->
-          {:cont, sequences}
-      end
-    end) == :conflict
-  end
-
-  defp directory_lifecycle_conflict?(events) do
-    directory_run_lifecycle_conflict?(events) or
-      directory_evaluation_lifecycle_conflict?(events)
-  end
-
-  defp directory_run_lifecycle_conflict?(events) do
-    Enum.reduce_while(events, %{}, &advance_directory_run_lifecycle/2) == :conflict
-  end
-
-  defp directory_evaluation_lifecycle_conflict?(events) do
-    Enum.reduce_while(events, %{}, &advance_directory_evaluation_lifecycle/2) == :conflict
-  end
-
-  defp advance_directory_run_lifecycle(
-         %{"run_id" => run_id, "type" => type},
-         lifecycles
-       )
-       when is_binary(run_id) and is_binary(type) do
-    if directory_lifecycle_identity?(run_id, type),
-      do: lifecycle_reduction(advance_run_lifecycle(lifecycles, run_id, type)),
-      else: {:cont, lifecycles}
-  end
-
-  defp advance_directory_run_lifecycle(_event, lifecycles), do: {:cont, lifecycles}
-
-  defp advance_directory_evaluation_lifecycle(
-         %{"run_id" => run_id, "type" => type, "data" => data} = event,
-         lifecycles
-       )
-       when is_binary(run_id) and is_binary(type) and is_map(data) do
-    if directory_lifecycle_identity?(run_id, type),
-      do: lifecycle_reduction(advance_evaluation_lifecycle(lifecycles, run_id, event)),
-      else: {:cont, lifecycles}
-  end
-
-  defp advance_directory_evaluation_lifecycle(_event, lifecycles),
-    do: {:cont, lifecycles}
-
-  defp lifecycle_reduction({:ok, advanced}), do: {:cont, advanced}
-  defp lifecycle_reduction({:error, _reason}), do: {:halt, :conflict}
-
-  defp directory_lifecycle_identity?(run_id, type),
-    do: valid_event_id(run_id) == :ok and type =~ @event_type
-
-  defp directory_malformed_event?(events),
-    do: Enum.any?(events, &match?({:error, _reason}, directory_event_shape(&1)))
-
-  defp directory_event_shape(event) when is_map(event) do
-    event
-    |> Map.put("schema_version", normalized_directory_version(event["schema_version"]))
-    |> Map.put("sequence", normalized_directory_sequence(event["sequence"]))
-    |> validate_event()
-    |> case do
-      :ok -> :ok
-      {:error, _reason} -> {:error, :malformed_event}
-    end
-  end
-
-  defp directory_event_shape(_event), do: {:error, :malformed_event}
-
-  defp normalized_directory_version(version) when is_integer(version) and version != 2, do: 2
-  defp normalized_directory_version(version), do: version
-
-  defp normalized_directory_sequence(sequence)
-       when not is_integer(sequence) or sequence <= 0,
-       do: 1
-
-  defp normalized_directory_sequence(sequence), do: sequence
-
-  defp maybe_directory_reason(reasons, true, reason), do: reasons ++ [reason]
-  defp maybe_directory_reason(reasons, false, _reason), do: reasons
-
-  defp advance_run_lifecycle(run_lifecycles, run_id, type) do
-    case {Map.get(run_lifecycles, run_id), type} do
-      {nil, "run-started"} ->
-        {:ok, Map.put(run_lifecycles, run_id, :open)}
-
-      {:open, "run-stopped"} ->
-        {:ok, Map.put(run_lifecycles, run_id, :stopped)}
-
-      {:open, "run-started"} ->
-        {:error, :malformed_source}
-
-      {:open, _type} ->
-        {:ok, run_lifecycles}
-
-      {_lifecycle, _type} ->
-        {:error, :malformed_source}
-    end
-  end
-
-  defp advance_evaluation_lifecycle(evaluations, run_id, %{
-         "type" => "evaluation-started",
-         "data" => data
-       }) do
-    evaluation_id = data["evaluation_id"]
-    environment = stringify(data["environment"])
-    parent_evaluation_id = data["parent_evaluation_id"]
-    key = {run_id, evaluation_id}
-
-    with :ok <- valid_event_id(evaluation_id),
-         false <- Map.has_key?(evaluations, key),
-         :ok <-
-           validate_parent_evaluation(
-             evaluations,
-             run_id,
-             environment,
-             parent_evaluation_id
-           ) do
-      {:ok,
-       Map.put(evaluations, key, %{
-         environment: environment,
-         parent_evaluation_id: parent_evaluation_id,
-         lifecycle: :open
-       })}
-    else
-      _invalid -> {:error, :malformed_source}
-    end
-  end
-
-  defp advance_evaluation_lifecycle(evaluations, run_id, %{
-         "type" => "evaluation-stopped",
-         "data" => data
-       }) do
-    evaluation_id = data["evaluation_id"]
-    environment = stringify(data["environment"])
-    parent_evaluation_id = data["parent_evaluation_id"]
-    key = {run_id, evaluation_id}
-
-    with :ok <- valid_event_id(evaluation_id),
-         %{lifecycle: :open} = started <- Map.get(evaluations, key),
-         true <- started.environment == environment,
-         true <- started.parent_evaluation_id == parent_evaluation_id do
-      {:ok, put_in(evaluations, [key, :lifecycle], :stopped)}
-    else
-      nil when is_nil(parent_evaluation_id) -> {:ok, evaluations}
-      _invalid -> {:error, :malformed_source}
-    end
-  end
-
-  defp advance_evaluation_lifecycle(evaluations, _run_id, %{"data" => data}) do
-    if Map.has_key?(data, "parent_evaluation_id"),
-      do: {:error, :malformed_source},
-      else: {:ok, evaluations}
-  end
-
-  defp validate_parent_evaluation(_evaluations, _run_id, _environment, nil), do: :ok
-
-  defp validate_parent_evaluation(
-         evaluations,
-         run_id,
-         "mission",
-         parent_evaluation_id
-       ) do
-    with :ok <- valid_event_id(parent_evaluation_id),
-         %{environment: "workflow", lifecycle: :open, parent_evaluation_id: nil} <-
-           Map.get(evaluations, {run_id, parent_evaluation_id}) do
-      :ok
-    else
-      _invalid -> {:error, :malformed_source}
-    end
-  end
-
-  defp validate_parent_evaluation(
-         _evaluations,
-         _run_id,
-         _environment,
-         _parent_evaluation_id
-       ),
-       do: {:error, :malformed_source}
-
-  defp valid_event_id(value)
-       when is_binary(value) and byte_size(value) in 1..256,
-       do: if(String.valid?(value), do: :ok, else: {:error, :malformed_source})
-
-  defp valid_event_id(_value), do: {:error, :malformed_source}
-
-  defp same_identity(state, run_id, trace_id) do
-    with existing_trace when existing_trace in [nil, trace_id] <-
-           Map.get(state.run_traces, run_id),
-         existing_run when existing_run in [nil, run_id] <- Map.get(state.trace_runs, trace_id) do
-      :ok
-    else
-      _other -> {:error, :malformed_source}
-    end
-  end
-
-  defp validate_event(event) when is_map(event) do
-    with true <- Enum.sort(Map.keys(event)) == Enum.sort(@event_keys),
-         2 <- event["schema_version"],
-         :ok <- valid_string(event["run_id"]),
-         :ok <- valid_string(event["trace_id"]),
-         sequence when is_integer(sequence) and sequence > 0 <- event["sequence"],
-         timestamp when is_binary(timestamp) <- event["timestamp"],
-         {:ok, _datetime, 0} <- DateTime.from_iso8601(timestamp),
-         type when is_binary(type) <- event["type"],
-         true <- type =~ @event_type,
-         true <- JSONValue.map?(event["data"]),
-         :ok <- validate_event_data(type, event["data"]) do
-      :ok
-    else
-      version when is_integer(version) and version != 2 -> {:error, :unsupported_version}
-      _ -> {:error, :malformed_source}
-    end
-  end
-
-  defp validate_event(_event), do: {:error, :malformed_source}
-
-  defp validate_event_data(type, data) do
-    with :ok <- validate_current_event_data(type, data),
-         :ok <- validate_run_stopped_usage(type, data) do
-      validate_run_stopped_result_hash(type, data)
-    end
-  end
-
-  defp validate_run_stopped_result_hash("run-stopped", data) do
-    case Map.fetch(data, "result_hash") do
-      :error ->
-        :ok
-
-      {:ok, result_hash} ->
-        if stringify(data["outcome"]) == "ok" and ResultIdentity.valid_hash?(result_hash),
-          do: :ok,
-          else: {:error, :malformed_source}
-    end
-  end
-
-  defp validate_run_stopped_result_hash(_type, _data), do: :ok
-
-  defp validate_current_event_data("run-started", data) do
-    singular =
-      ~w(mission_prelude mission_inventory_hash mission_inventory_bytes mission_model_context_hash mission_model_context_bytes)
-
-    if is_map(data["missions"]) and Enum.all?(singular, &(not Map.has_key?(data, &1))) and
-         not Map.has_key?(data, "mission_name") and
-         valid_prelude_projection?(data["workflow_prelude"]) and
-         valid_mission_preludes?(data["missions"]) do
-      :ok
-    else
-      {:error, :malformed_source}
-    end
-  end
-
-  defp validate_current_event_data(type, data)
-       when type in ["run-stopped", "events-dropped"] do
-    if Map.has_key?(data, "mission_name"), do: {:error, :malformed_source}, else: :ok
-  end
-
-  defp validate_current_event_data(_type, data) do
-    environment = stringify(data["environment"])
-
-    case environment do
-      "mission" ->
-        if valid_string(data["mission_name"]) == :ok,
-          do: :ok,
-          else: {:error, :malformed_source}
-
-      "workflow" ->
-        if Map.has_key?(data, "mission_name"), do: {:error, :malformed_source}, else: :ok
-
-      _other ->
-        if Map.has_key?(data, "mission_name"), do: {:error, :malformed_source}, else: :ok
-    end
-  end
-
-  defp valid_mission_preludes?(missions) do
-    Enum.all?(missions, fn {_name, metadata} ->
-      is_map(metadata) and valid_prelude_projection?(metadata["prelude"])
-    end)
-  end
-
-  # The prelude projection is the only canonical commitment a private
-  # `prelude-source` record can be proven against, so it is validated to
-  # producer grade here rather than interpreted leniently later. A component
-  # list without an aligned dependency list, or an identity that is not a bare
-  # digest, cannot be reconstructed and is rejected as malformed.
-  defp valid_prelude_projection?(nil), do: true
-
-  defp valid_prelude_projection?(prelude) when is_map(prelude) do
-    component_ids = prelude["component_ids"]
-
-    is_list(component_ids) and Enum.all?(component_ids, &(valid_string(&1) == :ok)) and
-      component_ids == Enum.uniq(component_ids) and
-      valid_prelude_hash?(prelude["hash"], component_ids) and
-      valid_dependency_indices?(prelude["dependency_indices"], length(component_ids))
-  end
-
-  defp valid_prelude_projection?(_prelude), do: false
-
-  # A nil identity means no bundle at all, which can name no components. A
-  # bundle always carries a digest, whether or not it compiled any component.
-  defp valid_prelude_hash?(nil, component_ids), do: component_ids == []
-  defp valid_prelude_hash?(hash, _component_ids) when is_binary(hash), do: hash =~ @bundle_hash
-  defp valid_prelude_hash?(_hash, _component_ids), do: false
-
-  defp valid_dependency_indices?(dependency_indices, count) when is_list(dependency_indices) do
-    length(dependency_indices) == count and
-      dependency_indices
-      |> Enum.with_index()
-      |> Enum.all?(fn {indices, position} -> valid_dependency_list?(indices, position) end)
-  end
-
-  defp valid_dependency_indices?(_dependency_indices, _count), do: false
-
-  defp valid_dependency_list?(indices, position) when is_list(indices) do
-    Enum.all?(indices, &(is_integer(&1) and &1 >= 0 and &1 < position)) and
-      indices == Enum.sort(indices) and indices == Enum.uniq(indices)
-  end
-
-  defp valid_dependency_list?(_indices, _position), do: false
-
-  defp validate_run_stopped_usage("run-stopped", data) do
-    case Map.fetch(data, "usage") do
-      :error ->
-        :ok
-
-      {:ok, usage} when is_map(usage) ->
-        with :ok <- validate_subordinate_source_checks(usage),
-             do: validate_terminal_llm_spend(usage)
-
-      _invalid_usage ->
-        {:error, :malformed_source}
-    end
-  end
-
-  defp validate_run_stopped_usage(_type, _data), do: :ok
-
-  defp validate_subordinate_source_checks(usage) do
-    case Map.fetch(usage, "subordinate_source_checks") do
-      :error -> :ok
-      {:ok, count} when is_integer(count) and count >= 0 -> :ok
-      _invalid_count -> {:error, :malformed_source}
-    end
-  end
-
-  defp validate_terminal_llm_spend(usage) do
-    case Map.fetch(usage, "llm_spend") do
-      :error ->
-        :ok
-
-      {:ok, spend} ->
-        case LLMUsageSummary.validate_spend(spend) do
-          {:ok, _spend} -> :ok
-          {:error, :invalid_llm_spend} -> {:error, :malformed_source}
-        end
-    end
   end
 
   defp runs(events, source_kind) do

--- a/lib/ptc_runner/kernel/trace_log.ex
+++ b/lib/ptc_runner/kernel/trace_log.ex
@@ -57,6 +57,7 @@ defmodule PtcRunner.Kernel.TraceLog do
   alias PtcRunner.Kernel.SafeMetadata
   alias PtcRunner.Kernel.TraceDirectoryAdmission
   alias PtcRunner.Kernel.TraceEventValidation
+  alias PtcRunner.Kernel.TraceIsolationPresentation
   alias PtcRunner.Kernel.TracePublication
   alias PtcRunner.Lisp.RetainedSize
 
@@ -352,6 +353,18 @@ defmodule PtcRunner.Kernel.TraceLog do
       do: metadata
 
   def source_presence_metadata(_operation, _metadata), do: %{}
+
+  @doc false
+  @spec directory_source_metadata(map()) :: map()
+  def directory_source_metadata(%{
+        excluded_trace_files: excluded,
+        isolated_components: components,
+        known_isolated_run_ids: known_run_ids
+      }) do
+    Map.merge(excluded, TraceIsolationPresentation.metadata(components, known_run_ids))
+  end
+
+  def directory_source_metadata(%{excluded_trace_files: excluded}), do: excluded
 
   @doc false
   @spec compile_analysis([map()], :sanitized | :private | map()) :: map()
@@ -1119,9 +1132,9 @@ defmodule PtcRunner.Kernel.TraceLog do
           &mission_matches?(&1, arguments["mission_name"])
         )
 
-      result = selected |> counters(selected_run_events) |> Map.merge(metadata)
+      aggregate = counters(selected, selected_run_events)
 
-      with :ok <- ResultLimit.validate(result, max_result_bytes), do: {:ok, result}
+      fit_metadata(metadata, max_result_bytes, &Map.merge(aggregate, &1))
     end
   end
 
@@ -1987,8 +2000,8 @@ defmodule PtcRunner.Kernel.TraceLog do
              include_sanitized: false
            ),
          {:ok, capture} <- retain_transient_directory(capture, trace_log.max_retained_bytes) do
-      {:ok, capture.events, capture.source_id, capture.run_sources, capture.excluded_trace_files,
-       capture.known_isolated_run_ids}
+      {:ok, capture.events, capture.source_id, capture.run_sources,
+       directory_source_metadata(capture), capture.known_isolated_run_ids}
     end
   end
 
@@ -3018,25 +3031,68 @@ defmodule PtcRunner.Kernel.TraceLog do
          max_result_bytes,
          metadata
        ) do
-    result = page_result(selected, all_items, offset, source_id, query_id, metadata)
+    full_result = fn fitted_metadata ->
+      page_result(selected, all_items, offset, source_id, query_id, fitted_metadata)
+    end
 
-    cond do
-      ResultLimit.within?(result, max_result_bytes) ->
+    case fit_metadata_result(metadata, max_result_bytes, full_result) do
+      {:ok, result, _fitted_metadata} ->
         {:ok, result}
 
-      selected == [] ->
+      {:exhausted, fitted_metadata} ->
+        fit_page_items(
+          selected,
+          all_items,
+          offset,
+          source_id,
+          query_id,
+          max_result_bytes,
+          fitted_metadata
+        )
+    end
+  end
+
+  defp fit_page_items(
+         selected,
+         all_items,
+         offset,
+         source_id,
+         query_id,
+         max_result_bytes,
+         metadata
+       ) do
+    base = page_result([], all_items, offset, source_id, query_id, metadata)
+
+    cond do
+      not ResultLimit.within?(base, max_result_bytes) ->
         {:error, :result_limit_exceeded}
+
+      selected == [] ->
+        {:ok, base}
 
       true ->
         context = {all_items, offset, source_id, query_id, max_result_bytes, metadata}
+        fit_page_prefix(selected, context, 1, length(selected) - 1, nil)
+    end
+  end
 
-        fit_page_prefix(
-          selected,
-          context,
-          1,
-          length(selected) - 1,
-          nil
-        )
+  defp fit_metadata(metadata, max_result_bytes, build_result) do
+    case fit_metadata_result(metadata, max_result_bytes, build_result) do
+      {:ok, result, _metadata} -> {:ok, result}
+      {:exhausted, _metadata} -> {:error, :result_limit_exceeded}
+    end
+  end
+
+  defp fit_metadata_result(metadata, max_result_bytes, build_result) do
+    result = build_result.(metadata)
+
+    if ResultLimit.within?(result, max_result_bytes) do
+      {:ok, result, metadata}
+    else
+      case TraceIsolationPresentation.shrink(metadata) do
+        {:ok, smaller} -> fit_metadata_result(smaller, max_result_bytes, build_result)
+        :exhausted -> {:exhausted, metadata}
+      end
     end
   end
 

--- a/lib/ptc_runner/kernel/trace_log.ex
+++ b/lib/ptc_runner/kernel/trace_log.ex
@@ -32,6 +32,13 @@ defmodule PtcRunner.Kernel.TraceLog do
   isolation component, but excludes absolute paths, opposite-class names, and
   advisory exclusion counts.
 
+  A direct directory query creates that admission transiently on every call
+  under the same entry, file, source, retained, and result ceilings as an
+  immutable snapshot. Consequently a direct cursor observes later selected
+  evidence as `:source_changed`, while a snapshot cursor stays bound to its
+  retained admission. Run-scoped queries distinguish a grant-visible isolated
+  claim as `:run_isolated` from an absent or out-of-grant run as `:not_found`.
+
   The internal trace-snapshot owner uses this module's canonical validation and
   query execution against one immutable directory capture or one exact selected
   canonical file. A snapshot is
@@ -47,16 +54,21 @@ defmodule PtcRunner.Kernel.TraceLog do
   alias PtcRunner.Kernel.PrivateDirectory
   alias PtcRunner.Kernel.PublicationHandle
   alias PtcRunner.Kernel.ResultLimit
+  alias PtcRunner.Kernel.SafeMetadata
   alias PtcRunner.Kernel.TraceDirectoryAdmission
   alias PtcRunner.Kernel.TraceEventValidation
   alias PtcRunner.Kernel.TracePublication
+  alias PtcRunner.Lisp.RetainedSize
 
   @default_source_bytes 8_000_000
+  @default_retained_bytes 32_000_000
   @default_result_bytes 1_000_000
   @default_capture_directory_entries 4_096
   @default_capture_trace_files 1_024
   @capture_listing_timeout_ms 5_000
   @capture_listing_heap_words 1_000_000
+  @direct_capture_timeout_ms 15_000
+  @direct_capture_heap_words 10_000_000
   @default_limit 20
   @max_limit 100
   @max_cursor_bytes 1_024
@@ -105,35 +117,48 @@ defmodule PtcRunner.Kernel.TraceLog do
   sync
   """
 
-  @enforce_keys [:source, :source_kind, :max_source_bytes, :max_result_bytes]
-  defstruct [:source, :source_kind, :max_source_bytes, :max_result_bytes]
+  @enforce_keys [
+    :source,
+    :source_kind,
+    :max_source_bytes,
+    :max_retained_bytes,
+    :max_result_bytes,
+    :max_directory_entries,
+    :max_trace_files
+  ]
+  defstruct @enforce_keys
 
   @type source :: EventSink.t() | {:file, binary()} | {:directory, binary()}
   @type t :: %__MODULE__{
           source: source(),
           source_kind: :sanitized | :private,
           max_source_bytes: pos_integer(),
-          max_result_bytes: pos_integer()
+          max_retained_bytes: pos_integer(),
+          max_result_bytes: pos_integer(),
+          max_directory_entries: pos_integer(),
+          max_trace_files: pos_integer()
         }
 
   @spec new(keyword()) :: {:ok, t()} | {:error, :invalid_trace_log}
   @doc """
   Constructs a query boundary from required `:source` and optional positive
-  `:max_source_bytes` and `:max_result_bytes` limits.
+  `:max_source_bytes` and `:max_result_bytes` limits. Directory sources also
+  accept `:max_retained_bytes`, `:max_directory_entries`, and
+  `:max_trace_files`; all five directory limits may be lowered but never raised
+  above the canonical directory-query ceilings.
   """
   def new(opts) when is_list(opts) do
-    with true <- Keyword.keys(opts) -- [:source, :max_source_bytes, :max_result_bytes] == [],
-         {:ok, source, source_kind} <- validate_source(Keyword.get(opts, :source)),
-         max_source_bytes when is_integer(max_source_bytes) and max_source_bytes > 0 <-
-           Keyword.get(opts, :max_source_bytes, @default_source_bytes),
-         max_result_bytes when is_integer(max_result_bytes) and max_result_bytes > 0 <-
-           Keyword.get(opts, :max_result_bytes, @default_result_bytes) do
+    with {:ok, source, source_kind} <- validate_source(Keyword.get(opts, :source)),
+         {:ok, limits} <- trace_log_limits(source, opts) do
       {:ok,
        %__MODULE__{
          source: source,
          source_kind: source_kind,
-         max_source_bytes: max_source_bytes,
-         max_result_bytes: max_result_bytes
+         max_source_bytes: limits.max_source_bytes,
+         max_retained_bytes: limits.max_retained_bytes,
+         max_result_bytes: limits.max_result_bytes,
+         max_directory_entries: limits.max_directory_entries,
+         max_trace_files: limits.max_trace_files
        }}
     else
       _ -> {:error, :invalid_trace_log}
@@ -142,25 +167,122 @@ defmodule PtcRunner.Kernel.TraceLog do
 
   def new(_opts), do: {:error, :invalid_trace_log}
 
+  defp trace_log_limits({:directory, _path}, opts) do
+    allowed = [
+      :source,
+      :max_source_bytes,
+      :max_retained_bytes,
+      :max_result_bytes,
+      :max_directory_entries,
+      :max_trace_files
+    ]
+
+    with true <- Keyword.keys(opts) -- allowed == [],
+         {:ok, max_source_bytes} <-
+           bounded_limit(opts, :max_source_bytes, @default_source_bytes),
+         {:ok, max_retained_bytes} <-
+           bounded_limit(opts, :max_retained_bytes, @default_retained_bytes),
+         {:ok, max_result_bytes} <-
+           bounded_limit(opts, :max_result_bytes, @default_result_bytes),
+         {:ok, max_directory_entries} <-
+           bounded_limit(opts, :max_directory_entries, @default_capture_directory_entries),
+         {:ok, max_trace_files} <-
+           bounded_limit(opts, :max_trace_files, @default_capture_trace_files) do
+      {:ok,
+       %{
+         max_source_bytes: max_source_bytes,
+         max_retained_bytes: max_retained_bytes,
+         max_result_bytes: max_result_bytes,
+         max_directory_entries: max_directory_entries,
+         max_trace_files: max_trace_files
+       }}
+    else
+      _invalid -> {:error, :invalid_trace_log}
+    end
+  end
+
+  defp trace_log_limits(_source, opts) do
+    with true <- Keyword.keys(opts) -- [:source, :max_source_bytes, :max_result_bytes] == [],
+         {:ok, max_source_bytes} <- positive_limit(opts, :max_source_bytes, @default_source_bytes),
+         {:ok, max_result_bytes} <- positive_limit(opts, :max_result_bytes, @default_result_bytes) do
+      {:ok,
+       %{
+         max_source_bytes: max_source_bytes,
+         max_retained_bytes: @default_retained_bytes,
+         max_result_bytes: max_result_bytes,
+         max_directory_entries: @default_capture_directory_entries,
+         max_trace_files: @default_capture_trace_files
+       }}
+    else
+      _invalid -> {:error, :invalid_trace_log}
+    end
+  end
+
+  defp bounded_limit(opts, key, maximum) do
+    case Keyword.get(opts, key, maximum) do
+      value when is_integer(value) and value in 1..maximum//1 -> {:ok, value}
+      _invalid -> {:error, :invalid_trace_log}
+    end
+  end
+
+  defp positive_limit(opts, key, default) do
+    case Keyword.get(opts, key, default) do
+      value when is_integer(value) and value > 0 -> {:ok, value}
+      _invalid -> {:error, :invalid_trace_log}
+    end
+  end
+
   @spec query(t(), :list_runs | :get_run | :list_turns | :counters, map()) ::
           {:ok, map()} | {:error, atom()}
   @doc "Executes one validated, source-scoped bounded trace query."
   def query(%__MODULE__{} = trace_log, operation, arguments)
       when operation in [:list_runs, :get_run, :list_turns, :counters] and is_map(arguments) do
-    with {:ok, events, source_id, source_metadata} <- load(trace_log),
-         do:
-           execute(
-             operation,
-             events,
-             source_id,
-             arguments,
-             trace_log.max_result_bytes,
-             trace_log.source_kind,
-             source_presence_metadata(operation, source_metadata)
-           )
+    with {:ok, events, source_id, source_kind, source_metadata, known_isolated_run_ids} <-
+           load(trace_log) do
+      result_metadata =
+        operation
+        |> source_presence_metadata(source_metadata)
+        |> reserve_snapshot_hash(trace_log.source, source_id)
+
+      operation
+      |> execute(
+        events,
+        source_id,
+        arguments,
+        trace_log.max_result_bytes,
+        source_kind,
+        result_metadata
+      )
+      |> maybe_run_isolated(operation, arguments, known_isolated_run_ids)
+      |> strip_reserved_snapshot_hash(trace_log.source)
+    end
   end
 
   def query(_trace_log, _operation, _arguments), do: {:error, :invalid_query}
+
+  defp reserve_snapshot_hash(metadata, {:directory, _path}, source_id),
+    do: Map.put(metadata, "snapshot_hash", SafeMetadata.fingerprint(source_id))
+
+  defp reserve_snapshot_hash(metadata, _source, _source_id), do: metadata
+
+  defp strip_reserved_snapshot_hash({:ok, result}, {:directory, _path}),
+    do: {:ok, Map.delete(result, "snapshot_hash")}
+
+  defp strip_reserved_snapshot_hash(result, _source), do: result
+
+  defp maybe_run_isolated(
+         {:error, :not_found},
+         operation,
+         %{"run_id" => run_id},
+         known_isolated_run_ids
+       )
+       when operation in [:get_run, :list_turns] and is_binary(run_id) do
+    if MapSet.member?(known_isolated_run_ids, run_id),
+      do: {:error, :run_isolated},
+      else: {:error, :not_found}
+  end
+
+  defp maybe_run_isolated(result, _operation, _arguments, _known_isolated_run_ids), do: result
 
   @doc false
   @spec query_loaded(
@@ -170,7 +292,8 @@ defmodule PtcRunner.Kernel.TraceLog do
           map(),
           pos_integer(),
           :sanitized | :private | %{binary() => :sanitized | :private},
-          map()
+          map(),
+          MapSet.t(binary())
         ) :: {:ok, map()} | {:error, atom()}
   def query_loaded(
         events,
@@ -179,7 +302,8 @@ defmodule PtcRunner.Kernel.TraceLog do
         arguments,
         max_result_bytes,
         source_kind,
-        metadata \\ %{}
+        metadata \\ %{},
+        known_isolated_run_ids \\ MapSet.new()
       )
 
   def query_loaded(
@@ -189,16 +313,21 @@ defmodule PtcRunner.Kernel.TraceLog do
         arguments,
         max_result_bytes,
         source_kind,
-        metadata
+        metadata,
+        known_isolated_run_ids
       )
       when is_list(events) and is_binary(source_id) and
              operation in [:list_runs, :get_run, :list_turns, :counters] and is_map(arguments) and
              is_integer(max_result_bytes) and max_result_bytes > 0 and
-             (source_kind in [:sanitized, :private] or is_map(source_kind)) and is_map(metadata) do
-    if valid_query_source_kind?(events, source_kind),
-      do:
-        execute(operation, events, source_id, arguments, max_result_bytes, source_kind, metadata),
-      else: {:error, :invalid_query}
+             (source_kind in [:sanitized, :private] or is_map(source_kind)) and is_map(metadata) and
+             is_struct(known_isolated_run_ids, MapSet) do
+    if valid_query_source_kind?(events, source_kind) do
+      operation
+      |> execute(events, source_id, arguments, max_result_bytes, source_kind, metadata)
+      |> maybe_run_isolated(operation, arguments, known_isolated_run_ids)
+    else
+      {:error, :invalid_query}
+    end
   end
 
   def query_loaded(
@@ -208,7 +337,8 @@ defmodule PtcRunner.Kernel.TraceLog do
         _arguments,
         _max_result_bytes,
         _source_kind,
-        _metadata
+        _metadata,
+        _known_isolated_run_ids
       ),
       do: {:error, :invalid_query}
 
@@ -1820,38 +1950,67 @@ defmodule PtcRunner.Kernel.TraceLog do
     |> EventSink.events()
     |> normalize()
     |> validate_loaded(trace_log.max_source_bytes)
-    |> with_source_metadata(%{})
+    |> with_source_metadata(trace_log.source_kind, %{})
   catch
     :exit, _reason -> {:error, :source_unavailable}
   end
 
-  defp load(%__MODULE__{source: {:file, path}, max_source_bytes: max_bytes}) do
+  defp load(%__MODULE__{source: {:file, path}, max_source_bytes: max_bytes} = trace_log) do
     with {:ok, source} <- read_regular_file(path, max_bytes),
          {:ok, events} <- decode_jsonl(source),
-         do: events |> validate_loaded(max_bytes) |> with_source_metadata(%{})
+         do:
+           events
+           |> validate_loaded(max_bytes)
+           |> with_source_metadata(trace_log.source_kind, %{})
   end
 
-  defp load(%__MODULE__{source: {:directory, directory}, max_source_bytes: max_bytes} = trace_log) do
-    with {:ok, %File.Stat{type: :directory}} <- File.lstat(directory),
-         {:ok, listed} <- File.ls(directory),
-         names = supported_names(listed, trace_log.source_kind),
-         {:ok, events} <- load_files(directory, names, max_bytes) do
-      events
-      |> validate_loaded(max_bytes)
-      |> with_source_metadata(excluded_trace_files(listed, names, trace_log.source_kind))
-    else
-      {:error, reason} = error when reason in [:source_limit_exceeded, :malformed_source] ->
-        error
-
-      _ ->
-        {:error, :source_unavailable}
+  defp load(%__MODULE__{source: {:directory, directory}} = trace_log) do
+    case BoundedWorker.run(
+           fn -> load_directory_admission(directory, trace_log) end,
+           timeout_ms: @direct_capture_timeout_ms,
+           max_heap_words: @direct_capture_heap_words,
+           cancel_with_caller: true
+         ) do
+      {:ok, result} -> result
+      {:error, :heap_exceeded} -> {:error, :source_retained_limit_exceeded}
+      {:error, _reason} -> {:error, :source_unavailable}
     end
   end
 
-  defp with_source_metadata({:ok, events, source_id}, metadata),
-    do: {:ok, events, source_id, metadata}
+  defp load_directory_admission(directory, trace_log) do
+    with {:ok, capture} <-
+           capture_directory(directory,
+             max_source_bytes: trace_log.max_source_bytes,
+             max_directory_entries: trace_log.max_directory_entries,
+             max_trace_files: trace_log.max_trace_files,
+             source_kind: trace_log.source_kind,
+             include_sanitized: false
+           ),
+         {:ok, capture} <- retain_transient_directory(capture, trace_log.max_retained_bytes) do
+      {:ok, capture.events, capture.source_id, capture.run_sources, capture.excluded_trace_files,
+       capture.known_isolated_run_ids}
+    end
+  end
 
-  defp with_source_metadata({:error, _reason} = error, _metadata), do: error
+  defp with_source_metadata({:ok, events, source_id}, source_kind, metadata),
+    do: {:ok, events, source_id, source_kind, metadata, MapSet.new()}
+
+  defp with_source_metadata({:error, _reason} = error, _source_kind, _metadata), do: error
+
+  defp retain_transient_directory(capture, max_retained_bytes) do
+    retained_capture = RetainedSize.detach_binaries(capture)
+
+    case RetainedSize.bytes(retained_capture) do
+      retained_bytes when is_integer(retained_bytes) and retained_bytes <= max_retained_bytes ->
+        {:ok, retained_capture}
+
+      retained_bytes when is_integer(retained_bytes) ->
+        {:error, :source_retained_limit_exceeded}
+
+      :oversized ->
+        {:error, :source_retained_limit_exceeded}
+    end
+  end
 
   # One trace directory holds both sanitized and private artifacts, and one
   # query boundary reads exactly one kind. Staying silent about the other kind
@@ -1870,15 +2029,6 @@ defmodule PtcRunner.Kernel.TraceLog do
 
   defp exclusion_key(:sanitized), do: "excluded_private_trace_files"
   defp exclusion_key(:private), do: "excluded_sanitized_trace_files"
-
-  defp supported_names(names, source_kind) do
-    names
-    |> Enum.filter(&supported_name?(&1, source_kind))
-    |> Enum.sort()
-  end
-
-  defp supported_name?(name, source_kind),
-    do: trace_file_name?(name) and private_path?(name) == (source_kind == :private)
 
   defp trace_file_name?(name) do
     TraceDirectoryAdmission.source_kind(name) in [:sanitized, :private]
@@ -2490,24 +2640,6 @@ defmodule PtcRunner.Kernel.TraceLog do
     _exception -> {:error, :source_unavailable}
   catch
     _kind, _reason -> {:error, :source_unavailable}
-  end
-
-  defp load_files(directory, names, max_bytes) do
-    Enum.reduce_while(names, {:ok, {[], 0}}, fn name, {:ok, {event_groups, bytes}} ->
-      path = Path.join(directory, name)
-      remaining = max_bytes - bytes
-
-      with {:ok, source} <- read_regular_file(path, remaining),
-           {:ok, events} <- decode_jsonl(source) do
-        {:cont, {:ok, {[events | event_groups], bytes + byte_size(source)}}}
-      else
-        {:error, _reason} = error -> {:halt, error}
-      end
-    end)
-    |> case do
-      {:ok, {event_groups, _bytes}} -> {:ok, event_groups |> Enum.reverse() |> List.flatten()}
-      {:error, _reason} = error -> error
-    end
   end
 
   defp read_regular_file(_path, remaining) when remaining < 0,

--- a/lib/ptc_runner/kernel/trace_log.ex
+++ b/lib/ptc_runner/kernel/trace_log.ex
@@ -2406,6 +2406,129 @@ defmodule PtcRunner.Kernel.TraceLog do
     end
   end
 
+  @doc false
+  @spec directory_event_reasons([map()]) ::
+          [
+            :unsupported_version
+            | :sequence_conflict
+            | :lifecycle_conflict
+            | :malformed_event
+          ]
+  def directory_event_reasons(events) when is_list(events) do
+    []
+    |> maybe_directory_reason(unsupported_directory_version?(events), :unsupported_version)
+    |> maybe_directory_reason(directory_sequence_conflict?(events), :sequence_conflict)
+    |> maybe_directory_reason(directory_lifecycle_conflict?(events), :lifecycle_conflict)
+    |> maybe_directory_reason(directory_malformed_event?(events), :malformed_event)
+  end
+
+  defp unsupported_directory_version?(events) do
+    Enum.any?(events, fn event ->
+      case Map.fetch(event, "schema_version") do
+        {:ok, version} when is_integer(version) -> version != 2
+        _other -> false
+      end
+    end)
+  end
+
+  defp directory_sequence_conflict?(events) do
+    Enum.reduce_while(events, %{}, fn event, sequences ->
+      case {event["trace_id"], event["sequence"]} do
+        {trace_id, sequence} when is_binary(trace_id) and is_integer(sequence) and sequence > 0 ->
+          cond do
+            valid_event_id(trace_id) != :ok ->
+              {:cont, sequences}
+
+            sequence > Map.get(sequences, trace_id, 0) ->
+              {:cont, Map.put(sequences, trace_id, sequence)}
+
+            true ->
+              {:halt, :conflict}
+          end
+
+        {trace_id, _sequence} when is_binary(trace_id) ->
+          if valid_event_id(trace_id) == :ok,
+            do: {:halt, :conflict},
+            else: {:cont, sequences}
+
+        _invalid_identity ->
+          {:cont, sequences}
+      end
+    end) == :conflict
+  end
+
+  defp directory_lifecycle_conflict?(events) do
+    directory_run_lifecycle_conflict?(events) or
+      directory_evaluation_lifecycle_conflict?(events)
+  end
+
+  defp directory_run_lifecycle_conflict?(events) do
+    Enum.reduce_while(events, %{}, &advance_directory_run_lifecycle/2) == :conflict
+  end
+
+  defp directory_evaluation_lifecycle_conflict?(events) do
+    Enum.reduce_while(events, %{}, &advance_directory_evaluation_lifecycle/2) == :conflict
+  end
+
+  defp advance_directory_run_lifecycle(
+         %{"run_id" => run_id, "type" => type},
+         lifecycles
+       )
+       when is_binary(run_id) and is_binary(type) do
+    if directory_lifecycle_identity?(run_id, type),
+      do: lifecycle_reduction(advance_run_lifecycle(lifecycles, run_id, type)),
+      else: {:cont, lifecycles}
+  end
+
+  defp advance_directory_run_lifecycle(_event, lifecycles), do: {:cont, lifecycles}
+
+  defp advance_directory_evaluation_lifecycle(
+         %{"run_id" => run_id, "type" => type, "data" => data} = event,
+         lifecycles
+       )
+       when is_binary(run_id) and is_binary(type) and is_map(data) do
+    if directory_lifecycle_identity?(run_id, type),
+      do: lifecycle_reduction(advance_evaluation_lifecycle(lifecycles, run_id, event)),
+      else: {:cont, lifecycles}
+  end
+
+  defp advance_directory_evaluation_lifecycle(_event, lifecycles),
+    do: {:cont, lifecycles}
+
+  defp lifecycle_reduction({:ok, advanced}), do: {:cont, advanced}
+  defp lifecycle_reduction({:error, _reason}), do: {:halt, :conflict}
+
+  defp directory_lifecycle_identity?(run_id, type),
+    do: valid_event_id(run_id) == :ok and type =~ @event_type
+
+  defp directory_malformed_event?(events),
+    do: Enum.any?(events, &match?({:error, _reason}, directory_event_shape(&1)))
+
+  defp directory_event_shape(event) when is_map(event) do
+    event
+    |> Map.put("schema_version", normalized_directory_version(event["schema_version"]))
+    |> Map.put("sequence", normalized_directory_sequence(event["sequence"]))
+    |> validate_event()
+    |> case do
+      :ok -> :ok
+      {:error, _reason} -> {:error, :malformed_event}
+    end
+  end
+
+  defp directory_event_shape(_event), do: {:error, :malformed_event}
+
+  defp normalized_directory_version(version) when is_integer(version) and version != 2, do: 2
+  defp normalized_directory_version(version), do: version
+
+  defp normalized_directory_sequence(sequence)
+       when not is_integer(sequence) or sequence <= 0,
+       do: 1
+
+  defp normalized_directory_sequence(sequence), do: sequence
+
+  defp maybe_directory_reason(reasons, true, reason), do: reasons ++ [reason]
+  defp maybe_directory_reason(reasons, false, _reason), do: reasons
+
   defp advance_run_lifecycle(run_lifecycles, run_id, type) do
     case {Map.get(run_lifecycles, run_id), type} do
       {nil, "run-started"} ->

--- a/lib/ptc_runner/kernel/trace_snapshot.ex
+++ b/lib/ptc_runner/kernel/trace_snapshot.ex
@@ -296,9 +296,12 @@ defmodule PtcRunner.Kernel.TraceSnapshot do
 
   def handle_call({token, {:run_exists, run_id}}, _from, %{token: token} = state) do
     result =
-      if valid_run_id?(run_id),
-        do: {:ok, Map.has_key?(state.analysis.runs_by_id, run_id)},
-        else: {:error, :invalid_query}
+      cond do
+        not valid_run_id?(run_id) -> {:error, :invalid_query}
+        Map.has_key?(state.analysis.runs_by_id, run_id) -> {:ok, true}
+        isolated_run?(state, run_id) -> {:error, :run_isolated}
+        true -> {:ok, false}
+      end
 
     {:reply, result, state}
   end
@@ -495,17 +498,17 @@ defmodule PtcRunner.Kernel.TraceSnapshot do
         TraceLog.compile_analysis(capture.events, capture.run_sources)
       end)
 
+    retained_capture = RetainedSize.detach_binaries(capture)
+
     retained_value =
-      if capture[:version] == :directory_admission_v1,
-        do: capture,
-        else: {capture.events, capture.run_sources, capture.analysis}
+      if retained_capture[:version] == :directory_admission_v1,
+        do: retained_capture,
+        else: {retained_capture.events, retained_capture.run_sources, retained_capture.analysis}
 
     retained_bytes = RetainedSize.bytes(retained_value)
 
     cond do
       is_integer(retained_bytes) and retained_bytes <= config.max_retained_bytes ->
-        retained_capture = RetainedSize.detach_binaries(capture)
-
         {:ok, retained_capture, retained_bytes}
 
       is_integer(retained_bytes) ->
@@ -630,7 +633,9 @@ defmodule PtcRunner.Kernel.TraceSnapshot do
         with :ok <- ResultLimit.validate(result, max_bytes), do: {:ok, result}
 
       :error ->
-        {:error, :not_found}
+        if isolated_run?(state, run_id),
+          do: {:error, :run_isolated},
+          else: {:error, :not_found}
     end
   end
 
@@ -642,9 +647,18 @@ defmodule PtcRunner.Kernel.TraceSnapshot do
       arguments,
       max_bytes,
       state.run_sources,
-      metadata
+      metadata,
+      known_isolated_run_ids(state)
     )
   end
+
+  defp isolated_run?(state, run_id),
+    do: MapSet.member?(known_isolated_run_ids(state), run_id)
+
+  defp known_isolated_run_ids(%{directory_admission: %{known_isolated_run_ids: run_ids}}),
+    do: run_ids
+
+  defp known_isolated_run_ids(_state), do: MapSet.new()
 
   defp valid_run_id?(run_id),
     do: is_binary(run_id) and byte_size(run_id) in 1..4_096 and String.valid?(run_id)

--- a/lib/ptc_runner/kernel/trace_snapshot.ex
+++ b/lib/ptc_runner/kernel/trace_snapshot.ex
@@ -613,10 +613,15 @@ defmodule PtcRunner.Kernel.TraceSnapshot do
   defp query_with_snapshot_hash(state, operation, arguments) do
     metadata =
       %{"snapshot_hash" => state.info.snapshot_hash}
-      |> Map.merge(TraceLog.source_presence_metadata(operation, state.info.excluded_trace_files))
+      |> Map.merge(TraceLog.source_presence_metadata(operation, source_metadata(state)))
 
     snapshot_query(state, operation, arguments, state.max_result_bytes, metadata)
   end
+
+  defp source_metadata(%{directory_admission: %{} = admission}),
+    do: TraceLog.directory_source_metadata(admission)
+
+  defp source_metadata(state), do: state.info.excluded_trace_files
 
   defp snapshot_query(
          state,

--- a/lib/ptc_runner/kernel/trace_snapshot.ex
+++ b/lib/ptc_runner/kernel/trace_snapshot.ex
@@ -490,18 +490,21 @@ defmodule PtcRunner.Kernel.TraceSnapshot do
   end
 
   defp retain_capture(capture, config) do
-    analysis = TraceLog.compile_analysis(capture.events, capture.run_sources)
+    capture =
+      Map.put_new_lazy(capture, :analysis, fn ->
+        TraceLog.compile_analysis(capture.events, capture.run_sources)
+      end)
 
-    retained_bytes =
-      RetainedSize.bytes({capture.events, capture.run_sources, analysis})
+    retained_value =
+      if capture[:version] == :directory_admission_v1,
+        do: capture,
+        else: {capture.events, capture.run_sources, capture.analysis}
+
+    retained_bytes = RetainedSize.bytes(retained_value)
 
     cond do
       is_integer(retained_bytes) and retained_bytes <= config.max_retained_bytes ->
-        retained_capture =
-          capture
-          |> Map.put(:events, RetainedSize.detach_binaries(capture.events))
-          |> Map.put(:run_sources, RetainedSize.detach_binaries(capture.run_sources))
-          |> Map.put(:analysis, RetainedSize.detach_binaries(analysis))
+        retained_capture = RetainedSize.detach_binaries(capture)
 
         {:ok, retained_capture, retained_bytes}
 
@@ -586,6 +589,8 @@ defmodule PtcRunner.Kernel.TraceSnapshot do
       events: capture.events,
       run_sources: capture.run_sources,
       analysis: capture.analysis,
+      directory_admission:
+        if(capture[:version] == :directory_admission_v1, do: capture, else: nil),
       source_id: capture.source_id,
       max_result_bytes: max_result_bytes,
       info: %{

--- a/ptc_viewer/README.md
+++ b/ptc_viewer/README.md
@@ -71,6 +71,13 @@ and canonical activity, plus one semantic `conversation` result when the Viewer
 was started with an authorized inspection artifact. The URL carries
 `#/run/<run-id>`, so a run view can be bookmarked and reloaded.
 
+Directory discovery accepts producer-owned `<run-id>.jsonl` and
+`<run-id>.private.jsonl` files with one matching run and trace identity per
+file. Stable damaged files and connected split/conflicting identities are
+isolated without hiding disjoint valid runs. The Runs tab renders the
+Kernel's bounded isolation evidence; it never rescans or reclassifies files in
+the browser.
+
 The canonical transcript keeps canonical events as its execution spine. With
 an authorized inspection artifact, it also shows each evaluation's exact
 generated program from the semantic conversation projection and the feedback

--- a/ptc_viewer/README.md
+++ b/ptc_viewer/README.md
@@ -204,7 +204,11 @@ live ingestion and controls, not the trace browser as a whole.
 
 Query parameters are passed to `Kernel.TraceLog`; `limit` is decoded as an
 integer and `tags` as a JSON object. The routes preserve not-found, invalid
-query, unavailable-adapter, and adapter-failure classifications.
+query, unavailable-adapter, and adapter-failure classifications. Run listings
+render the Kernel's bounded `isolation` object as a damaged-source notice while
+retaining any separate source-kind exclusion notice. An isolated run claim is
+returned as `422 run_isolated`; direct retained-size refusal is returned as
+`413 Trace source retained size exceeded`.
 
 ## Architecture
 

--- a/ptc_viewer/lib/ptc_viewer/router.ex
+++ b/ptc_viewer/lib/ptc_viewer/router.ex
@@ -696,6 +696,12 @@ defmodule PtcViewer.Router do
       {:error, :source_limit_exceeded} ->
         send_resp(conn, 413, "Trace source too large")
 
+      {:error, :source_retained_limit_exceeded} ->
+        send_resp(conn, 413, "Trace source retained size exceeded")
+
+      {:error, :run_isolated} ->
+        send_resp(conn, 422, "run_isolated")
+
       {:error, reason} when reason in [:malformed_source, :unsupported_version] ->
         send_resp(conn, 422, "Unsupported trace source")
 

--- a/ptc_viewer/priv/static/js/app.js
+++ b/ptc_viewer/priv/static/js/app.js
@@ -5,7 +5,7 @@ import { createAnalyzeButton, createReplController, nextTabName, readViewerConfi
 import { createRunCatalog } from './run-catalog.js';
 import { createLiveController, liveTokenFromSearch } from './live.js';
 import { commitCurrentLoad } from './current-load.js';
-import { displayRunName, emptyRunsMessage, excludedTraceNote, formatRunSpend, searchableRunFields } from './run-display.js';
+import { displayRunName, emptyRunsMessage, formatRunSpend, searchableRunFields, traceSourceNotes } from './run-display.js';
 import { truncate } from './utils.js';
 
 function formatDate(isoString) {
@@ -110,7 +110,7 @@ function RunPicker() {
   const { runs, page, query, selectedRunId } = state;
   const visible = runs.filter(run => matchesQuery(run, query));
   const selected = runs.find(run => run.run_id === selectedRunId) || null;
-  const excluded = excludedTraceNote(page);
+  const sourceNotes = traceSourceNotes(page);
 
   // With a run open the list is reference material, not the task at hand: it
   // collapses to one control that both names the current run and returns to
@@ -140,7 +140,7 @@ function RunPicker() {
     <div class="file-picker-panel">
       <div class="file-picker-header">
         <h3>Kernel runs <span class="file-picker-count">${runs.length}${page?.truncated ? '+' : ''}</span></h3>
-        ${runs.length > 0 && excluded && html`<p class="file-picker-note">${excluded}</p>`}
+        ${runs.length > 0 && sourceNotes.map(note => html`<p class="file-picker-note" key=${note}>${note}</p>`)}
         <input type="search" class="file-picker-search" placeholder="Filter by run id, status or bundle"
                aria-label="Filter runs" value=${query}
                onInput=${event => { state.query = event.currentTarget.value; renderRunPicker(); }} />

--- a/ptc_viewer/priv/static/js/run-display.js
+++ b/ptc_viewer/priv/static/js/run-display.js
@@ -94,12 +94,36 @@ export function excludedTraceNote(page) {
   return null;
 }
 
+export function damagedTraceNote(page) {
+  const isolation = page?.isolation;
+  if (!isolation || typeof isolation !== 'object' || Array.isArray(isolation)) return null;
+
+  const components = countedIsolation(isolation.component_count);
+  const sources = countedIsolation(isolation.source_count);
+  const runs = nonNegativeIsolation(isolation.known_run_count);
+  if (!components || !sources || runs === null) return null;
+
+  return `${sources} damaged trace ${plural(sources, 'source')} isolated in ${components} ${plural(components, 'component')}; ${runs} known ${plural(runs, 'run')} ${runs === 1 ? 'is' : 'are'} unavailable.`;
+}
+
+export function traceSourceNotes(page) {
+  return [damagedTraceNote(page), excludedTraceNote(page)].filter(Boolean);
+}
+
 export function emptyRunsMessage(page) {
-  return excludedTraceNote(page) || 'No canonical runs in this trace directory.';
+  return traceSourceNotes(page).join(' ') || 'No canonical runs in this trace directory.';
 }
 
 function countedExclusion(value) {
   return Number.isSafeInteger(value) && value > 0 ? value : 0;
+}
+
+function countedIsolation(value) {
+  return Number.isSafeInteger(value) && value > 0 ? value : 0;
+}
+
+function nonNegativeIsolation(value) {
+  return Number.isSafeInteger(value) && value >= 0 ? value : null;
 }
 
 function plural(count, noun) {

--- a/ptc_viewer/test/ptc_viewer/router_test.exs
+++ b/ptc_viewer/test/ptc_viewer/router_test.exs
@@ -169,6 +169,25 @@ defmodule PtcViewer.RouterTest do
     end)
   end
 
+  test "canonical routes preserve isolated-run and retained-size failures", %{
+    trace_dir: trace_dir
+  } do
+    for {reason, expected_status, expected_body} <- [
+          {:run_isolated, 422, "run_isolated"},
+          {:source_retained_limit_exceeded, 413, "Trace source retained size exceeded"}
+        ] do
+      response =
+        conn(:get, "/api/kernel/runs/damaged")
+        |> call_router(
+          trace_dir: trace_dir,
+          kernel_trace_adapter: fn _, _, _ -> {:error, reason} end
+        )
+
+      assert response.status == expected_status
+      assert response.resp_body == expected_body
+    end
+  end
+
   test "conversation route is unconfigured by default and delegates a fixed source", %{
     trace_dir: trace_dir
   } do

--- a/ptc_viewer/test/run_display.mjs
+++ b/ptc_viewer/test/run_display.mjs
@@ -1,10 +1,12 @@
 import assert from 'node:assert/strict';
 import {
   displayRunName,
+  damagedTraceNote,
   emptyRunsMessage,
   excludedTraceNote,
   formatRunSpend,
   searchableRunFields,
+  traceSourceNotes,
   validSpend
 } from '../priv/static/js/run-display.js';
 
@@ -80,5 +82,34 @@ assert.equal(excludedTraceNote({ omitted_count: 12 }), null);
 assert.equal(excludedTraceNote({ excluded_private_trace_files: 0 }), null);
 assert.equal(excludedTraceNote({ excluded_private_trace_files: '3' }), null);
 assert.equal(excludedTraceNote(null), null);
+
+const isolation = {
+  component_count: 2,
+  source_count: 3,
+  known_run_count: 4,
+  reasons: [],
+  examples: [],
+  examples_omitted_count: 2
+};
+
+assert.equal(
+  damagedTraceNote({ isolation }),
+  '3 damaged trace sources isolated in 2 components; 4 known runs are unavailable.'
+);
+assert.equal(damagedTraceNote({ isolation: { ...isolation, source_count: '3' } }), null);
+assert.equal(damagedTraceNote(null), null);
+
+assert.deepEqual(
+  traceSourceNotes({ isolation, excluded_private_trace_files: 1 }),
+  [
+    '3 damaged trace sources isolated in 2 components; 4 known runs are unavailable.',
+    '1 private trace file excluded — set "viewer": { "private": true } in ptc-project.json to read them.'
+  ]
+);
+
+assert.equal(
+  emptyRunsMessage({ items: [], omitted_count: 0, isolation }),
+  '3 damaged trace sources isolated in 2 components; 4 known runs are unavailable.'
+);
 
 process.stdout.write('ok');

--- a/site/reference/application-manifest/index.html
+++ b/site/reference/application-manifest/index.html
@@ -240,10 +240,14 @@ trace sources provide the <code class="inline">activity</code> collection and re
 <code class="inline">evidence_unavailable</code> for private collections. An inspection alias composes
 its required trace snapshot with authorized private records. Set the
 trace dependency's config to <code class="inline">{&quot;expose&quot;: false}</code> when only the aggregate
-inspection namespace should be callable.</p><p>Snapshot acquisition is fail closed and immutable: malformed, duplicate,
-orphaned, or oversized evidence rejects the capture rather than exposing a
-partial catalog. Private inspection also requires every selected provider to
-accept the <code class="inline">private_inspection</code> data class before any directory opens.</p><p>Treat the workflow bundle and manifest as application code. Treat
+inspection namespace should be callable.</p><p>Trace-directory acquisition is immutable: stable malformed, duplicate, or
+identity-conflicting trace files isolate their connected component while
+disjoint valid runs remain available. Namespace mutation and whole-source
+limits reject the capture rather than installing a partial generation.
+Inspection snapshots remain fail closed for malformed, duplicate, orphaned, or
+oversized private inspection records. Private inspection also requires every
+selected provider to accept the <code class="inline">private_inspection</code> data class before any
+directory opens.</p><p>Treat the workflow bundle and manifest as application code. Treat
 model-generated source, mission input, file content, and provider output as
 untrusted data. <a href="/reference/host-installation/">Host configuration</a> documents the
 installed side of every provider source.</p><h2 id="narrow-installed-limits">Narrow installed limits</h2><p>Manifest limits are positive hard ceilings:</p><pre><code class="json language-json">&quot;limits&quot;: {

--- a/site/reference/cli/index.html
+++ b/site/reference/cli/index.html
@@ -379,8 +379,10 @@ remain authoritative, and unrelated directory members are not listed, opened,
 sized, decoded, or counted toward directory or aggregate source limits. The
 selected files still keep their individual source, record, retained-memory,
 heap, deadline, and result ceilings. Whole-directory snapshots used by
-<code class="inline">private-run-analysis-v1</code> stay a distinct source variant and still fail closed
-on malformed or mismatched members.</p><p>The parent of <code class="inline">--private-output</code> must already exist and be reached without a
+<code class="inline">private-run-analysis-v1</code> stay a distinct source variant: they admit only
+filename-bound one-run files, isolate a stable damaged connected component,
+and keep disjoint healthy runs queryable. Namespace or selected-file mutation
+still rejects the whole capture.</p><p>The parent of <code class="inline">--private-output</code> must already exist and be reached without a
 symbolic link — on macOS <code class="inline">/tmp</code> is a symlink, so <code class="inline">/tmp/out.json</code> is refused.
 Trace, inspection, and output directories must be pairwise physically separate:
 no directory may equal, contain, or be contained by either of the others. A
@@ -405,7 +407,12 @@ selected address. If an explicitly selected port is occupied, the command
 probes loopback: another PTC Viewer is reported with its exact project document
 path, while any other listener is reported as an occupied service. The command
 runs in the foreground until <code class="inline">Ctrl+C</code>, and opens a browser only when the project
-asks for it <em>and</em> a terminal is attached.</p><p>The Viewer does not search the invocation directory or its parents for a
+asks for it <em>and</em> a terminal is attached.</p><p>Directory discovery expects producer-owned <code class="inline">&lt;run-id&gt;.jsonl</code> and
+<code class="inline">&lt;run-id&gt;.private.jsonl</code> names, each containing exactly that one run and one
+trace identity. The run list reports bounded damaged-source evidence when a
+stable malformed, mismatched, split, or conflicting component is isolated;
+unrelated valid runs remain available. A selected namespace change during
+capture fails the refresh rather than installing a partial generation.</p><p>The Viewer does not search the invocation directory or its parents for a
 <code class="inline">.env</code> file. Environment-backed provider credentials come from the inherited
 process environment, the project's <code class="inline">host.env_file</code>, or an explicit
 <code class="inline">--env-file FILE</code>. The command-line file is resolved when the Viewer starts

--- a/site/reference/debug-navigation/index.html
+++ b/site/reference/debug-navigation/index.html
@@ -255,7 +255,14 @@ the failure it is rather than as a setting the reader could change.
 return. It never reports evidence withheld by policy. A source grant that
 withheld trace files of the other kind reports that separately, as
 <code class="inline">excluded_private_trace_files</code> or <code class="inline">excluded_sanitized_trace_files</code> on a run
-listing or counters query.</p><h3 id="join-on-correlation-ids-never-on-sequence-numbers">Join on correlation ids, never on sequence numbers</h3><p>A transcript turn and a trace event live in different sequence
+listing or counters query.</p><p>Damaged evidence is also separate from pagination and policy exclusion.
+<code class="inline">list_runs</code> and <code class="inline">counters</code> carry the same bounded <code class="inline">isolation</code> summary with
+exact component, source, known-run, and reason totals plus capped examples.
+The Viewer renders that object as a damaged-source notice without hiding the
+source-kind exclusion notice. Opening a grant-visible run claim that belongs
+only to an isolated component answers <code class="inline">422 run_isolated</code>; a direct trace
+capture that exceeds its retained-memory ceiling answers
+<code class="inline">413 Trace source retained size exceeded</code>.</p><h3 id="join-on-correlation-ids-never-on-sequence-numbers">Join on correlation ids, never on sequence numbers</h3><p>A transcript turn and a trace event live in different sequence
 spaces. Turn <code class="inline">request_sequence</code> orders records inside the inspection snapshot;
 canonical <code class="inline">sequence</code> orders the run's event stream. Turn 1 reporting request
 sequence 12 says nothing about trace event 12, which is an unrelated

--- a/site/reference/host-installation/index.html
+++ b/site/reference/host-installation/index.html
@@ -276,7 +276,13 @@ immutable captures:</p><pre><code class="json language-json">&quot;history&quot;
 <code class="inline">ptc_private_trace_snapshot</code> reads ordinary and <code class="inline">.private.jsonl</code> traces and
 classifies the run as <code class="inline">private_inspection</code>. An inspection snapshot requires
 exactly one of those trace sources so it can validate every private artifact
-against the captured trace evidence.</p><p>Set a trace selection's manifest config to <code class="inline">{&quot;expose&quot;: false}</code> when it exists
+against the captured trace evidence.</p><p>Whole-directory trace snapshots admit filename-bound <code class="inline">&lt;run-id&gt;.jsonl</code> or
+<code class="inline">&lt;run-id&gt;.private.jsonl</code> members containing exactly one matching run and trace
+identity. Stable malformed, mismatched, split, or conflicting members are
+isolated by connected identity component while disjoint valid runs remain
+queryable. Selected namespace mutation rejects the complete capture; it never
+installs a partial snapshot. Explicit single-file trace sources remain a
+separate filename-agnostic aggregate contract.</p><p>Set a trace selection's manifest config to <code class="inline">{&quot;expose&quot;: false}</code> when it exists
 only as the inspection source's dependency. It still supplies the frozen trace
 capture without creating a second analysis namespace. The
 <a href="https://github.com/andreasronge/ptc_runner/blob/main/docs/maintainers/trace-log-contract.md#query-contract">TraceLog and run-analysis reference</a>

--- a/site/reference/project-files/index.html
+++ b/site/reference/project-files/index.html
@@ -167,7 +167,12 @@ creates the complete layout atomically; an existing incomplete, permissive, or
 symlinked layout is refused. When a pre-existing directory fails the owner-only
 (0700) check, the command names the path and the <code class="inline">chmod 700</code> remedy rather than
 a bare publication failure. Artifact files retain the normal no-replace and
-privacy rules.</p><h2 id="overrides-and-lazy-environment-loading">Overrides and lazy environment loading</h2><p>An explicit command value wins over the corresponding project default for host,
+privacy rules.</p><p>The trace filenames are also the canonical directory-discovery contract. Each
+file contains exactly the run ID named by its stem and one trace identity;
+arbitrary aggregate filenames and split histories remain supported only when a
+caller explicitly selects one file, not when Viewer or run analysis discovers a
+directory. Stable damaged components are isolated without hiding unrelated
+valid runs.</p><h2 id="overrides-and-lazy-environment-loading">Overrides and lazy environment loading</h2><p>An explicit command value wins over the corresponding project default for host,
 environment, and trace/inspection/result destinations:</p><pre><code class="console language-console">ptc run ptc-project.json --host-config deployment/staging-host.json
 ptc run ptc-project.json --trace-dir tmp/one-off-traces
 ptc repl --project ptc-project.json --env-file deployment/staging.env

--- a/test/ptc_runner/kernel/bounded_worker_test.exs
+++ b/test/ptc_runner/kernel/bounded_worker_test.exs
@@ -57,6 +57,170 @@ defmodule PtcRunner.Kernel.BoundedWorkerTest do
     end
   end
 
+  test "caller guard never copies the bounded callback closure" do
+    test = self()
+    payload = List.duplicate(:captured, 100_000)
+
+    caller =
+      spawn(fn ->
+        receive do
+          :run ->
+            result =
+              BoundedWorker.run(
+                fn ->
+                  send(test, {:bounded_worker_started, self()})
+
+                  receive do
+                    :finish -> length(payload)
+                  end
+                end,
+                timeout_ms: 5_000,
+                max_heap_words: 1_000_000,
+                cancel_with_caller: true
+              )
+
+            send(test, {:bounded_worker_result, result})
+        end
+      end)
+
+    assert :erlang.trace(caller, true, [:procs, {:tracer, test}]) == 1
+    send(caller, :run)
+
+    assert_receive {:trace, ^caller, :spawn, guard, _initial_call}
+    assert_receive {:bounded_worker_started, worker}
+    assert {:total_heap_size, guard_heap_words} = Process.info(guard, :total_heap_size)
+    assert guard_heap_words < 10_000
+
+    send(worker, :finish)
+    assert_receive {:bounded_worker_result, {:ok, 100_000}}
+  end
+
+  test "initial callback closure must fit the worker heap before execution" do
+    test = self()
+    payload = List.duplicate(:captured, 100_000)
+
+    assert {:error, :heap_exceeded} =
+             BoundedWorker.run(
+               fn ->
+                 send(test, {:oversized_callback_ran, length(payload)})
+                 :done
+               end,
+               timeout_ms: 1_000,
+               max_heap_words: 10_000,
+               cancel_with_caller: true
+             )
+
+    refute_receive {:oversized_callback_ran, _size}
+  end
+
+  test "completion after the absolute deadline cannot win from the mailbox" do
+    test = self()
+
+    caller =
+      spawn(fn ->
+        result =
+          BoundedWorker.run(
+            fn ->
+              send(test, {:late_worker_ready, self()})
+
+              receive do
+                :finish ->
+                  send(test, {:late_worker_finished, self()})
+                  :late
+              end
+            end,
+            timeout_ms: 10,
+            max_heap_words: 10_000,
+            cancel_with_caller: true
+          )
+
+        send(test, {:late_worker_result, result})
+      end)
+
+    assert_receive {:late_worker_ready, worker}
+    assert true = :erlang.suspend_process(caller)
+    timer = :erlang.start_timer(20, self(), :deadline_elapsed)
+    assert_receive {:timeout, ^timer, :deadline_elapsed}
+    send(worker, :finish)
+    assert_receive {:late_worker_finished, ^worker}
+    assert true = :erlang.resume_process(caller)
+    assert_receive {:late_worker_result, {:error, :timeout}}
+  end
+
+  test "a worker delayed past startup deadline never invokes the callback" do
+    test = self()
+
+    caller =
+      spawn(fn ->
+        receive do
+          :run ->
+            result =
+              BoundedWorker.run(
+                fn ->
+                  send(test, :expired_callback_ran)
+                  :done
+                end,
+                timeout_ms: 200,
+                max_heap_words: 10_000,
+                cancel_with_caller: true,
+                startup_fault_hook: fn worker ->
+                  send(test, {:startup_worker, worker})
+
+                  receive do
+                    :continue_startup -> :ok
+                  end
+                end
+              )
+
+            send(test, {:expired_start_result, result})
+        end
+      end)
+
+    assert :erlang.trace(caller, true, [:send, {:tracer, test}]) == 1
+    send(caller, :run)
+    assert_receive {:startup_worker, worker}
+
+    try do
+      assert true = :erlang.suspend_process(worker)
+      send(caller, :continue_startup)
+      assert_receive {:trace, ^caller, :send, {_start_ref, :run}, ^worker}
+      assert true = :erlang.suspend_process(caller)
+      worker_ref = Process.monitor(worker)
+
+      timer = :erlang.start_timer(250, self(), :startup_deadline_elapsed)
+      assert_receive {:timeout, ^timer, :startup_deadline_elapsed}
+      assert true = :erlang.resume_process(worker)
+      assert_receive {:DOWN, ^worker_ref, :process, ^worker, :normal}
+      refute_receive :expired_callback_ran
+
+      assert true = :erlang.resume_process(caller)
+      assert_receive {:expired_start_result, {:error, :timeout}}
+    after
+      send(caller, :continue_startup)
+      resume_if_suspended(worker)
+      resume_if_suspended(caller)
+      if Process.alive?(caller), do: Process.exit(caller, :kill)
+    end
+  end
+
+  test "startup timeouts leave no guard acknowledgements in the caller mailbox" do
+    for _iteration <- 1..20 do
+      assert {:error, :timeout} =
+               BoundedWorker.run(fn -> :unexpected end,
+                 timeout_ms: 0,
+                 max_heap_words: 10_000,
+                 cancel_with_caller: true
+               )
+    end
+
+    assert {:messages, messages} = Process.info(self(), :messages)
+
+    refute Enum.any?(messages, fn
+             {_guard_ref, :armed} -> true
+             _other -> false
+           end)
+  end
+
   test "termination drains a result already ordered before worker DOWN" do
     parent = self()
     reply_alias = Process.alias()
@@ -64,7 +228,7 @@ defmodule PtcRunner.Kernel.BoundedWorkerTest do
 
     {worker, monitor_ref} =
       spawn_monitor(fn ->
-        send(reply_alias, {reply_ref, :late_result})
+        send(reply_alias, {reply_ref, System.monotonic_time(:millisecond), :late_result})
         send(parent, :late_result_sent)
 
         receive do
@@ -75,7 +239,7 @@ defmodule PtcRunner.Kernel.BoundedWorkerTest do
     assert_receive :late_result_sent
     assert :ok = BoundedWorker.terminate(worker, monitor_ref, reply_alias, reply_ref)
     refute Process.alive?(worker)
-    refute_receive {^reply_ref, :late_result}
+    refute_receive {^reply_ref, _completed_at_ms, :late_result}
     refute_receive {:DOWN, ^monitor_ref, :process, ^worker, _reason}
   end
 
@@ -176,5 +340,10 @@ defmodule PtcRunner.Kernel.BoundedWorkerTest do
     assert_receive {:timeout_cleanup, ^caller}
     Process.exit(caller, :kill)
     assert_receive {:DOWN, ^worker_ref, :process, ^worker, :killed}
+  end
+
+  defp resume_if_suspended(pid) do
+    if Process.alive?(pid) and Process.info(pid, :status) == {:status, :suspended},
+      do: :erlang.resume_process(pid)
   end
 end

--- a/test/ptc_runner/kernel/bounded_worker_test.exs
+++ b/test/ptc_runner/kernel/bounded_worker_test.exs
@@ -46,6 +46,17 @@ defmodule PtcRunner.Kernel.BoundedWorkerTest do
              )
   end
 
+  test "guarded heap exhaustion keeps its classification across startup" do
+    for _iteration <- 1..100 do
+      assert {:error, :heap_exceeded} =
+               BoundedWorker.run(fn -> Enum.to_list(1..1_000_000) end,
+                 timeout_ms: 1_000,
+                 max_heap_words: 10_000,
+                 cancel_with_caller: true
+               )
+    end
+  end
+
   test "termination drains a result already ordered before worker DOWN" do
     parent = self()
     reply_alias = Process.alias()

--- a/test/ptc_runner/kernel/host_installation_test.exs
+++ b/test/ptc_runner/kernel/host_installation_test.exs
@@ -1622,7 +1622,7 @@ defmodule PtcRunner.Kernel.HostInstallationTest do
     File.mkdir_p!(trace_directory)
 
     File.write!(
-      Path.join(trace_directory, "run.jsonl"),
+      Path.join(trace_directory, "captured.jsonl"),
       Jason.encode!(trace_event("captured", 1, "run-started")) <>
         "\n" <>
         Jason.encode!(trace_event("captured", 2, "run-stopped")) <> "\n"
@@ -1698,7 +1698,7 @@ defmodule PtcRunner.Kernel.HostInstallationTest do
             }} = callbacks["history.runs"].(%{})
 
     File.write!(
-      Path.join(trace_directory, "run.jsonl"),
+      Path.join(trace_directory, "captured.jsonl"),
       Jason.encode!(trace_event("changed", 1, "run-started")) <> "\n"
     )
 
@@ -1726,7 +1726,7 @@ defmodule PtcRunner.Kernel.HostInstallationTest do
     File.mkdir_p!(trace_directory)
 
     File.write!(
-      Path.join(trace_directory, "captured.private.jsonl"),
+      Path.join(trace_directory, "private-run.private.jsonl"),
       Jason.encode!(trace_event("private-run", 1, "run-started")) <>
         "\n" <> Jason.encode!(trace_event("private-run", 2, "run-stopped")) <> "\n"
     )

--- a/test/ptc_runner/kernel/host_installation_test.exs
+++ b/test/ptc_runner/kernel/host_installation_test.exs
@@ -298,8 +298,8 @@ defmodule PtcRunner.Kernel.HostInstallationTest do
     caller_ref = Process.monitor(caller)
 
     try do
-      assert_receive {:trace, ^authority_owner, :spawn, callback_guard, _spawned}
-      assert_receive {:trace, ^callback_guard, :spawn, callback_worker, _spawned}
+      assert_receive {:trace, ^authority_owner, :spawn, _callback_guard, _spawned}
+      assert_receive {:trace, ^authority_owner, :spawn, callback_worker, _spawned}
       callback_ref = Process.monitor(callback_worker)
       assert true = :erlang.suspend_process(callback_worker)
 

--- a/test/ptc_runner/kernel/host_installation_test.exs
+++ b/test/ptc_runner/kernel/host_installation_test.exs
@@ -298,7 +298,8 @@ defmodule PtcRunner.Kernel.HostInstallationTest do
     caller_ref = Process.monitor(caller)
 
     try do
-      assert_receive {:trace, ^authority_owner, :spawn, callback_worker, _spawned}
+      assert_receive {:trace, ^authority_owner, :spawn, callback_guard, _spawned}
+      assert_receive {:trace, ^callback_guard, :spawn, callback_worker, _spawned}
       callback_ref = Process.monitor(callback_worker)
       assert true = :erlang.suspend_process(callback_worker)
 

--- a/test/ptc_runner/kernel/run_analysis_profile_test.exs
+++ b/test/ptc_runner/kernel/run_analysis_profile_test.exs
@@ -776,13 +776,32 @@ defmodule PtcRunner.Kernel.PrivateRunAnalysisProfileTest do
   end
 
   @tag :tmp_dir
-  test "a directory whose only artifact holds no runs is captured, not refused", %{tmp_dir: root} do
+  test "a directory whose only artifact is empty is captured with isolation evidence", %{
+    tmp_dir: root
+  } do
     traces = Path.join(root, "traces")
     File.mkdir_p!(traces)
     File.write!(Path.join(traces, "empty.jsonl"), "")
 
     assert {:ok, resources} = PublicRunAnalysisProfile.capture(%{"traces" => traces}, [])
     assert {:ok, %{file_count: 1, run_count: 0}} = AnalysisResources.info(resources)
+
+    trace = AnalysisResources.handle(resources, :traces)
+
+    assert {:ok, %{"items" => [], "isolation" => isolation}} =
+             TraceSnapshot.query(trace, :list_runs, %{})
+
+    assert isolation["component_count"] == 1
+    assert isolation["known_run_count"] == 1
+
+    assert isolation["reasons"] == [
+             %{
+               "reason" => "malformed_jsonl",
+               "component_count" => 1,
+               "source_count" => 1
+             }
+           ]
+
     AnalysisResources.stop(resources)
   end
 

--- a/test/ptc_runner/kernel/run_analysis_test.exs
+++ b/test/ptc_runner/kernel/run_analysis_test.exs
@@ -1306,17 +1306,18 @@ defmodule PtcRunner.Kernel.RunAnalysisTest do
     second = TestHelpers.llm_snapshot("writer", "stable-v1", "openrouter:vendor/model-b")
     reviewer = TestHelpers.llm_snapshot("reviewer", "review-v2", "openrouter:vendor/model-a")
 
-    File.write!(
-      Path.join(directory, "counters.jsonl"),
-      Enum.map_join(
-        counter_run("first", first, "ok", %{"input" => 3, "output" => 2, "total_cost" => 0.25}) ++
-          counter_run("second", second, "ok", %{"input" => 5}) ++
-          counter_run("review", reviewer, "ok", %{"input" => 7}, "reviewer", "review-v2") ++
-          counter_run("private", nil, "error", nil),
-        "",
-        &(Jason.encode!(&1) <> "\n")
-      )
-    )
+    runs = [
+      {"first",
+       counter_run("first", first, "ok", %{"input" => 3, "output" => 2, "total_cost" => 0.25})},
+      {"second", counter_run("second", second, "ok", %{"input" => 5})},
+      {"review", counter_run("review", reviewer, "ok", %{"input" => 7}, "reviewer", "review-v2")},
+      {"private", counter_run("private", nil, "error", nil)}
+    ]
+
+    Enum.each(runs, fn {run_id, events} ->
+      encoded = Enum.map_join(events, "", &(Jason.encode!(&1) <> "\n"))
+      File.write!(Path.join(directory, "#{run_id}.jsonl"), encoded)
+    end)
   end
 
   defp counter_run(

--- a/test/ptc_runner/kernel/run_analysis_test.exs
+++ b/test/ptc_runner/kernel/run_analysis_test.exs
@@ -15,8 +15,6 @@ defmodule PtcRunner.Kernel.RunAnalysisTest do
 
   @tag :tmp_dir
   test "run listing delegates the bounded native page", %{tmp_dir: root} do
-    File.write!(Path.join(root, "empty.jsonl"), "")
-
     {:ok, trace} =
       TraceSnapshot.start({:directory, root},
         max_result_bytes: HostConfig.minimum_snapshot_result_bytes()

--- a/test/ptc_runner/kernel/selected_canonical_snapshot_test.exs
+++ b/test/ptc_runner/kernel/selected_canonical_snapshot_test.exs
@@ -47,7 +47,7 @@ defmodule PtcRunner.Kernel.SelectedCanonicalSnapshotTest do
     on_exit(fn -> TraceSnapshot.stop(snapshot) end)
     assert {:ok, %{file_count: 2, run_count: 1}} = TraceSnapshot.info(snapshot)
     assert {:ok, true} = TraceSnapshot.run_exists?(snapshot, fixture.run_id)
-    assert {:ok, false} = TraceSnapshot.run_exists?(snapshot, "broken")
+    assert {:error, :run_isolated} = TraceSnapshot.run_exists?(snapshot, "broken")
   end
 
   @tag :tmp_dir

--- a/test/ptc_runner/kernel/selected_canonical_snapshot_test.exs
+++ b/test/ptc_runner/kernel/selected_canonical_snapshot_test.exs
@@ -37,12 +37,17 @@ defmodule PtcRunner.Kernel.SelectedCanonicalSnapshotTest do
   end
 
   @tag :tmp_dir
-  test "directory capture still fails closed on an unselected malformed member", %{tmp_dir: root} do
+  test "directory capture isolates an unrelated malformed member", %{tmp_dir: root} do
     fixture = fixture!(root)
     File.write!(Path.join(fixture.traces, "broken.jsonl"), "{not-json\n")
 
-    assert {:error, :malformed_source} =
+    assert {:ok, snapshot} =
              TraceSnapshot.start({:private_authorized_directory, fixture.traces}, owner: self())
+
+    on_exit(fn -> TraceSnapshot.stop(snapshot) end)
+    assert {:ok, %{file_count: 2, run_count: 1}} = TraceSnapshot.info(snapshot)
+    assert {:ok, true} = TraceSnapshot.run_exists?(snapshot, fixture.run_id)
+    assert {:ok, false} = TraceSnapshot.run_exists?(snapshot, "broken")
   end
 
   @tag :tmp_dir

--- a/test/ptc_runner/kernel/trace_directory_admission_test.exs
+++ b/test/ptc_runner/kernel/trace_directory_admission_test.exs
@@ -47,7 +47,11 @@ defmodule PtcRunner.Kernel.TraceDirectoryAdmissionTest do
 
   test "malformed syntax retains only the filename claim" do
     assert {:ok, evidence} =
-             TraceDirectoryAdmission.evidence("claimed.jsonl", :sanitized, :malformed_jsonl)
+             TraceDirectoryAdmission.evidence(
+               "claimed.jsonl",
+               :sanitized,
+               :malformed_jsonl
+             )
 
     assert evidence.filename_run_claim == "claimed"
     assert evidence.embedded_run_claims == []
@@ -222,11 +226,13 @@ defmodule PtcRunner.Kernel.TraceDirectoryAdmissionTest do
 
   test "classify refuses forged evidence without raising" do
     assert {:ok, valid} = evidence("valid.jsonl", :sanitized, [event("valid", "trace")])
+    unsupported = Map.put(event("valid", "trace"), "schema_version", 3)
 
     for forged <- [
           Map.delete(valid, :status),
           %{valid | source_name: <<255>>},
-          %{valid | reasons: [:unknown_reason]}
+          %{valid | reasons: [:unknown_reason]},
+          %{valid | events: [unsupported], status: {:decoded, [unsupported]}}
         ] do
       assert {:error, :invalid_evidence} = TraceDirectoryAdmission.classify([forged])
     end

--- a/test/ptc_runner/kernel/trace_directory_admission_test.exs
+++ b/test/ptc_runner/kernel/trace_directory_admission_test.exs
@@ -1,0 +1,249 @@
+defmodule PtcRunner.Kernel.TraceDirectoryAdmissionTest do
+  use ExUnit.Case, async: true
+
+  alias PtcRunner.Kernel.TraceDirectoryAdmission
+
+  test "canonical filename claims use the frozen ASCII grammar" do
+    maximum_stem = "a" <> String.duplicate("z", 255)
+    valid = ["a.jsonl", "A-1._z.jsonl", maximum_stem <> ".jsonl", "run.private.jsonl"]
+
+    for name <- valid do
+      kind = if String.ends_with?(name, ".private.jsonl"), do: :private, else: :sanitized
+
+      run_id =
+        name |> String.replace_suffix(".private.jsonl", "") |> String.replace_suffix(".jsonl", "")
+
+      assert {:ok, %{filename_run_claim: ^run_id, source_name: ^name, reasons: []}} =
+               evidence(name, kind, [event(run_id, "trace")])
+    end
+
+    invalid = [
+      ".jsonl",
+      "-run.jsonl",
+      "bad name.jsonl",
+      <<"bad", 0, ".jsonl">>,
+      <<"bad", 255, ".jsonl">>,
+      String.duplicate("a", 257) <> ".jsonl"
+    ]
+
+    for name <- invalid do
+      assert {:ok,
+              %{
+                raw_name: ^name,
+                filename_run_claim: nil,
+                source_name: nil,
+                reasons: [:invalid_filename]
+              }} = evidence(name, :sanitized, [event("embedded", "trace")])
+    end
+  end
+
+  test "the reserved private suffix determines source class" do
+    assert {:error, :invalid_evidence} =
+             evidence("secret.private.jsonl", :sanitized, [event("secret.private", "trace")])
+
+    assert {:error, :invalid_evidence} =
+             evidence("secret.jsonl", :private, [event("secret", "trace")])
+  end
+
+  test "malformed syntax retains only the filename claim" do
+    assert {:ok, evidence} =
+             TraceDirectoryAdmission.evidence("claimed.jsonl", :sanitized, :malformed_jsonl)
+
+    assert evidence.filename_run_claim == "claimed"
+    assert evidence.embedded_run_claims == []
+    assert evidence.embedded_trace_claims == []
+    assert evidence.reasons == [:malformed_jsonl]
+  end
+
+  test "the claim graph isolates a complete transitive component" do
+    assert {:ok, first} = evidence("one.jsonl", :sanitized, [event("one", "trace-a")])
+
+    assert {:ok, bridge} =
+             evidence("two.jsonl", :sanitized, [
+               event("one", "trace-b"),
+               Map.put(event("two", "trace-b"), "sequence", 2)
+             ])
+
+    assert {:ok, third} = evidence("three.jsonl", :sanitized, [event("three", "trace-b")])
+    assert {:ok, healthy} = evidence("healthy.jsonl", :sanitized, [event("healthy", "trace-ok")])
+
+    assert {:ok, classification} =
+             TraceDirectoryAdmission.classify([healthy, third, bridge, first])
+
+    assert [%{source_name: "healthy.jsonl"}] = classification.admitted
+
+    assert [component] = classification.isolated
+    assert component.source_names == ["one.jsonl", "three.jsonl", "two.jsonl"]
+    assert component.run_claims == ["one", "three", "two"]
+    assert component.trace_claims == ["trace-a", "trace-b"]
+
+    assert component.reasons == [
+             :filename_run_mismatch,
+             :run_identity_conflict,
+             :trace_identity_conflict
+           ]
+
+    assert classification.known_isolated_run_ids == MapSet.new(["one", "three", "two"])
+  end
+
+  test "classification ordering is independent of input order and omits unsafe names" do
+    unsafe_name = <<"unsafe", 255, ".jsonl">>
+    assert {:ok, unsafe} = evidence(unsafe_name, :sanitized, [event("unsafe", "trace-u")])
+    assert {:ok, alpha} = evidence("alpha.jsonl", :sanitized, [event("alpha", "trace-a")])
+
+    assert {:ok, forward} = TraceDirectoryAdmission.classify([unsafe, alpha])
+    assert {:ok, reverse} = TraceDirectoryAdmission.classify([alpha, unsafe])
+    assert forward == reverse
+
+    assert [admitted, isolated] = forward.components
+    assert admitted.source_names == ["alpha.jsonl"]
+    assert isolated.source_names == []
+    assert isolated.source_count == 1
+    assert isolated.sources_omitted_count == 1
+    assert isolated.reasons == [:invalid_filename]
+    assert hd(isolated.sources).raw_name == unsafe_name
+  end
+
+  test "reason order is closed and deterministic" do
+    assert {:ok, evidence} =
+             TraceDirectoryAdmission.evidence(
+               "wrong.jsonl",
+               :sanitized,
+               {:decoded,
+                [
+                  event("embedded", "trace")
+                  |> Map.put("schema_version", 3)
+                  |> Map.put("sequence", 0)
+                  |> Map.put("timestamp", "invalid")
+                ]}
+             )
+
+    assert evidence.reasons == [
+             :unsupported_version,
+             :filename_run_mismatch,
+             :sequence_conflict,
+             :malformed_event
+           ]
+
+    assert TraceDirectoryAdmission.reason_order() == [
+             :invalid_filename,
+             :not_regular,
+             :unreadable,
+             :malformed_jsonl,
+             :unsupported_version,
+             :filename_run_mismatch,
+             :run_identity_conflict,
+             :trace_identity_conflict,
+             :sequence_conflict,
+             :lifecycle_conflict,
+             :malformed_event
+           ]
+  end
+
+  test "producer-grade semantics are part of evidence construction" do
+    malformed = event("malformed", "trace") |> put_in(["data", "missions"], nil)
+    assert {:ok, malformed_evidence} = evidence("malformed.jsonl", :sanitized, [malformed])
+    assert malformed_evidence.reasons == [:malformed_event]
+
+    later_event =
+      event("sequence", "trace")
+      |> Map.put("type", "custom")
+      |> Map.put("data", %{})
+
+    duplicate_sequence = [event("sequence", "trace"), later_event]
+    assert {:ok, sequence_evidence} = evidence("sequence.jsonl", :sanitized, duplicate_sequence)
+    assert sequence_evidence.reasons == [:sequence_conflict]
+
+    duplicate_start = [
+      event("lifecycle", "trace"),
+      Map.put(event("lifecycle", "trace"), "sequence", 2)
+    ]
+
+    assert {:ok, lifecycle_evidence} = evidence("lifecycle.jsonl", :sanitized, duplicate_start)
+    assert lifecycle_evidence.reasons == [:lifecycle_conflict]
+
+    malformed_duplicate_start =
+      duplicate_start
+      |> List.update_at(1, &Map.put(&1, "timestamp", "invalid"))
+
+    assert {:ok, combined_evidence} =
+             evidence("lifecycle.jsonl", :sanitized, malformed_duplicate_start)
+
+    assert combined_evidence.reasons == [:lifecycle_conflict, :malformed_event]
+
+    overlong_run_id = String.duplicate("r", 257)
+
+    invalid_identity =
+      event(overlong_run_id, "trace")
+      |> Map.put("type", "custom")
+      |> Map.put("data", %{})
+
+    assert {:ok, invalid_identity_evidence} =
+             evidence("expected.jsonl", :sanitized, [invalid_identity])
+
+    assert invalid_identity_evidence.reasons == [:filename_run_mismatch, :malformed_event]
+
+    invalid_type = event("invalid-type", "trace") |> Map.put("type", "INVALID")
+
+    assert {:ok, invalid_type_evidence} =
+             evidence("invalid-type.jsonl", :sanitized, [invalid_type])
+
+    assert invalid_type_evidence.reasons == [:malformed_event]
+
+    invalid_evaluation =
+      event("evaluation", "trace")
+      |> Map.put("sequence", 2)
+      |> Map.put("type", "evaluation-started")
+      |> Map.put("data", %{
+        "evaluation_id" => "",
+        "environment" => "workflow",
+        "parent_evaluation_id" => nil
+      })
+
+    assert {:ok, evaluation_evidence} =
+             evidence("evaluation.jsonl", :sanitized, [
+               event("evaluation", "trace"),
+               invalid_evaluation
+             ])
+
+    assert evaluation_evidence.reasons == [:lifecycle_conflict]
+
+    forbidden_parent =
+      event("parent", "trace")
+      |> Map.put("sequence", 2)
+      |> Map.put("type", "custom")
+      |> Map.put("data", %{"parent_evaluation_id" => "parent-eval"})
+
+    assert {:ok, parent_evidence} =
+             evidence("parent.jsonl", :sanitized, [event("parent", "trace"), forbidden_parent])
+
+    assert parent_evidence.reasons == [:lifecycle_conflict]
+  end
+
+  test "classify refuses forged evidence without raising" do
+    assert {:ok, valid} = evidence("valid.jsonl", :sanitized, [event("valid", "trace")])
+
+    for forged <- [
+          Map.delete(valid, :status),
+          %{valid | source_name: <<255>>},
+          %{valid | reasons: [:unknown_reason]}
+        ] do
+      assert {:error, :invalid_evidence} = TraceDirectoryAdmission.classify([forged])
+    end
+  end
+
+  defp evidence(name, kind, events),
+    do: TraceDirectoryAdmission.evidence(name, kind, {:decoded, events})
+
+  defp event(run_id, trace_id) do
+    %{
+      "schema_version" => 2,
+      "run_id" => run_id,
+      "trace_id" => trace_id,
+      "sequence" => 1,
+      "timestamp" => "2026-08-26T00:00:00Z",
+      "type" => "run-started",
+      "data" => %{"missions" => %{}}
+    }
+  end
+end

--- a/test/ptc_runner/kernel/trace_directory_capture_test.exs
+++ b/test/ptc_runner/kernel/trace_directory_capture_test.exs
@@ -1,0 +1,326 @@
+defmodule PtcRunner.Kernel.TraceDirectoryCaptureTest do
+  use ExUnit.Case, async: true
+
+  alias PtcRunner.Kernel.TraceLog
+  alias PtcRunner.Kernel.TraceSnapshot
+  alias PtcRunner.Lisp.RetainedSize
+
+  @tag :tmp_dir
+  test "a damaged file is isolated beside a healthy filename-bound run", %{tmp_dir: directory} do
+    write_events(directory, "healthy.jsonl", [event("healthy", "trace-healthy", 1)])
+    File.write!(member(directory, "broken.jsonl"), "not-json\n")
+
+    assert {:ok, capture} = TraceLog.capture_directory(directory)
+    assert capture.version == :directory_admission_v1
+    assert capture.grant_class == :sanitized
+    assert Enum.map(capture.events, & &1["run_id"]) == ["healthy"]
+    assert capture.run_sources == %{"healthy" => :sanitized}
+    assert capture.analysis.runs_by_id |> Map.keys() == ["healthy"]
+    assert capture.known_isolated_run_ids == MapSet.new(["broken"])
+
+    assert [%{source_names: ["broken.jsonl"], reasons: [:malformed_jsonl]}] =
+             capture.isolated_components
+  end
+
+  @tag :tmp_dir
+  test "file evidence uses the closed local reason vocabulary", %{tmp_dir: directory} do
+    File.write!(member(directory, "empty.jsonl"), "")
+
+    File.write!(
+      member(directory, "duplicate.jsonl"),
+      ~s({"schema_version":2,"schema_version":2}\n)
+    )
+
+    File.write!(member(directory, "invalid.jsonl"), "{\n")
+    File.write!(member(directory, "nonobject.jsonl"), "[]\n")
+
+    unsupported = Map.put(event("version", "trace-version", 1), "schema_version", 3)
+    write_events(directory, "version.jsonl", [unsupported])
+    write_events(directory, "mismatch.jsonl", [event("other", "trace-other", 1)])
+
+    write_events(directory, "multi.jsonl", [
+      event("first", "trace-first", 1),
+      event("second", "trace-second", 1)
+    ])
+
+    write_events(directory, "sequence.jsonl", [
+      event("sequence", "trace-sequence", 1),
+      event("sequence", "trace-sequence", 1, "custom", %{})
+    ])
+
+    write_events(directory, "lifecycle.jsonl", [
+      event("lifecycle", "trace-lifecycle", 1),
+      event("lifecycle", "trace-lifecycle", 2)
+    ])
+
+    File.ln_s!(member(directory, "empty.jsonl"), member(directory, "linked.jsonl"))
+
+    assert {:ok, capture} = TraceLog.capture_directory(directory)
+    reasons = evidence_reasons(capture)
+
+    for name <- ["empty.jsonl", "duplicate.jsonl", "invalid.jsonl", "nonobject.jsonl"] do
+      assert reasons[name] == [:malformed_jsonl]
+    end
+
+    assert reasons["version.jsonl"] == [:unsupported_version]
+    assert reasons["mismatch.jsonl"] == [:filename_run_mismatch]
+
+    assert reasons["multi.jsonl"] == [:filename_run_mismatch]
+
+    assert Enum.find(capture.isolated_components, &(&1.source_names == ["multi.jsonl"])).reasons ==
+             [:filename_run_mismatch, :trace_identity_conflict]
+
+    assert reasons["sequence.jsonl"] == [:sequence_conflict]
+    assert reasons["lifecycle.jsonl"] == [:lifecycle_conflict]
+    assert reasons["linked.jsonl"] == [:not_regular]
+  end
+
+  @tag :tmp_dir
+  test "a stable unreadable regular member is isolated", %{tmp_dir: directory} do
+    path = member(directory, "unreadable.jsonl")
+    write_events(directory, "unreadable.jsonl", [event("unreadable", "trace", 1)])
+    File.chmod!(path, 0o000)
+    on_exit(fn -> File.chmod(path, 0o600) end)
+
+    assert {:error, :eacces} = File.read(path)
+    assert {:ok, capture} = TraceLog.capture_directory(directory)
+
+    assert [%{source_names: ["unreadable.jsonl"], reasons: [:unreadable]}] =
+             capture.isolated_components
+
+    assert capture.source_bytes == File.stat!(path).size
+  end
+
+  @tag :tmp_dir
+  test "invalid basenames stay in proof and identity but not safe source metadata", %{
+    tmp_dir: directory
+  } do
+    raw_name = "-unsafe.jsonl"
+    source = Jason.encode!(event("embedded", "trace-embedded", 1)) <> "\n"
+    File.write!(member(directory, raw_name), source)
+
+    assert {:ok, first} = TraceLog.capture_directory(directory)
+
+    assert [%{source_names: [], source_count: 1, sources_omitted_count: 1}] =
+             first.isolated_components
+
+    assert [%{raw_name: ^raw_name, content_digest: digest}] = first.source_proofs
+    assert is_binary(digest) and byte_size(digest) == 32
+
+    File.write!(member(directory, raw_name), source <> "\n")
+    assert {:ok, second} = TraceLog.capture_directory(directory)
+    refute second.source_id == first.source_id
+  end
+
+  @tag :tmp_dir
+  test "run and trace claim conflicts isolate complete connected components", %{
+    tmp_dir: directory
+  } do
+    write_events(directory, "same.jsonl", [event("same", "trace-same", 1)])
+    write_events(directory, "other.jsonl", [event("same", "trace-same", 2, "custom", %{})])
+    write_events(directory, "left.jsonl", [event("left", "shared-trace", 1)])
+    write_events(directory, "right.jsonl", [event("right", "shared-trace", 2)])
+
+    assert {:ok, capture} = TraceLog.capture_directory(directory)
+    assert capture.events == []
+
+    assert Enum.map(capture.isolated_components, & &1.source_names) == [
+             ["left.jsonl", "right.jsonl"],
+             ["other.jsonl", "same.jsonl"]
+           ]
+
+    assert Enum.map(capture.isolated_components, & &1.reasons) == [
+             [:trace_identity_conflict],
+             [
+               :filename_run_mismatch,
+               :run_identity_conflict,
+               :trace_identity_conflict,
+               :lifecycle_conflict
+             ]
+           ]
+  end
+
+  @tag :tmp_dir
+  test "normal, private-only, and mixed grants select only their authorized classes", %{
+    tmp_dir: directory
+  } do
+    write_events(directory, "normal.jsonl", [event("normal", "trace-normal", 1)])
+    write_events(directory, "private.private.jsonl", [event("private", "trace-private", 1)])
+
+    assert {:ok, normal} = TraceLog.capture_directory(directory)
+    assert normal.grant_class == :sanitized
+    assert Map.keys(normal.run_sources) == ["normal"]
+    assert normal.excluded_trace_files == %{"excluded_private_trace_files" => 1}
+    refute inspect(normal.source_proofs) =~ "private.private.jsonl"
+
+    assert {:ok, private} =
+             TraceLog.capture_directory(directory,
+               source_kind: :private,
+               include_sanitized: false
+             )
+
+    assert private.grant_class == :private
+    assert Map.keys(private.run_sources) == ["private"]
+    assert private.excluded_trace_files == %{"excluded_sanitized_trace_files" => 1}
+    refute inspect(private.source_proofs) =~ "normal.jsonl"
+
+    assert {:ok, mixed} = TraceLog.capture_directory(directory, source_kind: :private)
+    assert mixed.grant_class == :mixed_private_authorized
+    assert Map.keys(mixed.run_sources) |> Enum.sort() == ["normal", "private"]
+    assert mixed.excluded_trace_files == %{}
+    refute mixed.source_id == private.source_id
+  end
+
+  @tag :tmp_dir
+  test "source identity is deterministic and excludes opposite-class activity", %{
+    tmp_dir: first_directory
+  } do
+    second_directory = first_directory <> "-second"
+    File.mkdir!(second_directory)
+    on_exit(fn -> File.rm_rf!(second_directory) end)
+
+    write_events(first_directory, "b.jsonl", [event("b", "trace-b", 1)])
+    write_events(first_directory, "a.jsonl", [event("a", "trace-a", 1)])
+    write_events(second_directory, "a.jsonl", [event("a", "trace-a", 1)])
+    write_events(second_directory, "b.jsonl", [event("b", "trace-b", 1)])
+
+    assert {:ok, first} = TraceLog.capture_directory(first_directory)
+    assert {:ok, second} = TraceLog.capture_directory(second_directory)
+    assert first.source_id == second.source_id
+
+    write_events(first_directory, "hidden.private.jsonl", [event("hidden", "trace-hidden", 1)])
+    assert {:ok, with_excluded} = TraceLog.capture_directory(first_directory)
+    assert with_excluded.source_id == first.source_id
+    assert with_excluded.excluded_trace_files == %{"excluded_private_trace_files" => 1}
+  end
+
+  @tag :tmp_dir
+  test "excluded-class namespace changes are advisory unless they cross the entry ceiling", %{
+    tmp_dir: directory
+  } do
+    write_events(directory, "normal.jsonl", [event("normal", "trace-normal", 1)])
+    test = self()
+
+    capture =
+      Task.async(fn ->
+        TraceLog.capture_directory(directory,
+          listing_hook: fn ->
+            send(test, {:listing, self()})
+
+            receive do
+              :continue -> :ok
+            end
+          end
+        )
+      end)
+
+    assert_receive {:listing, first_listing}, 5_000
+    send(first_listing, :continue)
+    assert_receive {:listing, second_listing}, 5_000
+    write_events(directory, "private.private.jsonl", [event("private", "trace-private", 1)])
+    send(second_listing, :continue)
+    assert_receive {:listing, final_listing}, 5_000
+    send(final_listing, :continue)
+
+    assert {:ok, captured} = Task.await(capture)
+    assert Map.keys(captured.run_sources) == ["normal"]
+    assert captured.excluded_trace_files == %{"excluded_private_trace_files" => 1}
+
+    File.rm!(member(directory, "private.private.jsonl"))
+
+    limited =
+      Task.async(fn ->
+        TraceLog.capture_directory(directory,
+          max_directory_entries: 1,
+          listing_hook: fn ->
+            send(test, {:limited_listing, self()})
+
+            receive do
+              :continue -> :ok
+            end
+          end
+        )
+      end)
+
+    assert_receive {:limited_listing, first_limited}, 5_000
+    send(first_limited, :continue)
+    assert_receive {:limited_listing, second_limited}, 5_000
+    write_events(directory, "private.private.jsonl", [event("private", "trace-private", 1)])
+    send(second_limited, :continue)
+    assert {:error, :source_limit_exceeded} = Task.await(limited)
+  end
+
+  @tag :tmp_dir
+  test "directory root replacement rejects the complete capture", %{tmp_dir: directory} do
+    write_events(directory, "stable.jsonl", [event("stable", "trace-stable", 1)])
+    original = directory <> "-original"
+    on_exit(fn -> File.rm_rf(original) end)
+    test = self()
+
+    capture =
+      Task.async(fn ->
+        TraceLog.capture_directory(directory,
+          capture_hook: fn ->
+            send(test, {:captured, self()})
+
+            receive do
+              :continue -> :ok
+            end
+          end
+        )
+      end)
+
+    assert_receive {:captured, capture_pid}, 5_000
+    File.rename!(directory, original)
+    File.mkdir!(directory)
+    write_events(directory, "stable.jsonl", [event("stable", "trace-stable", 1)])
+    send(capture_pid, :continue)
+
+    assert {:error, :source_changed} = Task.await(capture)
+  end
+
+  @tag :tmp_dir
+  test "snapshot retention charges the complete directory admission value", %{tmp_dir: directory} do
+    write_events(directory, "healthy.jsonl", [event("healthy", "trace-healthy", 1)])
+    File.write!(member(directory, "broken.jsonl"), "bad\n")
+
+    assert {:ok, capture} = TraceLog.capture_directory(directory)
+    expected_retained_bytes = RetainedSize.bytes(capture)
+
+    assert {:ok, snapshot} = TraceSnapshot.start({:directory, directory}, owner: self())
+    on_exit(fn -> TraceSnapshot.stop(snapshot) end)
+    assert {:ok, %{retained_bytes: ^expected_retained_bytes}} = TraceSnapshot.info(snapshot)
+
+    assert {:error,
+            {:source_retained_limit_exceeded,
+             %{measured_bytes: ^expected_retained_bytes, limit_bytes: 1}}} =
+             TraceSnapshot.start({:directory, directory}, owner: self(), max_retained_bytes: 1)
+  end
+
+  defp evidence_reasons(capture) do
+    capture.components
+    |> Enum.flat_map(& &1.sources)
+    |> Map.new(&{&1.source_name, &1.reasons})
+  end
+
+  defp write_events(directory, name, events) do
+    encoded = Enum.map_join(events, "", &(Jason.encode!(&1) <> "\n"))
+    File.write!(member(directory, name), encoded)
+  end
+
+  defp member(directory, raw_name), do: directory <> "/" <> raw_name
+
+  defp event(run_id, trace_id, sequence, type \\ "run-started", data \\ nil) do
+    data = data || if(type == "run-started", do: %{"missions" => %{}}, else: %{})
+
+    %{
+      "schema_version" => 2,
+      "run_id" => run_id,
+      "trace_id" => trace_id,
+      "sequence" => sequence,
+      "timestamp" => "2026-08-26T00:00:00Z",
+      "type" => type,
+      "data" => data
+    }
+  end
+end

--- a/test/ptc_runner/kernel/trace_directory_query_test.exs
+++ b/test/ptc_runner/kernel/trace_directory_query_test.exs
@@ -414,8 +414,8 @@ defmodule PtcRunner.Kernel.TraceDirectoryQueryTest do
     :erlang.trace(caller, true, [:procs, :set_on_spawn])
     send(caller, :query)
 
-    assert_receive {:trace, ^caller, :spawn, guard, _spawned}, 5_000
-    assert_receive {:trace, ^guard, :spawn, worker, _spawned}, 5_000
+    assert_receive {:trace, ^caller, :spawn, _guard, _spawned}, 5_000
+    assert_receive {:trace, ^caller, :spawn, worker, _spawned}, 5_000
     worker_ref = Process.monitor(worker)
     true = :erlang.suspend_process(worker)
     send(linked, :fail)

--- a/test/ptc_runner/kernel/trace_directory_query_test.exs
+++ b/test/ptc_runner/kernel/trace_directory_query_test.exs
@@ -1,0 +1,267 @@
+defmodule PtcRunner.Kernel.TraceDirectoryQueryTest do
+  use ExUnit.Case, async: true
+
+  alias PtcRunner.Kernel.EventSink
+  alias PtcRunner.Kernel.Limits
+  alias PtcRunner.Kernel.ProviderError
+  alias PtcRunner.Kernel.RunAnalysisCapability
+  alias PtcRunner.Kernel.TraceLog
+  alias PtcRunner.Kernel.TraceSnapshot
+  alias PtcRunner.Lisp.RetainedSize
+
+  @tag :tmp_dir
+  test "direct and snapshot queries share one isolated directory admission", %{tmp_dir: directory} do
+    write_events(directory, "healthy.jsonl", [event("healthy", "trace-healthy", 1)])
+    File.write!(Path.join(directory, "broken.jsonl"), "not-json\n")
+    File.write!(Path.join(directory, "private.private.jsonl"), "not-json\n")
+
+    assert {:ok, trace_log} = TraceLog.new(source: {:directory, directory})
+    assert {:ok, snapshot} = TraceSnapshot.start({:directory, directory}, owner: self())
+    on_exit(fn -> TraceSnapshot.stop(snapshot) end)
+
+    for {operation, arguments} <- [
+          {:list_runs, %{}},
+          {:get_run, %{"run_id" => "healthy"}},
+          {:list_turns, %{"run_id" => "healthy"}},
+          {:counters, %{}}
+        ] do
+      assert {:ok, direct} = TraceLog.query(trace_log, operation, arguments)
+      assert {:ok, frozen} = TraceSnapshot.query(snapshot, operation, arguments)
+      assert Map.delete(frozen, "snapshot_hash") == direct
+    end
+
+    for operation <- [:get_run, :list_turns] do
+      assert {:error, :run_isolated} =
+               TraceLog.query(trace_log, operation, %{"run_id" => "broken"})
+
+      assert {:error, :run_isolated} =
+               TraceSnapshot.query(snapshot, operation, %{"run_id" => "broken"})
+
+      assert {:error, :not_found} =
+               TraceLog.query(trace_log, operation, %{"run_id" => "absent"})
+
+      assert {:error, :not_found} =
+               TraceSnapshot.query(snapshot, operation, %{"run_id" => "absent"})
+
+      assert {:error, :not_found} =
+               TraceLog.query(trace_log, operation, %{"run_id" => "private"})
+
+      assert {:error, :not_found} =
+               TraceSnapshot.query(snapshot, operation, %{"run_id" => "private"})
+    end
+
+    assert {:error, :run_isolated} = TraceSnapshot.run_exists?(snapshot, "broken")
+
+    assert {:ok, capabilities} = RunAnalysisCapability.from_snapshots(snapshot)
+    open = Enum.find(capabilities, &(&1.name == "analysis-open"))
+    read = Enum.find(capabilities, &(&1.name == "analysis-read"))
+
+    for {capability, arguments} <- [
+          {open, %{"run_id" => "broken"}},
+          {read, %{"run_id" => "broken", "collection" => "turns"}}
+        ] do
+      assert {:error,
+              %ProviderError{
+                kind: :unavailable,
+                details: "analysis run is isolated by damaged trace evidence",
+                retryable?: false
+              }} = capability.callback.(arguments)
+    end
+  end
+
+  @tag :tmp_dir
+  test "direct cursors bind isolation evidence while snapshot cursors stay frozen", %{
+    tmp_dir: directory
+  } do
+    write_events(directory, "a.jsonl", [event("a", "trace-a", 1)])
+    write_events(directory, "b.jsonl", [event("b", "trace-b", 1)])
+    File.write!(Path.join(directory, "broken.jsonl"), "bad\n")
+
+    assert {:ok, trace_log} = TraceLog.new(source: {:directory, directory})
+    assert {:ok, snapshot} = TraceSnapshot.start({:directory, directory}, owner: self())
+    on_exit(fn -> TraceSnapshot.stop(snapshot) end)
+
+    assert {:ok, %{"next_cursor" => direct_cursor}} =
+             TraceLog.query(trace_log, :list_runs, %{"limit" => 1})
+
+    assert {:ok, %{"next_cursor" => snapshot_cursor}} =
+             TraceSnapshot.query(snapshot, :list_runs, %{"limit" => 1})
+
+    File.write!(Path.join(directory, "broken.jsonl"), "different-bad\n")
+
+    assert {:error, :source_changed} =
+             TraceLog.query(trace_log, :list_runs, %{"limit" => 1, "cursor" => direct_cursor})
+
+    assert {:ok, %{"items" => [_]}} =
+             TraceSnapshot.query(snapshot, :list_runs, %{
+               "limit" => 1,
+               "cursor" => snapshot_cursor
+             })
+  end
+
+  @tag :tmp_dir
+  test "direct directory construction and admission share the hard ceilings", %{
+    tmp_dir: directory
+  } do
+    for {option, value} <- [
+          {:max_source_bytes, 8_000_001},
+          {:max_retained_bytes, 32_000_001},
+          {:max_result_bytes, 1_000_001},
+          {:max_directory_entries, 4_097},
+          {:max_trace_files, 1_025}
+        ] do
+      assert {:error, :invalid_trace_log} =
+               TraceLog.new([{:source, {:directory, directory}}, {option, value}])
+    end
+
+    write_events(directory, "one.jsonl", [event("one", "trace-one", 1)])
+    write_events(directory, "two.jsonl", [event("two", "trace-two", 1)])
+
+    assert {:ok, entry_limited} =
+             TraceLog.new(source: {:directory, directory}, max_directory_entries: 1)
+
+    assert {:error, :source_limit_exceeded} = TraceLog.query(entry_limited, :list_runs, %{})
+
+    assert {:ok, file_limited} =
+             TraceLog.new(source: {:directory, directory}, max_trace_files: 1)
+
+    assert {:error, :source_limit_exceeded} = TraceLog.query(file_limited, :list_runs, %{})
+
+    assert {:ok, snapshot} = TraceSnapshot.start({:directory, directory}, owner: self())
+    on_exit(fn -> TraceSnapshot.stop(snapshot) end)
+    assert {:ok, %{retained_bytes: retained_bytes}} = TraceSnapshot.info(snapshot)
+
+    assert {:ok, exact} =
+             TraceLog.new(
+               source: {:directory, directory},
+               max_retained_bytes: retained_bytes
+             )
+
+    assert {:ok, %{"items" => [_, _]}} = TraceLog.query(exact, :list_runs, %{})
+
+    assert {:ok, too_small} =
+             TraceLog.new(
+               source: {:directory, directory},
+               max_retained_bytes: retained_bytes - 1
+             )
+
+    assert {:error, :source_retained_limit_exceeded} =
+             TraceLog.query(too_small, :list_runs, %{})
+  end
+
+  @tag :tmp_dir
+  test "directory-only limits do not change explicit file and sink construction", %{
+    tmp_dir: directory
+  } do
+    path = Path.join(directory, "aggregate.any-name.jsonl")
+    write_events(directory, Path.basename(path), [event("one", "trace-one", 1)])
+
+    for source <- [{:file, path}, start_sink()] do
+      if match?(%EventSink{}, source), do: on_exit(fn -> EventSink.stop(source) end)
+
+      assert {:ok, _trace_log} =
+               TraceLog.new(
+                 source: source,
+                 max_source_bytes: 8_000_001,
+                 max_result_bytes: 1_000_001
+               )
+
+      for option <- [:max_retained_bytes, :max_directory_entries, :max_trace_files] do
+        assert {:error, :invalid_trace_log} =
+                 TraceLog.new([{:source, source}, {option, 1}])
+      end
+    end
+  end
+
+  @tag :tmp_dir
+  test "direct and snapshot pages reserve the same exact result budget", %{tmp_dir: directory} do
+    for index <- 1..4 do
+      rich_event =
+        event("run-#{index}", "trace-#{index}", 1)
+        |> put_in(["data", "labels"], %{
+          "name" => String.duplicate("n", 128),
+          "tags" => %{"suite" => "integration", "stage" => "validating"}
+        })
+
+      write_events(directory, "run-#{index}.jsonl", [rich_event])
+    end
+
+    assert {:ok, unbounded} = TraceLog.new(source: {:directory, directory})
+    assert {:ok, full_direct} = TraceLog.query(unbounded, :list_runs, %{})
+
+    exact_direct_bytes =
+      max(byte_size(Jason.encode!(full_direct)), RetainedSize.bytes(full_direct))
+
+    assert {:ok, direct} =
+             TraceLog.new(
+               source: {:directory, directory},
+               max_result_bytes: exact_direct_bytes
+             )
+
+    assert {:ok, snapshot} =
+             TraceSnapshot.start({:directory, directory},
+               owner: self(),
+               max_result_bytes: exact_direct_bytes
+             )
+
+    on_exit(fn -> TraceSnapshot.stop(snapshot) end)
+
+    assert {:ok, direct_page} = TraceLog.query(direct, :list_runs, %{})
+    assert {:ok, snapshot_page} = TraceSnapshot.query(snapshot, :list_runs, %{})
+    assert Map.delete(snapshot_page, "snapshot_hash") == direct_page
+    assert length(direct_page["items"]) < 4
+  end
+
+  @tag :tmp_dir
+  test "direct admission does not trap an arbitrary caller's linked exits", %{tmp_dir: directory} do
+    write_events(directory, "healthy.jsonl", [event("healthy", "trace-healthy", 1)])
+    assert {:ok, trace_log} = TraceLog.new(source: {:directory, directory})
+    test = self()
+    linked = spawn(fn -> receive do: (:fail -> exit(:linked_failure)) end)
+
+    caller =
+      spawn(fn ->
+        Process.link(linked)
+
+        receive do
+          :query -> send(test, {:query_result, TraceLog.query(trace_log, :list_runs, %{})})
+        end
+      end)
+
+    caller_ref = Process.monitor(caller)
+    :erlang.trace(caller, true, [:procs, :set_on_spawn])
+    send(caller, :query)
+
+    assert_receive {:trace, ^caller, :spawn, guard, _spawned}, 5_000
+    assert_receive {:trace, ^guard, :spawn, worker, _spawned}, 5_000
+    worker_ref = Process.monitor(worker)
+    true = :erlang.suspend_process(worker)
+    send(linked, :fail)
+
+    assert_receive {:DOWN, ^caller_ref, :process, ^caller, :linked_failure}, 5_000
+    refute_receive {:query_result, _result}
+    assert_receive {:DOWN, ^worker_ref, :process, ^worker, :killed}, 5_000
+  end
+
+  defp write_events(directory, name, events) do
+    encoded = Enum.map_join(events, "", &(Jason.encode!(&1) <> "\n"))
+    File.write!(Path.join(directory, name), encoded)
+  end
+
+  defp start_sink do
+    {:ok, sink} = EventSink.start(:normal, Limits.defaults())
+    sink
+  end
+
+  defp event(run_id, trace_id, sequence) do
+    %{
+      "schema_version" => 2,
+      "run_id" => run_id,
+      "trace_id" => trace_id,
+      "sequence" => sequence,
+      "timestamp" => "2026-08-26T00:00:00Z",
+      "type" => "run-started",
+      "data" => %{"missions" => %{}}
+    }
+  end
+end

--- a/test/ptc_runner/kernel/trace_directory_query_test.exs
+++ b/test/ptc_runner/kernel/trace_directory_query_test.exs
@@ -70,6 +70,188 @@ defmodule PtcRunner.Kernel.TraceDirectoryQueryTest do
   end
 
   @tag :tmp_dir
+  test "directory catalog queries report exact bounded isolation evidence", %{
+    tmp_dir: directory
+  } do
+    write_events(directory, "healthy.jsonl", [event("healthy", "trace-healthy", 1)])
+    write_events(directory, "healthy-two.jsonl", [event("healthy-two", "trace-healthy-two", 1)])
+    File.write!(Path.join(directory, "broken.jsonl"), "not-json\n")
+
+    write_events(directory, "alpha.jsonl", [event("shared", "trace-alpha", 1)])
+    write_events(directory, "beta.jsonl", [event("shared", "trace-beta", 1)])
+
+    expected = %{
+      "component_count" => 2,
+      "source_count" => 3,
+      "known_run_count" => 4,
+      "reasons" => [
+        %{"reason" => "malformed_jsonl", "component_count" => 1, "source_count" => 1},
+        %{
+          "reason" => "filename_run_mismatch",
+          "component_count" => 1,
+          "source_count" => 2
+        },
+        %{
+          "reason" => "run_identity_conflict",
+          "component_count" => 1,
+          "source_count" => 2
+        }
+      ],
+      "examples" => [
+        %{
+          "sources" => ["alpha.jsonl", "beta.jsonl"],
+          "source_count" => 2,
+          "sources_omitted_count" => 0,
+          "reasons" => ["filename_run_mismatch", "run_identity_conflict"]
+        },
+        %{
+          "sources" => ["broken.jsonl"],
+          "source_count" => 1,
+          "sources_omitted_count" => 0,
+          "reasons" => ["malformed_jsonl"]
+        }
+      ],
+      "examples_omitted_count" => 0
+    }
+
+    assert {:ok, trace_log} = TraceLog.new(source: {:directory, directory})
+    assert {:ok, snapshot} = TraceSnapshot.start({:directory, directory}, owner: self())
+    on_exit(fn -> TraceSnapshot.stop(snapshot) end)
+
+    for {operation, arguments} <- [
+          {:list_runs, %{"limit" => 1}},
+          {:list_runs, %{"status" => "absent"}},
+          {:counters, %{"status" => "absent"}}
+        ] do
+      assert {:ok, %{"isolation" => ^expected} = direct} =
+               TraceLog.query(trace_log, operation, arguments)
+
+      assert {:ok, %{"isolation" => ^expected} = frozen} =
+               TraceSnapshot.query(snapshot, operation, arguments)
+
+      assert Map.delete(frozen, "snapshot_hash") == direct
+    end
+
+    assert {:ok, %{"next_cursor" => cursor}} =
+             TraceSnapshot.query(snapshot, :list_runs, %{"limit" => 1})
+
+    assert {:ok, %{"isolation" => ^expected, "items" => [_]}} =
+             TraceSnapshot.query(snapshot, :list_runs, %{"limit" => 1, "cursor" => cursor})
+
+    assert {:ok, run} = TraceLog.query(trace_log, :get_run, %{"run_id" => "healthy"})
+    refute Map.has_key?(run, "isolation")
+
+    assert {:ok, turns} = TraceSnapshot.query(snapshot, :list_turns, %{"run_id" => "healthy"})
+    refute Map.has_key?(turns, "isolation")
+  end
+
+  @tag :tmp_dir
+  test "isolation examples and source names have deterministic presentation caps", %{
+    tmp_dir: directory
+  } do
+    for index <- 1..18 do
+      File.write!(
+        Path.join(directory, "broken-#{String.pad_leading(to_string(index), 2, "0")}.jsonl"),
+        "bad\n"
+      )
+    end
+
+    File.write!(Path.join(directory, "!.jsonl"), "bad\n")
+
+    for index <- 1..10 do
+      write_events(directory, "a-joined-#{index}.jsonl", [event("shared", "trace-#{index}", 1)])
+    end
+
+    assert {:ok, trace_log} = TraceLog.new(source: {:directory, directory})
+    assert {:ok, %{"isolation" => isolation}} = TraceLog.query(trace_log, :list_runs, %{})
+
+    assert isolation["component_count"] == 20
+    assert isolation["source_count"] == 29
+    assert isolation["known_run_count"] == 29
+    assert length(isolation["examples"]) == 16
+    assert isolation["examples_omitted_count"] == 4
+
+    invalid = hd(isolation["examples"])
+    assert invalid["sources"] == []
+    assert invalid["source_count"] == 1
+    assert invalid["sources_omitted_count"] == 1
+
+    joined = Enum.find(isolation["examples"], &(&1["source_count"] == 10))
+    assert length(joined["sources"]) == 8
+    assert joined["sources"] == Enum.sort(joined["sources"])
+    assert joined["sources_omitted_count"] == 2
+  end
+
+  @tag :tmp_dir
+  test "result fitting drops isolation examples before canonical run items", %{
+    tmp_dir: directory
+  } do
+    write_events(directory, "healthy.jsonl", [event("healthy", "trace-healthy", 1)])
+
+    for index <- 1..4 do
+      name = "#{String.duplicate("damaged", 12)}-#{index}.jsonl"
+      File.write!(Path.join(directory, name), "bad\n")
+    end
+
+    assert {:ok, unbounded} = TraceSnapshot.start({:directory, directory}, owner: self())
+    on_exit(fn -> TraceSnapshot.stop(unbounded) end)
+    assert {:ok, full_page} = TraceSnapshot.query(unbounded, :list_runs, %{})
+    assert length(full_page["isolation"]["examples"]) == 4
+
+    fitted_isolation =
+      full_page["isolation"]
+      |> Map.put("examples", [])
+      |> Map.put("examples_omitted_count", 4)
+
+    expected_page = Map.put(full_page, "isolation", fitted_isolation)
+    exact_bytes = max(byte_size(Jason.encode!(expected_page)), RetainedSize.bytes(expected_page))
+
+    assert {:ok, snapshot} =
+             TraceSnapshot.start({:directory, directory},
+               owner: self(),
+               max_result_bytes: exact_bytes
+             )
+
+    on_exit(fn -> TraceSnapshot.stop(snapshot) end)
+
+    assert {:ok, ^expected_page} = TraceSnapshot.query(snapshot, :list_runs, %{})
+
+    assert {:ok, direct} =
+             TraceLog.new(source: {:directory, directory}, max_result_bytes: exact_bytes)
+
+    assert {:ok, direct_page} = TraceLog.query(direct, :list_runs, %{})
+    assert direct_page == Map.delete(expected_page, "snapshot_hash")
+
+    assert {:ok, full_counters} = TraceSnapshot.query(unbounded, :counters, %{})
+
+    expected_counters = Map.put(full_counters, "isolation", fitted_isolation)
+
+    exact_counter_bytes =
+      max(byte_size(Jason.encode!(expected_counters)), RetainedSize.bytes(expected_counters))
+
+    assert {:ok, counter_snapshot} =
+             TraceSnapshot.start({:directory, directory},
+               owner: self(),
+               max_result_bytes: exact_counter_bytes
+             )
+
+    on_exit(fn -> TraceSnapshot.stop(counter_snapshot) end)
+    assert {:ok, ^expected_counters} = TraceSnapshot.query(counter_snapshot, :counters, %{})
+
+    assert {:ok, counter_direct} =
+             TraceLog.new(source: {:directory, directory}, max_result_bytes: exact_counter_bytes)
+
+    assert {:ok, direct_counters} = TraceLog.query(counter_direct, :counters, %{})
+    assert direct_counters == Map.delete(expected_counters, "snapshot_hash")
+
+    assert {:ok, impossible} =
+             TraceLog.new(source: {:directory, directory}, max_result_bytes: 1)
+
+    assert {:error, :result_limit_exceeded} = TraceLog.query(impossible, :list_runs, %{})
+    assert {:error, :result_limit_exceeded} = TraceLog.query(impossible, :counters, %{})
+  end
+
+  @tag :tmp_dir
   test "direct cursors bind isolation evidence while snapshot cursors stay frozen", %{
     tmp_dir: directory
   } do

--- a/test/ptc_runner/kernel/trace_log_test.exs
+++ b/test/ptc_runner/kernel/trace_log_test.exs
@@ -754,7 +754,7 @@ defmodule PtcRunner.Kernel.TraceLogTest do
   @tag :tmp_dir
   test "private JSONL sources require reserved names and explicit grants", %{tmp_dir: directory} do
     normal_path = Path.join(directory, "normal.jsonl")
-    private_path = Path.join(directory, "secret.private.jsonl")
+    private_path = Path.join(directory, "private.private.jsonl")
     normal_event = decoded_event("normal", 1, "run-started")
     private_event = decoded_event("private", 1, "run-started")
 
@@ -795,7 +795,7 @@ defmodule PtcRunner.Kernel.TraceLogTest do
 
     assert :ok =
              TraceLog.append_jsonl(
-               Path.join(directory, "secret.private.jsonl"),
+               Path.join(directory, "private.private.jsonl"),
                [decoded_event("private", 1, "run-started")],
                private: true
              )
@@ -903,8 +903,8 @@ defmodule PtcRunner.Kernel.TraceLogTest do
 
   @tag :tmp_dir
   test "cursors are bound to their operation and filters", %{tmp_dir: directory} do
-    File.write!(Path.join(directory, "a.jsonl"), jsonl_event("first", 1, "run-started"))
-    File.write!(Path.join(directory, "b.jsonl"), jsonl_event("second", 1, "run-started"))
+    File.write!(Path.join(directory, "first.jsonl"), jsonl_event("first", 1, "run-started"))
+    File.write!(Path.join(directory, "second.jsonl"), jsonl_event("second", 1, "run-started"))
 
     {:ok, trace_log} = TraceLog.new(source: {:directory, directory})
 

--- a/test/ptc_runner/kernel/trace_snapshot_test.exs
+++ b/test/ptc_runner/kernel/trace_snapshot_test.exs
@@ -11,8 +11,6 @@ defmodule PtcRunner.Kernel.TraceSnapshotTest do
   test "the accepted minimum result ceiling can return an empty page", %{
     tmp_dir: directory
   } do
-    File.write!(Path.join(directory, "empty.jsonl"), "")
-
     assert {:ok, snapshot} =
              TraceSnapshot.start({:directory, directory},
                owner: self(),

--- a/test/ptc_runner/kernel/trace_snapshot_test.exs
+++ b/test/ptc_runner/kernel/trace_snapshot_test.exs
@@ -35,7 +35,7 @@ defmodule PtcRunner.Kernel.TraceSnapshotTest do
   test "captures one immutable normal directory and reuses canonical queries", %{
     tmp_dir: directory
   } do
-    path = Path.join(directory, "normal.jsonl")
+    path = Path.join(directory, "first.jsonl")
     private_path = Path.join(directory, "hidden.private.jsonl")
     inspection_path = Path.join(directory, "hidden.ptcins")
 
@@ -162,17 +162,20 @@ defmodule PtcRunner.Kernel.TraceSnapshotTest do
   end
 
   @tag :tmp_dir
-  test "private-authorized capture rejects one run split across source classes", %{
+  test "private-authorized capture isolates one run split across source classes", %{
     tmp_dir: directory
   } do
-    write_events(Path.join(directory, "run.jsonl"), [event("split", 1, "run-started")])
+    write_events(Path.join(directory, "split.jsonl"), [event("split", 1, "run-started")])
 
-    write_events(Path.join(directory, "run.private.jsonl"), [
+    write_events(Path.join(directory, "split.private.jsonl"), [
       event("split", 2, "run-stopped")
     ])
 
-    assert {:error, :malformed_source} =
+    assert {:ok, snapshot} =
              TraceSnapshot.start({:private_authorized_directory, directory}, owner: self())
+
+    assert {:ok, %{run_count: 0, file_count: 2}} = TraceSnapshot.info(snapshot)
+    assert :ok = TraceSnapshot.stop(snapshot)
   end
 
   @tag :tmp_dir
@@ -202,8 +205,8 @@ defmodule PtcRunner.Kernel.TraceSnapshotTest do
 
   @tag :tmp_dir
   test "snapshot cursors remain bound to the immutable capture", %{tmp_dir: directory} do
-    write_events(Path.join(directory, "a.jsonl"), [event("first", 1, "run-started")])
-    write_events(Path.join(directory, "b.jsonl"), [event("second", 1, "run-started")])
+    write_events(Path.join(directory, "first.jsonl"), [event("first", 1, "run-started")])
+    write_events(Path.join(directory, "second.jsonl"), [event("second", 1, "run-started")])
 
     assert {:ok, snapshot} = TraceSnapshot.start({:directory, directory}, owner: self())
     on_exit(fn -> TraceSnapshot.stop(snapshot) end)
@@ -211,7 +214,7 @@ defmodule PtcRunner.Kernel.TraceSnapshotTest do
     assert {:ok, %{"items" => [_], "next_cursor" => cursor}} =
              TraceSnapshot.query(snapshot, :list_runs, %{"limit" => 1})
 
-    write_events(Path.join(directory, "c.jsonl"), [event("third", 1, "run-started")])
+    write_events(Path.join(directory, "third.jsonl"), [event("third", 1, "run-started")])
 
     assert {:ok, %{"items" => [_], "next_cursor" => nil}} =
              TraceSnapshot.query(snapshot, :list_runs, %{"limit" => 1, "cursor" => cursor})
@@ -232,7 +235,7 @@ defmodule PtcRunner.Kernel.TraceSnapshotTest do
       |> event(1, "run-started")
       |> put_in(["data", "labels"], %{"name" => String.duplicate("x", 1_024)})
 
-    write_events(Path.join(directory, "trace.jsonl"), [oversized])
+    write_events(Path.join(directory, "oversized.jsonl"), [oversized])
 
     assert {:ok, snapshot} =
              TraceSnapshot.start({:directory, directory},
@@ -257,7 +260,10 @@ defmodule PtcRunner.Kernel.TraceSnapshotTest do
         |> put_in(["data", "labels"], %{"name" => "run-#{index}", "tags" => tags})
       end)
 
-    write_events(Path.join(directory, "runs.jsonl"), events)
+    Enum.each(events, fn event ->
+      write_events(Path.join(directory, event["run_id"] <> ".jsonl"), [event])
+    end)
+
     assert {:ok, trace_log} = TraceLog.new(source: {:directory, directory})
     assert {:ok, raw_page} = TraceLog.query(trace_log, :list_runs, %{})
 
@@ -299,7 +305,7 @@ defmodule PtcRunner.Kernel.TraceSnapshotTest do
 
   @tag :tmp_dir
   test "safe metadata is bounded and contains no source path", %{tmp_dir: directory} do
-    path = Path.join(directory, "trace.jsonl")
+    path = Path.join(directory, "visible.jsonl")
     write_events(path, [event("visible", 1, "run-started")])
 
     assert {:ok, snapshot} = TraceSnapshot.start({:directory, directory}, owner: self())
@@ -329,7 +335,7 @@ defmodule PtcRunner.Kernel.TraceSnapshotTest do
   test "unexpected calls, casts, and messages do not terminate the snapshot", %{
     tmp_dir: directory
   } do
-    write_events(Path.join(directory, "trace.jsonl"), [event("stable", 1, "run-started")])
+    write_events(Path.join(directory, "stable.jsonl"), [event("stable", 1, "run-started")])
 
     assert {:ok, snapshot} = TraceSnapshot.start({:directory, directory}, owner: self())
     on_exit(fn -> TraceSnapshot.stop(snapshot) end)
@@ -344,7 +350,7 @@ defmodule PtcRunner.Kernel.TraceSnapshotTest do
 
   @tag :tmp_dir
   test "encoded and retained capture ceilings fail independently", %{tmp_dir: directory} do
-    path = Path.join(directory, "trace.jsonl")
+    path = Path.join(directory, "bounded.jsonl")
     write_events(path, [event("bounded", 1, "run-started")])
 
     assert {:ok, snapshot} = TraceSnapshot.start({:directory, directory}, owner: self())
@@ -374,7 +380,7 @@ defmodule PtcRunner.Kernel.TraceSnapshotTest do
 
   @tag :tmp_dir
   test "capture heap exhaustion returns a stable retained-limit error", %{tmp_dir: directory} do
-    write_events(Path.join(directory, "trace.jsonl"), [event("bounded", 1, "run-started")])
+    write_events(Path.join(directory, "bounded.jsonl"), [event("bounded", 1, "run-started")])
 
     assert {:error, :source_retained_limit_exceeded} =
              TraceSnapshot.start({:directory, directory},
@@ -385,7 +391,7 @@ defmodule PtcRunner.Kernel.TraceSnapshotTest do
 
   @tag :tmp_dir
   test "construction limits may be lowered but not raised", %{tmp_dir: directory} do
-    write_events(Path.join(directory, "trace.jsonl"), [event("bounded", 1, "run-started")])
+    write_events(Path.join(directory, "bounded.jsonl"), [event("bounded", 1, "run-started")])
 
     raised_limits = [
       max_source_bytes: 8_000_001,
@@ -406,7 +412,7 @@ defmodule PtcRunner.Kernel.TraceSnapshotTest do
   test "directory entry and trace file ceilings bound capture work", %{tmp_dir: directory} do
     File.write!(Path.join(directory, "ignored-a"), "")
     File.write!(Path.join(directory, "ignored-b"), "")
-    write_events(Path.join(directory, "trace.jsonl"), [event("bounded", 1, "run-started")])
+    write_events(Path.join(directory, "bounded.jsonl"), [event("bounded", 1, "run-started")])
 
     assert {:error, :source_limit_exceeded} =
              TraceSnapshot.start({:directory, directory},
@@ -429,7 +435,7 @@ defmodule PtcRunner.Kernel.TraceSnapshotTest do
   test "snapshot and live directories agree at the exact source byte ceiling", %{
     tmp_dir: directory
   } do
-    path = Path.join(directory, "a.jsonl")
+    path = Path.join(directory, "exact.jsonl")
     write_events(path, [event("exact", 1, "run-started")])
     File.write!(Path.join(directory, "z.jsonl"), "")
     source_bytes = File.stat!(path).size
@@ -451,23 +457,29 @@ defmodule PtcRunner.Kernel.TraceSnapshotTest do
   end
 
   @tag :tmp_dir
-  test "fails closed on malformed and unsupported canonical input", %{tmp_dir: directory} do
-    path = Path.join(directory, "trace.jsonl")
+  test "isolates malformed and unsupported canonical input", %{tmp_dir: directory} do
+    path = Path.join(directory, "version.jsonl")
     unsupported = Map.put(event("version", 1, "run-started"), "schema_version", 3)
     write_events(path, [unsupported])
 
-    assert {:error, :unsupported_version} =
+    assert {:ok, unsupported_snapshot} =
              TraceSnapshot.start({:directory, directory}, owner: self())
+
+    assert {:ok, %{run_count: 0}} = TraceSnapshot.info(unsupported_snapshot)
+    assert :ok = TraceSnapshot.stop(unsupported_snapshot)
 
     File.write!(path, ~s({"schema_version":2,"schema_version":2}\n))
 
-    assert {:error, :malformed_source} =
+    assert {:ok, malformed_snapshot} =
              TraceSnapshot.start({:directory, directory}, owner: self())
+
+    assert {:ok, %{run_count: 0}} = TraceSnapshot.info(malformed_snapshot)
+    assert :ok = TraceSnapshot.stop(malformed_snapshot)
   end
 
   @tag :tmp_dir
   test "detects a directory file change between inventory and capture", %{tmp_dir: directory} do
-    path = Path.join(directory, "trace.jsonl")
+    path = Path.join(directory, "before.jsonl")
     write_events(path, [event("before", 1, "run-started")])
     test = self()
 
@@ -494,7 +506,7 @@ defmodule PtcRunner.Kernel.TraceSnapshotTest do
 
   @tag :tmp_dir
   test "detects a same-size rewrite after the baseline content read", %{tmp_dir: directory} do
-    path = Path.join(directory, "trace.jsonl")
+    path = Path.join(directory, "before.jsonl")
     before = event("before", 1, "run-started")
     after_rewrite = event("change", 1, "run-started")
     assert byte_size(Jason.encode!(before)) == byte_size(Jason.encode!(after_rewrite))
@@ -524,7 +536,7 @@ defmodule PtcRunner.Kernel.TraceSnapshotTest do
 
   @tag :tmp_dir
   test "detects a same-size rewrite during the final inventory", %{tmp_dir: directory} do
-    path = Path.join(directory, "trace.jsonl")
+    path = Path.join(directory, "before.jsonl")
     before = event("before", 1, "run-started")
     after_rewrite = event("change", 1, "run-started")
     assert byte_size(Jason.encode!(before)) == byte_size(Jason.encode!(after_rewrite))
@@ -559,7 +571,7 @@ defmodule PtcRunner.Kernel.TraceSnapshotTest do
 
   @tag :tmp_dir
   test "the token and owner control snapshot lifetime", %{tmp_dir: directory} do
-    write_events(Path.join(directory, "trace.jsonl"), [event("owned", 1, "run-started")])
+    write_events(Path.join(directory, "owned.jsonl"), [event("owned", 1, "run-started")])
 
     owner =
       spawn(fn ->
@@ -590,7 +602,7 @@ defmodule PtcRunner.Kernel.TraceSnapshotTest do
 
   @tag :tmp_dir
   test "owner death cancels snapshot construction", %{tmp_dir: directory} do
-    write_events(Path.join(directory, "trace.jsonl"), [event("owned", 1, "run-started")])
+    write_events(Path.join(directory, "owned.jsonl"), [event("owned", 1, "run-started")])
     test = self()
 
     owner =
@@ -638,7 +650,7 @@ defmodule PtcRunner.Kernel.TraceSnapshotTest do
 
   @tag :tmp_dir
   test "owner death cancels bounded directory enumeration", %{tmp_dir: directory} do
-    write_events(Path.join(directory, "trace.jsonl"), [event("owned", 1, "run-started")])
+    write_events(Path.join(directory, "owned.jsonl"), [event("owned", 1, "run-started")])
     test = self()
 
     owner =
@@ -672,7 +684,7 @@ defmodule PtcRunner.Kernel.TraceSnapshotTest do
 
   @tag :tmp_dir
   test "snapshot-backed capabilities retain only the opaque handle", %{tmp_dir: directory} do
-    write_events(Path.join(directory, "trace.jsonl"), [event("capability", 1, "run-started")])
+    write_events(Path.join(directory, "capability.jsonl"), [event("capability", 1, "run-started")])
 
     assert {:ok, snapshot} = TraceSnapshot.start({:directory, directory}, owner: self())
     on_exit(fn -> TraceSnapshot.stop(snapshot) end)

--- a/test/ptc_runner/kernel/trace_snapshot_test.exs
+++ b/test/ptc_runner/kernel/trace_snapshot_test.exs
@@ -73,7 +73,8 @@ defmodule PtcRunner.Kernel.TraceSnapshotTest do
     assert Map.delete(snapshot_counters, "snapshot_hash") == expected_counters
     assert snapshot_counters["snapshot_hash"] == snapshot_hash
 
-    write_events(path, [event("changed", 1, "run-started")])
+    File.rm!(path)
+    write_events(Path.join(directory, "changed.jsonl"), [event("changed", 1, "run-started")])
     write_events(Path.join(directory, "later.jsonl"), [event("later", 1, "run-started")])
 
     assert {:ok, frozen_runs} = TraceSnapshot.query(snapshot, :list_runs, %{})

--- a/test/ptc_runner/kernel/viewer_adapter_test.exs
+++ b/test/ptc_runner/kernel/viewer_adapter_test.exs
@@ -16,7 +16,7 @@ defmodule PtcRunner.Kernel.ViewerAdapterTest do
   @tag :tmp_dir
   test "viewer conversation preserves the canonical analysis snapshot identity", %{tmp_dir: root} do
     fixture = PrivateInspectionFixture.create!(root)
-    {:ok, trace} = TraceSnapshot.start({:private_authorized_directory, fixture.traces})
+    {:ok, trace} = TraceSnapshot.start({:directory, fixture.traces})
     {:ok, inspection} = InspectionSnapshot.start({:directory, fixture.inspection}, trace)
     on_exit(fn -> InspectionSnapshot.stop(inspection) end)
     on_exit(fn -> TraceSnapshot.stop(trace) end)

--- a/test/ptc_runner/kernel/viewer_adapter_test.exs
+++ b/test/ptc_runner/kernel/viewer_adapter_test.exs
@@ -176,7 +176,7 @@ defmodule PtcRunner.Kernel.ViewerAdapterTest do
 
   @tag :tmp_dir
   test "viewer API and TraceLog return the same source-scoped projection", %{tmp_dir: directory} do
-    path = Path.join(directory, "kernel.jsonl")
+    path = Path.join(directory, "viewer-run.jsonl")
 
     connector = %{
       "provider" => "fixture-mcp",

--- a/test/ptc_runner/viewer_snapshot_store_test.exs
+++ b/test/ptc_runner/viewer_snapshot_store_test.exs
@@ -5,8 +5,7 @@ defmodule PtcRunner.ViewerSnapshotStoreTest do
 
   @tag :tmp_dir
   test "a requested refresh atomically exposes a newly completed run", %{tmp_dir: directory} do
-    path = Path.join(directory, "runs.jsonl")
-    write_events(path, [event("first", 1, "run-started")])
+    write_events(Path.join(directory, "first.jsonl"), [event("first", 1, "run-started")])
 
     assert {:ok, store} =
              ViewerSnapshotStore.start({:directory, directory}, fn _trace, _deadline ->
@@ -21,8 +20,7 @@ defmodule PtcRunner.ViewerSnapshotStoreTest do
     assert {:error, :not_found} =
              ViewerSnapshotStore.query(store, :get_run, %{"run_id" => "second"})
 
-    write_events(path, [
-      event("first", 1, "run-started"),
+    write_events(Path.join(directory, "second.jsonl"), [
       event("second", 1, "run-started"),
       event("second", 2, "run-stopped")
     ])


### PR DESCRIPTION
Closes #1654.

## Summary

- add one immutable, filename-bound directory admission classifier with bounded inventory, stable source proof, connected-component isolation, and canonical producer validation
- route direct `TraceLog` and retained `TraceSnapshot` directory queries through the same admission result, including exact limits, source identity, cursor behavior, and `:run_isolated` semantics
- expose bounded isolation evidence through run analysis and Viewer surfaces without leaking unsafe or out-of-grant names
- preserve generated run-reference filenames in the Viewer demo and update retained/generated operator documentation
- harden `BoundedWorker` after cumulative review so callback closures enter only the heap-limited worker, initial heap and startup are enforced before execution, and late/expired results cannot bypass the absolute deadline

## Verification

- cumulative base-guarded independent Codex review: approved with no actionable findings
- `mix precommit`
- `MIX_ENV=dev mix docs --warnings-as-errors`
- `scripts/ci/core-tests.sh --schedulers 4`: 7,166 passed
- normal pre-push hook:
  - documentation links and ExDoc passed
  - core tests: 7,166 passed
  - Credo, duplication, specification, generated artifacts, upstream audit, and Dialyzer passed
  - release verification passed
  - Viewer validation: 123 passed
