### PR TITLE
perf(lisp): reuse parent context for closure calls

### DIFF
--- a/lib/ptc_runner/kernel/evaluation.ex
+++ b/lib/ptc_runner/kernel/evaluation.ex
@@ -43,7 +43,6 @@ defmodule PtcRunner.Kernel.Evaluation do
   alias PtcRunner.Kernel.Environment
   alias PtcRunner.Kernel.Events
   alias PtcRunner.Kernel.InspectionSink
-  alias PtcRunner.Kernel.Library
   alias PtcRunner.Kernel.ProjectionError
   alias PtcRunner.Kernel.RunState
   alias PtcRunner.Kernel.RuntimeTools
@@ -418,7 +417,6 @@ defmodule PtcRunner.Kernel.Evaluation do
       strict_data: true,
       data_grants: DataKeys.source_referenceable_forms(environment.data),
       missing_data_params_message: @missing_data_params_message,
-      shipped_library_ids: Library.component_ids(),
       component_catalog: Environment.catalog(environment),
       inspect_only: Map.get(capture, :inspect_only, false)
     ]

--- a/lib/ptc_runner/kernel/repl_session.ex
+++ b/lib/ptc_runner/kernel/repl_session.ex
@@ -33,7 +33,6 @@ defmodule PtcRunner.Kernel.ReplSession do
   alias PtcRunner.Kernel.Events
   alias PtcRunner.Kernel.EventSink
   alias PtcRunner.Kernel.InspectionSink
-  alias PtcRunner.Kernel.Library
   alias PtcRunner.Kernel.Limits
   alias PtcRunner.Kernel.MissionEnvironment
   alias PtcRunner.Kernel.PrivateDirectory
@@ -876,7 +875,6 @@ defmodule PtcRunner.Kernel.ReplSession do
         link: true,
         strict_data: true,
         data_grants: DataKeys.source_referenceable_forms(session.config.input),
-        shipped_library_ids: Library.component_ids(),
         component_catalog: Environment.catalog(session.config.workflow_environment),
         inspect_only: session.config.inspect_only
       )

--- a/lib/ptc_runner/kernel/runner.ex
+++ b/lib/ptc_runner/kernel/runner.ex
@@ -17,7 +17,6 @@ defmodule PtcRunner.Kernel.Runner do
   alias PtcRunner.Kernel.EventSink
   alias PtcRunner.Kernel.InspectionSink
   alias PtcRunner.Kernel.JSONValue
-  alias PtcRunner.Kernel.Library
   alias PtcRunner.Kernel.LLMBudget
   alias PtcRunner.Kernel.LLMReplayDiagnostic
   alias PtcRunner.Kernel.ProjectionError
@@ -260,7 +259,6 @@ defmodule PtcRunner.Kernel.Runner do
       telemetry_run: state.pid,
       strict_data: true,
       data_grants: DataKeys.source_referenceable_forms(config.input),
-      shipped_library_ids: Library.component_ids(),
       component_catalog: Environment.catalog(config.workflow_environment),
       inspect_only: config.inspect_only
     ]

--- a/lib/ptc_runner/lisp.ex
+++ b/lib/ptc_runner/lisp.ex
@@ -302,13 +302,6 @@ defmodule PtcRunner.Lisp do
       for selected overrides whose replacement source removed an export.
       Omitting the ownership map keeps the ordinary miss, so embedded callers
       are unchanged.
-    - `:shipped_library_ids` - Optional catalog of shipped library component IDs.
-      The Kernel passes `PtcRunner.Kernel.Library.component_ids/0` so `doc` and
-      `apropos` can name an unattached shipped library. The catalog contains
-      library IDs, not export refs, so a `doc` redirect does not assert that the
-      requested export exists.
-      `nil` (the default) keeps today's miss message, so embedded `run/2`
-      callers are unchanged.
     - `:component_catalog` - Optional attested Kernel component catalog for the
       selected environment. Public `run/2` strips this option so a direct
       caller cannot inject a Kernel graph. Kernel evaluations pass it only
@@ -847,7 +840,6 @@ defmodule PtcRunner.Lisp do
       strict_data: Keyword.get(opts, :strict_data, false),
       data_grants: Keyword.get(opts, :data_grants),
       missing_data_params_message: Keyword.get(opts, :missing_data_params_message),
-      shipped_library_ids: Keyword.get(opts, :shipped_library_ids),
       component_catalog: Keyword.get(opts, :component_catalog),
       inspect_only: Keyword.get(opts, :inspect_only, false),
       strict_transitive_calls: Keyword.get(opts, :strict_transitive_calls, false),
