### PR TITLE
fix(worktree): initialize Linux checkouts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,10 +122,13 @@ how it was verified.
 Never start work in the shared checkout — create a worktree before the first
 edit, even for a plan-only document. `scripts/worktree.sh new <branch> [issue]`
 branches from `origin/main`, and with an issue number claims it: assign,
-comment, refuse one already taken. `scripts/worktree.sh gc` removes worktrees
-merged into `origin/main` that are clean and a day idle (`--yes` to act); it
-never deletes a branch, because the branch is the artifact and the checkout is
-a rebuildable cache. Run it before creating a new one.
+comment, refuse one already taken. It also seeds and initializes the worktree:
+install shared hooks, install the pinned `mise` toolchain, fetch dependencies,
+and compile. Use `scripts/worktree.sh init [<dir>]` to repair or initialize an
+existing checkout. `scripts/worktree.sh gc` removes worktrees merged into
+`origin/main` that are clean and a day idle (`--yes` to act); it never deletes
+a branch, because the branch is the artifact and the checkout is a rebuildable
+cache. Run it before creating a new one.
 
 Setting up a fresh clone or worktree — toolchain, dependencies, git hooks,
 Dialyzer PLT, and the local MCP E2E server — is covered once in the
@@ -214,6 +217,11 @@ what is specific to running in the Cloud VM.
   a non-interactive script that is *not* sourced from `~/.bashrc`, prefix
   commands with `~/.local/bin/mise exec -- …` (for example
   `~/.local/bin/mise exec -- mix test`) so the pinned tools resolve.
+- **Cloud shells default to a group-writable umask.** `scripts/worktree.sh init`
+  removes unsafe write permissions from existing checkout directories, but a
+  child script cannot change its caller's umask. Prefix later build and test
+  commands with `umask 0022;` so temporary directories also satisfy private
+  destination safety checks.
 - **Reinstalling deps does not rebuild.** The startup update script only runs
   `mix deps.get`; run `mix compile` yourself after pulling changes or editing
   `mix.exs`/`mix.lock`/prelude sources. The bundled native launcher's C binary

--- a/docs/maintainers/development-setup.md
+++ b/docs/maintainers/development-setup.md
@@ -9,8 +9,10 @@ forget.
 
 ## Toolchain and dependencies
 
