### PR TITLE
feat(viewer): show external labels and agent progress

### DIFF
--- a/docs/maintainers/trace-log-contract.md
+++ b/docs/maintainers/trace-log-contract.md
@@ -1204,10 +1204,13 @@ to the caller and does not fail the evaluation:
 | `annotation_type` | accepted `data` |
 | --- | --- |
 | `"progress"` | `{"stage": started \| planning \| executing \| validating \| completed \| failed}` — that key and no other |
-| `"agent-action"` | `{"turn": 0..127, "kind": tool-call \| protocol-error \| provider-error \| max-calls \| model-output-truncated}`, or that plus `{"phase": 0..7, "phase_turn": 0..127, "mission": <name>}` — exactly two keys or exactly five |
+| `"agent-action"` | `{"turn": 0..127, "max_turns": 1..128, "invocation": "agent-<16 lowercase hex>", "kind": tool-call \| protocol-error \| provider-error \| max-calls \| model-output-truncated}`, or that plus `{"phase": 0..7, "phase_turn": 0..127, "mission": <name>}` — exactly four keys or exactly seven |
 
 Keyword types and keys normalize (`:phase-turn` → `"phase_turn"`). A phased
-`agent-action` takes all three extra keys or none. `mission` is the phase's
+`agent-action` takes all three phase keys or none. Callers provide every field
+except `invocation`; the runtime adds that run-local opaque correlation value
+before validation and emission. `max_turns` is the configured total ceiling for
+the invocation, and `turn` is always strictly less than it. `mission` is the phase's
 mission name: a lowercase letter, then up to 127 letters, digits, `.`, `_`, or
 `-`. The vocabulary never carries detailed reasons, generated source, or model
 content. A non-string annotation type is a malformed call, not this

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1017,9 +1017,12 @@ manifest, working directory, or command:
 ptc viewer ptc-project.json --env-file .env
 ```
 
-Viewer-launched workflow cards use the manifest label and workflow entry as
-their human-facing title, while retaining the `cmd-...` value as the stable run
-identifier. The Live tab and `GET /api/live/runs` list newest first, and each
+Viewer-launched workflows and CLI runs attached through `PTC_VIEWER_URL` use
+the manifest label and workflow entry as their human-facing title, while
+retaining the `cmd-...` value as the stable run identifier. That exact label
+(or the manifest filename when no label is declared) and entry are sent in
+plaintext only to the explicitly configured Viewer; the trace keeps its
+fingerprinted label. The Live tab and `GET /api/live/runs` list newest first, and each
 card shows when the Viewer first saw that run, so an edited ceiling cannot be
 read off an older card as a stale enforcement.
 

--- a/lib/ptc_runner/kernel/command_engine.ex
+++ b/lib/ptc_runner/kernel/command_engine.ex
@@ -42,6 +42,7 @@ defmodule PtcRunner.Kernel.CommandEngine do
   alias PtcRunner.Kernel.ProjectArtifactRoot
   alias PtcRunner.Kernel.ProjectResolver
   alias PtcRunner.Kernel.PublicationAuthority
+  alias PtcRunner.LiveStatus
 
   @fallback_run_ref "cmd-00000000000000000000000000"
   @frontend_commands CommandDeclaration.frontend_commands()
@@ -157,7 +158,7 @@ defmodule PtcRunner.Kernel.CommandEngine do
                runtime
              ) do
           {:ok, %CommandPreparation{} = preparation} ->
-            dispatch_preparation(preparation, runtime, entry, presentation?)
+            dispatch_preparation(preparation, runtime, entry, arguments, presentation?)
 
           terminal ->
             with_rejection(terminal)
@@ -168,11 +169,13 @@ defmodule PtcRunner.Kernel.CommandEngine do
     end
   end
 
-  defp dispatch_preparation(preparation, runtime, entry, true) do
-    CommandRunDispatch.dispatch_frontend(preparation, runtime, entry.frontend)
+  defp dispatch_preparation(preparation, runtime, entry, arguments, true) do
+    package = preparation.prepared_run.request.package
+    label = LiveStatus.application_label_for(package, arguments.application)
+    CommandRunDispatch.dispatch_frontend(preparation, runtime, entry.frontend, label)
   end
 
-  defp dispatch_preparation(preparation, runtime, _entry, false),
+  defp dispatch_preparation(preparation, runtime, _entry, _arguments, false),
     do: with_rejection(CommandRunDispatch.dispatch(preparation, runtime))
 
   defp with_rejection({status, %CommandOutcome{} = outcome}) when status in [:ok, :error],

--- a/lib/ptc_runner/kernel/command_run_dispatch.ex
+++ b/lib/ptc_runner/kernel/command_run_dispatch.ex
@@ -12,11 +12,17 @@ defmodule PtcRunner.Kernel.CommandRunDispatch do
   alias PtcRunner.Kernel.ProviderExecution
   alias PtcRunner.Kernel.PublicationAuthority
   alias PtcRunner.Kernel.RunCoordinator
+  alias PtcRunner.LiveStatus
 
   @spec dispatch(CommandPreparation.t(), CommandRuntime.t()) ::
           {:ok, CommandOutcome.t()} | {:error, CommandOutcome.t()}
   def dispatch(%CommandPreparation{} = preparation, %CommandRuntime{} = runtime) do
-    case dispatch_after_preflight(CommandDestination.preflight(preparation), preparation, runtime) do
+    case dispatch_after_preflight(
+           CommandDestination.preflight(preparation),
+           preparation,
+           runtime,
+           nil
+         ) do
       {status, outcome, _rejection} -> {status, outcome}
     end
   end
@@ -25,43 +31,52 @@ defmodule PtcRunner.Kernel.CommandRunDispatch do
   @spec dispatch_frontend(
           CommandPreparation.t(),
           CommandRuntime.t(),
-          :standalone | :mix
+          :standalone | :mix,
+          binary()
         ) ::
           {:ok, CommandOutcome.t(), nil}
           | {:error, CommandOutcome.t(), PtcRunner.Kernel.CommandRejection.t() | nil}
   def dispatch_frontend(
         %CommandPreparation{} = preparation,
         %CommandRuntime{} = runtime,
-        frontend
+        frontend,
+        external_label
       )
-      when frontend in [:standalone, :mix] do
+      when frontend in [:standalone, :mix] and is_binary(external_label) do
     preparation
     |> CommandDestination.preflight_frontend(frontend)
-    |> dispatch_after_preflight(preparation, runtime)
+    |> dispatch_after_preflight(preparation, runtime, external_label)
   end
 
-  defp dispatch_after_preflight({:ok, authority}, preparation, runtime),
-    do: with_rejection(execute_preflighted(preparation, runtime, authority))
+  defp dispatch_after_preflight({:ok, authority}, preparation, runtime, external_label),
+    do: with_rejection(execute_preflighted(preparation, runtime, authority, external_label))
 
-  defp dispatch_after_preflight({:ok, authority, nil}, preparation, runtime),
-    do: with_rejection(execute_preflighted(preparation, runtime, authority))
+  defp dispatch_after_preflight({:ok, authority, nil}, preparation, runtime, external_label),
+    do: with_rejection(execute_preflighted(preparation, runtime, authority, external_label))
 
-  defp dispatch_after_preflight({:error, %CommandOutcome{} = outcome}, _preparation, _runtime),
-    do: {:error, outcome, nil}
+  defp dispatch_after_preflight(
+         {:error, %CommandOutcome{} = outcome},
+         _preparation,
+         _runtime,
+         _label
+       ),
+       do: {:error, outcome, nil}
 
   defp dispatch_after_preflight(
          {:error, %CommandOutcome{} = outcome, rejection},
          _preparation,
-         _runtime
+         _runtime,
+         _label
        ),
        do: {:error, outcome, rejection}
 
   defp with_rejection({status, %CommandOutcome{} = outcome}) when status in [:ok, :error],
     do: {status, outcome, nil}
 
-  defp execute_preflighted(preparation, runtime, authority) do
+  defp execute_preflighted(preparation, runtime, authority, external_label) do
     with :ok <- maybe_setup_environment(preparation, runtime),
          {:ok, execution} <- provider_execution(preparation, runtime) do
+      runtime = attach_external_live_status(runtime, external_label)
       execute_started(preparation, runtime, authority, execution)
     else
       {:error, reason} ->
@@ -95,6 +110,15 @@ defmodule PtcRunner.Kernel.CommandRunDispatch do
     PublicationAuthority.close(authority)
     CommandPreparation.close(preparation)
   end
+
+  defp attach_external_live_status(%{live_status: nil} = runtime, label) when is_binary(label) do
+    case LiveStatus.external_target(label) do
+      nil -> runtime
+      target -> elem(CommandRuntime.with_live_status(runtime, target), 1)
+    end
+  end
+
+  defp attach_external_live_status(runtime, _label), do: runtime
 
   defp execute_started(preparation, runtime, authority, execution) do
     case execute_run(preparation, authority, execution, runtime) do

--- a/lib/ptc_runner/kernel/runtime_tools.ex
+++ b/lib/ptc_runner/kernel/runtime_tools.ex
@@ -27,6 +27,7 @@ defmodule PtcRunner.Kernel.RuntimeTools do
   alias PtcRunner.Kernel.ValueContract
   alias PtcRunner.Kernel.ValueContractDiagnostic
   alias PtcRunner.Kernel.WorkflowEnvironment
+
   alias PtcRunner.Lisp
   alias PtcRunner.Lisp.EvaluatorErrorCatalog
   alias PtcRunner.Lisp.Keyword, as: LispKeyword
@@ -35,6 +36,7 @@ defmodule PtcRunner.Kernel.RuntimeTools do
   alias PtcRunner.Lisp.TrustedTool
   alias PtcRunner.LLM.OutputLimit
 
+  @agent_invocation_key {__MODULE__, :agent_invocation}
   @mission_contract_version 1
   @mission_routes [
     {"cap-describe", :capability_description},
@@ -1506,13 +1508,18 @@ defmodule PtcRunner.Kernel.RuntimeTools do
   defp annotate(state, event_sink, %{"type" => type, "data" => data})
        when is_binary(type) do
     limit = RunState.limits(state).event_payload_bytes
+    data = enrich_agent_action(type, data)
     payload = %{annotation_type: type, data: data, provenance: :workflow}
     bytes = RetainedSize.bytes_with_cap(payload, limit)
 
     if SafeMetadata.annotation?(type, data) and is_integer(bytes) and bytes <= limit do
       case Events.emit(state, event_sink, "workflow-annotation", payload) do
-        :ok -> %{status: :ok}
-        {:error, :event_sink_error} -> %{status: :error, kind: :event_sink_error}
+        :ok ->
+          relay_agent_action(state, type, data)
+          %{status: :ok}
+
+        {:error, :event_sink_error} ->
+          %{status: :error, kind: :event_sink_error}
       end
     else
       %{
@@ -1525,6 +1532,45 @@ defmodule PtcRunner.Kernel.RuntimeTools do
 
   defp annotate(state, event_sink, _arguments),
     do: protocol_error(state, event_sink, :invalid_workflow_annotation)
+
+  defp enrich_agent_action("agent-action", data) when is_map(data) do
+    invocation =
+      case {Map.get(data, "turn"), Process.get(@agent_invocation_key)} do
+        {0, _previous} -> mint_agent_invocation_id()
+        {_turn, nil} -> mint_agent_invocation_id()
+        {_turn, current} -> current
+      end
+
+    Process.put(@agent_invocation_key, invocation)
+    Map.put(data, "invocation", invocation)
+  end
+
+  defp enrich_agent_action(_type, data), do: data
+
+  defp mint_agent_invocation_id do
+    {self(), System.unique_integer([:positive, :monotonic])}
+    |> :erlang.term_to_binary()
+    |> then(&:crypto.hash(:sha256, &1))
+    |> binary_part(0, 8)
+    |> Base.encode16(case: :lower)
+    |> then(&("agent-" <> &1))
+  end
+
+  defp relay_agent_action(state, "agent-action", data) do
+    :telemetry.execute(
+      [:ptc_runner, :agent, :action],
+      %{},
+      %{
+        live_run: state.pid,
+        invocation: data["invocation"],
+        turn: data["turn"],
+        max_turns: data["max_turns"],
+        kind: data["kind"]
+      }
+    )
+  end
+
+  defp relay_agent_action(_state, _type, _data), do: :ok
 
   defp protocol_error(state, event_sink, reason) do
     case RunState.protocol_error(state) do

--- a/lib/ptc_runner/kernel/safe_metadata.ex
+++ b/lib/ptc_runner/kernel/safe_metadata.ex
@@ -158,10 +158,10 @@ defmodule PtcRunner.Kernel.SafeMetadata do
   Returns whether an annotation belongs to the finite canonical vocabulary.
 
   `"progress"` carries exactly one enumerated `stage`. `"agent-action"` is
-  the shipped agent loop's coarse per-turn record: exactly the keys `turn`
-  (an integer from 0 through 127, matching the loop's maximum turn count)
-  and `kind` (one of `tool-call`, `protocol-error`, `provider-error`, or
-  `max-calls`, or `model-output-truncated`).
+  the shipped agent loop's coarse per-turn record: `turn` (an integer from 0
+  through 127), `max_turns` (1 through 128), a runtime-authored opaque
+  `invocation` identifier, and `kind` (one of `tool-call`, `protocol-error`,
+  `provider-error`, `max-calls`, or `model-output-truncated`).
   A phased agent run adds exactly `phase` (0 through 7), `phase_turn`
   (0 through 127), and `mission` (the phase's mission name) — all three or
   none, so a partial shape stays out of the vocabulary. It never carries
@@ -172,29 +172,46 @@ defmodule PtcRunner.Kernel.SafeMetadata do
       when map_size(data) == 1 and stage in @progress_stages,
       do: true
 
-  def annotation?("agent-action", %{"turn" => turn, "kind" => kind} = data)
-      when map_size(data) == 2 and is_integer(turn) and turn >= 0 and turn <= 127 and
-             kind in @agent_action_kinds,
-      do: true
+  def annotation?(
+        "agent-action",
+        %{
+          "turn" => turn,
+          "max_turns" => max_turns,
+          "invocation" => invocation,
+          "kind" => kind
+        } = data
+      )
+      when map_size(data) == 4,
+      do: valid_agent_action?(turn, max_turns, invocation, kind)
 
   def annotation?(
         "agent-action",
         %{
           "turn" => turn,
+          "max_turns" => max_turns,
+          "invocation" => invocation,
           "kind" => kind,
           "phase" => phase,
           "phase_turn" => phase_turn,
           "mission" => mission
         } = data
       )
-      when map_size(data) == 5 and is_integer(turn) and turn >= 0 and turn <= 127 and
-             kind in @agent_action_kinds and is_integer(phase) and phase >= 0 and phase <= 7 and
-             is_integer(phase_turn) and phase_turn >= 0 and phase_turn <= 127 and
-             is_binary(mission) do
-    mission =~ ~r/\A[a-z][a-z0-9._-]{0,127}\z/
+      when map_size(data) == 7 do
+    valid_agent_action?(turn, max_turns, invocation, kind) and
+      is_integer(phase) and phase >= 0 and phase <= 7 and
+      is_integer(phase_turn) and phase_turn >= 0 and phase_turn <= 127 and
+      is_binary(mission) and
+      mission =~ ~r/\A[a-z][a-z0-9._-]{0,127}\z/
   end
 
   def annotation?(_type, _data), do: false
+
+  defp valid_agent_action?(turn, max_turns, invocation, kind) do
+    is_integer(turn) and turn >= 0 and turn <= 127 and turn < max_turns and
+      is_integer(max_turns) and max_turns >= 1 and max_turns <= 128 and
+      is_binary(invocation) and invocation =~ ~r/\Aagent-[0-9a-f]{16}\z/ and
+      kind in @agent_action_kinds
+  end
 
   @spec failure_taxonomy(term()) :: map()
   @doc """

--- a/lib/ptc_runner/live_status.ex
+++ b/lib/ptc_runner/live_status.ex
@@ -11,8 +11,43 @@ defmodule PtcRunner.LiveStatus do
   run.
   """
 
+  alias PtcRunner.Kernel.ApplicationPackage
   alias PtcRunner.LiveStatus.Reporter
   alias PtcRunner.LiveStatus.Target
+  alias PtcRunner.Utf8
+
+  @doc false
+  @spec external_target(binary() | nil) :: Target.t() | nil
+  def external_target(label) do
+    case System.get_env("PTC_VIEWER_URL") do
+      url when is_binary(url) and url != "" ->
+        token = System.get_env("PTC_VIEWER_TOKEN")
+
+        case Target.new(
+               fn run_id, frame -> Reporter.report_http(url, run_id, frame, token) end,
+               label: label
+             ) do
+          {:ok, target} -> target
+          _error -> nil
+        end
+
+      _absent ->
+        nil
+    end
+  end
+
+  @doc false
+  @spec application_label_for(ApplicationPackage.t(), binary()) :: binary()
+  def application_label_for(%ApplicationPackage{} = package, application)
+      when is_binary(application) do
+    name = get_in(package.manifest, ["labels", "name"]) || Path.basename(application)
+    application_label(name, package.entry)
+  end
+
+  @doc false
+  @spec application_label(binary(), binary()) :: binary()
+  def application_label(name, entry) when is_binary(name) and is_binary(entry),
+    do: Utf8.truncate_valid("#{name} · #{entry}", 256)
 
   @target_key {__MODULE__, :target}
 

--- a/lib/ptc_runner/live_status/reporter.ex
+++ b/lib/ptc_runner/live_status/reporter.ex
@@ -32,6 +32,7 @@ defmodule PtcRunner.LiveStatus.Reporter do
     [:ptc_runner, :parallel, :budget],
     [:ptc_runner, :capability, :start],
     [:ptc_runner, :capability, :stop],
+    [:ptc_runner, :agent, :action],
     [:ptc_runner, :lisp, :execute, :start],
     [:ptc_runner, :lisp, :execute, :stop]
   ]
@@ -252,6 +253,17 @@ defmodule PtcRunner.LiveStatus.Reporter do
     })
   end
 
+  defp apply_telemetry(state, [:ptc_runner, :agent, :action], _measurements, metadata) do
+    push_activity(state, %{
+      kind: "agent",
+      name: metadata.invocation,
+      status: metadata.kind,
+      turn: metadata.turn,
+      max_turns: metadata.max_turns,
+      duration_ms: nil
+    })
+  end
+
   defp apply_telemetry(state, [:ptc_runner, :lisp, :execute, :start], _measurements, _metadata),
     do: push_activity(state, %{kind: "evaluation", name: nil, status: "start", duration_ms: nil})
 
@@ -350,7 +362,13 @@ defmodule PtcRunner.LiveStatus.Reporter do
   defp request(%Target{} = target, run_id, frame, _viewer_token),
     do: Target.report(target, run_id, frame)
 
-  defp request(viewer_url, run_id, frame, viewer_token) when is_binary(viewer_url) do
+  defp request(viewer_url, run_id, frame, viewer_token) when is_binary(viewer_url),
+    do: report_http(viewer_url, run_id, frame, viewer_token)
+
+  @doc false
+  def report_http(viewer_url, run_id, frame, viewer_token)
+      when is_binary(viewer_url) and is_binary(run_id) and is_map(frame) do
+    viewer_url = String.trim_trailing(viewer_url, "/")
     encoded_run_id = URI.encode(run_id, &URI.char_unreserved?/1)
     url = viewer_url <> "/api/live/runs/" <> encoded_run_id
 

--- a/lib/ptc_runner/live_status/target.ex
+++ b/lib/ptc_runner/live_status/target.ex
@@ -47,8 +47,10 @@ defmodule PtcRunner.LiveStatus.Target do
   @spec report(term(), binary(), map()) :: :ok | :error
   def report(%__MODULE__{} = target, run_id, frame)
       when is_binary(run_id) and is_map(frame) do
-    _result = target.report.(run_id, frame)
-    :ok
+    case target.report.(run_id, frame) do
+      :error -> :error
+      _result -> :ok
+    end
   rescue
     _exception -> :error
   catch

--- a/lib/ptc_runner/viewer_frontend.ex
+++ b/lib/ptc_runner/viewer_frontend.ex
@@ -42,6 +42,7 @@ defmodule PtcRunner.ViewerFrontend do
   alias PtcRunner.Kernel.ProjectConfig
   alias PtcRunner.Kernel.ViewerBinding
   alias PtcRunner.Kernel.ViewerProjectAdapter
+  alias PtcRunner.LiveStatus
   alias PtcRunner.ViewerLaunchAdapter
   alias PtcRunner.ViewerSnapshotStore
 
@@ -435,9 +436,7 @@ defmodule PtcRunner.ViewerFrontend do
   defp workflow_label(project) do
     case describe_project(project) do
       {:ok, %{name: name, entry: entry}} when is_binary(name) ->
-        [name, entry]
-        |> Enum.join(" · ")
-        |> String.slice(0, 256)
+        LiveStatus.application_label(name, entry)
 
       _unavailable ->
         "workflow"

--- a/priv/preludes/kernel/agent.core.clj
+++ b/priv/preludes/kernel/agent.core.clj
@@ -332,11 +332,14 @@
       "agent-action"
       (if (get context :phased?)
         {:turn (get state :agent-turn)
+         :max-turns (get context :total-max-turns)
          :phase (get state :phase-index)
          :phase-turn (get state :phase-turn)
          :mission (get phase "mission")
          :kind (get action :kind)}
-        {:turn (get state :phase-turn) :kind (get action :kind)}))))
+        {:turn (get state :phase-turn)
+         :max-turns (get phase "max_turns")
+         :kind (get action :kind)}))))
 
 (defn- native-contract-violation [violation]
   (let [native {:kind (keyword (get violation "kind"))

--- a/ptc_viewer/priv/static/js/live.js
+++ b/ptc_viewer/priv/static/js/live.js
@@ -1031,12 +1031,24 @@ function sparkPath(samples) {
 
 /* ---------- activity feed ---------- */
 
+export function activityPresentation(entry) {
+  if (entry?.kind === 'agent' && Number.isInteger(entry.turn) && Number.isInteger(entry.max_turns)) {
+    return {
+      name: entry.name || 'agent',
+      status: `turn ${entry.turn + 1} of ${entry.max_turns} · ${entry.status}`
+    };
+  }
+  return {
+    name: entry.name || (entry.kind === 'evaluation' ? 'evaluation' : entry.kind),
+    status: entry.status === 'start' ? 'started' : entry.status
+  };
+}
+
 function renderActivity(list, entries) {
   const rows = entries.slice(0, 14).map(entry => {
     const li = document.createElement('li');
     li.className = `live-event kind-${entry.kind || 'other'}`;
-    const name = entry.name || (entry.kind === 'evaluation' ? 'evaluation' : entry.kind);
-    const status = entry.status === 'start' ? 'started' : entry.status;
+    const { name, status } = activityPresentation(entry);
     const duration = entry.duration_ms != null ? fmtSeconds(entry.duration_ms) : '';
     li.innerHTML = `
       <span class="live-event-t"></span>

