### PR TITLE
fix(agent): render fitting nested observations

### DIFF
--- a/docs/agent-library-reference.md
+++ b/docs/agent-library-reference.md
@@ -470,11 +470,13 @@ Successful observations contain a heap-proportional value preview and
 chronological `println` output. Preview traversal has independent collection,
 depth, node, string, character, and UTF-8 byte ceilings; it does not first
 serialize the complete value. The default pass preserves sibling shape under a
-small per-string ceiling. When the shape pass reports only the string cap and
-no explicit string ceiling was supplied, one bounded greedy pass may replace
-the preview with an exact rendering, but only when the complete compact
-representation fits every active ceiling. An incomplete retry is discarded in
-favor of the original shape-preserving preview.
+small per-string ceiling. When the shape pass reports truncation only from
+implicit ceilings, one bounded greedy pass raises the item and depth ceilings
+to larger internal traversal bounds and the node and string ceilings to the
+output budget. It replaces the preview only when the complete compact
+representation fits every active ceiling; an incomplete retry is discarded in
+favor of the original shape-preserving preview. Explicit traversal ceilings
+never trigger this adaptive pass.
 
 Feedback distinguishes value-preview truncation from `println` output omitted
 while assembling the bounded observation. For an ordinary successful result,

--- a/lib/ptc_runner/lisp/value_preview.ex
+++ b/lib/ptc_runner/lisp/value_preview.ex
@@ -5,10 +5,11 @@ defmodule PtcRunner.Lisp.ValuePreview do
   Unlike `PtcRunner.Lisp.Format`, this module is deliberately bounded. Its
   default pass samples collections and preserves sibling shape while enforcing
   depth, node, string, character, and UTF-8 byte ceilings. When the shape pass
-  reports only the string cap and no explicit string ceiling was supplied, one
-  bounded greedy pass may replace the preview with an exact rendering if every
-  part fits all remaining ceilings. Otherwise the original shape-preserving
-  preview wins.
+  reports truncation from implicit ceilings, one bounded greedy pass may lift
+  node and string ceilings to the output budget and item and depth ceilings to
+  larger internal traversal bounds. It replaces the preview with an exact
+  rendering only if every part fits those bounds. Otherwise the original
+  shape-preserving preview wins.
 
   Neither pass recursively sanitizes a complete value or materializes a
   complete collection before applying the traversal ceilings.
@@ -43,6 +44,8 @@ defmodule PtcRunner.Lisp.ValuePreview do
   @default_max_depth 4
   @default_max_nodes 256
   @default_max_string_chars 256
+  @max_complete_items 256
+  @max_complete_depth 256
   @sampled_key_limit 24
   @sort_key_chars 64
   @large_integer Integer.pow(10, 100)
@@ -179,12 +182,14 @@ defmodule PtcRunner.Lisp.ValuePreview do
   end
 
   defp maybe_render_complete(shape, value, opts, shape_policy, sampled_keys) do
-    if shape.caps_hit == [:string] and not Keyword.has_key?(opts, :max_string_chars) do
-      complete_policy = %{
+    if shape.truncated? and retryable_caps?(shape.caps_hit, opts) do
+      complete_policy =
         shape_policy
-        | allocation_mode: :complete,
-          max_string_chars: shape_policy.max_chars
-      }
+        |> Map.put(:allocation_mode, :complete)
+        |> lift_implicit_cap(opts, :max_items)
+        |> lift_implicit_cap(opts, :max_depth)
+        |> lift_implicit_cap(opts, :max_nodes)
+        |> lift_implicit_cap(opts, :max_string_chars)
 
       case render_once(value, complete_policy, sampled_keys) do
         %Result{truncated?: false, caps_hit: []} = complete -> complete
@@ -196,6 +201,26 @@ defmodule PtcRunner.Lisp.ValuePreview do
   rescue
     _error -> shape
   end
+
+  defp lift_implicit_cap(policy, opts, cap) do
+    if Keyword.has_key?(opts, cap),
+      do: policy,
+      else: Map.put(policy, cap, implicit_complete_cap(cap, policy.max_chars))
+  end
+
+  defp retryable_caps?(caps, opts) do
+    Enum.all?(caps, fn
+      :items -> not Keyword.has_key?(opts, :max_items)
+      :depth -> not Keyword.has_key?(opts, :max_depth)
+      :nodes -> not Keyword.has_key?(opts, :max_nodes)
+      :string -> not Keyword.has_key?(opts, :max_string_chars)
+      :output -> true
+    end)
+  end
+
+  defp implicit_complete_cap(:max_items, max_chars), do: min(max_chars, @max_complete_items)
+  defp implicit_complete_cap(:max_depth, max_chars), do: min(max_chars, @max_complete_depth)
+  defp implicit_complete_cap(_cap, max_chars), do: max_chars
 
   defp unavailable do
     %Result{
@@ -727,7 +752,7 @@ defmodule PtcRunner.Lisp.ValuePreview do
       end
 
     {key_text, key_truncated?, key_caps, nodes} =
-      render_key(key, key_budget_chars, key_budget_bytes, nodes, policy)
+      render_key(key, depth + 1, key_budget_chars, key_budget_bytes, nodes, policy)
 
     separator = " "
     remaining_chars = max(chars - String.length(key_text) - 1, 0)
@@ -746,17 +771,17 @@ defmodule PtcRunner.Lisp.ValuePreview do
     }
   end
 
