### PR TITLE
fix(mcp): decode element-dense responses within declared limits

### DIFF
--- a/lib/ptc_runner/kernel/mcp_protocol.ex
+++ b/lib/ptc_runner/kernel/mcp_protocol.ex
@@ -129,28 +129,41 @@ defmodule PtcRunner.Kernel.MCPProtocol do
   def valid_tool_name?(name),
     do: is_binary(name) and String.valid?(name) and name =~ @upstream_name
 
-  @spec decode_response(binary(), pos_integer()) :: {:ok, map()} | {:error, :mcp_protocol_error}
+  @spec decode_response(binary(), pos_integer()) ::
+          {:ok, map()} | {:error, :mcp_protocol_error | :mcp_response_exceeded}
   def decode_response(body, id) when is_binary(body) and is_integer(id) and id > 0 do
     case decode_message(body) do
       {:ok, {:response, ^id, decoded}} -> {:ok, decoded}
+      {:error, :mcp_response_exceeded} -> {:error, :mcp_response_exceeded}
       _invalid -> {:error, :mcp_protocol_error}
     end
   end
 
   @spec decode_message(binary()) ::
-          {:ok, inbound_message()} | {:error, :mcp_protocol_error}
+          {:ok, inbound_message()} | {:error, :mcp_protocol_error | :mcp_response_exceeded}
   def decode_message(body) when is_binary(body) do
     with true <- within_document_depth?(body),
-         {:ok, decoded} <- StrictJSON.decode(body),
+         {:ok, decoded} <- admit_document(body),
          true <- JSONValue.map?(decoded),
          "2.0" <- decoded["jsonrpc"] do
       classify_message(decoded)
     else
+      {:error, :mcp_response_exceeded} -> {:error, :mcp_response_exceeded}
       _reason -> {:error, :mcp_protocol_error}
     end
   end
 
   def decode_message(_body), do: {:error, :mcp_protocol_error}
+
+  # A decode the host cannot finish within its own worker bounds is the
+  # host declining the message, not the server violating the protocol.
+  defp admit_document(body) do
+    case StrictJSON.decode_classified(body) do
+      {:ok, decoded} -> {:ok, decoded}
+      {:invalid, _reason} -> {:error, :mcp_protocol_error}
+      {:unavailable, _cause} -> {:error, :mcp_response_exceeded}
+    end
+  end
 
   @doc false
   @spec within_document_depth?(term()) :: boolean()

--- a/lib/ptc_runner/kernel/mcp_source.ex
+++ b/lib/ptc_runner/kernel/mcp_source.ex
@@ -1935,6 +1935,7 @@ defmodule PtcRunner.Kernel.MCPSource do
   defp decode_sse(body, id) do
     case consume_sse_events(body, nil, id, true) do
       {:ok, _rest, response, _at_start?} when is_map(response) -> {:ok, response}
+      {:error, :mcp_response_exceeded} -> {:error, :mcp_response_exceeded}
       _result -> {:error, :mcp_protocol_error}
     end
   end
@@ -1969,6 +1970,9 @@ defmodule PtcRunner.Kernel.MCPSource do
 
       {:ok, {:response, ^id, decoded}} when is_nil(response) ->
         {:ok, decoded}
+
+      {:error, :mcp_response_exceeded} ->
+        {:error, :mcp_response_exceeded}
 
       _invalid ->
         {:error, :mcp_protocol_error}

--- a/lib/ptc_runner/kernel/mcp_source.ex
+++ b/lib/ptc_runner/kernel/mcp_source.ex
@@ -1866,8 +1866,8 @@ defmodule PtcRunner.Kernel.MCPSource do
           end
         end
 
-      {:error, :mcp_protocol_error} ->
-        {:halt, %{response | body: :mcp_protocol_error}}
+      {:error, reason} when reason in [:mcp_protocol_error, :mcp_response_exceeded] ->
+        {:halt, %{response | body: reason}}
     end
   end
 
