### PR TITLE
fix(inspection): count retained turns in the run record

### DIFF
--- a/docs/maintainers/trace-log-contract.md
+++ b/docs/maintainers/trace-log-contract.md
@@ -432,9 +432,9 @@ completion semantics omit that catalog field.
 Every collection the private inspection record counts also carries
 `item_count`, the number of items that run retained for it. A zero is a
 measured zero for that run, not an unread or withheld page. `activity` is
-canonical rather than retained and `turns` is compiled from retained
-exchanges, so neither owns a retained count and both omit the field, as does
-every collection on a capture with no private inspection record.
+canonical rather than retained, so it is the only collection that owns no
+retained count and omits the field, as does every collection on a capture
+with no private inspection record.
 The `turns` entry also owns the transcript projection boundary:
 `projection_scope: "model_conversation"` and `projection_not_included` name
 the scope certified by a published transcript and the evidence surfaces it

--- a/lib/ptc_runner/kernel/inspection_artifact/assembler.ex
+++ b/lib/ptc_runner/kernel/inspection_artifact/assembler.ex
@@ -856,6 +856,7 @@ defmodule PtcRunner.Kernel.InspectionArtifact.Assembler do
       Enum.reject(pairs, fn {_id, input} -> capability_class(input) == :model end)
 
     counts = %{
+      "turns" => length(conversation.turns),
       "model_exchanges" => length(model),
       "incomplete_model_exchanges" =>
         Enum.count(model, fn {id, _} -> not Map.has_key?(state.outputs, id) end),
@@ -872,7 +873,6 @@ defmodule PtcRunner.Kernel.InspectionArtifact.Assembler do
       "explicit_failure_values" => length(state.execution_meta.failures)
     }
 
-    _ = conversation
     insert(state, :count, {state.run_id, :summary}, counts)
   end
 

--- a/test/mix/tasks/ptc_repl_test.exs
+++ b/test/mix/tasks/ptc_repl_test.exs
@@ -1583,7 +1583,8 @@ defmodule PtcRunner.ReplFrontendTest do
              "incomplete_capability_calls" => 1,
              "incomplete_model_exchanges" => 1,
              "model_exchanges" => 2,
-             "provider_exchanges" => 0
+             "provider_exchanges" => 0,
+             "turns" => 1
            }
 
     catalog = Map.new(opened["collections"], &{&1["name"], &1})
@@ -1593,8 +1594,8 @@ defmodule PtcRunner.ReplFrontendTest do
     assert catalog["model_exchanges"]["item_count"] == 2
     assert catalog["capability_calls"]["item_count"] == 2
     assert catalog["prelude_sources"]["item_count"] == 0
+    assert catalog["turns"]["item_count"] == 1
     refute Map.has_key?(catalog["activity"], "item_count")
-    refute Map.has_key?(catalog["turns"], "item_count")
 
     assert Enum.map(model_page["items"], & &1["complete?"]) == [true, false]
     assert Enum.map(capability_page["items"], & &1["complete?"]) == [true, false]

