### PR TITLE
fix(examples): grant viewer demo workspace

### DIFF
--- a/examples/viewer-demo/01-recovery.json
+++ b/examples/viewer-demo/01-recovery.json
@@ -50,7 +50,10 @@
         }
       ],
       "data": {
-      }
+      },
+      "providers": [
+        "workspace"
+      ]
     }
   }
 }

--- a/examples/viewer-demo/02-bulk.json
+++ b/examples/viewer-demo/02-bulk.json
@@ -50,7 +50,10 @@
         }
       ],
       "data": {
-      }
+      },
+      "providers": [
+        "workspace"
+      ]
     }
   }
 }

--- a/examples/viewer-demo/03-limits.json
+++ b/examples/viewer-demo/03-limits.json
@@ -54,7 +54,10 @@
         }
       ],
       "data": {
-      }
+      },
+      "providers": [
+        "workspace"
+      ]
     }
   }
 }

--- a/examples/viewer-demo/04-loop-limit.json
+++ b/examples/viewer-demo/04-loop-limit.json
@@ -50,7 +50,10 @@
         }
       ],
       "data": {
-      }
+      },
+      "providers": [
+        "workspace"
+      ]
     }
   }
 }

--- a/examples/viewer-demo/05-memory.json
+++ b/examples/viewer-demo/05-memory.json
@@ -13,7 +13,7 @@
         "library": "agent.core"
       }
     ],
-    "entry": "demo.agent/run"
+    "entry": "demo.agent/run-terminal-error"
   },
   "input": {
     "value": {
@@ -50,7 +50,10 @@
         }
       ],
       "data": {
-      }
+      },
+      "providers": [
+        "workspace"
+      ]
     }
   }
 }

--- a/examples/viewer-demo/README.md
+++ b/examples/viewer-demo/README.md
@@ -22,8 +22,8 @@ The script regenerates the granted `files/` root, launches
 `--trace-dir` and `--inspect` into one owner-only project artifact root, writes
 each trace and inspection artifact under its generated run-reference filename,
 the project document beside it, and prints the `mix ptc viewer` command that
-opens it. Node.js and `npx` are required; the first run may download that
-package. A rerun removes only the generated artifacts recorded by the prior
+opens it. Node.js, `npx`, and `jq` are required; the first run may download the
+MCP package. A rerun removes only the generated artifacts recorded by the prior
 pass, so the Viewer continues to contain exactly the five current journeys. That
 project grants the Viewer the private inspection artifacts, so treat the
 browser tab as a private sink.
@@ -36,7 +36,7 @@ browser tab as a private sink.
 | `02-bulk` | The task calls `demo.files/sum-values`, which itself reads `index.txt` plus all 30 listed record files (31 `workspace.read` calls, just under the installed per-name quota of 32) and computes a sum the model cannot fabricate (3255). | Long capability lists in the transcript, per-call private payloads, deterministic bulk event volume (~76 events), ok status. |
 | `03-limits` | Same task, but the manifest lowers `mission_capability_calls_per_name` to 6, so `sum-values` exhausts the quota mid-evaluation and the model receives the failure as feedback. | `limit-exceeded` events, error feedback turns, quota-error envelopes in private payloads. |
 | `04-loop-limit` | The task calls `demo.files/spin-forever`, an unbounded `loop`/`recur`, which hits the evaluator's deterministic loop-iteration bound. | Error-outcome runs in the picker, `:loop_limit_exceeded` feedback turns, `explicit_failure` terminal reason. |
-| `05-memory` | The task calls `demo.files/exhaust-memory`, which doubles a string until the in-evaluator heap budget rejects it. | `:memory_exceeded` error feedback, error-outcome run, heap-budget message in the dialogue. |
+| `05-memory` | The task calls `demo.files/exhaust-memory`, which doubles a string until the in-evaluator heap budget rejects it. A second turn retains that feedback in the dialogue; the dedicated workflow entry then fails the demo even if the model turns the failure into a successful prose result. | `:memory_exceeded` error feedback, error-outcome run, heap-budget message in the dialogue. |
 
 The bulk read volume and journey 03's quota trigger are deterministic (the
 reads happen inside the mission prelude, not at the model's discretion); turn

--- a/examples/viewer-demo/agent.clj
+++ b/examples/viewer-demo/agent.clj
@@ -2,3 +2,9 @@
 
 (defn run [input]
   (agent.core/run (get input "task") {"max_turns" (get input "max_turns" 6)}))
+
+(defn run-terminal-error [input]
+  (let [outcome (agent.core/run-outcome
+                  (get input "task")
+                  {"max_turns" (get input "max_turns" 6)})]
+    (fail {:kind :viewer-demo-terminal-error :agent-outcome outcome})))

--- a/examples/viewer-demo/run.sh
+++ b/examples/viewer-demo/run.sh
@@ -9,6 +9,11 @@
 # fails the script.
 set -euo pipefail
 