-  defp render_key(key, chars, bytes, nodes, policy) when is_binary(key),
+  defp render_key(key, _depth, chars, bytes, nodes, policy) when is_binary(key),
     do: render_string(key, chars, bytes, nodes, policy)
 
-  defp render_key(%LispKeyword{} = key, chars, bytes, nodes, policy),
+  defp render_key(%LispKeyword{} = key, _depth, chars, bytes, nodes, policy),
     do: render_keyword(key, chars, bytes, nodes, policy)
 
-  defp render_key(key, chars, bytes, nodes, _policy) when is_atom(key),
+  defp render_key(key, _depth, chars, bytes, nodes, _policy) when is_atom(key),
     do: leaf(":" <> Atom.to_string(key), chars, bytes, nodes)
 
-  defp render_key(key, chars, bytes, nodes, policy),
-    do: render_value(key, 0, chars, bytes, nodes, policy)
+  defp render_key(key, depth, chars, bytes, nodes, policy),
+    do: render_value(key, depth, chars, bytes, nodes, policy)
 
   defp render_sequence(open, close, items, more?, cap, render_context) do
     %{depth: depth, chars: chars, bytes: bytes, nodes: nodes, policy: policy} = render_context
@@ -814,6 +839,7 @@ defmodule PtcRunner.Lisp.ValuePreview do
             caps: []
           })
 
+        parts = Enum.reverse(parts)
         needs_marker? = sequence.more? or stopped?
         marker = if(parts == [], do: "...", else: " ...")
 
@@ -869,7 +895,7 @@ defmodule PtcRunner.Lisp.ValuePreview do
         state
         | nodes: next_nodes,
           remaining_count: state.remaining_count - 1,
-          parts: state.parts ++ [next],
+          parts: [next | state.parts],
           used_chars: state.used_chars + String.length(next),
           used_bytes: state.used_bytes + byte_size(next),
           truncated?: state.truncated? or child_truncated?,

--- a/site/reference/agent-library-reference/index.html
+++ b/site/reference/agent-library-reference/index.html
@@ -361,11 +361,13 @@ definitions and history.</p><h2 id="feedback-bounds-and-disclosure">Feedback bou
 chronological <code class="inline">println</code> output. Preview traversal has independent collection,
 depth, node, string, character, and UTF-8 byte ceilings; it does not first
 serialize the complete value. The default pass preserves sibling shape under a
-small per-string ceiling. When the shape pass reports only the string cap and
-no explicit string ceiling was supplied, one bounded greedy pass may replace
-the preview with an exact rendering, but only when the complete compact
-representation fits every active ceiling. An incomplete retry is discarded in
-favor of the original shape-preserving preview.</p><p>Feedback distinguishes value-preview truncation from <code class="inline">println</code> output omitted
+small per-string ceiling. When the shape pass reports truncation only from
+implicit ceilings, one bounded greedy pass raises the item and depth ceilings
+to larger internal traversal bounds and the node and string ceilings to the
+output budget. It replaces the preview only when the complete compact
+representation fits every active ceiling; an incomplete retry is discarded in
+favor of the original shape-preserving preview. Explicit traversal ceilings
+never trigger this adaptive pass.</p><p>Feedback distinguishes value-preview truncation from <code class="inline">println</code> output omitted
 while assembling the bounded observation. For an ordinary successful result,
 the exact retained value is available as <code class="inline">*1</code>, so feedback advises reusing it
 instead of repeating a capability call. An explicit return does not advance

--- a/test/ptc_runner/kernel/agent_library_test.exs
+++ b/test/ptc_runner/kernel/agent_library_test.exs
@@ -2950,6 +2950,17 @@ defmodule PtcRunner.Kernel.AgentLibraryTest do
     assert observation.text =~ inspect(get_in(page, ["items", Access.at(0), "text"]))
   end
 