@@ -1892,6 +1892,10 @@ defmodule PtcRunner.Kernel.MCPSource do
 
   defp response_body(%{body: {:mcp_sse_response, response}}, _id), do: {:ok, response}
   defp response_body(%{body: :mcp_protocol_error}, _id), do: {:error, :mcp_protocol_error}
+
+  defp response_body(%{body: :mcp_response_exceeded}, _id),
+    do: {:error, :mcp_response_exceeded}
+
   defp response_body(%{body: {:mcp_sse, _state}}, _id), do: {:error, :mcp_protocol_error}
 
   defp response_body(%{body: body} = response, id) when is_binary(body) do
@@ -1914,6 +1918,7 @@ defmodule PtcRunner.Kernel.MCPSource do
          true <- MCPProtocol.discovery_method_unsupported_error?(body, method) do
       {:error, :mcp_discovery_method_unsupported}
     else
+      {:error, :mcp_response_exceeded} -> {:error, :mcp_response_exceeded}
       _invalid -> {:error, :mcp_protocol_error}
     end
   end

--- a/lib/ptc_runner/kernel/mcp_stdio_transport.ex
+++ b/lib/ptc_runner/kernel/mcp_stdio_transport.ex
@@ -748,8 +748,8 @@ defmodule PtcRunner.Kernel.MCPStdioTransport do
       {:ok, {:response, id, response}} ->
         consume_response(id, response, byte_size(line), state)
 
-      {:error, :mcp_protocol_error} ->
-        {:error, :mcp_protocol_error, state}
+      {:error, reason} when reason in [:mcp_protocol_error, :mcp_response_exceeded] ->
+        {:error, reason, state}
     end
   end
 

--- a/lib/ptc_runner/kernel/strict_json.ex
+++ b/lib/ptc_runner/kernel/strict_json.ex
@@ -14,7 +14,12 @@ defmodule PtcRunner.Kernel.StrictJSON do
   @max_depth 64
   @max_nodes 100_000
   @timeout_ms 1_000
-  @max_heap_words 2_000_000
+  # Must cover full materialization plus admission of any document that
+  # satisfies `@max_nodes`, or the node limit is unreachable and legal inputs
+  # die in the worker (issue #1676). The worst admissible shape -- a flat
+  # object at the node limit -- peaks near 4.5M words; 8M words (64 MB on a
+  # 64-bit BEAM) keeps the kill a backstop rather than the operative bound.
+  @max_heap_words 8_000_000
 
   @type error ::
           :invalid_json

--- a/test/ptc_runner/kernel/mcp_protocol_test.exs
+++ b/test/ptc_runner/kernel/mcp_protocol_test.exs
@@ -102,6 +102,32 @@ defmodule PtcRunner.Kernel.MCPProtocolTest do
     end
   end
 