--- a/ptc_viewer/test/live_ui.mjs
+++ b/ptc_viewer/test/live_ui.mjs
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import {
+  activityPresentation,
   fmtLimit,
   formatLiveSpend,
   evaluationPresentation,
@@ -20,6 +21,15 @@ import {
   runRoute,
   uniqueComponents
 } from '../priv/static/js/live.js';
+
+assert.deepEqual(
+  activityPresentation({kind: 'agent', name: 'agent-a1', status: 'tool-call', turn: 1, max_turns: 6}),
+  {name: 'agent-a1', status: 'turn 2 of 6 · tool-call'}
+);
+assert.deepEqual(
+  activityPresentation({kind: 'agent', name: 'agent-b2', status: 'provider-error', turn: 0, max_turns: 2}),
+  {name: 'agent-b2', status: 'turn 1 of 2 · provider-error'}
+);
 
 // Limits arrive as raw catalog rows; the panel is responsible for making them
 // readable without inventing units it was not given.

--- a/site/reference/cli/index.html
+++ b/site/reference/cli/index.html
@@ -560,9 +560,12 @@ and then opens its detail view in the Runs tab. The Viewer therefore does not
 need to be restarted after a run it launched.</p><p>The ordinary project command also configures the Live project details and one
 fixed launch target from that same project document. The browser may edit
 workflow input or choose one declared mission, but it cannot choose a project,
-manifest, working directory, or command:</p><pre><code class="console language-console">ptc viewer ptc-project.json --env-file .env</code></pre><p>Viewer-launched workflow cards use the manifest label and workflow entry as
-their human-facing title, while retaining the <code class="inline">cmd-...</code> value as the stable run
-identifier. The Live tab and <code class="inline">GET /api/live/runs</code> list newest first, and each
+manifest, working directory, or command:</p><pre><code class="console language-console">ptc viewer ptc-project.json --env-file .env</code></pre><p>Viewer-launched workflows and CLI runs attached through <code class="inline">PTC_VIEWER_URL</code> use
+the manifest label and workflow entry as their human-facing title, while
+retaining the <code class="inline">cmd-...</code> value as the stable run identifier. That exact label
+(or the manifest filename when no label is declared) and entry are sent in
+plaintext only to the explicitly configured Viewer; the trace keeps its
+fingerprinted label. The Live tab and <code class="inline">GET /api/live/runs</code> list newest first, and each
 card shows when the Viewer first saw that run, so an edited ceiling cannot be
 read off an older card as a stale enforcement.</p><p>The command is already a long-running PtcRunner host, so Viewer-started work
 runs inside that BEAM instance under the ordinary execution-session owner. A

--- a/test/githooks/pre_push_test.exs
+++ b/test/githooks/pre_push_test.exs
@@ -514,6 +514,8 @@ defmodule PtcRunner.GitHooks.PrePushTest do
             # test a forced full run instead. Cases that want a mode set it
             # through extra_env, which wins by coming last.
             {"PTC_PRE_PUSH_SERIAL", nil},
+            {"PTC_MANAGED_OPERATION_CONTEXT", nil},
+            {"PTC_OPERATION_ACTIVE", nil},
             {"FORCE_FULL_PRE_PUSH", nil}
           ] ++ extra_env,
       stderr_to_stdout: true

