### PR TITLE
fix(analysis): publish retained item counts in the run collection catalog

### DIFF
--- a/docs/maintainers/trace-log-contract.md
+++ b/docs/maintainers/trace-log-contract.md
@@ -429,6 +429,12 @@ list, such as `generated[].evaluation_id` on a turn.
 The `model_exchanges` and `capability_calls` entries additionally advertise
 `item_completeness_field: "complete?"`; collections without per-item
 completion semantics omit that catalog field.
+Every collection the private inspection record counts also carries
+`item_count`, the number of items that run retained for it. A zero is a
+measured zero for that run, not an unread or withheld page. `activity` is
+canonical rather than retained and `turns` is compiled from retained
+exchanges, so neither owns a retained count and both omit the field, as does
+every collection on a capture with no private inspection record.
 The `turns` entry also owns the transcript projection boundary:
 `projection_scope: "model_conversation"` and `projection_not_included` name
 the scope certified by a published transcript and the evidence surfaces it
@@ -448,6 +454,19 @@ also advertise `turns`, `model_exchanges`, `capability_calls`,
 `provider_exchanges`, `generated_sources`, `prelude_sources`,
 `execution_prints`, and `execution_errors`. Public recipes report those private
 collections as unavailable and reject reads without changing authority.
+
+`provider_exchanges` holds MCP wire traffic and nothing else. Only the MCP
+client writes its records, so a run that installed no MCP provider retains no
+provider exchange and advertises `item_count: 0`. No LLM wire bytes are
+retained on any surface: `model_exchanges` holds the normalized request the
+runtime handed the model capability and the value that capability returned,
+not the bytes exchanged with the provider. Provider-side content that never
+reaches that boundary — billed reasoning tokens with no returned text, for
+instance — therefore leaves no content anywhere. Attested usage is the only
+record that it happened: the `tokens` map a normalized `model_exchanges`
+result carries when the provider reported usage, and the `analysis/counters`
+aggregate, which counts `missing_usage_calls` separately rather than reading
+absent usage as zero.
 
 Every raw `model_exchanges` and `capability_calls` item carries `complete?`.
 Completed items retain their result, output sequence, and output timestamp.

--- a/lib/ptc_runner/kernel/run_analysis.ex
+++ b/lib/ptc_runner/kernel/run_analysis.ex
@@ -15,9 +15,12 @@ defmodule PtcRunner.Kernel.RunAnalysis do
   exchanges, reconstructed turns, generated source with static prelude-call
   facts, effective prelude source, and workflow execution diagnostics. The
   catalog identifies snapshot and sequence domains, identifier locations, and
