### PR TITLE
test(kernel): follow the explicit-failure diagnostic in the nightly example

### DIFF
--- a/test/ptc_runner/kernel/debug_a_failed_run_example_test.exs
+++ b/test/ptc_runner/kernel/debug_a_failed_run_example_test.exs
@@ -37,7 +37,7 @@ defmodule PtcRunner.Kernel.DebugAFailedRunExampleTest do
     File.rm_rf!(Path.join(example, "debugger/.ptc"))
 
     assert {target_output, 5} = run(Path.join(example, "target.ptc-project.json"))
-    assert target_output =~ "execution/workflow_failed"
+    assert target_output =~ "execution/explicit_failure"
 
     assert {debugger_output, 0} = run(Path.join(example, "debugger.ptc-project.json"))
     assert Jason.decode!(debugger_output) == %{"artifact_class" => "private", "status" => "ok"}
@@ -354,7 +354,7 @@ defmodule PtcRunner.Kernel.DebugAFailedRunExampleTest do
 
     target = Path.join(example, "target-workflow-control.ptc-project.json")
     assert {target_output, 5} = run(target)
-    assert target_output =~ "execution/workflow_failed"
+    assert target_output =~ "execution/explicit_failure"
 
     base = File.read!(Path.join(example, "target-workflow-control/main.clj"))
 


### PR DESCRIPTION
## Why

The scheduled [Nightly run 33245334332](https://github.com/andreasronge/ptc_runner/actions/runs/33245334332) failed with 2 of 18 tests red, both in `PtcRunner.Kernel.DebugAFailedRunExampleTest`:

```
code:  assert target_output =~ "execution/workflow_failed"
left:  "** (Mix) error: execution/explicit_failure: the workflow signalled an
        explicit failure; its value is retained in the run's private inspection
        record (run_ref: cmd-4v9sd5f79s68ynp1z7nkzrvmhe)\n"
```

PR #1703 split `execution/explicit_failure` out of `execution/workflow_failed` in `DiagnosticCatalog` (`lib/ptc_runner/kernel/diagnostic_catalog.ex:231`). The `debug-a-failed-run` target ends in `(fail {:kind "order-total-mismatch"})`, so `mix ptc run` now reports the new, more specific code. Exit status stays 5 — only the code string moved, which is why `assert {output, 5} = run(...)` still passed.

Both assertions carry `@tag :nightly` because they shell out to real `mix ptc run` subprocesses, so the PR gates never ran them and the break only surfaced in the scheduled workflow. `test/fixtures/command-human-v4.json` is the only other reference to the old code and is an unrelated human-projection fixture.

## Verification

- `mix test test/ptc_runner/kernel/debug_a_failed_run_example_test.exs --include nightly` — 8 passed
- `mix nightly` — 18 passed, 7869 excluded
- `scripts/ci/core-tests.sh` — 7499 passed
- `mix precommit` — clean

## Not in this PR

`main` is separately red: [CI 33236476616](https://github.com/andreasronge/ptc_runner/actions/runs/33236476616) fails on `command_engine_global_state_test.exs:725`, an unrelated in-flight-LLM-timeout race. Filed for its own change.

https://claude.ai/code/session_01FbU3GFUEsrPGCuYA6ASG2g