--- a/test/ptc_runner/kernel/agent_core_characterization_test.exs
+++ b/test/ptc_runner/kernel/agent_core_characterization_test.exs
@@ -581,7 +581,15 @@ defmodule PtcRunner.Kernel.AgentCoreCharacterizationTest do
 
     assert Enum.any?(events, fn event ->
              event.type == "workflow-annotation" and
-               event.data.data == %{"turn" => 0, "kind" => "provider-error"}
+               match?(
+                 %{
+                   "turn" => 0,
+                   "max_turns" => 1,
+                   "invocation" => "agent-" <> _,
+                   "kind" => "provider-error"
+                 },
+                 event.data.data
+               )
            end)
   end
 
@@ -761,7 +769,7 @@ defmodule PtcRunner.Kernel.AgentCoreCharacterizationTest do
     config.event_sink
     |> EventSink.events()
     |> Enum.filter(&(&1.type == "workflow-annotation"))
-    |> Enum.map(& &1.data.data)
+    |> Enum.map(&Map.drop(&1.data.data, ["invocation", "max_turns"]))
   end
 
   defp phased_source do

--- a/test/ptc_runner/kernel/agent_library_test.exs
+++ b/test/ptc_runner/kernel/agent_library_test.exs
@@ -495,7 +495,15 @@ defmodule PtcRunner.Kernel.AgentLibraryTest do
 
     assert [annotation] = Enum.filter(events, &(&1.type == "workflow-annotation"))
     assert annotation.data.annotation_type == "agent-action"
