### PR TITLE
fix(cli): refuse a private run with no result destination

### DIFF
--- a/lib/ptc_runner/kernel/command_destination.ex
+++ b/lib/ptc_runner/kernel/command_destination.ex
@@ -11,7 +11,8 @@ defmodule PtcRunner.Kernel.CommandDestination do
   alias PtcRunner.Kernel.PublicationAuthority
 
   @artifact_names ["trace", "inspection", "result"]
-  @option_keys [:trace_dir, :inspect, :output, :private_output]
+  @result_keys [:output, :private_output]
+  @option_keys [:trace_dir, :inspect] ++ @result_keys
 
   @spec capture(map()) :: {map(), [atom()]}
   def capture(options) when is_map(options) do
@@ -71,7 +72,7 @@ defmodule PtcRunner.Kernel.CommandDestination do
     %{
       "trace" => requested_state(options, [:trace_dir, :trace]),
       "inspection" => requested_state(options, [:inspect]),
-      "result" => requested_state(options, [:output, :private_output])
+      "result" => requested_state(options, @result_keys)
     }
   end
 
@@ -101,7 +102,8 @@ defmodule PtcRunner.Kernel.CommandDestination do
     options = preparation.artifact_destinations
 
     result =
-      with :ok <- ensure_project_artifact_root(preparation) do
+      with :ok <- ensure_project_artifact_root(preparation),
+           :ok <- ensure_private_result_destination(preparation, options) do
         PublicationAuthority.authorize(
           preparation.run_ref,
           Map.to_list(options),
@@ -256,6 +258,26 @@ defmodule PtcRunner.Kernel.CommandDestination do
       end
 
     CommandRejection.destination_collision(:run, first, second, frontend)
+  end
+
+  # Commands that publish a result reach this path; `doctor --connect` does not,
+  # and authorizes no result destination of its own. A run whose result is
+  # private-class therefore has nowhere to publish unless one was requested:
+  # stdout is not a private destination. Refusing here keeps the refusal in
+  # phase 6, before any provider activity, and gives it the same diagnostic a
+  # normal destination already earns inside `PublicationAuthority.authorize/4`.
+  defp ensure_private_result_destination(preparation, options) do
+    prepared = preparation.prepared_run
+
+    private? =
+      PublicationAuthority.private_result?(
+        prepared.effective_event_policy,
+        prepared.effective_data_class
+      )
+
+    if private? and not Enum.any?(@result_keys, &Map.has_key?(options, &1)),
+      do: {:error, :private_destination_required},
+      else: :ok
   end
 
   defp internal_outcome(%CommandPreparation{run_ref: run_ref}) do

--- a/lib/ptc_runner/kernel/publication_authority.ex
+++ b/lib/ptc_runner/kernel/publication_authority.ex
@@ -83,6 +83,19 @@ defmodule PtcRunner.Kernel.PublicationAuthority do
 
   def new(_opts), do: {:error, :invalid_publication_authority}
 
+  @doc """
+  Whether a run under `event_policy` and `provider_class` produces a private
+  result.
+
+  A command that publishes a result consults this before authorizing, because a
+  private result has no publishable destination unless one was requested.
+  """
+  @spec private_result?(:normal | :private, :normal | :private_inspection) :: boolean()
+  def private_result?(event_policy, provider_class)
+      when event_policy in [:normal, :private] and
+             provider_class in [:normal, :private_inspection],
+      do: event_policy == :private or provider_class == :private_inspection
+
   @doc "Authorizes all requested artifact destinations during phase 6."
   @spec authorize(binary(), keyword(), :normal | :private, :normal | :private_inspection) ::
           {:ok, t()} | {:error, authorization_error()}
@@ -91,7 +104,7 @@ defmodule PtcRunner.Kernel.PublicationAuthority do
              provider_class in [:normal, :private_inspection] do
     with true <- valid_run_ref?(run_ref, true),
          true <- Keyword.keyword?(opts),
-         private? <- event_policy == :private or provider_class == :private_inspection,
+         private? <- private_result?(event_policy, provider_class),
          trace_mode <- if(Keyword.has_key?(opts, :trace_dir), do: :exclusive, else: :append),
          :ok <- validate_option_keys(opts),
          {:ok, targets} <- targets(run_ref, opts, private?),

--- a/test/ptc_runner/kernel/llm_replay_test.exs
+++ b/test/ptc_runner/kernel/llm_replay_test.exs
@@ -987,6 +987,7 @@ defmodule PtcRunner.Kernel.LLMReplayTest do
       paths = write_application(dir)
       private_input = Path.join(dir, "private-input.json")
       inspection = Path.join(dir, "private-run.ptcins")
+      private_output = Path.join(dir, "private-result.json")
       secret = "PRIVATE_REPLAY_PROMPT"
 
       File.write!(private_input, Jason.encode!(%{"secret" => secret}))
@@ -1012,7 +1013,9 @@ defmodule PtcRunner.Kernel.LLMReplayTest do
                  "--private-input",
                  Path.basename(private_input),
                  "--inspect",
-                 inspection
+                 inspection,
+                 "--private-output",
+                 private_output
                ])
 
       assert miss.envelope["artifact_class"] == "private", inspect(miss.envelope)