--- a/test/ptc_runner/kernel/inspection_snapshot_test.exs
+++ b/test/ptc_runner/kernel/inspection_snapshot_test.exs
@@ -817,6 +817,7 @@ defmodule PtcRunner.Kernel.InspectionSnapshotTest do
     assert {:ok,
             %{
               "counts" => %{
+                "turns" => 1,
                 "model_exchanges" => 2,
                 "incomplete_model_exchanges" => 1,
                 "capability_calls" => 2,

--- a/test/ptc_runner/kernel/run_analysis_test.exs
+++ b/test/ptc_runner/kernel/run_analysis_test.exs
@@ -61,6 +61,7 @@ defmodule PtcRunner.Kernel.RunAnalysisTest do
               "collections" => collections
             }} = RunAnalysis.query(analysis, :open, %{"run_id" => run_id})
 
+    assert counts["turns"] == 1
     assert counts["capability_calls"] == 1
     assert counts["provider_exchanges"] == 1
     assert counts["incomplete_model_exchanges"] == 0
@@ -76,10 +77,11 @@ defmodule PtcRunner.Kernel.RunAnalysisTest do
 
     assert Enum.find(collections, &(&1["name"] == "provider_exchanges"))["item_count"] == 1
     assert Enum.find(collections, &(&1["name"] == "capability_calls"))["item_count"] == 1
+    assert Enum.find(collections, &(&1["name"] == "turns"))["item_count"] == 1
 
     assert collections
            |> Enum.reject(&Map.has_key?(&1, "item_count"))
-           |> Enum.map(& &1["name"]) == ~w(activity turns)
+           |> Enum.map(& &1["name"]) == ~w(activity)
 
     assert Enum.find(collections, &(&1["name"] == "activity")) ==
              %{
@@ -210,6 +212,31 @@ defmodule PtcRunner.Kernel.RunAnalysisTest do
                "run_id" => run_id,
                "collection" => "activity",
                "limit" => 101
+             })
+  end
+
+  @tag :tmp_dir
+  test "a run that called no model reports a measured zero turn count", %{tmp_dir: root} do
+    fixture = PrivateInspectionFixture.create_result!(root, 42)
+    {:ok, trace} = TraceSnapshot.start({:private_authorized_directory, fixture.traces})
+    {:ok, inspection} = InspectionSnapshot.start({:directory, fixture.inspection}, trace)
+    on_exit(fn -> InspectionSnapshot.stop(inspection) end)
+    on_exit(fn -> TraceSnapshot.stop(trace) end)
+    assert {:ok, analysis} = RunAnalysis.new(trace, inspection)
+
+    assert {:ok, %{"inspection" => %{"counts" => counts}, "collections" => collections}} =
+             RunAnalysis.query(analysis, :open, %{"run_id" => fixture.run_id})
+
+    assert counts["turns"] == 0
+
+    turns = Enum.find(collections, &(&1["name"] == "turns"))
+    assert turns["available?"]
+    assert turns["item_count"] == 0
+
+    assert {:ok, %{"items" => []}} =
+             RunAnalysis.query(analysis, :read, %{
+               "run_id" => fixture.run_id,
+               "collection" => "turns"
              })
   end
 


### PR DESCRIPTION
## Summary

- Store `"turns" => length(conversation.turns)` in the private inspection run record's `counts` map and drop the `_ = conversation` discard in `materialize_counts/2`, so `analysis/open` publishes `item_count` for `turns` like every other retained collection.
- Correct `docs/maintainers/trace-log-contract.md`: `activity` is canonical rather than retained and is now the only collection that owns no retained count.
- Extend the interrupted-run count assertion in `inspection_snapshot_test.exs`, the catalog assertions in `run_analysis_test.exs`, and the private-analysis REPL assertions in `ptc_repl_test.exs`; add a `run_analysis_test.exs` case that opens a capture with no model calls and asserts the measured `0`.

`available?` semantics and every other count are unchanged, and recorded fixtures without the key stay readable because `put_item_count/3` tolerates an absent key. No test pinned a literal hash of a freshly assembled artifact, so nothing needed re-recording.

## Validation

- `mix test test/ptc_runner/kernel/run_analysis_test.exs test/ptc_runner/kernel/inspection_snapshot_test.exs test/ptc_runner/kernel/inspection_sink_test.exs`
- `mix test test/mix/tasks/ptc_repl_test.exs test/ptc_runner/kernel/run_analysis_profile_test.exs test/ptc_runner/kernel/viewer_adapter_test.exs`
- One cumulative base-guarded Codex review against `origin/main`: no actionable findings.

## Retrospective

- Follow-up: `test/ptc_runner/lisp/heap_rebaseline_test.exs:270` ("compile scope checks do not enumerate high-cardinality continuation memory") failed once under the pre-push suite at 122797 vs a 120208 + 20000 budget, then passed on a rerun of the file with the same seed (49435) and on the next full pre-push run. The reduction budget appears sensitive to machine load rather than to this change.
- Repository instruction gap: none.

Closes #1828

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013XSjizuCnbGaY2LNDr4H1W