### PR TITLE
fix(transcript): correlate repeated generated sources

### DIFF
--- a/docs/maintainers/trace-log-contract.md
+++ b/docs/maintainers/trace-log-contract.md
@@ -481,8 +481,18 @@ Generated programs carry `prelude_calls_available?` and a sorted
 `prelude_calls` list of `{ref, component_id}` entries. Exact
 `prelude_call`/`prelude_component` filters work on both `generated_sources` and
 `turns`. The association between a turn and generated source is explicitly
-`source_match`; duplicate identical sources are marked ambiguous rather than
-given a fabricated causal identity.
+`source_match`. Matching partitions retained tool-call occurrences and
+generated-source records by source. A source can match only an earlier model
+response, and an association is exact only when every complete chronology-
+respecting one-to-one assignment puts that evaluation on the same turn.
+Repeated identical programs are therefore distinct occurrences;
+multiple identical calls in one response retain multiple evaluation records on
+that turn. Delayed evaluation may cross later model requests without losing its
+candidate producer. If the retained occurrence counts differ, or multiple
+complete assignments put an evaluation on different turns, every still-
+possible evaluation retains one chronology-respecting match marked ambiguous,
+rather than being multiplied across candidate turns or given a fabricated
+causal identity.
 
 Private execution errors, generated programs, and effective prelude sources may
 carry a `relationships` list. Each relationship has this closed shape:

--- a/lib/ptc_runner/kernel/conversation_projection.ex
+++ b/lib/ptc_runner/kernel/conversation_projection.ex
@@ -2,27 +2,25 @@ defmodule PtcRunner.Kernel.ConversationProjection do
   @moduledoc false
 
   alias PtcRunner.Kernel.ConversationMessage
+  alias PtcRunner.Kernel.GeneratedSourceAssociation
 
   @spec compile([map()], [map()], map()) :: map()
   def compile(exchanges, programs, trace_facts)
       when is_list(exchanges) and is_list(programs) and is_map(trace_facts) do
     reconstructed = conversation_streams(exchanges)