+if ! command -v jq >/dev/null 2>&1; then
+  echo "FAIL: jq is required to validate private model feedback" >&2
+  exit 1
+fi
+
 demo_dir="$(cd "$(dirname "$0")" && pwd)"
 repo_root="$(cd "$demo_dir/../.." && pwd)"
 out="${1:-$repo_root/tmp/viewer-demo}"
@@ -127,6 +132,35 @@ require_evidence() {
   fi
 }
 
+require_private_feedback() {
+  local journey=$1 pattern=$2 label=$3
+  local run_ref private_analysis
+  run_ref="$(basename "$journey_trace" .jsonl)"
+
+  if ! private_analysis="$(
+    mix ptc repl \
+      --profile private-run-analysis-v1 \
+      --resource "traces=$artifacts/traces" \
+      --resource "inspection=$artifacts/inspection" \
+      --private-unattended \
+      --format jsonl \
+      -e "(analysis/read \"$run_ref\" {\"collection\" \"turns\" \"limit\" 100})"
+  )"; then
+    echo "FAIL: $journey could not query private feedback" >&2
+    exit 1
+  fi
+
+  if ! jq -s -e --arg pattern "$pattern" \
+    'any(.[]
+         | select(.type == "evaluation")
+         | .result.value.items[]?.feedback[]?.content
+         | strings;
+         contains($pattern))' <<<"$private_analysis" >/dev/null; then
+    echo "FAIL: $journey missing $label in its reconstructed model feedback" >&2
+    exit 1
+  fi
+}
+
 run_journey 01-recovery ok
 run_journey 02-bulk ok
 run_journey 03-limits any
@@ -134,13 +168,13 @@ require_evidence 03-limits "$journey_trace" '"limit-exceeded"' "limit-exceeded e
 
 # 04/05 must fail for the advertised reason, not from an unrelated
 # provider or runtime error: the canonical trace must end in an error
-# outcome and the private feedback must carry the intended error code.
+# outcome and a private semantic query must find the intended feedback.
 run_journey 04-loop-limit error
 require_evidence 04-loop-limit "$journey_trace" '"outcome":"error"' "an error run outcome"
-require_evidence 04-loop-limit "$journey_inspection" 'loop_limit_exceeded' "loop-limit feedback"
+require_private_feedback 04-loop-limit 'loop_limit_exceeded' "loop-limit feedback"
 run_journey 05-memory error
 require_evidence 05-memory "$journey_trace" '"outcome":"error"' "an error run outcome"
-require_evidence 05-memory "$journey_inspection" 'memory_exceeded' "heap-budget feedback"
+require_private_feedback 05-memory 'mission heap budget' "heap-budget feedback"
 
 # The project document must name an application, and it must be a portable
 # path beneath the document -- so one journey manifest is copied next to it.

--- a/test/ptc_runner/kernel/tutorial_examples_contract_test.exs
+++ b/test/ptc_runner/kernel/tutorial_examples_contract_test.exs
@@ -65,5 +65,12 @@ defmodule PtcRunner.Kernel.TutorialExamplesContractTest do
     end
   end
 
+  test "the viewer memory journey preserves feedback and forces a terminal demo error" do
+    manifest = decode!(Path.join(@viewer_examples, "05-memory.json"))
+
+    assert manifest["input"]["value"]["max_turns"] == 2
+    assert manifest["workflow"]["entry"] == "demo.agent/run-terminal-error"
+  end
+
   defp decode!(path), do: path |> File.read!() |> Jason.decode!()
 end

--- a/test/ptc_runner/kernel/tutorial_examples_test.exs
+++ b/test/ptc_runner/kernel/tutorial_examples_test.exs
@@ -167,6 +167,7 @@ defmodule PtcRunner.Kernel.TutorialExamplesTest do
 
       assert Enum.map(manifest.providers.workflow, & &1["name"]) == ["deepseek"]
       assert Enum.map(manifest.providers.mission, & &1["name"]) == ["workspace"]
+      assert manifest.missions["default"].provider_occurrences == [0]
     end
   end
 


### PR DESCRIPTION
## Summary
- grant the selected `workspace` mission provider to all five viewer-demo manifests
- make the memory journey retain real heap feedback while deterministically ending as an error
- validate loop/heap feedback through the private analysis profile instead of raw artifact greps
- add regression coverage and document/preflight `jq`

## Verification
- `mix test test/ptc_runner/kernel/tutorial_examples_test.exs test/ptc_runner/kernel/tutorial_examples_contract_test.exs`
- `bash examples/viewer-demo/run.sh` (real DeepSeek/OpenRouter; all five journeys)
- real Viewer browser: five runs (3 ok/2 error), recovery/private dialogue and heap feedback rendered, no console errors
- `mix precommit`
- `MIX_ENV=dev mix docs --warnings-as-errors`
- normal pre-push hook
- three independent Codex review passes; final clean

Closes #1671
