### PR TITLE
test(viewer): control terminal attachment

### DIFF
--- a/lib/ptc_runner/viewer_frontend.ex
+++ b/lib/ptc_runner/viewer_frontend.ex
@@ -241,14 +241,20 @@ defmodule PtcRunner.ViewerFrontend do
   defp start_viewer(project, overrides, snapshots, callbacks) do
     options = viewer_options(project, overrides, snapshots, callbacks)
 
-    # credo:disable-for-next-line Credo.Check.Refactor.Apply
-    case apply(@viewer, :start, [options]) do
-      {:ok, pid} ->
-        finish_start(pid, Keyword.fetch!(options, :ip), snapshots, callbacks)
+    with :ok <- invoke_before_viewer_start(callbacks.before_viewer_start, options),
+         result <- default_viewer_start(options) do
+      case result do
+        {:ok, pid} ->
+          finish_start(pid, Keyword.fetch!(options, :ip), snapshots, callbacks)
 
+        {:error, _reason} = error ->
+          ViewerSnapshotStore.stop(snapshots)
+          classify_start_error(error, options)
+      end
+    else
       {:error, _reason} = error ->
         ViewerSnapshotStore.stop(snapshots)
-        classify_start_error(error, options)
+        error
     end
   end
 
@@ -281,14 +287,28 @@ defmodule PtcRunner.ViewerFrontend do
       capture = Keyword.get(opts, :capture_inspection, &capture_inspection/3)
       listener = Keyword.get_lazy(opts, :listener_info, &default_listener_info/0)
       project_loader = Keyword.get(opts, :project_loader, &ProjectConfig.load/1)
+      before_viewer_start = Keyword.get(opts, :before_viewer_start, fn _options -> :ok end)
       frontend = Keyword.get(opts, :frontend, :mix)
       env_file = Keyword.get(opts, :env_file)
 
+      terminal_attached =
+        Keyword.get_lazy(opts, :terminal_attached, &AnalysisTerminal.attached?/0)
+
       if keys --
-           [:capture_inspection, :listener_info, :project_loader, :device, :frontend, :env_file] ==
+           [
+             :capture_inspection,
+             :listener_info,
+             :project_loader,
+             :before_viewer_start,
+             :device,
+             :frontend,
+             :env_file,
+             :terminal_attached
+           ] ==
            [] and
            length(keys) == MapSet.size(MapSet.new(keys)) and is_function(capture, 3) and
            is_function(listener, 1) and is_function(project_loader, 1) and
+           is_function(before_viewer_start, 1) and is_boolean(terminal_attached) and
            frontend in [:mix, :standalone] and
            valid_env_file?(env_file),
          do:
@@ -297,8 +317,10 @@ defmodule PtcRunner.ViewerFrontend do
               capture_inspection: capture,
               listener_info: listener,
               project_loader: project_loader,
+              before_viewer_start: before_viewer_start,
               frontend: frontend,
-              env_file: env_file
+              env_file: env_file,
+              terminal_attached: terminal_attached
             }},
          else: {:error, :invalid_viewer_config}
     else
@@ -309,6 +331,23 @@ defmodule PtcRunner.ViewerFrontend do
   defp default_listener_info do
     # credo:disable-for-next-line Credo.Check.Refactor.Apply
     fn pid -> apply(@viewer, :listener_info, [pid]) end
+  end
+
+  defp default_viewer_start(options) do
+    # credo:disable-for-next-line Credo.Check.Refactor.Apply
+    apply(@viewer, :start, [options])
+  end
+
+  defp invoke_before_viewer_start(callback, options) do
+    case callback.(options) do
+      :ok -> :ok
+      {:error, _reason} = error -> error
+      _invalid -> {:error, :viewer_start_failed}
+    end
+  rescue
+    _exception -> {:error, :viewer_start_failed}
+  catch
+    _kind, _reason -> {:error, :viewer_start_failed}
   end
 
   defp invoke_project_loader(callback, path) do
@@ -373,7 +412,7 @@ defmodule PtcRunner.ViewerFrontend do
       port: Map.get(overrides, :port) || project.viewer.port,
       trace_dir: Path.join(project.artifact_root, "traces"),
       private_traces: private?,