--- a/test/ptc_runner/kernel/publication_authority_test.exs
+++ b/test/ptc_runner/kernel/publication_authority_test.exs
@@ -244,6 +244,49 @@ defmodule PtcRunner.Kernel.PublicationAuthorityTest do
   end
 
   @tag :tmp_dir
+  test "a private result refuses a normal destination and an absent one alike", %{tmp_dir: dir} do
+    # A private result publishes to a file or not at all, so naming a normal
+    # destination and naming none are the same mistake. Only the first was
+    # refused: the second authorized the run, spent the provider activity, and
+    # failed internally at publication with nothing to act on.
+    application = application!(dir, "private-result", %{"events" => %{"policy" => "private"}})
+
+    for destination_args <- [["--output", Path.join(dir, "normal.json")], []] do
+      assert {:ok, preparation} =
+               CommandEngine.prepare(["run", application | destination_args])
+
+      assert {:error, outcome} = CommandEngine.preflight(preparation)
+      assert outcome.envelope["error"]["phase"] == "destination"
+      assert outcome.envelope["error"]["code"] == "private_destination_required"
+      assert outcome.envelope["error"]["provider_activity"] == false
+      assert outcome.envelope["execution"] == %{"state" => "not_started"}
+      refute Jason.encode!(outcome.envelope) =~ dir
+    end
+
+    assert {:ok, preparation} =
+             CommandEngine.prepare([
+               "run",
+               application,
+               "--private-output",
+               Path.join(dir, "private.json")
+             ])
+
+    assert {:ok, authority} = CommandEngine.preflight(preparation)
+    assert :ok = PublicationAuthority.abort(authority)
+    assert :ok = CommandPreparation.close(preparation)
+  end
+
+  test "an active doctor authorizes no result destination under a private policy" do
+    # `doctor --connect` publishes no result, so the requirement above must not
+    # reach it; it authorizes with no destinations at all.
+    assert {:ok, authority} =
+             PublicationAuthority.authorize("private-doctor", [], :private, :private_inspection)
+
+    assert PublicationAuthority.authorized?(authority)
+    assert :ok = PublicationAuthority.abort(authority)
+  end
+
+  @tag :tmp_dir
   test "independent authorities cannot reserve the same requested name", %{tmp_dir: dir} do
     target = Path.join(dir, "same-target.jsonl")
 


### PR DESCRIPTION
Closes #1688.

## The gap

A private-class run publishes its result to a private file or not at all. Naming a *normal* destination was already refused; naming *none* was not:

| invocation | before | after |
| --- | --- | --- |
| `run` (no result flag) | `internal/internal_error`, exit 70, **after** the model calls | `destination/private_destination_required`, exit 7 |
| `run --output FILE` | `private_destination_required`, exit 7 | unchanged |
| `run --private-output FILE` | ok | unchanged |
| `doctor --connect` | ready | unchanged |
| normal-class `run` | ok | unchanged |

The unhandled combination was "stdout is the implicit destination, and the result is private-class". `internal/internal_error` is by construction the one message a caller cannot act on, and it was reached from a configuration `ptc validate` accepts.

The envelope showed the cost of getting it wrong late:

```json
"execution": {"outcome": "ok", "state": "finished"},
"usage": {"capability_calls": {"workflow/llm-request": 1}},
"error": {"code": "internal_error", "phase": "internal"}
```

The workflow ran to completion — real provider calls on a live model — before failing with nothing to act on. The refusal now lands in phase 6 with `execution.state: not_started` and `provider_activity: false`.

## Where the check goes, and why not the obvious place

The tempting one-line fix is to key `PublicationAuthority.validate_result_class/2` on `private_output` instead of `output`. That is wrong: `ptc doctor --connect` also calls `authorize/4`, with no destinations at all (`command_doctor.ex:308`), and publishes no result. Making `authorize/4` demand a private result destination moves the identical `internal_error` onto doctor — confirmed empirically before discarding that approach.

The requirement belongs to commands that publish a result, so it goes in the run preflight (`CommandDestination.authorize_prepared/2`). `run` and `repl` reach it; `doctor` does not. The private-result predicate is extracted to `PublicationAuthority.private_result?/2` so the preflight and `authorize/4` cannot drift on what "private" means.

## Tests

- `publication_authority_test.exs` — a private run refuses a normal destination and an absent one alike, asserting `state: not_started` and `provider_activity: false`; plus a guard that an active doctor still authorizes with no destinations, which pins the regression described above.
- `llm_replay_test.exs` — the existing private replay-miss test ran a private-class workflow with no result destination, i.e. it relied on the gap. It now passes `--private-output`; its privacy assertions are unchanged.

## Verification

Against the shipped `llm-replay` example with `data_class: private_inspection`, all five rows of the table above reproduced by hand through `mix ptc`. `mix test` 7448 passed, `mix precommit` clean. Independent `codex review` reported no actionable findings.

Not included: the issue's optional suggestion that `ptc validate` warn that a private-class install will require `--private-output` at run time. That is a separate mechanism.

https://claude.ai/code/session_018JQbbVY9ZJh4Fh6DQUshRH