### PR TITLE
fix(transcript): point refusals to private REPL

### DIFF
--- a/docs/reference/debug-navigation.md
+++ b/docs/reference/debug-navigation.md
@@ -326,36 +326,19 @@ model exchange is missing, and no turn or generated-source association is
 ambiguous. It is a statement about the reconstruction, not a promise that every
 field of every record is present. `ptc transcript` refuses to write a file at
 all unless `complete?` holds, so that field is always `true` in a published
-transcript; read it over `/api/analysis/runs/{id}/conversation`, which applies
-no such gate, when you need it to be able to say no.
+transcript. The same reconstruction is ungated in
+`ptc repl --profile private-run-analysis-v2`; run `ptc docs repl` for the
+complete headless invocation.
 
 The refusal names which of the three facts failed and by how much, because they
 have different next actions. `transcript/ambiguous_evidence` means nothing is
 missing: the run is complete and every expected exchange was
 captured, but some turn or generated-source association resolves to more than
-one predecessor. Re-running does not help; read the ungated route instead.
+one predecessor. Re-running does not help; read the ungated `turns` collection
+through the private analysis REPL instead.
 `transcript/incomplete_evidence` means the trace is not terminal or
 dropped events, or the inspection artifact does not carry every exchange the
 trace expects — both facts about the capture rather than the reconstruction.
-
-### Reaching the ungated reconstruction
-
-`/api/analysis/runs/{id}/conversation` is served by `ptc viewer` and needs the
-project's private grant. Four separate decisions withhold it — two about the
-project, two about the run — and the Viewer's private routes answer for each by
-name, so the reason body is the next action rather than a bare status:
-
-| answer | cause | next action |
-| --- | --- | --- |
-| `404 inspection_not_configured` | the project records no inspection artifact | set `artifacts.trace` and `artifacts.inspection` and run again |
-| `404 inspection_not_private` | the artifact exists, this Viewer was not granted it | set `viewer.private` and Refresh the Runs list; nothing needs re-running |
-| `404 inspection_run_not_recorded` | the Viewer reads private evidence, this run recorded none | run the project again, now that `artifacts.inspection` is set |
-| `404 inspection_run_mismatch` | the Viewer is pinned to a different run's artifact | start the Viewer for this run |
-
-Every other answer is a transport status with prose, not a reason code: the
-route reports a source that is unavailable, changed, oversized, or malformed as
-the failure it is rather than as a setting the reader could change.
-`/api/analysis/runs/{id}/preludes` answers on the same terms.
 
 `omitted_count` is pagination: how many selected items this page did not
 return. It never reports evidence withheld by policy. A source grant that

--- a/docs/reference/project-files.md
+++ b/docs/reference/project-files.md
@@ -197,19 +197,13 @@ The REPL and private-data settings are orthogonal. Enabling both presents the
 public-trace REPL alongside the private evidence panels without adding private
 inspection authority to the evaluation session.
 