-      open: project.viewer.open and AnalysisTerminal.attached?(),
+      open: project.viewer.open and callbacks.terminal_attached,
       trace_source: source,
       inspection_source: if(recorded?, do: source),
       kernel_trace_adapter: PtcRunner.Kernel.ProjectViewerAdapter,

--- a/test/ptc_runner/viewer_frontend_test.exs
+++ b/test/ptc_runner/viewer_frontend_test.exs
@@ -479,16 +479,33 @@ defmodule PtcRunner.ViewerFrontendTest do
   end
 
   @tag :tmp_dir
-  test "browser opening stays inert without an attached terminal", %{tmp_dir: directory} do
-    # The suite never runs with stdin and stdout both on a terminal, so this
-    # asserts the gate rather than simulating it: a project that asks to open a
-    # browser must still not launch one here.
-    refute AnalysisTerminal.attached?()
+  test "browser opening follows the classified terminal attachment", %{tmp_dir: directory} do
     project_path = viewer_project(directory, %{"open" => true})
 
-    assert {:ok, viewer, _address, _port} = ViewerFrontend.start(project_path)
-    on_exit(fn -> if Process.alive?(viewer), do: PtcViewer.stop(viewer) end)
-    assert :ok = PtcViewer.stop(viewer)
+    for {terminal_attached, expected_open} <- [{false, false}, {true, true}] do
+      assert {:ok, options} = captured_viewer_options(project_path, terminal_attached)
+      assert Keyword.fetch!(options, :open) == expected_open
+    end
+  end
+
+  @tag :tmp_dir
+  test "browser opening classifies the real terminal lazily when no override is supplied", %{
+    tmp_dir: directory
+  } do
+    project_path = viewer_project(directory, %{"open" => true})
+
+    assert {:ok, options} = captured_viewer_options(project_path)
+    assert Keyword.fetch!(options, :open) == AnalysisTerminal.attached?()
+  end
+
+  @tag :tmp_dir
+  test "invalid classified terminal attachment is rejected", %{tmp_dir: directory} do
+    project_path = viewer_project(directory)
+
+    for invalid <- [nil, :yes, 1, "true"] do
+      assert {:error, :invalid_viewer_config} =
+               ViewerFrontend.start(project_path, %{}, terminal_attached: invalid)
+    end
   end
 
   @tag :tmp_dir
@@ -585,6 +602,26 @@ defmodule PtcRunner.ViewerFrontendTest do
 
   defp announce(address, port) do
     ViewerFrontend.announce(address, port, :stdio)
+  end
+
+  defp captured_viewer_options(project_path, terminal_attached \\ :default) do
+    parent = self()
+
+    before_viewer_start = fn options ->
+      send(parent, {:viewer_options, options})
+      {:error, :viewer_options_captured}
+    end
+
+    options = [before_viewer_start: before_viewer_start]
+
+    options =
+      if terminal_attached == :default,
+        do: options,
+        else: Keyword.put(options, :terminal_attached, terminal_attached)
+
+    assert {:error, :viewer_options_captured} = ViewerFrontend.start(project_path, %{}, options)
+    assert_receive {:viewer_options, viewer_options}
+    {:ok, viewer_options}
   end
 
   defp live_nonce(base_url) do


### PR DESCRIPTION
## Summary

- classify terminal attachment once at the internal Viewer frontend boundary
- require both the project browser-opening preference and the classified terminal state for `open: true`
- replace the ambient terminal assertion with deterministic attached, detached, default, and invalid-value coverage without starting a browser

## Verification

- focused Viewer frontend suite: 25 passed
- focused Viewer test under a PTY: passed
- `mix precommit`
- `scripts/ci/core-tests.sh`: 7,718 passed before rebase
- normal push hook on the rebased tree:
  - core tests: 7,761 passed
  - Viewer tests: 125 passed
  - documentation, static analysis, Dialyzer, and release verification passed
- independent Codex reviews: initial review clean; cumulative review findings fixed and follow-up approved; final rebased cumulative review clean

Closes #1736

## Agent retrospective

The first test seam substituted a fake Viewer process, which independent review correctly identified as an incomplete lifecycle abstraction. Replacing it with a pre-start options observer made the test both more direct and resource-safe: it proves the exact `open` option and aborts before any Viewer or browser process starts. Rebasing late also caught concurrent Viewer work on `main`; the change applied cleanly and all gates were rerun on the final tree.
