### PR TITLE
feat(analysis): capture bounded private run-catalog generations

### DIFF
--- a/.duplication-baseline.json
+++ b/.duplication-baseline.json
@@ -36,75 +36,6 @@
       ],
       "type": "type_i"
     },
-    "1ad84c238333bf508e3aff4f4d62a0153d948dad47d64eba093bc65ae486b79b": {
-      "describe": "type_i mass=43 lib/ptc_runner/kernel/analysis_session.ex:271 <-> lib/ptc_runner/kernel/execution_session_owner.ex:364 <-> lib/ptc_runner/kernel/host_installation_owner.ex:352 <-> lib/ptc_runner/kernel/mcp_oauth/store/memory.ex:704 <-> lib/ptc_runner/kernel/mcp_oauth/token_manager.ex:426 <-> lib/ptc_runner/kernel/mcp_request_context.ex:356 <-> lib/ptc_runner/kernel/mcp_stdio_transport.ex:396 <-> lib/ptc_runner/kernel/provider_session.ex:1231 <-> lib/ptc_runner/kernel/provider_task_tracker.ex:111 <-> lib/ptc_runner/kernel/session_trace.ex:292 <-> lib/ptc_runner/kernel/trace_snapshot.ex:374 <-> lib/ptc_runner/kernel/viewer_repl_backend.ex:357",
-      "files": [
-        "lib/ptc_runner/kernel/analysis_session.ex",
-        "lib/ptc_runner/kernel/execution_session_owner.ex",
-        "lib/ptc_runner/kernel/host_installation_owner.ex",
-        "lib/ptc_runner/kernel/mcp_oauth/store/memory.ex",
-        "lib/ptc_runner/kernel/mcp_oauth/token_manager.ex",
-        "lib/ptc_runner/kernel/mcp_request_context.ex",
-        "lib/ptc_runner/kernel/mcp_stdio_transport.ex",
-        "lib/ptc_runner/kernel/provider_session.ex",
-        "lib/ptc_runner/kernel/provider_task_tracker.ex",
-        "lib/ptc_runner/kernel/session_trace.ex",
-        "lib/ptc_runner/kernel/trace_snapshot.ex",
-        "lib/ptc_runner/kernel/viewer_repl_backend.ex"
-      ],
-      "mass": 43,
-      "occurrences": [
-        {
-          "file": "lib/ptc_runner/kernel/analysis_session.ex",
-          "snippet": "bb3704f9e43b4527e7ccf365039a43e289f6703b0758d6e4803423f6562db0bb"
-        },
-        {
-          "file": "lib/ptc_runner/kernel/execution_session_owner.ex",
-          "snippet": "bb3704f9e43b4527e7ccf365039a43e289f6703b0758d6e4803423f6562db0bb"
-        },
-        {
-          "file": "lib/ptc_runner/kernel/host_installation_owner.ex",
-          "snippet": "bb3704f9e43b4527e7ccf365039a43e289f6703b0758d6e4803423f6562db0bb"
-        },
-        {
-          "file": "lib/ptc_runner/kernel/mcp_oauth/store/memory.ex",
-          "snippet": "bb3704f9e43b4527e7ccf365039a43e289f6703b0758d6e4803423f6562db0bb"
-        },
-        {
-          "file": "lib/ptc_runner/kernel/mcp_oauth/token_manager.ex",
-          "snippet": "bb3704f9e43b4527e7ccf365039a43e289f6703b0758d6e4803423f6562db0bb"
-        },
-        {
-          "file": "lib/ptc_runner/kernel/mcp_request_context.ex",
-          "snippet": "bb3704f9e43b4527e7ccf365039a43e289f6703b0758d6e4803423f6562db0bb"
-        },
-        {
-          "file": "lib/ptc_runner/kernel/mcp_stdio_transport.ex",
-          "snippet": "bb3704f9e43b4527e7ccf365039a43e289f6703b0758d6e4803423f6562db0bb"
-        },
-        {
-          "file": "lib/ptc_runner/kernel/provider_session.ex",
-          "snippet": "bb3704f9e43b4527e7ccf365039a43e289f6703b0758d6e4803423f6562db0bb"
-        },
-        {
-          "file": "lib/ptc_runner/kernel/provider_task_tracker.ex",
-          "snippet": "bb3704f9e43b4527e7ccf365039a43e289f6703b0758d6e4803423f6562db0bb"
-        },
-        {
-          "file": "lib/ptc_runner/kernel/session_trace.ex",
-          "snippet": "bb3704f9e43b4527e7ccf365039a43e289f6703b0758d6e4803423f6562db0bb"
-        },
-        {
-          "file": "lib/ptc_runner/kernel/trace_snapshot.ex",
-          "snippet": "bb3704f9e43b4527e7ccf365039a43e289f6703b0758d6e4803423f6562db0bb"
-        },
-        {
-          "file": "lib/ptc_runner/kernel/viewer_repl_backend.ex",
-          "snippet": "bb3704f9e43b4527e7ccf365039a43e289f6703b0758d6e4803423f6562db0bb"
-        }
-      ],
-      "type": "type_i"
-    },
     "22056ec49615795b1324c4437d32391888ecc86567ef20660bb47ec6460df34c": {
       "describe": "type_ii mass=36 lib/ptc_runner/lisp/java/surface/validator.ex:1999 <-> lib/ptc_runner/lisp/java/surface/validator.ex:365",
       "files": [
@@ -202,8 +133,82 @@
       ],
       "type": "type_i"
     },