-  raw collections whose items carry an explicit completeness field. Private
-  error and source items carry typed relationships that package exact follow-up
-  reads without performing them or diagnosing their evidence.
+  raw collections whose items carry an explicit completeness field. Each
+  collection the private inspection record counts also reports the `item_count`
+  that run retained, so an empty page is a measured zero rather than an
+  unexplained absence. Private error and source items carry typed relationships
+  that package exact follow-up reads without performing them or diagnosing
+  their evidence.
   """
 
   alias PtcRunner.Kernel.InspectionSnapshot
@@ -265,13 +268,11 @@ defmodule PtcRunner.Kernel.RunAnalysis do
          {:ok, run} <- TraceSnapshot.query(analysis.traces, :get_run, arguments),
          {:ok, inspection} <- inspection_run(analysis.inspection, run_id),
          {:ok, result} <- inspection_result(analysis.inspection, run_id) do
-      private_available? = inspection["available?"] == true
-
       bounded_result(analysis, %{
         "run" => run,
         "inspection" => inspection,
         "result" => result,
-        "collections" => collection_catalog(private_available?)
+        "collections" => collection_catalog(inspection)
       })
     else
       false -> {:error, :invalid_query}
@@ -351,7 +352,10 @@ defmodule PtcRunner.Kernel.RunAnalysis do
     end
   end
 
-  defp collection_catalog(private_available?) do
+  defp collection_catalog(inspection) do
+    private_available? = inspection["available?"] == true
+    counts = retained_counts(inspection)
+
     Enum.map(@collections, fn collection ->
       %{
         "name" => collection.name,
@@ -363,10 +367,23 @@ defmodule PtcRunner.Kernel.RunAnalysis do
         "sequence_domain" => collection.sequence_domain,
         "identifier_locations" => collection.identifier_locations
       }
+      |> put_item_count(collection, counts)
       |> put_catalog_option(collection, :item_completeness_field)
       |> put_catalog_option(collection, :projection_scope)
       |> put_catalog_option(collection, :projection_not_included)
     end)
+  end
+
+  defp retained_counts(%{"available?" => true, "counts" => counts}) when is_map(counts),
+    do: counts
+
+  defp retained_counts(_inspection), do: %{}
+
+  defp put_item_count(catalog, collection, counts) do
+    case Map.fetch(counts, Atom.to_string(collection.operation)) do
+      {:ok, count} when is_integer(count) -> Map.put(catalog, "item_count", count)
+      _other -> catalog
+    end
   end
 
   defp put_catalog_option(catalog, collection, key) do

--- a/test/mix/tasks/ptc_repl_test.exs
+++ b/test/mix/tasks/ptc_repl_test.exs
@@ -1586,6 +1586,16 @@ defmodule PtcRunner.ReplFrontendTest do
              "provider_exchanges" => 0
            }
 
+    catalog = Map.new(opened["collections"], &{&1["name"], &1})
+
+    assert catalog["provider_exchanges"]["available?"]
+    assert catalog["provider_exchanges"]["item_count"] == 0
+    assert catalog["model_exchanges"]["item_count"] == 2
+    assert catalog["capability_calls"]["item_count"] == 2
+    assert catalog["prelude_sources"]["item_count"] == 0
+    refute Map.has_key?(catalog["activity"], "item_count")
+    refute Map.has_key?(catalog["turns"], "item_count")
+
     assert Enum.map(model_page["items"], & &1["complete?"]) == [true, false]
     assert Enum.map(capability_page["items"], & &1["complete?"]) == [true, false]
 

--- a/test/ptc_runner/kernel/run_analysis_test.exs
+++ b/test/ptc_runner/kernel/run_analysis_test.exs
@@ -74,6 +74,13 @@ defmodule PtcRunner.Kernel.RunAnalysisTest do
              "projection_not_included" => ~w(prelude_sources capability_schemas result)
            }
 
+    assert Enum.find(collections, &(&1["name"] == "provider_exchanges"))["item_count"] == 1
+    assert Enum.find(collections, &(&1["name"] == "capability_calls"))["item_count"] == 1
+
+    assert collections
+           |> Enum.reject(&Map.has_key?(&1, "item_count"))
+           |> Enum.map(& &1["name"]) == ~w(activity turns)
+
     assert Enum.find(collections, &(&1["name"] == "activity")) ==
              %{
                "authority" => "public",
@@ -1158,6 +1165,7 @@ defmodule PtcRunner.Kernel.RunAnalysisTest do
 
     assert Enum.find(collections, &(&1["name"] == "activity"))["available?"]
     refute Enum.find(collections, &(&1["name"] == "turns"))["available?"]
+    refute Enum.any?(collections, &Map.has_key?(&1, "item_count"))
 
     assert {:ok, %{"items" => [_ | _]}} =
              RunAnalysis.query(analysis, :read, %{


### PR DESCRIPTION
## Summary

- `analysis/open` now publishes `item_count` on every collection the private
  inspection record counts, read from the run record's `counts` map keyed by
  collection operation. An empty `provider_exchanges` page on an LLM-only run
  reads as a measured zero for that run instead of "the wire log is empty".
- `activity` is canonical rather than retained and `turns` is compiled from
  retained exchanges, so both omit the field, as does every collection on a
  capture with no private inspection record. `available?` keeps its existing
  meaning for every collection.
- `ptc docs traces` now states, where the collection is defined, that
  `provider_exchanges` holds MCP wire traffic and nothing else, and that no LLM
  wire bytes are retained on any surface — `model_exchanges` is the normalized
  capability request and response, not the bytes exchanged with the provider.
  The corollary is stated too: provider-side content that never reaches that
  boundary leaves no record, and attested usage is the only evidence it happened.

Non-goals, per the triage: retaining LLM wire bytes, renaming the collection to
`mcp_provider_exchanges`, and a stronger `applicable?` that would need a new
fact in the inspection artifact.

## Validation

- `mix test test/mix/tasks/ptc_repl_test.exs test/ptc_runner/kernel/run_analysis_test.exs`
  — the command-boundary case asserts the catalog through
  `--profile private-run-analysis-v2 --format jsonl` on an LLM-only fixture
  (`provider_exchanges` advertised available with `item_count: 0`). Both new
  assertions fail on the parent commit.
- `MIX_ENV=dev mix docs --warnings-as-errors`.
- `mix ptc.gen_docs` produced no diff: `docs/maintainers/trace-log-contract.md`
  is served by `ptc docs traces` but is not a published site page.

## Retrospective

- Follow-up: `turns` carries no retained count because the inspection artifact
  records none, even though `materialize_counts/2` already receives the
  reconstructed conversation and discards it (`_ = conversation`,
  `lib/ptc_runner/kernel/inspection_artifact/assembler.ex`). Adding
  `"turns" => length(conversation.turns)` would complete the catalog, but it
  changes the artifact's counts contract and belongs in its own change.
- Repository instruction: none.

Closes #1784

https://claude.ai/code/session_01WEcNV7owbSR2acvKx9QVHT
