### PR TITLE
docs(mcp): correct acquisition-timeout defaults and Node prerequisite

### DIFF
--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -100,30 +100,46 @@ That per-operation value is the lowest of:
 
 - the installation's `ceilings.timeout_ms` in `ptc-host.json`, default `5000`;
 - for a mission provider, the manifest's `limits.evaluation_timeout_ms`,
-  default `1000`; and
+  default `30000`; and
 - the provider entry's own `config.timeout_ms` under the manifest's `providers`,
   when it sets one. It may only narrow the two above, never widen them — a
   larger value is refused as an invalid selection.
 
-Every one of them must be wide enough, because the lowest wins. Raising one
-while another stays at its default changes nothing. In `ptc.json`:
-
-```json
-{"limits": {"evaluation_timeout_ms": 20000}}
-```
-
-and in `ptc-host.json`, beside the installation's `transport`:
+Every one of them must be wide enough, because the lowest wins — raising one
+that is not the lowest changes nothing. On stock defaults the lowest is the
+installed ceiling, at `5000`, and the mission budget is already `30000`, so any
+budget up to `30000` needs only the ceiling raised, in `ptc-host.json` beside
+the installation's `transport`:
 
 ```json
 {"ceilings": {"timeout_ms": 20000}}
+```
+
+Past `30000` the mission budget becomes the lowest in turn, so a wider one takes
+both: `{"ceilings": {"timeout_ms": 40000}}` in `ptc-host.json`, and in
+`ptc.json`:
+
+```json
+{"limits": {"evaluation_timeout_ms": 40000}}
+```
+
+Both sit inside the run clock. `limits.run_duration_ms` bounds the complete run,
+active preflight and provider acquisition included, and it too defaults to
+`30000`, so a per-operation budget past that is only reachable with headroom
+there as well — sized for the whole sequence rather than one operation:
+
+```json
+{"limits": {"run_duration_ms": 120000}}
 ```
 
 `start_timeout_ms` inside the stdio transport bounds one step: the launcher
 handshake that spawns the child. The runtime applies it as
 `min(start_timeout_ms, remaining transport-start budget)`, so it can only narrow,
 never widen, the values above — but once those are raised past its `5000`
-default, that default becomes the narrower cap on the handshake. Raise it too if
-the step that expires is the spawn rather than the answer:
+default, that default becomes the narrower cap on the handshake. On stock
+defaults it and the installed ceiling are both `5000`, so the spawn step has
+`5000` ms whichever one you raise alone. Raise it too if the step that expires is
+the spawn rather than the answer:
 
 ```json
 {"start_timeout_ms": 15000}
@@ -140,7 +156,7 @@ loaded machine, is the usual cause.
 ## Run the checked-in file agent
 
 The tutorial launches [`ptc-fs-mcp@0.1.0`](https://www.npmjs.com/package/ptc-fs-mcp)
-through `npx`. It requires Node.js 22 or newer and `npx`; the first run may
+through `npx`. It requires Node.js 20.19 or newer and `npx`; the first run may
 download that package.
 
 ```console

--- a/site/reference/mcp/index.html
+++ b/site/reference/mcp/index.html
@@ -160,22 +160,32 @@ it to each step separately: once to starting the transport, which for stdio
 covers launcher staging and the child spawn, and again to each discovery request,
 beginning with <code class="inline">server/discover</code>. It is not a single budget for the whole
 sequence, so a slow start and a slow answer can add up past any one of them.</p><p>That per-operation value is the lowest of:</p><ul><li>the installation's <code class="inline">ceilings.timeout_ms</code> in <code class="inline">ptc-host.json</code>, default <code class="inline">5000</code>;</li><li>for a mission provider, the manifest's <code class="inline">limits.evaluation_timeout_ms</code>,
-default <code class="inline">1000</code>; and</li><li>the provider entry's own <code class="inline">config.timeout_ms</code> under the manifest's <code class="inline">providers</code>,
+default <code class="inline">30000</code>; and</li><li>the provider entry's own <code class="inline">config.timeout_ms</code> under the manifest's <code class="inline">providers</code>,
 when it sets one. It may only narrow the two above, never widen them — a
