### PR TITLE
test(kernel): give the bounded-worker timeout test a budget that covers spawn latency

### DIFF
--- a/test/ptc_runner/kernel/bounded_worker_test.exs
+++ b/test/ptc_runner/kernel/bounded_worker_test.exs
@@ -7,6 +7,11 @@ defmodule PtcRunner.Kernel.BoundedWorkerTest do
   test "timeout kills the worker without leaking monitor or result messages" do
     parent = self()
 
+    # The deadline is armed before the worker is spawned, so the budget has to
+    # cover the spawn's scheduling latency as well: a 1 ms budget under a loaded
+    # scheduler killed the worker before it ran, and the test then waited for a
+    # message that was never sent. The worker blocks forever once it has
+    # reported in, so a generous budget changes only how long the test takes.
     assert {:error, :timeout} =
              BoundedWorker.run(
                fn ->
@@ -16,7 +21,7 @@ defmodule PtcRunner.Kernel.BoundedWorkerTest do
                    :never -> :unexpected
                  end
                end,
-               timeout_ms: 1,
+               timeout_ms: 500,
                max_heap_words: 10_000
              )
 


### PR DESCRIPTION
## Summary

- `test/ptc_runner/kernel/bounded_worker_test.exs`: the timeout test ran its worker with a 1 ms budget and then asserted the worker had reported its pid. `BoundedWorker.run/2` arms the deadline before spawning, so that budget also had to cover scheduling latency; on a loaded CI scheduler the worker was killed before it ran. The budget is now 500 ms with a comment saying why. The worker blocks forever once it has reported in, so nothing else about the test changes.

## Validation

- The file five times in a row under `CI=1` after the change, 14 passed each time.
- `scripts/ci/core-tests.sh --schedulers 4` on merged main before the change did not reproduce the failure, consistent with a scheduling race.

## Retrospective

- Follow-up: none.
- Instruction: none.

Closes #1833

https://claude.ai/code/session_01KZpAhEfT9ijhfFbXassJE9