-    assert annotation.data.data == %{"turn" => 0, "kind" => "tool-call"}
+
+    assert annotation.data.data == %{
+             "turn" => 0,
+             "max_turns" => 2,
+             "invocation" => annotation.data.data["invocation"],
+             "kind" => "tool-call"
+           }
+
+    assert annotation.data.data["invocation"] =~ ~r/\Aagent-[0-9a-f]{16}\z/
     assert_receive {:provider_closed, :terminal_success}
     refute_receive {:provider_closed, :terminal_success}
   end
@@ -580,6 +588,8 @@ defmodule PtcRunner.Kernel.AgentLibraryTest do
 
     assert explore_annotation == %{
              "turn" => 0,
+             "max_turns" => 2,
+             "invocation" => explore_annotation["invocation"],
              "kind" => "tool-call",
              "phase" => 0,
              "phase_turn" => 0,
@@ -588,6 +598,64 @@ defmodule PtcRunner.Kernel.AgentLibraryTest do
 
     assert synthesize_annotation["phase"] == 1
     assert synthesize_annotation["mission"] == "synthesize"
+    assert synthesize_annotation["max_turns"] == 2
+    assert synthesize_annotation["invocation"] == explore_annotation["invocation"]
+  end
+
+  test "concurrent agent invocations publish distinct turn budgets" do
+    response = fn id ->
+      %{
+        content: nil,
+        tool_calls: [
+          %{id: id, name: "run_ptc_lisp", args: %{"program" => "(return 42)"}}
+        ]
+      }
+    end
+
+    {:ok, config} = agent_config([response.("one"), response.("two")])
+
+    assert {:ok, %{value: [42, 42]}} =
+             Kernel.run(
+               ~S|(return (pmap (fn [limit] (agent.core/run-value "Compute" {"max_turns" limit})) [1 2]))|,
+               config
+             )
+
+    progress =
+      config.event_sink
+      |> EventSink.events()
+      |> Enum.filter(&(&1.type == "workflow-annotation"))
+      |> Enum.map(& &1.data.data)
+
+    assert Enum.sort(Enum.map(progress, & &1["max_turns"])) == [1, 2]
+    assert progress |> Enum.map(& &1["invocation"]) |> Enum.uniq() |> length() == 2
+  end
+
+  test "sequential agent invocations receive distinct correlation identifiers" do
+    response = fn id ->
+      %{
+        content: nil,
+        tool_calls: [
+          %{id: id, name: "run_ptc_lisp", args: %{"program" => "(return 42)"}}
+        ]
+      }
+    end
+
+    {:ok, config} = agent_config([response.("one"), response.("two")])
+
+    assert {:ok, %{value: [42, 42]}} =
+             Kernel.run(
+               ~S|(return [(agent.core/run-value "First" {"max_turns" 1}) (agent.core/run-value "Second" {"max_turns" 2})])|,
+               config
+             )
+
+    progress =
+      config.event_sink
+      |> EventSink.events()
+      |> Enum.filter(&(&1.type == "workflow-annotation"))
+      |> Enum.map(& &1.data.data)
+
+    assert Enum.sort(Enum.map(progress, & &1["max_turns"])) == [1, 2]
+    assert progress |> Enum.map(& &1["invocation"]) |> Enum.uniq() |> length() == 2
   end
 
   # A non-final terminal-only phase would hand off to the next phase when it

--- a/test/ptc_runner/kernel/command_engine_global_state_test.exs
+++ b/test/ptc_runner/kernel/command_engine_global_state_test.exs
@@ -16,6 +16,7 @@ defmodule PtcRunner.Kernel.CommandEngineGlobalStateTest do
   alias PtcRunner.Kernel.CommandRenderer
   alias PtcRunner.Kernel.ProviderError
   alias PtcRunner.StandaloneCLI
+  alias PtcRunner.TestSupport.HTTPRequest
   alias PtcRunner.TestSupport.LLMSupport
 
   @tag :tmp_dir
@@ -276,12 +277,14 @@ defmodule PtcRunner.Kernel.CommandEngineGlobalStateTest do
   end
 
   @tag :tmp_dir
-  test "doctor --connect sets up selected environment credentials before active work", %{
+  test "commands resolve deferred environment before active work and live reporting", %{
     tmp_dir: directory
   } do
     environment_name = "PTC_TEST_DOCTOR_CONNECT_TOKEN"
     previous_environment = System.get_env(environment_name)
+    previous_viewer_url = System.get_env("PTC_VIEWER_URL")
     System.put_env(environment_name, "ambient-secret")
+    System.put_env("PTC_VIEWER_URL", "http://127.0.0.1:1")
 
     provider_applications = LLMSupport.snapshot_provider_applications()
 
@@ -315,6 +318,10 @@ defmodule PtcRunner.Kernel.CommandEngineGlobalStateTest do
         do: System.put_env(environment_name, previous_environment),
         else: System.delete_env(environment_name)
 
+      if previous_viewer_url,
+        do: System.put_env("PTC_VIEWER_URL", previous_viewer_url),
+        else: System.delete_env("PTC_VIEWER_URL")
+
       Enum.each(previous, fn
         {key, {:ok, value}} -> Application.put_env(:ptc_runner, key, value)
         {key, :error} -> Application.delete_env(:ptc_runner, key)
@@ -340,7 +347,23 @@ defmodule PtcRunner.Kernel.CommandEngineGlobalStateTest do
 
     application = doctor_application(directory, "command-owned-model", workflow: ["model"])
     env_file = Path.join(directory, "model.env")
-    File.write!(env_file, "#{environment_name}=test-secret\n")
+    {:ok, listener} = :gen_tcp.listen(0, [:binary, active: false, reuseaddr: true])
+    {:ok, port} = :inet.port(listener)
+    parent = self()
+
+    _server =
+      spawn(fn ->
+        {:ok, socket} = :gen_tcp.accept(listener)
+        {:ok, request} = HTTPRequest.receive_complete(socket)
+        send(parent, {:deferred_viewer_request, request})
+        :ok = :gen_tcp.send(socket, "HTTP/1.1 200 OK\r\ncontent-length: 0\r\n\r\n")
+        :ok = :gen_tcp.close(socket)
+      end)
+
+    File.write!(
+      env_file,
+      "#{environment_name}=test-secret\nPTC_VIEWER_URL=http://127.0.0.1:#{port}\n"
+    )
 
     presentation =
       StandaloneCLI.execute([
@@ -384,6 +407,20 @@ defmodule PtcRunner.Kernel.CommandEngineGlobalStateTest do
                }
              ]
            }
+
+    assert %{exit_status: 0} =
+             StandaloneCLI.execute([
+               "run",
+               application,
+               "--host-config",
+               host_path,
+               "--env-file",
+               env_file
+             ])
+
+    assert_receive {:deferred_viewer_request, request}, 2_000
+    assert request =~ ~s|"label":"ptc.json · app/run"|
+    :ok = :gen_tcp.close(listener)
   end
 
   @tag :tmp_dir

--- a/test/ptc_runner/kernel/repl_session_test.exs
+++ b/test/ptc_runner/kernel/repl_session_test.exs
@@ -99,7 +99,7 @@ defmodule PtcRunner.Kernel.ReplSessionTest do
     assert {:ok, step, session} =
              ReplSession.eval(
                session,
-               ~S|(workflow.event/annotate "agent-action" {:turn 0 :kind "tool-call"})|
+               ~S|(workflow.event/annotate "agent-action" {:turn 0 :max-turns 1 :kind "tool-call"})|
              )
 
     assert step.return[:status] == :ok or step.return["status"] == "ok"

--- a/test/ptc_runner/kernel/safe_metadata_test.exs
+++ b/test/ptc_runner/kernel/safe_metadata_test.exs
@@ -12,18 +12,23 @@ defmodule PtcRunner.Kernel.SafeMetadataTest do
             "max-calls",
             "model-output-truncated"
           ] do
-        assert SafeMetadata.annotation?("agent-action", %{"turn" => 0, "kind" => kind})
+        assert SafeMetadata.annotation?("agent-action", action(0, kind))
       end
 
-      assert SafeMetadata.annotation?("agent-action", %{"turn" => 5, "kind" => "tool-call"})
+      assert SafeMetadata.annotation?("agent-action", action(5, "tool-call"))
     end
 
     test "bounds turn to 0..127" do
-      assert SafeMetadata.annotation?("agent-action", %{"turn" => 127, "kind" => "tool-call"})
-      refute SafeMetadata.annotation?("agent-action", %{"turn" => 128, "kind" => "tool-call"})
-      refute SafeMetadata.annotation?("agent-action", %{"turn" => -1, "kind" => "tool-call"})
-      refute SafeMetadata.annotation?("agent-action", %{"turn" => 1.0, "kind" => "tool-call"})
-      refute SafeMetadata.annotation?("agent-action", %{"turn" => "0", "kind" => "tool-call"})
+      assert SafeMetadata.annotation?("agent-action", %{
+               action(127, "tool-call")
+               | "max_turns" => 128
+             })
+
+      refute SafeMetadata.annotation?("agent-action", action(128, "tool-call"))
+      refute SafeMetadata.annotation?("agent-action", action(6, "tool-call"))
+      refute SafeMetadata.annotation?("agent-action", action(-1, "tool-call"))
+      refute SafeMetadata.annotation?("agent-action", action(1.0, "tool-call"))
+      refute SafeMetadata.annotation?("agent-action", action("0", "tool-call"))
     end
 
     test "accepts the phased shape with phase, phase-turn, and mission" do
@@ -36,6 +41,8 @@ defmodule PtcRunner.Kernel.SafeMetadataTest do
           ] do
         assert SafeMetadata.annotation?("agent-action", %{
                  "turn" => 3,
+                 "max_turns" => 6,
+                 "invocation" => "agent-0123456789abcdef",
                  "kind" => kind,
                  "phase" => 1,
                  "phase_turn" => 0,
@@ -47,6 +54,8 @@ defmodule PtcRunner.Kernel.SafeMetadataTest do
     test "bounds the phased fields and refuses a partial phased shape" do
       phased = %{
         "turn" => 0,
+        "max_turns" => 6,
+        "invocation" => "agent-0123456789abcdef",
         "kind" => "tool-call",
         "phase" => 0,
         "phase_turn" => 0,
@@ -80,8 +89,8 @@ defmodule PtcRunner.Kernel.SafeMetadataTest do
 
       refute SafeMetadata.annotation?("agent-action", %{"turn" => 0})
       refute SafeMetadata.annotation?("agent-action", %{"kind" => "tool-call"})
-      refute SafeMetadata.annotation?("agent-action", %{"turn" => 0, "kind" => "thinking"})
-      refute SafeMetadata.annotation?("agent-action", %{"turn" => 0, "kind" => nil})
+      refute SafeMetadata.annotation?("agent-action", action(0, "thinking"))
+      refute SafeMetadata.annotation?("agent-action", action(0, nil))
 
       refute SafeMetadata.annotation?("agent-action", %{
                "turn" => 0,
@@ -112,8 +121,9 @@ defmodule PtcRunner.Kernel.SafeMetadataTest do
     # change, or this test fails.
     @published [
       {"progress", ["stage"]},
-      {"agent-action", ["turn", "kind"]},
-      {"agent-action", ["turn", "kind", "phase", "phase_turn", "mission"]}
+      {"agent-action", ["turn", "max_turns", "invocation", "kind"]},
+      {"agent-action",
+       ["turn", "max_turns", "invocation", "kind", "phase", "phase_turn", "mission"]}
     ]
 
     test "annotation?/2 accepting clauses are exactly the published rows" do
@@ -147,29 +157,40 @@ defmodule PtcRunner.Kernel.SafeMetadataTest do
 
       assert agent_row =~ ~s("agent-action")
       refute agent_row =~ "progress"
-      assert agent_row =~ "exactly two keys or exactly five"
+      assert agent_row =~ "exactly four keys or exactly seven"
 
-      [two_key, five_key] = String.split(agent_row, "or that plus", parts: 2)
+      [base_key, phased_key] = String.split(agent_row, "or that plus", parts: 2)
 
-      assert two_key =~ ~s("turn": #{bounds.turn})
-      assert two_key =~ ~s("kind")
-      refute two_key =~ "phase"
-      refute two_key =~ "mission"
+      assert base_key =~ ~s("turn": #{bounds.turn})
+      assert base_key =~ ~s("max_turns": 1..128)
+      assert base_key =~ ~s("invocation")
+      assert base_key =~ ~s("kind")
+      refute base_key =~ "phase"
+      refute base_key =~ "mission"
 
-      assert five_key =~ ~s("phase": #{bounds.phase})
-      assert five_key =~ ~s("phase_turn": #{bounds.phase_turn})
-      assert five_key =~ ~s("mission")
+      assert phased_key =~ ~s("phase": #{bounds.phase})
+      assert phased_key =~ ~s("phase_turn": #{bounds.phase_turn})
+      assert phased_key =~ ~s("mission")
 
       for kind <- kinds do
-        assert two_key =~ kind
+        assert base_key =~ kind
       end
 
-      unescaped_kinds = String.replace(two_key, "\\", "")
+      unescaped_kinds = String.replace(base_key, "\\", "")
       assert unescaped_kinds =~ Enum.join(kinds, " | ")
 
       assert section =~ "a lowercase letter, then up to #{bounds.mission_max} letters, digits"
       assert source =~ ~s|~r/\\A[a-z][a-z0-9._-]{0,#{bounds.mission_max}}\\z/|
     end
+  end
+
+  defp action(turn, kind) do
+    %{
+      "turn" => turn,
+      "max_turns" => 6,
+      "invocation" => "agent-0123456789abcdef",
+      "kind" => kind
+    }
   end
 
   describe "capability rejection class" do

--- a/test/ptc_runner/live_status_test.exs
+++ b/test/ptc_runner/live_status_test.exs
@@ -2,6 +2,8 @@ defmodule PtcRunner.LiveStatusTest do
   # async: false — mutates the PTC_VIEWER_URL environment variable.
   use ExUnit.Case, async: false
 
+  import PtcRunner.TestSupport.Eventually, only: [assert_eventually: 1]
+
   alias PtcRunner.Kernel
   alias PtcRunner.Kernel.Capability
   alias PtcRunner.Kernel.EventSink
@@ -16,8 +18,63 @@ defmodule PtcRunner.LiveStatusTest do
   alias PtcRunner.Kernel.WorkflowEnvironment
   alias PtcRunner.LiveStatus.Reporter
   alias PtcRunner.LiveStatus.Target
+  alias PtcRunner.MixCommandAdapter
+  alias PtcRunner.TestSupport.HTTPRequest
+
+  @tag :tmp_dir
+  test "an externally attached CLI run carries the manifest application identity", %{tmp_dir: dir} do
+    manifest = Path.join(dir, "ptc.json")
+    File.write!(Path.join(dir, "app.clj"), "(ns app) (defn run [input] input)")
+
+    File.write!(manifest, ~S|{
+      "version": 1,
+      "labels": {"name": "invoice-triage"},
+      "workflow": {
+        "components": [{"id": "app", "path": "app.clj"}],
+        "entry": "app/run"
+      },
+      "input": {"value": {}}
+    }|)
+
+    {:ok, listener} = :gen_tcp.listen(0, [:binary, active: false, reuseaddr: true])
+    {:ok, port} = :inet.port(listener)
+    parent = self()
+
+    server =
+      spawn(fn ->
+        {:ok, socket} = :gen_tcp.accept(listener)
+        {:ok, request} = HTTPRequest.receive_complete(socket)
+        send(parent, {:external_cli_request, request})
+        :ok = :gen_tcp.send(socket, "HTTP/1.1 200 OK\r\ncontent-length: 0\r\n\r\n")
+        :ok = :gen_tcp.close(socket)
+      end)
+
+    server_ref = Process.monitor(server)
+
+    System.put_env("PTC_VIEWER_URL", "http://127.0.0.1:#{port}")
+    on_exit(fn -> System.delete_env("PTC_VIEWER_URL") end)
+
+    assert %{exit_status: 0} = MixCommandAdapter.execute(["run", manifest])
+    assert_receive {:external_cli_request, request}, 2_000
+    assert request =~ ~s|"label":"invoice-triage · app/run"|
+    :ok = :gen_tcp.close(listener)
+    assert_receive {:DOWN, ^server_ref, :process, ^server, :normal}, 2_000
+  end
 
   @moduletag :capture_log
+
+  test "the reporter records a failed target delivery" do
+    {:ok, target} = Target.new(fn _run_id, _frame -> :error end)
+    {:ok, limits} = Limits.new()
+    {:ok, sink} = EventSink.start(:normal, limits, run_id: "failed-delivery")
+    {:ok, config} = run_config(limits, sink, %{})
+    {:ok, run_state} = RunState.start(limits)
+    {:ok, reporter} = Reporter.start(target, config, run_state)
+
+    assert assert_eventually(fn -> :sys.get_state(reporter).post_failed? end)
+    assert :ok = Reporter.stop(reporter)
+    assert :ok = RunState.stop(run_state)
+  end
 
   test "telemetry delivery is isolated to its correlated run" do
     run_ref = self()
@@ -43,6 +100,45 @@ defmodule PtcRunner.LiveStatusTest do
              )
 
     assert_receive {:live_telemetry, [:ptc_runner, :capability, :start], %{}, %{}}
+  end
+
+  test "agent progress remains scoped to concurrent invocation identities" do
+    parent = self()
+    {:ok, target} = Target.new(fn _run_id, frame -> send(parent, {:live_frame, frame}) end)
+    {:ok, limits} = Limits.new()
+    {:ok, sink} = EventSink.start(:normal, limits, run_id: "concurrent-agent-progress")
+    {:ok, config} = run_config(limits, sink, %{})
+    {:ok, run_state} = RunState.start(limits)
+    {:ok, reporter} = Reporter.start(target, config, run_state)
+    assert_receive {:live_frame, _frame}
+
+    for progress <- [
+          %{invocation: "agent-aaaaaaaaaaaaaaaa", turn: 1, max_turns: 6, kind: "tool-call"},
+          %{invocation: "agent-bbbbbbbbbbbbbbbb", turn: 0, max_turns: 2, kind: "provider-error"}
+        ] do
+      Reporter.handle_telemetry(
+        [:ptc_runner, :agent, :action],
+        %{},
+        Map.put(progress, :live_run, run_state.pid),
+        {reporter, run_state.pid}
+      )
+    end
+
+    assert :ok = Reporter.complete(reporter, :ok, nil, nil)
+    assert_receive {:live_frame, %{phase: "ok", activity: activity}}, 2_000
+
+    assert Enum.any?(
+             activity,
+             &match?(%{name: "agent-aaaaaaaaaaaaaaaa", turn: 1, max_turns: 6}, &1)
+           )
+
+    assert Enum.any?(
+             activity,
+             &match?(%{name: "agent-bbbbbbbbbbbbbbbb", turn: 0, max_turns: 2}, &1)
+           )
+
+    assert :ok = Reporter.stop(reporter)
+    assert :ok = RunState.stop(run_state)
   end
 
   test "the reporter stops when the run owner dies" do

--- a/test/support/http_request.ex
+++ b/test/support/http_request.ex
@@ -1,0 +1,37 @@
+defmodule PtcRunner.TestSupport.HTTPRequest do
+  @moduledoc false
+
+  def receive_complete(socket, timeout \\ 2_000), do: receive_complete(socket, "", timeout)
+
+  defp receive_complete(socket, buffered, timeout) do
+    case complete?(buffered) do
+      true ->
+        {:ok, buffered}
+
+      false ->
+        with {:ok, bytes} <- :gen_tcp.recv(socket, 0, timeout),
+             do: receive_complete(socket, buffered <> bytes, timeout)
+    end
+  end
+
+  defp complete?(request) do
+    case :binary.split(request, "\r\n\r\n") do
+      [headers, body] -> byte_size(body) >= content_length(headers)
+      [_headers_only] -> false
+    end
+  end
+
+  defp content_length(headers) do
+    headers
+    |> String.split("\r\n")
+    |> Enum.find_value(0, fn line ->
+      case String.split(line, ":", parts: 2) do
+        [name, value] ->
+          if String.downcase(name) == "content-length", do: String.to_integer(String.trim(value))
+
+        _other ->
+          nil
+      end
+    end)
+  end
+end


### PR DESCRIPTION
Closes #1769

## Summary
- derive externally attached CLI run titles from the already-acquired application snapshot and resolve the Viewer target after deferred environment setup
- extend canonical `agent-action` annotations with bounded total turns and runtime-authored per-invocation correlation, then relay and render `turn x of y` rows
- keep concurrent and sequential agent invocations distinct, share byte-safe labels with Viewer-launched workflows, and document the Viewer-only plaintext disclosure

## Verification
- `mix precommit`
- focused Elixir tests for CLI labels, deferred dotenv resolution, annotation bounds, phased/sequential/concurrent invocations, and failed delivery
- `node ptc_viewer/test/live_ui.mjs`
- `mix ptc.gen_docs`
- normal `git push` pre-push gate: 7,759 core tests plus doctests/properties, static analysis, Dialyzer, ExDoc, release verification, and 125 Viewer tests
- two independent Codex reviews: incremental and cumulative against refreshed `origin/main`; both clean after follow-up fixes

The requested packaged external model-backed probe could not be run because this workspace has no OpenRouter, OpenAI, or Anthropic credential. The packaged release gate and deterministic external HTTP attachment coverage passed.

## Retrospective
The key design lesson was to carry display identity beside the privacy-fingerprinted trace label and to relay the shipped agent loop’s canonical annotation rather than reconstructing progress in the reporter. Review also caught two important boundary details: dotenv-backed Viewer configuration must be resolved before target creation, and cumulative turns for phased agents must be paired with the total invocation ceiling.