### PR TITLE
fix(analysis): isolate inspection for damaged traces

### DIFF
--- a/docs/maintainers/kernel.md
+++ b/docs/maintainers/kernel.md
@@ -419,6 +419,13 @@ discovery. The private-authorized capture instead selects both ordinary and
 admitted run, and still excludes inspection artifacts. A run split across
 files or source classes is isolated as one connected component.
 
+The private inspection snapshot carries that decision forward: a sealed
+`.ptcins` artifact whose exact run and trace footer identity belongs to an
+isolated trace component is validated into disposable indexes and dropped with
+the component. Its digest remains part of inspection snapshot identity, while
+disjoint healthy trace and inspection pairs remain queryable and retain the
+trace classifier's bounded isolation metadata.
+
 The default aggregate encoded-source ceiling is 8,000,000 bytes. Snapshot
 retention independently limits the decoded representation to 32,000,000
 retained bytes, and query results keep the 1,000,000-byte default. Capture

--- a/docs/maintainers/trace-log-contract.md
+++ b/docs/maintainers/trace-log-contract.md
@@ -1070,6 +1070,16 @@ canonical event source, local Viewer access, or the active run does not imply
 inspection authority. Calls emit ordinary bounded capability facts without
 copying returned payloads into the trace.
 
+Directory-backed private analysis carries trace isolation across the
+correlation boundary. When an inspection footer's exact run and trace digests
+resolve to one isolated trace component, admission checks its record frames and
+complete seal in disposable indexes, commits the artifact digest to inspection
+snapshot identity, and discards those private rows. Other inspection artifacts
+continue through normal trace correlation, so a healthy run remains navigable
+and the trace run listing reports the isolated source and classifier reason.
+This is isolation, not a legacy trace reader: the rejected trace representation
+never enters the canonical analysis projection.
+
 Active-run trace self-query remains unsupported. Every trace capability call
 adds events to the same sink, while pagination cursors are source-digest-bound;
 the query would mutate the source it is paging. Same-run correction retains the

--- a/docs/reference/repl.md
+++ b/docs/reference/repl.md
@@ -364,10 +364,13 @@ stdin remain unattended input and require `--private-unattended` instead.
 
 The trace, inspection, and analysis-trace directories must be physically
 separate, including through ancestors and symlink aliases. Capture validates
-every private artifact against its matching run. A malformed, changed,
-uncorrelated, oversized, or unsupported artifact rejects the complete private
-source. Use the PtcRunner build matching the artifact's reported schema when
-versions differ.
+every private artifact against its matching run. When trace directory
+admission isolates a damaged run, a sealed inspection artifact carrying that
+same run and trace identity is isolated with it; healthy correlated runs remain
+available, and `(analysis/runs {})` reports the trace source and isolation
+reason. Other malformed, changed, uncorrelated, oversized, or unsupported
+inspection artifacts still reject the complete private source. Use the
+PtcRunner build matching the artifact's reported schema when versions differ.
 
 Private authority adds collections to the same navigation surface rather than
 adding smart diagnosis APIs:

--- a/lib/ptc_runner/kernel/inspection_artifact/admission.ex
+++ b/lib/ptc_runner/kernel/inspection_artifact/admission.ex
@@ -5,7 +5,10 @@ defmodule PtcRunner.Kernel.InspectionArtifact.Admission do
   inserts bounded ETS rows; and releases each evidence payload before the next
   frame is read. After that ingest scan, seal confirmation rehashes evidence
   bytes without decoding records so a same-size overwrite cannot publish a