@@ -1288,7 +1280,6 @@ defmodule PtcRunner.Lisp do
       strict_data: strict_data,
       data_grants: data_grants,
       missing_data_params_message: missing_data_params_message,
-      shipped_library_ids: shipped_library_ids,
       component_catalog: component_catalog,
       inspect_only: inspect_only,
       strict_transitive_calls: strict_transitive_calls,
@@ -1336,7 +1327,6 @@ defmodule PtcRunner.Lisp do
         strict_data: strict_data,
         data_grants: data_grants,
         missing_data_params_message: missing_data_params_message,
-        shipped_library_ids: shipped_library_ids,
         component_catalog: component_catalog,
         inspect_only: inspect_only,
         strict_transitive_calls: strict_transitive_calls,

--- a/lib/ptc_runner/lisp/eval/context.ex
+++ b/lib/ptc_runner/lisp/eval/context.ex
@@ -113,10 +113,6 @@ defmodule PtcRunner.Lisp.Eval.Context do
     # Kernel-supplied diagnostic used when `data/params` is missing under
     # strict data. `nil` treats `params` as an ordinary missing key.
     missing_data_params_message: nil,
-    # Kernel-supplied catalog of shipped library component IDs. `nil` means
-    # Introspection should not distinguish unattached shipped refs from
-    # unknown ones.
-    shipped_library_ids: nil,
     # Selected Kernel environment component catalog. `nil` for direct Lisp.run/2.
     component_catalog: nil,
     # When true, tool/Kernel/provider routes fail with inspect_only_unavailable.
@@ -224,7 +220,6 @@ defmodule PtcRunner.Lisp.Eval.Context do
           strict_data: boolean(),
           data_grants: [String.t()] | nil,
           missing_data_params_message: String.t() | nil,
-          shipped_library_ids: MapSet.t(String.t()) | nil,
           component_catalog: term() | nil,
           inspect_only: boolean(),
           strict_transitive_calls: boolean(),
@@ -316,7 +311,6 @@ defmodule PtcRunner.Lisp.Eval.Context do
       data_grants: normalize_data_grants(Keyword.get(opts, :data_grants)),
       missing_data_params_message:
         normalize_missing_params_message(Keyword.get(opts, :missing_data_params_message)),
-      shipped_library_ids: normalize_shipped_library_ids(Keyword.get(opts, :shipped_library_ids)),
       component_catalog: Keyword.get(opts, :component_catalog),
       inspect_only: Keyword.get(opts, :inspect_only, false),
       strict_transitive_calls: Keyword.get(opts, :strict_transitive_calls, false),
@@ -335,15 +329,25 @@ defmodule PtcRunner.Lisp.Eval.Context do
   @doc false
   @spec new_child(t(), map(), map(), keyword()) :: t()
   def new_child(%__MODULE__{} = parent, user_ns, env, opts \\ []) do
-    opts =
-      [
-        tool_call_budget: parent.tool_call_budget,
-        tool_activity: parent.tool_activity
-      ] ++ opts
-
-    parent.ctx
-    |> new(user_ns, env, parent.tool_exec, parent.turn_history, opts)
-    |> inherit_prelude(parent)
+    %{
+      parent
+      | user_ns: user_ns,
+        env: env,
+        effects: Effects.empty(),
+        locals: MapSet.new(),
+        max_print_length: Keyword.get(opts, :max_print_length, @default_print_length),
+        max_tool_call_result_bytes:
+          Keyword.get(opts, :max_tool_call_result_bytes, @default_tool_call_result_bytes),
+        pmap_timeout: Keyword.get(opts, :pmap_timeout, @default_pmap_timeout),
+        parallel_deadline_cap: Keyword.get(opts, :parallel_deadline_cap),
+        pmap_max_concurrency:
+          Keyword.get(opts, :pmap_max_concurrency, @default_pmap_max_concurrency),
+        pmap_deadline: nil,
+        max_heap: Keyword.get(opts, :max_heap),
+        worker_max_heap: Keyword.get(opts, :worker_max_heap, Keyword.get(opts, :max_heap)),
+        parallel_budget: Keyword.get(opts, :parallel_budget),
+        tools_meta: Keyword.get(opts, :tools_meta, %{})
+    }
   end
 
   @doc false
@@ -384,13 +388,6 @@ defmodule PtcRunner.Lisp.Eval.Context do
     do: message
 
   defp normalize_missing_params_message(_message), do: nil