-Tool versions are pinned in `mise.toml`. From a new clone or worktree, install
-the toolchain and dependencies before running tests:
+Tool versions are pinned in `mise.toml`. `scripts/worktree.sh new` performs the
+commands below automatically for a new worktree. From a new clone, or to repair
+a partially initialized checkout, run `scripts/worktree.sh init`; its
+equivalent manual sequence is:
 
 ```bash
 mise install
@@ -44,10 +46,19 @@ The focused tests use only a loopback raw HTTP fixture and no credentials.
 ## Worktree seeding
 
 `scripts/worktree.sh new` seeds a fresh worktree with the main checkout's
-`deps/`, `_build/`, and `priv/plts/` (root, Viewer, and launcher) so the
-commands above become incremental instead of cold. It prints one line per
-artifact saying whether it was seeded or why not — copy skipped, source not
-built, already present, or pinned by a file that differs from the main
+`deps/`, `_build/`, and `priv/plts/` (root, Viewer, and launcher), then runs
+`scripts/worktree.sh init` so the checkout is ready for tests. Initialization
+installs the shared Git hooks, installs the pinned toolchain through `mise`,
+fetches root/Viewer/launcher dependencies, and compiles the root project. It
+removes unsafe write permissions from checkout directories and uses a `0022`
+umask so Linux cloud agents do not retain or create group-writable directory
+trees that fail private-destination safety tests. Pass `new --no-init` only
+when deliberately deferring that work, then run `scripts/worktree.sh init
+<dir>` before editing or testing.
+
+Seeding makes initialization incremental instead of cold. It prints one line
+per artifact saying whether it was seeded or why not — copy skipped, source
+not built, already present, or pinned by a file that differs from the main
 checkout's copy.
 
 That last key is per artifact, not per seed: every artifact is pinned by
@@ -103,8 +114,14 @@ scripts/worktree.sh seed <dir>    # seed another worktree
 
 ## Git hooks
 
-Run `./scripts/install-hooks.sh` once per clone. Linked worktrees share the
-clone's installed hook wrappers, so they do not need to reinstall them.
+`scripts/worktree.sh new` and `scripts/worktree.sh init` run
+`./scripts/install-hooks.sh` automatically. Linked worktrees share the clone's
+installed hook wrappers, so this is idempotent and also repairs a clone whose
+wrappers are absent. Run `./scripts/install-hooks.sh` directly only when
+setting up a clone without using the worktree lifecycle script. The wrappers
+set a `0022` umask and, when `mix` is absent from Git's non-interactive `PATH`,
+run the tracked hooks through the same `mise` resolution used by worktree
+initialization.
 
 The script also registers the merge driver for
 `priv/semantic_build_projection.json`. That projection is derived, its hashes

--- a/scripts/hook-runtime.sh
+++ b/scripts/hook-runtime.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# Run a tracked hook with the pinned toolchain even when Git starts it from a
+# non-interactive shell where mise has not amended PATH. The umask applies to
+# the hook and every gate it launches, including ExUnit temporary directories.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/mise-runtime.sh
+source "$SCRIPT_DIR/mise-runtime.sh"
+
+TARGET="${1:-}"
+[ -n "$TARGET" ] || {
+  echo "❌ Hook runtime requires a tracked hook path" >&2
+  exit 1
+}
+shift
+
+umask 0022
+
+if command -v mix >/dev/null 2>&1; then
+  exec "$TARGET" "$@"
+fi
+
+if ! MISE_EXECUTABLE="$(ptc_mise_executable)"; then
+  echo "❌ mix is not on PATH and mise could not be found" >&2
+  echo "   Run scripts/worktree.sh init or set MISE_BIN before committing." >&2
+  exit 1
+fi
+
+exec "$MISE_EXECUTABLE" exec -- "$TARGET" "$@"

--- a/scripts/mise-runtime.sh
+++ b/scripts/mise-runtime.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# Shared non-interactive mise resolution for repository lifecycle scripts and
+# installed Git-hook wrappers.
+
+ptc_mise_executable() {
+  if [ -n "${MISE_BIN:-}" ] && [ -x "$MISE_BIN" ]; then
+    printf '%s' "$MISE_BIN"
+  elif command -v mise >/dev/null 2>&1; then
+    command -v mise
+  elif [ -n "${HOME:-}" ] && [ -x "$HOME/.local/bin/mise" ]; then
+    printf '%s' "$HOME/.local/bin/mise"
+  else
+    return 1
+  fi
+}

--- a/scripts/pre-commit.template
+++ b/scripts/pre-commit.template
@@ -2,4 +2,5 @@
 
 # Compatibility entry point for clones installed with scripts/install-hooks.sh.
 # Keep the tracked implementation in one place.
-exec "$(git rev-parse --show-toplevel)/.githooks/pre-commit" "$@"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+exec bash "$REPO_ROOT/scripts/hook-runtime.sh" "$REPO_ROOT/.githooks/pre-commit" "$@"

--- a/scripts/pre-push
+++ b/scripts/pre-push
@@ -2,4 +2,5 @@
 
 # Compatibility entry point for clones installed with scripts/install-hooks.sh.
 # Keep the tracked implementation in one place.
-exec "$(git rev-parse --show-toplevel)/.githooks/pre-push" "$@"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+exec bash "$REPO_ROOT/scripts/hook-runtime.sh" "$REPO_ROOT/.githooks/pre-push" "$@"

--- a/scripts/worktree.sh
+++ b/scripts/worktree.sh
@@ -3,7 +3,8 @@
 # Worktree lifecycle.
 #
 #   scripts/worktree.sh gc [--yes] [--no-fetch] [--no-issues]
-#   scripts/worktree.sh new <branch> [issue-number]
+#   scripts/worktree.sh new [--no-init] <branch> [issue-number]
+#   scripts/worktree.sh init [<dir>]
 #   scripts/worktree.sh seed [<dir>]
 #
 # A worktree is a cache, not an artifact. `git worktree remove` never deletes
@@ -17,6 +18,10 @@
 # as well as the ones you made by hand.
 
 set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/mise-runtime.sh
+source "$SCRIPT_DIR/mise-runtime.sh"
 
 BASE="origin/main"
 DO_REMOVE=0
@@ -33,8 +38,42 @@ die() {
 mtime_of() {
   case "$(uname -s)" in
     Darwin) stat -f %m "$1" 2>/dev/null || printf '0' ;;
-    *) stat -c %m "$1" 2>/dev/null || printf '0' ;;
+    Linux) stat -c %Y "$1" 2>/dev/null || printf '0' ;;
+    *)
+      stat -c %Y "$1" 2>/dev/null || stat -f %m "$1" 2>/dev/null || printf '0'
+      ;;
   esac
+}
+
+initialize_worktree() {
+  local dst="$1" mise_bin
+
+  [ -d "$dst" ] || die "$dst is not a directory"
+  [ -f "$dst/mise.toml" ] || die "$dst does not look like a PtcRunner checkout"
+  mise_bin="$(ptc_mise_executable)" ||
+    die "mise is required to initialize a worktree; install it or set MISE_BIN"
+  find "$dst" -type d -exec chmod go-w {} + ||
+    die "could not remove unsafe directory permissions from $dst"
+
+  echo ""
+  echo "🔧 Initializing $dst"
+
+  (
+    cd "$dst"
+    # Cloud VMs commonly inherit a group-writable umask. Checkout directories
+    # were normalized above; create later artifacts with the permissions
+    # expected by local and GitHub private-destination safety gates too.
+    umask 0022
+    bash scripts/install-hooks.sh
+    "$mise_bin" install
+    "$mise_bin" exec -- mix deps.get
+    (cd ptc_viewer && "$mise_bin" exec -- mix deps.get)
+    (cd ptc_runner_launcher && "$mise_bin" exec -- mix deps.get)
+    "$mise_bin" exec -- mix compile
+  )
+
+  echo ""
+  echo "✅ Worktree initialized: $dst"
 }
 
 # A worktree stopped part-way through an operation is not idle, however clean
@@ -334,6 +373,14 @@ cmd_seed() {
   seed_worktree "$main_wt" "$dst"
 }
 
+cmd_init() {
+  local dst="${1:-$(pwd -P)}"
+
+  [ "$#" -le 1 ] || die "usage: scripts/worktree.sh init [<dir>]"
+  dst="$(cd "$dst" 2>/dev/null && pwd -P)" || die "$dst is not a directory"
+  initialize_worktree "$dst"
+}
+
 cmd_gc() {
   local main_wt current_wt path head branch flags dirt
   local reapable="" held="" unmerged="" count_reapable=0
@@ -456,9 +503,20 @@ cmd_gc() {
 }
 
 cmd_new() {
-  local branch="${1:-}" issue="${2:-}" main_wt slug dir assignees state
+  local do_init=1 branch issue main_wt slug dir assignees state
 
-  [ -n "$branch" ] || die "usage: scripts/worktree.sh new <branch> [issue-number]"
+  if [ "${1:-}" = "--no-init" ]; then
+    do_init=0
+    shift
+  fi
+
+  branch="${1:-}"
+  issue="${2:-}"
+
+  [ -n "$branch" ] ||
+    die "usage: scripts/worktree.sh new [--no-init] <branch> [issue-number]"
+  [ "$#" -le 2 ] ||
+    die "usage: scripts/worktree.sh new [--no-init] <branch> [issue-number]"
 
   main_wt="$(main_worktree)"
   slug="$(printf '%s' "$branch" | tr '/' '-')"
@@ -499,7 +557,12 @@ Assignment here is advisory, not a lock. If this claim has no commits on \`${bra
 
   echo ""
   echo "📁 $dir"
-  echo "   Fresh worktrees need the setup in AGENTS.md before tests will run."
+
+  if [ "$do_init" = "1" ]; then
+    initialize_worktree "$dir"
+  else
+    echo "   Initialization skipped; run scripts/worktree.sh init \"$dir\" before testing."
+  fi
 }
 
 usage() {
@@ -510,13 +573,22 @@ scripts/worktree.sh gc [--yes] [--idle-hours N] [--no-fetch] [--no-issues]
     With --yes, remove them; branches are always kept. --quiet prints only a
     one-line count, and nothing at all when there is nothing to reclaim.
 
-scripts/worktree.sh new <branch> [issue-number]
+scripts/worktree.sh new [--no-init] <branch> [issue-number]
     Create a worktree beside the main checkout, branched from origin/main,
     and seed it with the main checkout's deps, _build, and project-PLT
     artifacts when toolchain and lockfiles match (Mix revalidates them, so
     a stale seed only costs a rebuild). With an issue number, verify it is
     open and unassigned, then assign it and post a claim comment. The branch
-    name must contain the issue number.
+    name must contain the issue number. By default, install the shared Git
+    hooks, install the pinned mise toolchain, fetch root/Viewer/launcher
+    dependencies, and compile the root project. --no-init leaves those steps
+    for a later `scripts/worktree.sh init`.
+
+scripts/worktree.sh init [<dir>]
+    Initialize an existing checkout (default: the current directory): install
+    the clone-shared Git hooks, install the pinned mise toolchain, fetch all
+    three Mix projects' dependencies, and compile the root project. Safe to
+    re-run. Finds mise on PATH, at $HOME/.local/bin/mise, or via MISE_BIN.
 
 scripts/worktree.sh seed [<dir>]
     Seed an existing worktree (default: the current one) from the main
@@ -549,6 +621,7 @@ main() {
       cmd_gc
       ;;
     new) cmd_new "$@" ;;
+    init) cmd_init "$@" ;;
     seed) cmd_seed "$@" ;;
     ""| -h | --help | help) usage ;;
     *)

--- a/test/githooks/install_hooks_test.exs
+++ b/test/githooks/install_hooks_test.exs
@@ -47,12 +47,63 @@ defmodule PtcRunner.GitHooks.InstallHooksTest do
     assert git(repo, ["config", "--get", "merge.ptc-generated.driver"]) == "true"
   end
 
+  @tag :tmp_dir
+  test "installed hooks use mise and a safe umask in non-interactive shells", %{tmp_dir: dir} do
+    repo = init_repo(dir)
+    bin = Path.join(dir, "bin")
+    log = Path.join(dir, "hook.log")
+    File.mkdir_p!(bin)
+
+    write_executable!(
+      Path.join(bin, "mise"),
+      ~S"""
+      #!/usr/bin/env bash
+      printf 'mise|%s\n' "$*" >> "$PTC_HOOK_LOG"
+      shift
+      [ "${1:-}" = "--" ] && shift
+      exec "$@"
+      """
+    )
+
+    tracked_hook = Path.join([repo, ".githooks", "pre-commit"])
+
+    write_executable!(
+      tracked_hook,
+      ~S"""
+      #!/usr/bin/env bash
+      printf 'hook|%s\n' "$(umask)" >> "$PTC_HOOK_LOG"
+      """
+    )
+
+    {_, 0} = install(repo)
+
+    {output, status} =
+      System.cmd(Path.join([repo, ".git", "hooks", "pre-commit"]), [],
+        cd: repo,
+        env:
+          GitEnv.clear(
+            HOME: dir,
+            PATH: bin <> ":/usr/bin:/bin",
+            PTC_HOOK_LOG: log
+          ),
+        stderr_to_stdout: true
+      )
+
+    assert status == 0, output
+
+    assert log |> File.read!() |> String.split("\n", trim: true) == [
+             "mise|exec -- #{tracked_hook}",
+             "hook|0022"
+           ]
+  end
+
   defp init_repo(dir) do
     repo = Path.join(dir, "clone")
     File.mkdir_p!(Path.join(repo, "scripts"))
     {_, 0} = System.cmd("git", ["init", "-q", "."], cd: repo, env: @git_env)
 
-    for script <- ~w(install-hooks.sh pre-commit.template pre-push) do
+    for script <-
+          ~w(install-hooks.sh pre-commit.template pre-push hook-runtime.sh mise-runtime.sh) do
       File.cp!(Path.join([@repo_root, "scripts", script]), Path.join([repo, "scripts", script]))
     end
 
@@ -70,5 +121,11 @@ defmodule PtcRunner.GitHooks.InstallHooksTest do
   defp git(repo, args) do
     {output, _status} = System.cmd("git", args, cd: repo, env: @git_env, stderr_to_stdout: true)
     String.trim(output)
+  end
+
+  defp write_executable!(path, contents) do
+    File.mkdir_p!(Path.dirname(path))
+    File.write!(path, contents)
+    File.chmod!(path, 0o755)
   end
 end

--- a/test/ptc_runner/kernel/bounded_worker_test.exs
+++ b/test/ptc_runner/kernel/bounded_worker_test.exs
@@ -257,7 +257,11 @@ defmodule PtcRunner.Kernel.BoundedWorkerTest do
             end
           end,
           timeout_ms: 60_000,
-          max_heap_words: 10_000,
+          # This case isolates caller cancellation, not heap enforcement. A
+          # 10k-word worker can hit its heap limit before the test installs
+          # its monitor under full-suite scheduler pressure and report
+          # `:noproc` instead of the cancellation reason being asserted.
+          max_heap_words: 100_000,
           cancel_with_caller: true
         )
       end)

--- a/test/scripts/worktree_seed_test.exs
+++ b/test/scripts/worktree_seed_test.exs
@@ -175,6 +175,63 @@ defmodule PtcRunner.Scripts.WorktreeSeedTest do
     assert output =~ "refusing to seed the main checkout from itself"
   end
 
+  test "gc reads worktree activity timestamps portably" do
+    %{main: main, worktree: worktree} = repo_with_worktree()
+    git!(main, ["update-ref", "refs/remotes/origin/main", "HEAD"])
+
+    {output, status} =
+      System.cmd(
+        "bash",
+        [@script, "gc", "--no-fetch", "--no-issues", "--idle-hours", "0"],
+        cd: main,
+        env: @git_env,
+        stderr_to_stdout: true
+      )
+
+    assert status == 0, output
+    refute output =~ "integer expression expected"
+    assert output =~ "Reclaimable"
+    assert output =~ worktree
+  end
+
+  test "new initializes the worktree through mise by default" do
+    %{main: main, log: log, path: path, worktree: worktree} = repo_with_origin()
+
+    {output, status} =
+      System.cmd(
+        "bash",
+        [
+          "-c",
+          ~S|umask 0002; exec bash "$1" new test/linux-bootstrap|,
+          "worktree-bootstrap-test",
+          @script
+        ],
+        cd: main,
+        env:
+          GitEnv.clear(
+            PATH: path <> ":" <> System.fetch_env!("PATH"),
+            PTC_INIT_LOG: log
+          ),
+        stderr_to_stdout: true
+      )
+
+    assert status == 0, output
+    assert output =~ "Worktree initialized: #{worktree}"
+
+    for directory <- [worktree, Path.join(worktree, "ptc_viewer")] do
+      assert Bitwise.band(File.stat!(directory).mode, 0o022) == 0
+    end
+
+    assert log |> File.read!() |> String.split("\n", trim: true) == [
+             "hooks|#{worktree}|0022",
+             "mise|install|#{worktree}|0022",
+             "mise|exec -- mix deps.get|#{worktree}|0022",
+             "mise|exec -- mix deps.get|#{worktree}/ptc_viewer|0022",
+             "mise|exec -- mix deps.get|#{worktree}/ptc_runner_launcher|0022",
+             "mise|exec -- mix compile|#{worktree}|0022"
+           ]
+  end
+
   defp repo_with_worktree do
     root =
       Path.join(
@@ -201,6 +258,55 @@ defmodule PtcRunner.Scripts.WorktreeSeedTest do
     %{main: main, worktree: worktree}
   end
 
+  defp repo_with_origin do
+    root =
+      Path.join(
+        System.tmp_dir!(),
+        "ptc-worktree-new-#{System.unique_integer([:positive, :monotonic])}"
+      )
+
+    main = Path.join(root, "main checkout")
+    remote = Path.join(root, "origin.git")
+    bin = Path.join(root, "bin")
+    log = Path.join(root, "init.log")
+    worktree = main <> "-test-linux-bootstrap"
+    File.mkdir_p!(main)
+    File.mkdir_p!(bin)
+    on_exit(fn -> File.rm_rf!(root) end)
+
+    git!(main, ["init", "--quiet"])
+    git!(main, ["config", "user.email", "seed@example.test"])
+    git!(main, ["config", "user.name", "Seed Test"])
+
+    Enum.each(@key_files, &write!(main, &1, "pinned\n"))
+
+    write_executable!(
+      main,
+      "scripts/install-hooks.sh",
+      ~S"""
+      #!/usr/bin/env bash
+      printf 'hooks|%s|%s\n' "$PWD" "$(umask)" >> "$PTC_INIT_LOG"
+      """
+    )
+
+    write_executable!(
+      root,
+      "bin/mise",
+      ~S"""
+      #!/usr/bin/env bash
+      printf 'mise|%s|%s|%s\n' "$*" "$PWD" "$(umask)" >> "$PTC_INIT_LOG"
+      """
+    )
+
+    git!(main, ["add", "."])
+    git!(main, ["commit", "--quiet", "-m", "base"])
+    git!(root, ["init", "--quiet", "--bare", remote])
+    git!(main, ["remote", "add", "origin", remote])
+    git!(main, ["push", "--quiet", "origin", "HEAD:main"])
+
+    %{main: main, log: log, path: bin, worktree: worktree}
+  end
+
   defp seed(main, worktree) do
     System.cmd("bash", [@script, "seed", worktree],
       cd: main,
@@ -217,6 +323,11 @@ defmodule PtcRunner.Scripts.WorktreeSeedTest do
     full_path = Path.join(repo, path)
     File.mkdir_p!(Path.dirname(full_path))
     File.write!(full_path, contents)
+  end
+
+  defp write_executable!(repo, path, contents) do
+    write!(repo, path, contents)
+    File.chmod!(Path.join(repo, path), 0o755)
   end
 
   defp git!(repo, args) do


### PR DESCRIPTION
## Summary

- make worktree garbage collection portable across GNU/Linux and macOS
- initialize new worktrees by default with mise, dependencies, hooks, compilation, and safe directory permissions
- add an explicit init command and a --no-init escape hatch
- make installed Git hooks resolve the pinned toolchain in noninteractive Linux shells
- document the Linux bootstrap and umask behavior
- stabilize the caller-cancellation test exposed under full-suite load

## Verification

- focused worktree and hook lifecycle tests
- caller-cancellation regression repeated 100 times with the reported seed
- mix precommit
- MIX_ENV=dev mix docs --warnings-as-errors
- scripts/ci/core-tests.sh (7,643 passed, 388 excluded)
- full pre-push hook: documentation, core tests, static analysis and Dialyzer, release, Viewer, and launcher validation