### PR TITLE
docs(agent-guide): name offline model scaffold

### DIFF
--- a/.guide-budget-baseline.json
+++ b/.guide-budget-baseline.json
@@ -8,8 +8,8 @@
   },
   "guides": {
     "docs/guides/agent-cli-usage.md": {
-      "words": 690,
-      "density": 5.0,
+      "words": 701,
+      "density": 5.2,
       "blockers": 2,
       "tics": 1.0
     },

--- a/docs/guides/agent-cli-usage.md
+++ b/docs/guides/agent-cli-usage.md
@@ -26,20 +26,21 @@ application document, and `ptc docs functions` for the built-in library.
 
 ## Follow the loop
 
-Each step fails early and cheaply, so run them in order rather than jumping
-straight to a credentialed run.
+Choose one `ptc init` form, then run the remaining steps in order so each fails
+early and cheaply.
 
 ```console
-ptc init hello-ptc                       # generate a working application
+ptc init hello-ptc                       # a plain application
+ptc init hello-ptc --example llm-replay  # or a model with no credential
 ptc validate hello-ptc/ptc-project.json  # compile without executing
-ptc repl --project hello-ptc/ptc-project.json -e '(main/run {"name" "world"})'
+ptc repl --project hello-ptc/ptc-project.json -e '(dir)'
 ptc doctor hello-ptc/ptc-project.json    # check provider readiness locally
 ptc run hello-ptc/ptc-project.json --envelope out.json
 ```
 
 `ptc init` writes a complete project, including an `AGENTS.md` that points a
-later agent back at these commands. Edit `main.clj` for behavior and `ptc.json`
-for input, providers, missions, and limits.
+later agent back at these commands. Edit the component selected by `ptc.json`
+for behavior, and edit `ptc.json` for input and limits.
 
 ## Experiment before committing to a file
 

--- a/site/guides/agent-cli-usage/index.html
+++ b/site/guides/agent-cli-usage/index.html
@@ -108,14 +108,15 @@ so both always describe the version you actually invoke.</p><h2 id="ask-the-bina
 <code class="inline">ptc docs</code> prints pages embedded at build time. Neither can drift from the
 running executable. Prefer both over any remembered flag, built-in, or manifest
 field, and over any page you fetched from the web for a different version.</p><p>Start with <code class="inline">ptc docs agent-guide</code> (this page), <code class="inline">ptc docs manifest</code> for the
-application document, and <code class="inline">ptc docs functions</code> for the built-in library.</p><h2 id="follow-the-loop">Follow the loop</h2><p>Each step fails early and cheaply, so run them in order rather than jumping
-straight to a credentialed run.</p><pre><code class="console language-console">ptc init hello-ptc                       # generate a working application
+application document, and <code class="inline">ptc docs functions</code> for the built-in library.</p><h2 id="follow-the-loop">Follow the loop</h2><p>Choose one <code class="inline">ptc init</code> form, then run the remaining steps in order so each fails
+early and cheaply.</p><pre><code class="console language-console">ptc init hello-ptc                       # a plain application
+ptc init hello-ptc --example llm-replay  # or a model with no credential
 ptc validate hello-ptc/ptc-project.json  # compile without executing
-ptc repl --project hello-ptc/ptc-project.json -e '(main/run {&quot;name&quot; &quot;world&quot;})'
+ptc repl --project hello-ptc/ptc-project.json -e '(dir)'
 ptc doctor hello-ptc/ptc-project.json    # check provider readiness locally
 ptc run hello-ptc/ptc-project.json --envelope out.json</code></pre><p><code class="inline">ptc init</code> writes a complete project, including an <code class="inline">AGENTS.md</code> that points a
-later agent back at these commands. Edit <code class="inline">main.clj</code> for behavior and <code class="inline">ptc.json</code>
-for input, providers, missions, and limits.</p><h2 id="experiment-before-committing-to-a-file">Experiment before committing to a file</h2><p><code class="inline">ptc repl</code> is the cheapest place to check a language question, and its
+later agent back at these commands. Edit the component selected by <code class="inline">ptc.json</code>
+for behavior, and edit <code class="inline">ptc.json</code> for input and limits.</p><h2 id="experiment-before-committing-to-a-file">Experiment before committing to a file</h2><p><code class="inline">ptc repl</code> is the cheapest place to check a language question, and its
 discovery functions work in every input context — not only at a terminal, so a
 detached agent gets the same answers:</p><pre><code class="console language-console">ptc repl --project PROJECT.json -e '(apropos &quot;json&quot;)'   # search attached exports
 ptc repl --project PROJECT.json -e '(doc &quot;reduce&quot;)'     # print one function's documentation

--- a/test/ptc_runner/kernel/example_library_test.exs
+++ b/test/ptc_runner/kernel/example_library_test.exs
@@ -1,12 +1,15 @@
 defmodule PtcRunner.Kernel.ExampleLibraryTest do
   use ExUnit.Case, async: false
 
+  import ExUnit.CaptureIO
+
   alias PtcRunner.Dotenv
   alias PtcRunner.Kernel.CommandContract
   alias PtcRunner.Kernel.CommandEngine
   alias PtcRunner.Kernel.CommandOutcome
   alias PtcRunner.Kernel.ExampleLibrary
   alias PtcRunner.Kernel.ProjectConfig
+  alias PtcRunner.MixCommandAdapter
 
   @root Path.expand("../../..", __DIR__)
 
@@ -200,12 +203,33 @@ defmodule PtcRunner.Kernel.ExampleLibraryTest do
   test "init materializes the replay example as a one-argument project run", %{
     tmp_dir: directory
   } do
+    assert {:ok, %CommandOutcome{envelope: docs_envelope}} =
+             CommandEngine.dispatch(["docs", "agent-guide"])
+
+    guide = docs_envelope["result"]["content"]
+    assert guide =~ "Choose one `ptc init` form"
+    assert guide =~ "ptc init hello-ptc --example llm-replay"
+    assert guide =~ "ptc repl --project hello-ptc/ptc-project.json -e '(dir)'"
+
     target = Path.join(directory, "llm-replay")
 
     assert {:ok, %CommandOutcome{}} =
              CommandEngine.dispatch(["init", target, "--example", "llm-replay"])
 
     assert File.exists?(Path.join(target, "ptc-project.json"))
+
+    repl_output =
+      capture_io(fn ->
+        MixCommandAdapter.run_task([
+          "repl",
+          "--project",
+          Path.join(target, "ptc-project.json"),
+          "-e",
+          "(dir)"
+        ]).outcome
+      end)
+
+    assert repl_output == ~s(["cap" "example.replay"]\n)
 
     assert {:ok, %CommandOutcome{envelope: envelope}} =
              CommandEngine.dispatch(["run", Path.join(target, "ptc-project.json")])


### PR DESCRIPTION
## Summary

- Present the plain scaffold and `--example llm-replay` as explicit alternatives in the agent guide.
- Keep the rest of the loop valid for either choice by using component-neutral REPL discovery and editing guidance.
- Regenerate the site page, refresh the required guide budget, and cover the served guide command through materialization, REPL, and replay execution.

Closes #1782.

## Validation

- Offline end-to-end run with `OPENROUTER_API_KEY` removed returned `{"content":"Frozen answer","model":"frozen-model"}`.
- Offline doctor envelope evidence: `{"model_aliases":[{"alias":"frozen-model","default":false,"installation_revision":"llm-replay-example-v1","selected":true,"source":"llm_replay"}],"provider_activity":false,"readiness":"ready"}`.
- `mix test test/ptc_runner/kernel/example_library_test.exs` (12 passed).
- `mix ptc.gen_docs`, `mix ptc.verify_docs`, `scripts/guide_budget.sh check`, and `MIX_ENV=dev mix docs --warnings-as-errors` passed.
- `mix precommit` passed on the final tree.
- Normal `git push` pre-push gates passed: 7,833 core tests, static analysis and Dialyzer, release verification, 135 Viewer tests, and 42 launcher tests plus package verification.
- Two cold independent Codex reviews completed. The incremental session and cumulative base-guarded session were clean after focused follow-ups.

## Retrospective

The initial one-line alternative exposed a hidden coupling in the surrounding loop: `main/run` and `main.clj` only exist in the plain scaffold. Making the remaining commands component-neutral fixed the full reader journey, and tying the served guide text to an executed replay REPL/run regression test should prevent that coupling from returning. The guide budget increased only for the required runnable model-init rung, so its baseline was deliberately refreshed.