-
-  defp normalize_shipped_library_ids(ids) when is_list(ids) do
-    ids |> Enum.filter(&is_binary/1) |> MapSet.new()
-  end
-
-  defp normalize_shipped_library_ids(%MapSet{} = ids), do: ids
-  defp normalize_shipped_library_ids(_ids), do: nil
 
   defp normalize_namespace_requirers(requirers) when is_map(requirers) do
     Map.new(requirers, fn
@@ -616,45 +613,6 @@ defmodule PtcRunner.Lisp.Eval.Context do
   @spec update_user_ns(t(), map()) :: t()
   def update_user_ns(%__MODULE__{} = context, new_user_ns) do
     %{context | user_ns: new_user_ns}
-  end
-
-  @doc """
-  Copies the attached prelude tables and shared run-scoped resources from
-  `source` onto `context`.
-
-  Sub-contexts built with `new/6` for closure/thunk evaluation start with empty
-  prelude tables; this re-installs them so a qualified prelude call made from
-  inside a user closure still resolves.
-  """
-  @spec inherit_prelude(t(), t()) :: t()
-  def inherit_prelude(%__MODULE__{} = context, %__MODULE__{} = source) do
-    %{
-      context
-      | prelude_exports: source.prelude_exports,
-        prelude: source.prelude,
-        strict_transitive_calls: source.strict_transitive_calls,
-        private_tool_authority?: source.private_tool_authority?,
-        direct_namespaces: source.direct_namespaces,
-        transitive_namespace_requirers: source.transitive_namespace_requirers,
-        prelude_export_mask: source.prelude_export_mask,
-        shipped_export_owners: source.shipped_export_owners,
-        attached_component_ids: source.attached_component_ids,
-        max_tool_calls: source.max_tool_calls,
-        loop_limit: source.loop_limit,
-        tool_call_budget: source.tool_call_budget,
-        tool_activity: source.tool_activity,
-        tool_failure_token: source.tool_failure_token,
-        failure_origin: source.failure_origin,
-        return_origin: source.return_origin,
-        origin_stack: source.origin_stack,
-        prelude_caller_user_ns_stack: source.prelude_caller_user_ns_stack,
-        strict_data: source.strict_data,
-        data_grants: source.data_grants,
-        missing_data_params_message: source.missing_data_params_message,
-        shipped_library_ids: source.shipped_library_ids,
-        component_catalog: source.component_catalog,
-        inspect_only: source.inspect_only
-    }
   end
 
   @doc false

--- a/test/ptc_runner/lisp/eval/context_test.exs
+++ b/test/ptc_runner/lisp/eval/context_test.exs
@@ -2,6 +2,7 @@ defmodule PtcRunner.Lisp.Eval.ContextTest do
   use ExUnit.Case, async: true
 
   alias PtcRunner.Lisp.Eval.Context
+  alias PtcRunner.Lisp.Eval.Effects
 
   doctest PtcRunner.Lisp.Eval.Context
 
@@ -29,6 +30,114 @@ defmodule PtcRunner.Lisp.Eval.ContextTest do
     assert child.private_tool_authority? === parent.private_tool_authority?
     assert child.user_ns == %{"scope" => "child"}
     assert child.env == %{"x" => 1}
+  end
+
+  test "child contexts inherit run state while resetting invocation state" do
+    tool_exec = fn _, _, _ -> nil end
+    tool_failure_token = make_ref()
+    parallel_budget = self()
+    prelude_exports = %{"demo/value" => {:callable, %{}}}
+    prelude = %{artifact: true}
+    effects = %Effects{prints: ["parent"]}
+
+    parent =
+      Context.new(%{"input" => 1}, %{"scope" => "parent"}, %{"old" => 0}, tool_exec, [:turn],
+        tool_failure_token: tool_failure_token,
+        failure_origin: :capability,
+        return_origin: :direct_tool_call,
+        origin_stack: [%{type: :user_closure}],
+        prelude_caller_user_ns_stack: [%{"caller" => true}],
+        loop_limit: 25,
+        max_tool_calls: 4,
+        max_print_length: 99,
+        max_tool_call_result_bytes: 88,
+        pmap_timeout: 77,
+        parallel_deadline_cap: 66,
+        pmap_max_concurrency: 3,
+        max_heap: 55,
+        worker_max_heap: 44,
+        parallel_budget: parallel_budget,
+        tools_meta: %{"tool" => %{private: true}},
+        strict_data: true,
+        data_grants: ["one"],
+        missing_data_params_message: "missing",
+        component_catalog: %{entries: []},
+        inspect_only: true,
+        strict_transitive_calls: true,
+        private_tool_authority?: true,
+        direct_namespaces: ["demo"],
+        transitive_namespace_requirers: %{"dep" => ["component"]},
+        prelude_export_mask: %{"demo" => ["demo/value"]},
+        shipped_export_owners: %{"demo/value" => "component"},
+        attached_component_ids: ["component"]
+      )
+      |> Map.merge(%{
+        effects: effects,
+        locals: MapSet.new(["parent-local"]),
+        pmap_deadline: 33,
+        prelude_exports: prelude_exports,
+        prelude: prelude
+      })
+
+    child = Context.new_child(parent, %{"scope" => "child"}, %{"x" => 1})
+
+    inherited_fields =
+      Map.keys(Map.from_struct(parent)) --
+        [
+          :user_ns,
+          :env,
+          :effects,
+          :locals,
+          :max_print_length,
+          :max_tool_call_result_bytes,
+          :pmap_timeout,
+          :parallel_deadline_cap,
+          :pmap_max_concurrency,
+          :pmap_deadline,
+          :max_heap,
+          :worker_max_heap,
+          :parallel_budget,
+          :tools_meta
+        ]
+
+    assert Map.take(child, inherited_fields) === Map.take(parent, inherited_fields)
+    assert child.user_ns == %{"scope" => "child"}
+    assert child.env == %{"x" => 1}
+    assert child.effects == Effects.empty()
+    assert child.locals == MapSet.new()
+    assert child.max_print_length == 2_000
+    assert child.max_tool_call_result_bytes == 16_384
+    assert child.pmap_timeout == 5_000
+    assert child.parallel_deadline_cap == nil
+    assert child.pmap_max_concurrency == Context.default_pmap_max_concurrency()
+    assert child.pmap_deadline == nil
+    assert child.max_heap == nil
+    assert child.worker_max_heap == nil
+    assert child.parallel_budget == nil
+    assert child.tools_meta == %{}
+
+    overridden =
+      Context.new_child(parent, %{}, %{},
+        max_print_length: 9,
+        max_tool_call_result_bytes: 8,
+        pmap_timeout: 7,
+        parallel_deadline_cap: 6,
+        pmap_max_concurrency: 5,
+        max_heap: 4,
+        worker_max_heap: 3,
+        parallel_budget: parallel_budget,
+        tools_meta: %{"override" => %{}}
+      )
+
+    assert overridden.max_print_length == 9
+    assert overridden.max_tool_call_result_bytes == 8
+    assert overridden.pmap_timeout == 7
+    assert overridden.parallel_deadline_cap == 6
+    assert overridden.pmap_max_concurrency == 5
+    assert overridden.max_heap == 4
+    assert overridden.worker_max_heap == 3
+    assert overridden.parallel_budget === parallel_budget
+    assert overridden.tools_meta == %{"override" => %{}}
   end
 
   test "loop_limit defaults to nil and consume_loop_iteration is activation-local" do


### PR DESCRIPTION
## Summary

- derive closure evaluation contexts directly from the immutable parent struct instead of rebuilding and re-inheriting the full context
- preserve the existing child inheritance/reset contract with exhaustive field coverage, including shared atomics, authority/origins, parallel resources, component catalog, and inspect-only state
- remove the dead `inherit_prelude/2` helper and unread `shipped_library_ids` option/field plumbing

Closes #1796

## Validation

- `MIX_ENV=test mix compile --warnings-as-errors`
- 656 focused evaluator, closure, parallel, sandbox, component-catalog, inspect-only, and REPL tests
- `mix bench.check --skip-heap` with the committed baseline unchanged
  - `closure_apply`: 3,752 reductions (max 4,562.5)
  - `public_prelude`: 21,517 reductions (max 26,802.5)
  - `strict_transitive_prelude`: 21,547 reductions (max 26,903.1)
- `mix precommit`
- normal pre-push gate: 7,802 core tests, Dialyzer (0 errors), ExDoc/link validation, release verification, and 135 Viewer tests
- two required independent review passes plus a fresh post-rebase base-guarded review: no actionable findings

## Retrospective

The regression came from treating a child closure context as a fresh run context and then copying run state back into it. Modeling the boundary as an immutable parent derivation both makes the ownership semantics clearer and removes work whose cost grew with every newly added context field. The exhaustive field-classification test should make future context additions prompt an explicit inherit-versus-reset decision before they can silently affect closure behavior or performance.
