### PR TITLE
fix(replay): stabilize heap failure observations

### DIFF
--- a/docs/guides/evaluating-with-replay.md
+++ b/docs/guides/evaluating-with-replay.md
@@ -91,8 +91,9 @@ dependencies, or grant a provider; the
 [component reference](../reference/component-contracts.md#evaluate-one-replacement-component)
 lists its fields and validation rules.
 
-Replay removes model sampling as a variable. It does not make MCP content
-deterministic unless that content is frozen as well.
+Replay removes model sampling as a variable, but every model-visible
+observation must remain stable. For details, see the
+[exact request-matching requirement](../reference/host-installation.md#choose-a-provider-source).
 
 ## Next steps
 

--- a/docs/reference/host-installation.md
+++ b/docs/reference/host-installation.md
@@ -385,7 +385,13 @@ blank lines. Nothing the line contains is published. The other local checks
 
 Fixture matching is exact: changed messages, tools, schema, or provider-neutral
 parameters produce another `request_hash` rather than silently consuming
-unrelated evidence. A structured-output fixture uses the public
+unrelated evidence. That request includes every model-visible observation
+accumulated during the run. Frozen MCP response content is therefore necessary
+but not sufficient when opaque cursors, generated identifiers, timestamps, or
+runtime diagnostics can vary between hosts. When recording a portable fixture,
+keep those values stable and retain host-specific measurements only in
+structured details that do not enter a later model request. A
+structured-output fixture uses the public
 `structured_output` object rather than encoded `content`. A miss is a provider
 error with `:kind :provider_error` and `:reason :not_found`, and `llm/request`
 returns that envelope as a value with

--- a/lib/ptc_runner/lisp.ex
+++ b/lib/ptc_runner/lisp.ex
@@ -1887,10 +1887,8 @@ defmodule PtcRunner.Lisp do
       "the #{info.limit_bytes}-byte setup ceiling (raise :setup_max_heap or shrink the grant)"
   end
 
-  defp memory_exceeded_message(%{phase: :eval} = info) do
-    "heap limit exceeded: program used more than its #{info.budget_bytes}-byte " <>
-      "budget above the #{info.baseline_bytes}-byte environment baseline " <>
-      "(limit #{info.limit_bytes} bytes)"
+  defp memory_exceeded_message(%{phase: :eval}) do
+    "heap limit exceeded: program exceeded its evaluation heap budget"
   end
 
   defp memory_exceeded_message(bytes) when is_integer(bytes),

--- a/site/guides/evaluating-with-replay/index.html
+++ b/site/guides/evaluating-with-replay/index.html
@@ -131,8 +131,9 @@ component the manifest already selects, including one selected through a
 dependency such as <code class="inline">agent.prompt</code>. It cannot add a component, change
 dependencies, or grant a provider; the
 <a href="/reference/component-contracts/#evaluate-one-replacement-component">component reference</a>
-lists its fields and validation rules.</p><p>Replay removes model sampling as a variable. It does not make MCP content
-deterministic unless that content is frozen as well.</p><h2 id="next-steps">Next steps</h2><ul><li><a href="/guides/components-and-preludes/">Inspect and customize components</a> has the
+lists its fields and validation rules.</p><p>Replay removes model sampling as a variable, but every model-visible
+observation must remain stable. For details, see the
+<a href="/reference/host-installation/#choose-a-provider-source">exact request-matching requirement</a>.</p><h2 id="next-steps">Next steps</h2><ul><li><a href="/guides/components-and-preludes/">Inspect and customize components</a> has the
 materialize and validate commands.</li><li><a href="/reference/kernel-limits-reference/">Kernel limits</a> lists the ceilings that must
 stay equal between the two runs.</li></ul>
 </article>

--- a/site/reference/host-installation/index.html
+++ b/site/reference/host-installation/index.html
@@ -345,7 +345,13 @@ blank lines. Nothing the line contains is published. The other local checks
 (an installed model's adapter, an MCP server's executable) stay out of
 <code class="inline">validate</code>.</p><p>Fixture matching is exact: changed messages, tools, schema, or provider-neutral
 parameters produce another <code class="inline">request_hash</code> rather than silently consuming
-unrelated evidence. A structured-output fixture uses the public
+unrelated evidence. That request includes every model-visible observation
+accumulated during the run. Frozen MCP response content is therefore necessary
+but not sufficient when opaque cursors, generated identifiers, timestamps, or
+runtime diagnostics can vary between hosts. When recording a portable fixture,
+keep those values stable and retain host-specific measurements only in
+structured details that do not enter a later model request. A
+structured-output fixture uses the public
 <code class="inline">structured_output</code> object rather than encoded <code class="inline">content</code>. A miss is a provider
 error with <code class="inline">:kind :provider_error</code> and <code class="inline">:reason :not_found</code>, and <code class="inline">llm/request</code>
 returns that envelope as a value with

--- a/test/ptc_runner/kernel/agent_library_test.exs
+++ b/test/ptc_runner/kernel/agent_library_test.exs
@@ -10,6 +10,7 @@ defmodule PtcRunner.Kernel.AgentLibraryTest do
   alias PtcRunner.Kernel.Library
   alias PtcRunner.Kernel.Limits
   alias PtcRunner.Kernel.LLMCapability
+  alias PtcRunner.Kernel.LLMReplay
   alias PtcRunner.Kernel.LLMRouter
   alias PtcRunner.Kernel.MissionEnvironment
   alias PtcRunner.Kernel.ModelContract
@@ -3760,6 +3761,47 @@ defmodule PtcRunner.Kernel.AgentLibraryTest do
     assert feedback =~ "previously committed definitions remain"
     assert feedback =~ "filter"
     assert feedback =~ "reduce"
+  end
+
+  test "heap-kill correction requests and retained execution stay stable across baselines" do
+    run = fn padding ->
+      responses = [
+        agent_return(
+          "explode",
+          ~S|(reduce (fn [acc i] (conj acc (range 0 4096))) [] (range 0 4096))|
+        ),
+        agent_return("recover", "(return 42)")
+      ]
+
+      {:ok, config} =
+        agent_config(responses, [evaluation_heap_words: 200_000],
+          mission_data: %{"baseline_padding" => padding}
+        )
+
+      assert {:ok, %{value: outcome}} =
+               Kernel.run(
+                 ~S|(return (agent.core/run-outcome "Recover efficiently" {"max_turns" 2 "retain_programs" 2}))|,
+                 config
+               )
+
+      assert_receive {:agent_request, first_request}
+      assert_receive {:agent_request, correction_request}
+
+      assert [failed, %{"execution" => %{"outcome" => "returned"}}] = outcome["programs"]
+      assert failed["execution"]["kind"] == "memory_exceeded"
+
+      {first_request, correction_request, failed["execution"]}
+    end
+
+    small = run.([0])
+    large = run.(Enum.to_list(1..20_000))
+
+    assert elem(small, 0) == elem(large, 0)
+    assert elem(small, 1) == elem(large, 1)
+    assert elem(small, 2) == elem(large, 2)
+
+    assert {:ok, small_hash} = LLMReplay.request_hash(elem(small, 1))
+    assert {:ok, ^small_hash} = LLMReplay.request_hash(elem(large, 1))
   end
 
   test "agent distinguishes retained-definition rejection from a heap kill" do

--- a/test/ptc_runner/lisp/heap_rebaseline_test.exs
+++ b/test/ptc_runner/lisp/heap_rebaseline_test.exs
@@ -93,6 +93,42 @@ defmodule PtcRunner.Lisp.HeapRebaselineTest do
       assert step.fail.details.limit_bytes >= step.fail.details.budget_bytes
     end
 
+    test "eval heap messages stay stable across different environment baselines" do
+      program = "(count (vec (range 2000000)))"
+
+      assert {:error, small} =
+               Lisp.run(program,
+                 context: %{"padding" => [0]},
+                 filter_context: false,
+                 max_heap: @default_max_heap,
+                 setup_max_heap: 6_000_000,
+                 timeout: 5_000
+               )
+
+      assert {:error, large} =
+               Lisp.run(program,
+                 context: %{"padding" => Enum.to_list(1..100_000)},
+                 filter_context: false,
+                 max_heap: @default_max_heap,
+                 setup_max_heap: 6_000_000,
+                 timeout: 5_000
+               )
+
+      assert small.fail.details.baseline_bytes != large.fail.details.baseline_bytes
+      assert small.fail.message == large.fail.message
+
+      assert small.fail.message ==
+               "heap limit exceeded: program exceeded its evaluation heap budget"
+
+      for step <- [small, large] do
+        assert step.fail.details.phase == :eval
+        assert step.fail.details.budget_bytes == @default_max_heap * 8
+
+        assert step.fail.details.limit_bytes ==
+                 step.fail.details.baseline_bytes + step.fail.details.budget_bytes
+      end
+    end
+
     test "an evaluation timeout preserves prepared native continuation memory" do
       owner = self()
 


### PR DESCRIPTION
## Summary

- replace baseline-dependent evaluation heap messages with fixed model-visible text while preserving exact byte diagnostics as structured fields
- verify correction request hashes and retained execution summaries stay identical across different environment baselines
- clarify that portable replay requires every model-visible observation to remain stable

Refs #1799. This does not close the cross-repository acceptance issue; deterministic cursors remain tracked by andreasronge/ptc-fs-mcp#3.

## Validation

- `mix test test/ptc_runner/lisp/heap_rebaseline_test.exs test/ptc_runner/kernel/agent_library_test.exs`
- `mix test test/documentation_guidelines_test.exs:53`
- two independent Codex review sessions, including a cumulative base-guarded review and follow-up, reported no actionable findings

## Retrospective

- Untracked follow-up work: andreasronge/ptc-fs-mcp#3 must add and release deterministic signed cursors before #1799 can run its fresh-process and cross-filesystem acceptance cases.
- Missing, wrong, or guessed repository instruction: none.