### PR TITLE
chore(hooks): coordinate managed pre-push gates

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -18,6 +18,16 @@
 #
 set -e
 
+# A PtcManager-managed agent may reach the expensive verification gates through
+# an ordinary `git push`. Coordinate the whole hook once so every child gate is
+# covered by the same operation lease and process-tree memory boundary. Local
+# clones and CI do not receive the managed context, so their hook is unchanged.
+if [ -n "${PTC_MANAGED_OPERATION_CONTEXT:-}" ] &&
+   [ -z "${PTC_OPERATION_ACTIVE:-}" ]; then
+  : "${PTC_OPERATION_WRAPPER:?managed pre-push requires PTC_OPERATION_WRAPPER}"
+  exec "$PTC_OPERATION_WRAPPER" run --label verify -- "$0" "$@"
+fi
+
 HOOK_REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 run_docs_gate() {

--- a/test/githooks/pre_push_test.exs
+++ b/test/githooks/pre_push_test.exs
@@ -8,6 +8,56 @@ defmodule PtcRunner.GitHooks.PrePushTest do
   @executable_guides Path.expand("../support/executable_guides.txt", __DIR__)
   @git_env GitEnv.clear()
 
+  test "managed pushes coordinate the complete hook exactly once" do
+    %{repo: repo, path: path} = git_repo_with_change("docs/plans/managed-hook.md")
+    operation_marker = install_operation_wrapper!(path)
+
+    {output, status} =
+      run_hook(repo, path, [
+        {"PTC_MANAGED_OPERATION_CONTEXT", "/managed/context.json"},
+        {"PTC_OPERATION_WRAPPER", Path.join(fake_bin(path), "ptc-operation")},
+        {"OPERATION_MARKER", operation_marker}
+      ])
+
+    assert status == 0, output
+    assert output =~ "Plan-only push, skipping full pre-push gate"
+
+    assert File.read!(operation_marker) |> String.split("\n", trim: true) ==
+             ["run --label verify -- #{Path.join(repo, ".githooks/pre-push")}"]
+  end
+
+  test "an active operation does not recursively coordinate the hook" do
+    %{repo: repo, path: path} = git_repo_with_change("docs/plans/nested-hook.md")
+    operation_marker = install_operation_wrapper!(path)
+
+    {output, status} =
+      run_hook(repo, path, [
+        {"PTC_MANAGED_OPERATION_CONTEXT", "/managed/context.json"},
+        {"PTC_OPERATION_WRAPPER", Path.join(fake_bin(path), "ptc-operation")},
+        {"PTC_OPERATION_ACTIVE", "1"},
+        {"OPERATION_MARKER", operation_marker}
+      ])
+
+    assert status == 0, output
+    assert output =~ "Plan-only push, skipping full pre-push gate"
+    refute File.exists?(operation_marker)
+  end
+
+  test "an unmanaged Mac push ignores an available operation wrapper" do
+    %{repo: repo, path: path} = git_repo_with_change("docs/plans/local-hook.md")
+    operation_marker = install_operation_wrapper!(path)
+
+    {output, status} =
+      run_hook(repo, path, [
+        {"PTC_OPERATION_WRAPPER", Path.join(fake_bin(path), "ptc-operation")},
+        {"OPERATION_MARKER", operation_marker}
+      ])
+
+    assert status == 0, output
+    assert output =~ "Plan-only push, skipping full pre-push gate"
+    refute File.exists?(operation_marker)
+  end
+
   test "planning-only changes skip the full gate" do
     %{repo: repo, mix_marker: mix_marker, path: path} =
       git_repo_with_change("docs/plans/kernel-notes.md")
@@ -469,6 +519,23 @@ defmodule PtcRunner.GitHooks.PrePushTest do
       stderr_to_stdout: true
     )
   end
+
+  defp install_operation_wrapper!(path) do
+    bin = fake_bin(path)
+    marker = Path.join(Path.dirname(bin), "operation-called")
+
+    write_executable!(Path.join(bin, "ptc-operation"), """
+    #!/bin/sh
+    printf '%s\n' "$*" >> "$OPERATION_MARKER"
+    [ "$1" = "run" ] && [ "$2" = "--label" ] && [ "$3" = "verify" ] && [ "$4" = "--" ]
+    shift 4
+    PTC_OPERATION_ACTIVE=1 exec "$@"
+    """)
+
+    marker
+  end
+
+  defp fake_bin(path), do: path |> String.split(":") |> hd()
 
   defp write_changed_file!(repo, path, contents) do
     full_path = Path.join(repo, path)


### PR DESCRIPTION
## Summary

- run the complete tracked pre-push gate through one PtcManager operation lease when a managed context is present
- preserve the existing direct behavior on Macs and in CI
- reuse an active operation instead of recursively acquiring another slot

## Verification

- `mix test test/githooks/pre_push_test.exs` — 23 passed
- `mix precommit` — passed; duplication baseline unchanged
- verified `git push` gate — 7,723 core tests, static analysis, Dialyzer, release verification, documentation, and 125 Viewer tests passed