-Because `artifacts.inspection` and `viewer.private` must both hold, the private
-routes distinguish which one is missing: `inspection_not_configured` for a
-project that records no inspection artifact, `inspection_not_private` for one
-that records it and withheld the grant. The second needs no re-run — the
-artifact on disk is already usable once the Viewer refreshes after the grant.
-Revoking the grant takes effect on the next request without Refresh.
-
-A run can also fall outside evidence the Viewer does hold, which the routes
-name separately from the project settings: `inspection_run_not_recorded` for a
-run made before `artifacts.inspection` was set, and `inspection_run_mismatch`
-for a Viewer pinned to one other run's artifact. The
-[debug-navigation reference](debug-navigation.md#reaching-the-ungated-reconstruction)
-carries the complete table.
+Because `artifacts.inspection` and `viewer.private` must both hold, granting the
+Viewer access to an existing inspection artifact needs no re-run. The artifact
+on disk is already usable once the Viewer refreshes after the grant. Revoking
+the grant takes effect on the next request without Refresh. For headless access
+to the same reconstructed conversation, use
+`ptc repl --profile private-run-analysis-v2`; run `ptc docs repl` for the
+complete invocation.
 
 Viewer-started workflows and missions use the project's `host.env_file` when
 one is declared. `ptc viewer ptc-project.json --env-file FILE` supplies an

--- a/docs/reference/repl.md
+++ b/docs/reference/repl.md
@@ -661,12 +661,13 @@ mutually exclusive with `--private-terminal`:
 ```console
 ptc repl \
   --profile private-run-analysis-v2 \
+  --run RUN_ID \
   --resource traces=tmp/tutorial-traces \
   --resource inspection=tmp/tutorial-inspection \
   --session-trace-dir tmp/analysis-traces \
   --private-unattended \
   --format jsonl \
-  -e '(analysis/read "run-id" {"collection" "turns" "limit" 100})' \
+  -e '(analysis/read "RUN_ID" {"collection" "turns" "limit" 100})' \
   >tmp/private-analysis.jsonl
 ```
 

--- a/lib/ptc_runner/transcript_frontend.ex
+++ b/lib/ptc_runner/transcript_frontend.ex
@@ -226,21 +226,22 @@ defmodule PtcRunner.TranscriptFrontend do
          "transcript evidence is incomplete: the canonical trace records no terminal run " <>
            "event or reports dropped events, so the conversation cannot be certified " <>
            "(#{missing} missing model #{plural(missing, "exchange")}, " <>
-           "#{ambiguity} ambiguous #{plural(ambiguity, "association")}). " <> ungated_route()}
+           "#{ambiguity} ambiguous #{plural(ambiguity, "association")}). " <> ungated_repl_hint()}
 
       missing > 0 ->
         {:error, :incomplete_evidence,
          "transcript evidence is incomplete: #{missing} model " <>
            "#{plural(missing, "exchange")} the canonical trace expects " <>
            "#{plural(missing, "was", "were")} not captured under --inspection " <>
-           "(#{ambiguity} ambiguous #{plural(ambiguity, "association")}). " <> ungated_route()}
+           "(#{ambiguity} ambiguous #{plural(ambiguity, "association")}). " <>
+           ungated_repl_hint()}
 
       ambiguity > 0 ->
         {:error, :ambiguous_evidence,
          "transcript evidence is ambiguous: #{ambiguity} turn or generated-source " <>
            "#{plural(ambiguity, "association")} #{plural(ambiguity, "resolves", "resolve")} " <>
            "to more than one predecessor. Nothing is missing: the canonical trace is " <>
-           "complete and every expected model exchange was captured. " <> ungated_route()}
+           "complete and every expected model exchange was captured. " <> ungated_repl_hint()}
 
       true ->
         :ok
@@ -248,12 +249,12 @@ defmodule PtcRunner.TranscriptFrontend do
   end
 
   # `ptc transcript` publishes only a reconstruction it can certify. The
-  # Viewer's analysis route applies no such gate, so it is the next action for
-  # every refusal above rather than a workaround for one of them.
-  defp ungated_route,
+  # private analysis profile applies no such gate and is present in every
+  # distribution, so it is the next action for every refusal above.
+  defp ungated_repl_hint,
     do:
-      "A Viewer started with viewer.private: true serves the ungated reconstruction at " <>
-        "/api/analysis/runs/RUN_ID/conversation."
+      "The same reconstruction is ungated in ptc repl --profile private-run-analysis-v2; " <>
+        "see ptc docs repl."
 
   defp count(conversation, key) do
     case Map.get(conversation, key) do

--- a/site/reference/debug-navigation/index.html
+++ b/site/reference/debug-navigation/index.html
@@ -263,21 +263,17 @@ model exchange is missing, and no turn or generated-source association is
 ambiguous. It is a statement about the reconstruction, not a promise that every
 field of every record is present. <code class="inline">ptc transcript</code> refuses to write a file at
 all unless <code class="inline">complete?</code> holds, so that field is always <code class="inline">true</code> in a published
