### PR TITLE
refactor(kernel): consolidate owner status redaction

### DIFF
--- a/.duplication-baseline.json
+++ b/.duplication-baseline.json
@@ -133,82 +133,8 @@
       ],
       "type": "type_i"
     },
-    "4dc0df361a20ca0d61881045c1daad230b93b9bd21918cce321138f86cda3186": {
-      "describe": "type_i mass=43 lib/ptc_runner/kernel/analysis_session.ex:271 <-> lib/ptc_runner/kernel/execution_session_owner.ex:364 <-> lib/ptc_runner/kernel/host_installation_owner.ex:352 <-> lib/ptc_runner/kernel/mcp_oauth/store/memory.ex:704 <-> lib/ptc_runner/kernel/mcp_oauth/token_manager.ex:426 <-> lib/ptc_runner/kernel/mcp_request_context.ex:356 <-> lib/ptc_runner/kernel/mcp_stdio_transport.ex:396 <-> lib/ptc_runner/kernel/provider_session.ex:1231 <-> lib/ptc_runner/kernel/provider_task_tracker.ex:111 <-> lib/ptc_runner/kernel/run_catalog_snapshot.ex:200 <-> lib/ptc_runner/kernel/session_trace.ex:292 <-> lib/ptc_runner/kernel/trace_snapshot.ex:397 <-> lib/ptc_runner/kernel/viewer_repl_backend.ex:357",
-      "files": [
-        "lib/ptc_runner/kernel/analysis_session.ex",
-        "lib/ptc_runner/kernel/execution_session_owner.ex",
-        "lib/ptc_runner/kernel/host_installation_owner.ex",
-        "lib/ptc_runner/kernel/mcp_oauth/store/memory.ex",
-        "lib/ptc_runner/kernel/mcp_oauth/token_manager.ex",
-        "lib/ptc_runner/kernel/mcp_request_context.ex",
-        "lib/ptc_runner/kernel/mcp_stdio_transport.ex",
-        "lib/ptc_runner/kernel/provider_session.ex",
-        "lib/ptc_runner/kernel/provider_task_tracker.ex",
-        "lib/ptc_runner/kernel/run_catalog_snapshot.ex",
-        "lib/ptc_runner/kernel/session_trace.ex",
-        "lib/ptc_runner/kernel/trace_snapshot.ex",
-        "lib/ptc_runner/kernel/viewer_repl_backend.ex"
-      ],
-      "mass": 43,
-      "occurrences": [
-        {
-          "file": "lib/ptc_runner/kernel/analysis_session.ex",
-          "snippet": "bb3704f9e43b4527e7ccf365039a43e289f6703b0758d6e4803423f6562db0bb"
-        },
-        {
-          "file": "lib/ptc_runner/kernel/execution_session_owner.ex",
-          "snippet": "bb3704f9e43b4527e7ccf365039a43e289f6703b0758d6e4803423f6562db0bb"
-        },
-        {
-          "file": "lib/ptc_runner/kernel/host_installation_owner.ex",
-          "snippet": "bb3704f9e43b4527e7ccf365039a43e289f6703b0758d6e4803423f6562db0bb"
-        },
-        {
-          "file": "lib/ptc_runner/kernel/mcp_oauth/store/memory.ex",
-          "snippet": "bb3704f9e43b4527e7ccf365039a43e289f6703b0758d6e4803423f6562db0bb"
-        },
-        {
-          "file": "lib/ptc_runner/kernel/mcp_oauth/token_manager.ex",
-          "snippet": "bb3704f9e43b4527e7ccf365039a43e289f6703b0758d6e4803423f6562db0bb"
-        },
-        {
-          "file": "lib/ptc_runner/kernel/mcp_request_context.ex",
-          "snippet": "bb3704f9e43b4527e7ccf365039a43e289f6703b0758d6e4803423f6562db0bb"
-        },
-        {
-          "file": "lib/ptc_runner/kernel/mcp_stdio_transport.ex",
-          "snippet": "bb3704f9e43b4527e7ccf365039a43e289f6703b0758d6e4803423f6562db0bb"
-        },
-        {
-          "file": "lib/ptc_runner/kernel/provider_session.ex",
-          "snippet": "bb3704f9e43b4527e7ccf365039a43e289f6703b0758d6e4803423f6562db0bb"
-        },
-        {
-          "file": "lib/ptc_runner/kernel/provider_task_tracker.ex",
-          "snippet": "bb3704f9e43b4527e7ccf365039a43e289f6703b0758d6e4803423f6562db0bb"
-        },
-        {
-          "file": "lib/ptc_runner/kernel/run_catalog_snapshot.ex",
-          "snippet": "bb3704f9e43b4527e7ccf365039a43e289f6703b0758d6e4803423f6562db0bb"
-        },
-        {
-          "file": "lib/ptc_runner/kernel/session_trace.ex",
-          "snippet": "bb3704f9e43b4527e7ccf365039a43e289f6703b0758d6e4803423f6562db0bb"
-        },
-        {
-          "file": "lib/ptc_runner/kernel/trace_snapshot.ex",
-          "snippet": "bb3704f9e43b4527e7ccf365039a43e289f6703b0758d6e4803423f6562db0bb"
-        },
-        {
-          "file": "lib/ptc_runner/kernel/viewer_repl_backend.ex",
-          "snippet": "bb3704f9e43b4527e7ccf365039a43e289f6703b0758d6e4803423f6562db0bb"
-        }
-      ],
-      "type": "type_i"
-    },
     "4fb8929e2db79521808dac424116c41338c86ecc4e7ab9725165845d8846ccdd": {
-      "describe": "type_i mass=36 test/ptc_runner/kernel/mcp_request_context_test.exs:608 <-> test/ptc_runner/kernel/mcp_source_test.exs:2881",
+      "describe": "type_i mass=36 test/ptc_runner/kernel/mcp_request_context_test.exs:608 <-> test/ptc_runner/kernel/mcp_source_test.exs:2986",
       "files": [
         "test/ptc_runner/kernel/mcp_request_context_test.exs",
         "test/ptc_runner/kernel/mcp_source_test.exs"
@@ -227,7 +153,7 @@
       "type": "type_i"
     },
     "5025f164ab7fddef95cecc3c564bcedeaf12838c4a55d7b80167eb45bff0eadd": {
-      "describe": "type_i mass=31 test/ptc_runner/kernel/core_contract_test.exs:790 <-> test/ptc_runner/kernel/core_contract_test.exs:833",
+      "describe": "type_i mass=31 test/ptc_runner/kernel/core_contract_test.exs:863 <-> test/ptc_runner/kernel/core_contract_test.exs:906",
       "files": [
         "test/ptc_runner/kernel/core_contract_test.exs"
       ],
@@ -245,7 +171,7 @@
       "type": "type_i"
     },
     "5ef621c02ed0857b4ef273d1e724ca264db4525e6d0c07e8f9558bf4c0a7e377": {
-      "describe": "type_i mass=30 lib/ptc_runner/kernel/llm_replay_owner.ex:65 <-> lib/ptc_runner/kernel/trace_snapshot.ex:392",
+      "describe": "type_i mass=30 lib/ptc_runner/kernel/llm_replay_owner.ex:65 <-> lib/ptc_runner/kernel/trace_snapshot.ex:412",
       "files": [
         "lib/ptc_runner/kernel/llm_replay_owner.ex",
         "lib/ptc_runner/kernel/trace_snapshot.ex"
@@ -264,7 +190,7 @@
       "type": "type_i"
     },
     "621a8fcdaa04246456265b2ed4cf9c7c8510c612d22b6e291352611505c044ed": {
-      "describe": "type_i mass=32 lib/ptc_runner/kernel/session_trace.ex:390 <-> lib/ptc_runner/kernel/session_trace.ex:42",
+      "describe": "type_i mass=32 lib/ptc_runner/kernel/session_trace.ex:394 <-> lib/ptc_runner/kernel/session_trace.ex:44",
       "files": [
         "lib/ptc_runner/kernel/session_trace.ex"
       ],
@@ -282,7 +208,7 @@
       "type": "type_i"
     },
     "63a8b9c6c7c94c8476d3c81cb58c4476cdee5a342d1cf2833db339a202db6d6e": {
-      "describe": "type_i mass=50 lib/ptc_runner/lisp.ex:2156 <-> lib/ptc_runner/lisp.ex:2309",
+      "describe": "type_i mass=50 lib/ptc_runner/lisp.ex:2176 <-> lib/ptc_runner/lisp.ex:2329",
       "files": [
         "lib/ptc_runner/lisp.ex"
       ],
@@ -300,7 +226,7 @@
       "type": "type_i"
     },
     "676ecb4412a54eef2f319df5d6c64399e2b5faf84ad2ef979bf9c871fb5f32fd": {
-      "describe": "type_ii mass=30 lib/ptc_runner/kernel/event_sink.ex:296 <-> lib/ptc_runner/kernel/inspection_sink.ex:268 <-> lib/ptc_runner/kernel/llm_replay_owner.ex:65 <-> lib/ptc_runner/kernel/trace_snapshot.ex:392",
+      "describe": "type_ii mass=30 lib/ptc_runner/kernel/event_sink.ex:299 <-> lib/ptc_runner/kernel/inspection_sink.ex:268 <-> lib/ptc_runner/kernel/llm_replay_owner.ex:65 <-> lib/ptc_runner/kernel/trace_snapshot.ex:412",
       "files": [
         "lib/ptc_runner/kernel/event_sink.ex",
         "lib/ptc_runner/kernel/inspection_sink.ex",
@@ -382,7 +308,7 @@
       "type": "type_ii"
     },
     "763c8a9e4ef38af437133014657da3890afd363f089b1e1693f858ab67849dbe": {
-      "describe": "type_i mass=57 lib/ptc_runner/kernel/inspection_snapshot.ex:143 <-> lib/ptc_runner/kernel/trace_snapshot.ex:182",
+      "describe": "type_i mass=57 lib/ptc_runner/kernel/inspection_snapshot.ex:159 <-> lib/ptc_runner/kernel/trace_snapshot.ex:202",
       "files": [
         "lib/ptc_runner/kernel/inspection_snapshot.ex",
         "lib/ptc_runner/kernel/trace_snapshot.ex"
@@ -396,75 +322,6 @@
         {
           "file": "lib/ptc_runner/kernel/trace_snapshot.ex",
           "snippet": "90b58f7565e3a727d5fd25b635efd901fedadab4e073573e2b790ebdd6716bf0"
-        }
-      ],
-      "type": "type_i"
-    },
-    "79ed5035598bef16f41582b12ef838c103875cedbe3a920d31a44b860e54c939": {
-      "describe": "type_i mass=30 lib/ptc_runner/kernel/analysis_session.ex:726 <-> lib/ptc_runner/kernel/host_installation_owner.ex:362 <-> lib/ptc_runner/kernel/mcp_oauth/store/memory.ex:1528 <-> lib/ptc_runner/kernel/mcp_oauth/token_manager.ex:919 <-> lib/ptc_runner/kernel/mcp_request_context.ex:379 <-> lib/ptc_runner/kernel/mcp_stdio_transport.ex:1159 <-> lib/ptc_runner/kernel/provider_session.ex:1692 <-> lib/ptc_runner/kernel/provider_task_tracker.ex:148 <-> lib/ptc_runner/kernel/run_state.ex:1362 <-> lib/ptc_runner/kernel/session_trace.ex:540 <-> lib/ptc_runner/kernel/trace_snapshot.ex:689 <-> lib/ptc_runner/kernel/viewer_repl_backend.ex:609",
-      "files": [
-        "lib/ptc_runner/kernel/analysis_session.ex",
-        "lib/ptc_runner/kernel/host_installation_owner.ex",
-        "lib/ptc_runner/kernel/mcp_oauth/store/memory.ex",
-        "lib/ptc_runner/kernel/mcp_oauth/token_manager.ex",
-        "lib/ptc_runner/kernel/mcp_request_context.ex",
-        "lib/ptc_runner/kernel/mcp_stdio_transport.ex",
-        "lib/ptc_runner/kernel/provider_session.ex",
-        "lib/ptc_runner/kernel/provider_task_tracker.ex",
-        "lib/ptc_runner/kernel/run_state.ex",
-        "lib/ptc_runner/kernel/session_trace.ex",
-        "lib/ptc_runner/kernel/trace_snapshot.ex",
-        "lib/ptc_runner/kernel/viewer_repl_backend.ex"
-      ],
-      "mass": 30,
-      "occurrences": [
-        {
-          "file": "lib/ptc_runner/kernel/analysis_session.ex",
-          "snippet": "4a836f0f9ee39c462a6caa4863661711bb67b60c06ac8f997cc56574aa524e13"
-        },
-        {
-          "file": "lib/ptc_runner/kernel/host_installation_owner.ex",
-          "snippet": "4a836f0f9ee39c462a6caa4863661711bb67b60c06ac8f997cc56574aa524e13"
-        },
-        {
-          "file": "lib/ptc_runner/kernel/mcp_oauth/store/memory.ex",
-          "snippet": "4a836f0f9ee39c462a6caa4863661711bb67b60c06ac8f997cc56574aa524e13"
-        },
-        {
-          "file": "lib/ptc_runner/kernel/mcp_oauth/token_manager.ex",
-          "snippet": "4a836f0f9ee39c462a6caa4863661711bb67b60c06ac8f997cc56574aa524e13"
-        },
-        {
-          "file": "lib/ptc_runner/kernel/mcp_request_context.ex",
-          "snippet": "4a836f0f9ee39c462a6caa4863661711bb67b60c06ac8f997cc56574aa524e13"
-        },
-        {
-          "file": "lib/ptc_runner/kernel/mcp_stdio_transport.ex",
-          "snippet": "4a836f0f9ee39c462a6caa4863661711bb67b60c06ac8f997cc56574aa524e13"
-        },
-        {
-          "file": "lib/ptc_runner/kernel/provider_session.ex",
-          "snippet": "4a836f0f9ee39c462a6caa4863661711bb67b60c06ac8f997cc56574aa524e13"
-        },
-        {
-          "file": "lib/ptc_runner/kernel/provider_task_tracker.ex",
-          "snippet": "4a836f0f9ee39c462a6caa4863661711bb67b60c06ac8f997cc56574aa524e13"
-        },
-        {
-          "file": "lib/ptc_runner/kernel/run_state.ex",
-          "snippet": "4a836f0f9ee39c462a6caa4863661711bb67b60c06ac8f997cc56574aa524e13"
-        },
-        {
-          "file": "lib/ptc_runner/kernel/session_trace.ex",
-          "snippet": "4a836f0f9ee39c462a6caa4863661711bb67b60c06ac8f997cc56574aa524e13"
-        },
-        {
-          "file": "lib/ptc_runner/kernel/trace_snapshot.ex",
-          "snippet": "4a836f0f9ee39c462a6caa4863661711bb67b60c06ac8f997cc56574aa524e13"
-        },
-        {
-          "file": "lib/ptc_runner/kernel/viewer_repl_backend.ex",
-          "snippet": "4a836f0f9ee39c462a6caa4863661711bb67b60c06ac8f997cc56574aa524e13"
         }
       ],
       "type": "type_i"
@@ -507,7 +364,7 @@
       "type": "type_i"
     },
     "8de541de6a8463e0066a928ed6f9484b223f9a92739fddd33b59298e252d99d6": {
-      "describe": "type_i mass=36 lib/ptc_runner/lisp/eval.ex:1251 <-> lib/ptc_runner/lisp/eval.ex:1305 <-> lib/ptc_runner/lisp/eval.ex:1325",
+      "describe": "type_i mass=36 lib/ptc_runner/lisp/eval.ex:1250 <-> lib/ptc_runner/lisp/eval.ex:1304 <-> lib/ptc_runner/lisp/eval.ex:1324",
       "files": [
         "lib/ptc_runner/lisp/eval.ex"
       ],
@@ -529,7 +386,7 @@
       "type": "type_i"
     },
     "9a5745cb297a916c230134aaad7350eec097cc0dff4429002490c01db7a8b665": {
-      "describe": "type_ii mass=39 lib/ptc_runner/kernel/trace_log.ex:1890 <-> lib/ptc_runner/kernel/trace_log.ex:2670",
+      "describe": "type_ii mass=39 lib/ptc_runner/kernel/trace_log.ex:1923 <-> lib/ptc_runner/kernel/trace_log.ex:2757",
       "files": [
         "lib/ptc_runner/kernel/trace_log.ex"
       ],
@@ -565,7 +422,7 @@
       "type": "type_i"
     },
     "b06e4bbe2481479f6a55f33afd45e868e6bf4c83ee58c63cb7f4747d3737d81e": {
-      "describe": "type_i mass=49 lib/ptc_runner/lisp/eval.ex:1207 <-> lib/ptc_runner/lisp/eval.ex:1223",
+      "describe": "type_i mass=49 lib/ptc_runner/lisp/eval.ex:1206 <-> lib/ptc_runner/lisp/eval.ex:1222",
       "files": [
         "lib/ptc_runner/lisp/eval.ex"
       ],
@@ -583,7 +440,7 @@
       "type": "type_i"
     },
     "b5c37bd099b8247b16c034f46e060422ed68e821028907619196297b940bbed1": {
-      "describe": "type_i mass=46 lib/ptc_runner/kernel/inspection_snapshot.ex:274 <-> lib/ptc_runner/kernel/trace_snapshot.ex:372",
+      "describe": "type_i mass=46 lib/ptc_runner/kernel/inspection_snapshot.ex:274 <-> lib/ptc_runner/kernel/trace_snapshot.ex:392",
       "files": [
         "lib/ptc_runner/kernel/inspection_snapshot.ex",
         "lib/ptc_runner/kernel/trace_snapshot.ex"
@@ -624,7 +481,7 @@
       "type": "type_i"
     },
     "da241194085c15f4be57bc5d899f9ed222f81e69ad6570a67ae780247351e332": {
-      "describe": "type_i mass=43 lib/ptc_runner/kernel/host_config.ex:2006 <-> lib/ptc_runner/kernel/manifest.ex:1474",
+      "describe": "type_i mass=43 lib/ptc_runner/kernel/host_config.ex:2108 <-> lib/ptc_runner/kernel/manifest.ex:1478",
       "files": [
         "lib/ptc_runner/kernel/host_config.ex",
         "lib/ptc_runner/kernel/manifest.ex"
@@ -643,7 +500,7 @@
       "type": "type_i"
     },
     "da641906daf03a70d98d9e3015bf17602e80d0c9d96e3f187b9e2bc2a4aad02a": {
-      "describe": "type_i mass=31 test/ptc_runner/kernel/agent_library_test.exs:3627 <-> test/ptc_runner/kernel/agent_library_test.exs:3854",
+      "describe": "type_i mass=31 test/ptc_runner/kernel/agent_library_test.exs:3635 <-> test/ptc_runner/kernel/agent_library_test.exs:3866",
       "files": [
         "test/ptc_runner/kernel/agent_library_test.exs"
       ],
@@ -698,7 +555,7 @@
       "type": "type_i"
     },
     "eab38378a7cf3498853edd5074f7c6842ab0039953eed003abfd7f9f7d98e75a": {
-      "describe": "type_i mass=41 test/ptc_runner/kernel/execution_session_owner_privacy_test.exs:236 <-> test/ptc_runner/kernel/provider_execution_lifecycle_test.exs:823 <-> test/ptc_runner/kernel/run_coordinator_execution_test.exs:747",
+      "describe": "type_i mass=41 test/ptc_runner/kernel/execution_session_owner_privacy_test.exs:237 <-> test/ptc_runner/kernel/provider_execution_lifecycle_test.exs:823 <-> test/ptc_runner/kernel/run_coordinator_execution_test.exs:738",
       "files": [
         "test/ptc_runner/kernel/execution_session_owner_privacy_test.exs",
         "test/ptc_runner/kernel/provider_execution_lifecycle_test.exs",
@@ -722,7 +579,7 @@
       "type": "type_i"
     },
     "ee759005e72ef863d7844779dc4a667b279c1d3f64dac872d2f277554e4b7036": {
-      "describe": "type_i mass=37 lib/ptc_runner/kernel/inspection_snapshot.ex:177 <-> lib/ptc_runner/kernel/trace_snapshot.ex:262",
+      "describe": "type_i mass=37 lib/ptc_runner/kernel/inspection_snapshot.ex:193 <-> lib/ptc_runner/kernel/trace_snapshot.ex:282",
       "files": [
         "lib/ptc_runner/kernel/inspection_snapshot.ex",
         "lib/ptc_runner/kernel/trace_snapshot.ex"
@@ -788,7 +645,7 @@
       "type": "type_i"
     },
     "f66f82977c275de48e7b4c9e8efc31bc68c18d12a7d60066e73b9e3e1af62eb2": {
-      "describe": "type_i mass=39 lib/ptc_runner/lisp/eval.ex:1251 <-> lib/ptc_runner/lisp/eval.ex:1325",
+      "describe": "type_i mass=39 lib/ptc_runner/lisp/eval.ex:1250 <-> lib/ptc_runner/lisp/eval.ex:1324",
       "files": [
         "lib/ptc_runner/lisp/eval.ex"
       ],
@@ -806,7 +663,7 @@
       "type": "type_i"
     },
     "fccf3d34ad4059288f46e6bd8af17812026e2f87b4791a87c608c50b8bee732d": {
-      "describe": "type_i mass=30 lib/ptc_runner/kernel/event_sink.ex:296 <-> lib/ptc_runner/kernel/inspection_sink.ex:268",
+      "describe": "type_i mass=30 lib/ptc_runner/kernel/event_sink.ex:299 <-> lib/ptc_runner/kernel/inspection_sink.ex:268",
       "files": [
         "lib/ptc_runner/kernel/event_sink.ex",
         "lib/ptc_runner/kernel/inspection_sink.ex"

--- a/docs/maintainers/duplication-gate.md
+++ b/docs/maintainers/duplication-gate.md
@@ -37,8 +37,8 @@ Suppress when independent contracts happen to look alike and extraction would
 couple them. Put a reason above one copy:
 
 ```elixir
-# ex_dna:disable-for-next-line — GenServer callback, intentionally per-module
-def format_status(_reason, _status), do: [data: [{~c"State", :redacted}]]
+# ex_dna:disable-for-next-line — owner-specific lifecycle fallback
+def handle_cast(_request, state), do: {:noreply, state}
 ```
 
 Suppressing one occurrence removes the clone from the report. Common examples

--- a/lib/ptc_runner/kernel/analysis_session.ex
+++ b/lib/ptc_runner/kernel/analysis_session.ex
@@ -19,6 +19,7 @@ defmodule PtcRunner.Kernel.AnalysisSession do
   one that was never produced.
   """
   use GenServer
+  use PtcRunner.Kernel.OwnerStatusRedaction
 
   alias PtcRunner.Kernel.AnalysisAssembly
   alias PtcRunner.Kernel.AnalysisProfileRegistry
@@ -268,16 +269,6 @@ defmodule PtcRunner.Kernel.AnalysisSession do
 
   def handle_info({:EXIT, _pid, _reason}, state), do: {:noreply, state}
   def handle_info(_message, state), do: {:noreply, state}
-
-  if {:format_status, 1} in GenServer.behaviour_info(:callbacks) do
-    @impl GenServer
-    def format_status(status), do: redact_status(status)
-  else
-    def format_status(status), do: redact_status(status)
-  end
-
-  @impl GenServer
-  def format_status(_reason, _status), do: [data: [{~c"State", :redacted}]]
 
   defp close_state(%{lifecycle: :closed} = state, _outcome, _reason), do: {:ok, state}
 
@@ -723,14 +714,6 @@ defmodule PtcRunner.Kernel.AnalysisSession do
   defp lifecycle_error(:persistence_failed), do: :persistence_failed
   defp lifecycle_error(:backend_failed), do: :backend_failed
   defp lifecycle_error(_lifecycle), do: :session_closed
-
-  defp redact_status(status) do
-    Map.new(status, fn
-      {key, _value} when key in [:state, :message, :reason] -> {key, :redacted}
-      {:log, _value} -> {:log, []}
-      key_value -> key_value
-    end)
-  end
 
   defp call(%__MODULE__{pid: pid, token: token}, request, timeout) do
     GenServer.call(pid, {token, request}, timeout)

--- a/lib/ptc_runner/kernel/execution_session_owner.ex
+++ b/lib/ptc_runner/kernel/execution_session_owner.ex
@@ -2,6 +2,7 @@ defmodule PtcRunner.Kernel.ExecutionSessionOwner do
   @moduledoc false
 
   use GenServer
+  use PtcRunner.Kernel.OwnerStatusRedaction
 
   alias PtcRunner.Kernel.CommandDiagnostic
   alias PtcRunner.Kernel.ConnectivityResult
@@ -362,16 +363,6 @@ defmodule PtcRunner.Kernel.ExecutionSessionOwner do
 
   def handle_info(_message, state), do: {:noreply, state}
 
-  if {:format_status, 1} in GenServer.behaviour_info(:callbacks) do
-    @impl GenServer
-    def format_status(status), do: redact_status(status)
-  else
-    def format_status(status), do: redact_status(status)
-  end
-
-  @impl GenServer
-  def format_status(_reason, _status), do: [data: [{~c"State", :redacted}]]
-
   @impl GenServer
   def terminate(_reason, state) do
     _state = abort(state)
@@ -731,13 +722,5 @@ defmodule PtcRunner.Kernel.ExecutionSessionOwner do
     PreparedRun.close(prepared)
   catch
     :exit, _reason -> :ok
-  end
-
-  defp redact_status(status) do
-    Map.new(status, fn
-      {key, _value} when key in [:authority, :state, :message, :reason] -> {key, :redacted}
-      {:log, _value} -> {:log, []}
-      key_value -> key_value
-    end)
   end
 end

--- a/lib/ptc_runner/kernel/host_installation_owner.ex
+++ b/lib/ptc_runner/kernel/host_installation_owner.ex
@@ -2,6 +2,7 @@ defmodule PtcRunner.Kernel.HostInstallationOwner do
   @moduledoc false
 
   use GenServer
+  use PtcRunner.Kernel.OwnerStatusRedaction
 
   alias PtcRunner.Kernel.BoundedWorker
   alias PtcRunner.Kernel.Deadline
@@ -348,24 +349,6 @@ defmodule PtcRunner.Kernel.HostInstallationOwner do
 
   def handle_info({:"ETS-TRANSFER", _table, _from, :credential_leases}, state),
     do: {:noreply, state}
-
-  if {:format_status, 1} in GenServer.behaviour_info(:callbacks) do
-    @impl GenServer
-    def format_status(status), do: redact_status(status)
-  else
-    def format_status(status), do: redact_status(status)
-  end
-
-  @impl GenServer
-  def format_status(_reason, _status), do: [data: [{~c"State", :redacted}]]
-
-  defp redact_status(status) do
-    Map.new(status, fn
-      {key, _value} when key in [:state, :message, :reason] -> {key, :redacted}
-      {:log, _value} -> {:log, []}
-      key_value -> key_value
-    end)
-  end
 
   defp safe_owner_call(host, request, operation) do
     HostInstallation.owner_call(host, request)

--- a/lib/ptc_runner/kernel/mcp_oauth/manager_cleanup_worker.ex
+++ b/lib/ptc_runner/kernel/mcp_oauth/manager_cleanup_worker.ex
@@ -2,6 +2,7 @@ defmodule PtcRunner.Kernel.MCPOAuth.ManagerCleanupWorker do
   @moduledoc false
 
   use GenServer
+  use PtcRunner.Kernel.OwnerStatusRedaction
 
   alias PtcRunner.Kernel.MCPOAuth.TokenManager
 
@@ -88,14 +89,4 @@ defmodule PtcRunner.Kernel.MCPOAuth.ManagerCleanupWorker do
     Process.send_after(self(), :close, delay_ms || state.retry_ms)
     {:noreply, %{state | retry_ms: min(state.retry_ms * 2, @maximum_retry_ms)}}
   end
-
-  if {:format_status, 1} in GenServer.behaviour_info(:callbacks) do
-    @impl GenServer
-    def format_status(_status), do: %{state: :redacted}
-  else
-    def format_status(_status), do: %{state: :redacted}
-  end
-
-  @impl GenServer
-  def format_status(_reason, _status), do: [data: [{~c"State", :redacted}]]
 end

--- a/lib/ptc_runner/kernel/mcp_oauth/store/memory.ex
+++ b/lib/ptc_runner/kernel/mcp_oauth/store/memory.ex
@@ -15,6 +15,7 @@ defmodule PtcRunner.Kernel.MCPOAuth.Store.Memory do
   """
 
   use GenServer
+  use PtcRunner.Kernel.OwnerStatusRedaction
 
   alias PtcRunner.Kernel.Deadline
   alias PtcRunner.Kernel.MCPOAuth.Binding
@@ -700,16 +701,6 @@ defmodule PtcRunner.Kernel.MCPOAuth.Store.Memory do
   end
 
   def terminate(_reason, _state), do: :ok
-
-  if {:format_status, 1} in GenServer.behaviour_info(:callbacks) do
-    @impl GenServer
-    def format_status(status), do: redact_status(status)
-  else
-    def format_status(status), do: redact_status(status)
-  end
-
-  @impl GenServer
-  def format_status(_reason, _status), do: [data: [{~c"State", :redacted}]]
 
   defp validate_authority_batch(state, tenant_id, authorities)
        when is_binary(tenant_id) and is_list(authorities) and length(authorities) <= 128 do
@@ -1524,12 +1515,4 @@ defmodule PtcRunner.Kernel.MCPOAuth.Store.Memory do
   end
 
   defp now_ms, do: System.monotonic_time(:millisecond)
-
-  defp redact_status(status) do
-    Map.new(status, fn
-      {key, _value} when key in [:state, :message, :reason] -> {key, :redacted}
-      {:log, _value} -> {:log, []}
-      key_value -> key_value
-    end)
-  end
 end

--- a/lib/ptc_runner/kernel/mcp_oauth/token_manager.ex
+++ b/lib/ptc_runner/kernel/mcp_oauth/token_manager.ex
@@ -23,6 +23,7 @@ defmodule PtcRunner.Kernel.MCPOAuth.TokenManager do
   """
 
   use GenServer
+  use PtcRunner.Kernel.OwnerStatusRedaction
 
   alias PtcRunner.Kernel.Deadline
   alias PtcRunner.Kernel.MCPOAuth.Authority
@@ -422,16 +423,6 @@ defmodule PtcRunner.Kernel.MCPOAuth.TokenManager do
   end
 
   def handle_info(_message, state), do: {:noreply, state}
-
-  if {:format_status, 1} in GenServer.behaviour_info(:callbacks) do
-    @impl GenServer
-    def format_status(status), do: redact_status(status)
-  else
-    def format_status(status), do: redact_status(status)
-  end
-
-  @impl GenServer
-  def format_status(_reason, _status), do: [data: [{~c"State", :redacted}]]
 
   defp usable_grant(pid, config, deadline_ms) do
     with {:ok, grant} <-
@@ -915,12 +906,4 @@ defmodule PtcRunner.Kernel.MCPOAuth.TokenManager do
 
   defp local_requirement_satisfied?(nil, _generation, _granted), do: true
   defp local_requirement_satisfied?(_requirement, _generation, _granted), do: false
-
-  defp redact_status(status) do
-    Map.new(status, fn
-      {key, _value} when key in [:state, :message, :reason] -> {key, :redacted}
-      {:log, _value} -> {:log, []}
-      key_value -> key_value
-    end)
-  end
 end

--- a/lib/ptc_runner/kernel/mcp_request_context.ex
+++ b/lib/ptc_runner/kernel/mcp_request_context.ex
@@ -2,6 +2,7 @@ defmodule PtcRunner.Kernel.MCPRequestContext do
   @moduledoc false
 
   use GenServer
+  use PtcRunner.Kernel.OwnerStatusRedaction
 
   alias PtcRunner.Kernel.MCPOAuth.ManagerCleanup
   alias PtcRunner.Kernel.MCPOAuth.TokenManager
@@ -353,16 +354,6 @@ defmodule PtcRunner.Kernel.MCPRequestContext do
 
   def handle_info(_message, state), do: {:noreply, state}
 
-  if {:format_status, 1} in GenServer.behaviour_info(:callbacks) do
-    @impl GenServer
-    def format_status(status), do: redact_status(status)
-  else
-    def format_status(status), do: redact_status(status)
-  end
-
-  @impl GenServer
-  def format_status(_reason, _status), do: [data: [{~c"State", :redacted}]]
-
   defp safe_call(pid, request, timeout \\ 5_000) do
     GenServer.call(pid, request, timeout)
   catch
@@ -374,14 +365,6 @@ defmodule PtcRunner.Kernel.MCPRequestContext do
 
   defp fence_request_worker do
     Process.exit(self(), :kill)
-  end
-
-  defp redact_status(status) do
-    Map.new(status, fn
-      {key, _value} when key in [:state, :message, :reason] -> {key, :redacted}
-      {:log, _value} -> {:log, []}
-      key_value -> key_value
-    end)
   end
 
   defp release_active(state, caller, demonitor? \\ true) do

--- a/lib/ptc_runner/kernel/mcp_stdio_transport.ex
+++ b/lib/ptc_runner/kernel/mcp_stdio_transport.ex
@@ -2,6 +2,7 @@ defmodule PtcRunner.Kernel.MCPStdioTransport do
   @moduledoc false
 
   use GenServer
+  use PtcRunner.Kernel.OwnerStatusRedaction
 
   alias PtcRunner.Kernel.MCPProtocol
   alias PtcRunner.Kernel.ResourceRegistrar
@@ -392,16 +393,6 @@ defmodule PtcRunner.Kernel.MCPStdioTransport do
   end
 
   def handle_info(_message, state), do: {:noreply, state}
-
-  if {:format_status, 1} in GenServer.behaviour_info(:callbacks) do
-    @impl GenServer
-    def format_status(status), do: redact_status(status)
-  else
-    def format_status(status), do: redact_status(status)
-  end
-
-  @impl GenServer
-  def format_status(_reason, _status), do: [data: [{~c"State", :redacted}]]
 
   @impl GenServer
   def terminate(_reason, state) do
@@ -1154,14 +1145,6 @@ defmodule PtcRunner.Kernel.MCPStdioTransport do
     end)
 
     %{state | exchange_waiters: :queue.new()}
-  end
-
-  defp redact_status(status) do
-    Map.new(status, fn
-      {key, _value} when key in [:state, :message, :reason] -> {key, :redacted}
-      {:log, _value} -> {:log, []}
-      key_value -> key_value
-    end)
   end
 
   defp monotonic_ms, do: System.monotonic_time(:millisecond)

--- a/lib/ptc_runner/kernel/provider_session.ex
+++ b/lib/ptc_runner/kernel/provider_session.ex
@@ -90,6 +90,7 @@ defmodule PtcRunner.Kernel.ProviderSession do
   """
 
   use GenServer
+  use PtcRunner.Kernel.OwnerStatusRedaction
 
   alias PtcRunner.Kernel.Attestation
   alias PtcRunner.Kernel.BoundedWorker
@@ -1228,16 +1229,6 @@ defmodule PtcRunner.Kernel.ProviderSession do
 
   def handle_info(_message, state), do: {:noreply, state}
 
-  if {:format_status, 1} in GenServer.behaviour_info(:callbacks) do
-    @impl GenServer
-    def format_status(status), do: redact_status(status)
-  else
-    def format_status(status), do: redact_status(status)
-  end
-
-  @impl GenServer
-  def format_status(_reason, _status), do: [data: [{~c"State", :redacted}]]
-
   @impl GenServer
   def terminate(_reason, state) do
     {_result, _state} = state |> begin_terminal_cleanup() |> drain()
@@ -1688,12 +1679,4 @@ defmodule PtcRunner.Kernel.ProviderSession do
 
   defp compatible_run_duration?(%__MODULE__{run_duration_ms: run_duration_ms}, limits),
     do: run_duration_ms == limits.run_duration_ms
-
-  defp redact_status(status) do
-    Map.new(status, fn
-      {key, _value} when key in [:state, :message, :reason] -> {key, :redacted}
-      {:log, _value} -> {:log, []}
-      key_value -> key_value
-    end)
-  end
 end

--- a/lib/ptc_runner/kernel/provider_task_tracker.ex
+++ b/lib/ptc_runner/kernel/provider_task_tracker.ex
@@ -12,6 +12,7 @@ defmodule PtcRunner.Kernel.ProviderTaskTracker do
   # connector closes and none can be attached behind it.
 
   use GenServer
+  use PtcRunner.Kernel.OwnerStatusRedaction
 
   @enforce_keys [:pid, :token]
   defstruct [:pid, :token]
@@ -108,16 +109,6 @@ defmodule PtcRunner.Kernel.ProviderTaskTracker do
 
   def handle_info(_message, state), do: {:noreply, state}
 
-  if {:format_status, 1} in GenServer.behaviour_info(:callbacks) do
-    @impl GenServer
-    def format_status(status), do: redact_status(status)
-  else
-    def format_status(status), do: redact_status(status)
-  end
-
-  @impl GenServer
-  def format_status(_reason, _status), do: [data: [{~c"State", :redacted}]]
-
   # A killed task always yields the `:DOWN` this reaps, so the loop terminates
   # without its own timer. Only provider monitors are consumed; a lifecycle
   # notification that arrives mid-drain stays queued for the clause above.
@@ -143,13 +134,5 @@ defmodule PtcRunner.Kernel.ProviderTaskTracker do
     call(tracker, request)
   catch
     :exit, _reason -> {:error, :closed}
-  end
-
-  defp redact_status(status) do
-    Map.new(status, fn
-      {key, _value} when key in [:state, :message, :reason] -> {key, :redacted}
-      {:log, _value} -> {:log, []}
-      key_value -> key_value
-    end)
   end
 end

--- a/lib/ptc_runner/kernel/run_catalog_snapshot.ex
+++ b/lib/ptc_runner/kernel/run_catalog_snapshot.ex
@@ -18,6 +18,7 @@ defmodule PtcRunner.Kernel.RunCatalogSnapshot do
   """
 
   use GenServer
+  use PtcRunner.Kernel.OwnerStatusRedaction
 
   alias PtcRunner.Kernel.BoundedCapture
   alias PtcRunner.Kernel.RunCatalog
@@ -247,23 +248,6 @@ defmodule PtcRunner.Kernel.RunCatalogSnapshot do
     do: {:stop, :normal, state}
 
   def handle_info(_message, state), do: {:noreply, state}
-
-  # This OTP-version guard around `format_status/1` is byte-identical in the
-  # twelve other owner modules that carry it. A suppression comment does not
-  # attach to a bare module-level `if`, so this occurrence joins that cluster
-  # in `.duplication-baseline.json` rather than being marked here.
-  if {:format_status, 1} in GenServer.behaviour_info(:callbacks) do
-    @impl GenServer
-    def format_status(status), do: redact_status(status)
-  else
-    def format_status(status), do: redact_status(status)
-  end
-
-  @impl GenServer
-  def format_status(_reason, _status), do: [data: [{~c"State", :redacted}]]
-
-  defp redact_status(status) when is_map(status), do: Map.put(status, :state, :redacted)
-  defp redact_status(status), do: status
 
   defp call(%__MODULE__{pid: pid, token: token}, request) when is_pid(pid) do
     GenServer.call(pid, {token, request}, :infinity)

--- a/lib/ptc_runner/kernel/run_catalog_snapshot.ex
+++ b/lib/ptc_runner/kernel/run_catalog_snapshot.ex
@@ -237,9 +237,9 @@ defmodule PtcRunner.Kernel.RunCatalogSnapshot do
 
   @impl GenServer
   # ex_dna:disable-for-next-line — GenServer callbacks, intentionally per-module.
-  # An owner's reaction to its owner's death and the redaction of its own state
-  # are part of that owner's contract; routing them through a shared module
-  # would couple the lifecycles of otherwise independent snapshots.
+  # An owner's fallback and reaction to its owner's death are part of that
+  # owner's lifecycle contract; sharing them would couple otherwise independent
+  # snapshots.
   def handle_cast(_request, state), do: {:noreply, state}
 
   @impl GenServer

--- a/lib/ptc_runner/kernel/run_state.ex
+++ b/lib/ptc_runner/kernel/run_state.ex
@@ -51,6 +51,7 @@ defmodule PtcRunner.Kernel.RunState do
   survive a later sandbox timeout or heap kill and are cleared with the lease.
   """
   use GenServer
+  use PtcRunner.Kernel.OwnerStatusRedaction
 
   alias PtcRunner.Kernel.Deadline
   alias PtcRunner.Kernel.EventSink
@@ -1446,15 +1447,6 @@ defmodule PtcRunner.Kernel.RunState do
     end
   end
 
-  if {:format_status, 1} in GenServer.behaviour_info(:callbacks) do
-    @impl GenServer
-  end
-
-  def format_status(status), do: redact_status(status)
-
-  @impl GenServer
-  def format_status(_reason, _status), do: [data: [{~c"State", :redacted}]]
-
   @impl GenServer
   def terminate(_reason, state) do
     state.reservations
@@ -1495,14 +1487,6 @@ defmodule PtcRunner.Kernel.RunState do
     %{state | closed?: true, provider_tasks: 0, reservations: %{}}
     |> maybe_complete_evaluation_release()
     |> admit_from_queue()
-  end
-
-  defp redact_status(status) do
-    Map.new(status, fn
-      {key, _value} when key in [:state, :message, :reason] -> {key, :redacted}
-      {:log, _value} -> {:log, []}
-      key_value -> key_value
-    end)
   end
 
   defp drain_providers(refs) when map_size(refs) == 0, do: :ok

--- a/lib/ptc_runner/kernel/session_trace.ex
+++ b/lib/ptc_runner/kernel/session_trace.ex
@@ -16,6 +16,7 @@ defmodule PtcRunner.Kernel.SessionTrace do
   no surviving caller-visible retry authority.
   """
   use GenServer
+  use PtcRunner.Kernel.OwnerStatusRedaction
 
   alias PtcRunner.Kernel.AnalysisResources
   alias PtcRunner.Kernel.EventSink
@@ -295,16 +296,6 @@ defmodule PtcRunner.Kernel.SessionTrace do
 
   def handle_info(_message, state), do: {:noreply, state}
 
-  if {:format_status, 1} in GenServer.behaviour_info(:callbacks) do
-    @impl GenServer
-    def format_status(status), do: redact_status(status)
-  else
-    def format_status(status), do: redact_status(status)
-  end
-
-  @impl GenServer
-  def format_status(_reason, _status), do: [data: [{~c"State", :redacted}]]
-
   @impl GenServer
   def terminate(_reason, state) do
     _state = cleanup_resources(state)
@@ -567,14 +558,6 @@ defmodule PtcRunner.Kernel.SessionTrace do
   end
 
   defp stop_attached_session(_state), do: :ok
-
-  defp redact_status(status) do
-    Map.new(status, fn
-      {key, _value} when key in [:state, :message, :reason] -> {key, :redacted}
-      {:log, _value} -> {:log, []}
-      key_value -> key_value
-    end)
-  end
 
   defp call(%__MODULE__{pid: pid, token: token}, request, timeout \\ 5_000),
     do: GenServer.call(pid, {token, request}, timeout)

--- a/lib/ptc_runner/kernel/trace_snapshot.ex
+++ b/lib/ptc_runner/kernel/trace_snapshot.ex
@@ -2,6 +2,7 @@ defmodule PtcRunner.Kernel.TraceSnapshot do
   @moduledoc false
 
   use GenServer
+  use PtcRunner.Kernel.OwnerStatusRedaction
 
   alias PtcRunner.Kernel.BoundedCapture
   alias PtcRunner.Kernel.ResourceRegistrar
@@ -413,16 +414,6 @@ defmodule PtcRunner.Kernel.TraceSnapshot do
 
   def handle_info(_message, state), do: {:noreply, state}
 
-  if {:format_status, 1} in GenServer.behaviour_info(:callbacks) do
-    @impl GenServer
-    def format_status(status), do: redact_status(status)
-  else
-    def format_status(status), do: redact_status(status)
-  end
-
-  @impl GenServer
-  def format_status(_reason, _status), do: [data: [{~c"State", :redacted}]]
-
   defp call(%__MODULE__{pid: pid, token: token}, request) when is_pid(pid) do
     GenServer.call(pid, {token, request}, :infinity)
   catch
@@ -790,12 +781,4 @@ defmodule PtcRunner.Kernel.TraceSnapshot do
 
   defp valid_run_id?(run_id),
     do: is_binary(run_id) and byte_size(run_id) in 1..4_096 and String.valid?(run_id)
-
-  defp redact_status(status) do
-    Map.new(status, fn
-      {key, _value} when key in [:state, :message, :reason] -> {key, :redacted}
-      {:log, _value} -> {:log, []}
-      key_value -> key_value
-    end)
-  end
 end

--- a/lib/ptc_runner/kernel/viewer_repl_backend.ex
+++ b/lib/ptc_runner/kernel/viewer_repl_backend.ex
@@ -2,6 +2,7 @@ defmodule PtcRunner.Kernel.ViewerReplBackend do
   @moduledoc false
 
   use GenServer
+  use PtcRunner.Kernel.OwnerStatusRedaction
 
   alias PtcRunner.Kernel.ViewerReplSessionWorker
   alias PtcRunner.Lisp.Formatter
@@ -354,16 +355,6 @@ defmodule PtcRunner.Kernel.ViewerReplBackend do
   def handle_info({:EXIT, _pid, _reason}, state), do: {:noreply, state}
   def handle_info(_message, state), do: {:noreply, state}
 
-  if {:format_status, 1} in GenServer.behaviour_info(:callbacks) do
-    @impl GenServer
-    def format_status(status), do: redact_status(status)
-  else
-    def format_status(status), do: redact_status(status)
-  end
-
-  @impl GenServer
-  def format_status(_reason, _status), do: [data: [{~c"State", :redacted}]]
-
   @impl GenServer
   def terminate(_reason, state) do
     workers =
@@ -605,14 +596,6 @@ defmodule PtcRunner.Kernel.ViewerReplBackend do
 
   defp cancel_timer(timer) when is_reference(timer), do: Process.cancel_timer(timer)
   defp cancel_timer(_timer), do: false
-
-  defp redact_status(status) do
-    Map.new(status, fn
-      {key, _value} when key in [:state, :message, :reason] -> {key, :redacted}
-      {:log, _value} -> {:log, []}
-      key_value -> key_value
-    end)
-  end
 
   defp call(%__MODULE__{pid: pid, token: token}, request, timeout \\ 5_000) do
     GenServer.call(pid, {token, request}, timeout)

--- a/ptc_viewer/lib/ptc_viewer/inspection_store.ex
+++ b/ptc_viewer/lib/ptc_viewer/inspection_store.ex
@@ -3,6 +3,8 @@ defmodule PtcViewer.InspectionStore do
 
   use GenServer
 
+  alias PtcViewer.OwnerStatusRedaction
+
   def start(source), do: GenServer.start(__MODULE__, source)
   def attach(store, owner), do: GenServer.call(store, {:attach, owner})
   def fetch(store), do: GenServer.call(store, :fetch)
@@ -31,19 +33,11 @@ defmodule PtcViewer.InspectionStore do
 
   if {:format_status, 1} in GenServer.behaviour_info(:callbacks) do
     @impl GenServer
-    def format_status(status), do: redact_status(status)
+    def format_status(status), do: OwnerStatusRedaction.format(status)
   else
-    def format_status(status), do: redact_status(status)
+    def format_status(status), do: OwnerStatusRedaction.format(status)
   end
 
   @impl GenServer
-  def format_status(_reason, _status), do: [data: [{~c"State", :redacted}]]
-
-  defp redact_status(status) do
-    Map.new(status, fn
-      {key, _value} when key in [:state, :message, :reason] -> {key, :redacted}
-      {:log, _value} -> {:log, []}
-      key_value -> key_value
-    end)
-  end
+  def format_status(reason, status), do: OwnerStatusRedaction.format(reason, status)
 end

--- a/ptc_viewer/lib/ptc_viewer/owner_status_redaction.ex
+++ b/ptc_viewer/lib/ptc_viewer/owner_status_redaction.ex
@@ -1,0 +1,10 @@
+defmodule PtcViewer.OwnerStatusRedaction do
+  @moduledoc false
+
+  @spec format(term()) :: map()
+  def format(_status),
+    do: %{state: :redacted, message: :redacted, reason: :redacted, log: []}
+
+  @spec format(term(), term()) :: keyword()
+  def format(_reason, _status), do: [data: [{~c"State", :redacted}]]
+end

--- a/ptc_viewer/lib/ptc_viewer/repl_store.ex
+++ b/ptc_viewer/lib/ptc_viewer/repl_store.ex
@@ -11,6 +11,8 @@ defmodule PtcViewer.ReplStore do
 
   use GenServer
 
+  alias PtcViewer.OwnerStatusRedaction
+
   @operation_timeout_ms 25_000
   @short_timeout_ms 2_000
   @recovery_retry_ms 1_000
@@ -288,13 +290,13 @@ defmodule PtcViewer.ReplStore do
 
   if {:format_status, 1} in GenServer.behaviour_info(:callbacks) do
     @impl GenServer
-    def format_status(status), do: redact_status(status)
+    def format_status(status), do: OwnerStatusRedaction.format(status)
   else
-    def format_status(status), do: redact_status(status)
+    def format_status(status), do: OwnerStatusRedaction.format(status)
   end
 
   @impl GenServer
-  def format_status(_reason, _status), do: [data: [{~c"State", :redacted}]]
+  def format_status(reason, status), do: OwnerStatusRedaction.format(reason, status)
 
   @impl GenServer
   def terminate(_reason, state) do
@@ -1100,14 +1102,6 @@ defmodule PtcViewer.ReplStore do
   end
 
   defp authorize_nonce(_actual, _expected), do: {:error, :forbidden_request}
-
-  defp redact_status(status) do
-    Map.new(status, fn
-      {key, _value} when key in [:state, :message, :reason] -> {key, :redacted}
-      {:log, _value} -> {:log, []}
-      key_value -> key_value
-    end)
-  end
 
   defp call(store, request) do
     GenServer.call(store, request, :infinity)

--- a/ptc_viewer/lib/ptc_viewer/server.ex
+++ b/ptc_viewer/lib/ptc_viewer/server.ex
@@ -3,6 +3,8 @@ defmodule PtcViewer.Server do
 
   use GenServer
 
+  alias PtcViewer.OwnerStatusRedaction
+
   alias PtcViewer.InspectionStore
   alias PtcViewer.LiveSecurity
   alias PtcViewer.ReplConnection
@@ -225,13 +227,13 @@ defmodule PtcViewer.Server do
 
   if {:format_status, 1} in GenServer.behaviour_info(:callbacks) do
     @impl GenServer
-    def format_status(status), do: redact_status(status)
+    def format_status(status), do: OwnerStatusRedaction.format(status)
   else
-    def format_status(status), do: redact_status(status)
+    def format_status(status), do: OwnerStatusRedaction.format(status)
   end
 
   @impl GenServer
-  def format_status(_reason, _status), do: [data: [{~c"State", :redacted}]]
+  def format_status(reason, status), do: OwnerStatusRedaction.format(reason, status)
 
   @impl GenServer
   def terminate(_reason, state) do
@@ -447,13 +449,5 @@ defmodule PtcViewer.Server do
     end)
 
     :ok
-  end
-
-  defp redact_status(status) do
-    Map.new(status, fn
-      {key, _value} when key in [:state, :message, :reason] -> {key, :redacted}
-      {:log, _value} -> {:log, []}
-      key_value -> key_value
-    end)
   end
 end

--- a/ptc_viewer/test/ptc_viewer/owner_status_redaction_test.exs
+++ b/ptc_viewer/test/ptc_viewer/owner_status_redaction_test.exs
@@ -1,0 +1,26 @@
+defmodule PtcViewer.OwnerStatusRedactionTest do
+  use ExUnit.Case, async: true
+
+  alias PtcViewer.OwnerStatusRedaction
+
+  test "both projections discard every supplied status field" do
+    status = %{
+      state: "private-state",
+      authority: "private-authority",
+      message: "private-message",
+      reason: "private-reason",
+      log: ["private-log"],
+      unexpected_private_field: "private-extra"
+    }
+
+    assert OwnerStatusRedaction.format(status) == %{
+             state: :redacted,
+             message: :redacted,
+             reason: :redacted,
+             log: []
+           }
+
+    assert OwnerStatusRedaction.format(:terminate, [[], status]) ==
+             [data: [{~c"State", :redacted}]]
+  end
+end

--- a/test/ptc_runner/kernel/execution_session_owner_privacy_test.exs
+++ b/test/ptc_runner/kernel/execution_session_owner_privacy_test.exs
@@ -43,19 +43,20 @@ defmodule PtcRunner.Kernel.ExecutionSessionOwnerPrivacyTest do
     assert inspect(status) =~ "redacted"
   end
 
-  test "crash-report projections redact state, message, reason, and log" do
+  test "both status callbacks return closed redacted projections" do
     fixture = provider_fixture()
     owner = own_execution(fixture)
     state = :sys.get_state(ExecutionSessionOwner.pid(owner))
 
-    assert %{state: :redacted, message: :redacted, reason: :redacted, log: []} =
-             ExecutionSessionOwner.format_status(%{
-               state: state,
-               message:
-                 {:"$gen_call", {self(), make_ref()}, {:resource, :put, :memory, @credential}},
-               reason: {:badmatch, @host_secret},
-               log: [{:error, @authorization_url}]
-             })
+    assert ExecutionSessionOwner.format_status(%{
+             state: state,
+             authority: @credential,
+             message:
+               {:"$gen_call", {self(), make_ref()}, {:resource, :put, :memory, @credential}},
+             reason: {:badmatch, @host_secret},
+             log: [{:error, @authorization_url}],
+             unexpected_private_field: @host_secret
+           }) == %{state: :redacted, message: :redacted, reason: :redacted, log: []}
 
     assert ExecutionSessionOwner.format_status(:terminate, [[], state]) ==
              [data: [{~c"State", :redacted}]]


### PR DESCRIPTION
## Summary

- migrate the remaining Kernel owner callbacks to `PtcRunner.Kernel.OwnerStatusRedaction`
- enforce closed status projections for the standalone Viewer owners through a shared function helper
- strengthen direct privacy coverage for both callback arities and remove the resolved duplication baseline entries

## Verification

- focused Kernel privacy tests (11 passed)
- focused Viewer owner/server/REPL tests (28 passed)
- `scripts/duplication_gate.sh check`
- `mix precommit`
- two independent Codex review passes; final follow-up reported no findings

## Agent retrospective

The independent review exposed the separately compiled Viewer as a parallel owner-status boundary outside the root duplication scan. Its full suite also has 15 JavaScript-rendering tests that could not run because `node` is absent in this worker; all 110 BEAM-only tests and the 28 focused affected tests passed. Consider making the Viewer gate report the Node prerequisite more explicitly.

Closes #1717