### PR TITLE
docs(missions): distinguish grants from handoff data

### DIFF
--- a/.guide-budget-baseline.json
+++ b/.guide-budget-baseline.json
@@ -50,8 +50,8 @@
       "tics": 0.5
     },
     "docs/guides/designing-agent-workflows.md": {
-      "words": 698,
-      "density": 2.1,
+      "words": 677,
+      "density": 2.0,
       "blockers": 0,
       "tics": 0.0
     },

--- a/docs/guides/designing-agent-workflows.md
+++ b/docs/guides/designing-agent-workflows.md
@@ -121,12 +121,10 @@ defined in this example's `03-specialists/workflow.clj`:
     (return report)))
 ```
 
-Ticket text is written by customers, so `quarantined` wraps it in an
-`<untrusted_tickets>` block before it enters the second task. The block asks
-the model to treat that text as data.
-
-What holds regardless is the grant: the escalation mission has no tickets and
-no tools. The example's README says what its live test checks in the report.
+`quarantined` marks customer text as data but is only a prompt-level mitigation.
+[The mission boundary](../reference/application-manifest.md#supply-input-and-named-missions)
+limits capabilities. It does not filter handoff data, and this example provides
+no such guarantee; trusted workflow code must perform that filtering.
 
 ```console
 ptc run support-triage/03-specialists.ptc-project.json

--- a/docs/reference/application-manifest.md
+++ b/docs/reference/application-manifest.md
@@ -122,6 +122,14 @@ one or more providers remain unresolved until those providers are acquired.
 `"default"` is an ordinary declared name, not an implicit fallback.
 Definitions and `*1`/`*2`/`*3` history never cross between missions.
 
+A mission boundary is a capability boundary, not a data boundary. A mission's
+grant limits the code, data, and providers available inside that mission, but
+does not prevent that data from reaching a later mission when trusted workflow
+code includes it in the handoff. If a later mission must not receive some
+content, filter it deterministically in workflow code before the handoff.
+Prompt instructions or wrappers that mark content as untrusted may help a model
+treat it as data, but they do not enforce the grant.
+
 Workflow code selects the mission explicitly with the `kernel/eval*`,
 `kernel/check-source`, or mission-introspection functions. The shipped
 `agent.core` loop uses `"default"` only when its own mission option is omitted,
@@ -158,6 +166,11 @@ envelope and terminal diagnostic include its JSON Pointer. Terminal rendering
 escapes unusual contract-authored property names rather than emitting their
 control bytes. Missing-required failures name the first missing schema-declared
 property, including when the absent property is at the contract root.
+
+Result and phase-return schemas validate structure and declared value
+constraints. They do not sanitize data or determine its sensitivity. For
+example, an array `maxItems` bound can limit the number of entries but cannot
+stop a model from choosing a secret-bearing entry over a safe one.
 
 Terminal agent helpers also give a model-authored candidate one ordinary
 correction turn when budget remains. `agent.core/run` validates the exact

--- a/examples/support-triage/README.md
+++ b/examples/support-triage/README.md
@@ -55,8 +55,8 @@ to see exactly what a design decision added.
 `<untrusted_tickets>` block before they enter the escalation task, because
 ticket text is customer-authored. The block tells the model to treat that text
 as data; it does not stop a misleading ticket from producing a wrong team or
-priority. The mission grant is what holds: the escalation mission has no
-tickets and no tools, so injected text cannot reach a capability or the wider
-pool. The scheduled live test for this example checks each escalation's id,
-priority, team, and first action against the policy; only the summary prose
-goes unchecked.
+priority. The mission grant prevents the escalation model from calling a
+capability or reading the wider ticket pool directly. It does not filter the
+handoff, so this example provides no data-flow guarantee. The scheduled live
+test checks each escalation's id, priority, team, and first action against the
+policy; only the summary prose goes unchecked.

--- a/site/guides/designing-agent-workflows/index.html
+++ b/site/guides/designing-agent-workflows/index.html
@@ -148,10 +148,10 @@ defined in this example's <code class="inline">03-specialists/workflow.clj</code
                       &quot;\n\nBreached tickets, highest priority first:\n&quot;
                       (quarantined (pr-str ranked)))
                  {&quot;mission&quot; &quot;escalation&quot; &quot;max_turns&quot; 4})]