-transcript; read it over <code class="inline">/api/analysis/runs/{id}/conversation</code>, which applies
-no such gate, when you need it to be able to say no.</p><p>The refusal names which of the three facts failed and by how much, because they
+transcript. The same reconstruction is ungated in
+<code class="inline">ptc repl --profile private-run-analysis-v2</code>; run <code class="inline">ptc docs repl</code> for the
+complete headless invocation.</p><p>The refusal names which of the three facts failed and by how much, because they
 have different next actions. <code class="inline">transcript/ambiguous_evidence</code> means nothing is
 missing: the run is complete and every expected exchange was
 captured, but some turn or generated-source association resolves to more than
-one predecessor. Re-running does not help; read the ungated route instead.
+one predecessor. Re-running does not help; read the ungated <code class="inline">turns</code> collection
+through the private analysis REPL instead.
 <code class="inline">transcript/incomplete_evidence</code> means the trace is not terminal or
 dropped events, or the inspection artifact does not carry every exchange the
-trace expects — both facts about the capture rather than the reconstruction.</p><h3 id="reaching-the-ungated-reconstruction">Reaching the ungated reconstruction</h3><p><code class="inline">/api/analysis/runs/{id}/conversation</code> is served by <code class="inline">ptc viewer</code> and needs the
-project's private grant. Four separate decisions withhold it — two about the
-project, two about the run — and the Viewer's private routes answer for each by
-name, so the reason body is the next action rather than a bare status:</p><div class="table-wrap"><table><thead><tr><th style="text-align: left;">answer</th><th style="text-align: left;">cause</th><th style="text-align: left;">next action</th></tr></thead><tbody><tr><td style="text-align: left;"><code class="inline">404 inspection_not_configured</code></td><td style="text-align: left;">the project records no inspection artifact</td><td style="text-align: left;">set <code class="inline">artifacts.trace</code> and <code class="inline">artifacts.inspection</code> and run again</td></tr><tr><td style="text-align: left;"><code class="inline">404 inspection_not_private</code></td><td style="text-align: left;">the artifact exists, this Viewer was not granted it</td><td style="text-align: left;">set <code class="inline">viewer.private</code> and Refresh the Runs list; nothing needs re-running</td></tr><tr><td style="text-align: left;"><code class="inline">404 inspection_run_not_recorded</code></td><td style="text-align: left;">the Viewer reads private evidence, this run recorded none</td><td style="text-align: left;">run the project again, now that <code class="inline">artifacts.inspection</code> is set</td></tr><tr><td style="text-align: left;"><code class="inline">404 inspection_run_mismatch</code></td><td style="text-align: left;">the Viewer is pinned to a different run's artifact</td><td style="text-align: left;">start the Viewer for this run</td></tr></tbody></table></div><p>Every other answer is a transport status with prose, not a reason code: the
-route reports a source that is unavailable, changed, oversized, or malformed as
-the failure it is rather than as a setting the reader could change.
-<code class="inline">/api/analysis/runs/{id}/preludes</code> answers on the same terms.</p><p><code class="inline">omitted_count</code> is pagination: how many selected items this page did not
+trace expects — both facts about the capture rather than the reconstruction.</p><p><code class="inline">omitted_count</code> is pagination: how many selected items this page did not
 return. It never reports evidence withheld by policy. A source grant that
 withheld trace files of the other kind reports that separately, as
 <code class="inline">excluded_private_trace_files</code> or <code class="inline">excluded_sanitized_trace_files</code> on a run

--- a/site/reference/project-files/index.html
+++ b/site/reference/project-files/index.html
@@ -214,17 +214,13 @@ it. The Live project header and <code class="inline">/api/live/project</code> ex
 document path, so a working page cannot silently look like the project whose
 startup just failed.</p><p>The REPL and private-data settings are orthogonal. Enabling both presents the
 public-trace REPL alongside the private evidence panels without adding private
