### PR TITLE
feat(viewer): explain workflow model sessions

### DIFF
--- a/lib/ptc_runner/kernel/project_viewer_adapter.ex
+++ b/lib/ptc_runner/kernel/project_viewer_adapter.ex
@@ -43,6 +43,20 @@ defmodule PtcRunner.Kernel.ProjectViewerAdapter do
 
   def conversation(_source, _run_id), do: {:error, :invalid_inspection_query}
 
+  @spec result(
+          {:inspection_snapshot, InspectionSnapshot.t()}
+          | {:viewer_snapshot_store, ViewerSnapshotStore.t()},
+          binary()
+        ) ::
+          {:ok, map()} | {:error, atom()}
+  def result({:inspection_snapshot, snapshot}, run_id),
+    do: InspectionSnapshot.query(snapshot, :result, %{"run_id" => run_id})
+
+  def result({:viewer_snapshot_store, store}, run_id),
+    do: ViewerSnapshotStore.result(store, run_id)
+
+  def result(_source, _run_id), do: {:error, :invalid_inspection_query}
+
   @spec preludes(
           {:inspection_snapshot, InspectionSnapshot.t()}
           | {:viewer_snapshot_store, ViewerSnapshotStore.t()},

--- a/lib/ptc_runner/kernel/viewer_adapter.ex
+++ b/lib/ptc_runner/kernel/viewer_adapter.ex
@@ -67,6 +67,19 @@ defmodule PtcRunner.Kernel.ViewerAdapter do
     end
   end
 
+  @spec result(inspection_grant(), binary()) :: {:ok, map()} | {:error, atom()}
+  @doc "Returns the pinned run's authorized terminal application result."
+  def result({:inspection_v4, granted_run_id, snapshot, _trace_snapshot}, run_id)
+      when is_binary(granted_run_id) and is_binary(run_id) do
+    cond do
+      not InspectionSnapshot.valid?(snapshot) -> {:error, :invalid_inspection_query}
+      granted_run_id != run_id -> {:error, :inspection_run_mismatch}
+      true -> InspectionSnapshot.query(snapshot, :result, %{"run_id" => run_id})
+    end
+  end
+
+  def result(_grant, _run_id), do: {:error, :invalid_inspection_query}
+
   @spec preludes(inspection_grant(), binary()) :: {:ok, map()} | {:error, atom()}
   @doc "Returns the pinned run's exact effective prelude sources."
   def preludes(grant, run_id), do: inspection_collection(grant, run_id, :effective_preludes)

--- a/lib/ptc_runner/viewer_snapshot_store.ex
+++ b/lib/ptc_runner/viewer_snapshot_store.ex
@@ -79,6 +79,12 @@ defmodule PtcRunner.ViewerSnapshotStore do
 
   def conversation(_store, _run_id), do: {:error, :invalid_inspection_query}
 
+  @spec result(t(), binary()) :: {:ok, map()} | {:error, atom()}
+  def result(%__MODULE__{} = store, run_id) when is_binary(run_id),
+    do: call(store, {:result, run_id})
+
+  def result(_store, _run_id), do: {:error, :invalid_inspection_query}
+
   @spec preludes(t(), binary()) :: {:ok, map()} | {:error, atom()}
   def preludes(%__MODULE__{} = store, run_id) when is_binary(run_id),
     do: call(store, {:preludes, run_id})
@@ -209,6 +215,9 @@ defmodule PtcRunner.ViewerSnapshotStore do
 
   defp respond({:conversation, run_id}, state, outcome),
     do: respond_inspection(state, outcome, :conversation, run_id)
+
+  defp respond({:result, run_id}, state, outcome),
+    do: respond_inspection(state, outcome, :result, run_id)
 
   defp respond({:preludes, run_id}, state, outcome),
     do: respond_inspection(state, outcome, :preludes, run_id)
@@ -460,6 +469,9 @@ defmodule PtcRunner.ViewerSnapshotStore do
 
   defp inspect_snapshot(snapshot, :conversation, run_id),
     do: ProjectViewerAdapter.conversation({:inspection_snapshot, snapshot}, run_id)
+
+  defp inspect_snapshot(snapshot, :result, run_id),
+    do: ProjectViewerAdapter.result({:inspection_snapshot, snapshot}, run_id)
 
   defp inspect_snapshot(snapshot, :preludes, run_id),
     do: ProjectViewerAdapter.preludes({:inspection_snapshot, snapshot}, run_id)

--- a/ptc_viewer/README.md
+++ b/ptc_viewer/README.md
@@ -19,7 +19,12 @@ mix ptc viewer ptc-project.json --env-file .env
 ```
 
 That command also derives the Live tab's fixed launch target and project
-details from the named project. A Viewer-started workflow runs inside the same
+details from the named project. Live shows a declared application map with the
+workflow entry and available mission environments; it is configuration, not a
+claim that every mission runs. Selecting **workflow** runs the application with
+the edited JSON input. Selecting a mission instead evaluates one PTC-Lisp
+expression in that mission sandbox; it is a focused environment test, not a
+way to start that workflow stage. A Viewer-started workflow runs inside the same
 long-lived PtcRunner BEAM instance under the ordinary execution-session owner,
 preserving the project's host, environment, and artifact defaults without
 starting a `mix` or `ptc` child process. No programmatic `PtcViewer.start/1`
@@ -78,14 +83,41 @@ isolated without hiding disjoint valid runs. The Runs tab renders the
 Kernel's bounded isolation evidence; it never rescans or reclassifies files in
 the browser.
 
+The run page first summarizes the evaluations that actually occurred, in
+canonical start order, and groups repeated capability calls by name. This is
+recorded execution evidence; the Viewer does not infer dependencies from timing
+or imply that a configured mission ran. Individual evaluations, capability
+calls, and raw canonical events remain in the collapsed execution transcript.
+If the bounded eager read leaves more event pages, the overview labels itself
+partial until the operator loads them. If the trace reports dropped events, the
+overview also states that it is incomplete and that those events cannot be
+recovered. When both conditions apply, it distinguishes the retained pages that
+can still be loaded from the dropped events that cannot.
+
+When private evidence associates a generated program with a mission
+evaluation, the overview links that evaluation to its model session. Expanding
+the session shows the prompt, input added for that turn, model response, and
+program. Model turns are presented one-based: one turn means the model was
+called once; a later turn exists only when the loop called it again with
+feedback or another instruction. The raw zero-based `agent-action` annotation
+remains available, but the transcript describes its meaning first.
+
 The canonical transcript keeps canonical events as its execution spine. With
 an authorized inspection artifact, it also shows each evaluation's exact
 generated program from the semantic conversation projection and the feedback
 reconstructed on the following turn. Ambiguous program-to-turn associations
 are not guessed into result blocks. Private model requests and responses also
-appear in the separate **Model conversation** panel produced by `RunAnalysis`;
-ambiguous exchanges are omitted from streams and reported by the semantic
-result rather than guessed into a turn.
+appear in the separate **Model sessions & programs** panel produced by
+`RunAnalysis`. That panel leads with the model input, response, generated
+programs, and tool feedback; the complete raw turn record stays one disclosure
+away. It labels a session with captured mission names when available, retaining
+the opaque stream ID as provenance. The Viewer does not expose a run's final
+application value from the sanitized trace. When the host grants the run's
+private inspection artifact, the Viewer reads the existing authorized result
+projection and displays it separately from per-turn feedback. Run envelopes
+remain the canonical automation interface; ambiguous exchanges are omitted
+from streams and reported by the semantic result rather than guessed into a
+turn.
 
 The browser cannot choose a server path or discover inspection files. Startup
 pins the operator-selected artifact, validates it against the captured
@@ -194,6 +226,7 @@ live ingestion and controls, not the trace browser as a whole.
 | `GET /api/kernel/runs/:run_id/turns` | `list_turns` with bounded filters and pagination |
 | `GET /api/kernel/counters` | `counters` |
 | `GET /api/analysis/runs/:run_id/conversation` | Presentation over the bounded `turns` collection |
+| `GET /api/analysis/runs/:run_id/result` | Authorized terminal application result from the pinned inspection projection |
 | `GET /api/analysis/runs/:run_id/preludes` | Bounded effective prelude sources from the pinned inspection projection |
 | `GET /api/analysis/runs/:run_id/execution-errors` | Authorized workflow execution-error records from the pinned inspection projection |
 | `GET /api/analysis/runs/:run_id/explicit-failure-values` | Dedicated explicit-failure-value records from the pinned inspection projection |

--- a/ptc_viewer/lib/ptc_viewer/api.ex
+++ b/ptc_viewer/lib/ptc_viewer/api.ex
@@ -20,6 +20,9 @@ defmodule PtcViewer.Api do
   @doc "Delegates semantic private conversation reconstruction to the configured host adapter."
   def conversation(config, run_id), do: inspection_query(config, :conversation, run_id)
 
+  @doc "Delegates authorized terminal application-result retrieval to the configured host adapter."
+  def result(config, run_id), do: inspection_query(config, :result, run_id)
+
   @doc "Delegates private effective-prelude source retrieval to the configured host adapter."
   def preludes(config, run_id), do: inspection_query(config, :preludes, run_id)
 

--- a/ptc_viewer/lib/ptc_viewer/router.ex
+++ b/ptc_viewer/lib/ptc_viewer/router.ex
@@ -121,6 +121,10 @@ defmodule PtcViewer.Router do
     send_analysis(conn, PtcViewer.Api.conversation(viewer_config(conn), run_id))
   end
 
+  get "/api/analysis/runs/:run_id/result" do
+    send_analysis(conn, PtcViewer.Api.result(viewer_config(conn), run_id))
+  end
+
   get "/api/analysis/runs/:run_id/preludes" do
     send_analysis(conn, PtcViewer.Api.preludes(viewer_config(conn), run_id))
   end
@@ -741,6 +745,9 @@ defmodule PtcViewer.Router do
       # The first two are about the run, the last two about the project.
       {:error, :not_found} ->
         send_resp(conn, 404, "inspection_run_not_recorded")
+
+      {:error, :result_not_found} ->
+        send_resp(conn, 404, "inspection_result_not_recorded")
 
       {:error, :inspection_run_mismatch} ->
         send_resp(conn, 404, "inspection_run_mismatch")

--- a/ptc_viewer/lib/ptc_viewer/server.ex
+++ b/ptc_viewer/lib/ptc_viewer/server.ex
@@ -328,6 +328,7 @@ defmodule PtcViewer.Server do
         [
           :pin_inspection,
           :conversation,
+          :result,
           :preludes,
           :execution_errors,
           :explicit_failure_values

--- a/ptc_viewer/priv/static/css/styles.css
+++ b/ptc_viewer/priv/static/css/styles.css
@@ -1200,6 +1200,7 @@ button:focus-visible, textarea:focus-visible, summary:focus-visible {
 
 /* === Canonical Kernel transcript === */
 .kernel-transcript {
+  min-width: 0;
   max-width: 1120px;
   margin: 0 auto 48px;
 }
@@ -1297,7 +1298,11 @@ button:focus-visible, textarea:focus-visible, summary:focus-visible {
   font-size: 12px;
 }
 .kt-terminal-cause strong { color: var(--error); white-space: nowrap; }
-.kt-terminal-cause span { color: #d7c3bf; }
+.kt-terminal-cause span {
+  min-width: 0;
+  color: #d7c3bf;
+  overflow-wrap: anywhere;
+}
 
 .kt-privacy-note {
   display: flex;
@@ -1462,6 +1467,16 @@ button:focus-visible, textarea:focus-visible, summary:focus-visible {
 .kt-empty { padding: 24px; border: 1px dashed var(--border); border-radius: 8px; text-align: center; }
 
 .kt-call-list { display: flex; flex-direction: column; gap: 5px; }
+.kt-capability-summary { display: flex; flex-wrap: wrap; gap: 6px; }
+.kt-capability-group {
+  padding: 3px 8px; border: 1px solid var(--border); border-radius: 999px;
+  color: var(--muted); font-size: 10px;
+}
+.kt-capability-group strong { color: var(--fg); font-family: 'SF Mono', Consolas, Monaco, monospace; }
+.kt-capability-group-error { border-color: rgba(244, 71, 71, 0.45); color: var(--error); }
+.kt-capability-details { margin-top: 8px; }
+.kt-capability-details > summary { color: var(--muted); cursor: pointer; font-size: 10px; }
+.kt-capability-details[open] > summary { margin-bottom: 6px; }
 .kt-call { overflow: hidden; border: 1px solid rgba(60, 60, 60, 0.82); border-radius: 6px; background: var(--bg); }
 .kt-call > summary { min-height: 35px; padding: 6px 9px; cursor: pointer; list-style: none; }
 .kt-call-icon { width: 18px; color: var(--warning); text-align: center; }
@@ -1492,6 +1507,9 @@ button:focus-visible, textarea:focus-visible, summary:focus-visible {
 .kt-annotation { margin: 5px 0; border-left: 2px solid var(--keyword); background: var(--bg); }
 .kt-annotation > summary { padding: 6px 9px; cursor: pointer; }
 .kt-annotation > summary span { color: var(--muted); font-size: 10px; }
+.kt-annotation-body { padding: 0 9px 9px; }
+.kt-annotation-body > p { margin: 4px 0 8px; color: var(--muted); font-size: 10px; }
+.kt-annotation-body details > summary { cursor: pointer; color: var(--muted); font-size: 10px; }
 .kt-annotation pre,
 .kt-raw pre { max-height: 420px; margin: 0; padding: 10px; overflow: auto; background: #181818; color: #c8d0d4; font-size: 11px; white-space: pre-wrap; }
 
@@ -1530,6 +1548,8 @@ button:focus-visible, textarea:focus-visible, summary:focus-visible {
   .kt-component-deps { display: flex; flex-wrap: wrap; gap: 3px; margin: 4px 0 0; }
   .kt-summary-meta > span:not(.kt-status) { display: none; }
   .kt-evaluation-body { padding-left: 13px; }
+  .kt-observed-step { grid-template-columns: 26px minmax(0, 1fr) auto; }
+  .kt-observed-calls { grid-column: 2 / -1; }
   .kt-turn-eval { align-items: flex-start; flex-direction: column; }
   .kt-turn-eval-facts { flex-wrap: wrap; min-width: 0; }
 }
@@ -1853,6 +1873,40 @@ button:focus-visible, textarea:focus-visible, summary:focus-visible {
 .inspection-record > summary code { color: var(--fg); font-size: 10px; }
 .inspection-record pre { max-height: 520px; margin: 0 0 10px; padding: 12px; overflow: auto; background: #181818; color: #ffd8dc; font-size: 11px; white-space: pre; word-break: normal; }
 
+.semantic-streams { display: flex; flex-direction: column; gap: 10px; padding: 4px 16px 16px; }
+.semantic-stream {
+  overflow: hidden;
+  border: 1px solid rgba(244, 71, 71, 0.25);
+  border-radius: 8px;
+  background: var(--bg-light);
+}
+.semantic-stream > summary {
+  display: flex; align-items: center; justify-content: space-between; gap: 14px;
+  padding: 11px 13px; cursor: pointer; list-style: none;
+}
+.semantic-stream > summary::-webkit-details-marker,
+.semantic-turn > summary::-webkit-details-marker { display: none; }
+.semantic-stream-main { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.semantic-stream-main strong { color: var(--fg); font-size: 13px; }
+.semantic-stream-main code { color: var(--muted); font-size: 9px; }
+.semantic-stream-meta { color: var(--muted); font-size: 10px; white-space: nowrap; }
+.semantic-stream-body { display: flex; flex-direction: column; gap: 10px; padding: 0 10px 10px; }
+.semantic-turn { margin: 0; }
+.semantic-turn-body { padding: 10px 12px 12px; }
+.semantic-turn-body > .kt-turn-in,
+.semantic-turn-body > .kt-turn-out { padding-right: 2px; padding-left: 2px; }
+.semantic-turn-body > .kt-turn-out { border-top: 0; }
+.semantic-feedback { border-top: 1px dashed rgba(60, 60, 60, 0.65); }
+.semantic-association-warning { margin: 8px 2px; color: var(--warning); font-size: 10px; }
+.semantic-token-summary { margin: 7px 2px; color: var(--muted); font-size: 10px; overflow-wrap: anywhere; }
+.semantic-raw-turn { margin: 9px 2px 0; border-top: 1px solid var(--border); }
+.semantic-raw-turn > summary { padding: 8px 0 3px; color: var(--muted); cursor: pointer; font-size: 10px; }
+.semantic-raw-turn pre {
+  max-height: 520px; margin: 5px 0 0; padding: 12px; overflow: auto;
+  border-radius: 6px; background: #181818; color: #ffd8dc;
+  font-size: 11px; white-space: pre; word-break: normal;
+}
+
 /* === Log-analysis REPL === */
 .primary-tabs { display: flex; gap: 3px; padding: 3px; border: 1px solid var(--border); border-radius: 6px; }
 .primary-tab {
@@ -1993,6 +2047,60 @@ button:focus-visible, textarea:focus-visible, summary:focus-visible {
    Preludes, fingerprints, the captured system prompt and the execution
    transcript are supporting evidence rather than the story of the run, so they
    are collapsed panels below the dialogue instead of always-open sections. */
+.kt-observed {
+  margin: 18px 0 0;
+  padding: 16px;
+  border: 1px solid rgba(86, 156, 214, 0.38);
+  border-radius: 9px;
+  background: var(--bg-light);
+}
+.kt-observed-heading { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+.kt-observed-heading span { color: var(--accent); font-size: 9px; letter-spacing: 0.12em; text-transform: uppercase; }
+.kt-observed-heading h3 { margin: 3px 0 0; font-size: 17px; }
+.kt-observed-heading > strong { color: var(--muted); font-size: 10px; }
+.kt-observed > p { margin: 8px 0 12px; color: var(--muted); font-size: 10px; }
+.kt-observed-steps { display: flex; flex-direction: column; gap: 6px; margin: 0; padding: 0; list-style: none; }
+.kt-observed-step {
+  display: grid; grid-template-columns: 26px minmax(130px, 1fr) minmax(180px, 2fr) auto;
+  gap: 10px; align-items: center; min-width: 0; padding: 9px 10px;
+  border: 1px solid var(--border); border-radius: 7px; background: var(--bg);
+}
+.kt-observed-number {
+  display: grid; width: 22px; height: 22px; place-items: center;
+  border: 1px solid var(--accent); border-radius: 50%; color: var(--accent); font-size: 9px;
+}
+.kt-observed-mission .kt-observed-number { border-color: var(--keyword); color: var(--keyword); }
+.kt-observed-main { display: flex; flex-direction: column; min-width: 0; }
+.kt-observed-main strong { overflow: hidden; color: var(--fg); font-size: 12px; text-overflow: ellipsis; white-space: nowrap; }
+.kt-observed-main small { color: var(--muted); font-size: 9px; }
+.kt-model-session-link {
+  width: fit-content; margin-top: 4px; color: var(--accent); font-size: 9px;
+  text-decoration: none;
+}
+.kt-model-session-link:hover { text-decoration: underline; }
+.kt-evaluation-result-note {
+  margin: 9px 0; padding: 9px 11px; border-left: 2px solid var(--success);
+  background: rgba(78, 201, 176, 0.05); color: var(--muted); font-size: 10px;
+}
+.kt-evaluation-result-note strong { color: var(--success); }
+.kt-observed-calls { display: flex; flex-wrap: wrap; gap: 5px; min-width: 0; }
+.kt-observed-calls span {
+  padding: 2px 7px; border: 1px solid var(--border); border-radius: 999px;
+  color: var(--muted); font: 9px 'SF Mono', Consolas, Monaco, monospace;
+}
+.kt-application-result {
+  margin-top: 12px; border: 1px solid rgba(78, 201, 176, 0.38);
+  border-radius: 8px; background: rgba(78, 201, 176, 0.05); overflow: hidden;
+}
+.kt-application-result > summary {
+  display: flex; align-items: center; gap: 9px; padding: 10px 13px; cursor: pointer;
+}
+.kt-application-result > pre {
+  max-height: 360px; margin: 0; padding: 12px 13px; overflow: auto;
+  border-top: 1px solid rgba(78, 201, 176, 0.22); color: var(--success);
+  white-space: pre-wrap; overflow-wrap: anywhere;
+}
+
 .kt-reference { display: flex; flex-direction: column; gap: 10px; margin-top: 24px; }
 .kt-reference-panel {
   background: var(--bg-light);
@@ -2364,6 +2472,37 @@ button:focus-visible, textarea:focus-visible, summary:focus-visible {
   color: var(--fg); border-color: var(--muted);
 }
 
+.live-application-map {
+  margin-top: 10px; padding: 13px 15px;
+  border: 1px solid var(--border); border-radius: 10px; background: var(--live-surface);
+}
+.live-application-map-head { display: flex; align-items: baseline; justify-content: space-between; gap: 12px; }
+.live-application-map-note { color: var(--muted); font-size: 10px; }
+.live-application-map-body {
+  display: grid; grid-template-columns: minmax(180px, 0.8fr) minmax(260px, 1.7fr);
+  gap: 14px; margin-top: 10px;
+}
+.live-application-group-label {
+  margin-bottom: 5px; color: var(--muted); font-size: 9px;
+  letter-spacing: 0.07em; text-transform: uppercase;
+}
+.live-application-missions { display: grid; grid-template-columns: repeat(auto-fit, minmax(130px, 1fr)); gap: 6px; }
+.live-application-card {
+  display: flex; flex-direction: column; min-width: 0; padding: 9px 10px;
+  border: 1px solid var(--border); border-left: 3px solid var(--live-eval);
+  border-radius: 7px; background: var(--bg);
+}
+.live-application-card[data-kind="mission"] { border-left-color: var(--keyword); }
+.live-application-kind { color: var(--muted); font-size: 8px; letter-spacing: 0.08em; text-transform: uppercase; }
+.live-application-name { margin-top: 2px; color: var(--fg); font-size: 12px; }
+.live-application-entry {
+  overflow: hidden; margin-top: 3px; color: var(--accent); font-size: 9px;
+  text-overflow: ellipsis; white-space: nowrap;
+}
+.live-application-counts { margin-top: 5px; color: var(--muted); font-size: 9px; }
+.live-application-empty { color: var(--muted); font-size: 11px; font-style: italic; }
+.live-application-explanation { margin: 9px 0 0; color: var(--muted); font-size: 10px; }
+
 .live-project-panel {
   margin-top: 10px; padding: 12px 16px;
   background: var(--live-surface);
@@ -2441,6 +2580,7 @@ button:focus-visible, textarea:focus-visible, summary:focus-visible {
 
 /* --- launch environment chips --- */
 .live-launch-envs { display: flex; flex-wrap: wrap; gap: 6px; margin: 10px 0 4px; }
+.live-launch-mode-note { margin: 4px 0 12px; color: var(--muted); font-size: 10px; }
 .live-env-chip {
   background: none; border: 1px solid var(--border); border-radius: 999px;
   padding: 3px 12px; cursor: pointer; font-size: 11px; color: var(--muted);
@@ -2511,4 +2651,9 @@ button:focus-visible, textarea:focus-visible, summary:focus-visible {
   margin: 6px 0 0; padding: 8px; overflow-x: auto;
   background: var(--bg-light); border-radius: 4px;
   color: var(--fg); font-size: 11px; white-space: pre-wrap;
+}
+
+@media (max-width: 640px) {
+  .live-application-map-body { grid-template-columns: 1fr; }
+  .semantic-stream > summary { align-items: flex-start; flex-direction: column; }
 }

--- a/ptc_viewer/priv/static/js/app.js
+++ b/ptc_viewer/priv/static/js/app.js
@@ -302,12 +302,13 @@ async function fetchAllTurns(runId) {
 
 async function loadRun(runId, routeGeneration) {
   const [
-    runResponse, turnsResult, conversationResponse, preludesResponse,
+    runResponse, turnsResult, conversationResponse, resultResponse, preludesResponse,
     executionErrorsResponse, explicitFailureValuesResponse
   ] = await Promise.all([
     fetch(`/api/kernel/runs/${encodeURIComponent(runId)}`),
     fetchAllTurns(runId),
     fetch(`/api/analysis/runs/${encodeURIComponent(runId)}/conversation`),
+    fetch(`/api/analysis/runs/${encodeURIComponent(runId)}/result`),
     fetch(`/api/analysis/runs/${encodeURIComponent(runId)}/preludes`),
     fetch(`/api/analysis/runs/${encodeURIComponent(runId)}/execution-errors`),
     fetch(`/api/analysis/runs/${encodeURIComponent(runId)}/explicit-failure-values`)
@@ -329,6 +330,13 @@ async function loadRun(runId, routeGeneration) {
             'available?': false,
             status: conversationResponse.status,
             reason: await safeBodyText(conversationResponse)
+          };
+      const result = resultResponse.ok
+        ? await resultResponse.json()
+        : {
+            'available?': false,
+            status: resultResponse.status,
+            reason: await safeBodyText(resultResponse)
           };
       // Both private routes report an absence the same way, because the
       // transcript states it the same way: the reason code, not the status.
@@ -359,6 +367,7 @@ async function loadRun(runId, routeGeneration) {
           metadata: await runResponse.json(),
           turns: turnsResult.turns,
           conversation,
+          result,
           preludes,
           execution_errors,
           explicit_failure_values,
@@ -428,6 +437,7 @@ function renderRun(data, { fresh = false, routeGeneration = state.routeGeneratio
           renderRun({
             metadata,
             conversation,
+            result: data.result,
             preludes: data.preludes,
             execution_errors: data.execution_errors,
             explicit_failure_values: data.explicit_failure_values,

--- a/ptc_viewer/priv/static/js/kernel-transcript.js
+++ b/ptc_viewer/priv/static/js/kernel-transcript.js
@@ -18,6 +18,7 @@ import { html, mount, rawHtml, toMarkup } from './preact.js';
 import { highlightLisp } from './highlight.js';
 import { privateEvidenceAbsence } from './private-evidence.js';
 import { evaluationPresentation } from './evaluation-evidence.js';
+import { modelSessionDomId } from './semantic-conversation.js';
 
 const SUCCESS = new Set(['ok', 'continued', 'returned', 'completed', 'success']);
 const FAILURE = new Set([
@@ -50,14 +51,16 @@ export function renderKernelTranscriptMarkup(data) {
 function KernelTranscript({
   metadata = {}, turns = {}, conversation = null, preludes = null,
   execution_errors = null, explicit_failure_values = null,
-  last_evaluation_error = null, options = {}
+  result = null, last_evaluation_error = null, options = {}
 }) {
   const events = [...(turns.items || [])].sort((left, right) => left.sequence - right.sequence);
   const transcript = buildTranscript(events);
-  const partial = Boolean(turns.next_cursor);
+  const eventsDropped = metadata.truncated === true || events.some(event => event.type === 'events-dropped');
+  const partial = Boolean(turns.next_cursor) || eventsDropped;
   const preludeIndex = buildPreludeIndex(preludes);
   const privatePrograms = new Map();
   const privateResults = new Map();
+  const modelSessions = new Map();
 
   for (const stream of conversation?.streams || []) {
     const streamTurns = stream.turns || [];
@@ -65,7 +68,18 @@ function KernelTranscript({
     streamTurns.forEach((turn, index) => {
       const generated = turn.generated || [];
       generated.forEach(program => {
-        if (program?.evaluation_id) privatePrograms.set(program.evaluation_id, program);
+        if (program?.evaluation_id) {
+          privatePrograms.set(program.evaluation_id, program);
+          if (program['association_ambiguous?'] !== true) {
+            modelSessions.set(program.evaluation_id, {
+              streamId: stream.stream_id || '',
+              turn: turn.turn ?? index + 1,
+              turnCount: streamTurns.length,
+              terminalTurn: index === streamTurns.length - 1,
+              conversationComplete: conversation?.['complete?'] !== false
+            });
+          }
+        }
       });
 
       const feedback = streamTurns[index + 1]?.feedback || [];
@@ -89,6 +103,7 @@ function KernelTranscript({
   transcript.evaluations.forEach(evaluation => {
     evaluation.privateProgram = privatePrograms.get(evaluation.id) || null;
     evaluation.privateResult = privateResults.get(evaluation.id) || null;
+    evaluation.modelSession = modelSessions.get(evaluation.id) || null;
   });
 
   return html`
@@ -97,8 +112,13 @@ function KernelTranscript({
                eventCount=${events.length} truncatedPage=${partial}
                lastEvaluationError=${last_evaluation_error}
                executionErrors=${execution_errors}
-               explicitFailureValues=${explicit_failure_values} />
+               explicitFailureValues=${explicit_failure_values}
+               result=${result} />
       <${Provenance} />
+      <${ObservedExecution} transcript=${transcript} partial=${partial}
+                            eventsDropped=${eventsDropped}
+                            moreEvents=${Boolean(turns.next_cursor)}
+                            modelSessionCount=${conversation?.streams?.length || 0} />
       <${Reference} metadata=${metadata} transcript=${transcript}
                     preludeIndex=${preludeIndex} options=${options} />
       ${turns.next_cursor && html`
@@ -110,11 +130,74 @@ function KernelTranscript({
   `;
 }
 
+function ObservedExecution({ transcript, partial, eventsDropped, moreEvents, modelSessionCount }) {
+  if (!transcript.evaluations.length) return null;
+  const modelEvaluationCount = transcript.evaluations.filter(evaluation => evaluation.modelSession).length;
+
+  return html`
+    <section class="kt-observed" aria-label="Observed execution">
+      <div class="kt-observed-heading">
+        <div><span>Observed run</span><h3>${eventsDropped && moreEvents
+          ? 'What is visible so far'
+          : eventsDropped
+          ? 'What is visible in recorded events'
+          : partial ? 'What is visible in loaded events' : 'What actually ran'}</h3></div>
+        <strong>${transcript.evaluations.length} evaluation${transcript.evaluations.length === 1 ? '' : 's'}${moreEvents ? ' loaded' : eventsDropped ? ' recorded' : ''}</strong>
+      </div>
+      <p>${eventsDropped && moreEvents
+        ? 'This is a partial summary. More retained events can be loaded, while the trace also reports dropped events that cannot be recovered.'
+        : eventsDropped
+        ? 'This summary is incomplete because the trace reports dropped events; those missing events cannot be loaded.'
+        : moreEvents
+          ? 'This is a partial summary. Load the remaining events before treating it as the complete run.'
+        : 'Evaluations appear in recorded start order. A model session generates a program; the Kernel then evaluates it inside the named mission environment.'}</p>
+      <ol class="kt-observed-steps">
+        ${transcript.evaluations.map((evaluation, index) => {
+          const environment = environmentOf(evaluation) || 'unknown';
+          const missionName = missionNameOf(evaluation);
+          const groups = capabilityGroups(evaluation.capabilities);
+          const session = evaluation.modelSession;
+          return html`
+            <li class=${`kt-observed-step kt-observed-${safeClass(environment)}`} key=${evaluation.id}>
+              <span class="kt-observed-number">${index + 1}</span>
+              <span class="kt-observed-main">
+                <strong>${environment === 'mission' ? missionName || 'Mission' : capitalize(environment)}</strong>
+                <small>${session
+                  ? `Model turn ${session.turn} generated a program for this mission`
+                  : environment === 'workflow' && modelEvaluationCount
+                    ? `Orchestrated ${modelSessionCount} model session${modelSessionCount === 1 ? '' : 's'} across ${modelEvaluationCount} mission evaluation${modelEvaluationCount === 1 ? '' : 's'}`
+                    : environment === 'mission' ? 'mission evaluation' : `${environment} evaluation`}</small>
+                ${session?.streamId && html`
+                  <a class="kt-model-session-link" href=${`#${modelSessionDomId(session.streamId)}`}
+                     onClick=${revealModelSession}>Open prompt, response & program</a>`}
+              </span>
+              <span class="kt-observed-calls">
+                ${groups.map(group => html`<span key=${group.name}>${overviewCapabilityName(group.name)} × ${group.count}</span>`)}
+                ${groups.length === 0 && html`<span>no capability calls</span>`}
+              </span>
+              <${StatusBadge} status=${statusOf(evaluation)} />
+            </li>`;
+        })}
+      </ol>
+    </section>
+  `;
+}
+
+function overviewCapabilityName(name) {
+  return {
+    'llm-request': 'model calls',
+    'kernel-eval': 'mission programs evaluated',
+    'kernel-mission-model-context': 'mission prompts prepared',
+    'kernel-result-contract': 'result checks',
+    'workflow-annotate': 'agent lifecycle markers'
+  }[name] || name;
+}
+
 // --- Identity and summary -------------------------------------------------
 
 function Hero({
   metadata, transcript, title: displayTitle, eventCount, truncatedPage,
-  lastEvaluationError, executionErrors, explicitFailureValues
+  lastEvaluationError, executionErrors, explicitFailureValues, result
 }) {
   const status = metadata.status || (metadata.complete ? 'complete' : 'incomplete');
   const bundle = metadata.workflow_prelude?.hash;
@@ -155,6 +238,7 @@ function Hero({
       <${Tags} tags=${metadata.tags || metadata.labels?.tags} />
     </div>
     <${TerminalCause} event=${transcript.terminal} lastEvaluationError=${lastEvaluationError} />
+    <${ApplicationResult} result=${result} />
     <${AuthorizedEvaluatorEvidence} executionErrors=${executionErrors}
                                     explicitFailureValues=${explicitFailureValues} />
     <div class="kt-metrics" aria-label="Run summary">
@@ -165,6 +249,23 @@ function Hero({
       <${Metric} value=${errorCount} label="errors" tone=${errorCount > 0 ? 'error' : ''} />
       <${Metric} value=${eventCount} label=${truncatedPage ? 'events loaded' : 'events'} />
     </div>
+  `;
+}
+
+function ApplicationResult({ result }) {
+  if (!result || result['available?'] === false || !Object.prototype.hasOwnProperty.call(result, 'value')) {
+    return null;
+  }
+
+  const value = json(result.value);
+  return html`
+    <details class="kt-application-result" open=${value.length <= 500}>
+      <summary>
+        <strong>Application result</strong>
+        <span class="kt-private-badge">private evidence</span>
+      </summary>
+      <pre>${value}</pre>
+    </details>
   `;
 }
 
@@ -279,7 +380,7 @@ function Reference({ metadata, transcript, preludeIndex, options }) {
       <//>
       <${Disclosure} className="kt-reference-panel" summary="Execution transcript"
                      hint=${`${transcript.evaluations.length} evaluations · ${transcript.capabilities.length} capability calls`}
-                     open=${true}>
+                     open=${false}>
         <div class="kt-toolbar">
           <span>Evaluations in canonical order</span>
           <div>
@@ -591,7 +692,14 @@ function EvaluationSource({ evaluation, preludeIndex }) {
           <pre class="kt-code" key=${message?.tool_call_id || index}>${message?.content ?? json(message)}</pre>`)}
       </details>
     `
-    : null;
+    : evaluation.privateProgram && evaluation.modelSession?.terminalTurn &&
+        evaluation.modelSession?.conversationComplete && SUCCESS.has(statusOf(evaluation))
+      ? html`
+        <p class="kt-evaluation-result-note">
+          <strong>Returned to the workflow.</strong>
+          ${' '}No later model turn was made, so the exact mission return value is not duplicated as model feedback.
+        </p>`
+      : null;
 
   return html`${sourceBlock}${resultBlock}`;
 }
@@ -629,15 +737,40 @@ function Capabilities({ capabilities }) {
     return html`<div class="kt-subsection-empty">No capability calls in this environment.</div>`;
   }
 
+  const groups = capabilityGroups(capabilities);
+  const hasFailure = capabilities.some(capability => isFailure(statusOf(capability)));
+
   return html`
     <section class="kt-subsection">
       <h4>Capability calls <span>${capabilities.length}</span></h4>
-      <div class="kt-call-list">
-        ${capabilities.map(capability => html`
-          <${Capability} key=${capability.id} capability=${capability} />`)}
+      <div class="kt-capability-summary">
+        ${groups.map(group => html`
+          <span class=${group.failures ? 'kt-capability-group kt-capability-group-error' : 'kt-capability-group'}
+                key=${group.name}>
+            <strong>${group.name}</strong> × ${group.count}${group.failures ? ` · ${group.failures} failed` : ''}
+          </span>`)}
       </div>
+      <details class="kt-capability-details" open=${hasFailure}>
+        <summary>${capabilities.length} individual call${capabilities.length === 1 ? '' : 's'}</summary>
+        <div class="kt-call-list">
+          ${capabilities.map(capability => html`
+            <${Capability} key=${capability.id} capability=${capability} />`)}
+        </div>
+      </details>
     </section>
   `;
+}
+
+function capabilityGroups(capabilities) {
+  const groups = new Map();
+  for (const capability of capabilities || []) {
+    const name = nameOf(capability) || 'unknown capability';
+    const group = groups.get(name) || { name, count: 0, failures: 0 };
+    group.count += 1;
+    if (isFailure(statusOf(capability))) group.failures += 1;
+    groups.set(name, group);
+  }
+  return [...groups.values()];
 }
 
 function Capability({ capability }) {
@@ -675,14 +808,55 @@ function Annotations({ annotations }) {
       ${annotations.map(event => html`
         <details class="kt-annotation" key=${event.sequence}>
           <summary>
-            <strong>${String(event.data?.annotation_type || 'annotation')}</strong>
+            <strong>${annotationSummary(event)}</strong>
             <span>#${event.sequence}</span>
           </summary>
-          <pre>${json(event.data?.data)}</pre>
+          <div class="kt-annotation-body">
+            <p>${annotationExplanation(event)}</p>
+            <details>
+              <summary>Raw annotation</summary>
+              <pre>${json(event.data?.data)}</pre>
+            </details>
+          </div>
         </details>
       `)}
     </section>
   `;
+}
+
+function annotationSummary(event) {
+  const type = event.data?.annotation_type;
+  const data = event.data?.data;
+  if (type !== 'agent-action' || !Number.isInteger(data?.turn)) {
+    return String(type || 'annotation');
+  }
+
+  const turn = data.turn + 1;
+  const limit = Number.isInteger(data.max_turns) ? ` of ${data.max_turns}` : '';
+  const mission = typeof data.mission === 'string' ? ` · ${data.mission}` : '';
+  const action = data.kind === 'tool-call' ? 'program requested' : String(data.kind || 'agent action');
+  return `Model turn ${turn}${limit}${mission} · ${action}`;
+}
+
+function annotationExplanation(event) {
+  const type = event.data?.annotation_type;
+  const data = event.data?.data;
+  if (type === 'agent-action' && data?.kind === 'tool-call') {
+    return 'The model returned a PTC-Lisp program for evaluation. Its source, prompt and response are private evidence linked from the observed mission above.';
+  }
+  return 'A workflow-authored lifecycle marker. The raw record is retained below for exact inspection.';
+}
+
+function revealModelSession(event) {
+  const targetId = event.currentTarget?.getAttribute('href')?.slice(1);
+  const target = targetId ? document.getElementById(targetId) : null;
+  if (!target) return;
+
+  event.preventDefault();
+  target.open = true;
+  target.querySelector(':scope > .semantic-stream-body > .semantic-turn')?.setAttribute('open', '');
+  target.querySelector('.kt-system-prompt')?.setAttribute('open', '');
+  target.scrollIntoView({ block: 'start', behavior: 'smooth' });
 }
 
 function Limits({ limits }) {

--- a/ptc_viewer/priv/static/js/live.js
+++ b/ptc_viewer/priv/static/js/live.js
@@ -264,13 +264,16 @@ async function initLaunch(root, project, mutationNonce, liveToken) {
   root.innerHTML = `
     <div class="live-launch-card">
       <div class="live-launch-head">
-        <span class="live-section-label">Launch a run</span>
+        <span class="live-section-label" data-role="mode">Run application</span>
         <span class="live-launch-target" data-role="target"></span>
       </div>
       <div class="live-launch-envs" data-role="envs" hidden></div>
-      <label class="live-launch-label" data-role="input-label">Input object — the only thing the browser controls; passed to the project's run input</label>
+      <p class="live-launch-mode-note" data-role="mode-note" hidden>
+        Workflow runs the application. A mission selection tests one expression in that mission sandbox; it does not run a workflow stage.
+      </p>
+      <label class="live-launch-label" data-role="input-label">Application input (JSON)</label>
       <textarea class="live-launch-input" data-role="editor" spellcheck="false" rows="10"></textarea>
-      <label class="live-launch-label" data-role="expr-label" hidden>Expression — evaluated once in this mission session; no live frames yet, the result is the output tail below</label>
+      <label class="live-launch-label" data-role="expr-label" hidden>PTC-Lisp expression to evaluate once in this mission sandbox</label>
       <input type="text" class="live-launch-expr" data-role="expr" spellcheck="false" placeholder="(dir)" hidden />
       <div class="live-launch-foot">
         <span class="live-launch-validity" data-role="validity"></span>
@@ -292,7 +295,7 @@ async function initLaunch(root, project, mutationNonce, liveToken) {
   const validate = () => {
     if (state.mission) {
       const expression = fields.expr.value.trim();
-      fields.validity.textContent = expression ? `mission ${state.mission}` : 'expression required';
+      fields.validity.textContent = expression ? `ready to test ${state.mission}` : 'enter an expression';
       fields.validity.dataset.state = expression ? 'ok' : 'bad';
       fields.run.disabled = !expression || state.running;
       return expression || null;
@@ -324,16 +327,21 @@ async function initLaunch(root, project, mutationNonce, liveToken) {
     fields.editor.hidden = Boolean(mission);
     fields['expr-label'].hidden = !mission;
     fields.expr.hidden = !mission;
+    fields.mode.textContent = mission ? `Test mission: ${mission}` : 'Run application';
+    fields.run.textContent = mission ? '▶ Evaluate expression' : '▶ Run application';
     validate();
   };
 
   renderEnvironmentChips(fields.envs, project, selectEnvironment);
+  fields['mode-note'].hidden = fields.envs.hidden;
 
   const setStatus = (status) => {
     state.running = status?.status === 'running';
     fields.run.disabled = state.running || fields.validity.dataset.state === 'bad';
     for (const chip of fields.envs.querySelectorAll('button')) chip.disabled = state.running;
-    fields.run.textContent = state.running ? 'Running…' : '▶ Run';
+    fields.run.textContent = state.running
+      ? 'Running…'
+      : state.mission ? '▶ Evaluate expression' : '▶ Run application';
     if (!status || status.status === 'idle') {
       fields.status.hidden = true;
       return;
@@ -492,6 +500,7 @@ function initProject(root, project) {
       <span class="live-project-entry" data-role="entry"></span>
       <button type="button" class="live-project-disclose" data-role="disclose" aria-expanded="false">Details ▸</button>
     </div>
+    <section class="live-application-map" data-role="application-map"></section>
     <div class="live-project-panel" data-role="panel" hidden>
       <section class="live-project-section">
         <button type="button" class="live-project-head" data-role="env-head" aria-expanded="false">
@@ -541,6 +550,7 @@ function initProject(root, project) {
     f['source-body'].textContent = component.source || '(source unavailable)';
   };
 
+  renderApplicationMap(f['application-map'], project);
   f['env-count'].textContent = plural(environments.length, 'environment');
   f['comp-count'].textContent = plural(components.length, 'component');
   const leading = leadingLimitRows(limits);
@@ -567,6 +577,79 @@ function initProject(root, project) {
   ]) {
     head.addEventListener('click', () => toggleSection(head, body));
   }
+}
+
+export function applicationOverview(project) {
+  const environmentsAvailable = Array.isArray(project?.environments);
+  const environments = environmentsAvailable ? project.environments : [];
+  const workflow = environments.find(environment => environment?.kind === 'workflow') || null;
+  const missions = environments.filter(environment => environment?.kind === 'mission');
+  return {
+    available: environmentsAvailable && workflow !== null,
+    entry: project?.entry || '',
+    workflow,
+    missions,
+  };
+}
+
+function renderApplicationMap(container, project) {
+  const overview = applicationOverview(project);
+  if (!overview.available) {
+    container.hidden = true;
+    return;
+  }
+
+  container.hidden = false;
+  const heading = el('div', 'live-application-map-head');
+  heading.append(
+    el('span', 'live-section-label', 'Declared application'),
+    el('span', 'live-application-map-note', 'Configuration, not execution history'),
+  );
+
+  const body = el('div', 'live-application-map-body');
+  const workflow = el('div', 'live-application-group');
+  workflow.append(el('div', 'live-application-group-label', 'Application entry'));
+  workflow.append(applicationEnvironmentCard(overview.workflow, overview.entry, 'workflow'));
+  body.append(workflow);
+
+  const missions = el('div', 'live-application-group');
+  missions.append(el('div', 'live-application-group-label', 'Available mission environments'));
+  const missionCards = el('div', 'live-application-missions');
+  if (overview.missions.length) {
+    missionCards.append(...overview.missions.map(environment =>
+      applicationEnvironmentCard(environment, '', 'mission')
+    ));
+  } else {
+    missionCards.append(el('span', 'live-application-empty', 'No missions declared'));
+  }
+  missions.append(missionCards);
+  body.append(missions);
+
+  const explanation = el(
+    'p',
+    'live-application-explanation',
+    'Missions are available to the workflow. This map does not claim that every mission runs.',
+  );
+  container.replaceChildren(heading, body, explanation);
+}
+
+function applicationEnvironmentCard(environment, entry, fallbackKind) {
+  const card = el('article', 'live-application-card');
+  const kind = environment?.kind || fallbackKind;
+  card.dataset.kind = kind;
+  card.append(
+    el('span', 'live-application-kind', kind),
+    el('strong', 'live-application-name', environment?.name || kind),
+  );
+  if (entry) card.append(el('code', 'live-application-entry', entry));
+
+  const counts = [
+    plural(countOf(environment?.components), 'component'),
+    plural(countOf(environment?.providers), 'provider'),
+  ];
+  if (countOf(environment?.tools)) counts.push(plural(countOf(environment.tools), 'tool'));
+  card.append(el('span', 'live-application-counts', counts.join(' · ')));
+  return card;
 }
 
 function toggleSection(head, body) {

--- a/ptc_viewer/priv/static/js/semantic-conversation.js
+++ b/ptc_viewer/priv/static/js/semantic-conversation.js
@@ -1,4 +1,5 @@
-import { html, mount, toMarkup } from './preact.js';
+import { html, mount, rawHtml, toMarkup } from './preact.js';
+import { highlightLisp } from './highlight.js';
 import { privateEvidenceAbsence } from './private-evidence.js';
 
 export function renderSemanticConversation(container, conversation) {
@@ -23,6 +24,38 @@ export function renderSemanticConversationMarkup(conversation) {
   return toMarkup(html`<${Conversation} conversation=${conversation} />`);
 }
 
+export function modelSessionDomId(streamId) {
+  return `model-session-${safeClass(streamId || 'unknown')}`;
+}
+
+export function streamPresentation(stream) {
+  const turns = Array.isArray(stream?.turns) ? stream.turns : [];
+  const missions = [];
+  for (const turn of turns) {
+    for (const program of turn?.generated || []) {
+      if (
+        program?.['association_ambiguous?'] !== true &&
+        typeof program?.mission_name === 'string' &&
+        !missions.includes(program.mission_name)
+      ) {
+        missions.push(program.mission_name);
+      }
+    }
+  }
+
+  const programs = turns.reduce(
+    (count, turn) => count + (turn?.generated || []).filter(presentableProgram).length,
+    0,
+  );
+  return {
+    label: missions.length ? missions.join(' → ') : stream?.stream_id || 'model session',
+    streamId: stream?.stream_id || '',
+    turns: turns.length,
+    programs,
+    outcome: String(turns.at(-1)?.outcome || 'incomplete'),
+  };
+}
+
 function Conversation({ conversation }) {
   if (!conversation) return null;
 
@@ -35,14 +68,17 @@ function Conversation({ conversation }) {
     : undefined;
   const status = unavailable
     ? (configuration ? configuration.status : `Unavailable (HTTP ${conversation.status || 'error'})`)
-    : `${streams.length} stream(s)`;
+    : `${streams.length} model session${streams.length === 1 ? '' : 's'}`;
 
   return html`
     <section class="inspection-panel semantic-conversation">
       <div class="inspection-heading">
-        <div><span>Private analysis</span><h3>Model conversation</h3></div>
+        <div><span>Private analysis</span><h3>Model sessions & programs</h3></div>
         <strong>${status}</strong>
       </div>
+      <p class="inspection-counts">
+        What each model received, generated, and saw again as tool feedback. One turn means the model was called once; a successful first program needs no correction turn. Raw records remain available inside each turn.
+      </p>
       ${unavailable && configuration && html`
         <div class="inspection-sensitivity">${configuration.cause}</div>`}
       ${unavailable && !configuration && html`
@@ -59,22 +95,172 @@ function Conversation({ conversation }) {
         </div>`}
       ${!unavailable && !streams.length && !incomplete && html`
         <div class="inspection-counts">No model exchanges were captured for this run.</div>`}
-      ${streams.map(stream => html`
-        <div class="inspection-record" key=${stream.stream_id}>
-          <h4>${stream.stream_id}</h4>
-          ${stream.turns.map(turn => html`
-            <details key=${turn.request_sequence} open>
-              <summary>Turn ${turn.turn}</summary>
-              <pre>${JSON.stringify({
-                system: turn.system,
-                messages_added: turn.messages_added,
-                assistant: turn.assistant,
-                generated: turn.generated,
-                feedback: turn.feedback,
-                tokens: turn.tokens,
-                outcome: turn.outcome
-              }, null, 2)}</pre>
-            </details>`)}
-        </div>`)}
+      <div class="semantic-streams">
+        ${streams.map(stream => html`<${ModelStream} key=${stream.stream_id} stream=${stream} />`)}
+      </div>
     </section>`;
+}
+
+function ModelStream({ stream }) {
+  const presentation = streamPresentation(stream);
+  return html`
+    <details class="semantic-stream" id=${modelSessionDomId(presentation.streamId)}>
+      <summary>
+        <span class="semantic-stream-main">
+          <strong>${presentation.label}</strong>
+          ${presentation.streamId && presentation.label !== presentation.streamId && html`
+            <code>${presentation.streamId}</code>`}
+        </span>
+        <span class="semantic-stream-meta">
+          ${plural(presentation.turns, 'turn')} · ${plural(presentation.programs, 'program')} · ${presentation.outcome}
+        </span>
+      </summary>
+      <div class="semantic-stream-body">
+        ${(stream.turns || []).map(turn => html`
+          <${ModelTurn} key=${turn.request_sequence ?? turn.turn} turn=${turn} />`)}
+      </div>
+    </details>
+  `;
+}
+
+function ModelTurn({ turn }) {
+  const generated = turn.generated || [];
+  const programs = generated.filter(presentableProgram);
+  const ambiguousPrograms = generated.length - programs.length;
+  const messages = turn.messages_added || [];
+  const feedback = turn.feedback || [];
+  const promptMessages = messages.filter(message => message?.role !== 'tool');
+  return html`
+    <details class="kt-turn semantic-turn" open>
+      <summary class="kt-turn-header">
+        <strong>Turn ${turn.turn ?? '?'}</strong>
+        <span class="kt-turn-meta">
+          ${plural(programs.length, 'program')} · ${String(turn.outcome || 'incomplete')}
+        </span>
+      </summary>
+      <div class="semantic-turn-body">
+        <${SystemPrompt} turn=${turn} />
+        ${promptMessages.length > 0 && html`
+          <section class="kt-turn-in">
+            <div class="kt-turn-label">Input added this turn</div>
+            ${promptMessages.map((message, index) => html`
+              <${Message} key=${message?.id || index} message=${message} />`)}
+          </section>`}
+        <${AssistantOutput} assistant=${turn.assistant} />
+        ${programs.length > 0 && html`
+          <section class="kt-turn-out">
+            <div class="kt-turn-label">Generated programs</div>
+            ${programs.map((program, index) => html`
+              <div class="kt-program" key=${program?.evaluation_id || index}>
+                <div class="kt-program-label">
+                  ${program?.mission_name ? `${program.mission_name} · ` : ''}${program?.evaluation_id || `program ${index + 1}`}
+                </div>
+                ${rawHtml('pre', 'kt-code kt-code-lisp', highlightLisp(program?.source || ''))}
+              </div>`)}
+          </section>`}
+        ${feedback.length > 0 && html`
+          <section class="kt-turn-in semantic-feedback">
+            <div class="kt-turn-label">Tool feedback in this turn</div>
+            ${feedback.map((message, index) => html`
+              <${Message} key=${message?.tool_call_id || index} message=${message} />`)}
+          </section>`}
+        ${ambiguousPrograms > 0 && html`
+          <p class="semantic-association-warning">
+            ${plural(ambiguousPrograms, 'generated source')} had an ambiguous turn association and appears only in the raw record.
+          </p>`}
+        ${turn.tokens && html`
+          <div class="semantic-token-summary">Tokens: ${compactValue(turn.tokens)}</div>`}
+        <details class="semantic-raw-turn">
+          <summary>Raw turn record</summary>
+          <pre>${displayValue({
+            system: turn.system,
+            messages_added: turn.messages_added,
+            assistant: turn.assistant,
+            generated: turn.generated,
+            feedback: turn.feedback,
+            tokens: turn.tokens,
+            outcome: turn.outcome
+          })}</pre>
+        </details>
+      </div>
+    </details>
+  `;
+}
+
+function SystemPrompt({ turn }) {
+  if (!Object.prototype.hasOwnProperty.call(turn, 'system')) {
+    return html`<p class="kt-prompt-same">System prompt unchanged from the previous turn.</p>`;
+  }
+  if (turn.system == null) {
+    return html`<p class="kt-prompt-same">No system prompt was sent.</p>`;
+  }
+
+  return html`
+    <details class="kt-system-prompt">
+      <summary>System prompt <span>model input</span></summary>
+      <pre class="kt-code">${displayValue(turn.system)}</pre>
+    </details>
+  `;
+}
+
+function AssistantOutput({ assistant }) {
+  if (!assistant) return null;
+  const content = assistant.content;
+  const reasoning = assistant.reasoning;
+  if (content == null && reasoning == null) return null;
+
+  return html`
+    <section class="kt-turn-out">
+      <div class="kt-turn-label">Model response</div>
+      ${reasoning != null && html`
+        <div class="kt-msg kt-msg-reasoning">
+          <span class="kt-msg-role">Reasoning</span>
+          <div class="kt-msg-content">${displayValue(reasoning)}</div>
+        </div>`}
+      ${content != null && html`
+        <div class="kt-msg kt-msg-assistant">
+          <span class="kt-msg-role">Assistant</span>
+          <div class="kt-msg-content">${displayValue(content)}</div>
+        </div>`}
+    </section>
+  `;
+}
+
+function Message({ message }) {
+  const role = message?.role || 'message';
+  return html`
+    <div class=${`kt-msg kt-msg-${safeClass(role)}`}>
+      <span class="kt-msg-role">${role}</span>
+      <div class="kt-msg-content">${displayValue(message?.content ?? message)}</div>
+    </div>
+  `;
+}
+
+function presentableProgram(program) {
+  return program?.['association_ambiguous?'] !== true;
+}
+
+function displayValue(value) {
+  if (typeof value === 'string') return value;
+  try {
+    return JSON.stringify(value ?? null, null, 2);
+  } catch (_error) {
+    return String(value);
+  }
+}
+
+function compactValue(value) {
+  try {
+    return JSON.stringify(value);
+  } catch (_error) {
+    return String(value);
+  }
+}
+
+function plural(count, noun) {
+  return `${count} ${noun}${count === 1 ? '' : 's'}`;
+}
+
+function safeClass(value) {
+  return String(value).replace(/[^a-z0-9-]/gi, '-').toLowerCase();
 }

--- a/ptc_viewer/test/kernel_transcript_test.exs
+++ b/ptc_viewer/test/kernel_transcript_test.exs
@@ -329,6 +329,277 @@ defmodule PtcViewer.KernelTranscriptTest do
     assert rendered =~ "mission unavailable"
   end
 
+  test "summarizes observed evaluations and repeated capability calls", %{tmp_dir: directory} do
+    rendered =
+      render(directory, %{
+        "metadata" => %{"run_id" => "overview-run", "status" => "ok"},
+        "turns" => %{
+          "items" => [
+            event(1, "evaluation-started", %{
+              "evaluation_id" => "workflow-1",
+              "environment" => "workflow"
+            }),
+            event(2, "evaluation-started", %{
+              "evaluation_id" => "mission-1",
+              "environment" => "mission",
+              "mission_name" => "review"
+            }),
+            event(3, "capability-started", %{
+              "capability_id" => "read-1",
+              "environment" => "mission",
+              "mission_name" => "review",
+              "name" => "workspace.read"
+            }),
+            event(4, "capability-stopped", %{
+              "capability_id" => "read-1",
+              "environment" => "mission",
+              "mission_name" => "review",
+              "name" => "workspace.read",
+              "status" => "ok"
+            }),
+            event(5, "capability-started", %{
+              "capability_id" => "read-2",
+              "environment" => "mission",
+              "mission_name" => "review",
+              "name" => "workspace.read"
+            }),
+            event(6, "capability-stopped", %{
+              "capability_id" => "read-2",
+              "environment" => "mission",
+              "mission_name" => "review",
+              "name" => "workspace.read",
+              "status" => "ok"
+            }),
+            event(7, "evaluation-stopped", %{
+              "evaluation_id" => "mission-1",
+              "environment" => "mission",
+              "mission_name" => "review",
+              "status" => "ok"
+            }),
+            event(8, "workflow-annotation", %{
+              "annotation_type" => "agent-action",
+              "data" => %{
+                "invocation" => "agent-596be325449c5d0c",
+                "kind" => "tool-call",
+                "max_turns" => 16,
+                "turn" => 0
+              }
+            }),
+            event(9, "evaluation-stopped", %{
+              "evaluation_id" => "workflow-1",
+              "environment" => "workflow",
+              "status" => "ok"
+            })
+          ]
+        },
+        "conversation" => %{
+          "streams" => [
+            %{
+              "stream_id" => "review-session",
+              "turns" => [
+                %{
+                  "turn" => 1,
+                  "generated" => [
+                    %{
+                      "evaluation_id" => "mission-1",
+                      "mission_name" => "review",
+                      "source" => "(return :ok)"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        "result" => %{"value" => "reviewed"}
+      })
+
+    assert rendered =~ "What actually ran"
+    assert rendered =~ "A model session generates a program"
+    assert rendered =~ "Orchestrated 1 model session across 1 mission evaluation"
+    assert rendered =~ ">review</strong>"
+    assert rendered =~ "Model turn 1 generated a program for this mission"
+    assert rendered =~ "Open prompt, response &amp; program"
+    assert rendered =~ ~s(href="#model-session-review-session")
+    assert rendered =~ "Returned to the workflow."
+    assert rendered =~ "exact mission return value is not duplicated as model feedback"
+    assert rendered =~ "workspace.read × 2"
+    assert rendered =~ "2 individual calls"
+    assert rendered =~ "Model turn 1 of 16 · program requested"
+    assert rendered =~ "The model returned a PTC-Lisp program for evaluation."
+    assert rendered =~ "Application result"
+    assert rendered =~ "reviewed"
+    refute rendered =~ ~s(class="kt-reference-panel" open="")
+  end
+
+  test "labels an observed execution summary as partial while events remain", %{
+    tmp_dir: directory
+  } do
+    rendered =
+      render(directory, %{
+        "metadata" => %{"run_id" => "partial-run"},
+        "turns" => %{
+          "next_cursor" => "more-events",
+          "items" => [
+            event(1, "evaluation-started", %{
+              "evaluation_id" => "workflow-1",
+              "environment" => "workflow"
+            })
+          ]
+        }
+      })
+
+    assert rendered =~ "What is visible in loaded events"
+    assert rendered =~ "1 evaluation loaded"
+    assert rendered =~ "This is a partial summary."
+    refute rendered =~ "What actually ran"
+  end
+
+  test "labels dropped canonical events as incomplete and not loadable", %{tmp_dir: directory} do
+    rendered =
+      render(directory, %{
+        "metadata" => %{"run_id" => "dropped-run", "truncated" => true},
+        "turns" => %{
+          "items" => [
+            event(1, "evaluation-started", %{
+              "evaluation_id" => "workflow-1",
+              "environment" => "workflow"
+            })
+          ]
+        }
+      })
+
+    assert rendered =~ "What is visible in recorded events"
+    assert rendered =~ "trace reports dropped events"
+    assert rendered =~ "missing events cannot be loaded"
+    refute rendered =~ "What actually ran"
+  end
+
+  test "distinguishes loadable retained pages from irrecoverably dropped events", %{
+    tmp_dir: directory
+  } do
+    rendered =
+      render(directory, %{
+        "metadata" => %{"run_id" => "partial-dropped-run", "truncated" => true},
+        "turns" => %{
+          "next_cursor" => "more-retained-events",
+          "items" => [
+            event(1, "evaluation-started", %{
+              "evaluation_id" => "workflow-1",
+              "environment" => "workflow"
+            })
+          ]
+        }
+      })
+
+    assert rendered =~ "What is visible so far"
+    assert rendered =~ "1 evaluation loaded"
+    assert rendered =~ "More retained events can be loaded"
+    assert rendered =~ "dropped events that cannot be recovered"
+  end
+
+  test "counts retry evaluations within one stream as one model session", %{tmp_dir: directory} do
+    events = [
+      event(1, "evaluation-started", %{
+        "evaluation_id" => "workflow-1",
+        "environment" => "workflow"
+      }),
+      event(2, "evaluation-started", %{
+        "evaluation_id" => "mission-1",
+        "environment" => "mission",
+        "mission_name" => "review"
+      }),
+      event(3, "evaluation-stopped", %{
+        "evaluation_id" => "mission-1",
+        "environment" => "mission",
+        "mission_name" => "review",
+        "status" => "returned"
+      }),
+      event(4, "evaluation-started", %{
+        "evaluation_id" => "mission-2",
+        "environment" => "mission",
+        "mission_name" => "review"
+      }),
+      event(5, "evaluation-stopped", %{
+        "evaluation_id" => "mission-2",
+        "environment" => "mission",
+        "mission_name" => "review",
+        "status" => "returned"
+      }),
+      event(6, "evaluation-stopped", %{
+        "evaluation_id" => "workflow-1",
+        "environment" => "workflow",
+        "status" => "ok"
+      })
+    ]
+
+    rendered =
+      render(directory, %{
+        "metadata" => %{"run_id" => "retry-run"},
+        "turns" => %{"items" => events},
+        "conversation" => %{
+          "streams" => [
+            %{
+              "stream_id" => "one-session",
+              "turns" => [
+                %{"turn" => 1, "generated" => [%{"evaluation_id" => "mission-1"}]},
+                %{"turn" => 2, "generated" => [%{"evaluation_id" => "mission-2"}]}
+              ]
+            }
+          ]
+        }
+      })
+
+    assert rendered =~ "1 model session across 2 mission evaluations"
+    refute rendered =~ "2 model sessions"
+  end
+
+  test "counts a failed model session even when it generated no mission evaluation", %{
+    tmp_dir: directory
+  } do
+    rendered =
+      render(directory, %{
+        "metadata" => %{"run_id" => "failed-session-run"},
+        "turns" => %{
+          "items" => [
+            event(1, "evaluation-started", %{
+              "evaluation_id" => "workflow-1",
+              "environment" => "workflow"
+            }),
+            event(2, "evaluation-started", %{
+              "evaluation_id" => "mission-1",
+              "environment" => "mission",
+              "mission_name" => "analysis"
+            }),
+            event(3, "evaluation-stopped", %{
+              "evaluation_id" => "mission-1",
+              "environment" => "mission",
+              "mission_name" => "analysis",
+              "status" => "returned"
+            }),
+            event(4, "evaluation-stopped", %{
+              "evaluation_id" => "workflow-1",
+              "environment" => "workflow",
+              "status" => "error"
+            })
+          ]
+        },
+        "conversation" => %{
+          "streams" => [
+            %{
+              "stream_id" => "successful",
+              "turns" => [
+                %{"turn" => 1, "generated" => [%{"evaluation_id" => "mission-1"}]}
+              ]
+            },
+            %{"stream_id" => "provider-failure", "turns" => [%{"turn" => 1, "generated" => []}]}
+          ]
+        }
+      })
+
+    assert rendered =~ "Orchestrated 2 model sessions across 1 mission evaluation"
+  end
+
   defp private_program_data(ambiguous?) do
     program = ~S|(runs/diagnose "failed-run")|
 

--- a/ptc_viewer/test/live_ui.mjs
+++ b/ptc_viewer/test/live_ui.mjs
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import {
   activityPresentation,
+  applicationOverview,
   fmtLimit,
   formatLiveSpend,
   evaluationPresentation,
@@ -21,6 +22,21 @@ import {
   runRoute,
   uniqueComponents
 } from '../priv/static/js/live.js';
+
+const application = applicationOverview({
+  entry: 'demo.workflow/run',
+  environments: [
+    { name: 'workflow', kind: 'workflow', components: [] },
+    { name: 'analysis', kind: 'mission', components: [] },
+    { name: 'review', kind: 'mission', components: [] }
+  ]
+});
+assert.equal(application.available, true);
+assert.equal(application.entry, 'demo.workflow/run');
+assert.equal(application.workflow.name, 'workflow');
+assert.deepEqual(application.missions.map(environment => environment.name), ['analysis', 'review']);
+assert.equal(applicationOverview({name: 'opaque host project'}).available, false);
+assert.equal(applicationOverview({environments: []}).available, false);
 
 assert.deepEqual(
   activityPresentation({kind: 'agent', name: 'agent-a1', status: 'tool-call', turn: 1, max_turns: 6}),

--- a/ptc_viewer/test/ptc_viewer/api_test.exs
+++ b/ptc_viewer/test/ptc_viewer/api_test.exs
@@ -91,6 +91,9 @@ defmodule PtcViewer.ApiTest do
 
     assert_receive {:inspection, ^source, "run-1"}
 
+    assert {:error, :unavailable} = PtcViewer.Api.result(config, "run-1")
+    refute_receive {:inspection, ^source, "run-1"}
+
     # No store and no adapter is a project that records no inspection artifact;
     # a store that cannot answer is evidence out of reach. Only the second is
     # worth retrying, so the two do not share a reason.
@@ -122,6 +125,23 @@ defmodule PtcViewer.ApiTest do
 
     assert {:ok, %{"source" => actual_source, "run_id" => "run-1", "items" => []}} =
              PtcViewer.Api.preludes(config, "run-1")
+
+    assert actual_source == inspect(source)
+  end
+
+  test "result delegates the pinned inspection grant", %{trace_dir: trace_dir} do
+    source = {:pinned, "run.ptcins"}
+    {:ok, store} = PtcViewer.InspectionStore.start(source)
+    on_exit(fn -> if Process.alive?(store), do: PtcViewer.InspectionStore.stop(store) end)
+
+    config = [
+      trace_dir: trace_dir,
+      inspection_store: store,
+      inspection_adapter: PtcViewer.PinningInspectionTestAdapter
+    ]
+
+    assert {:ok, %{"source" => actual_source, "run_id" => "run-1", "value" => "done"}} =
+             PtcViewer.Api.result(config, "run-1")
 
     assert actual_source == inspect(source)
   end

--- a/ptc_viewer/test/ptc_viewer/router_test.exs
+++ b/ptc_viewer/test/ptc_viewer/router_test.exs
@@ -289,6 +289,34 @@ defmodule PtcViewer.RouterTest do
     end)
   end
 
+  test "result route delegates the pinned inspection source", %{trace_dir: trace_dir} do
+    source = {:pinned, "fixed.ptcins"}
+    {:ok, store} = PtcViewer.InspectionStore.start(source)
+    on_exit(fn -> if Process.alive?(store), do: PtcViewer.InspectionStore.stop(store) end)
+
+    response =
+      conn(:get, "/api/analysis/runs/run-1/result")
+      |> call_router(
+        trace_dir: trace_dir,
+        inspection_store: store,
+        inspection_adapter: PtcViewer.PinningInspectionTestAdapter
+      )
+
+    assert response.status == 200
+    assert Jason.decode!(response.resp_body)["value"] == "done"
+
+    missing =
+      conn(:get, "/api/analysis/runs/run-1/result")
+      |> call_router(
+        trace_dir: trace_dir,
+        inspection_store: store,
+        inspection_adapter: PtcViewer.MissingResultInspectionTestAdapter
+      )
+
+    assert missing.status == 404
+    assert missing.resp_body == "inspection_result_not_recorded"
+  end
+
   test "prelude route delegates only the pinned inspection grant", %{trace_dir: trace_dir} do
     source = {:pinned, "fixed.ptcins"}
     {:ok, store} = PtcViewer.InspectionStore.start(source)

--- a/ptc_viewer/test/ptc_viewer/semantic_conversation_test.exs
+++ b/ptc_viewer/test/ptc_viewer/semantic_conversation_test.exs
@@ -104,6 +104,88 @@ defmodule PtcViewer.SemanticConversationTest do
     # An unchanged prompt is carried once per stream, so the second turn
     # renders without repeating it rather than showing an empty field.
     refute rendered =~ ~s("system": null)
+    assert rendered =~ "System prompt unchanged from the previous turn."
+  end
+
+  test "distinguishes no prompt, de-duplicates feedback, and withholds ambiguous joins", %{
+    tmp_dir: directory
+  } do
+    rendered =
+      render(directory, %{
+        "complete?" => false,
+        "ambiguous?" => true,
+        "streams" => [
+          %{
+            "stream_id" => "stream-ambiguous",
+            "turns" => [
+              %{
+                "turn" => 1,
+                "system" => nil,
+                "messages_added" => [
+                  %{"role" => "tool", "tool_call_id" => "call-1", "content" => "once"}
+                ],
+                "feedback" => [
+                  %{"role" => "tool", "tool_call_id" => "call-1", "content" => "once"}
+                ],
+                "generated" => [
+                  %{
+                    "mission_name" => "wrong-if-guessed",
+                    "source" => "(return :ambiguous)",
+                    "association_ambiguous?" => true
+                  }
+                ],
+                "outcome" => "ok"
+              }
+            ]
+          }
+        ]
+      })
+
+    assert rendered =~ "No system prompt was sent."
+    assert length(Regex.scan(~r/class="kt-msg kt-msg-tool"/, rendered)) == 1
+    assert rendered =~ "1 generated source had an ambiguous turn association"
+    refute rendered =~ "Generated programs"
+    refute rendered =~ ">wrong-if-guessed</strong>"
+    assert rendered =~ "(return :ambiguous)"
+  end
+
+  test "presents model sessions and generated programs before the raw record", %{
+    tmp_dir: directory
+  } do
+    rendered =
+      render(directory, %{
+        "complete?" => true,
+        "streams" => [
+          %{
+            "stream_id" => "stream-7",
+            "turns" => [
+              %{
+                "turn" => 1,
+                "request_sequence" => 4,
+                "messages_added" => [%{"role" => "user", "content" => "check this"}],
+                "generated" => [
+                  %{
+                    "mission_name" => "review",
+                    "evaluation_id" => "eval-7",
+                    "source" => ~S|(+ 1 2)|
+                  }
+                ],
+                "outcome" => "ok"
+              }
+            ]
+          }
+        ]
+      })
+
+    assert rendered =~ "Model sessions &amp; programs"
+    assert rendered =~ "One turn means the model was called once"
+    assert rendered =~ ">review</strong>"
+    assert rendered =~ "stream-7"
+    assert rendered =~ "Input added this turn"
+    assert rendered =~ "Generated programs"
+    assert rendered =~ "eval-7"
+    assert rendered =~ "Raw turn record"
+    assert rendered =~ "check this"
   end
 
   defp render(directory, conversation) do

--- a/ptc_viewer/test/support/inspection_test_adapter.ex
+++ b/ptc_viewer/test/support/inspection_test_adapter.ex
@@ -6,6 +6,7 @@ defmodule PtcViewer.TestInspectionAdapter do
   end
 
   def conversation(_source, _run_id), do: {:error, :not_called}
+  def result(_source, _run_id), do: {:error, :not_called}
   def preludes(_source, _run_id), do: {:error, :not_called}
   def execution_errors(_source, _run_id), do: {:error, :not_called}
   def explicit_failure_values(_source, _run_id), do: {:error, :not_called}
@@ -19,6 +20,9 @@ defmodule PtcViewer.PinningInspectionTestAdapter do
   def conversation(source, run_id),
     do: {:ok, %{"source" => inspect(source), "run_id" => run_id, "streams" => []}}
 
+  def result(source, run_id),
+    do: {:ok, %{"source" => inspect(source), "run_id" => run_id, "value" => "done"}}
+
   def preludes(source, run_id),
     do: {:ok, %{"source" => inspect(source), "run_id" => run_id, "items" => []}}
 
@@ -27,4 +31,10 @@ defmodule PtcViewer.PinningInspectionTestAdapter do
 
   def explicit_failure_values(source, run_id),
     do: {:ok, %{"source" => inspect(source), "run_id" => run_id, "items" => []}}
+end
+
+defmodule PtcViewer.MissingResultInspectionTestAdapter do
+  @moduledoc false
+
+  def result(_source, _run_id), do: {:error, :result_not_found}
 end

--- a/test/ptc_runner/kernel/inspection_lab_test.exs
+++ b/test/ptc_runner/kernel/inspection_lab_test.exs
@@ -166,7 +166,7 @@ defmodule PtcRunner.Kernel.InspectionLabTest do
         )
 
       assert rendered =~ "Private analysis"
-      assert rendered =~ "Model conversation"
+      assert rendered =~ "Model sessions &amp; programs"
       assert rendered =~ "Turn 1"
       assert rendered =~ "Canonical Kernel trace"
       assert rendered =~ "Mission inventory"

--- a/test/ptc_runner/kernel/viewer_adapter_test.exs
+++ b/test/ptc_runner/kernel/viewer_adapter_test.exs
@@ -43,6 +43,7 @@ defmodule PtcRunner.Kernel.ViewerAdapterTest do
 
     assert {:ok, actual} = ViewerAdapter.conversation(grant, fixture.run_id)
     assert actual == expected
+    assert {:error, :result_not_found} = ViewerAdapter.result(grant, fixture.run_id)
     assert {:ok, ^expected_preludes} = ViewerAdapter.preludes(grant, fixture.run_id)
     assert {:error, :inspection_run_mismatch} = ViewerAdapter.preludes(grant, "another-run")
 
@@ -67,6 +68,9 @@ defmodule PtcRunner.Kernel.ViewerAdapterTest do
 
     project_source = {:inspection_snapshot, inspection}
     assert {:ok, ^expected} = ProjectViewerAdapter.conversation(project_source, fixture.run_id)
+
+    assert {:error, :result_not_found} =
+             ProjectViewerAdapter.result(project_source, fixture.run_id)
 
     assert {:ok, ^expected_preludes} =
              ProjectViewerAdapter.preludes(project_source, fixture.run_id)

--- a/test/ptc_runner/viewer_snapshot_store_test.exs
+++ b/test/ptc_runner/viewer_snapshot_store_test.exs
@@ -73,10 +73,14 @@ defmodule PtcRunner.ViewerSnapshotStoreTest do
     assert {:ok, %{"complete?" => true, "streams" => [_ | _]}} =
              ViewerSnapshotStore.conversation(store, fixture.run_id)
 
+    assert {:error, :result_not_found} = ViewerSnapshotStore.result(store, fixture.run_id)
+
     write_project(directory, false)
 
     assert {:error, :inspection_not_private} =
              ViewerSnapshotStore.conversation(store, fixture.run_id)
+
+    assert {:error, :inspection_not_private} = ViewerSnapshotStore.result(store, fixture.run_id)
 
     refute InspectionSnapshot.alive?(inspection)
     refute ViewerSnapshotStore.inspection?(store)


### PR DESCRIPTION
## Summary

- show the declared application and observed workflow/mission execution separately
- connect mission evaluations to model prompts, responses, generated programs, feedback, and the authorized terminal result
- collapse noisy details, group capability calls, and clarify one-turn sessions and incomplete traces
- prevent long failure payloads from overflowing the run view

## Verification

- full local pre-push hook passed (documentation, 7,780 root checks, static analysis/Dialyzer, production release, and 135 Viewer tests)
- `MIX_ENV=test mix test test/ptc_runner/kernel/viewer_adapter_test.exs test/ptc_runner/viewer_snapshot_store_test.exs` (19 tests)
- `MIX_ENV=test mix test test/ptc_runner/kernel/inspection_lab_test.exs --include nightly`
- browser checks against recorded successful and failed DABStep runs