### PR TITLE
chore(agents): configure PtcManager workspace

### DIFF
--- a/.ptc-manager.yml
+++ b/.ptc-manager.yml
@@ -1,0 +1,4 @@
+version: 1
+bootstrap:
+  command: ./scripts/ptc/bootstrap
+  timeout_minutes: 30

--- a/scripts/ptc/bootstrap
+++ b/scripts/ptc/bootstrap
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Herdr creates the worktree. Reuse compatible build artifacts from the main
+# checkout, then let PtcRunner's existing worktree initializer install hooks,
+# fetch dependencies, and validate the pinned toolchain before an agent starts.
+./scripts/worktree.sh seed .
+./scripts/worktree.sh init .

--- a/scripts/worktree.sh
+++ b/scripts/worktree.sh
@@ -64,6 +64,11 @@ initialize_worktree() {
     # were normalized above; create later artifacts with the permissions
     # expected by local and GitHub private-destination safety gates too.
     umask 0022
+    # The caller has already chosen to execute this repository-owned lifecycle
+    # script. Trust the same checked-in toolchain config explicitly so fresh,
+    # path-unique Herdr worktrees do not stop at mise's interactive trust gate.
+    "$mise_bin" trust --yes "$dst/mise.toml" >/dev/null ||
+      die "could not trust the pinned mise configuration in $dst"
     bash scripts/install-hooks.sh
     "$mise_bin" install
     "$mise_bin" exec -- mix deps.get

--- a/test/scripts/worktree_seed_test.exs
+++ b/test/scripts/worktree_seed_test.exs
@@ -223,6 +223,7 @@ defmodule PtcRunner.Scripts.WorktreeSeedTest do
     end
 
     assert log |> File.read!() |> String.split("\n", trim: true) == [
+             "mise|trust --yes #{worktree}/mise.toml|#{worktree}|0022",
              "hooks|#{worktree}|0022",
              "mise|install|#{worktree}|0022",
              "mise|exec -- mix deps.get|#{worktree}|0022",


### PR DESCRIPTION
## Summary

- add the strict repository-owned `.ptc-manager.yml` bootstrap contract
- prepare Herdr worktrees through PtcRunner’s existing seed and initialization lifecycle
- trust the checked-in mise configuration non-interactively inside the normalized worktree umask
- cover the new mise trust step in the worktree lifecycle integration test

PtcManager uses direct agent publication for this repository, so the optional broker verification section is intentionally omitted. Repository hooks and GitHub CI remain the publication and merge gates.

## Validation

- `mix precommit`
- `mix test test/scripts/worktree_seed_test.exs:197`
- local Herdr exact-commit workspace canary: worktree creation 1.1s, repository setup 50.0s
- full pre-push gate: 7,716 core tests plus Dialyzer/static analysis, release, Viewer, launcher, and documentation validation