-    (return report)))</code></pre><p>Ticket text is written by customers, so <code class="inline">quarantined</code> wraps it in an
-<code class="inline">&lt;untrusted_tickets&gt;</code> block before it enters the second task. The block asks
-the model to treat that text as data.</p><p>What holds regardless is the grant: the escalation mission has no tickets and
-no tools. The example's README says what its live test checks in the report.</p><pre><code class="console language-console">ptc run support-triage/03-specialists.ptc-project.json</code></pre><pre><code class="json language-json">{&quot;escalations&quot;:[
+    (return report)))</code></pre><p><code class="inline">quarantined</code> marks customer text as data but is only a prompt-level mitigation.
+<a href="/reference/application-manifest/#supply-input-and-named-missions">The mission boundary</a>
+limits capabilities. It does not filter handoff data, and this example provides
+no such guarantee; trusted workflow code must perform that filtering.</p><pre><code class="console language-console">ptc run support-triage/03-specialists.ptc-project.json</code></pre><pre><code class="json language-json">{&quot;escalations&quot;:[
   {&quot;id&quot;:&quot;T-1004&quot;,&quot;priority&quot;:81,&quot;team&quot;:&quot;payments&quot;,
    &quot;first_action&quot;:&quot;send the refund-policy summary&quot;},
   {&quot;id&quot;:&quot;T-1001&quot;,&quot;priority&quot;:75,&quot;team&quot;:&quot;payments&quot;,

--- a/site/reference/application-manifest/index.html
+++ b/site/reference/application-manifest/index.html
@@ -161,7 +161,13 @@ requirement that the mission environment does not supply implicitly. Add an
 appropriate provider selection or remove the requirement. Missions selecting
 one or more providers remain unresolved until those providers are acquired.
 <code class="inline">&quot;default&quot;</code> is an ordinary declared name, not an implicit fallback.
-Definitions and <code class="inline">*1</code>/<code class="inline">*2</code>/<code class="inline">*3</code> history never cross between missions.</p><p>Workflow code selects the mission explicitly with the <code class="inline">kernel/eval*</code>,
+Definitions and <code class="inline">*1</code>/<code class="inline">*2</code>/<code class="inline">*3</code> history never cross between missions.</p><p>A mission boundary is a capability boundary, not a data boundary. A mission's
+grant limits the code, data, and providers available inside that mission, but
+does not prevent that data from reaching a later mission when trusted workflow
+code includes it in the handoff. If a later mission must not receive some
+content, filter it deterministically in workflow code before the handoff.
+Prompt instructions or wrappers that mark content as untrusted may help a model
+treat it as data, but they do not enforce the grant.</p><p>Workflow code selects the mission explicitly with the <code class="inline">kernel/eval*</code>,
 <code class="inline">kernel/check-source</code>, or mission-introspection functions. The shipped
 <code class="inline">agent.core</code> loop uses <code class="inline">&quot;default&quot;</code> only when its own mission option is omitted,
 and that mission must exist. The
@@ -184,7 +190,10 @@ safe failure projection identifies a non-root declared path, the command
 envelope and terminal diagnostic include its JSON Pointer. Terminal rendering
 escapes unusual contract-authored property names rather than emitting their
 control bytes. Missing-required failures name the first missing schema-declared
-property, including when the absent property is at the contract root.</p><p>Terminal agent helpers also give a model-authored candidate one ordinary
+property, including when the absent property is at the contract root.</p><p>Result and phase-return schemas validate structure and declared value
+constraints. They do not sanitize data or determine its sensitivity. For
+example, an array <code class="inline">maxItems</code> bound can limit the number of entries but cannot
+stop a model from choosing a secret-bearing entry over a safe one.</p><p>Terminal agent helpers also give a model-authored candidate one ordinary
 correction turn when budget remains. <code class="inline">agent.core/run</code> validates the exact
 final value it returns — the standard success envelope by default, or the
 raw object when <code class="inline">result_envelope</code> is false. <code class="inline">agent.main/run</code> and

--- a/test/ptc_runner/kernel/command_docs_test.exs
+++ b/test/ptc_runner/kernel/command_docs_test.exs
@@ -104,6 +104,20 @@ defmodule PtcRunner.Kernel.CommandDocsTest do
     assert content =~ "ptc init support-triage --example support-triage"
   end
 
+  test "mission docs distinguish capability grants from forwarded data" do
+    assert {:ok, guide} = DocumentationLibrary.fetch("designing-agent-workflows")
+    assert guide =~ "limits capabilities"
+    assert guide =~ "does not filter handoff data"
+    assert guide =~ "trusted workflow code must perform that filtering"
+    assert guide =~ "prompt-level mitigation"
+
+    assert {:ok, manifest} = DocumentationLibrary.fetch("manifest")
+    manifest = String.replace(manifest, ~r/\s+/, " ")
+    assert manifest =~ "does not prevent that data from reaching a later mission"
+    assert manifest =~ "do not sanitize data or determine its sensitivity"
+    assert manifest =~ "secret"
+  end
+
   test "served model docs distinguish cost reservations from measured spend" do
     assert {:ok, limits} = DocumentationLibrary.fetch("limits")
     limits = String.replace(limits, ~r/\s+/, " ")


### PR DESCRIPTION
## Summary

- clarify that mission grants constrain capabilities, not data forwarded by trusted workflow code
- document deterministic handoff filtering and the limits of result and phase-return schemas
- align the support-triage example, served-doc regression coverage, and generated site pages

Closes #1786

## Validation

- `mix test test/ptc_runner/kernel/command_docs_test.exs test/ptc_runner/kernel/support_triage_examples_test.exs` (23 passed)
- `mix ptc.verify_docs`
- `MIX_ENV=dev mix docs --warnings-as-errors`
- `mix precommit`
- normal pre-push gate: core 7,788 passed; Dialyzer/static analysis, release, Viewer 135, and launcher 42 passed
- one independent Codex review plus focused follow-up: clean

## Retrospective

The initial guide correction exposed two nearby documentation drifts: the materialized example repeated the old overclaim, and describing schemas as shape-only ignored enums and bounds. The independent review caught both. Rephrasing also preserved the zero-tic guide ceiling while tightening the word and density baselines.