+  test "decodes an element-dense response within the declared admission limits" do
+    # Issue #1676: decode cost scales with element count, not bytes. A
+    # response under the node limit must decode regardless of how its bytes
+    # distribute across elements.
+    padding = Enum.map_join(1..49_000, ",", &~s("p#{&1}"))
+
+    body =
+      ~s({"jsonrpc":"2.0","id":7,"result":{"structuredContent":{"padding":[) <>
+        padding <> ~s(]}}})
+
+    assert {:ok, {:response, 7, %{"result" => _result}}} = MCPProtocol.decode_message(body)
+  end
+
+  test "a decode that exceeds host processing bounds is response excess, not a protocol fault" do
+    # One million integers materialize past the decode worker's heap budget
+    # before the node limit can be counted. The server violated no protocol;
+    # the host declined to process the response. If the budget ever grows
+    # past this document's needs, it fails as `json_node_limit_exceeded`
+    # (a protocol error) instead and this document must grow with it.
+    array = "[" <> String.duplicate("1,", 999_999) <> "1]"
+    body = ~s({"jsonrpc":"2.0","id":7,"result":{"content":) <> array <> "}}"
+
+    assert {:error, :mcp_response_exceeded} = MCPProtocol.decode_message(body)
+    assert {:error, :mcp_response_exceeded} = MCPProtocol.decode_response(body, 7)
+  end
+
   test "rejects inbound JSON above the fixed document depth before decoding" do
     nested = String.duplicate("[", 64) <> "0" <> String.duplicate("]", 64)
     body = ~s({"jsonrpc":"2.0","id":7,"result":#{nested}})

--- a/test/ptc_runner/kernel/mcp_source_test.exs
+++ b/test/ptc_runner/kernel/mcp_source_test.exs
@@ -2354,6 +2354,50 @@ defmodule PtcRunner.Kernel.MCPSourceTest do
   end
 
   @tag :tmp_dir
+  test "an SSE decode the host cannot process within bounds is response excess", %{tmp_dir: dir} do
+    # Issue #1676: a well-formed SSE body whose decode exceeds the worker
+    # budget must surface as `mcp_response_exceeded`, not crash the SSE
+    # accumulator or masquerade as a protocol or transport fault. Both
+    # deliveries reach `accumulate_sse/4`; chunked also exercises buffer
+    # reassembly across stream chunks.
+    parent = self()
+
+    dense_result = %{
+      "resultType" => "complete",
+      "structuredContent" => %{"value" => 42},
+      "content" => List.duplicate(1, 900_000)
+    }
+
+    for chunked? <- [false, true] do
+      fixture =
+        fixture(parent, sse?: true, sse_chunked?: chunked?, structured_result: dense_result)
+
+      on_exit(fixture.close)
+
+      {:ok, built} =
+        dir
+        |> manifest(["remote.structured"],
+          program: single_call_program("remote.structured", "x"),
+          timeout_ms: 5_000,
+          evaluation_timeout_ms: 5_000
+        )
+        |> directory_request(registry(fixture.endpoint, timeout_ms: 5_000))
+        |> RunLifecycle.build()
+
+      assert {:ok, result} = Kernel.run(built.entry_source, built.config)
+
+      assert %{
+               "status" => "error",
+               "kind" => "provider_error",
+               "reason" => "invalid_result",
+               "details" => "mcp_response_exceeded"
+             } = get_in(result.value, ["value", "value"])
+
+      EventSink.stop(built.config.event_sink)
+    end
+  end
+
+  @tag :tmp_dir
   test "accepts bounded SSE responses and rejects malformed pagination and selection keys", %{
     tmp_dir: dir
   } do

--- a/test/ptc_runner/kernel/mcp_source_test.exs
+++ b/test/ptc_runner/kernel/mcp_source_test.exs
@@ -567,6 +567,65 @@ defmodule PtcRunner.Kernel.MCPSourceTest do
   end
 
   @tag :tmp_dir
+  test "an element-dense stdio result within byte limits reaches admission, not a protocol error",
+       %{tmp_dir: dir} do
+    # Issue #1676: decode cost scales with element count, not bytes. 45,000
+    # small strings (~400 KB) are within every transport bound, so the
+    # response must reach the dispatcher's retained-size admission -- with
+    # the exchange captured -- instead of killing the decode worker,
+    # failing the call as `mcp_protocol_error`, and poisoning transport
+    # cleanup for the whole run. Digest capture, because the full body's
+    # retained size is above the sealed-evidence record cap -- the ceiling
+    # digest mappings exist for.
+    marker = Path.join(dir, "stdio-dense")
+
+    tools = %{
+      "structured" => %{
+        as: "remote.structured",
+        effect: :read,
+        inspection_capture: :digest_results
+      }
+    }
+
+    inspection_path = Path.join(dir, "dense.ptcins")
+
+    # Enough evaluator heap to hold the dense value while the dispatcher
+    # measures it; the retained-size admission stays the binding limit.
+    {:ok, installed_limits} =
+      Limits.installed_defaults()
+      |> Map.from_struct()
+      |> Map.merge(%{evaluation_heap_words: 4_000_000})
+      |> Limits.new()
+
+    assert {:ok, %PtcRunner.Kernel.Result{value: value}} =
+             dir
+             |> manifest(["remote.structured"],
+               program: single_call_program("remote.structured", "x"),
+               max_result_bytes: 1_000_000,
+               timeout_ms: 5_000,
+               evaluation_timeout_ms: 5_000,
+               limits: %{"evaluation_heap_words" => 4_000_000}
+             )
+             |> directory_request(
+               stdio_registry(dir, marker, "structured-padded-dense",
+                 tools: tools,
+                 max_result_bytes: 1_000_000
+               ),
+               inspect: inspection_path,
+               installed_limits: installed_limits
+             )
+             |> RunLifecycle.build()
+             |> RunLifecycle.execute()
+
+    assert %{"status" => "error", "reason" => "provider_result_limit"} =
+             get_in(value, ["value", "value"])
+
+    assert {:ok, records} = StreamingInspection.read_path(inspection_path)
+    assert [response] = Enum.filter(records, &(&1["record_type"] == "mcp-response"))
+    assert %{"body_identity" => %{"sha256" => "sha256:" <> _}} = response["payload"]
+  end
+
+  @tag :tmp_dir
   test "a normalization-rejected result keeps its full error envelope while the body digests", %{
     tmp_dir: dir
   } do

--- a/test/ptc_runner/kernel/typed_canonical_json_test.exs
+++ b/test/ptc_runner/kernel/typed_canonical_json_test.exs
@@ -60,6 +60,17 @@ defmodule PtcRunner.Kernel.TypedCanonicalJSONTest do
              StrictJSON.admit([1, 2], max_nodes: 2)
   end
 
+  test "a document at the node limit decodes under the default heap budget" do
+    # Issue #1676: the decode worker's heap budget must cover the worst
+    # admissible document, or the declared node limit is unreachable and
+    # legal inputs die as `:invalid_json`. A flat object at the node limit
+    # is the most heap-expensive admissible shape.
+    source = "{" <> Enum.map_join(1..49_900, ",", &~s("k#{&1}":1)) <> "}"
+
+    assert {:ok, decoded} = StrictJSON.decode(source)
+    assert map_size(decoded) == 49_900
+  end
+
   test "root string inspection requires one unique root property" do
     assert {:ok, "ptc-project"} =
              StrictJSON.unique_root_string(

--- a/test/support/mcp_stdio_source_fixture.sh
+++ b/test/support/mcp_stdio_source_fixture.sh
@@ -110,7 +110,7 @@ do
       ;;
     *'"method":"tools/list"'*)
       printf '%s:%s\n' "$id" 'tools/list' >> "$marker"
-      if [ "$mode" = "structured-padded" ]; then
+      if [ "$mode" = "structured-padded" ] || [ "$mode" = "structured-padded-dense" ]; then
         printf '{"jsonrpc":"2.0","id":%s,"result":{"resultType":"complete","tools":[{"name":"structured","description":"Return one structured value.","inputSchema":{"type":"object","properties":{"query":{"type":"string","x-mcp-header":"Query"}},"required":["query"]},"outputSchema":{"type":"object","properties":{"value":{"type":"integer"},"padding":{"type":"array","items":{"type":"string"}}},"required":["value"]}}],"nextCursor":"page-2","ttlMs":0,"cacheScope":"private"}}\n' "$id"
       else
         printf '{"jsonrpc":"2.0","id":%s,"result":{"resultType":"complete","tools":[{"name":"structured","description":"Return one structured value.","inputSchema":{"type":"object","properties":{"query":{"type":"string","x-mcp-header":"Query"}},"required":["query"]},"outputSchema":{"type":"object","properties":{"value":{"type":"integer"}},"required":["value"]}}],"nextCursor":"page-2","ttlMs":0,"cacheScope":"private"}}\n' "$id"
@@ -124,6 +124,8 @@ do
       fi
       if [ "$mode" = "structured-padded" ]; then
         write_padded_structured_result "$id" 28000
+      elif [ "$mode" = "structured-padded-dense" ]; then
+        write_padded_structured_result "$id" 45000
       else
         printf '{"jsonrpc":"2.0","id":%s,"result":{"resultType":"complete","structuredContent":{"value":42},"content":[]}}\n' "$id"
       fi


### PR DESCRIPTION
Closes #1676.

## Root cause

`StrictJSON.decode/2` runs in a `BoundedWorker` with a 2,000,000-word (16 MB) `max_heap_size` kill bound — but its own declared `max_nodes` limit (100,000) admits documents that need up to ~4.5M words to materialize and admit. Decode heap scales with **element count**, not bytes (each small string costs sub-binary + cons + rebuild copies, while one 1 MB string is a single off-heap binary), which is exactly the issue's evidence table: 540 KB / 20k elements passed while 330 KB / 38k elements died.

Instrumentation confirmed the chain: the worker is killed (`{:error, :heap_exceeded}`), `StrictJSON.bounded/1` collapses the kill into `:invalid_json`, `MCPProtocol.decode_message/1` reports `:mcp_protocol_error`, and the stdio transport treats a well-formed response as a protocol violation — tearing down the transport with a failed outcome, which is the observed `provider_cleanup_error` ending the run. The "decodes in isolation" observation was near-cliff behavior: the kill check runs at GC points, so the effective threshold shifts slightly with allocation timing.

## Changes

- **Budget**: `@max_heap_words` 2M → 8M words (64 MB), sized from the measured worst admissible shape (a flat object at the node limit peaks near 4.5M words), so the kill is a backstop rather than the operative bound.
- **Classification**: `decode_message/1` now uses `StrictJSON.decode_classified/2`. Structural invalidity stays `:mcp_protocol_error`; worker unavailability (heap kill, timeout) becomes `:mcp_response_exceeded` — the host declining a response it cannot process within bounds, a reason both transports already handle.
- **Propagation**: stdio `consume_line/2`, HTTP `decode_response` callers, SSE streaming accumulation (`accumulate_sse/4` + a `:mcp_response_exceeded` body sentinel), `decode_sse/2`, `decode_sse_data/3`, and `http_protocol_error/2` all preserve the new reason.
- **Fixture**: `structured-padded-dense` stdio mode (45,000 elements).

## Tests (written failing-first)

- StrictJSON: a document at the node limit decodes under the default budget (the invariant that was broken).
- MCPProtocol: an element-dense response within declared limits decodes; a decode exceeding host bounds is `:mcp_response_exceeded`, not a protocol fault.
- Runtime stdio: a 45k-element response now reaches retained-size admission (`provider_result_limit`) with the exchange captured, instead of `mcp_protocol_error` + poisoned cleanup.
- HTTP SSE e2e: coalesced and chunked delivery of a decode-kill-sized body surface `invalid_result/mcp_response_exceeded` (mutation-checked against the `accumulate_sse` clause).

## Post-transport ceilings (documented, unchanged)

With the transport fixed, denser responses meet the next designed fail-closed limits: retained-size admission (`provider_result_limit`, ≥~21k small strings at the 1 MB floor), the sealed-evidence record cap under full capture (~41k; per-tool `inspection_capture: "digest_results"` is the designed answer), and the evaluator heap budget. These are intentional bounds, not this defect.

## Verification

Full suite (7279 passed), `mix precommit`, and `mix dialyzer` green. Codex review round 1 found the SSE accumulation CaseClauseError ([P1]) and the `http_protocol_error` collapse ([P2]) — both fixed in 14604e85; round 2 verified both resolved with no remaining actionable findings.