### PR TITLE
fix(kernel): own provider adapter field atoms

### DIFF
--- a/lib/ptc_runner/kernel/provider_registry.ex
+++ b/lib/ptc_runner/kernel/provider_registry.ex
@@ -790,7 +790,7 @@ defmodule PtcRunner.Kernel.ProviderRegistry do
   def adapter_request(request) do
     request
     |> Map.take(~w(system messages tools cache schema))
-    |> Map.new(fn {key, value} -> {String.to_existing_atom(key), adapter_value(key, value)} end)
+    |> Map.new(fn {key, value} -> {adapter_field(key), adapter_value(key, value)} end)
   end
 
   defp adapter_value("messages", messages) when is_list(messages),
@@ -812,7 +812,7 @@ defmodule PtcRunner.Kernel.ProviderRegistry do
             true -> value
           end
 
-        Map.put(map, String.to_existing_atom(key), value)
+        Map.put(map, adapter_field(key), value)
 
       _field, map ->
         map
@@ -827,7 +827,7 @@ defmodule PtcRunner.Kernel.ProviderRegistry do
       {key, value}, map
       when key in ["id", "type", "function", "name", "args", "args_error"] ->
         value = if key == "function", do: adapter_function(value), else: value
-        Map.put(map, String.to_existing_atom(key), value)
+        Map.put(map, adapter_field(key), value)
 
       _field, map ->
         map
@@ -839,10 +839,26 @@ defmodule PtcRunner.Kernel.ProviderRegistry do
   defp adapter_function(function) when is_map(function) do
     function
     |> Map.take(~w(name arguments))
-    |> Map.new(fn {key, value} -> {String.to_existing_atom(key), value} end)
+    |> Map.new(fn {key, value} -> {adapter_field(key), value} end)
   end
 
   defp adapter_function(function), do: function
+  defp adapter_field("system"), do: :system
+  defp adapter_field("messages"), do: :messages
+  defp adapter_field("tools"), do: :tools
+  defp adapter_field("cache"), do: :cache
+  defp adapter_field("schema"), do: :schema
+  defp adapter_field("role"), do: :role
+  defp adapter_field("content"), do: :content
+  defp adapter_field("tool_calls"), do: :tool_calls
+  defp adapter_field("tool_call_id"), do: :tool_call_id
+  defp adapter_field("id"), do: :id
+  defp adapter_field("type"), do: :type
+  defp adapter_field("function"), do: :function
+  defp adapter_field("name"), do: :name
+  defp adapter_field("args"), do: :args
+  defp adapter_field("args_error"), do: :args_error
+  defp adapter_field("arguments"), do: :arguments
   defp role("system"), do: :system
   defp role("user"), do: :user
   defp role("assistant"), do: :assistant

--- a/test/ptc_runner/kernel/provider_lifecycle_test.exs
+++ b/test/ptc_runner/kernel/provider_lifecycle_test.exs
@@ -588,6 +588,61 @@ defmodule PtcRunner.Kernel.ProviderLifecycleTest do
     assert Jason.decode!(call.function.arguments) == %{"program" => "(return 42)"}
   end
 
+  test "provider request adaptation owns every accepted field atom" do
+    {:ok, {_module, [atoms: atoms]}} =
+      ProviderRegistry |> :code.which() |> :beam_lib.chunks([:atoms])
+
+    owned = MapSet.new(atoms, fn {_index, atom} -> atom end)
+
+    for atom <- [
+          :system,
+          :messages,
+          :tools,
+          :cache,
+          :schema,
+          :role,
+          :content,
+          :tool_calls,
+          :tool_call_id,
+          :id,
+          :type,
+          :function,
+          :name,
+          :args,
+          :args_error,
+          :arguments
+        ] do
+      assert MapSet.member?(owned, atom),
+             "#{inspect(atom)} must be a literal in ProviderRegistry, not borrowed from another module"
+    end
+  end
+
+  test "provider request adaptation does not intern unknown fields" do
+    unknown = "provider_registry_unknown_field_1735"
+
+    assert_raise ArgumentError, fn -> String.to_existing_atom(unknown) end
+
+    request = %{
+      unknown => "request",
+      "messages" => [
+        %{
+          unknown => "message",
+          "tool_calls" => [
+            %{
+              unknown => "tool call",
+              "function" => %{"name" => "tool", "arguments" => "{}", unknown => "function"}
+            }
+          ]
+        }
+      ]
+    }
+
+    assert %{messages: [%{tool_calls: [%{function: %{name: "tool", arguments: "{}"}}]}]} =
+             ProviderRegistry.adapter_request(request)
+
+    assert_raise ArgumentError, fn -> String.to_existing_atom(unknown) end
+  end
+
   @tag :tmp_dir
   test "assembly failure closes successful providers in reverse order", %{tmp_dir: dir} do
     parent = self()


### PR DESCRIPTION
## Summary

- decode the closed provider request vocabulary through explicit atom-literal clauses owned by `ProviderRegistry`
- preserve existing filtering for unknown request, message, tool-call, and function fields without interning them
- add regressions covering every accepted field atom, unknown nested fields, and the existing correction-history path

## Verification

- fresh-BEAM reproduction from #1735
- `mix test test/ptc_runner/kernel/provider_lifecycle_test.exs` (34 passed)
- `mix precommit`
- configured pre-push gates:
  - core suite (7,776 passed)
  - core static analysis and Dialyzer
  - release verification
  - ExDoc and published-link validation
  - Viewer suite (125 passed)
- two configured independent Codex reviews plus the required post-rebase cumulative review; no actionable findings

## Retrospective

The original lifecycle test exercised the right behavior but could not reveal its dependency on the VM-wide atom table. Reading the compiled module's atom chunk makes ownership—not incidental test order—the invariant, while a separate unknown-field regression keeps the closed decoder honest. The base-guarded review also caught that `main` had advanced during the job, so the final tree was rebased and fully revalidated before publication.

Closes #1735