-inspection authority to the evaluation session.</p><p>Because <code class="inline">artifacts.inspection</code> and <code class="inline">viewer.private</code> must both hold, the private
-routes distinguish which one is missing: <code class="inline">inspection_not_configured</code> for a
-project that records no inspection artifact, <code class="inline">inspection_not_private</code> for one
-that records it and withheld the grant. The second needs no re-run — the
-artifact on disk is already usable once the Viewer refreshes after the grant.
-Revoking the grant takes effect on the next request without Refresh.</p><p>A run can also fall outside evidence the Viewer does hold, which the routes
-name separately from the project settings: <code class="inline">inspection_run_not_recorded</code> for a
-run made before <code class="inline">artifacts.inspection</code> was set, and <code class="inline">inspection_run_mismatch</code>
-for a Viewer pinned to one other run's artifact. The
-<a href="/reference/debug-navigation/#reaching-the-ungated-reconstruction">debug-navigation reference</a>
-carries the complete table.</p><p>Viewer-started workflows and missions use the project's <code class="inline">host.env_file</code> when
+inspection authority to the evaluation session.</p><p>Because <code class="inline">artifacts.inspection</code> and <code class="inline">viewer.private</code> must both hold, granting the
+Viewer access to an existing inspection artifact needs no re-run. The artifact
+on disk is already usable once the Viewer refreshes after the grant. Revoking
+the grant takes effect on the next request without Refresh. For headless access
+to the same reconstructed conversation, use
+<code class="inline">ptc repl --profile private-run-analysis-v2</code>; run <code class="inline">ptc docs repl</code> for the
+complete invocation.</p><p>Viewer-started workflows and missions use the project's <code class="inline">host.env_file</code> when
 one is declared. <code class="inline">ptc viewer ptc-project.json --env-file FILE</code> supplies an
 invocation-time override instead. PtcRunner never searches implicitly for
 <code class="inline">.env</code>; without either form, credentials must already be present in the Viewer

--- a/site/reference/repl/index.html
+++ b/site/reference/repl/index.html
@@ -478,12 +478,13 @@ disclosing any path:</p><pre><code class="text language-text">directories for --
 sink. It admits expressions, setup files, scripts, stdin, and JSON Lines and is
 mutually exclusive with <code class="inline">--private-terminal</code>:</p><pre><code class="console language-console">ptc repl \
   --profile private-run-analysis-v2 \
+  --run RUN_ID \
   --resource traces=tmp/tutorial-traces \
   --resource inspection=tmp/tutorial-inspection \
   --session-trace-dir tmp/analysis-traces \
   --private-unattended \
   --format jsonl \
-  -e '(analysis/read &quot;run-id&quot; {&quot;collection&quot; &quot;turns&quot; &quot;limit&quot; 100})' \
+  -e '(analysis/read &quot;RUN_ID&quot; {&quot;collection&quot; &quot;turns&quot; &quot;limit&quot; 100})' \
   &gt;tmp/private-analysis.jsonl</code></pre><p>The packaged command has no Mix build stream.</p><p>Both private switches are accident guards, not access control. A same-UID
 caller can read the source artifacts, and a pseudo-terminal can satisfy the
 terminal check. Unattended output may enter shell logs, coding-agent

--- a/test/mix/tasks/ptc_transcript_test.exs
+++ b/test/mix/tasks/ptc_transcript_test.exs
@@ -96,8 +96,7 @@ defmodule Mix.Tasks.PtcTranscriptTest do
     assert presentation.stderr =~ "transcript/ambiguous_evidence"
     refute presentation.stderr =~ "incomplete_evidence"
     assert presentation.stderr =~ "is ambiguous: 1 turn or generated-source association"
-    assert presentation.stderr =~ "viewer.private"
-    assert presentation.stderr =~ "/api/analysis/runs/RUN_ID/conversation"
+    assert_ungated_repl_hint(presentation.stderr)
     refute File.exists?(output)
   end
 
@@ -143,7 +142,33 @@ defmodule Mix.Tasks.PtcTranscriptTest do
     assert presentation.stderr =~ "1 model exchange the canonical trace expects"
     assert presentation.stderr =~ "not captured under --inspection"
     assert presentation.stderr =~ "0 ambiguous associations"