-larger value is refused as an invalid selection.</li></ul><p>Every one of them must be wide enough, because the lowest wins. Raising one
-while another stays at its default changes nothing. In <code class="inline">ptc.json</code>:</p><pre><code class="json language-json">{&quot;limits&quot;: {&quot;evaluation_timeout_ms&quot;: 20000}}</code></pre><p>and in <code class="inline">ptc-host.json</code>, beside the installation's <code class="inline">transport</code>:</p><pre><code class="json language-json">{&quot;ceilings&quot;: {&quot;timeout_ms&quot;: 20000}}</code></pre><p><code class="inline">start_timeout_ms</code> inside the stdio transport bounds one step: the launcher
+larger value is refused as an invalid selection.</li></ul><p>Every one of them must be wide enough, because the lowest wins — raising one
+that is not the lowest changes nothing. On stock defaults the lowest is the
+installed ceiling, at <code class="inline">5000</code>, and the mission budget is already <code class="inline">30000</code>, so any
+budget up to <code class="inline">30000</code> needs only the ceiling raised, in <code class="inline">ptc-host.json</code> beside
+the installation's <code class="inline">transport</code>:</p><pre><code class="json language-json">{&quot;ceilings&quot;: {&quot;timeout_ms&quot;: 20000}}</code></pre><p>Past <code class="inline">30000</code> the mission budget becomes the lowest in turn, so a wider one takes
+both: <code class="inline">{&quot;ceilings&quot;: {&quot;timeout_ms&quot;: 40000}}</code> in <code class="inline">ptc-host.json</code>, and in
+<code class="inline">ptc.json</code>:</p><pre><code class="json language-json">{&quot;limits&quot;: {&quot;evaluation_timeout_ms&quot;: 40000}}</code></pre><p>Both sit inside the run clock. <code class="inline">limits.run_duration_ms</code> bounds the complete run,
+active preflight and provider acquisition included, and it too defaults to
+<code class="inline">30000</code>, so a per-operation budget past that is only reachable with headroom
+there as well — sized for the whole sequence rather than one operation:</p><pre><code class="json language-json">{&quot;limits&quot;: {&quot;run_duration_ms&quot;: 120000}}</code></pre><p><code class="inline">start_timeout_ms</code> inside the stdio transport bounds one step: the launcher
 handshake that spawns the child. The runtime applies it as
 <code class="inline">min(start_timeout_ms, remaining transport-start budget)</code>, so it can only narrow,
 never widen, the values above — but once those are raised past its <code class="inline">5000</code>
-default, that default becomes the narrower cap on the handshake. Raise it too if
-the step that expires is the spawn rather than the answer:</p><pre><code class="json language-json">{&quot;start_timeout_ms&quot;: 15000}</code></pre><p>When a budget expires, the closed result is <code class="inline">provider_acquisition_timeout</code>,
+default, that default becomes the narrower cap on the handshake. On stock
+defaults it and the installed ceiling are both <code class="inline">5000</code>, so the spawn step has
+<code class="inline">5000</code> ms whichever one you raise alone. Raise it too if the step that expires is
+the spawn rather than the answer:</p><pre><code class="json language-json">{&quot;start_timeout_ms&quot;: 15000}</code></pre><p>When a budget expires, the closed result is <code class="inline">provider_acquisition_timeout</code>,
 which is retryable and distinct from <code class="inline">provider_unavailable</code>. It reports only
 that the clock ran out: the step that expired may have been the spawn or the
 discovery answer, so PtcRunner cannot say the server was reached, only that it
 never received the response needed to prove a protocol mismatch. Raise the
 budgets and run it again. A first launch on a cold npm cache, or any launch on a
 loaded machine, is the usual cause.</p><h2 id="run-the-checked-in-file-agent">Run the checked-in file agent</h2><p>The tutorial launches <a href="https://www.npmjs.com/package/ptc-fs-mcp"><code class="inline">ptc-fs-mcp@0.1.0</code></a>