-  snapshot.
+  snapshot. A caller that has already proven the artifact identity belongs to
+  an isolated trace component may return `:run_isolated` at the trace-facts
+  boundary; admission then returns the sealed frame indexes for disposal
+  without materializing trace-dependent projections.
   """
 
   alias PtcRunner.Kernel.InspectionArtifact.Assembler
@@ -22,7 +25,7 @@ defmodule PtcRunner.Kernel.InspectionArtifact.Admission do
           map(),
           keyword()
         ) ::
-          {:ok, map()} | {:error, atom()}
+          {:ok, map()} | {:isolated, map()} | {:error, atom()}
   def run(handle, indexes, trace_facts, limits, opts \\ [])
       when is_map(handle) and is_map(indexes) and is_function(trace_facts, 2) and is_map(limits) and
              is_list(opts) do
@@ -63,18 +66,39 @@ defmodule PtcRunner.Kernel.InspectionArtifact.Admission do
              },
              limits.io_buffer_bytes
            ),
-         :ok <- Handle.assert_stable(handle),
-         {:ok, trace_facts} <- trace_facts.(state.run_id, state.trace_id),
-         {:ok, state} <- Assembler.finish(state, trace_facts) do
-      {:ok,
-       %{
-         indexes: state.indexes,
-         run_id: state.run_id,
-         trace_id: state.trace_id,
-         record_count: state.record_count,
-         trace_facts: trace_facts,
-         turn_evidence: state.evidence
-       }}
+         :ok <- Handle.assert_stable(handle) do
+      finish_admission(state, trace_facts)
+    end
+  end
+
+  defp finish_admission(state, trace_facts) do
+    case trace_facts.(state.run_id, state.trace_id) do
+      {:ok, trace_facts} ->
+        with {:ok, state} <- Assembler.finish(state, trace_facts) do
+          {:ok,
+           %{
+             indexes: state.indexes,
+             run_id: state.run_id,
+             trace_id: state.trace_id,
+             record_count: state.record_count,
+             trace_facts: trace_facts,
+             turn_evidence: state.evidence
+           }}
+        end
+
+      {:error, :run_isolated} ->
+        with :ok <- Assembler.validate_complete(state) do
+          {:isolated,
+           %{
+             indexes: state.indexes,
+             run_id: state.run_id,
+             trace_id: state.trace_id,
+             record_count: state.record_count
+           }}
+        end
+
+      {:error, _reason} = error ->
+        error
     end
   end
 

--- a/lib/ptc_runner/kernel/inspection_artifact/assembler.ex
+++ b/lib/ptc_runner/kernel/inspection_artifact/assembler.ex
@@ -77,7 +77,7 @@ defmodule PtcRunner.Kernel.InspectionArtifact.Assembler do
   def finish(state, trace_facts) do
     state = Map.put(state, :pending_parents, Map.get(trace_facts, "parent_evaluation_ids", %{}))
 
-    with :ok <- closed_joins(state),
+    with :ok <- validate_complete(state),
          :ok <- validate_trace(state, trace_facts),
          conversation <- Conversation.finish(state.conversation, trace_facts),
          {:ok, state} <- materialize_pairs(state),
@@ -93,6 +93,10 @@ defmodule PtcRunner.Kernel.InspectionArtifact.Assembler do
       {:ok, Map.put(state, :evidence, conversation.evidence)}
     end
   end
+
+  @doc false
+  @spec validate_complete(map()) :: :ok | {:error, atom()}
+  def validate_complete(state), do: closed_joins(state)
 
   defp schema_version(%{"schema_version" => version}) do
     if version == Format.schema_version(), do: :ok, else: {:error, :invalid_record}

--- a/lib/ptc_runner/kernel/inspection_snapshot.ex
+++ b/lib/ptc_runner/kernel/inspection_snapshot.ex
@@ -195,7 +195,8 @@ defmodule PtcRunner.Kernel.InspectionSnapshot do
          {:ok, admitted} <-
            open_and_admit(inventory.files, source, trace_snapshot, limits, config, owner),
          :ok <- capture_hook(config.capture_hook),
-         :ok <- verify_all_handles(admitted.handles),
+         :ok <- verify_all_handles(admission_handles(admitted)),
+         :ok <- close_isolated_handles(admitted),
          true <- Indexes.within_retained?(admitted.indexes, limits) do
       digest = snapshot_digest(trace_info.snapshot_hash, admitted.digests)
       source_id = selected_source_id(source, digest, admitted)
@@ -371,23 +372,22 @@ defmodule PtcRunner.Kernel.InspectionSnapshot do
   defp admit_all(opened, source, trace_snapshot, indexes, limits, config) do
     result =
       Enum.reduce_while(opened, {:ok, empty_admission(indexes)}, fn {_path, handle}, {:ok, acc} ->
-        facts = fn run_id, trace_id -> paired_facts(trace_snapshot, run_id, trace_id) end
-
         opts = [
           during_admission_hook: config.admission_hook,
-          expected_identity: empty_identity(handle, trace_snapshot)
+          expected_identity: inspection_identity(handle, source, trace_snapshot)
         ]
 
         case opts[:expected_identity] do
+          {:isolated, identity} ->
+            opts = Keyword.put(opts, :expected_identity, identity)
+            admit_isolated(handle, acc, source, limits, opts)
+
           {:error, reason} ->
-            {:halt, {:error, reason, acc.handles}}
+            {:halt, {:error, reason, admission_handles(acc)}}
 
           {:ok, identity} ->
             opts = Keyword.put(opts, :expected_identity, identity)
-
-            admit_one(handle, acc, source, facts, limits, opts)
-
-          nil ->
+            facts = fn run_id, trace_id -> paired_facts(trace_snapshot, run_id, trace_id) end
             admit_one(handle, acc, source, facts, limits, opts)
         end
       end)
@@ -407,13 +407,38 @@ defmodule PtcRunner.Kernel.InspectionSnapshot do
       {:ok, admitted} ->
         case add_admitted(acc, admitted, handle, source) do
           {:ok, next} -> {:cont, {:ok, next}}
-          {:error, reason} -> {:halt, {:error, reason, acc.handles}}
+          {:error, reason} -> {:halt, {:error, reason, admission_handles(acc)}}
         end
 
       {:error, reason} ->
-        {:halt, {:error, reason, acc.handles}}
+        {:halt, {:error, reason, admission_handles(acc)}}
     end
   end
+
+  defp admit_isolated(handle, acc, {:directory, _directory}, limits, opts) do
+    isolated_indexes = Indexes.create(self())
+    isolated_facts = fn _run_id, _trace_id -> {:error, :run_isolated} end
+
+    result = Admission.run(handle, isolated_indexes, isolated_facts, limits, opts)
+    Indexes.delete_all(isolated_indexes)
+
+    case result do
+      {:isolated, isolated} ->
+        case add_isolated(acc, isolated, handle) do
+          {:ok, next} ->
+            {:cont, {:ok, next}}
+
+          {:error, reason} ->
+            {:halt, {:error, reason, admission_handles(acc)}}
+        end
+
+      {:error, reason} ->
+        {:halt, {:error, reason, admission_handles(acc)}}
+    end
+  end
+
+  defp admit_isolated(_handle, acc, _source, _limits, _opts),
+    do: {:halt, {:error, :inspection_correlation_missing, admission_handles(acc)}}
 
   defp open_and_admit(files, source, trace_snapshot, limits, config, owner) do
     with {:ok, opened} <- open_all(files) do
@@ -459,7 +484,7 @@ defmodule PtcRunner.Kernel.InspectionSnapshot do
             if accounting.charged_retained_bytes <= limits.max_retained_bytes do
               {:ok, admitted}
             else
-              cleanup_failed(admitted.indexes, admitted.handles)
+              cleanup_failed(admitted.indexes, admission_handles(admitted))
 
               {:error,
                {:source_retained_limit_exceeded,
@@ -512,14 +537,36 @@ defmodule PtcRunner.Kernel.InspectionSnapshot do
   end
 
   defp empty_admission(indexes) do
-    %{indexes: indexes, handles: %{}, trace_facts: %{}, turn_evidence: %{}, digests: %{}}
+    %{
+      indexes: indexes,
+      handles: %{},
+      isolated_handles: %{},
+      trace_facts: %{},
+      turn_evidence: %{},
+      digests: %{}
+    }
+  end
+
+  defp add_isolated(acc, isolated, handle) do
+    run_id = isolated.run_id
+
+    if Map.has_key?(acc.digests, run_id) do
+      {:error, :duplicate_inspection_run}
+    else
+      {:ok,
+       %{
+         acc
+         | isolated_handles: Map.put(acc.isolated_handles, run_id, handle),
+           digests: Map.put(acc.digests, run_id, handle.digest)
+       }}
+    end
   end
 
   defp add_admitted(acc, admitted, handle, source) do
     run_id = admitted.run_id
 
     cond do
-      Map.has_key?(acc.handles, run_id) ->
+      Map.has_key?(acc.digests, run_id) ->
         {:error, :duplicate_inspection_run}
 
       match?({:file, _path, requested} when requested != run_id, source) ->
@@ -550,15 +597,21 @@ defmodule PtcRunner.Kernel.InspectionSnapshot do
     end
   end
 
-  defp empty_identity(%{footer: %{record_count: 0} = footer}, trace_snapshot) do
-    TraceSnapshot.resolve_inspection_identity(
+  defp inspection_identity(%{footer: footer}, {:directory, _directory}, trace_snapshot) do
+    TraceSnapshot.resolve_directory_inspection_identity(
       trace_snapshot,
       footer.run_id_sha256,
       footer.trace_id_sha256
     )
   end
 
-  defp empty_identity(_handle, _trace_snapshot), do: nil
+  defp inspection_identity(%{footer: footer}, _source, trace_snapshot) do
+    TraceSnapshot.resolve_inspection_identity(
+      trace_snapshot,
+      footer.run_id_sha256,
+      footer.trace_id_sha256
+    )
+  end
 
   defp selected_source_id({:file, _path, run_ref}, digest, admitted) do
     case Map.fetch(admitted.indexes.trace_facts, run_ref) do
@@ -644,6 +697,14 @@ defmodule PtcRunner.Kernel.InspectionSnapshot do
         Process.exit(cleaner, :kill)
         :ok
     end
+  end
+
+  defp admission_handles(admitted),
+    do: Map.merge(admitted.handles, admitted.isolated_handles)
+
+  defp close_isolated_handles(admitted) do
+    admitted.isolated_handles |> Map.values() |> Enum.each(&Handle.close/1)
+    :ok
   end
 
   defp normalize_error(reason)

--- a/lib/ptc_runner/kernel/trace_snapshot.ex
+++ b/lib/ptc_runner/kernel/trace_snapshot.ex
@@ -215,13 +215,27 @@ defmodule PtcRunner.Kernel.TraceSnapshot do
 
   @doc false
   @spec resolve_inspection_identity(t(), binary(), binary()) ::
-          {:ok, %{run_id: binary(), trace_id: binary()}} | {:error, atom()}
+          {:ok, %{run_id: binary(), trace_id: binary()}}
+          | {:error, atom()}
   def resolve_inspection_identity(%__MODULE__{} = snapshot, run_digest, trace_digest)
       when is_binary(run_digest) and byte_size(run_digest) == 32 and is_binary(trace_digest) and
              byte_size(trace_digest) == 32,
       do: call(snapshot, {:resolve_inspection_identity, run_digest, trace_digest})
 
   def resolve_inspection_identity(_snapshot, _run_digest, _trace_digest),
+    do: {:error, :invalid_snapshot}
+
+  @doc false
+  @spec resolve_directory_inspection_identity(t(), binary(), binary()) ::
+          {:ok, %{run_id: binary(), trace_id: binary()}}
+          | {:isolated, %{run_id: binary(), trace_id: binary()}}
+          | {:error, atom()}
+  def resolve_directory_inspection_identity(%__MODULE__{} = snapshot, run_digest, trace_digest)
+      when is_binary(run_digest) and byte_size(run_digest) == 32 and is_binary(trace_digest) and
+             byte_size(trace_digest) == 32,
+      do: call(snapshot, {:resolve_directory_inspection_identity, run_digest, trace_digest})
+
+  def resolve_directory_inspection_identity(_snapshot, _run_digest, _trace_digest),
     do: {:error, :invalid_snapshot}
 
   @doc false
@@ -331,16 +345,21 @@ defmodule PtcRunner.Kernel.TraceSnapshot do
         _from,
         %{token: token} = state
       ) do
-    matches =
-      Enum.filter(state.analysis.facts_by_run_id, fn {run_id, facts} ->
-        :crypto.hash(:sha256, run_id) == run_digest and
-          :crypto.hash(:sha256, facts["trace_id"]) == trace_digest
-      end)
+    {:reply, admitted_inspection_identity(state, run_digest, trace_digest), state}
+  end
 
+  def handle_call(
+        {token, {:resolve_directory_inspection_identity, run_digest, trace_digest}},
+        _from,
+        %{token: token} = state
+      ) do
     result =
-      case matches do
-        [{run_id, %{"trace_id" => trace_id}}] -> {:ok, %{run_id: run_id, trace_id: trace_id}}
-        _none_or_ambiguous -> {:error, :inspection_correlation_missing}
+      case admitted_inspection_identity(state, run_digest, trace_digest) do
+        {:ok, _identity} = ok ->
+          ok
+
+        {:error, :inspection_correlation_missing} ->
+          isolated_inspection_identity(state, run_digest, trace_digest)
       end
 
     {:reply, result, state}
@@ -664,6 +683,47 @@ defmodule PtcRunner.Kernel.TraceSnapshot do
     do: run_ids
 
   defp known_isolated_run_ids(_state), do: MapSet.new()
+
+  defp admitted_inspection_identity(state, run_digest, trace_digest) do
+    matches =
+      Enum.filter(state.analysis.facts_by_run_id, fn {run_id, facts} ->
+        :crypto.hash(:sha256, run_id) == run_digest and
+          :crypto.hash(:sha256, facts["trace_id"]) == trace_digest
+      end)
+
+    case matches do
+      [{run_id, %{"trace_id" => trace_id}}] -> {:ok, %{run_id: run_id, trace_id: trace_id}}
+      _none_or_ambiguous -> {:error, :inspection_correlation_missing}
+    end
+  end
+
+  defp isolated_inspection_identity(
+         %{directory_admission: %{isolated_components: components}},
+         run_digest,
+         trace_digest
+       ) do
+    Enum.reduce_while(components, {:error, :inspection_correlation_missing}, fn component,
+                                                                                _missing ->
+      case {digest_match(component.run_claims, run_digest),
+            digest_match(component.trace_claims, trace_digest)} do
+        {{:ok, run_id}, {:ok, trace_id}} ->
+          {:halt, {:isolated, %{run_id: run_id, trace_id: trace_id}}}
+
+        _not_this_component ->
+          {:cont, {:error, :inspection_correlation_missing}}
+      end
+    end)
+  end
+
+  defp isolated_inspection_identity(_state, _run_digest, _trace_digest),
+    do: {:error, :inspection_correlation_missing}
+
+  defp digest_match(claims, expected) do
+    case Enum.filter(claims, &(:crypto.hash(:sha256, &1) == expected)) do
+      [claim] -> {:ok, claim}
+      _none_or_ambiguous -> :error
+    end
+  end
 
   defp valid_run_id?(run_id),
     do: is_binary(run_id) and byte_size(run_id) in 1..4_096 and String.valid?(run_id)

--- a/site/reference/repl/index.html
+++ b/site/reference/repl/index.html
@@ -303,10 +303,13 @@ authorization:</p><pre><code class="console language-console">ptc repl \
 interactive terminal with those definitions available. <code class="inline">--eval</code>, scripts, and
 stdin remain unattended input and require <code class="inline">--private-unattended</code> instead.</p><p>The trace, inspection, and analysis-trace directories must be physically
 separate, including through ancestors and symlink aliases. Capture validates
-every private artifact against its matching run. A malformed, changed,
-uncorrelated, oversized, or unsupported artifact rejects the complete private
-source. Use the PtcRunner build matching the artifact's reported schema when
-versions differ.</p><p>Private authority adds collections to the same navigation surface rather than
+every private artifact against its matching run. When trace directory
+admission isolates a damaged run, a sealed inspection artifact carrying that
+same run and trace identity is isolated with it; healthy correlated runs remain
+available, and <code class="inline">(analysis/runs {})</code> reports the trace source and isolation
+reason. Other malformed, changed, uncorrelated, oversized, or unsupported
+inspection artifacts still reject the complete private source. Use the
+PtcRunner build matching the artifact's reported schema when versions differ.</p><p>Private authority adds collections to the same navigation surface rather than
 adding smart diagnosis APIs:</p><pre><code class="clojure language-clojure">(def runs (analysis/runs {&quot;limit&quot; 20}))
 (def run-id (get (first (get runs &quot;items&quot;)) &quot;run_id&quot;))
 (analysis/open run-id)

--- a/test/mix/tasks/ptc_repl_test.exs
+++ b/test/mix/tasks/ptc_repl_test.exs
@@ -1161,6 +1161,52 @@ defmodule PtcRunner.ReplFrontendTest do
   end
 
   @tag :tmp_dir
+  test "private analysis isolates inspection paired with a damaged trace", %{
+    tmp_dir: directory
+  } do
+    healthy = PrivateInspectionFixture.create!(directory, "healthy")
+    damaged = PrivateInspectionFixture.create!(directory, "damaged")
+    PrivateInspectionFixture.rewrite_legacy_float_cost!(damaged)
+
+    output =
+      capture_io(fn ->
+        run_repl([
+          "--profile",
+          "private-run-analysis-v1",
+          "--resource",
+          "traces=#{healthy.traces}",
+          "--resource",
+          "inspection=#{healthy.inspection}",
+          "--session-trace-dir",
+          healthy.output,
+          "--private-unattended",
+          "--format",
+          "jsonl",
+          "-e",
+          "(analysis/runs {})"
+        ])
+      end)
+
+    records = decode_jsonl(output)
+    assert Enum.map(records, & &1["type"]) == ["session-started", "evaluation", "session-closed"]
+
+    assert List.first(records)["capture"] == %{
+             "inspection" => %{"file_count" => 2, "run_count" => 1},
+             "traces" => %{"file_count" => 2, "run_count" => 1}
+           }
+
+    assert %{
+             "items" => [%{"run_id" => "healthy"}],
+             "isolation" => %{
+               "component_count" => 1,
+               "known_run_count" => 1,
+               "reasons" => [%{"reason" => "malformed_event"}],
+               "examples" => [%{"sources" => ["damaged.jsonl"]}]
+             }
+           } = Enum.at(records, 1)["result"]["value"]
+  end
+
+  @tag :tmp_dir
   test "inspection profile setup explains an unsupported artifact schema", %{
     tmp_dir: directory
   } do

--- a/test/mix/tasks/ptc_transcript_test.exs
+++ b/test/mix/tasks/ptc_transcript_test.exs
@@ -482,6 +482,44 @@ defmodule Mix.Tasks.PtcTranscriptTest do
   end
 
   @tag :tmp_dir
+  test "a selected healthy run ignores an adjacent legacy-cost artifact", %{tmp_dir: root} do
+    healthy = canonical_create!(root)
+    damaged_run_id = PrivateInspectionFixture.command_run_ref(1)
+
+    damaged =
+      PrivateInspectionFixture.create!(Path.join(root, "damaged"), damaged_run_id)
+
+    PrivateInspectionFixture.rewrite_legacy_float_cost!(damaged)
+
+    File.cp!(
+      Path.join(damaged.traces, "#{damaged_run_id}.jsonl"),
+      Path.join(healthy.traces, "#{damaged_run_id}.jsonl")
+    )
+
+    File.cp!(
+      Path.join(damaged.inspection, "#{damaged_run_id}.ptcins"),
+      Path.join(healthy.inspection, "#{damaged_run_id}.ptcins")
+    )
+
+    output = Path.join(healthy.output, "healthy-among-damaged.private.json")
+    presentation = MixCommandAdapter.execute(transcript_argv(healthy, output))
+
+    assert presentation.exit_status == 0
+    assert presentation.stderr == ""
+    assert %{"run_id" => run_id} = output |> File.read!() |> Jason.decode!()
+    assert run_id == healthy.run_id
+
+    damaged_output = Path.join(healthy.output, "damaged.private.json")
+
+    damaged_presentation =
+      MixCommandAdapter.execute(transcript_argv(healthy, damaged_output, run_id: damaged_run_id))
+
+    assert damaged_presentation.exit_status == 1
+    assert damaged_presentation.stderr =~ "transcript/malformed_source"
+    refute File.exists?(damaged_output)
+  end
+
+  @tag :tmp_dir
   test "the private canonical trace suffix works when it is the only candidate", %{tmp_dir: root} do
     fixture = canonical_create!(root)
 

--- a/test/ptc_runner/kernel/inspection_snapshot_test.exs
+++ b/test/ptc_runner/kernel/inspection_snapshot_test.exs
@@ -53,6 +53,59 @@ defmodule PtcRunner.Kernel.InspectionSnapshotTest do
   end
 
   @tag :tmp_dir
+  test "isolates a sealed artifact paired with an isolated trace and keeps it pinned", %{
+    tmp_dir: root
+  } do
+    healthy = PrivateInspectionFixture.create!(root, "healthy")
+    damaged = PrivateInspectionFixture.create!(root, "damaged")
+    PrivateInspectionFixture.rewrite_legacy_float_cost!(damaged)
+
+    {:ok, trace_snapshot} =
+      TraceSnapshot.start({:private_authorized_directory, healthy.traces}, owner: self())
+
+    on_exit(fn -> TraceSnapshot.stop(trace_snapshot) end)
+
+    assert {:ok, snapshot} =
+             InspectionSnapshot.start({:directory, healthy.inspection}, trace_snapshot,
+               owner: self()
+             )
+
+    assert {:ok, %{file_count: 2, run_count: 1}} = InspectionSnapshot.info(snapshot)
+
+    assert {:ok, %{"items" => [%{"run_id" => "healthy"}]}} =
+             InspectionSnapshot.query(snapshot, :list_runs, %{})
+
+    assert :ok = InspectionSnapshot.stop(snapshot)
+
+    damaged_inspection = Path.join(healthy.inspection, "damaged.ptcins")
+
+    assert {:error, :source_changed} =
+             InspectionSnapshot.start({:directory, healthy.inspection}, trace_snapshot,
+               owner: self(),
+               capture_hook: fn -> File.write!(damaged_inspection, "\n", [:append]) end
+             )
+  end
+
+  @tag :tmp_dir
+  test "an isolated artifact still rejects an incomplete private join", %{tmp_dir: root} do
+    {trace, inspection} = source_directories(root)
+    write_run(trace, inspection, "damaged", :mcp_unclosed)
+
+    PrivateInspectionFixture.rewrite_legacy_float_cost!(%{
+      traces: trace,
+      run_id: "damaged"
+    })
+
+    {:ok, trace_snapshot} =
+      TraceSnapshot.start({:private_authorized_directory, trace}, owner: self())
+
+    on_exit(fn -> TraceSnapshot.stop(trace_snapshot) end)
+
+    assert {:error, :incomplete_inspection_correlation} =
+             InspectionSnapshot.start({:directory, inspection}, trace_snapshot, owner: self())
+  end
+
+  @tag :tmp_dir
   test "binds admission to the regular file inventoried before open", %{tmp_dir: root} do
     {trace, inspection} = source_directories(root)
     write_run(trace, inspection, "pinned-inventory", :basic)
@@ -1265,7 +1318,7 @@ defmodule PtcRunner.Kernel.InspectionSnapshotTest do
       arguments: %{"path" => "private-#{run_id}.txt"}
     })
 
-    if variant in [:mcp, :diagnostics] do
+    if variant in [:mcp, :diagnostics, :mcp_unclosed] do
       emit!(sink, "mcp-request", %{capability_id: "tool-#{run_id}", request_id: 7}, %{
         mission_name: "default",
         transport: :stdio,
@@ -1314,6 +1367,22 @@ defmodule PtcRunner.Kernel.InspectionSnapshotTest do
           "id" => 8,
           "result" => %{
             "content" => [%{"type" => "text", "text" => "second-secret-#{run_id}"}]
+          }
+        }
+      })
+    end
+
+    if variant == :mcp_unclosed do
+      emit!(sink, "mcp-request", %{capability_id: "tool-#{run_id}", request_id: 9}, %{
+        mission_name: "default",
+        transport: :stdio,
+        body: %{
+          "jsonrpc" => "2.0",
+          "id" => 9,
+          "method" => "tools/call",
+          "params" => %{
+            "name" => "read",
+            "arguments" => %{"path" => "unclosed-#{run_id}.txt"}
           }
         }
       })

--- a/test/ptc_runner/kernel/viewer_adapter_test.exs
+++ b/test/ptc_runner/kernel/viewer_adapter_test.exs
@@ -122,6 +122,34 @@ defmodule PtcRunner.Kernel.ViewerAdapterTest do
   end
 
   @tag :tmp_dir
+  test "zero-frame Viewer admission rejects an isolated trace without crashing", %{tmp_dir: root} do
+    fixture = PrivateInspectionFixture.create!(root, "isolated-viewer-run")
+    PrivateInspectionFixture.rewrite_legacy_float_cost!(fixture)
+
+    trace_path = Path.join(fixture.traces, "#{fixture.run_id}.jsonl")
+    File.rename!(trace_path, Path.join(fixture.traces, "#{fixture.run_id}.private.jsonl"))
+
+    inspection_path = Path.join(fixture.inspection, "empty-isolated-viewer-run.ptcins")
+
+    {:ok, handle} =
+      PublicationHandle.reserve_stream_for(inspection_path, :inspection, 0o600, self())
+
+    {:ok, sink} =
+      InspectionSink.start(
+        run_id: fixture.run_id,
+        trace_id: "trace-#{fixture.run_id}",
+        publication_handle: handle
+      )
+
+    assert {:ok, %{record_count: 0} = seal} = InspectionSink.seal(sink)
+    assert :ok = InspectionArtifact.publish_handle(handle, seal)
+    assert :ok = InspectionSink.stop(sink)
+
+    assert {:error, :inspection_correlation_missing} =
+             ViewerAdapter.pin_inspection(inspection_path, {:private_directory, fixture.traces})
+  end
+
+  @tag :tmp_dir
   test "pinning an exact trace file cannot acquire authority from a sibling", %{tmp_dir: root} do
     inspected = PrivateInspectionFixture.create!(Path.join(root, "inspected"), "inspected-run")
     selected = PrivateInspectionFixture.create!(Path.join(root, "selected"), "selected-run")

--- a/test/support/private_inspection_fixture.ex
+++ b/test/support/private_inspection_fixture.ex
@@ -27,6 +27,30 @@ defmodule PtcRunner.TestSupport.PrivateInspectionFixture do
     fixture
   end
 
+  @doc false
+  def rewrite_legacy_float_cost!(%{traces: traces, run_id: run_id}) do
+    path = Path.join(traces, "#{run_id}.jsonl")
+
+    events =
+      path
+      |> File.stream!()
+      |> Enum.map(&Jason.decode!/1)
+
+    events =
+      update_in(events, [Access.at(-1), "data"], fn data ->
+        Map.put(data, "usage", %{
+          "llm_spend" => %{
+            "state" => "available",
+            "input" => 1,
+            "output" => 2,
+            "total_cost" => 0.001326
+          }
+        })
+      end)
+
+    File.write!(path, encode_jsonl(events))
+  end
+
   def create_boundary_failure!(root, run_id \\ "boundary-failure-run") do
     %{traces: traces, inspection: inspection} = fixture = create_directories(root, run_id)
 


### PR DESCRIPTION
## Summary

- carry trace-directory isolation across the private inspection correlation boundary so damaged runs do not hide healthy runs
- validate and pin matching isolated `.ptcins` artifacts, commit their digests to snapshot identity, then discard their private rows
- keep legacy floating-point cost traces invalid; selected damaged transcripts still fail closed
- preserve selected-file and Viewer identity-resolution behavior
- document the directory-isolation contract and regenerate the REPL site reference

## Regression coverage

- private `analysis/runs` succeeds with healthy and damaged runs sharing trace/inspection directories
- isolated inspection artifacts remain source-stability checked and reject incomplete MCP joins
- zero-frame Viewer admission returns a normal correlation error for an isolated trace
- selected healthy transcripts ignore an adjacent legacy-cost artifact, while selecting that artifact fails

## Review

One independent Codex review found two issues: skipped trace-independent join closure for isolated artifacts and a broadened resolver result that could crash zero-frame Viewer admission. Both were fixed and the same review session approved the corrected tree with no remaining actionable findings.

## Verification

- `mix precommit`
- pre-push hook: 7,250 core tests; Credo/duplication/spec/generated docs; Dialyzer; ExDoc/link checks; release verification; 123 Viewer tests

Closes #1668