+  test "agent observation renders nested debug navigation filters within its budget" do
+    page = ValuePreviewFixture.debug_navigation_page()
+    observation = EvaluationObservation.success(%{value: page, prints: []}, 2_048)
+
+    refute observation.truncated?
+    refute observation.value_truncated?
+    assert observation.caps_hit == []
+    assert observation.text =~ ~S|"filters" {"component_id" "pricing.base"}|
+    assert observation.text =~ ~S|"source" "(ns pricing.rule)"|
+  end
+
   test "agent.feedback distinguishes retained values, returned values, and print omission" do
     retained =
       success_feedback(

--- a/test/ptc_runner/lisp/value_preview_test.exs
+++ b/test/ptc_runner/lisp/value_preview_test.exs
@@ -58,6 +58,17 @@ defmodule PtcRunner.Lisp.ValuePreviewTest do
     assert preview.text =~ ~S|"next_cursor" nil|
   end
 
+  test "renders a complete nested debug navigation page when it fits the observation budget" do
+    page = ValuePreviewFixture.debug_navigation_page()
+
+    preview = ValuePreview.render(page, max_chars: 2_048, max_bytes: 8_192)
+
+    refute preview.truncated?
+    assert preview.caps_hit == []
+    assert preview.text =~ ~S|"filters" {"component_id" "pricing.base"}|
+    assert preview.text =~ ~S|"source" "(ns pricing.rule)"|
+  end
+
   test "renders several long strings completely when their combined representation fits" do
     value = %{
       "alpha" => String.duplicate("a", 360),
@@ -71,6 +82,51 @@ defmodule PtcRunner.Lisp.ValuePreviewTest do
     assert preview.text =~ String.duplicate("a", 360)
     assert preview.text =~ String.duplicate("b", 360)
     assert preview.text =~ String.duplicate("c", 360)
+  end
+
+  test "renders a wider fitting value within the adaptive item bound" do
+    value = List.duplicate(0, 256)
+
+    preview = ValuePreview.render(value, max_chars: 65_536, max_bytes: 262_144)
+
+    refute preview.truncated?
+    assert preview.caps_hit == []
+    assert String.length(preview.text) == 513
+  end
+
+  test "keeps the adaptive exact pass bounded for extreme width" do
+    preview = ValuePreview.render(List.duplicate(0, 257), max_chars: 65_536)
+
+    assert preview.truncated?
+    assert preview.caps_hit == [:items]
+  end
+
+  test "keeps the adaptive exact pass bounded for extreme nesting" do
+    value = Enum.reduce(1..257, 0, fn _index, child -> [child] end)
+
+    preview = ValuePreview.render(value, max_chars: 65_536, max_bytes: 262_144)
+
+    assert preview.truncated?
+    assert preview.caps_hit == [:depth]
+  end
+
+  test "applies the adaptive depth bound through compound map keys" do
+    value = Enum.reduce(1..257, :leaf, fn _index, key -> %{key => 0} end)
+
+    preview = ValuePreview.render(value, max_chars: 65_536, max_bytes: 262_144)
+
+    assert preview.truncated?
+    assert preview.caps_hit != []
+  end
+
+  test "bounds eager sampling across nested lists with a shared wide tail" do
+    tail = List.duplicate(0, 257)
+    value = Enum.reduce(1..257, tail, fn _index, child -> [child | tail] end)
+
+    preview = ValuePreview.render(value, max_chars: 65_536, max_bytes: 262_144)
+
+    assert preview.truncated?
+    assert preview.caps_hit != []
   end
 
   test "renders long keyword and symbol-like labels completely when they fit" do

--- a/test/support/value_preview_fixture.ex
+++ b/test/support/value_preview_fixture.ex
@@ -13,4 +13,25 @@ defmodule PtcRunner.TestSupport.ValuePreviewFixture do
       "total_chars" => String.length(text)
     }
   end
+
+  def debug_navigation_page do
+    %{
+      "page" => %{
+        "items" => [
+          %{
+            "component_id" => "pricing.rule",
+            "relationships" => [
+              %{
+                "filters" => %{"component_id" => "pricing.base"},
+                "name" => "dependencies",
+                "state" => "complete"
+              }
+            ],
+            "source" => "(ns pricing.rule)"
+          }
+        ],
+        "next_cursor" => nil
+      }
+    }
+  end
 end


### PR DESCRIPTION
## Summary

- generalize the bounded exact-render retry so compact nested observations can lift implicit preview caps
- preserve explicit traversal limits and cap adaptive width/depth to keep previews heap-proportional
- make wide exact rendering linear, carry depth through compound map keys, and document the generalized contract
- add `debug.nav`-shaped observation regressions plus extreme width, depth, key, and shared-tail coverage

Closes #1809.

## Validation

- focused renderer, agent observation, and failed-run example tests: 170 passed, 5 excluded
- shipped offline failed-run capture and deterministic debugger walk: complete closure through `pricing.rule`
- `mix precommit`
- `MIX_ENV=dev mix docs --warnings-as-errors`
- pre-push gate: 7,827 core tests, static analysis/Dialyzer, release verification, and 135 Viewer tests
- two cold independent Codex review sessions, followed to clean results (`01a06cdd-4233-7cb3-8614-be91b777a0f9`, `01a06cef-7692-7ca3-8247-2cc469dc48bb`)

The optional live-model example was not rerun because no OpenRouter credential was configured in this workspace; its underlying observation path and the credential-free shipped debugger were exercised locally.

## Retrospective

The original depth fix exposed that lifting structural caps changes the renderer's resource envelope, not just its output. Independent review caught quadratic accumulation, compound-key depth reset, redundant explicit-cap retries, and shared-tail sampling amplification. Bounding adaptive width/depth while retaining the exact retry fixes the user-facing navigation failure without turning the preview path into unbounded presentation work.