-through <code class="inline">npx</code>. It requires Node.js 22 or newer and <code class="inline">npx</code>; the first run may
+through <code class="inline">npx</code>. It requires Node.js 20.19 or newer and <code class="inline">npx</code>; the first run may
 download that package.</p><pre><code class="console language-console">ptc init kernel-tutorial --example kernel-tutorial
 ptc doctor kernel-tutorial/03-file-agent.ptc-project.json</code></pre><p>Passive doctor validates the application, resolves <code class="inline">npx</code>, and checks the
 selected installation without loading the model credential or starting the


### PR DESCRIPTION
Closes #1627.

## What was wrong

Two numbers in `docs/reference/mcp.md`, both on the path someone follows when an
MCP provider times out during acquisition.

1. **`evaluation_timeout_ms` default.** The "lowest of" list said `1000`. The
   closed limit catalog says `30_000` (`lib/ptc_runner/kernel/limit_catalog.ex:57`).
   The value *was* `1_000` when the paragraph was written; `c19ebfdc` raised it
   and the prose did not follow. A reader diagnosing
   `provider_acquisition_timeout` therefore concluded a 1 s mission budget was
   binding, and tuned the value that was not biting.
2. **Node prerequisite.** The page required Node.js 22 for `ptc-fs-mcp@0.1.0`,
   while the published package declares `{ node: '>=20.19.0' }` and
   `ptc_runner_tutorial` says 20.19+ — so the two documents contradicted each
   other and sent readers on a supported Node to upgrade needlessly.

## What changed

Correcting the number alone would have left the section self-contradictory: with
the mission budget at `30000`, the existing example told the reader to *narrow*
it to `20000`, and the sentence "raising one while another stays at its default
changes nothing" no longer described the defaults it was written for. So the
surrounding guidance follows the number:

- on stock defaults the lowest of the three is the installed `ceilings.timeout_ms`
  at `5000`, and the examples say so instead of implying `evaluation_timeout_ms`
  is what to tune;
- the worked example is internally consistent — `20000` needs the ceiling alone,
  and anything past `30000` names matching values for both;
- the stdio transport's `start_timeout_ms` is also `5000`, so the spawn step —
  the one that usually expires on a cold `npx` launch — stays at `5000` ms if
  only one of the two is raised; and
- `limits.run_duration_ms` bounds the complete run, active preflight and
  acquisition included, and is `30000` too, so a budget past that needs headroom
  there as well.

The mirrored `site/reference/mcp/index.html` is regenerated by `mix ptc.gen_docs`.
Documentation only — no runtime behavior changes.

## Verification

- Defaults read from source: `LimitCatalog` (`evaluation_timeout_ms` and
  `run_duration_ms` both `30_000`), `HostConfig` (`ceilings.timeout_ms` `5_000`),
  `MCPStdioTransport` (`start_timeout_ms` `5_000`), and the run-clock bound at
  `ProviderCallbackBoundary`. `docs/guides/kernel-repl.md` and
  `docs/reference/repl.md` already said 30,000 ms, confirming the drift was
  isolated to this page.
- `npm view ptc-fs-mcp@0.1.0 engines` → `{ node: '>=20.19.0' }`.
- `mix ptc.gen_docs`, `mix precommit`, `MIX_ENV=dev mix docs --warnings-as-errors`,
  and the full pre-push suite (core tests, static analysis + Dialyzer, release
  verification, Viewer, launcher, ExDoc) all pass.

## Retrospective

The starting scope was two numbers. Both independent Codex review sessions found
that the *first* correction was incomplete in the same way the original drift
was: a number changed, its surrounding argument did not. Session 1 caught the
"changes nothing" claim and the mismatched `20000`/`40000` example pair; session
2 caught that a 40 s per-operation budget is unreachable anyway, because
`run_duration_ms` caps the whole run at 30 s by default. Neither was visible from
the issue — both needed the code read around the value, not just at it.

The lesson worth keeping: this paragraph derives a conclusion from several
defaults, so any one of them changing invalidates the conclusion, not just the
line quoting it. The generated site page has no such coupling and stayed correct
because it is projected; the prose drifted because nothing checks it. Worth
noting for the next default that moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NtUTPkS4hFnDGSR64fXePo