-    assert presentation.stderr =~ "/api/analysis/runs/RUN_ID/conversation"
+    assert_ungated_repl_hint(presentation.stderr)
+    refute File.exists?(output)
+  end
+
+  @tag :tmp_dir
+  test "a nonterminal trace reports canonical incompleteness and its counts", %{tmp_dir: root} do
+    fixture = canonical_create!(root)
+    trace_path = Path.join(fixture.traces, "#{fixture.run_id}.jsonl")
+
+    trace_without_terminal_event =
+      trace_path
+      |> File.read!()
+      |> String.split("\n", trim: true)
+      |> Enum.drop(-1)
+      |> Enum.join("\n")
+
+    File.write!(trace_path, trace_without_terminal_event <> "\n")
+    output = Path.join(fixture.output, "nonterminal.private.json")
+
+    presentation = MixCommandAdapter.execute(transcript_argv(fixture, output))
+
+    assert presentation.exit_status == 1
+    assert presentation.stderr =~ "transcript/incomplete_evidence"
+    assert presentation.stderr =~ "canonical trace records no terminal run event"
+    assert presentation.stderr =~ "0 missing model exchanges"
+    assert presentation.stderr =~ "0 ambiguous associations"
+    assert_ungated_repl_hint(presentation.stderr)
     refute File.exists?(output)
   end
 
@@ -786,5 +811,14 @@ defmodule Mix.Tasks.PtcTranscriptTest do
   defp without_option(argv, switch) do
     index = Enum.find_index(argv, &(&1 == switch))
     argv |> List.delete_at(index) |> List.delete_at(index)
+  end
+
+  defp assert_ungated_repl_hint(message) do
+    assert message =~
+             "The same reconstruction is ungated in ptc repl --profile private-run-analysis-v2"
+
+    assert message =~ "ptc docs repl"
+    refute message =~ "/api/"
+    refute message =~ "Viewer"
   end
 end


### PR DESCRIPTION
## Summary

- replace all `ptc transcript` refusal recovery text with the always-shipped private analysis REPL path
- retain the existing refusal causes and evidence counts, with regression coverage for ambiguous, missing-exchange, and nonterminal evidence
- remove the now-unneeded Viewer conversation-route contract and reason-code table from the debugging and project-file guides
- document `--run RUN_ID` in the headless REPL example so the selected-run semantics remain explicit

Closes #1795.

## Validation

- `mix test test/mix/tasks/ptc_transcript_test.exs` — 30 passed
- `scripts/verify_core_package.sh` — Hex package compiled without the optional Viewer
- `mix ptc.gen_docs`
- `MIX_ENV=dev mix docs --warnings-as-errors`
- `mix precommit`
- ordinary `git push` pre-push gate — 7,801 core tests, 122 doctests, 5 properties; Credo and duplication clean; Dialyzer zero errors; release verification passed; 135 Viewer tests passed
- two independent Codex reviews completed; the first caught the missing `--run RUN_ID` selector, which was addressed, and the cumulative review reported no actionable findings

The refusal and ungated reconstruction were also exercised against the same interrupted fixture. The source-tree frontend invocation corresponding to the shipped `ptc repl` command was:

```console
mix ptc repl \
  --profile private-run-analysis-v2 \
  --resource traces=/tmp/ptc-1795-probe.yg4QG4/traces \
  --resource inspection=/tmp/ptc-1795-probe.yg4QG4/inspection \
  --session-trace-dir /tmp/ptc-1795-probe.yg4QG4/analysis-traces \
  --private-unattended \
  --format jsonl \
  -e '(analysis/read "cmd-00000000000000000000000000" {"collection" "turns" "limit" 100})'
```

Its first output line was:

```json
{"capture":{"inspection":{"file_count":1,"run_count":1},"traces":{"file_count":1,"run_count":1}},"namespaces":["analysis","cap","prompt.audit"],"profile_digest":"sha256:1727ea98e9b77da2bfeb187520df30382538492f06914bb6a73e51c710ce4a63","profile_id":"private-run-analysis-v2","schema_version":1,"session_id":"private-run-analysis-f15c28ac1e6ffacd","type":"session-started"}
```

## Retrospective

The refusal was correct, but its recovery advice coupled a core CLI workflow to an optional presentation layer. Reusing the existing private analysis profile removes that dependency; review also exposed that the durable example needed `--run` to preserve exact selected-run behavior.