-    program_counts = Enum.frequencies_by(programs, & &1["source"])
+    association_result = generated_associations(reconstructed.streams, programs)
+    associations = association_result.by_turn
 
     items =
       Enum.flat_map(reconstructed.streams, fn stream ->
         Enum.map(stream["turns"], fn turn ->
           generated =
-            turn["assistant"]
-            |> generated_sources()
-            |> then(fn sources -> Enum.filter(programs, &(&1["source"] in sources)) end)
-            |> Enum.map(fn program ->
+            associations
+            |> Map.get(turn["capability_id"], [])
+            |> Enum.map(fn {program, ambiguous?} ->
               program
               |> Map.put("association", "source_match")
-              |> Map.put(
-                "association_ambiguous?",
-                Map.get(program_counts, program["source"], 0) > 1
-              )
+              |> Map.put("association_ambiguous?", ambiguous?)
             end)
 
           turn
@@ -44,7 +42,9 @@ defmodule PtcRunner.Kernel.ConversationProjection do
         Enum.any?(item["generated"], & &1["association_ambiguous?"])
       end)
 
-    ambiguity_count = length(reconstructed.ambiguous) + source_ambiguity_count
+    ambiguity_count =
+      length(reconstructed.ambiguous) + source_ambiguity_count +
+        association_result.unresolved_count
 
     %{
       items: items,
@@ -180,6 +180,34 @@ defmodule PtcRunner.Kernel.ConversationProjection do
   end
 
   defp generated_sources(_assistant), do: []
+
+  defp generated_associations(streams, programs) do
+    turns =
+      Enum.flat_map(streams, fn stream ->
+        stream["turns"]
+        |> Enum.map(fn turn ->
+          %{
+            id: turn["capability_id"],
+            sequence: turn["response_sequence"],
+            sources: generated_sources(turn["assistant"])
+          }
+        end)
+      end)
+
+    sources =
+      Enum.map(programs, fn program ->
+        %{sequence: program["sequence"] || 0, source: program["source"], record: program}
+      end)
+
+    result = GeneratedSourceAssociation.associate(turns, sources)
+
+    by_turn =
+      Map.new(result.by_turn, fn {turn_id, entries} ->
+        {turn_id, Enum.map(entries, fn {source, ambiguous?} -> {source.record, ambiguous?} end)}
+      end)
+
+    %{by_turn: by_turn, unresolved_count: result.unresolved_count}
+  end
 
   defp initial_stream_state do
     %{nodes: [], streams: %{}, stream_order: [], ambiguous: [], next_stream: 1}

--- a/lib/ptc_runner/kernel/generated_source_association.ex
+++ b/lib/ptc_runner/kernel/generated_source_association.ex
@@ -1,0 +1,154 @@
+defmodule PtcRunner.Kernel.GeneratedSourceAssociation do
+  @moduledoc false
+
+  @type turn :: %{
+          required(:id) => term(),
+          required(:sequence) => integer(),
+          required(:sources) => [term()]
+        }
+
+  @type source :: %{required(:sequence) => integer(), required(:source) => term()}
+
+  @spec associate([turn()], [source()]) :: %{
+          by_turn: %{term() => [{source(), boolean()}]},
+          unresolved_count: non_neg_integer()
+        }
+  def associate(turns, sources) when is_list(turns) and is_list(sources) do
+    occurrences =
+      Enum.flat_map(turns, fn turn ->
+        Enum.map(turn.sources, fn source ->
+          %{turn_id: turn.id, sequence: turn.sequence, source: source}
+        end)
+      end)
+
+    occurrences_by_source = Enum.group_by(occurrences, & &1.source)
+    sources_by_source = Enum.group_by(sources, & &1.source)
+
+    source_keys = Map.keys(occurrences_by_source)
+
+    {by_turn, unresolved_count} =
+      Enum.reduce(source_keys, {%{}, 0}, fn source_key, {associations, unresolved_count} ->
+        matching_occurrences = Map.get(occurrences_by_source, source_key, [])
+
+        first_occurrence_sequence =
+          matching_occurrences |> Enum.min_by(& &1.sequence) |> Map.fetch!(:sequence)
+
+        matching_sources =
+          sources_by_source
+          |> Map.get(source_key, [])
+          |> Enum.filter(&(&1.sequence > first_occurrence_sequence))
+
+        {entries, unresolved} = associate_identity(matching_occurrences, matching_sources)
+
+        {merge_associations(entries, associations), unresolved_count + unresolved}
+      end)
+
+    by_turn =
+      Map.new(by_turn, fn {turn_id, entries} ->
+        {turn_id, Enum.sort_by(entries, fn {source, _ambiguous?} -> source.sequence end)}
+      end)
+
+    %{by_turn: by_turn, unresolved_count: unresolved_count}
+  end
+
+  # Each retained tool-call occurrence and evaluation-source record is one side
+  # of the certification relation. For equal counts, chronological order gives
+  # a canonical one-to-one assignment. Adjacent pairs can exchange producers
+  # exactly when the earlier source follows the later response; those exchanges
+  # form ambiguity components. This is the Ferrers-graph matching test in
+  # O(n log n), without materializing every possible edge.
+  defp associate_identity(occurrences, sources) when length(occurrences) == length(sources) do
+    occurrences = Enum.sort_by(occurrences, & &1.sequence)
+    sources = Enum.sort_by(sources, & &1.sequence)
+
+    if Enum.zip_with(occurrences, sources, &(&2.sequence > &1.sequence)) |> Enum.all?() do
+      {exact_entries(occurrences, sources), 0}
+    else
+      ambiguous_fallback(occurrences, sources)
+    end
+  end
+
+  defp associate_identity(occurrences, sources) do
+    ambiguous_fallback(occurrences, sources)
+  end
+
+  defp exact_entries(occurrences, sources) do
+    max_eligible_indices = max_eligible_indices(occurrences, sources)
+    same_turn_run_ends = same_turn_run_ends(occurrences)
+
+    occurrences
+    |> Enum.zip(sources)
+    |> Enum.zip(max_eligible_indices)
+    |> Enum.with_index()
+    |> Enum.reduce({[], 0, nil}, fn {{{occurrence, source}, max_index}, index},
+                                    {entries, component_start, previous_source} ->
+      component_start =
+        if previous_source && previous_source.sequence > occurrence.sequence,
+          do: component_start,
+          else: index
+
+      ambiguous? = max_index > Map.fetch!(same_turn_run_ends, component_start)
+      entry = {occurrence.turn_id, source, ambiguous?}
+      {[entry | entries], component_start, source}
+    end)
+    |> elem(0)
+    |> Enum.reverse()
+  end
+
+  defp max_eligible_indices(occurrences, sources) do
+    indexed_occurrences = Enum.with_index(occurrences)
+
+    sources
+    |> Enum.map_reduce({indexed_occurrences, -1}, fn source, cursor ->
+      {max_index, cursor} = max_eligible_index(cursor, source.sequence)
+      {max_index, cursor}
+    end)
+    |> elem(0)
+  end
+
+  defp max_eligible_index({[{occurrence, index} | rest], _latest}, source_sequence)
+       when source_sequence > occurrence.sequence,
+       do: max_eligible_index({rest, index}, source_sequence)
+
+  defp max_eligible_index(cursor, _source_sequence), do: {elem(cursor, 1), cursor}
+
+  defp same_turn_run_ends(occurrences) do
+    occurrences
+    |> Enum.with_index()
+    |> Enum.chunk_by(fn {occurrence, _index} -> occurrence.turn_id end)
+    |> Enum.reduce(%{}, fn run, ends ->
+      {_occurrence, last_index} = List.last(run)
+      Enum.reduce(run, ends, fn {_occurrence, index}, acc -> Map.put(acc, index, last_index) end)
+    end)
+  end
+
+  defp ambiguous_fallback(occurrences, sources) do
+    occurrences = Enum.sort_by(occurrences, & &1.sequence)
+
+    {entries, _cursor} =
+      sources
+      |> Enum.sort_by(& &1.sequence)
+      |> Enum.map_reduce({occurrences, nil}, fn source, cursor ->
+        {latest, cursor} = preceding_occurrence(cursor, source.sequence)
+        entry = if latest, do: {latest.turn_id, source, true}
+        {entry, cursor}
+      end)
+
+    entries = Enum.reject(entries, &is_nil/1)
+
+    unresolved_count = length(sources) - length(entries)
+    {entries, unresolved_count}
+  end
+
+  defp preceding_occurrence({[occurrence | rest], _latest}, source_sequence)
+       when source_sequence > occurrence.sequence,
+       do: preceding_occurrence({rest, occurrence}, source_sequence)
+
+  defp preceding_occurrence(cursor, _source_sequence), do: {elem(cursor, 1), cursor}
+
+  defp merge_associations(entries, associations) do
+    Enum.reduce(entries, associations, fn {turn_id, source, ambiguous?}, acc ->
+      Map.update(acc, turn_id, [{source, ambiguous?}], &[{source, ambiguous?} | &1])
+    end)
+  end
+end

--- a/lib/ptc_runner/kernel/inspection_artifact/conversation.ex
+++ b/lib/ptc_runner/kernel/inspection_artifact/conversation.ex
@@ -9,6 +9,7 @@ defmodule PtcRunner.Kernel.InspectionArtifact.Conversation do
 
   alias PtcRunner.Kernel.ConversationMessage
   alias PtcRunner.Kernel.DeterministicJSON
+  alias PtcRunner.Kernel.GeneratedSourceAssociation
 
   @type node_row :: %{
           complete_hash: binary(),
@@ -78,8 +79,6 @@ defmodule PtcRunner.Kernel.InspectionArtifact.Conversation do
 
   @spec finish(map(), map()) :: map()
   def finish(state, trace_facts) when is_map(state) and is_map(trace_facts) do
-    source_counts = Enum.frequencies_by(state.source_hashes, & &1.hash)
-
     by_stream = Enum.group_by(state.turns, & &1.stream_id)
 
     turns =
@@ -89,7 +88,9 @@ defmodule PtcRunner.Kernel.InspectionArtifact.Conversation do
         |> Map.get(stream_id, [])
         |> Enum.sort_by(& &1.turn)
       end)
-      |> Enum.map(&attach_generated(&1, state.source_hashes, source_counts))
+
+    association_result = generated_associations(turns, state.source_hashes)
+    turns = Enum.map(turns, &attach_generated(&1, association_result.by_turn))
 
     expected = MapSet.new(Map.get(trace_facts, "expected_model_exchange_ids", []))
 
@@ -109,7 +110,8 @@ defmodule PtcRunner.Kernel.InspectionArtifact.Conversation do
         Enum.any?(turn.generated, & &1.association_ambiguous?)
       end)
 
-    ambiguity_count = length(state.ambiguous) + source_ambiguity_count
+    ambiguity_count =
+      length(state.ambiguous) + source_ambiguity_count + association_result.unresolved_count
 
     %{
       turns: turns,
@@ -257,23 +259,45 @@ defmodule PtcRunner.Kernel.InspectionArtifact.Conversation do
     end
   end
 
-  defp attach_generated(turn, source_hashes, source_counts) do
-    requested = MapSet.new(turn.program_hashes)
-
+  defp attach_generated(turn, associations) do
     generated =
-      source_hashes
-      |> Enum.reverse()
-      |> Enum.filter(&MapSet.member?(requested, &1.hash))
-      |> Enum.map(fn source ->
+      associations
+      |> Map.get(turn.ordinal, [])
+      |> Enum.map(fn {source, ambiguous?} ->
         %{
           sequence: source.sequence,
           evaluation_id: source.evaluation_id,
           association: "source_match",
-          association_ambiguous?: Map.get(source_counts, source.hash, 0) > 1
+          association_ambiguous?: ambiguous?
         }
       end)
 
     Map.put(turn, :generated, generated)
+  end
+
+  defp generated_associations(turns, source_hashes) do
+    turns =
+      Enum.map(turns, fn turn ->
+        %{
+          id: turn.ordinal,
+          sequence: turn.output_sequence,
+          sources: turn.program_hashes
+        }
+      end)
+
+    sources =
+      Enum.map(source_hashes, fn source ->
+        %{sequence: source.sequence, source: source.hash, record: source}
+      end)
+
+    result = GeneratedSourceAssociation.associate(turns, sources)
+
+    by_turn =
+      Map.new(result.by_turn, fn {turn_id, entries} ->
+        {turn_id, Enum.map(entries, fn {source, ambiguous?} -> {source.record, ambiguous?} end)}
+      end)
+
+    %{by_turn: by_turn, unresolved_count: result.unresolved_count}
   end
 
   defp prefix_match?(comparable, node) do

--- a/test/mix/tasks/ptc_transcript_test.exs
+++ b/test/mix/tasks/ptc_transcript_test.exs
@@ -102,6 +102,31 @@ defmodule Mix.Tasks.PtcTranscriptTest do
   end
 
   @tag :tmp_dir
+  test "a complete transcript accepts identical programs from different turns", %{tmp_dir: root} do
+    fixture =
+      PrivateInspectionFixture.create_repeated_source!(
+        root,
+        PrivateInspectionFixture.command_run_ref()
+      )
+
+    output = Path.join(fixture.output, "repeated.private.json")
+    presentation = MixCommandAdapter.execute(transcript_argv(fixture, output))
+
+    assert presentation.exit_status == 0
+    assert presentation.stderr == ""
+
+    assert %{"conversation" => %{"complete?" => true, "streams" => [%{"turns" => turns}]}} =
+             output |> File.read!() |> Jason.decode!()
+
+    assert Enum.map(turns, fn turn ->
+             Enum.map(turn["generated"], & &1["evaluation_id"])
+           end) == [
+             ["eval-1-#{fixture.run_id}"],
+             ["eval-2-#{fixture.run_id}"]
+           ]
+  end
+
+  @tag :tmp_dir
   test "an uncaptured model exchange reports incompleteness and its count", %{tmp_dir: root} do
     fixture =
       PrivateInspectionFixture.create_interrupted!(

--- a/test/ptc_runner/kernel/inspection_snapshot_test.exs
+++ b/test/ptc_runner/kernel/inspection_snapshot_test.exs
@@ -207,8 +207,8 @@ defmodule PtcRunner.Kernel.InspectionSnapshotTest do
              InspectionSnapshot.query(snapshot, :turns, %{"run_id" => run_id})
 
     assert Enum.map(generated, & &1["evaluation_id"]) == ["eval-one", "eval-two"]
-    assert Enum.all?(generated, & &1["association_ambiguous?"])
-    assert evidence["ambiguity_count"] == 1
+    refute Enum.any?(generated, & &1["association_ambiguous?"])
+    assert evidence["ambiguity_count"] == 0
   end
 
   test "query workers carry one copy of retained admission metadata" do

--- a/test/ptc_runner/kernel/run_analysis_test.exs
+++ b/test/ptc_runner/kernel/run_analysis_test.exs
@@ -842,15 +842,15 @@ defmodule PtcRunner.Kernel.RunAnalysisTest do
              ConversationProjection.streams(exchanges)
   end
 
-  test "turn projection labels duplicate source matches without inventing an exact edge" do
+  test "turn projection keeps multiple identical calls on their producing turn" do
     assistant = %{
       "role" => "assistant",
-      "tool_calls" => [%{"args" => %{"program" => "(return 42)"}}]
+      "tool_calls" => List.duplicate(%{"args" => %{"program" => "(return 42)"}}, 2)
     }
 
     programs = [
-      %{"evaluation_id" => "evaluation-1", "source" => "(return 42)"},
-      %{"evaluation_id" => "evaluation-2", "source" => "(return 42)"}
+      %{"evaluation_id" => "evaluation-1", "sequence" => 3, "source" => "(return 42)"},
+      %{"evaluation_id" => "evaluation-2", "sequence" => 4, "source" => "(return 42)"}
     ]
 
     projection =
@@ -862,9 +862,247 @@ defmodule PtcRunner.Kernel.RunAnalysisTest do
 
     assert [turn] = projection.items
     assert Enum.map(turn["generated"], & &1["association"]) == ["source_match", "source_match"]
+    refute Enum.any?(turn["generated"], & &1["association_ambiguous?"])
+    assert projection.evidence["complete?"]
+    assert projection.evidence["ambiguity_count"] == 0
+  end
+
+  test "turn projection preserves ambiguity when occurrence counts do not prove identity" do
+    source = "(return 42)"
+
+    assistant = %{
+      "role" => "assistant",
+      "tool_calls" => [%{"args" => %{"program" => source}}]
+    }
+
+    programs = [
+      %{"evaluation_id" => "evaluation-1", "sequence" => 3, "source" => source},
+      %{"evaluation_id" => "evaluation-2", "sequence" => 4, "source" => source}
+    ]
+
+    projection =
+      ConversationProjection.compile(
+        [exchange(1, [%{"role" => "user", "content" => "run it"}], assistant)],
+        programs,
+        %{"terminal?" => true, "events_dropped?" => false}
+      )
+
+    assert [turn] = projection.items
+
+    assert Enum.map(turn["generated"], & &1["evaluation_id"]) ==
+             ~w(evaluation-1 evaluation-2)
+
     assert Enum.all?(turn["generated"], & &1["association_ambiguous?"])
     refute projection.evidence["complete?"]
     assert projection.evidence["ambiguity_count"] == 1
+  end
+
+  test "ambiguous mismatched calls embed each evaluation at most once per turn" do
+    source = "(return 42)"
+    call = %{"args" => %{"program" => source}}
+    assistant = %{"role" => "assistant", "tool_calls" => [call, call]}
+    programs = [%{"evaluation_id" => "evaluation-1", "sequence" => 3, "source" => source}]
+
+    projection =
+      ConversationProjection.compile(
+        [exchange(1, [%{"role" => "user", "content" => "run it"}], assistant)],
+        programs,
+        %{"terminal?" => true, "events_dropped?" => false}
+      )
+
+    assert [%{"generated" => [generated]}] = projection.items
+    assert generated["evaluation_id"] == "evaluation-1"
+    assert generated["association_ambiguous?"]
+  end
+
+  test "concurrent identical turn responses remain ambiguous" do
+    source = "(return 42)"
+    assistant = %{"role" => "assistant", "tool_calls" => [%{"args" => %{"program" => source}}]}
+
+    exchanges = [
+      exchange(1, [%{"role" => "user", "content" => "first stream"}], assistant, "first"),
+      exchange(3, [%{"role" => "user", "content" => "second stream"}], assistant, "second")
+    ]
+
+    programs = [
+      %{"evaluation_id" => "evaluation-1", "sequence" => 5, "source" => source},
+      %{"evaluation_id" => "evaluation-2", "sequence" => 6, "source" => source}
+    ]
+
+    projection =
+      ConversationProjection.compile(exchanges, programs, %{
+        "terminal?" => true,
+        "events_dropped?" => false
+      })
+
+    assert Enum.all?(projection.items, fn turn ->
+             match?([%{"association_ambiguous?" => true}], turn["generated"])
+           end)
+
+    refute projection.evidence["complete?"]
+    assert projection.evidence["ambiguity_count"] == 2
+  end
+
+  test "identical programs in different turns are paired by chronology" do
+    source = "(return 42)"
+    call = %{"args" => %{"program" => source}}
+    first_assistant = %{"role" => "assistant", "content" => "one", "tool_calls" => [call]}
+    second_assistant = %{"role" => "assistant", "content" => "two", "tool_calls" => [call]}
+
+    exchanges = [
+      exchange(1, [%{"role" => "user", "content" => "first"}], first_assistant),
+      exchange(
+        5,
+        [
+          %{"role" => "user", "content" => "first"},
+          first_assistant,
+          %{"role" => "tool", "content" => "retry"}
+        ],
+        second_assistant
+      )
+    ]
+
+    programs = [
+      %{"evaluation_id" => "evaluation-1", "sequence" => 3, "source" => source},
+      %{"evaluation_id" => "evaluation-2", "sequence" => 7, "source" => source}
+    ]
+
+    projection =
+      ConversationProjection.compile(exchanges, programs, %{
+        "terminal?" => true,
+        "events_dropped?" => false
+      })
+
+    assert Enum.map(projection.items, fn turn ->
+             Enum.map(turn["generated"], & &1["evaluation_id"])
+           end) == [["evaluation-1"], ["evaluation-2"]]
+
+    assert projection.evidence["complete?"]
+  end
+
+  test "a delayed evaluation remains attached after a later model request" do
+    source = "(return 42)"
+
+    first_assistant = %{
+      "role" => "assistant",
+      "tool_calls" => [%{"args" => %{"program" => source}}]
+    }
+
+    exchanges = [
+      exchange(1, [%{"role" => "user", "content" => "first"}], first_assistant),
+      exchange(3, [%{"role" => "user", "content" => "unrelated"}], %{
+        "role" => "assistant",
+        "content" => "later"
+      })
+    ]
+
+    projection =
+      ConversationProjection.compile(
+        exchanges,
+        [%{"evaluation_id" => "delayed", "sequence" => 5, "source" => source}],
+        %{"terminal?" => true, "events_dropped?" => false}
+      )
+
+    assert [["delayed"], []] ==
+             Enum.map(projection.items, fn turn ->
+               Enum.map(turn["generated"], & &1["evaluation_id"])
+             end)
+
+    assert projection.evidence["complete?"]
+  end
+
+  test "a source captured before the model emitted those bytes is not conversation evidence" do
+    source = "(return 42)"
+    assistant = %{"role" => "assistant", "tool_calls" => [%{"args" => %{"program" => source}}]}
+
+    projection =
+      ConversationProjection.compile(
+        [exchange(3, [%{"role" => "user", "content" => "later"}], assistant)],
+        [%{"evaluation_id" => "too-early", "sequence" => 2, "source" => source}],
+        %{"terminal?" => true, "events_dropped?" => false}
+      )
+
+    assert [%{"generated" => []}] = projection.items
+    assert projection.evidence["complete?"]
+    assert projection.evidence["ambiguity_count"] == 0
+  end
+
+  test "a directly evaluated source absent from model output is not conversation evidence" do
+    assistant = %{"role" => "assistant", "content" => "no program"}
+
+    projection =
+      ConversationProjection.compile(
+        [exchange(1, [%{"role" => "user", "content" => "answer"}], assistant)],
+        [%{"evaluation_id" => "direct", "sequence" => 3, "source" => "(return :direct)"}],
+        %{"terminal?" => true, "events_dropped?" => false}
+      )
+
+    assert [%{"generated" => []}] = projection.items
+    assert projection.evidence["complete?"]
+    assert projection.evidence["ambiguity_count"] == 0
+  end
+
+  test "sequential identical calls remain ambiguous when both evaluations happen later" do
+    source = "(return 42)"
+    assistant = %{"role" => "assistant", "tool_calls" => [%{"args" => %{"program" => source}}]}
+
+    exchanges = [
+      exchange(1, [%{"role" => "user", "content" => "first"}], assistant),
+      exchange(3, [%{"role" => "user", "content" => "second"}], assistant)
+    ]
+
+    programs = [
+      %{"evaluation_id" => "evaluation-1", "sequence" => 5, "source" => source},
+      %{"evaluation_id" => "evaluation-2", "sequence" => 6, "source" => source}
+    ]
+
+    projection =
+      ConversationProjection.compile(exchanges, programs, %{
+        "terminal?" => true,
+        "events_dropped?" => false
+      })
+
+    assert Enum.all?(projection.items, fn turn ->
+             match?([%{"association_ambiguous?" => true}], turn["generated"])
+           end)
+
+    refute projection.evidence["complete?"]
+    assert projection.evidence["ambiguity_count"] == 2
+  end
+
+  test "turn capacity does not overmark an evaluation fixed to one turn" do
+    source = "(return 42)"
+    call = %{"args" => %{"program" => source}}
+
+    exchanges = [
+      exchange(1, [%{"role" => "user", "content" => "two"}], %{
+        "role" => "assistant",
+        "tool_calls" => [call, call]
+      }),
+      exchange(4, [%{"role" => "user", "content" => "one"}], %{
+        "role" => "assistant",
+        "tool_calls" => [call]
+      })
+    ]
+
+    programs =
+      Enum.map([3, 6, 7], fn sequence ->
+        %{"evaluation_id" => "evaluation-#{sequence}", "sequence" => sequence, "source" => source}
+      end)
+
+    projection =
+      ConversationProjection.compile(exchanges, programs, %{
+        "terminal?" => true,
+        "events_dropped?" => false
+      })
+
+    [first, second] = projection.items
+
+    assert [%{"evaluation_id" => "evaluation-3", "association_ambiguous?" => false} | _] =
+             first["generated"]
+
+    assert Enum.any?(first["generated"], & &1["association_ambiguous?"])
+    assert [%{"association_ambiguous?" => true}] = second["generated"]
   end
 
   @tag :tmp_dir

--- a/test/support/private_inspection_fixture.ex
+++ b/test/support/private_inspection_fixture.ex
@@ -151,6 +151,95 @@ defmodule PtcRunner.TestSupport.PrivateInspectionFixture do
     fixture
   end
 
+  @doc "Builds a complete two-turn capture whose turns emit identical source bytes."
+  def create_repeated_source!(root, run_id \\ "repeated-source-private-run") do
+    %{traces: traces, inspection: inspection} = fixture = create_directories(root, run_id)
+    capability_ids = ["llm-1-#{run_id}", "llm-2-#{run_id}"]
+
+    events =
+      [
+        event(run_id, 1, "run-started", %{"missions" => %{"default" => %{}}}),
+        workflow_evaluation_event(run_id, 2)
+      ] ++
+        Enum.flat_map(Enum.with_index(capability_ids, 1), fn {capability_id, index} ->
+          evaluation_id = "eval-#{index}-#{run_id}"
+
+          [
+            event(run_id, index * 4 - 1, "capability-started", %{
+              "capability_id" => capability_id,
+              "environment" => "workflow",
+              "name" => "llm-request"
+            }),
+            event(run_id, index * 4, "capability-stopped", %{
+              "capability_id" => capability_id,
+              "environment" => "workflow",
+              "name" => "llm-request",
+              "status" => "ok"
+            }),
+            event(run_id, index * 4 + 1, "evaluation-started", %{
+              "evaluation_id" => evaluation_id,
+              "parent_evaluation_id" => "workflow-eval-#{run_id}",
+              "environment" => "mission",
+              "mission_name" => "default",
+              "program_kind" => "ptc-lisp",
+              "source_hash" => @source_hash,
+              "source_bytes" => byte_size(@source)
+            }),
+            event(run_id, index * 4 + 2, "evaluation-stopped", %{
+              "evaluation_id" => evaluation_id,
+              "parent_evaluation_id" => "workflow-eval-#{run_id}",
+              "environment" => "mission",
+              "mission_name" => "default",
+              "status" => "returned"
+            })
+          ]
+        end) ++
+        [
+          event(run_id, 11, "evaluation-stopped", %{
+            "evaluation_id" => "workflow-eval-#{run_id}",
+            "environment" => "workflow",
+            "status" => "returned"
+          }),
+          event(run_id, 12, "run-stopped", %{"outcome" => "ok"})
+        ]
+
+    File.write!(Path.join(traces, "#{run_id}.jsonl"), encode_jsonl(events))
+    {sink, handle} = start_sink!(inspection, run_id)
+    user = %{"role" => "user", "content" => "run it twice"}
+    call = %{"id" => "program", "args" => %{"program" => @source}}
+    assistant = %{"role" => "assistant", "content" => nil, "tool_calls" => [call]}
+
+    _messages =
+      Enum.reduce(Enum.with_index(capability_ids, 1), [user], fn {capability_id, index},
+                                                                 messages ->
+        emit!(
+          sink,
+          "capability-input",
+          %{capability_id: capability_id},
+          llm_input(%{"messages" => messages, "system" => "private-system-#{run_id}"})
+        )
+
+        emit!(sink, "capability-output", %{capability_id: capability_id}, %{
+          environment: :workflow,
+          name: "llm-request",
+          result: %{status: :ok, value: Map.delete(assistant, "role")}
+        })
+
+        emit!(
+          sink,
+          "evaluation-source",
+          %{evaluation_id: "eval-#{index}-#{run_id}"},
+          evaluation_source_payload()
+        )
+
+        messages ++
+          [assistant, %{"role" => "tool", "tool_call_id" => "program", "content" => "ok"}]
+      end)
+
+    persist_inspection!(sink, handle)
+    fixture
+  end
+
   def create_result!(root, value, run_id \\ "private-result-run") do
     %{traces: traces, inspection: inspection} = fixture = create_directories(root, run_id)
     {:ok, result_hash} = ResultIdentity.strict_json_hash(value)


### PR DESCRIPTION
## Summary

- correlate generated-source records to retained model-call occurrences using chronology and per-turn occurrence capacity instead of run-wide source identity
- preserve genuine ambiguity, delayed evaluations, direct non-model sources, and multiple identical calls without multiplying records across turns
- share the association logic across both conversation projection paths and document the certification semantics

## Validation

- `mix precommit`
- focused projection, inspection, and transcript suite: 91 tests passed
- pre-push gates: 7,740 core tests, static analysis and Dialyzer, release verification, ExDoc/link checks, and 125 Viewer tests
- two independent cumulative review sessions, including an adversarial challenge, approved the final tree

## Retrospective

The first chronology-window approach was too narrow for delayed evaluations and too expensive when generalized as repeated full matching. Review pressure led to a bounded ordered-matching design that keeps delayed work visible, identifies only turn-level ambiguity that the retained evidence supports, and avoids quadratic record multiplication.

Closes #1743