### PR TITLE
fix(examples): bind inspection-lab artifacts to a canonical run reference

### DIFF
--- a/examples/kernel-inspection-lab/support/lab.exs
+++ b/examples/kernel-inspection-lab/support/lab.exs
@@ -4,6 +4,7 @@ defmodule PtcRunner.Examples.KernelInspectionLab do
   alias PtcRunner.Examples.KernelInspectionLab.MCPFixture
   alias PtcRunner.Kernel.ApplicationPackage
   alias PtcRunner.Kernel.Capability
+  alias PtcRunner.Kernel.CommandRunRef
   alias PtcRunner.Kernel.LLMCapability
   alias PtcRunner.Kernel.MCPSource
   alias PtcRunner.Kernel.ProviderRegistry
@@ -68,15 +69,22 @@ defmodule PtcRunner.Examples.KernelInspectionLab do
 
     manifest = manifest(name, mission_components, wrapper?)
     manifest_path = Path.join(directory, "ptc.json")
-    trace_path = Path.join(traces, "run.jsonl")
-    inspection_path = Path.join(inspection, "run.ptcins")
     :ok = File.write(manifest_path, Jason.encode!(manifest))
     registry = registry(endpoint, program, wrapper?, directory, cli)
 
-    with {:ok, request} <-
+    # Artifact discovery is filename-bound: `ptc transcript` selects
+    # `<run-ref>.jsonl` / `<run-ref>.ptcins`, and whole-directory admission
+    # isolates any trace whose stem is not its run ID. The lab therefore takes
+    # the same command run reference the CLI generates and names both artifacts
+    # after it, rather than inventing a run ID and a fixed filename.
+    with {:ok, run_ref} <- CommandRunRef.generate(),
+         trace_path = Path.join(traces, run_ref <> ".jsonl"),
+         inspection_path = Path.join(inspection, run_ref <> ".ptcins"),
+         {:ok, request} <-
            ApplicationPackage.request_directory(manifest_path,
              installed_limits: registry.installed_limits,
-             inspection_capture: true
+             inspection_capture: true,
+             event_identity: run_ref
            ),
          {:ok, built} <-
            RunBuilder.build(request, registry,
@@ -286,7 +294,6 @@ defmodule PtcRunner.Examples.KernelInspectionLab do
         ]
       },
       "limits" => %{"evaluation_timeout_ms" => 10_000, "run_duration_ms" => 60_000},
-      "events" => %{"run_id" => "inspection-lab-#{name}"},
       "labels" => %{"name" => "inspection-lab-#{name}", "tags" => %{"mode" => name}}
     }
   end


### PR DESCRIPTION
Fixes the 2026-08-26 `Nightly` failure ([run 32927190611](https://github.com/andreasronge/ptc_runner/actions/runs/32927190611)).

## What broke

`examples/kernel-inspection-lab/support/lab.exs` declared its own run ID
(`events.run_id = "inspection-lab-<name>"`) and wrote fixed `traces/run.jsonl` /
`inspection/run.ptcins` filenames. Artifact discovery has since become
filename-bound in two separate places, and the lab was updated for neither:

| Change | Effect on the lab |
| --- | --- |
| #1644 (`e7990d7b`) — `ptc transcript RUN_ID` selects only `<run-ref>.jsonl` / `<run-ref>.ptcins` and requires a canonical command run reference | `transcript/invalid_run_reference: RUN_ID must be a canonical PTC command run reference`, exit status 1 at `inspection_lab_test.exs:194`. **This is the Nightly failure.** |
| #1660 — whole-directory admission isolates a trace whose filename stem is not its run ID | On current `main` the same walk also fails *earlier*: `GET /api/kernel/runs/<id>` returns HTTP 422 `run_isolated` (`ptc_viewer/lib/ptc_viewer/router.ex:703`) at `inspection_lab_test.exs:138` |

Both products behave as designed. The example was stale.

Confirmed by bisecting the symptom: renaming the two artifacts to match the run
ID cleared the 422 and moved the failure to exactly the Nightly assertion,
leaving the run-reference error as the remaining cause.

## The fix

Take the same command run reference `mix ptc run --trace-dir` generates, pass it
as `event_identity` (the pattern at `command_acquisition.ex:466`), and name both
artifacts after it, instead of declaring `events.run_id` by hand. This mirrors
what #1660 already did for `examples/viewer-demo`.

## Why CI stayed green

`InspectionLabTest` is tagged `:nightly`, so it is excluded from `mix test` and
from PR CI. Both #1644 and #1660 merged green without ever running it. #1660's
own issue lists "`examples/viewer-demo` no longer renames canonical trace files
away from their run IDs" as acceptance criteria — `viewer-demo` was updated,
`kernel-inspection-lab` was missed.

## Verification

- `mix test test/ptc_runner/kernel/inspection_lab_test.exs --include nightly` — 1 passed (previously failing)
- `mix nightly` — 18 passed (previously 17/18)
- `mix credo --strict` — no issues
- pre-commit hook: format / compile --warnings-as-errors / credo passed