+    "4dc0df361a20ca0d61881045c1daad230b93b9bd21918cce321138f86cda3186": {
+      "describe": "type_i mass=43 lib/ptc_runner/kernel/analysis_session.ex:271 <-> lib/ptc_runner/kernel/execution_session_owner.ex:364 <-> lib/ptc_runner/kernel/host_installation_owner.ex:352 <-> lib/ptc_runner/kernel/mcp_oauth/store/memory.ex:704 <-> lib/ptc_runner/kernel/mcp_oauth/token_manager.ex:426 <-> lib/ptc_runner/kernel/mcp_request_context.ex:356 <-> lib/ptc_runner/kernel/mcp_stdio_transport.ex:396 <-> lib/ptc_runner/kernel/provider_session.ex:1231 <-> lib/ptc_runner/kernel/provider_task_tracker.ex:111 <-> lib/ptc_runner/kernel/run_catalog_snapshot.ex:200 <-> lib/ptc_runner/kernel/session_trace.ex:292 <-> lib/ptc_runner/kernel/trace_snapshot.ex:397 <-> lib/ptc_runner/kernel/viewer_repl_backend.ex:357",
+      "files": [
+        "lib/ptc_runner/kernel/analysis_session.ex",
+        "lib/ptc_runner/kernel/execution_session_owner.ex",
+        "lib/ptc_runner/kernel/host_installation_owner.ex",
+        "lib/ptc_runner/kernel/mcp_oauth/store/memory.ex",
+        "lib/ptc_runner/kernel/mcp_oauth/token_manager.ex",
+        "lib/ptc_runner/kernel/mcp_request_context.ex",
+        "lib/ptc_runner/kernel/mcp_stdio_transport.ex",
+        "lib/ptc_runner/kernel/provider_session.ex",
+        "lib/ptc_runner/kernel/provider_task_tracker.ex",
+        "lib/ptc_runner/kernel/run_catalog_snapshot.ex",
+        "lib/ptc_runner/kernel/session_trace.ex",
+        "lib/ptc_runner/kernel/trace_snapshot.ex",
+        "lib/ptc_runner/kernel/viewer_repl_backend.ex"
+      ],
+      "mass": 43,
+      "occurrences": [
+        {
+          "file": "lib/ptc_runner/kernel/analysis_session.ex",
+          "snippet": "bb3704f9e43b4527e7ccf365039a43e289f6703b0758d6e4803423f6562db0bb"
+        },
+        {
+          "file": "lib/ptc_runner/kernel/execution_session_owner.ex",
+          "snippet": "bb3704f9e43b4527e7ccf365039a43e289f6703b0758d6e4803423f6562db0bb"
+        },
+        {
+          "file": "lib/ptc_runner/kernel/host_installation_owner.ex",
+          "snippet": "bb3704f9e43b4527e7ccf365039a43e289f6703b0758d6e4803423f6562db0bb"
+        },
+        {
+          "file": "lib/ptc_runner/kernel/mcp_oauth/store/memory.ex",
+          "snippet": "bb3704f9e43b4527e7ccf365039a43e289f6703b0758d6e4803423f6562db0bb"
+        },
+        {
+          "file": "lib/ptc_runner/kernel/mcp_oauth/token_manager.ex",
+          "snippet": "bb3704f9e43b4527e7ccf365039a43e289f6703b0758d6e4803423f6562db0bb"
+        },
+        {
+          "file": "lib/ptc_runner/kernel/mcp_request_context.ex",
+          "snippet": "bb3704f9e43b4527e7ccf365039a43e289f6703b0758d6e4803423f6562db0bb"
+        },
+        {
+          "file": "lib/ptc_runner/kernel/mcp_stdio_transport.ex",
+          "snippet": "bb3704f9e43b4527e7ccf365039a43e289f6703b0758d6e4803423f6562db0bb"
+        },
+        {
+          "file": "lib/ptc_runner/kernel/provider_session.ex",
+          "snippet": "bb3704f9e43b4527e7ccf365039a43e289f6703b0758d6e4803423f6562db0bb"
+        },
+        {
+          "file": "lib/ptc_runner/kernel/provider_task_tracker.ex",
+          "snippet": "bb3704f9e43b4527e7ccf365039a43e289f6703b0758d6e4803423f6562db0bb"
+        },
+        {
+          "file": "lib/ptc_runner/kernel/run_catalog_snapshot.ex",
+          "snippet": "bb3704f9e43b4527e7ccf365039a43e289f6703b0758d6e4803423f6562db0bb"
+        },
+        {
+          "file": "lib/ptc_runner/kernel/session_trace.ex",
+          "snippet": "bb3704f9e43b4527e7ccf365039a43e289f6703b0758d6e4803423f6562db0bb"
+        },
+        {
+          "file": "lib/ptc_runner/kernel/trace_snapshot.ex",
+          "snippet": "bb3704f9e43b4527e7ccf365039a43e289f6703b0758d6e4803423f6562db0bb"
+        },
+        {
+          "file": "lib/ptc_runner/kernel/viewer_repl_backend.ex",
+          "snippet": "bb3704f9e43b4527e7ccf365039a43e289f6703b0758d6e4803423f6562db0bb"
+        }
+      ],
+      "type": "type_i"
+    },
     "4fb8929e2db79521808dac424116c41338c86ecc4e7ab9725165845d8846ccdd": {
-      "describe": "type_i mass=36 test/ptc_runner/kernel/mcp_request_context_test.exs:608 <-> test/ptc_runner/kernel/mcp_source_test.exs:2635",
+      "describe": "type_i mass=36 test/ptc_runner/kernel/mcp_request_context_test.exs:608 <-> test/ptc_runner/kernel/mcp_source_test.exs:2881",
       "files": [
         "test/ptc_runner/kernel/mcp_request_context_test.exs",
         "test/ptc_runner/kernel/mcp_source_test.exs"
@@ -240,7 +245,7 @@
       "type": "type_i"
     },
     "5ef621c02ed0857b4ef273d1e724ca264db4525e6d0c07e8f9558bf4c0a7e377": {
-      "describe": "type_i mass=30 lib/ptc_runner/kernel/llm_replay_owner.ex:65 <-> lib/ptc_runner/kernel/trace_snapshot.ex:369",
+      "describe": "type_i mass=30 lib/ptc_runner/kernel/llm_replay_owner.ex:65 <-> lib/ptc_runner/kernel/trace_snapshot.ex:392",
       "files": [
         "lib/ptc_runner/kernel/llm_replay_owner.ex",
         "lib/ptc_runner/kernel/trace_snapshot.ex"
@@ -295,7 +300,7 @@
       "type": "type_i"
     },
     "676ecb4412a54eef2f319df5d6c64399e2b5faf84ad2ef979bf9c871fb5f32fd": {
-      "describe": "type_ii mass=30 lib/ptc_runner/kernel/event_sink.ex:296 <-> lib/ptc_runner/kernel/inspection_sink.ex:225 <-> lib/ptc_runner/kernel/llm_replay_owner.ex:65 <-> lib/ptc_runner/kernel/trace_snapshot.ex:369",
+      "describe": "type_ii mass=30 lib/ptc_runner/kernel/event_sink.ex:296 <-> lib/ptc_runner/kernel/inspection_sink.ex:268 <-> lib/ptc_runner/kernel/llm_replay_owner.ex:65 <-> lib/ptc_runner/kernel/trace_snapshot.ex:392",
       "files": [
         "lib/ptc_runner/kernel/event_sink.ex",
         "lib/ptc_runner/kernel/inspection_sink.ex",
@@ -377,7 +382,7 @@
       "type": "type_ii"
     },
     "763c8a9e4ef38af437133014657da3890afd363f089b1e1693f858ab67849dbe": {
-      "describe": "type_i mass=57 lib/ptc_runner/kernel/inspection_snapshot.ex:131 <-> lib/ptc_runner/kernel/trace_snapshot.ex:181",
+      "describe": "type_i mass=57 lib/ptc_runner/kernel/inspection_snapshot.ex:143 <-> lib/ptc_runner/kernel/trace_snapshot.ex:182",
       "files": [
         "lib/ptc_runner/kernel/inspection_snapshot.ex",
         "lib/ptc_runner/kernel/trace_snapshot.ex"
@@ -396,7 +401,7 @@
       "type": "type_i"
     },
     "79ed5035598bef16f41582b12ef838c103875cedbe3a920d31a44b860e54c939": {
-      "describe": "type_i mass=30 lib/ptc_runner/kernel/analysis_session.ex:726 <-> lib/ptc_runner/kernel/host_installation_owner.ex:362 <-> lib/ptc_runner/kernel/mcp_oauth/store/memory.ex:1528 <-> lib/ptc_runner/kernel/mcp_oauth/token_manager.ex:919 <-> lib/ptc_runner/kernel/mcp_request_context.ex:379 <-> lib/ptc_runner/kernel/mcp_stdio_transport.ex:1159 <-> lib/ptc_runner/kernel/provider_session.ex:1692 <-> lib/ptc_runner/kernel/provider_task_tracker.ex:148 <-> lib/ptc_runner/kernel/run_state.ex:1335 <-> lib/ptc_runner/kernel/session_trace.ex:540 <-> lib/ptc_runner/kernel/trace_snapshot.ex:647 <-> lib/ptc_runner/kernel/viewer_repl_backend.ex:609",
+      "describe": "type_i mass=30 lib/ptc_runner/kernel/analysis_session.ex:726 <-> lib/ptc_runner/kernel/host_installation_owner.ex:362 <-> lib/ptc_runner/kernel/mcp_oauth/store/memory.ex:1528 <-> lib/ptc_runner/kernel/mcp_oauth/token_manager.ex:919 <-> lib/ptc_runner/kernel/mcp_request_context.ex:379 <-> lib/ptc_runner/kernel/mcp_stdio_transport.ex:1159 <-> lib/ptc_runner/kernel/provider_session.ex:1692 <-> lib/ptc_runner/kernel/provider_task_tracker.ex:148 <-> lib/ptc_runner/kernel/run_state.ex:1362 <-> lib/ptc_runner/kernel/session_trace.ex:540 <-> lib/ptc_runner/kernel/trace_snapshot.ex:689 <-> lib/ptc_runner/kernel/viewer_repl_backend.ex:609",
       "files": [
         "lib/ptc_runner/kernel/analysis_session.ex",
         "lib/ptc_runner/kernel/host_installation_owner.ex",
@@ -524,7 +529,7 @@
       "type": "type_i"
     },
     "9a5745cb297a916c230134aaad7350eec097cc0dff4429002490c01db7a8b665": {
-      "describe": "type_ii mass=39 lib/ptc_runner/kernel/trace_log.ex:1743 <-> lib/ptc_runner/kernel/trace_log.ex:2273",
+      "describe": "type_ii mass=39 lib/ptc_runner/kernel/trace_log.ex:1890 <-> lib/ptc_runner/kernel/trace_log.ex:2670",
       "files": [
         "lib/ptc_runner/kernel/trace_log.ex"
       ],
@@ -542,7 +547,7 @@
       "type": "type_ii"
     },
     "a37cf972b79c1c0917de2e14c4dd036e1626814b5e9eebab8c3b27caaa76733f": {
-      "describe": "type_i mass=54 test/ptc_runner/kernel/provider_declaration_test.exs:1573 <-> test/ptc_runner/kernel/provider_declaration_test.exs:2113",
+      "describe": "type_i mass=54 test/ptc_runner/kernel/provider_declaration_test.exs:1584 <-> test/ptc_runner/kernel/provider_declaration_test.exs:2124",
       "files": [
         "test/ptc_runner/kernel/provider_declaration_test.exs"
       ],
@@ -578,7 +583,7 @@
       "type": "type_i"
     },
     "b5c37bd099b8247b16c034f46e060422ed68e821028907619196297b940bbed1": {
-      "describe": "type_i mass=46 lib/ptc_runner/kernel/inspection_snapshot.ex:264 <-> lib/ptc_runner/kernel/trace_snapshot.ex:349",
+      "describe": "type_i mass=46 lib/ptc_runner/kernel/inspection_snapshot.ex:274 <-> lib/ptc_runner/kernel/trace_snapshot.ex:372",
       "files": [
         "lib/ptc_runner/kernel/inspection_snapshot.ex",
         "lib/ptc_runner/kernel/trace_snapshot.ex"
@@ -619,7 +624,7 @@
       "type": "type_i"
     },
     "da241194085c15f4be57bc5d899f9ed222f81e69ad6570a67ae780247351e332": {
-      "describe": "type_i mass=43 lib/ptc_runner/kernel/host_config.ex:1844 <-> lib/ptc_runner/kernel/manifest.ex:1455",
+      "describe": "type_i mass=43 lib/ptc_runner/kernel/host_config.ex:2006 <-> lib/ptc_runner/kernel/manifest.ex:1474",
       "files": [
         "lib/ptc_runner/kernel/host_config.ex",
         "lib/ptc_runner/kernel/manifest.ex"
@@ -717,7 +722,7 @@
       "type": "type_i"
     },
     "ee759005e72ef863d7844779dc4a667b279c1d3f64dac872d2f277554e4b7036": {
-      "describe": "type_i mass=37 lib/ptc_runner/kernel/inspection_snapshot.ex:165 <-> lib/ptc_runner/kernel/trace_snapshot.ex:247",
+      "describe": "type_i mass=37 lib/ptc_runner/kernel/inspection_snapshot.ex:177 <-> lib/ptc_runner/kernel/trace_snapshot.ex:262",
       "files": [
         "lib/ptc_runner/kernel/inspection_snapshot.ex",
         "lib/ptc_runner/kernel/trace_snapshot.ex"
@@ -801,7 +806,7 @@
       "type": "type_i"
     },
     "fccf3d34ad4059288f46e6bd8af17812026e2f87b4791a87c608c50b8bee732d": {
-      "describe": "type_i mass=30 lib/ptc_runner/kernel/event_sink.ex:296 <-> lib/ptc_runner/kernel/inspection_sink.ex:225",
+      "describe": "type_i mass=30 lib/ptc_runner/kernel/event_sink.ex:296 <-> lib/ptc_runner/kernel/inspection_sink.ex:268",
       "files": [
         "lib/ptc_runner/kernel/event_sink.ex",
         "lib/ptc_runner/kernel/inspection_sink.ex"

--- a/lib/ptc_runner/kernel/bounded_capture.ex
+++ b/lib/ptc_runner/kernel/bounded_capture.ex
@@ -1,0 +1,98 @@
+defmodule PtcRunner.Kernel.BoundedCapture do
+  @moduledoc """
+  One-shot owner-scoped capture under a heap limit and an absolute deadline.
+
+  A snapshot owner reads a source once, at start, and must not grow its own
+  heap doing so. The work therefore runs in a separate monitored process with
+  `:max_heap_size` set to kill, and the calling owner waits on three things at
+  once: the reply, the worker's death, and the death of the process the
+  capture belongs to.
+
+  The outcome is reported in one vocabulary — `:owner_down`, `:heap_exceeded`,
+  `:worker_failed`, `:deadline_exceeded` — and each caller maps it onto the
+  codes its own source contract publishes. A capture's own return value is
+  handed back wrapped in `{:ok, …}`, so a capture that answers `{:error, …}`
+  is never confused with a failure of the capture machinery itself.
+
+  Whatever ends the wait, the worker does not outlive it: a deadline or a dead
+  owner kills the worker and reaps its `:DOWN` before returning, so no capture
+  keeps reading a source nobody is waiting for.
+  """
+
+  @type failure :: :owner_down | :heap_exceeded | :worker_failed | :deadline_exceeded
+
+  @doc """
+  Runs `capture` for `:owner`, returning `{:ok, capture_result}` or a failure.
+
+  `:owner_ref` must be a monitor the caller already holds on `:owner`, so the
+  owner's death is observed rather than polled. `:deadline_ms` is an absolute
+  `System.monotonic_time(:millisecond)` value, not a duration, so a deadline
+  already spent yields no work rather than a fresh budget.
+  """
+  @spec for_owner((-> term()), keyword()) :: {:ok, term()} | {:error, failure()}
+  def for_owner(capture, opts) when is_function(capture, 0) and is_list(opts) do
+    owner = Keyword.fetch!(opts, :owner)
+    owner_ref = Keyword.fetch!(opts, :owner_ref)
+    max_heap_words = Keyword.fetch!(opts, :max_heap_words)
+    deadline_ms = Keyword.fetch!(opts, :deadline_ms)
+
+    reply_alias = Process.alias()
+    reply_ref = make_ref()
+
+    {worker, worker_ref} =
+      Process.spawn(
+        fn -> send(reply_alias, {reply_ref, capture.()}) end,
+        [
+          {:max_heap_size,
+           %{
+             size: max_heap_words,
+             kill: true,
+             error_logger: false,
+             include_shared_binaries: true
+           }},
+          :monitor
+        ]
+      )
+
+    await(
+      {worker, worker_ref},
+      {owner, owner_ref},
+      {reply_alias, reply_ref},
+      max(deadline_ms - System.monotonic_time(:millisecond), 0)
+    )
+  end
+
+  defp await({worker, worker_ref}, {owner, owner_ref}, {reply_alias, reply_ref}, timeout) do
+    receive do
+      {^reply_ref, result} ->
+        Process.unalias(reply_alias)
+        Process.demonitor(worker_ref, [:flush])
+        if Process.alive?(owner), do: {:ok, result}, else: {:error, :owner_down}
+
+      {:DOWN, ^owner_ref, :process, ^owner, _reason} ->
+        terminate(worker, worker_ref, reply_alias)
+        {:error, :owner_down}
+
+      {:DOWN, ^worker_ref, :process, ^worker, :killed} ->
+        Process.unalias(reply_alias)
+        {:error, :heap_exceeded}
+
+      {:DOWN, ^worker_ref, :process, ^worker, _reason} ->
+        Process.unalias(reply_alias)
+        {:error, :worker_failed}
+    after
+      timeout ->
+        terminate(worker, worker_ref, reply_alias)
+        {:error, :deadline_exceeded}
+    end
+  end
+
+  defp terminate(worker, worker_ref, reply_alias) do
+    Process.unalias(reply_alias)
+    Process.exit(worker, :kill)
+
+    receive do
+      {:DOWN, ^worker_ref, :process, ^worker, _reason} -> :ok
+    end
+  end
+end

--- a/lib/ptc_runner/kernel/inspection_artifact/format.ex
+++ b/lib/ptc_runner/kernel/inspection_artifact/format.ex
@@ -68,6 +68,46 @@ defmodule PtcRunner.Kernel.InspectionArtifact.Format do
 
   def decode_header(_other), do: {:error, :malformed_source}
 
+  @typedoc "Format and schema versions read without committing to a field layout."
+  @type versions :: %{format_version: pos_integer(), schema_version: pos_integer()}
+
+  @doc """
+  Reads a header's declared versions without requiring the current ones.
+
+  `decode_header/1` matches this version's constants, so it cannot tell an
+  artifact written by another version from a corrupt one. A bounded metadata
+  probe must report those two states differently, and the magic plus the two
+  version fields sit at fixed offsets for every version of the container.
+  """
+  @spec decode_header_versions(binary()) :: {:ok, versions()} | {:error, :malformed_source}
+  def decode_header_versions(
+        <<@header_magic::binary, format_version::unsigned-big-16, schema_version::unsigned-big-16,
+          _header_size::unsigned-big-32>>
+      )
+      when format_version > 0 and schema_version > 0,
+      do: {:ok, %{format_version: format_version, schema_version: schema_version}}
+
+  def decode_header_versions(_other), do: {:error, :malformed_source}
+
+  @doc """
+  Reads a footer's declared versions without requiring the current ones.
+
+  Only the magic and the two version fields are read. Nothing beyond them is
+  interpreted, because a footer written by another version may lay its
+  remaining fields out differently — including its own size, which is why a
+  reader that finds foreign versions here must not treat the trailing
+  `footer_size/0` bytes as a whole footer.
+  """
+  @spec decode_footer_versions(binary()) :: {:ok, versions()} | {:error, :malformed_source}
+  def decode_footer_versions(
+        <<@footer_magic::binary, format_version::unsigned-big-16, schema_version::unsigned-big-16,
+          _rest::binary>>
+      )
+      when format_version > 0 and schema_version > 0,
+      do: {:ok, %{format_version: format_version, schema_version: schema_version}}
+
+  def decode_footer_versions(_other), do: {:error, :malformed_source}
+
   @spec encode_frame(binary()) :: {:ok, binary()} | {:error, :invalid_frame}
   def encode_frame(payload) when is_binary(payload) do
     size = byte_size(payload)

--- a/lib/ptc_runner/kernel/run_catalog.ex
+++ b/lib/ptc_runner/kernel/run_catalog.ex
@@ -109,8 +109,16 @@ defmodule PtcRunner.Kernel.RunCatalog do
   end
 
   # Two entries may not both claim one run or trace identity. Stems are unique
-  # within a root, so this catches the case the filesystem cannot prevent: a
-  # trace whose embedded identity belongs to another entry's run.
+  # within a root, so this catches the cases the filesystem cannot prevent: a
+  # trace whose embedded identity belongs to another entry's run, and a sealed
+  # artifact copied under a second run's canonical name.
+  #
+  # Both halves claim into one space. A trace states its identities in
+  # plaintext and a footer states them only as digests, so the plaintext is
+  # hashed to meet the footer rather than the footer being trusted to name
+  # itself — otherwise the two halves would claim into spaces that never
+  # intersect, and an artifact duplicating another run's identity would leave
+  # the run it impersonates looking admissible.
   defp duplicated_identities(probes) do
     probes
     |> Enum.flat_map(&claimed_identities/1)
@@ -120,10 +128,23 @@ defmodule PtcRunner.Kernel.RunCatalog do
     |> MapSet.new()
   end
 
-  defp claimed_identities(%{run_ref: run_ref, trace: %{present: :probed, head: head}}),
-    do: [{{:run, head.run_id}, run_ref}, {{:trace, head.trace_id}, run_ref}]
+  defp claimed_identities(%{run_ref: run_ref, trace: trace, inspection: inspection}) do
+    Enum.map(trace_claims(trace) ++ inspection_claims(inspection), &{&1, run_ref})
+  end
 
-  defp claimed_identities(_probe), do: []
+  defp trace_claims(%{present: :probed, head: head}) do
+    [
+      {:run, Format.identity_sha256(head.run_id)},
+      {:trace, Format.identity_sha256(head.trace_id)}
+    ]
+  end
+
+  defp trace_claims(_trace), do: []
+
+  defp inspection_claims(%{present: :probed} = inspection),
+    do: [{:run, inspection.run_id_sha256}, {:trace, inspection.trace_id_sha256}]
+
+  defp inspection_claims(_inspection), do: []
 
   defp row(probe, duplicated) do
     correlation = correlation(probe)
@@ -313,26 +334,20 @@ defmodule PtcRunner.Kernel.RunCatalog do
     end
   end
 
-  # A row commitment covers the entry's reference, the trace's filesystem
-  # identity, the digest of the bytes actually probed, and the sealed artifact
-  # digest. Absent halves commit to their absence, so a generation captured
+  # A row commitment covers the entry's reference and, for each half, its
+  # classification, the descriptor identity it was read from, and a digest of
+  # the exact bytes probed. Committing to decoded values instead would miss a
+  # rewrite the decode carries through unchanged — a footer's stored
+  # `artifact_digest` is a claim a metadata-only probe never recomputes, so
+  # editing a footer field beside it changes the row while leaving the claim
+  # alone. Absent halves commit to their absence, so a generation captured
   # before a run was published cannot collide with one captured after.
   defp commitment(%{run_ref: run_ref, trace: trace, inspection: inspection}) do
-    {run_ref, trace_commitment(trace), inspection_commitment(inspection)}
+    {run_ref, half_commitment(trace), half_commitment(inspection)}
   end
 
-  defp trace_commitment(%{present: :probed, identity: identity, commitment: commitment}),
-    do: {:probed, identity, commitment}
-
-  defp trace_commitment(%{present: present}), do: {present}
-
-  defp inspection_commitment(%{present: :probed} = inspection),
-    do: {:probed, inspection.bytes, inspection.artifact_digest}
-
-  defp inspection_commitment(%{present: :versions} = inspection),
-    do: {:versions, inspection.bytes, inspection.format_version, inspection.schema_version}
-
-  defp inspection_commitment(%{present: present}), do: {present}
+  defp half_commitment(%{present: present} = half),
+    do: {present, Map.get(half, :identity), Map.get(half, :commitment)}
 
   defp digest(commitments) do
     [@catalog_version, 0, :erlang.term_to_binary(Enum.sort(commitments), [:deterministic])]
@@ -351,11 +366,15 @@ defmodule PtcRunner.Kernel.RunCatalog do
 
   defp valid_probe?(_probe), do: false
 
+  # Every field the classifier goes on to read is checked here, not a sample of
+  # them. A partial check is worse than none: it reports a contract
+  # (`{:error, :invalid_catalog}`) that it then breaks, raising out of a
+  # projection instead — an untyped `head.timestamp` reaching
+  # `DateTime.from_iso8601/1` is the shape that takes.
   defp valid_trace_probe?(%{present: :probed, head: head, tail: tail} = trace) do
-    Map.has_key?(trace, :bytes) and Map.has_key?(trace, :identity) and
-      Map.has_key?(trace, :commitment) and trace.source_kind in [:sanitized, :private] and
-      is_map(head) and is_map(head.labels) and is_binary(head.run_id) and
-      is_binary(head.trace_id) and (is_nil(tail) or is_map(tail))
+    non_neg_integer?(trace[:bytes]) and is_tuple(trace[:identity]) and
+      is_binary(trace[:commitment]) and trace[:source_kind] in [:sanitized, :private] and
+      valid_head?(head) and valid_tail?(tail)
   end
 
   defp valid_trace_probe?(%{present: present}),
@@ -363,21 +382,45 @@ defmodule PtcRunner.Kernel.RunCatalog do
 
   defp valid_trace_probe?(_trace), do: false
 
+  defp valid_head?(head) when is_map(head) do
+    is_binary(head[:run_id]) and head[:run_id] != "" and is_binary(head[:trace_id]) and
+      head[:trace_id] != "" and is_map(head[:labels]) and optional_binary?(head[:timestamp]) and
+      (is_nil(head[:schema_version]) or is_integer(head[:schema_version]))
+  end
+
+  defp valid_head?(_head), do: false
+
+  defp valid_tail?(nil), do: true
+
+  defp valid_tail?(tail) when is_map(tail) do
+    optional_binary?(tail[:timestamp]) and optional_binary?(tail[:status]) and
+      optional_binary?(tail[:terminal_reason]) and optional_binary?(tail[:result_hash])
+  end
+
+  defp valid_tail?(_tail), do: false
+
   defp valid_inspection_probe?(%{present: :probed} = inspection) do
-    Map.has_key?(inspection, :bytes) and Map.has_key?(inspection, :record_count) and
-      is_binary(inspection.run_id_sha256) and is_binary(inspection.trace_id_sha256) and
-      is_binary(inspection.artifact_digest)
+    non_neg_integer?(inspection[:bytes]) and non_neg_integer?(inspection[:record_count]) and
+      is_tuple(inspection[:identity]) and is_binary(inspection[:commitment]) and
+      is_integer(inspection[:format_version]) and is_integer(inspection[:schema_version]) and
+      is_binary(inspection[:run_id_sha256]) and is_binary(inspection[:trace_id_sha256]) and
+      is_binary(inspection[:artifact_digest])
   end
 
   defp valid_inspection_probe?(%{present: :versions} = inspection) do
-    Map.has_key?(inspection, :bytes) and is_integer(inspection.format_version) and
-      is_integer(inspection.schema_version)
+    non_neg_integer?(inspection[:bytes]) and is_tuple(inspection[:identity]) and
+      is_binary(inspection[:commitment]) and is_integer(inspection[:format_version]) and
+      is_integer(inspection[:schema_version])
   end
 
   defp valid_inspection_probe?(%{present: present}),
     do: present in [:absent, :malformed, :unstable]
 
   defp valid_inspection_probe?(_inspection), do: false
+
+  defp non_neg_integer?(value), do: is_integer(value) and value >= 0
+
+  defp optional_binary?(value), do: is_nil(value) or is_binary(value)
 
   defp unique_refs?(probes) do
     refs = Enum.map(probes, & &1.run_ref)

--- a/lib/ptc_runner/kernel/run_catalog.ex
+++ b/lib/ptc_runner/kernel/run_catalog.ex
@@ -1,0 +1,392 @@
+defmodule PtcRunner.Kernel.RunCatalog do
+  @moduledoc """
+  Immutable safe-metadata rows for one private run-cohort generation.
+
+  A generation is a captured value, not a view of a directory. It turns the
+  bounded probes of `PtcRunner.Kernel.RunCatalogProbe` into one frozen row per
+  canonical run stem, commits to their identities with a domain-separated
+  digest, and never re-lists anything afterwards. Filesystem change therefore
+  cannot alter an open generation: a later capture is a different generation
+  with a different digest.
+
+  ## What a row may say
+
+  A row carries only what a sealed artifact states about itself at O(1) cost:
+  identities, artifact presence and source class, schema and format versions,
+  byte and record counts, lifecycle timestamps and terminal status, the safe
+  `result_hash` fingerprint, the same `run-started` labels the public
+  `analysis/runs` surface already exposes, the sealed artifact digest, and the
+  correlation and admissibility of the pair.
+
+  A row never carries prompts, responses, generated source, capability
+  payloads, diagnostics, prints, result values, evidence-record content, or a
+  filesystem path — and never a counter that would require scanning a whole
+  trace (`evaluations`, `llm_calls`, `error_count`, `truncated`). Those stay
+  where they already are, behind admission, on `analysis/runs {"view" "full"}`
+  and `analysis/counters`.
+
+  "Non-copying" here means no payload copying: beyond a head line, a bounded
+  tail line, and a sealed container's fixed edges, nothing is read, decoded,
+  or retained. The bounded per-row metadata projection is the product.
+
+  ## Isolation
+
+  Classification is per row, and a row is the unit of failure. A malformed,
+  ambiguous, duplicate, unstable, or version-incompatible entry becomes an
+  isolated row carrying a path-free reason code — it never blocks the
+  generation, because nothing beyond its own probe was ever opened. Whole-
+  operation refusals belong to the probe and the owner, not here.
+  """
+
+  alias PtcRunner.Kernel.InspectionArtifact.Format
+  alias PtcRunner.Kernel.RunCatalogProbe
+
+  @catalog_version "ptc-run-catalog-v1"
+  @trace_schema_version 2
+  @max_row_bytes 2_048
+
+  # Most fundamental first: a reason that describes the entry itself outranks
+  # one that describes its relationship to another entry, so a row that is both
+  # malformed and duplicated reports the malformation it actually has.
+  @reason_order [
+    :ambiguous_trace,
+    :unstable_entry,
+    :malformed_metadata,
+    :unsupported_schema,
+    :filename_run_mismatch,
+    :duplicate_run_identity,
+    :inspection_correlation_missing
+  ]
+
+  @reason_rank @reason_order |> Enum.with_index() |> Map.new()
+
+  @type row :: %{binary() => term()}
+
+  @type generation :: %{
+          rows: [row()],
+          catalog_digest: binary(),
+          excluded_files: non_neg_integer()
+        }
+
+  @spec catalog_version() :: binary()
+  def catalog_version, do: @catalog_version
+
+  @spec max_row_bytes() :: pos_integer()
+  def max_row_bytes, do: @max_row_bytes
+
+  @spec reason_order() :: [atom()]
+  def reason_order, do: @reason_order
+
+  @doc """
+  Freezes one generation from the probes of a single capture.
+
+  Rows are ordered by run reference so a generation, its digest, and any
+  cursor derived from it stay stable for the lifetime of the capture.
+  """
+  @spec generation([RunCatalogProbe.probe()], non_neg_integer()) ::
+          {:ok, generation()} | {:error, :invalid_catalog}
+  def generation(probes, excluded_files)
+      when is_list(probes) and is_integer(excluded_files) and excluded_files >= 0 do
+    if Enum.all?(probes, &valid_probe?/1) and unique_refs?(probes) do
+      {:ok, build_generation(probes, excluded_files)}
+    else
+      {:error, :invalid_catalog}
+    end
+  end
+
+  def generation(_probes, _excluded_files), do: {:error, :invalid_catalog}
+
+  defp build_generation(probes, excluded_files) do
+    probes = Enum.sort_by(probes, & &1.run_ref)
+    duplicated = duplicated_identities(probes)
+    rows = Enum.map(probes, &row(&1, duplicated))
+
+    %{
+      rows: rows,
+      catalog_digest: digest(Enum.map(probes, &commitment/1)),
+      excluded_files: excluded_files
+    }
+  end
+
+  # Two entries may not both claim one run or trace identity. Stems are unique
+  # within a root, so this catches the case the filesystem cannot prevent: a
+  # trace whose embedded identity belongs to another entry's run.
+  defp duplicated_identities(probes) do
+    probes
+    |> Enum.flat_map(&claimed_identities/1)
+    |> Enum.group_by(&elem(&1, 0), &elem(&1, 1))
+    |> Enum.filter(fn {_identity, refs} -> refs |> Enum.uniq() |> length() > 1 end)
+    |> Enum.flat_map(fn {_identity, refs} -> refs end)
+    |> MapSet.new()
+  end
+
+  defp claimed_identities(%{run_ref: run_ref, trace: %{present: :probed, head: head}}),
+    do: [{{:run, head.run_id}, run_ref}, {{:trace, head.trace_id}, run_ref}]
+
+  defp claimed_identities(_probe), do: []
+
+  defp row(probe, duplicated) do
+    correlation = correlation(probe)
+    reasons = reasons(probe, correlation, duplicated)
+
+    probe
+    |> base_row(correlation, reasons)
+    |> bound_row()
+  end
+
+  defp base_row(probe, correlation, reasons) do
+    trace = probe.trace
+    inspection = probe.inspection
+    head = trace_head(trace)
+    tail = trace_tail(trace)
+
+    %{
+      "run_id" => probe.run_ref,
+      "trace_id" => head[:trace_id],
+      "trace_present" => trace_present(trace),
+      "inspection_present" => inspection.present != :absent,
+      "trace_schema_version" => head[:schema_version],
+      "inspection_format_version" => Map.get(inspection, :format_version),
+      "inspection_schema_version" => Map.get(inspection, :schema_version),
+      "trace_bytes" => Map.get(trace, :bytes),
+      "inspection_bytes" => Map.get(inspection, :bytes),
+      "inspection_record_count" => Map.get(inspection, :record_count),
+      "start_timestamp" => head[:timestamp],
+      "stop_timestamp" => tail[:timestamp],
+      "duration_ms" => duration_ms(head[:timestamp], tail[:timestamp]),
+      "status" => tail[:status],
+      "terminal_reason" => tail[:terminal_reason],
+      "result_hash" => tail[:result_hash],
+      "complete" => not is_nil(tail),
+      "name" => string_label(head, "name"),
+      "model" => string_label(head, "model"),
+      "provider" => string_label(head, "provider"),
+      "tags" => map_label(head, "tags"),
+      "labels" => (head && head.labels) || %{},
+      "artifact_digest" => artifact_digest(inspection),
+      "correlation" => correlation,
+      "state" => if(reasons == [], do: "admissible", else: "isolated"),
+      "isolation_reason" => reasons |> List.first() |> stringify_reason()
+    }
+  end
+
+  # An oversized row is a row the safe vocabulary cannot carry, so it is
+  # reduced field-wise and isolated rather than published in full or dropped.
+  # What is removed is exactly what a caller can grow without bound: the
+  # `run-started` label data and the terminal strings. Every field that
+  # survives is either an identity the probe already bounds, a validated
+  # timestamp, a fixed-width digest, or a number, so the reduced row is always
+  # inside the bound and the row schema keeps all of its keys.
+  defp bound_row(row) do
+    if row_bytes(row) <= @max_row_bytes do
+      row
+    else
+      Map.merge(row, %{
+        "labels" => %{},
+        "tags" => %{},
+        "name" => nil,
+        "model" => nil,
+        "provider" => nil,
+        "status" => nil,
+        "terminal_reason" => nil,
+        "result_hash" => nil,
+        "state" => "isolated",
+        "isolation_reason" => "malformed_metadata"
+      })
+    end
+  end
+
+  defp row_bytes(row) do
+    case Jason.encode(row) do
+      {:ok, encoded} -> byte_size(encoded)
+      {:error, _reason} -> @max_row_bytes + 1
+    end
+  end
+
+  defp trace_head(%{present: :probed, head: head}), do: head
+  defp trace_head(_trace), do: nil
+
+  defp trace_tail(%{present: :probed, tail: tail}), do: tail
+  defp trace_tail(_trace), do: nil
+
+  defp trace_present(%{present: :probed, source_kind: :private}), do: "private"
+  defp trace_present(%{present: :probed, source_kind: :sanitized}), do: "sanitized"
+  defp trace_present(%{present: :absent}), do: "absent"
+  defp trace_present(_trace), do: "unreadable"
+
+  # Label data reaches a row from a file, so its shape is asserted rather than
+  # assumed: a row field keeps one type whatever the envelope happened to
+  # carry, and anything else reads as absent.
+  defp string_label(head, key) do
+    case label(head, key) do
+      value when is_binary(value) -> value
+      _absent -> nil
+    end
+  end
+
+  defp map_label(head, key) do
+    case label(head, key) do
+      value when is_map(value) -> value
+      _absent -> %{}
+    end
+  end
+
+  defp label(nil, _key), do: nil
+  defp label(head, key), do: Map.get(head.labels, key)
+
+  defp artifact_digest(%{present: :probed, artifact_digest: digest}),
+    do: Base.encode16(digest, case: :lower)
+
+  defp artifact_digest(_inspection), do: nil
+
+  defp correlation(%{trace: trace, inspection: inspection} = probe) do
+    cond do
+      not usable?(trace) or not usable?(inspection) -> "unavailable"
+      trace.present == :absent and inspection.present == :absent -> "unavailable"
+      inspection.present == :absent -> "trace_only"
+      trace.present == :absent -> "inspection_only"
+      paired?(probe) -> "paired"
+      true -> "mismatch"
+    end
+  end
+
+  defp usable?(%{present: present}), do: present in [:probed, :absent]
+
+  # The footer commits to identity only as digests, so correlation is proven by
+  # hashing what the trace states and comparing — never by trusting a filename.
+  defp paired?(%{trace: %{head: head}, inspection: inspection}) do
+    inspection.trace_id_sha256 == Format.identity_sha256(head.trace_id)
+  end
+
+  defp reasons(probe, correlation, duplicated) do
+    []
+    |> add(probe.trace.present == :ambiguous, :ambiguous_trace)
+    |> add(unstable?(probe), :unstable_entry)
+    |> add(malformed?(probe), :malformed_metadata)
+    |> add(unsupported_schema?(probe), :unsupported_schema)
+    |> add(filename_mismatch?(probe), :filename_run_mismatch)
+    |> add(MapSet.member?(duplicated, probe.run_ref), :duplicate_run_identity)
+    |> add(correlation == "mismatch", :inspection_correlation_missing)
+    |> Enum.uniq()
+    |> Enum.sort_by(&Map.fetch!(@reason_rank, &1))
+  end
+
+  defp unstable?(%{trace: trace, inspection: inspection}),
+    do: trace.present == :unstable or inspection.present == :unstable
+
+  defp malformed?(%{trace: trace, inspection: inspection}),
+    do: trace.present == :malformed or inspection.present == :malformed
+
+  defp unsupported_schema?(%{trace: trace, inspection: inspection}) do
+    unsupported_trace_schema?(trace) or inspection.present == :versions
+  end
+
+  defp unsupported_trace_schema?(%{present: :probed, head: head}),
+    do: head.schema_version != @trace_schema_version
+
+  defp unsupported_trace_schema?(_trace), do: false
+
+  # Filenames are routing hints; embedded identity is authoritative. Both halves
+  # are checked against the stem the entry was found under, so a file that
+  # describes another run is isolated instead of published under this one.
+  defp filename_mismatch?(%{run_ref: run_ref, trace: trace, inspection: inspection}) do
+    trace_mismatch?(trace, run_ref) or inspection_mismatch?(inspection, run_ref)
+  end
+
+  defp trace_mismatch?(%{present: :probed, head: head}, run_ref), do: head.run_id != run_ref
+  defp trace_mismatch?(_trace, _run_ref), do: false
+
+  defp inspection_mismatch?(%{present: :probed, run_id_sha256: digest}, run_ref),
+    do: digest != Format.identity_sha256(run_ref)
+
+  defp inspection_mismatch?(_inspection, _run_ref), do: false
+
+  defp duration_ms(nil, _stop), do: nil
+  defp duration_ms(_start, nil), do: nil
+
+  defp duration_ms(start_timestamp, stop_timestamp) do
+    with {:ok, started_at, 0} <- DateTime.from_iso8601(start_timestamp),
+         {:ok, stopped_at, 0} <- DateTime.from_iso8601(stop_timestamp) do
+      max(DateTime.diff(stopped_at, started_at, :millisecond), 0)
+    else
+      _invalid -> nil
+    end
+  end
+
+  # A row commitment covers the entry's reference, the trace's filesystem
+  # identity, the digest of the bytes actually probed, and the sealed artifact
+  # digest. Absent halves commit to their absence, so a generation captured
+  # before a run was published cannot collide with one captured after.
+  defp commitment(%{run_ref: run_ref, trace: trace, inspection: inspection}) do
+    {run_ref, trace_commitment(trace), inspection_commitment(inspection)}
+  end
+
+  defp trace_commitment(%{present: :probed, identity: identity, commitment: commitment}),
+    do: {:probed, identity, commitment}
+
+  defp trace_commitment(%{present: present}), do: {present}
+
+  defp inspection_commitment(%{present: :probed} = inspection),
+    do: {:probed, inspection.bytes, inspection.artifact_digest}
+
+  defp inspection_commitment(%{present: :versions} = inspection),
+    do: {:versions, inspection.bytes, inspection.format_version, inspection.schema_version}
+
+  defp inspection_commitment(%{present: present}), do: {present}
+
+  defp digest(commitments) do
+    [@catalog_version, 0, :erlang.term_to_binary(Enum.sort(commitments), [:deterministic])]
+    |> then(&:crypto.hash(:sha256, &1))
+    |> Base.url_encode64(padding: false)
+  end
+
+  # A probe is validated before any row is built, and a probed half must carry
+  # the fields a row reads from it. Refusing the whole generation is the only
+  # honest answer to a probe the classifier cannot read: half a row would
+  # publish a state nothing observed.
+  defp valid_probe?(%{run_ref: run_ref, trace: trace, inspection: inspection}) do
+    is_binary(run_ref) and run_ref != "" and valid_trace_probe?(trace) and
+      valid_inspection_probe?(inspection)
+  end
+
+  defp valid_probe?(_probe), do: false
+
+  defp valid_trace_probe?(%{present: :probed, head: head, tail: tail} = trace) do
+    Map.has_key?(trace, :bytes) and Map.has_key?(trace, :identity) and
+      Map.has_key?(trace, :commitment) and trace.source_kind in [:sanitized, :private] and
+      is_map(head) and is_map(head.labels) and is_binary(head.run_id) and
+      is_binary(head.trace_id) and (is_nil(tail) or is_map(tail))
+  end
+
+  defp valid_trace_probe?(%{present: present}),
+    do: present in [:absent, :ambiguous, :malformed, :unstable]
+
+  defp valid_trace_probe?(_trace), do: false
+
+  defp valid_inspection_probe?(%{present: :probed} = inspection) do
+    Map.has_key?(inspection, :bytes) and Map.has_key?(inspection, :record_count) and
+      is_binary(inspection.run_id_sha256) and is_binary(inspection.trace_id_sha256) and
+      is_binary(inspection.artifact_digest)
+  end
+
+  defp valid_inspection_probe?(%{present: :versions} = inspection) do
+    Map.has_key?(inspection, :bytes) and is_integer(inspection.format_version) and
+      is_integer(inspection.schema_version)
+  end
+
+  defp valid_inspection_probe?(%{present: present}),
+    do: present in [:absent, :malformed, :unstable]
+
+  defp valid_inspection_probe?(_inspection), do: false
+
+  defp unique_refs?(probes) do
+    refs = Enum.map(probes, & &1.run_ref)
+    refs == Enum.uniq(refs)
+  end
+
+  defp add(reasons, true, reason), do: [reason | reasons]
+  defp add(reasons, false, _reason), do: reasons
+
+  defp stringify_reason(nil), do: nil
+  defp stringify_reason(reason), do: Atom.to_string(reason)
+end

--- a/lib/ptc_runner/kernel/run_catalog_probe.ex
+++ b/lib/ptc_runner/kernel/run_catalog_probe.ex
@@ -18,14 +18,22 @@ defmodule PtcRunner.Kernel.RunCatalogProbe do
   failure matrix, so this module reports only what it observed and stays a
   pure function of the filesystem.
 
-  Each probed file is `lstat`ed before and after its reads. A file whose
-  identity moved under the probe is reported `:unstable` rather than
-  described from bytes that no longer belong together.
+  A probe reports only bytes it can prove belong to the entry it inventoried.
+  Each file is `lstat`ed before the open, the opened descriptor is `fstat`ed
+  and compared before a byte is read, and the path is `lstat`ed again after —
+  so neither a file replaced under its path nor one rewritten mid-probe is
+  described as the file that was listed. Either reports `:unstable`.
+
+  What survives is validated rather than trusted: the two probed trace events
+  go through the same canonical trace-event validation a directory capture
+  applies, and a sealed container whose versions are this build's is validated
+  against the same header and footer contract its reader enforces.
   """
 
   alias PtcRunner.Kernel.BoundedWorker
   alias PtcRunner.Kernel.InspectionArtifact.Format
   alias PtcRunner.Kernel.TraceDirectoryAdmission
+  alias PtcRunner.Kernel.TraceEventValidation
 
   @head_bytes 65_536
   @tail_bytes 65_536
@@ -41,8 +49,22 @@ defmodule PtcRunner.Kernel.RunCatalogProbe do
   @type stat_identity ::
           {non_neg_integer(), non_neg_integer(), non_neg_integer(), non_neg_integer(), term()}
 
+  @typedoc """
+  A half whose bytes were read but did not decode into a describable state.
+
+  It still carries what it observed — the descriptor identity and a digest of
+  the exact bytes probed — because a generation must distinguish one malformed
+  file from another. Only a half that never reached any bytes carries neither.
+  """
+  @type malformed_probe :: %{
+          :present => :malformed,
+          optional(:identity) => stat_identity(),
+          optional(:commitment) => binary()
+        }
+
   @type trace_probe ::
-          %{present: :absent | :ambiguous | :malformed | :unstable}
+          %{present: :absent | :ambiguous | :unstable}
+          | malformed_probe()
           | %{
               present: :probed,
               source_kind: :sanitized | :private,
@@ -54,10 +76,13 @@ defmodule PtcRunner.Kernel.RunCatalogProbe do
             }
 
   @type inspection_probe ::
-          %{present: :absent | :malformed | :unstable}
+          %{present: :absent | :unstable}
+          | malformed_probe()
           | %{
               present: :versions,
               bytes: non_neg_integer(),
+              identity: stat_identity(),
+              commitment: binary(),
               format_version: pos_integer(),
               schema_version: pos_integer()
             }
@@ -66,6 +91,8 @@ defmodule PtcRunner.Kernel.RunCatalogProbe do
               format_version: pos_integer(),
               schema_version: pos_integer(),
               bytes: non_neg_integer(),
+              identity: stat_identity(),
+              commitment: binary(),
               record_count: non_neg_integer(),
               run_id_sha256: binary(),
               trace_id_sha256: binary(),
@@ -235,7 +262,7 @@ defmodule PtcRunner.Kernel.RunCatalogProbe do
   # commits to what it observed, so a row is never assembled from a head and a
   # tail that may belong to different contents.
   defp probe_stable(path, before, decode) do
-    case read_edges(path, before.size) do
+    case read_edges(path, before.size, stat_identity(before)) do
       {:ok, head, tail} ->
         case File.lstat(path, time: :posix) do
           {:ok, %File.Stat{type: :regular} = later} ->
@@ -247,20 +274,42 @@ defmodule PtcRunner.Kernel.RunCatalogProbe do
             %{present: :unstable}
         end
 
+      :moved ->
+        %{present: :unstable}
+
       :error ->
         %{present: :malformed}
     end
   end
 
-  defp read_edges(path, size) do
-    case :file.open(path, [:read, :binary, :raw]) do
+  # The descriptor, not the path, is what the reads come from, so the descriptor
+  # is what must be proven to be the inventoried file: a path can be replaced
+  # between the `lstat` and the `open` and restored before the closing `lstat`,
+  # which would commit replacement bytes under the original identity. Following
+  # `InspectionArtifact.Handle.open/2`, the opened file is `fstat`ed and
+  # compared before a single byte is read. The descriptor is deliberately not
+  # `:raw`: a raw descriptor is process-local and cannot be `fstat`ed.
+  defp read_edges(path, size, expected) do
+    case :file.open(path, [:read, :binary]) do
       {:ok, io} ->
-        result = read_windows(io, size)
+        result =
+          case opened_identity(io) do
+            {:ok, identity} when identity == expected -> read_windows(io, size)
+            _replaced -> :moved
+          end
+
         :file.close(io)
         result
 
       {:error, _reason} ->
         :error
+    end
+  end
+
+  defp opened_identity(io) do
+    case :file.read_file_info(io, time: :posix) do
+      {:ok, file_info} -> {:ok, stat_identity(File.Stat.from_record(file_info))}
+      {:error, _reason} -> :error
     end
   end
 
@@ -282,21 +331,56 @@ defmodule PtcRunner.Kernel.RunCatalogProbe do
     end
   end
 
+  # Both probed events are validated as canonical trace events before anything
+  # is projected from them. Projecting from a handful of hand-picked fields let
+  # a file the canonical reader rejects — a `run-stopped` missing its
+  # `trace_id`, a result hash contradicting its outcome — be published as a
+  # complete, admissible run. The rule lives in `TraceEventValidation`, which
+  # already owns per-event shape, run/trace identity agreement, sequence
+  # ordering, and run lifecycle; the probe hands it exactly the events the row
+  # is built from, so the check stays bounded to two events.
   defp decode_trace(head, {tail_bytes, tail_offset}, source_kind, stat) do
+    observed = %{
+      identity: stat_identity(stat),
+      commitment: :crypto.hash(:sha256, [head, tail_bytes])
+    }
+
     with {:ok, head_line} <- first_line(head),
-         {:ok, started} <- decode_started(head_line),
-         {:ok, stopped} <- decode_stopped(tail_bytes, tail_offset, started) do
+         {:ok, started} <- decode_event(head_line),
+         %{"type" => "run-started"} <- started,
+         {:ok, stopped} <- decode_stopped(tail_bytes, tail_offset, started),
+         :ok <- canonical_events(started, stopped) do
+      Map.merge(observed, projected_trace(started, stopped, source_kind, stat))
+    else
+      _invalid -> Map.put(observed, :present, :malformed)
+    end
+  end
+
+  # A schema version this build does not support is a state the row reports
+  # together with the version it declares, not a file the catalog calls corrupt.
+  # Every other validation failure is a refusal, and the row is isolated with
+  # nothing projected from it.
+  defp canonical_events(started, stopped) do
+    case TraceEventValidation.validate(Enum.reject([started, stopped], &is_nil/1)) do
+      :ok -> :ok
+      {:error, :unsupported_version} -> :ok
+      {:error, _malformed} -> :error
+    end
+  end
+
+  defp projected_trace(started, stopped, source_kind, stat) do
+    head = project_started(started)
+
+    if head do
       %{
         present: :probed,
         source_kind: source_kind,
         bytes: stat.size,
-        identity: stat_identity(stat),
-        commitment: :crypto.hash(:sha256, [head, tail_bytes]),
-        head: started,
-        tail: stopped
+        head: head,
+        tail: project_stopped(stopped)
       }
     else
-      :error -> %{present: :malformed}
+      %{present: :malformed}
     end
   end
 
@@ -330,21 +414,31 @@ defmodule PtcRunner.Kernel.RunCatalogProbe do
   defp wrap_line(nil), do: :error
   defp wrap_line(line), do: {:ok, line}
 
-  defp decode_started(line) do
-    with {:ok, event} <- decode_event(line),
-         %{"type" => "run-started", "run_id" => run_id, "trace_id" => trace_id} <- event,
-         true <- identifier?(run_id) and identifier?(trace_id) do
-      {:ok,
-       %{
-         run_id: run_id,
-         trace_id: trace_id,
-         schema_version: schema_version(event["schema_version"]),
-         timestamp: timestamp(event["timestamp"]),
-         labels: labels(event)
-       }}
-    else
-      _invalid -> :error
+  defp project_started(%{"run_id" => run_id, "trace_id" => trace_id} = event) do
+    if identifier?(run_id) and identifier?(trace_id) do
+      %{
+        run_id: run_id,
+        trace_id: trace_id,
+        schema_version: schema_version(event["schema_version"]),
+        timestamp: timestamp(event["timestamp"]),
+        labels: labels(event)
+      }
     end
+  end
+
+  defp project_started(_event), do: nil
+
+  defp project_stopped(nil), do: nil
+
+  defp project_stopped(event) do
+    data = event_data(event)
+
+    %{
+      timestamp: timestamp(event["timestamp"]),
+      status: stringify(data["outcome"]),
+      terminal_reason: stringify(data["reason"]),
+      result_hash: safe_string(data["result_hash"])
+    }
   end
 
   defp decode_stopped(tail_bytes, tail_offset, started) do
@@ -359,19 +453,7 @@ defmodule PtcRunner.Kernel.RunCatalogProbe do
   # for another run in this run's file is neither: the two lines disagree about
   # whose file this is, so the entry is refused.
   defp classify_tail(%{"type" => "run-stopped", "run_id" => run_id} = event, started) do
-    if run_id == started.run_id do
-      data = event_data(event)
-
-      {:ok,
-       %{
-         timestamp: timestamp(event["timestamp"]),
-         status: stringify(data["outcome"]),
-         terminal_reason: stringify(data["reason"]),
-         result_hash: safe_string(data["result_hash"])
-       }}
-    else
-      :error
-    end
+    if run_id == started["run_id"], do: {:ok, event}, else: :error
   end
 
   defp classify_tail(%{"type" => "run-stopped"}, _started), do: :error
@@ -449,6 +531,12 @@ defmodule PtcRunner.Kernel.RunCatalogProbe do
     end
   end
 
+  # The commitment is over the exact bytes the row is read from, not over the
+  # values decoded out of them. A footer's `artifact_digest` is a stored claim
+  # that a metadata-only probe never recomputes, so a rewritten `record_count`
+  # leaves that claim — and any commitment built from it — unchanged while the
+  # row it produces differs. Every outcome that got bytes commits to them,
+  # malformed and foreign-version probes included.
   defp decode_inspection(head, {tail_bytes, _tail_offset}, stat) do
     header = binary_part(head, 0, Format.header_size())
 
@@ -459,25 +547,36 @@ defmodule PtcRunner.Kernel.RunCatalogProbe do
         Format.footer_size()
       )
 
+    observed = %{
+      identity: stat_identity(stat),
+      commitment: :crypto.hash(:sha256, [header, footer_bytes])
+    }
+
     with {:ok, header_versions} <- Format.decode_header_versions(header),
          {:ok, footer_versions} <- Format.decode_footer_versions(footer_bytes),
          true <- header_versions == footer_versions do
-      inspection_row(header_versions, footer_bytes, stat)
+      Map.merge(observed, inspection_row(header_versions, header, footer_bytes, stat))
     else
-      _malformed -> %{present: :malformed}
+      _malformed -> Map.put(observed, :present, :malformed)
     end
   end
 
-  defp inspection_row(versions, footer_bytes, stat) do
+  defp inspection_row(versions, header, footer_bytes, stat) do
     if current_versions?(versions) do
-      current_inspection_row(versions, footer_bytes, stat)
+      current_inspection_row(versions, header, footer_bytes, stat)
     else
       versions |> Map.put(:present, :versions) |> Map.put(:bytes, stat.size)
     end
   end
 
-  defp current_inspection_row(versions, footer_bytes, stat) do
-    with {:ok, footer} <- Format.decode_footer(footer_bytes),
+  # `decode_header_versions/1` reads the two version fields without committing
+  # to a layout, which is what makes a foreign version reportable — but it says
+  # nothing about the rest of the current header. Once the versions are this
+  # build's, the whole header is validated the way the artifact reader validates
+  # it, so a container the reader would reject is never published as admissible.
+  defp current_inspection_row(versions, header, footer_bytes, stat) do
+    with {:ok, :header} <- Format.decode_header(header),
+         {:ok, footer} <- Format.decode_footer(footer_bytes),
          true <- footer.total_bytes == stat.size,
          true <- footer.evidence_offset == Format.header_size(),
          true <-

--- a/lib/ptc_runner/kernel/run_catalog_probe.ex
+++ b/lib/ptc_runner/kernel/run_catalog_probe.ex
@@ -120,7 +120,8 @@ defmodule PtcRunner.Kernel.RunCatalogProbe do
   that carry no canonical stem, which the catalog reports as `excluded_files`
   rather than as rows. Fails whole-operation with `:source_unavailable` for an
   unusable root and `:catalog_limit_exceeded` for a listing or stem count
-  beyond its bound.
+  beyond its bound. `:listing_hook` and `:file_probe_hook` exist only for tests
+  that need deterministic synchronization around filesystem operations.
   """
   @spec probe_all(binary(), binary(), keyword()) ::
           {:ok, %{probes: [probe()], excluded_files: non_neg_integer()}} | {:error, atom()}
@@ -131,10 +132,12 @@ defmodule PtcRunner.Kernel.RunCatalogProbe do
     max_directory_entries = Keyword.get(opts, :max_directory_entries, @default_directory_entries)
     max_files = Keyword.get(opts, :max_files, @default_files)
     listing_hook = Keyword.get(opts, :listing_hook)
+    file_probe_hook = Keyword.get(opts, :file_probe_hook)
 
     with true <- max_directory_entries in 1..@default_directory_entries,
          true <- max_files in 1..@default_files,
          true <- is_nil(listing_hook) or is_function(listing_hook, 0),
+         true <- is_nil(file_probe_hook) or is_function(file_probe_hook, 2),
          {:ok, trace_names} <- listing(traces_directory, max_directory_entries, listing_hook),
          {:ok, inspection_names} <-
            listing(inspection_directory, max_directory_entries, listing_hook) do
@@ -143,7 +146,8 @@ defmodule PtcRunner.Kernel.RunCatalogProbe do
         inspection_directory,
         trace_names,
         inspection_names,
-        max_files
+        max_files,
+        file_probe_hook
       )
     else
       false -> {:error, :invalid_catalog}
@@ -153,7 +157,14 @@ defmodule PtcRunner.Kernel.RunCatalogProbe do
 
   def probe_all(_traces_directory, _inspection_directory, _opts), do: {:error, :invalid_catalog}
 
-  defp collect(traces_directory, inspection_directory, trace_names, inspection_names, max_files) do
+  defp collect(
+         traces_directory,
+         inspection_directory,
+         trace_names,
+         inspection_names,
+         max_files,
+         file_probe_hook
+       ) do
     {trace_entries, excluded_traces} = trace_entries(trace_names)
     {inspection_entries, excluded_inspection} = inspection_entries(inspection_names)
 
@@ -167,8 +178,14 @@ defmodule PtcRunner.Kernel.RunCatalogProbe do
         Enum.map(stems, fn stem ->
           %{
             run_ref: stem,
-            trace: probe_trace(traces_directory, Map.get(trace_entries, stem, [])),
-            inspection: probe_inspection(inspection_directory, Map.get(inspection_entries, stem))
+            trace:
+              probe_trace(traces_directory, Map.get(trace_entries, stem, []), file_probe_hook),
+            inspection:
+              probe_inspection(
+                inspection_directory,
+                Map.get(inspection_entries, stem),
+                file_probe_hook
+              )
           }
         end)
 
@@ -238,16 +255,23 @@ defmodule PtcRunner.Kernel.RunCatalogProbe do
     end
   end
 
-  defp probe_trace(_directory, []), do: %{present: :absent}
-  defp probe_trace(_directory, [_first, _second | _rest]), do: %{present: :ambiguous}
+  defp probe_trace(_directory, [], _file_probe_hook), do: %{present: :absent}
 
-  defp probe_trace(directory, [{source_kind, name}]),
-    do: probe_trace_file(Path.join(directory, name), source_kind)
+  defp probe_trace(_directory, [_first, _second | _rest], _file_probe_hook),
+    do: %{present: :ambiguous}
 
-  defp probe_trace_file(path, source_kind) do
+  defp probe_trace(directory, [{source_kind, name}], file_probe_hook),
+    do: probe_trace_file(Path.join(directory, name), source_kind, file_probe_hook)
+
+  defp probe_trace_file(path, source_kind, file_probe_hook) do
     case File.lstat(path, time: :posix) do
       {:ok, %File.Stat{type: :regular, size: size} = before} when size > 0 ->
-        probe_stable(path, before, &decode_trace(&1, &2, source_kind, before))
+        probe_stable(
+          path,
+          before,
+          &decode_trace(&1, &2, source_kind, before),
+          file_probe_hook
+        )
 
       {:ok, %File.Stat{}} ->
         %{present: :malformed}
@@ -261,8 +285,8 @@ defmodule PtcRunner.Kernel.RunCatalogProbe do
   # is unchanged across the reads. One recheck, then isolation: the catalog
   # commits to what it observed, so a row is never assembled from a head and a
   # tail that may belong to different contents.
-  defp probe_stable(path, before, decode) do
-    case read_edges(path, before.size, stat_identity(before)) do
+  defp probe_stable(path, before, decode, file_probe_hook) do
+    case read_edges(path, before.size, stat_identity(before), file_probe_hook) do
       {:ok, head, tail} ->
         case File.lstat(path, time: :posix) do
           {:ok, %File.Stat{type: :regular} = later} ->
@@ -289,9 +313,13 @@ defmodule PtcRunner.Kernel.RunCatalogProbe do
   # `InspectionArtifact.Handle.open/2`, the opened file is `fstat`ed and
   # compared before a single byte is read. The descriptor is deliberately not
   # `:raw`: a raw descriptor is process-local and cannot be `fstat`ed.
-  defp read_edges(path, size, expected) do
+  defp read_edges(path, size, expected, file_probe_hook) do
+    run_file_probe_hook(file_probe_hook, :before_open, path)
+
     case :file.open(path, [:read, :binary]) do
       {:ok, io} ->
+        run_file_probe_hook(file_probe_hook, :after_open, path)
+
         result =
           case opened_identity(io) do
             {:ok, identity} when identity == expected -> read_windows(io, size)
@@ -305,6 +333,9 @@ defmodule PtcRunner.Kernel.RunCatalogProbe do
         :error
     end
   end
+
+  defp run_file_probe_hook(nil, _phase, _path), do: :ok
+  defp run_file_probe_hook(hook, phase, path), do: hook.(phase, path)
 
   defp opened_identity(io) do
     case :file.read_file_info(io, time: :posix) do
@@ -514,14 +545,14 @@ defmodule PtcRunner.Kernel.RunCatalogProbe do
 
   defp safe_string(_value), do: nil
 
-  defp probe_inspection(_directory, nil), do: %{present: :absent}
+  defp probe_inspection(_directory, nil, _file_probe_hook), do: %{present: :absent}
 
-  defp probe_inspection(directory, name) do
+  defp probe_inspection(directory, name, file_probe_hook) do
     path = Path.join(directory, name)
 
     case File.lstat(path, time: :posix) do
       {:ok, %File.Stat{type: :regular, size: size} = before} when size >= @sealed_edge_bytes ->
-        probe_stable(path, before, &decode_inspection(&1, &2, before))
+        probe_stable(path, before, &decode_inspection(&1, &2, before), file_probe_hook)
 
       {:ok, %File.Stat{}} ->
         %{present: :malformed}

--- a/lib/ptc_runner/kernel/run_catalog_probe.ex
+++ b/lib/ptc_runner/kernel/run_catalog_probe.ex
@@ -1,0 +1,511 @@
+defmodule PtcRunner.Kernel.RunCatalogProbe do
+  @moduledoc """
+  Bounded non-payload probes behind one private run-catalog generation.
+
+  A probe answers what a sealed artifact pair already states about itself
+  without opening either payload:
+
+  - a canonical trace contributes its first line (guaranteed `run-started`)
+    and the last complete line inside a bounded tail window (`run-stopped`
+    for a complete run);
+  - a `.ptcins` artifact contributes its 16-byte header and 192-byte footer,
+    read with two `pread/3` calls. No evidence frame is decoded.
+
+  Every read is bounded before it is issued: the two directory listings are
+  capped, the union of run stems is capped, and each file contributes at most
+  a head window, a tail window, and the container's fixed edges. Nothing here
+  classifies — `PtcRunner.Kernel.RunCatalog` owns the row vocabulary and the
+  failure matrix, so this module reports only what it observed and stays a
+  pure function of the filesystem.
+
+  Each probed file is `lstat`ed before and after its reads. A file whose
+  identity moved under the probe is reported `:unstable` rather than
+  described from bytes that no longer belong together.
+  """
+
+  alias PtcRunner.Kernel.BoundedWorker
+  alias PtcRunner.Kernel.InspectionArtifact.Format
+  alias PtcRunner.Kernel.TraceDirectoryAdmission
+
+  @head_bytes 65_536
+  @tail_bytes 65_536
+  @default_directory_entries 4_096
+  @default_files 1_024
+  @listing_timeout_ms 5_000
+  @listing_heap_words 1_000_000
+  @inspection_suffix ".ptcins"
+  @sealed_edge_bytes Format.header_size() + Format.footer_size()
+  @max_identity_bytes 256
+  @max_timestamp_bytes 64
+
+  @type stat_identity ::
+          {non_neg_integer(), non_neg_integer(), non_neg_integer(), non_neg_integer(), term()}
+
+  @type trace_probe ::
+          %{present: :absent | :ambiguous | :malformed | :unstable}
+          | %{
+              present: :probed,
+              source_kind: :sanitized | :private,
+              bytes: non_neg_integer(),
+              identity: stat_identity(),
+              commitment: binary(),
+              head: map(),
+              tail: map() | nil
+            }
+
+  @type inspection_probe ::
+          %{present: :absent | :malformed | :unstable}
+          | %{
+              present: :versions,
+              bytes: non_neg_integer(),
+              format_version: pos_integer(),
+              schema_version: pos_integer()
+            }
+          | %{
+              present: :probed,
+              format_version: pos_integer(),
+              schema_version: pos_integer(),
+              bytes: non_neg_integer(),
+              record_count: non_neg_integer(),
+              run_id_sha256: binary(),
+              trace_id_sha256: binary(),
+              artifact_digest: binary()
+            }
+
+  @type probe :: %{run_ref: binary(), trace: trace_probe(), inspection: inspection_probe()}
+
+  @spec head_bytes() :: pos_integer()
+  def head_bytes, do: @head_bytes
+
+  @spec tail_bytes() :: pos_integer()
+  def tail_bytes, do: @tail_bytes
+
+  @spec default_directory_entries() :: pos_integer()
+  def default_directory_entries, do: @default_directory_entries
+
+  @spec default_files() :: pos_integer()
+  def default_files, do: @default_files
+
+  @doc """
+  Probes every canonical run stem under one trace and inspection root pair.
+
+  Returns the probes in stem order together with the number of listed files
+  that carry no canonical stem, which the catalog reports as `excluded_files`
+  rather than as rows. Fails whole-operation with `:source_unavailable` for an
+  unusable root and `:catalog_limit_exceeded` for a listing or stem count
+  beyond its bound.
+  """
+  @spec probe_all(binary(), binary(), keyword()) ::
+          {:ok, %{probes: [probe()], excluded_files: non_neg_integer()}} | {:error, atom()}
+  def probe_all(traces_directory, inspection_directory, opts \\ [])
+
+  def probe_all(traces_directory, inspection_directory, opts)
+      when is_binary(traces_directory) and is_binary(inspection_directory) and is_list(opts) do
+    max_directory_entries = Keyword.get(opts, :max_directory_entries, @default_directory_entries)
+    max_files = Keyword.get(opts, :max_files, @default_files)
+    listing_hook = Keyword.get(opts, :listing_hook)
+
+    with true <- max_directory_entries in 1..@default_directory_entries,
+         true <- max_files in 1..@default_files,
+         true <- is_nil(listing_hook) or is_function(listing_hook, 0),
+         {:ok, trace_names} <- listing(traces_directory, max_directory_entries, listing_hook),
+         {:ok, inspection_names} <-
+           listing(inspection_directory, max_directory_entries, listing_hook) do
+      collect(
+        traces_directory,
+        inspection_directory,
+        trace_names,
+        inspection_names,
+        max_files
+      )
+    else
+      false -> {:error, :invalid_catalog}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  def probe_all(_traces_directory, _inspection_directory, _opts), do: {:error, :invalid_catalog}
+
+  defp collect(traces_directory, inspection_directory, trace_names, inspection_names, max_files) do
+    {trace_entries, excluded_traces} = trace_entries(trace_names)
+    {inspection_entries, excluded_inspection} = inspection_entries(inspection_names)
+
+    stems =
+      (Map.keys(trace_entries) ++ Map.keys(inspection_entries))
+      |> Enum.uniq()
+      |> Enum.sort()
+
+    if length(stems) <= max_files do
+      probes =
+        Enum.map(stems, fn stem ->
+          %{
+            run_ref: stem,
+            trace: probe_trace(traces_directory, Map.get(trace_entries, stem, [])),
+            inspection: probe_inspection(inspection_directory, Map.get(inspection_entries, stem))
+          }
+        end)
+
+      {:ok, %{probes: probes, excluded_files: excluded_traces + excluded_inspection}}
+    else
+      {:error, :catalog_limit_exceeded}
+    end
+  end
+
+  defp listing(directory, max_directory_entries, listing_hook) do
+    case BoundedWorker.run(
+           fn -> bounded_names(directory, max_directory_entries, listing_hook) end,
+           timeout_ms: @listing_timeout_ms,
+           max_heap_words: @listing_heap_words,
+           cancel_with_caller: true
+         ) do
+      {:ok, result} -> result
+      {:error, :heap_exceeded} -> {:error, :catalog_limit_exceeded}
+      {:error, _reason} -> {:error, :source_unavailable}
+    end
+  end
+
+  defp bounded_names(directory, max_directory_entries, listing_hook) do
+    if listing_hook, do: listing_hook.()
+
+    with {:ok, %File.Stat{type: :directory}} <- File.lstat(directory, time: :posix),
+         {:ok, names} <- File.ls(directory),
+         true <- length(names) <= max_directory_entries do
+      {:ok, names}
+    else
+      false -> {:error, :catalog_limit_exceeded}
+      _unavailable -> {:error, :source_unavailable}
+    end
+  end
+
+  defp trace_entries(names) do
+    Enum.reduce(names, {%{}, 0}, fn name, {entries, excluded} ->
+      case {TraceDirectoryAdmission.run_claim(name), TraceDirectoryAdmission.source_kind(name)} do
+        {stem, source_kind} when is_binary(stem) and not is_nil(source_kind) ->
+          {Map.update(entries, stem, [{source_kind, name}], &[{source_kind, name} | &1]),
+           excluded}
+
+        _uncatalogued ->
+          {entries, excluded + 1}
+      end
+    end)
+  end
+
+  defp inspection_entries(names) do
+    Enum.reduce(names, {%{}, 0}, fn name, {entries, excluded} ->
+      case inspection_stem(name) do
+        nil -> {entries, excluded + 1}
+        stem -> {Map.put(entries, stem, name), excluded}
+      end
+    end)
+  end
+
+  defp inspection_stem(name) do
+    suffix_size = byte_size(@inspection_suffix)
+
+    with true <- byte_size(name) > suffix_size,
+         true <-
+           binary_part(name, byte_size(name) - suffix_size, suffix_size) == @inspection_suffix do
+      TraceDirectoryAdmission.canonical_stem(binary_part(name, 0, byte_size(name) - suffix_size))
+    else
+      _other -> nil
+    end
+  end
+
+  defp probe_trace(_directory, []), do: %{present: :absent}
+  defp probe_trace(_directory, [_first, _second | _rest]), do: %{present: :ambiguous}
+
+  defp probe_trace(directory, [{source_kind, name}]),
+    do: probe_trace_file(Path.join(directory, name), source_kind)
+
+  defp probe_trace_file(path, source_kind) do
+    case File.lstat(path, time: :posix) do
+      {:ok, %File.Stat{type: :regular, size: size} = before} when size > 0 ->
+        probe_stable(path, before, &decode_trace(&1, &2, source_kind, before))
+
+      {:ok, %File.Stat{}} ->
+        %{present: :malformed}
+
+      {:error, _reason} ->
+        %{present: :unstable}
+    end
+  end
+
+  # Reads a file's bounded edges and reports them only if the entry's identity
+  # is unchanged across the reads. One recheck, then isolation: the catalog
+  # commits to what it observed, so a row is never assembled from a head and a
+  # tail that may belong to different contents.
+  defp probe_stable(path, before, decode) do
+    case read_edges(path, before.size) do
+      {:ok, head, tail} ->
+        case File.lstat(path, time: :posix) do
+          {:ok, %File.Stat{type: :regular} = later} ->
+            if stat_identity(before) == stat_identity(later),
+              do: decode.(head, tail),
+              else: %{present: :unstable}
+
+          _moved ->
+            %{present: :unstable}
+        end
+
+      :error ->
+        %{present: :malformed}
+    end
+  end
+
+  defp read_edges(path, size) do
+    case :file.open(path, [:read, :binary, :raw]) do
+      {:ok, io} ->
+        result = read_windows(io, size)
+        :file.close(io)
+        result
+
+      {:error, _reason} ->
+        :error
+    end
+  end
+
+  defp read_windows(io, size) do
+    head_length = min(size, @head_bytes)
+    tail_offset = max(size - @tail_bytes, 0)
+    tail_length = min(size, @tail_bytes)
+
+    with {:ok, head} <- pread(io, 0, head_length),
+         {:ok, tail} <- pread(io, tail_offset, tail_length) do
+      {:ok, head, {tail, tail_offset}}
+    end
+  end
+
+  defp pread(io, offset, length) do
+    case :file.pread(io, offset, length) do
+      {:ok, bytes} when byte_size(bytes) == length -> {:ok, bytes}
+      _short -> :error
+    end
+  end
+
+  defp decode_trace(head, {tail_bytes, tail_offset}, source_kind, stat) do
+    with {:ok, head_line} <- first_line(head),
+         {:ok, started} <- decode_started(head_line),
+         {:ok, stopped} <- decode_stopped(tail_bytes, tail_offset, started) do
+      %{
+        present: :probed,
+        source_kind: source_kind,
+        bytes: stat.size,
+        identity: stat_identity(stat),
+        commitment: :crypto.hash(:sha256, [head, tail_bytes]),
+        head: started,
+        tail: stopped
+      }
+    else
+      :error -> %{present: :malformed}
+    end
+  end
+
+  defp first_line(bytes) do
+    case :binary.split(bytes, "\n") do
+      [line, _rest] -> {:ok, line}
+      _unterminated -> :error
+    end
+  end
+
+  # The last line the probe may trust is the last one terminated inside the
+  # tail window. A window that starts mid-file discards its leading fragment,
+  # because those bytes continue a line whose start was never read.
+  defp last_complete_line(bytes, tail_offset) do
+    candidate =
+      if tail_offset > 0 do
+        case :binary.split(bytes, "\n") do
+          [_partial, rest] -> rest
+          _unterminated -> ""
+        end
+      else
+        bytes
+      end
+
+    case candidate |> :binary.split("\n", [:global]) |> Enum.reverse() do
+      [_trailing | terminated] -> Enum.find(terminated, &(&1 != "")) |> wrap_line()
+      [] -> :error
+    end
+  end
+
+  defp wrap_line(nil), do: :error
+  defp wrap_line(line), do: {:ok, line}
+
+  defp decode_started(line) do
+    with {:ok, event} <- decode_event(line),
+         %{"type" => "run-started", "run_id" => run_id, "trace_id" => trace_id} <- event,
+         true <- identifier?(run_id) and identifier?(trace_id) do
+      {:ok,
+       %{
+         run_id: run_id,
+         trace_id: trace_id,
+         schema_version: schema_version(event["schema_version"]),
+         timestamp: timestamp(event["timestamp"]),
+         labels: labels(event)
+       }}
+    else
+      _invalid -> :error
+    end
+  end
+
+  defp decode_stopped(tail_bytes, tail_offset, started) do
+    with {:ok, line} <- last_complete_line(tail_bytes, tail_offset),
+         {:ok, event} <- decode_event(line) do
+      classify_tail(event, started)
+    end
+  end
+
+  # A trailing line that is not `run-stopped` means the run never stopped, which
+  # is a state the catalog reports rather than a malformed file. A `run-stopped`
+  # for another run in this run's file is neither: the two lines disagree about
+  # whose file this is, so the entry is refused.
+  defp classify_tail(%{"type" => "run-stopped", "run_id" => run_id} = event, started) do
+    if run_id == started.run_id do
+      data = event_data(event)
+
+      {:ok,
+       %{
+         timestamp: timestamp(event["timestamp"]),
+         status: stringify(data["outcome"]),
+         terminal_reason: stringify(data["reason"]),
+         result_hash: safe_string(data["result_hash"])
+       }}
+    else
+      :error
+    end
+  end
+
+  defp classify_tail(%{"type" => "run-stopped"}, _started), do: :error
+  defp classify_tail(%{"type" => type}, _started) when is_binary(type), do: {:ok, nil}
+  defp classify_tail(_event, _started), do: :error
+
+  # A version a row reports is a number or nothing. Anything else is a value
+  # the row cannot carry within its byte bound and cannot compare against the
+  # supported version, so it reads as absent and the entry is isolated as
+  # unsupported rather than published with a version field of unknown shape.
+  defp schema_version(value) when is_integer(value) and value >= 0, do: value
+  defp schema_version(_value), do: nil
+
+  defp decode_event(line) do
+    case Jason.decode(line) do
+      {:ok, event} when is_map(event) -> {:ok, event}
+      _invalid -> :error
+    end
+  end
+
+  defp event_data(%{"data" => data}) when is_map(data), do: data
+  defp event_data(_event), do: %{}
+
+  defp labels(event) do
+    case event_data(event)["labels"] do
+      labels when is_map(labels) -> labels
+      _absent -> %{}
+    end
+  end
+
+  # The same claim bound canonical trace admission applies. A row must stay
+  # inside the catalog's per-row byte bound, and an identity is one of the
+  # fields that bound cannot drop, so an over-long one is refused at the probe
+  # rather than carried into a row that would then have to be reduced.
+  defp identifier?(value),
+    do: is_binary(value) and byte_size(value) in 1..@max_identity_bytes and String.valid?(value)
+
+  # ISO 8601 admits an unbounded fractional-second field, so a parse alone is
+  # not a bound: a syntactically valid timestamp can be kilobytes long. A row
+  # cannot drop its timestamps when it is reduced to fit, so the bound belongs
+  # here, and an over-long one is reported as no timestamp rather than carried.
+  defp timestamp(value) when is_binary(value) and byte_size(value) <= @max_timestamp_bytes do
+    case DateTime.from_iso8601(value) do
+      {:ok, _datetime, 0} -> value
+      _invalid -> nil
+    end
+  end
+
+  defp timestamp(_value), do: nil
+
+  defp stringify(value) when is_binary(value), do: safe_string(value)
+  defp stringify(value) when is_number(value) or is_boolean(value), do: to_string(value)
+  defp stringify(_value), do: nil
+
+  defp safe_string(value) when is_binary(value) do
+    if String.valid?(value), do: value
+  end
+
+  defp safe_string(_value), do: nil
+
+  defp probe_inspection(_directory, nil), do: %{present: :absent}
+
+  defp probe_inspection(directory, name) do
+    path = Path.join(directory, name)
+
+    case File.lstat(path, time: :posix) do
+      {:ok, %File.Stat{type: :regular, size: size} = before} when size >= @sealed_edge_bytes ->
+        probe_stable(path, before, &decode_inspection(&1, &2, before))
+
+      {:ok, %File.Stat{}} ->
+        %{present: :malformed}
+
+      {:error, _reason} ->
+        %{present: :unstable}
+    end
+  end
+
+  defp decode_inspection(head, {tail_bytes, _tail_offset}, stat) do
+    header = binary_part(head, 0, Format.header_size())
+
+    footer_bytes =
+      binary_part(
+        tail_bytes,
+        byte_size(tail_bytes) - Format.footer_size(),
+        Format.footer_size()
+      )
+
+    with {:ok, header_versions} <- Format.decode_header_versions(header),
+         {:ok, footer_versions} <- Format.decode_footer_versions(footer_bytes),
+         true <- header_versions == footer_versions do
+      inspection_row(header_versions, footer_bytes, stat)
+    else
+      _malformed -> %{present: :malformed}
+    end
+  end
+
+  defp inspection_row(versions, footer_bytes, stat) do
+    if current_versions?(versions) do
+      current_inspection_row(versions, footer_bytes, stat)
+    else
+      versions |> Map.put(:present, :versions) |> Map.put(:bytes, stat.size)
+    end
+  end
+
+  defp current_inspection_row(versions, footer_bytes, stat) do
+    with {:ok, footer} <- Format.decode_footer(footer_bytes),
+         true <- footer.total_bytes == stat.size,
+         true <- footer.evidence_offset == Format.header_size(),
+         true <-
+           footer.evidence_offset + footer.evidence_bytes + Format.footer_size() == stat.size do
+      %{
+        present: :probed,
+        format_version: versions.format_version,
+        schema_version: versions.schema_version,
+        bytes: stat.size,
+        record_count: footer.record_count,
+        run_id_sha256: footer.run_id_sha256,
+        trace_id_sha256: footer.trace_id_sha256,
+        artifact_digest: footer.artifact_digest
+      }
+    else
+      _malformed -> %{present: :malformed}
+    end
+  end
+
+  defp current_versions?(%{format_version: format_version, schema_version: schema_version}),
+    do: format_version == Format.format_version() and schema_version == Format.schema_version()
+
+  defp stat_identity(%File.Stat{
+         size: size,
+         inode: inode,
+         major_device: major,
+         minor_device: minor,
+         mtime: mtime
+       }),
+       do: {size, inode, major, minor, mtime}
+end

--- a/lib/ptc_runner/kernel/run_catalog_snapshot.ex
+++ b/lib/ptc_runner/kernel/run_catalog_snapshot.ex
@@ -1,0 +1,261 @@
+defmodule PtcRunner.Kernel.RunCatalogSnapshot do
+  @moduledoc """
+  Owner process holding one immutable private run-catalog generation.
+
+  Capture runs once, inside a heap- and deadline-bounded worker, and freezes
+  its rows into owner state. Nothing re-lists or re-probes afterwards, so a
+  filesystem that grows, shrinks, or changes under an open generation cannot
+  alter what this owner answers; a caller that wants current state captures a
+  new generation, which carries a different `catalog_digest`.
+
+  The owner is bound to the process that started it and exits when that owner
+  does. It holds no file descriptors: every probe closes its file before the
+  capture returns, so a generation costs bounded memory and no handles.
+
+  This owner is the discovery half of the two-stage cohort contract. It never
+  opens a private payload and never admits a source — selection admission
+  re-verifies the files it names, on its own authority.
+  """
+
+  use GenServer
+
+  alias PtcRunner.Kernel.BoundedCapture
+  alias PtcRunner.Kernel.RunCatalog
+  alias PtcRunner.Kernel.RunCatalogProbe
+  alias PtcRunner.Lisp.RetainedSize
+
+  @default_retained_bytes 4_194_304
+  @capture_heap_words 10_000_000
+  @capture_timeout_ms 15_000
+  @default_directory_entries RunCatalogProbe.default_directory_entries()
+  @default_files RunCatalogProbe.default_files()
+
+  @enforce_keys [:pid, :token]
+  defstruct @enforce_keys
+
+  @opaque t :: %__MODULE__{pid: pid(), token: reference()}
+
+  @spec default_retained_bytes() :: pos_integer()
+  def default_retained_bytes, do: @default_retained_bytes
+
+  @doc """
+  Captures one generation over a trace root and an inspection root.
+
+  Options lower, never raise, the capture bounds: `:max_directory_entries`,
+  `:max_files`, `:max_retained_bytes`, `:capture_heap_words`, and
+  `:capture_deadline_ms`. `:owner` names the process the generation belongs
+  to, and `:listing_hook` exists for tests that need to observe listing.
+
+  Whole-operation refusals are path-free: `:source_unavailable` for a root
+  that cannot be listed, and `:catalog_limit_exceeded` for a listing, stem
+  count, or retained projection beyond its bound.
+  """
+  @spec start({:private_authorized_catalog, binary(), binary()}, keyword()) ::
+          {:ok, t()} | {:error, atom()}
+  def start(source, opts \\ [])
+
+  def start({:private_authorized_catalog, traces, inspection}, opts)
+      when is_binary(traces) and is_binary(inspection) and is_list(opts) do
+    allowed = [
+      :owner,
+      :max_directory_entries,
+      :max_files,
+      :max_retained_bytes,
+      :capture_heap_words,
+      :capture_deadline_ms,
+      :listing_hook
+    ]
+
+    with true <- Keyword.keys(opts) -- allowed == [],
+         owner when is_pid(owner) <- Keyword.get(opts, :owner, self()),
+         max_directory_entries when max_directory_entries in 1..@default_directory_entries <-
+           Keyword.get(opts, :max_directory_entries, @default_directory_entries),
+         max_files when max_files in 1..@default_files <-
+           Keyword.get(opts, :max_files, @default_files),
+         max_retained_bytes when max_retained_bytes in 1..@default_retained_bytes <-
+           Keyword.get(opts, :max_retained_bytes, @default_retained_bytes),
+         capture_heap_words when capture_heap_words in 233..@capture_heap_words <-
+           Keyword.get(opts, :capture_heap_words, @capture_heap_words),
+         capture_deadline_ms when is_integer(capture_deadline_ms) <-
+           Keyword.get(
+             opts,
+             :capture_deadline_ms,
+             System.monotonic_time(:millisecond) + @capture_timeout_ms
+           ),
+         listing_hook when is_nil(listing_hook) or is_function(listing_hook, 0) <-
+           Keyword.get(opts, :listing_hook) do
+      token = make_ref()
+
+      config = %{
+        traces: traces,
+        inspection: inspection,
+        owner: owner,
+        token: token,
+        max_directory_entries: max_directory_entries,
+        max_files: max_files,
+        max_retained_bytes: max_retained_bytes,
+        capture_heap_words: capture_heap_words,
+        capture_deadline_ms: capture_deadline_ms,
+        listing_hook: listing_hook
+      }
+
+      case GenServer.start(__MODULE__, config) do
+        {:ok, pid} -> {:ok, %__MODULE__{pid: pid, token: token}}
+        {:error, reason} when is_atom(reason) -> {:error, reason}
+        {:error, _reason} -> {:error, :source_unavailable}
+      end
+    else
+      _invalid -> {:error, :invalid_catalog}
+    end
+  end
+
+  def start(_source, _opts), do: {:error, :invalid_catalog}
+
+  @doc """
+  Returns the generation's frozen rows, in run-reference order.
+
+  The list is bounded by the capture's retained-byte and stem-count limits.
+  Paging, filtering, and digest-bound cursors are the query surface's concern
+  and read the same frozen list.
+  """
+  @spec rows(t()) :: {:ok, [RunCatalog.row()]} | {:error, atom()}
+  def rows(%__MODULE__{} = snapshot), do: call(snapshot, :rows)
+  def rows(_snapshot), do: {:error, :invalid_catalog}
+
+  @doc "Returns the generation's identity and accounting, without any row."
+  @spec info(t()) :: {:ok, map()} | {:error, atom()}
+  def info(%__MODULE__{} = snapshot), do: call(snapshot, :info)
+  def info(_snapshot), do: {:error, :invalid_catalog}
+
+  @spec stop(term()) :: :ok
+  def stop(%__MODULE__{} = snapshot) do
+    _result = call(snapshot, :stop)
+    :ok
+  end
+
+  def stop(_snapshot), do: :ok
+
+  @doc false
+  @spec alive?(t()) :: boolean()
+  def alive?(%__MODULE__{pid: pid}), do: Process.alive?(pid)
+
+  @impl GenServer
+  def init(config) do
+    owner_ref = Process.monitor(config.owner)
+
+    case capture_for_owner(config, owner_ref) do
+      {:ok, generation, retained_bytes} ->
+        {:ok,
+         %{
+           token: config.token,
+           owner_ref: owner_ref,
+           rows: generation.rows,
+           info: %{
+             source: :ptc_run_catalog,
+             catalog_digest: generation.catalog_digest,
+             row_count: length(generation.rows),
+             excluded_files: generation.excluded_files,
+             retained_bytes: retained_bytes
+           }
+         }}
+
+      {:error, reason} ->
+        {:stop, reason}
+    end
+  end
+
+  @impl GenServer
+  def handle_call({token, :info}, _from, %{token: token} = state),
+    do: {:reply, {:ok, state.info}, state}
+
+  def handle_call({token, :rows}, _from, %{token: token} = state),
+    do: {:reply, {:ok, state.rows}, state}
+
+  def handle_call({token, :stop}, _from, %{token: token} = state),
+    do: {:stop, :normal, :ok, state}
+
+  def handle_call({_token, _request}, _from, state),
+    do: {:reply, {:error, :invalid_catalog}, state}
+
+  def handle_call(_request, _from, state), do: {:reply, {:error, :invalid_catalog}, state}
+
+  @impl GenServer
+  # ex_dna:disable-for-next-line — GenServer callbacks, intentionally per-module.
+  # An owner's reaction to its owner's death and the redaction of its own state
+  # are part of that owner's contract; routing them through a shared module
+  # would couple the lifecycles of otherwise independent snapshots.
+  def handle_cast(_request, state), do: {:noreply, state}
+
+  @impl GenServer
+  # ex_dna:disable-for-next-line — see the note on handle_cast/2 above.
+  def handle_info({:DOWN, owner_ref, :process, _owner, _reason}, %{owner_ref: owner_ref} = state),
+    do: {:stop, :normal, state}
+
+  def handle_info(_message, state), do: {:noreply, state}
+
+  # This OTP-version guard around `format_status/1` is byte-identical in the
+  # twelve other owner modules that carry it. A suppression comment does not
+  # attach to a bare module-level `if`, so this occurrence joins that cluster
+  # in `.duplication-baseline.json` rather than being marked here.
+  if {:format_status, 1} in GenServer.behaviour_info(:callbacks) do
+    @impl GenServer
+    def format_status(status), do: redact_status(status)
+  else
+    def format_status(status), do: redact_status(status)
+  end
+
+  @impl GenServer
+  def format_status(_reason, _status), do: [data: [{~c"State", :redacted}]]
+
+  defp redact_status(status) when is_map(status), do: Map.put(status, :state, :redacted)
+  defp redact_status(status), do: status
+
+  defp call(%__MODULE__{pid: pid, token: token}, request) when is_pid(pid) do
+    GenServer.call(pid, {token, request}, :infinity)
+  catch
+    :exit, _reason -> {:error, :catalog_unavailable}
+  end
+
+  defp call(_snapshot, _request), do: {:error, :invalid_catalog}
+
+  # A root wider than the capture's heap allowance is refused as a limit, not
+  # reported as an unavailable source: the files were readable, the projection
+  # was not affordable.
+  defp capture_for_owner(config, owner_ref) do
+    case BoundedCapture.for_owner(fn -> capture(config) end,
+           owner: config.owner,
+           owner_ref: owner_ref,
+           max_heap_words: config.capture_heap_words,
+           deadline_ms: config.capture_deadline_ms
+         ) do
+      {:ok, result} -> result
+      {:error, :owner_down} -> {:error, :catalog_unavailable}
+      {:error, :heap_exceeded} -> {:error, :catalog_limit_exceeded}
+      {:error, _failure} -> {:error, :source_unavailable}
+    end
+  end
+
+  defp capture(config) do
+    with {:ok, %{probes: probes, excluded_files: excluded_files}} <-
+           RunCatalogProbe.probe_all(config.traces, config.inspection,
+             max_directory_entries: config.max_directory_entries,
+             max_files: config.max_files,
+             listing_hook: config.listing_hook
+           ),
+         {:ok, generation} <- RunCatalog.generation(probes, excluded_files) do
+      retain(generation, config.max_retained_bytes)
+    end
+  end
+
+  # Rows are detached from the probe buffers they were sliced out of before
+  # they are measured and retained, so the generation owns the bytes it is
+  # charged for rather than pinning whole head and tail windows.
+  defp retain(generation, max_retained_bytes) do
+    retained = RetainedSize.detach_binaries(generation)
+
+    case RetainedSize.bytes_with_cap(retained, max_retained_bytes) do
+      bytes when is_integer(bytes) and bytes <= max_retained_bytes -> {:ok, retained, bytes}
+      _oversized -> {:error, :catalog_limit_exceeded}
+    end
+  end
+end

--- a/lib/ptc_runner/kernel/run_catalog_snapshot.ex
+++ b/lib/ptc_runner/kernel/run_catalog_snapshot.ex
@@ -44,7 +44,8 @@ defmodule PtcRunner.Kernel.RunCatalogSnapshot do
   Options lower, never raise, the capture bounds: `:max_directory_entries`,
   `:max_files`, `:max_retained_bytes`, `:capture_heap_words`, and
   `:capture_deadline_ms`. `:owner` names the process the generation belongs
-  to, and `:listing_hook` exists for tests that need to observe listing.
+  to, and `:listing_hook` and `:file_probe_hook` exist for tests that need
+  deterministic synchronization around filesystem operations.
 
   Whole-operation refusals are path-free: `:source_unavailable` for a root
   that cannot be listed, and `:catalog_limit_exceeded` for a listing, stem
@@ -63,7 +64,8 @@ defmodule PtcRunner.Kernel.RunCatalogSnapshot do
       :max_retained_bytes,
       :capture_heap_words,
       :capture_deadline_ms,
-      :listing_hook
+      :listing_hook,
+      :file_probe_hook
     ]
 
     with true <- Keyword.keys(opts) -- allowed == [],
@@ -83,7 +85,9 @@ defmodule PtcRunner.Kernel.RunCatalogSnapshot do
              System.monotonic_time(:millisecond) + @capture_timeout_ms
            ),
          listing_hook when is_nil(listing_hook) or is_function(listing_hook, 0) <-
-           Keyword.get(opts, :listing_hook) do
+           Keyword.get(opts, :listing_hook),
+         file_probe_hook when is_nil(file_probe_hook) or is_function(file_probe_hook, 2) <-
+           Keyword.get(opts, :file_probe_hook) do
       token = make_ref()
 
       config = %{
@@ -96,7 +100,8 @@ defmodule PtcRunner.Kernel.RunCatalogSnapshot do
         max_retained_bytes: max_retained_bytes,
         capture_heap_words: capture_heap_words,
         capture_deadline_ms: capture_deadline_ms,
-        listing_hook: listing_hook
+        listing_hook: listing_hook,
+        file_probe_hook: file_probe_hook
       }
 
       case GenServer.start(__MODULE__, config) do
@@ -240,7 +245,8 @@ defmodule PtcRunner.Kernel.RunCatalogSnapshot do
            RunCatalogProbe.probe_all(config.traces, config.inspection,
              max_directory_entries: config.max_directory_entries,
              max_files: config.max_files,
-             listing_hook: config.listing_hook
+             listing_hook: config.listing_hook,
+             file_probe_hook: config.file_probe_hook
            ),
          {:ok, generation} <- RunCatalog.generation(probes, excluded_files) do
       retain(generation, config.max_retained_bytes)

--- a/lib/ptc_runner/kernel/trace_directory_admission.ex
+++ b/lib/ptc_runner/kernel/trace_directory_admission.ex
@@ -93,6 +93,32 @@ defmodule PtcRunner.Kernel.TraceDirectoryAdmission do
   def source_kind(raw_name) when is_binary(raw_name), do: filename_source_kind(raw_name)
   def source_kind(_raw_name), do: nil
 
+  @doc """
+  Returns the canonical run stem a trace filename claims, or `nil`.
+
+  This module owns the canonical stem grammar, so every reader that needs to
+  route a filename to a run — directory admission here, and the bounded
+  catalog probe that never decodes a file's events — asks it rather than
+  restating the suffix and stem rules.
+  """
+  @spec run_claim(binary()) :: binary() | nil
+  def run_claim(raw_name) when is_binary(raw_name) do
+    case filename_source_kind(raw_name) do
+      nil -> nil
+      source_kind -> filename_run_claim(raw_name, source_kind)
+    end
+  end
+
+  def run_claim(_raw_name), do: nil
+
+  @doc "Returns `stem` when it is a canonical run stem, or `nil`."
+  @spec canonical_stem(binary()) :: binary() | nil
+  def canonical_stem(stem) when is_binary(stem) do
+    if canonical_stem?(stem), do: stem
+  end
+
+  def canonical_stem(_stem), do: nil
+
   @spec classify([file_evidence()]) :: {:ok, classification()} | {:error, :invalid_evidence}
   def classify(evidence) when is_list(evidence) do
     if Enum.all?(evidence, &valid_evidence?/1) do

--- a/lib/ptc_runner/kernel/trace_snapshot.ex
+++ b/lib/ptc_runner/kernel/trace_snapshot.ex
@@ -3,6 +3,7 @@ defmodule PtcRunner.Kernel.TraceSnapshot do
 
   use GenServer
 
+  alias PtcRunner.Kernel.BoundedCapture
   alias PtcRunner.Kernel.ResourceRegistrar
   alias PtcRunner.Kernel.ResultLimit
   alias PtcRunner.Kernel.SafeMetadata
@@ -548,59 +549,16 @@ defmodule PtcRunner.Kernel.TraceSnapshot do
   end
 
   defp capture_for_owner(capture, owner, owner_ref, capture_heap_words, capture_deadline_ms) do
-    reply_alias = Process.alias()
-    reply_ref = make_ref()
-
-    {worker, worker_ref} =
-      Process.spawn(
-        fn -> send(reply_alias, {reply_ref, capture.()}) end,
-        [
-          {:max_heap_size,
-           %{
-             size: capture_heap_words,
-             kill: true,
-             error_logger: false,
-             include_shared_binaries: true
-           }},
-          :monitor
-        ]
-      )
-
-    timeout = max(capture_deadline_ms - System.monotonic_time(:millisecond), 0)
-
-    receive do
-      {^reply_ref, result} ->
-        Process.unalias(reply_alias)
-        Process.demonitor(worker_ref, [:flush])
-
-        if Process.alive?(owner),
-          do: result,
-          else: {:error, :snapshot_unavailable}
-
-      {:DOWN, ^owner_ref, :process, ^owner, _reason} ->
-        terminate_capture(worker, worker_ref, reply_alias)
-        {:error, :snapshot_unavailable}
-
-      {:DOWN, ^worker_ref, :process, ^worker, :killed} ->
-        Process.unalias(reply_alias)
-        {:error, :source_retained_limit_exceeded}
-
-      {:DOWN, ^worker_ref, :process, ^worker, _reason} ->
-        Process.unalias(reply_alias)
-        {:error, :source_unavailable}
-    after
-      timeout ->
-        terminate_capture(worker, worker_ref, reply_alias)
-        {:error, :source_unavailable}
-    end
-  end
-
-  defp terminate_capture(worker, worker_ref, reply_alias) do
-    Process.unalias(reply_alias)
-    Process.exit(worker, :kill)
-
-    receive do
-      {:DOWN, ^worker_ref, :process, ^worker, _reason} -> :ok
+    case BoundedCapture.for_owner(capture,
+           owner: owner,
+           owner_ref: owner_ref,
+           max_heap_words: capture_heap_words,
+           deadline_ms: capture_deadline_ms
+         ) do
+      {:ok, result} -> result
+      {:error, :owner_down} -> {:error, :snapshot_unavailable}
+      {:error, :heap_exceeded} -> {:error, :source_retained_limit_exceeded}
+      {:error, _failure} -> {:error, :source_unavailable}
     end
   end
 

--- a/test/ptc_runner/kernel/run_catalog_snapshot_test.exs
+++ b/test/ptc_runner/kernel/run_catalog_snapshot_test.exs
@@ -504,6 +504,64 @@ defmodule PtcRunner.Kernel.RunCatalogSnapshotTest do
     assert row!(rows, second.run_id)["isolation_reason"] == "filename_run_mismatch"
   end
 
+  @tag :tmp_dir
+  test "a replacement opened under the inventoried path is detected by descriptor identity", %{
+    tmp_dir: root
+  } do
+    fixture = fixture!(root, 43)
+    path = trace_path(root, fixture.run_id)
+    original = Path.join(root, "inventoried-trace.jsonl")
+    replacement = Path.join(root, "replacement-trace.jsonl")
+    File.cp!(path, replacement)
+    test = self()
+    synchronization = make_ref()
+
+    file_probe_hook = fn
+      :before_open, ^path ->
+        synchronize_file_probe(test, synchronization, :before_open, :continue_open)
+
+      :after_open, ^path ->
+        synchronize_file_probe(test, synchronization, :after_open, :continue_probe)
+
+      _phase, _other_path ->
+        :ok
+    end
+
+    capture =
+      Task.async(fn ->
+        RunCatalogSnapshot.start(
+          catalog_source(root),
+          owner: test,
+          file_probe_hook: file_probe_hook
+        )
+      end)
+
+    assert_receive {^synchronization, :before_open, capture_pid}, 5_000
+    File.rename!(path, original)
+    File.rename!(replacement, path)
+    send(capture_pid, {synchronization, :continue_open})
+
+    assert_receive {^synchronization, :after_open, ^capture_pid}, 5_000
+    File.rename!(path, replacement)
+    File.rename!(original, path)
+    send(capture_pid, {synchronization, :continue_probe})
+
+    assert {:ok, snapshot} = Task.await(capture)
+    on_exit(fn -> RunCatalogSnapshot.stop(snapshot) end)
+    assert {:ok, rows} = RunCatalogSnapshot.rows(snapshot)
+    row = row!(rows, fixture.run_id)
+    assert row["state"] == "isolated"
+    assert row["isolation_reason"] == "unstable_entry"
+  end
+
+  defp synchronize_file_probe(test, synchronization, phase, continuation) do
+    send(test, {synchronization, phase, self()})
+
+    receive do
+      {^synchronization, ^continuation} -> :ok
+    end
+  end
+
   defp await_stopped(snapshot) do
     if RunCatalogSnapshot.alive?(snapshot) do
       await_stopped(snapshot)

--- a/test/ptc_runner/kernel/run_catalog_snapshot_test.exs
+++ b/test/ptc_runner/kernel/run_catalog_snapshot_test.exs
@@ -1,0 +1,494 @@
+defmodule PtcRunner.Kernel.RunCatalogSnapshotTest do
+  use ExUnit.Case, async: true
+
+  alias PtcRunner.Kernel.InspectionArtifact.Format
+  alias PtcRunner.Kernel.RunCatalog
+  alias PtcRunner.Kernel.RunCatalogSnapshot
+  alias PtcRunner.TestSupport.PrivateInspectionFixture
+
+  @tag :tmp_dir
+  test "a paired cohort lists safe metadata without opening either payload", %{tmp_dir: root} do
+    first = fixture!(root, 1)
+    second = fixture!(root, 2)
+
+    rows = rows!(root)
+
+    assert Enum.map(rows, & &1["run_id"]) == Enum.sort([first.run_id, second.run_id])
+
+    row = row!(rows, first.run_id)
+
+    assert row["trace_id"] == "trace-#{first.run_id}"
+    assert row["trace_present"] == "sanitized"
+    assert row["inspection_present"] == true
+    assert row["correlation"] == "paired"
+    assert row["state"] == "admissible"
+    assert row["isolation_reason"] == nil
+    assert row["trace_schema_version"] == 2
+    assert row["inspection_format_version"] == Format.format_version()
+    assert row["inspection_schema_version"] == Format.schema_version()
+    assert row["status"] == "failed"
+    assert row["complete"] == true
+    assert row["start_timestamp"] == "2026-07-26T12:00:01Z"
+    assert row["stop_timestamp"] == "2026-07-26T12:00:08Z"
+    assert row["duration_ms"] == 7_000
+    assert row["inspection_record_count"] > 0
+    assert row["inspection_bytes"] == File.stat!(inspection_path(root, first.run_id)).size
+    assert row["trace_bytes"] == File.stat!(trace_path(root, first.run_id)).size
+    assert row["artifact_digest"] =~ ~r/\A[0-9a-f]{64}\z/
+  end
+
+  @tag :tmp_dir
+  test "rows carry no private payload content and no filesystem path", %{tmp_dir: root} do
+    fixture = fixture!(root, 3)
+    encoded = root |> rows!() |> Jason.encode!()
+
+    for secret <- [
+          "private-prompt-#{fixture.run_id}",
+          "private-answer-#{fixture.run_id}",
+          "private-system-#{fixture.run_id}",
+          "private-tool-result-#{fixture.run_id}",
+          "private-print-#{fixture.run_id}",
+          "(return 42)"
+        ] do
+      refute encoded =~ secret
+    end
+
+    refute encoded =~ root
+    refute encoded =~ "traces"
+    refute encoded =~ ".ptcins"
+  end
+
+  @tag :tmp_dir
+  test "a row reports a missing half instead of refusing the generation", %{tmp_dir: root} do
+    paired = fixture!(root, 4)
+    trace_only = fixture!(root, 5)
+    inspection_only = fixture!(root, 6)
+
+    File.rm!(inspection_path(root, trace_only.run_id))
+    File.rm!(trace_path(root, inspection_only.run_id))
+
+    rows = rows!(root)
+
+    assert row!(rows, paired.run_id)["correlation"] == "paired"
+
+    trace_only_row = row!(rows, trace_only.run_id)
+    assert trace_only_row["correlation"] == "trace_only"
+    assert trace_only_row["state"] == "admissible"
+    assert trace_only_row["inspection_present"] == false
+    assert trace_only_row["inspection_bytes"] == nil
+
+    inspection_only_row = row!(rows, inspection_only.run_id)
+    assert inspection_only_row["correlation"] == "inspection_only"
+    assert inspection_only_row["state"] == "admissible"
+    assert inspection_only_row["trace_id"] == nil
+    assert inspection_only_row["trace_present"] == "absent"
+    assert inspection_only_row["inspection_record_count"] > 0
+  end
+
+  @tag :tmp_dir
+  test "both trace filename variants isolate one row and no other", %{tmp_dir: root} do
+    healthy = fixture!(root, 7)
+    ambiguous = fixture!(root, 8)
+
+    path = trace_path(root, ambiguous.run_id)
+    File.cp!(path, Path.join(root, "traces/#{ambiguous.run_id}.private.jsonl"))
+
+    rows = rows!(root)
+
+    assert row!(rows, healthy.run_id)["state"] == "admissible"
+
+    row = row!(rows, ambiguous.run_id)
+    assert row["state"] == "isolated"
+    assert row["isolation_reason"] == "ambiguous_trace"
+    assert row["trace_present"] == "unreadable"
+  end
+
+  @tag :tmp_dir
+  test "an unsupported sealed schema shows its versions and isolates the row", %{tmp_dir: root} do
+    fixture = fixture!(root, 9)
+    rewrite_sealed_schema!(inspection_path(root, fixture.run_id), Format.schema_version() + 1)
+
+    row = root |> rows!() |> row!(fixture.run_id)
+
+    assert row["state"] == "isolated"
+    assert row["isolation_reason"] == "unsupported_schema"
+    assert row["inspection_schema_version"] == Format.schema_version() + 1
+    assert row["inspection_format_version"] == Format.format_version()
+    assert row["inspection_record_count"] == nil
+    assert row["artifact_digest"] == nil
+  end
+
+  @tag :tmp_dir
+  test "a header and footer that disagree about the schema isolate the row", %{tmp_dir: root} do
+    fixture = fixture!(root, 33)
+    PrivateInspectionFixture.rewrite_schema!(Path.join(root, "inspection"), 1)
+
+    row = root |> rows!() |> row!(fixture.run_id)
+
+    assert row["state"] == "isolated"
+    assert row["isolation_reason"] == "malformed_metadata"
+    assert row["inspection_schema_version"] == nil
+  end
+
+  @tag :tmp_dir
+  test "an unsupported trace schema isolates the row", %{tmp_dir: root} do
+    fixture = fixture!(root, 10)
+    rewrite_trace!(root, fixture.run_id, &Map.put(&1, "schema_version", 3))
+
+    row = root |> rows!() |> row!(fixture.run_id)
+
+    assert row["state"] == "isolated"
+    assert row["isolation_reason"] == "unsupported_schema"
+    assert row["trace_schema_version"] == 3
+  end
+
+  @tag :tmp_dir
+  test "a schema version of the wrong shape isolates the row", %{tmp_dir: root} do
+    fixture = fixture!(root, 36)
+
+    rewrite_trace!(
+      root,
+      fixture.run_id,
+      &Map.put(&1, "schema_version", String.duplicate("2", 4_000))
+    )
+
+    row = root |> rows!() |> row!(fixture.run_id)
+
+    assert row["state"] == "isolated"
+    assert row["isolation_reason"] == "unsupported_schema"
+    assert row["trace_schema_version"] == nil
+    assert byte_size(Jason.encode!(row)) <= RunCatalog.max_row_bytes()
+  end
+
+  @tag :tmp_dir
+  test "a malformed head line isolates the row", %{tmp_dir: root} do
+    healthy = fixture!(root, 11)
+    broken = fixture!(root, 12)
+    File.write!(trace_path(root, broken.run_id), "{not-json\n")
+
+    rows = rows!(root)
+
+    assert row!(rows, healthy.run_id)["state"] == "admissible"
+
+    row = row!(rows, broken.run_id)
+    assert row["isolation_reason"] == "malformed_metadata"
+    assert row["trace_present"] == "unreadable"
+    assert row["correlation"] == "unavailable"
+  end
+
+  @tag :tmp_dir
+  test "a truncated sealed artifact isolates the row", %{tmp_dir: root} do
+    fixture = fixture!(root, 13)
+    path = inspection_path(root, fixture.run_id)
+    bytes = File.read!(path)
+    File.write!(path, binary_part(bytes, 0, byte_size(bytes) - 1))
+
+    row = root |> rows!() |> row!(fixture.run_id)
+
+    assert row["state"] == "isolated"
+    assert row["isolation_reason"] == "malformed_metadata"
+  end
+
+  @tag :tmp_dir
+  test "a filename that routes to another run isolates the row", %{tmp_dir: root} do
+    fixture = fixture!(root, 14)
+    impostor = PrivateInspectionFixture.command_run_ref(15)
+
+    File.rename!(trace_path(root, fixture.run_id), trace_path(root, impostor))
+    File.rm!(inspection_path(root, fixture.run_id))
+
+    row = root |> rows!() |> row!(impostor)
+
+    assert row["state"] == "isolated"
+    assert row["isolation_reason"] == "filename_run_mismatch"
+  end
+
+  @tag :tmp_dir
+  test "two entries claiming one trace identity isolate both", %{tmp_dir: root} do
+    first = fixture!(root, 16)
+    second = fixture!(root, 17)
+
+    rewrite_trace!(root, second.run_id, &Map.put(&1, "trace_id", "trace-#{first.run_id}"))
+
+    rows = rows!(root)
+
+    for run_id <- [first.run_id, second.run_id] do
+      row = row!(rows, run_id)
+      assert row["state"] == "isolated"
+      assert row["isolation_reason"] == "duplicate_run_identity"
+    end
+  end
+
+  @tag :tmp_dir
+  test "a trace and artifact that disagree about the trace report a mismatch", %{tmp_dir: root} do
+    fixture = fixture!(root, 18)
+    rewrite_trace!(root, fixture.run_id, &Map.put(&1, "trace_id", "trace-unrelated"))
+
+    row = root |> rows!() |> row!(fixture.run_id)
+
+    assert row["correlation"] == "mismatch"
+    assert row["state"] == "isolated"
+    assert row["isolation_reason"] == "inspection_correlation_missing"
+  end
+
+  @tag :tmp_dir
+  test "an unbounded but well-formed timestamp cannot grow a row", %{tmp_dir: root} do
+    fixture = fixture!(root, 34)
+    padded = "2026-07-26T12:00:01." <> String.duplicate("1", 5_000) <> "Z"
+    assert {:ok, _datetime, 0} = DateTime.from_iso8601(padded)
+    rewrite_trace!(root, fixture.run_id, &Map.put(&1, "timestamp", padded))
+
+    row = root |> rows!() |> row!(fixture.run_id)
+
+    assert row["start_timestamp"] == nil
+    assert row["duration_ms"] == nil
+    assert byte_size(Jason.encode!(row)) <= RunCatalog.max_row_bytes()
+  end
+
+  @tag :tmp_dir
+  test "a label of the wrong shape reads as absent, never as a row field", %{tmp_dir: root} do
+    fixture = fixture!(root, 35)
+
+    rewrite_trace!(root, fixture.run_id, fn event ->
+      if event["type"] == "run-started" do
+        put_in(event, ["data", "labels"], %{"name" => %{"nested" => true}, "tags" => "not-a-map"})
+      else
+        event
+      end
+    end)
+
+    row = root |> rows!() |> row!(fixture.run_id)
+
+    assert row["name"] == nil
+    assert row["tags"] == %{}
+    assert row["state"] == "admissible"
+  end
+
+  @tag :tmp_dir
+  test "files without a canonical stem are counted, never listed as rows", %{tmp_dir: root} do
+    fixture = fixture!(root, 19)
+    assert {:ok, %{excluded_files: baseline}} = RunCatalogSnapshot.info(capture!(root))
+
+    File.write!(Path.join(root, "traces/notes.txt"), "ignored\n")
+    File.write!(Path.join(root, "traces/.hidden.jsonl"), "ignored\n")
+    File.write!(Path.join(root, "inspection/leftover.tmp"), "ignored\n")
+
+    snapshot = capture!(root)
+
+    assert {:ok, %{row_count: 1, excluded_files: excluded}} = RunCatalogSnapshot.info(snapshot)
+    assert excluded == baseline + 3
+    assert {:ok, [%{"run_id" => run_id}]} = RunCatalogSnapshot.rows(snapshot)
+    assert run_id == fixture.run_id
+  end
+
+  @tag :tmp_dir
+  test "an open generation is unchanged by a run published after its capture", %{tmp_dir: root} do
+    first = fixture!(root, 20)
+
+    open = capture!(root)
+    assert {:ok, %{catalog_digest: digest, row_count: 1}} = RunCatalogSnapshot.info(open)
+
+    second = fixture!(root, 21)
+
+    assert {:ok, %{catalog_digest: ^digest, row_count: 1}} = RunCatalogSnapshot.info(open)
+    assert {:ok, [%{"run_id" => only}]} = RunCatalogSnapshot.rows(open)
+    assert only == first.run_id
+
+    later = capture!(root)
+    assert {:ok, %{catalog_digest: later_digest, row_count: 2}} = RunCatalogSnapshot.info(later)
+    refute later_digest == digest
+    assert Enum.sort([first.run_id, second.run_id]) == Enum.map(rows!(root), & &1["run_id"])
+  end
+
+  @tag :tmp_dir
+  test "an unchanged root captures to the same generation digest", %{tmp_dir: root} do
+    fixture!(root, 22)
+
+    assert {:ok, %{catalog_digest: digest}} = RunCatalogSnapshot.info(capture!(root))
+    assert {:ok, %{catalog_digest: ^digest}} = RunCatalogSnapshot.info(capture!(root))
+  end
+
+  @tag :tmp_dir
+  test "rewriting an artifact in place changes the next generation digest", %{tmp_dir: root} do
+    fixture = fixture!(root, 23)
+
+    assert {:ok, %{catalog_digest: digest}} = RunCatalogSnapshot.info(capture!(root))
+
+    rewrite_trace!(root, fixture.run_id, &Map.put(&1, "timestamp", "2026-07-26T13:00:00Z"))
+
+    assert {:ok, %{catalog_digest: changed}} = RunCatalogSnapshot.info(capture!(root))
+    refute changed == digest
+  end
+
+  @tag :tmp_dir
+  test "a cohort beyond the stem bound refuses the whole capture", %{tmp_dir: root} do
+    fixture!(root, 24)
+    fixture!(root, 25)
+
+    assert {:error, :catalog_limit_exceeded} =
+             RunCatalogSnapshot.start(catalog_source(root), owner: self(), max_files: 1)
+  end
+
+  @tag :tmp_dir
+  test "a listing beyond its entry bound refuses the whole capture", %{tmp_dir: root} do
+    fixture!(root, 26)
+    fixture!(root, 27)
+
+    assert {:error, :catalog_limit_exceeded} =
+             RunCatalogSnapshot.start(catalog_source(root),
+               owner: self(),
+               max_directory_entries: 1
+             )
+  end
+
+  @tag :tmp_dir
+  test "a retained projection beyond its bound refuses the whole capture", %{tmp_dir: root} do
+    fixture!(root, 28)
+
+    assert {:error, :catalog_limit_exceeded} =
+             RunCatalogSnapshot.start(catalog_source(root), owner: self(), max_retained_bytes: 1)
+  end
+
+  @tag :tmp_dir
+  test "an unusable root refuses the whole capture", %{tmp_dir: root} do
+    fixture!(root, 29)
+
+    assert {:error, :source_unavailable} =
+             RunCatalogSnapshot.start(
+               {:private_authorized_catalog, Path.join(root, "traces"),
+                Path.join(root, "absent")},
+               owner: self()
+             )
+  end
+
+  @tag :tmp_dir
+  test "an owner's exit stops its generation", %{tmp_dir: root} do
+    fixture!(root, 30)
+    test_pid = self()
+
+    owner =
+      spawn(fn ->
+        {:ok, snapshot} = RunCatalogSnapshot.start(catalog_source(root), owner: self())
+        send(test_pid, {:captured, snapshot})
+
+        receive do
+          :release -> :ok
+        end
+      end)
+
+    assert_receive {:captured, snapshot}
+    assert RunCatalogSnapshot.alive?(snapshot)
+
+    owner_ref = Process.monitor(owner)
+    send(owner, :release)
+    assert_receive {:DOWN, ^owner_ref, :process, ^owner, _reason}
+
+    assert {:error, :catalog_unavailable} = await_stopped(snapshot)
+  end
+
+  @tag :tmp_dir
+  test "an explicit stop releases the generation", %{tmp_dir: root} do
+    fixture!(root, 31)
+    snapshot = capture!(root)
+
+    assert :ok = RunCatalogSnapshot.stop(snapshot)
+    assert {:error, :catalog_unavailable} = RunCatalogSnapshot.info(snapshot)
+    assert :ok = RunCatalogSnapshot.stop(snapshot)
+  end
+
+  test "a source that is not a catalog pair is refused" do
+    assert {:error, :invalid_catalog} = RunCatalogSnapshot.start({:directory, "/tmp"})
+    assert {:error, :invalid_catalog} = RunCatalogSnapshot.rows(:not_a_snapshot)
+    assert {:error, :invalid_catalog} = RunCatalogSnapshot.info(:not_a_snapshot)
+  end
+
+  @tag :tmp_dir
+  test "capture bounds may be lowered but never raised", %{tmp_dir: root} do
+    fixture!(root, 32)
+
+    assert {:error, :invalid_catalog} =
+             RunCatalogSnapshot.start(catalog_source(root), owner: self(), max_files: 1_025)
+
+    assert {:error, :invalid_catalog} =
+             RunCatalogSnapshot.start(catalog_source(root),
+               owner: self(),
+               max_retained_bytes: RunCatalogSnapshot.default_retained_bytes() + 1
+             )
+
+    assert {:error, :invalid_catalog} =
+             RunCatalogSnapshot.start(catalog_source(root), owner: self(), unsupported: true)
+  end
+
+  defp await_stopped(snapshot) do
+    if RunCatalogSnapshot.alive?(snapshot) do
+      await_stopped(snapshot)
+    else
+      RunCatalogSnapshot.info(snapshot)
+    end
+  end
+
+  defp capture!(root) do
+    assert {:ok, snapshot} = RunCatalogSnapshot.start(catalog_source(root), owner: self())
+    on_exit(fn -> RunCatalogSnapshot.stop(snapshot) end)
+    snapshot
+  end
+
+  defp rows!(root) do
+    assert {:ok, rows} = root |> capture!() |> RunCatalogSnapshot.rows()
+    rows
+  end
+
+  defp row!(rows, run_id) do
+    assert row = Enum.find(rows, &(&1["run_id"] == run_id))
+    row
+  end
+
+  defp catalog_source(root),
+    do: {:private_authorized_catalog, Path.join(root, "traces"), Path.join(root, "inspection")}
+
+  defp fixture!(root, seed),
+    do: PrivateInspectionFixture.create!(root, PrivateInspectionFixture.command_run_ref(seed))
+
+  defp trace_path(root, run_id), do: Path.join(root, "traces/#{run_id}.jsonl")
+  defp inspection_path(root, run_id), do: Path.join(root, "inspection/#{run_id}.ptcins")
+
+  # Rewrites both declared schema versions, so the container stays internally
+  # consistent and states a version this build does not support - which is the
+  # state a real version bump produces, and a different one from corruption.
+  defp rewrite_sealed_schema!(path, schema_version) do
+    bytes = File.read!(path)
+
+    <<header_magic::binary-size(8), format::unsigned-big-16, _schema::unsigned-big-16,
+      header_rest::binary-size(4), body::binary>> = bytes
+
+    footer_size = Format.footer_size()
+    body_size = byte_size(body) - footer_size
+
+    <<evidence::binary-size(^body_size), footer_magic::binary-size(8),
+      footer_format::unsigned-big-16, _footer_schema::unsigned-big-16, footer_rest::binary>> =
+      body
+
+    File.write!(path, [
+      header_magic,
+      <<format::unsigned-big-16, schema_version::unsigned-big-16>>,
+      header_rest,
+      evidence,
+      footer_magic,
+      <<footer_format::unsigned-big-16, schema_version::unsigned-big-16>>,
+      footer_rest
+    ])
+  end
+
+  defp rewrite_trace!(root, run_id, transform) do
+    path = trace_path(root, run_id)
+
+    events =
+      path
+      |> File.read!()
+      |> String.split("\n", trim: true)
+      |> Enum.map(&Jason.decode!/1)
+      |> Enum.map(transform)
+
+    File.write!(path, Enum.map_join(events, "", &(Jason.encode!(&1) <> "\n")))
+  end
+end

--- a/test/ptc_runner/kernel/run_catalog_snapshot_test.exs
+++ b/test/ptc_runner/kernel/run_catalog_snapshot_test.exs
@@ -154,8 +154,11 @@ defmodule PtcRunner.Kernel.RunCatalogSnapshotTest do
 
     row = root |> rows!() |> row!(fixture.run_id)
 
+    # A version that is not a number is not a version this build cannot read —
+    # it is an event the canonical reader rejects outright, so the row reports
+    # the malformation and projects no version at all.
     assert row["state"] == "isolated"
-    assert row["isolation_reason"] == "unsupported_schema"
+    assert row["isolation_reason"] == "malformed_metadata"
     assert row["trace_schema_version"] == nil
     assert byte_size(Jason.encode!(row)) <= RunCatalog.max_row_bytes()
   end
@@ -419,6 +422,88 @@ defmodule PtcRunner.Kernel.RunCatalogSnapshotTest do
              RunCatalogSnapshot.start(catalog_source(root), owner: self(), unsupported: true)
   end
 
+  @tag :tmp_dir
+  test "a probed event that is not a canonical trace event isolates the row", %{tmp_dir: root} do
+    fixture = fixture!(root, 37)
+
+    rewrite_trace!(root, fixture.run_id, fn event ->
+      if event["type"] == "run-stopped", do: Map.delete(event, "trace_id"), else: event
+    end)
+
+    row = root |> rows!() |> row!(fixture.run_id)
+
+    assert row["state"] == "isolated"
+    assert row["isolation_reason"] == "malformed_metadata"
+    refute row["complete"]
+  end
+
+  @tag :tmp_dir
+  test "a run-stopped whose result hash contradicts its outcome isolates the row", %{
+    tmp_dir: root
+  } do
+    fixture = fixture!(root, 38)
+
+    rewrite_trace!(root, fixture.run_id, fn event ->
+      if event["type"] == "run-stopped",
+        do: put_in(event, ["data", "result_hash"], "not-a-hash"),
+        else: event
+    end)
+
+    row = root |> rows!() |> row!(fixture.run_id)
+
+    assert row["state"] == "isolated"
+    assert row["isolation_reason"] == "malformed_metadata"
+  end
+
+  @tag :tmp_dir
+  test "a rewritten footer field changes the next generation digest", %{tmp_dir: root} do
+    fixture = fixture!(root, 39)
+    path = inspection_path(root, fixture.run_id)
+
+    assert {:ok, %{catalog_digest: digest}} = RunCatalogSnapshot.info(capture!(root))
+    before_count = row!(rows!(root), fixture.run_id)["inspection_record_count"]
+
+    rewrite_footer_record_count!(path, before_count + 1)
+
+    assert {:ok, %{catalog_digest: changed}} = RunCatalogSnapshot.info(capture!(root))
+    refute changed == digest
+    assert row!(rows!(root), fixture.run_id)["inspection_record_count"] == before_count + 1
+  end
+
+  @tag :tmp_dir
+  test "a current-version header with invalid geometry isolates the row", %{tmp_dir: root} do
+    fixture = fixture!(root, 40)
+    path = inspection_path(root, fixture.run_id)
+    <<prefix::binary-size(12), _declared::unsigned-big-32, rest::binary>> = File.read!(path)
+    File.write!(path, <<prefix::binary, 17::unsigned-big-32, rest::binary>>)
+
+    row = root |> rows!() |> row!(fixture.run_id)
+
+    assert row["state"] == "isolated"
+    assert row["isolation_reason"] == "malformed_metadata"
+  end
+
+  @tag :tmp_dir
+  test "an artifact claiming another run's identity isolates every claimant", %{tmp_dir: root} do
+    first = fixture!(root, 41)
+    second = fixture!(root, 42)
+
+    File.cp!(inspection_path(root, first.run_id), inspection_path(root, second.run_id))
+
+    rows = rows!(root)
+
+    # Both claimants are isolated, never only the impersonator: the run whose
+    # identity was copied is no longer selectable either. The impostor reports
+    # the more specific defect it also has — its bytes are not the run its name
+    # claims — while the impersonated run reports the duplication alone.
+    for run_id <- [first.run_id, second.run_id] do
+      assert row!(rows, run_id)["state"] == "isolated"
+    end
+
+    assert row!(rows, first.run_id)["isolation_reason"] == "duplicate_run_identity"
+    assert row!(rows, second.run_id)["isolation_reason"] == "filename_run_mismatch"
+  end
+
   defp await_stopped(snapshot) do
     if RunCatalogSnapshot.alive?(snapshot) do
       await_stopped(snapshot)
@@ -477,6 +562,19 @@ defmodule PtcRunner.Kernel.RunCatalogSnapshotTest do
       <<footer_format::unsigned-big-16, schema_version::unsigned-big-16>>,
       footer_rest
     ])
+  end
+
+  # Rewrites one footer field and nothing else. The footer's stored
+  # `artifact_digest` is a claim, not a recomputation, so this leaves that claim
+  # intact — which is exactly the case a commitment must still distinguish.
+  defp rewrite_footer_record_count!(path, record_count) do
+    bytes = File.read!(path)
+    footer_offset = byte_size(bytes) - Format.footer_size()
+    record_count_offset = footer_offset + 40
+
+    <<head::binary-size(^record_count_offset), _count::unsigned-big-64, rest::binary>> = bytes
+
+    File.write!(path, <<head::binary, record_count::unsigned-big-64, rest::binary>>)
   end
 
   defp rewrite_trace!(root, run_id, transform) do

--- a/test/ptc_runner/kernel/run_catalog_test.exs
+++ b/test/ptc_runner/kernel/run_catalog_test.exs
@@ -115,6 +115,24 @@ defmodule PtcRunner.Kernel.RunCatalogTest do
                  0
                )
     end
+
+    test "a probed field the classifier reads is refused rather than raised on" do
+      for {path, value} <- [
+            {[:head, :timestamp], 42},
+            {[:head, :schema_version], "2"},
+            {[:tail, :timestamp], 42},
+            {[:tail, :status], 42},
+            {[:tail, :terminal_reason], %{}},
+            {[:tail, :result_hash], 42},
+            {[:bytes], "512"},
+            {[:commitment], :not_a_digest}
+          ] do
+        probe = probe(trace: put_in(trace_probe([]), Enum.map(path, &Access.key!/1), value))
+
+        assert {:error, :invalid_catalog} = RunCatalog.generation([probe], 0),
+               "expected #{inspect(path)} = #{inspect(value)} to be refused"
+      end
+    end
   end
 
   describe "row bounds" do
@@ -186,13 +204,17 @@ defmodule PtcRunner.Kernel.RunCatalogTest do
   end
 
   defp inspection_probe(overrides) do
+    run_id = Keyword.fetch!(overrides, :run_id)
+
     %{
       present: :probed,
       format_version: Format.format_version(),
       schema_version: Format.schema_version(),
       bytes: 4_096,
+      identity: {4_096, 9, 2, 3, 0},
+      commitment: :crypto.hash(:sha256, "header-footer-#{run_id}"),
       record_count: 12,
-      run_id_sha256: Format.identity_sha256(Keyword.fetch!(overrides, :run_id)),
+      run_id_sha256: Format.identity_sha256(run_id),
       trace_id_sha256: Format.identity_sha256(@trace_id),
       artifact_digest: :crypto.hash(:sha256, "artifact")
     }

--- a/test/ptc_runner/kernel/run_catalog_test.exs
+++ b/test/ptc_runner/kernel/run_catalog_test.exs
@@ -1,0 +1,200 @@
+defmodule PtcRunner.Kernel.RunCatalogTest do
+  use ExUnit.Case, async: true
+
+  alias PtcRunner.Kernel.InspectionArtifact.Format
+  alias PtcRunner.Kernel.RunCatalog
+
+  @run_ref "cmd-00000000000000000000000001"
+  @trace_id "trace-cmd-00000000000000000000000001"
+
+  describe "states no filesystem can be made to hold still for" do
+    test "an entry that moved under its own probe is isolated, never described" do
+      {:ok, %{rows: [row]}} =
+        RunCatalog.generation([probe(trace: %{present: :unstable})], 0)
+
+      assert row["run_id"] == @run_ref
+      assert row["state"] == "isolated"
+      assert row["isolation_reason"] == "unstable_entry"
+      assert row["trace_present"] == "unreadable"
+      assert row["trace_id"] == nil
+      assert row["trace_bytes"] == nil
+    end
+
+    test "an unstable sealed artifact isolates its row" do
+      {:ok, %{rows: [row]}} =
+        RunCatalog.generation([probe(inspection: %{present: :unstable})], 0)
+
+      assert row["isolation_reason"] == "unstable_entry"
+      assert row["inspection_present"] == true
+      assert row["artifact_digest"] == nil
+    end
+  end
+
+  describe "reason precedence" do
+    test "an entry that is both malformed and duplicated reports the malformation" do
+      duplicate = fn run_ref ->
+        probe(run_ref: run_ref, trace: trace_probe(run_id: run_ref))
+      end
+
+      {:ok, %{rows: rows}} =
+        RunCatalog.generation(
+          [
+            %{duplicate.("cmd-0000000000000000000000000a") | inspection: %{present: :malformed}},
+            duplicate.("cmd-0000000000000000000000000b")
+          ],
+          0
+        )
+
+      [malformed, plain] = rows
+
+      assert malformed["isolation_reason"] == "malformed_metadata"
+      assert plain["isolation_reason"] == "duplicate_run_identity"
+    end
+
+    test "every reason the catalog can report is ordered" do
+      assert RunCatalog.reason_order() == Enum.uniq(RunCatalog.reason_order())
+      assert Enum.all?(RunCatalog.reason_order(), &is_atom/1)
+    end
+  end
+
+  describe "generation identity" do
+    test "the same probes commit to the same digest regardless of capture order" do
+      probes = [
+        probe(
+          run_ref: "cmd-0000000000000000000000000a",
+          trace: trace_probe(run_id: "cmd-0000000000000000000000000a")
+        ),
+        probe(
+          run_ref: "cmd-0000000000000000000000000b",
+          trace: trace_probe(run_id: "cmd-0000000000000000000000000b")
+        )
+      ]
+
+      {:ok, forward} = RunCatalog.generation(probes, 0)
+      {:ok, reversed} = RunCatalog.generation(Enum.reverse(probes), 0)
+
+      assert forward.catalog_digest == reversed.catalog_digest
+      assert Enum.map(forward.rows, & &1["run_id"]) == Enum.map(reversed.rows, & &1["run_id"])
+    end
+
+    test "an absent half commits to its absence" do
+      {:ok, paired} = RunCatalog.generation([probe()], 0)
+      {:ok, trace_only} = RunCatalog.generation([probe(inspection: %{present: :absent})], 0)
+
+      refute paired.catalog_digest == trace_only.catalog_digest
+    end
+
+    test "the same bytes under a different reference are a different generation" do
+      {:ok, first} = RunCatalog.generation([probe()], 0)
+
+      {:ok, second} =
+        RunCatalog.generation([probe(run_ref: "cmd-0000000000000000000000000z")], 0)
+
+      refute first.catalog_digest == second.catalog_digest
+    end
+
+    test "a probe list that repeats a reference is refused" do
+      assert {:error, :invalid_catalog} = RunCatalog.generation([probe(), probe()], 0)
+      assert {:error, :invalid_catalog} = RunCatalog.generation([%{run_ref: @run_ref}], 0)
+      assert {:error, :invalid_catalog} = RunCatalog.generation([probe()], -1)
+    end
+
+    test "a probed half missing a field a row reads refuses the generation" do
+      assert {:error, :invalid_catalog} =
+               RunCatalog.generation([probe(trace: %{present: :probed})], 0)
+
+      assert {:error, :invalid_catalog} =
+               RunCatalog.generation([probe(inspection: %{present: :probed})], 0)
+
+      assert {:error, :invalid_catalog} =
+               RunCatalog.generation([probe(trace: %{present: :unrecognised})], 0)
+
+      assert {:error, :invalid_catalog} =
+               RunCatalog.generation(
+                 [probe(trace: put_in(trace_probe([]), [:head, :trace_id], 42))],
+                 0
+               )
+    end
+  end
+
+  describe "row bounds" do
+    test "label data beyond the row bound is reduced and isolated, not published" do
+      labels = %{"name" => String.duplicate("n", RunCatalog.max_row_bytes())}
+
+      {:ok, %{rows: [row]}} =
+        RunCatalog.generation([probe(trace: trace_probe(labels: labels))], 0)
+
+      assert row["state"] == "isolated"
+      assert row["isolation_reason"] == "malformed_metadata"
+      assert row["name"] == nil
+      assert row["labels"] == %{}
+      assert row["run_id"] == @run_ref
+      assert row["trace_id"] == @trace_id
+      assert byte_size(Jason.encode!(row)) <= RunCatalog.max_row_bytes()
+    end
+
+    test "label data inside the bound is published as the public surface exposes it" do
+      labels = %{
+        "name" => "cohort-arm",
+        "model" => "model-a",
+        "provider" => "provider-a",
+        "tags" => %{"suite" => "conformance"}
+      }
+
+      {:ok, %{rows: [row]}} =
+        RunCatalog.generation([probe(trace: trace_probe(labels: labels))], 0)
+
+      assert row["state"] == "admissible"
+      assert row["name"] == "cohort-arm"
+      assert row["model"] == "model-a"
+      assert row["provider"] == "provider-a"
+      assert row["tags"] == %{"suite" => "conformance"}
+    end
+  end
+
+  defp probe(overrides \\ []) do
+    run_ref = Keyword.get(overrides, :run_ref, @run_ref)
+
+    %{
+      run_ref: run_ref,
+      trace: Keyword.get(overrides, :trace, trace_probe(run_id: run_ref)),
+      inspection: Keyword.get(overrides, :inspection, inspection_probe(run_id: run_ref))
+    }
+  end
+
+  defp trace_probe(overrides) do
+    %{
+      present: :probed,
+      source_kind: :sanitized,
+      bytes: 512,
+      identity: {512, 1, 2, 3, 0},
+      commitment: :crypto.hash(:sha256, "head-tail"),
+      head: %{
+        run_id: Keyword.get(overrides, :run_id, @run_ref),
+        trace_id: @trace_id,
+        schema_version: 2,
+        timestamp: "2026-07-26T12:00:01Z",
+        labels: Keyword.get(overrides, :labels, %{})
+      },
+      tail: %{
+        timestamp: "2026-07-26T12:00:08Z",
+        status: "ok",
+        terminal_reason: nil,
+        result_hash: nil
+      }
+    }
+  end
+
+  defp inspection_probe(overrides) do
+    %{
+      present: :probed,
+      format_version: Format.format_version(),
+      schema_version: Format.schema_version(),
+      bytes: 4_096,
+      record_count: 12,
+      run_id_sha256: Format.identity_sha256(Keyword.fetch!(overrides, :run_id)),
+      trace_id_sha256: Format.identity_sha256(@trace_id),
+      artifact_digest: :crypto.hash(:sha256, "artifact")
+    }
+  end
+end


### PR DESCRIPTION
Refs #1642 — implements **step 1 of the four-PR breakdown** frozen in [the design-decisions comment](https://github.com/andreasronge/ptc_runner/issues/1642#issuecomment-5445118504): the `RunCatalog` capture owner. Steps 2–4 remain; see **Remaining work** below.

> Current head `5d6921e`. The review of the first revision raised six findings, all fixed; every review thread is resolved and no question is outstanding. See **Review history** below.

## The frozen contract this implements

Per §1, §2, §4 and §5 of the design comment, as amended by [the accepted schema amendment](https://github.com/andreasronge/ptc_runner/issues/1642#issuecomment-5449287788):

- **Derived immutable snapshot, no sidecars, no persisted catalog file.** A generation is an in-memory capture owned by `RunCatalogSnapshot`, built from bounded probes: a `.ptcins` container's 16-byte header and 192-byte footer (two `pread`s, no frame decoded), and a canonical trace's first line plus the last complete line inside a bounded tail window.
- **Identity is verified, never trusted from a filename.** `sha256(stem) == footer.run_id_sha256` and `sha256(trace head trace_id) == footer.trace_id_sha256`; a disagreement isolates the row. The two probed trace events are additionally validated by `TraceEventValidation`, so a file the canonical reader rejects is never published as admissible.
- **The bytes read are the bytes committed to.** Each file is `lstat`ed before the open, the opened descriptor is `fstat`ed and compared before a byte is read, and the path is `lstat`ed again after — so neither a file replaced under its path nor one rewritten mid-probe is described as the file that was listed.
- **Generation digest.** `sha256("ptc-run-catalog-v1\0" <> sorted per-row commitments)`, where each commitment is `{run_ref, trace half, inspection half}` and each half is `{present, descriptor identity, sha256 of the exact bytes probed}`. Committing to *bytes* rather than to decoded values is load-bearing: a footer's stored `artifact_digest` is a claim a metadata-only probe never recomputes, so a commitment derived from it misses a rewrite of any other footer field. Halves that read bytes but did not decode — malformed, foreign-version — commit to them too; only a half that never reached any bytes carries an absent marker. Nothing re-lists after capture, so a growing root cannot alter an open generation.
- **Row schema (§2)** as specified, including the exclusions: no prompts, responses, generated source, capability payloads, diagnostics, prints, result values, evidence content, filesystem paths, or any field needing a whole-trace scan. Plus the two amended enum values, `correlation: "unavailable"` and `trace_present: "unreadable"`, for an entry whose probe failed on a half.
- **Failure matrix (§4).** Per-row isolation with path-free codes — `ambiguous_trace`, `malformed_metadata`, `unstable_entry`, `unsupported_schema`, `filename_run_mismatch`, `duplicate_run_identity` — and whole-operation refusals `source_unavailable` / `catalog_limit_exceeded`. A malformed *unselected* entry never blocks the generation. Every duplicate claimant is isolated; the primary reason follows existing precedence.
- **Limits (§5).** 4,096 directory entries, 1,024 stems, 65,536-byte head + 65,536-byte tail + 208 sealed edge bytes per file, 2,048-byte rows, 4,194,304 retained bytes, 15,000 ms capture deadline, 5,000 ms listing deadline. All may be lowered by a caller and none raised.

## Decisions the frozen comment left unstated

1. **`correlation: "unavailable"` and `trace_present: "unreadable"`** — values beyond the original enums, for an entry whose probe failed on a half. **Proposed on #1642 and accepted into the frozen contract.**
2. **Correlation-mismatch row reason** — reuses the existing `inspection_correlation_missing`, the code the matrix already assigns to that state on the selection side.
3. **Oversized-row reason** — the reduced row is isolated as `malformed_metadata`.
4. **Header/footer version disagreement is `malformed_metadata`, not `unsupported_schema`** — an internally inconsistent container is corruption, not a version this build cannot read.
5. **A tail `run-stopped` naming a different run is `malformed_metadata`** — the two lines disagree about whose file it is.
6. **A non-integer `schema_version` is `malformed_metadata`, not `unsupported_schema`** — it is not a version this build cannot read, it is an event the canonical reader rejects.
7. **Identity strings bounded to 256 bytes** (matching `TraceDirectoryAdmission`'s existing claim bound) **and timestamps to 64 bytes.** ISO 8601 admits an unbounded fractional-second field, so a parse alone is not a bound; the row byte bound cannot drop either field, so both are bounded at the probe.
8. **Extracted `BoundedCapture`.** The duplication gate flagged the owner-capture loop as a copy of `TraceSnapshot`'s; both now share one owner-scoped implementation, each mapping its outcome onto its own source codes.

## Verification

Toolchain had to be installed in this container (`mise install` → Erlang 29.0.3 / Elixir 1.20.2, per `mise.toml`).

| Command | Result on `5d6921e` |
|---|---|
| `mix compile --warnings-as-errors` | clean |
| `mix precommit` | passes; duplication `new=0` |
| `mix dialyzer --format short` | `Total errors: 0` |
| `MIX_ENV=dev mix docs --warnings-as-errors` | clean (it caught a moduledoc link to a hidden module) |
| `mix test` (catalog files) | 45 passed |
| GitHub CI | all checks green |

The full suite in this container reports seven **pre-existing environment failures** unrelated to this diff: re-running those files on clean `main` in the same container reproduces the identical seven. Four are `chmod`-based tests asserting `:eacces`, defeated by the container running as root; two need IPv6 (`:eafnosupport`); one REPL frontend test is in the same class. GitHub CI passes all of them, which confirms the diagnosis.

The repo's pre-push hook is not installed in this fresh clone (`core.hooksPath` unset), so each gate it invokes was run by hand.

## Review history

Six reproduced findings on the first revision, all fixed. Each reproduction is now a test.

**P1 — probed events were not validated as canonical trace events.** Projecting from a handful of hand-picked fields let a file the canonical reader rejects be published as complete and admissible. The two probed events now go through `TraceEventValidation`. `{:error, :unsupported_version}` still projects so the row can report its declared version; every other failure isolates the row.

**P1 — the generation digest was bound to decoded values.** Rewriting `record_count` in a footer changed the row while leaving `catalog_digest` identical, because the commitment was built from the footer's stored `artifact_digest`. Both halves now commit to the exact bytes probed plus descriptor identity.

**P2 — the opened descriptor was never `fstat`ed.** A path replaced between `lstat` and `open` and restored before the closing `lstat` could commit replacement bytes under the original identity. Fixed following `Handle.open/2`; this required dropping `:raw`, since a raw descriptor is process-local and cannot be `fstat`ed. I judged the window untestable without a `Process.sleep` or a test-only export; the maintainer showed otherwise in `5d6921e`, adding a nil-by-default `:file_probe_hook` on the same footing as the existing `:listing_hook` and a rendezvous-based regression that swaps the file before `open` and restores it before the closing `lstat`, so only the `fstat` can catch it.

**P2 — current-version header geometry was unvalidated.** A declared header size of 17 was accepted although the artifact reader rejects it. `Format.decode_header/1` now validates the whole header once the versions are recognised as this build's.

**P2 — duplicate detection ignored inspection-footer identity claims.** Traces state identities in plaintext and footers only as digests, so the two halves claimed into spaces that could never intersect, and copying one run's artifact over another's canonical name left the impersonated run admissible. The plaintext is now hashed to meet the footer.

**P2 — classifier inputs were only partially validated.** The partial check advertised `{:error, :invalid_catalog}` and then broke it by raising out of a projection. Every field the classifier reads is now validated.

## Remaining work

Steps 2–4 of the frozen breakdown are untouched by this PR:

2. **`analysis-catalog` capability + `private-run-catalog-v1` profile** — paging, the filter vocabulary plus `correlation`/`state`, digest-bound cursors reusing the `TraceLog` cursor helpers, `excluded_files` accounting, REPL/JSONL wiring. `RunCatalogSnapshot.rows/1` is the frozen list that surface will page over.
3. **Bounded multi-run selected capture** — `{:selected_canonical_set, dir, run_refs}` in `SelectedCanonicalSource` and both snapshots, repeated `--run` on `private-run-analysis-v1`, `max_selected_runs` (16), aggregate-limit enforcement, and the `duplicate_selected_run` / `selected_set_limit_exceeded` / isolated-run refusals.
4. **Docs, diagnostics, integration** — `docs/reference/repl.md`, `cli.md`, `docs/maintainers/trace-log-contract.md`, `debug-navigation.md`, stable code-catalog additions.

Because the catalog has no user-facing surface until step 2, this PR adds no user documentation; the contract lives in the three module docs. Acceptance-list coverage is correspondingly partial: catalog growth during paging, stale cursors, and bounded incremental opening are step 2/3 concerns. Covered here: duplicate identities across both halves, missing pairs, changed manifests, malformed entries selected and unselected, non-canonical events, descriptor replacement under the inventoried path, large catalogs, generation immutability under a growing root, digest stability and change, payload-content leak checks, and owner cleanup.