### PR TITLE
fix(build): cache project PLTs and stabilize verification tests

### DIFF
--- a/docs/maintainers/development-setup.md
+++ b/docs/maintainers/development-setup.md
@@ -65,9 +65,34 @@ with the seed, so do not seed from a checkout whose `deps/` you have edited.
 The staging, atomic promotion, and PLT rules are documented in the seeding
 section of `scripts/worktree.sh`.
 
-To warm the cache, keep the main checkout built: `mix compile` and
-`mix dialyzer` there make every subsequent worktree cheap. To fill gaps in an
-existing worktree (artifacts already present are left untouched):
+Project PLTs also have a shared snapshot cache at
+`~/.cache/ptc_runner/project_plts` (override with `PTC_PROJECT_PLT_CACHE`).
+Initialization restores a private copy when the main-checkout seed did not
+provide one. `scripts/ci/core-dialyzer.sh`, used by pre-push, restores missing
+PLTs and publishes after successful analysis. Failed gates never publish.
+The cache key includes the actual Erlang/ERTS and Elixir versions, OS,
+architecture, `mix.exs`, and `mix.lock`; a lockfile change can use the newest
+snapshot with otherwise identical settings as an incremental starting point.
+Hashing all of `mix.exs` deliberately invalidates more than just PLT options.
+GitHub Actions retains its existing cache, and non-test Mix environments do
+not publish to this cache.
+
+Both the main-checkout seed and shared snapshots relocate the PLT's absolute
+BEAM paths to the destination checkout while preserving their checksums.
+Otherwise Dialyzer would remove and re-add every dependency from the old path.
+Shared snapshots store checkout paths under a placeholder prefix; the cache
+only supports the checked classic PLT record layout and skips unknown layouts.
+Dialyzer still checks the actual destination BEAM contents.
+
+Snapshots are validated before atomic publication under a nonblocking OS
+lock. Readers copy a complete snapshot under the same lock, validate it, and
+remove Dialyxir's shortcut hash so it rechecks the worktree's modules. Cache
+failure or a busy lock falls back to ordinary Dialyzer work. Existing local
+PLTs are left untouched. Python 3 and the pinned BEAM runtime are required,
+as they are for the existing hooks and toolchain.
+
+Keep the main checkout built with `mix compile` to warm dependency and build
+seeds. To fill gaps in an existing worktree:
 
 ```bash
 scripts/worktree.sh seed          # seed the current worktree

--- a/ptc_runner_launcher/README.md
+++ b/ptc_runner_launcher/README.md
@@ -61,6 +61,12 @@ interpreter the script's path rather than a descriptor, so the interpreter opens
 it a second time and no launcher check covers that lookup. A macOS host must
 therefore keep the executable path hierarchy immutable for the whole of startup.
 
+The conformance suite tests replacement during hashing with a test-only build
+that interposes the executable read and renames the target at that exact point.
+A marker proves the replacement occurred; no delay or large padded script is
+needed. The shipped launcher contains no synchronization hook. This check does
+not cover macOS's later interpreter path lookup described above.
+
 The Elixir API is intentionally small:
 
 ```elixir

--- a/ptc_runner_launcher/test/fixtures/mcp_stdio_hash_race_fixture.c
+++ b/ptc_runner_launcher/test/fixtures/mcp_stdio_hash_race_fixture.c
@@ -1,0 +1,35 @@
+/* Test-only read interposition. The shipped launcher has no race hook. */
+#include <unistd.h>
+
+static ssize_t race_read(int fd, void *buffer, size_t count);
+#define read race_read
+#include "../../c_src/ptc_runner_launcher.c"
+#undef read
+
+static ssize_t race_read(int fd, void *buffer, size_t count) {
+  static bool replaced = false;
+  struct stat opened;
+  struct stat target;
+  ssize_t result = read(fd, buffer, count);
+
+  /* Bootstrap and watchdog reads use pipes. Only the executable's regular
+   * file descriptor can match here, after its first bytes have been read and
+   * before sha256_fd consumes them or reaches the final identity check. */
+  if (!replaced && result > 0 && fstat(fd, &opened) == 0 &&
+      S_ISREG(opened.st_mode) && stat(PTC_RACE_TARGET, &target) == 0 &&
+      opened.st_dev == target.st_dev && opened.st_ino == target.st_ino) {
+    int marker;
+
+    if (rename(PTC_RACE_IMPOSTOR, PTC_RACE_TARGET) != 0) {
+      _exit(125);
+    }
+    replaced = true;
+    marker = open(PTC_RACE_MARKER, O_WRONLY | O_CREAT | O_EXCL, 0600);
+    if (marker < 0 || write(marker, "during-hash", 11) != 11) {
+      _exit(125);
+    }
+    (void)close(marker);
+  }
+
+  return result;
+}

--- a/ptc_runner_launcher/test/ptc_runner_launcher/conformance_test.exs
+++ b/ptc_runner_launcher/test/ptc_runner_launcher/conformance_test.exs
@@ -6,25 +6,7 @@ defmodule PtcRunnerLauncher.ConformanceTest do
   @fixture Path.expand("../fixtures/mcp_stdio_launcher_fixture.sh", __DIR__)
   @native_fixture Path.expand("../fixtures/mcp_stdio_native_fixture.c", __DIR__)
 
-  # The identity hash is the only interval long enough to swap an executable
-  # into, so the raced target is large enough that hashing it is still running
-  # when the replacement lands: 64 MiB takes a third of a second here, and the
-  # swap fires 80 ms in.
-  #
-  # The delay is deliberately biased early. Landing before the target is opened
-  # only costs the case its coverage -- the launcher hashes the impostor and
-  # refuses on identity. Landing after `execve` would be worse than useless on
-  # macOS, because an interpreted target is reopened by its interpreter through
-  # a path no launcher check covers, and the case would then go red over a
-  # documented limitation rather than a regression. Startup alone rules out
-  # reaching `execve` within 80 ms of a 64 MiB target.
-  #
-  # This is a probe rather than a gate: nothing here can tell coverage from a
-  # miss, and making it deterministic would mean a synchronization point inside
-  # a binary whose job is deciding what may execute. What it cannot do is pass
-  # while the impostor runs.
-  @race_target_mebibytes 64
-  @race_swap_delay_ms 80
+  @hash_race_fixture Path.expand("../fixtures/mcp_stdio_hash_race_fixture.c", __DIR__)
 
   setup_all do
     compiler = System.find_executable("cc") || flunk("C compiler is unavailable")
@@ -578,27 +560,48 @@ defmodule PtcRunnerLauncher.ConformanceTest do
   end
 
   @tag :tmp_dir
-  @tag :slow
   test "a replacement landing during the identity hash never reaches exec", %{tmp_dir: dir} do
     authorized = Path.join(dir, "server")
     impostor = Path.join(dir, "impostor")
-    on_exit(fn -> File.rm_rf(dir) end)
+    marker = Path.join(dir, "swapped")
+    fixture = Path.join(dir, "hash-race-launcher")
+    compiler = System.find_executable("cc") || flunk("C compiler is unavailable")
 
-    frozen = write_padded_script(authorized, "AUTHORIZED-EXECUTED", @race_target_mebibytes)
-    write_padded_script(impostor, "IMPOSTOR-EXECUTED", 0)
+    for {path, output} <- [{authorized, "AUTHORIZED-EXECUTED"}, {impostor, "IMPOSTOR-EXECUTED"}] do
+      File.write!(path, "#!/bin/sh\nprintf '#{output}\\n'\nread _ || true\n")
+      File.chmod!(path, 0o700)
+    end
 
-    racer =
-      Task.async(fn ->
-        # Deliberate scaffolding, not a wait for a result: the interval under
-        # test is defined by wall-clock position inside the launcher's hash and
-        # the launcher publishes nothing to synchronize on.
-        Process.sleep(@race_swap_delay_ms)
-        :file.rename(impostor, authorized)
-      end)
+    frozen = executable_sha256(authorized)
+
+    # Compile the actual launcher with read interposed only in this fixture.
+    # The replacement happens after the first executable read, so neither CPU
+    # speed nor interpreter startup can move the swap outside the hash window.
+    assert {_, 0} =
+             System.cmd(
+               compiler,
+               [
+                 "-D_GNU_SOURCE",
+                 "-D_DARWIN_C_SOURCE",
+                 "-std=c11",
+                 "-Wall",
+                 "-Wextra",
+                 "-Werror",
+                 "-Wpedantic",
+                 "-DPTC_RACE_TARGET=#{inspect(authorized)}",
+                 "-DPTC_RACE_IMPOSTOR=#{inspect(impostor)}",
+                 "-DPTC_RACE_MARKER=#{inspect(marker)}",
+                 "-o",
+                 fixture,
+                 @hash_race_fixture
+               ],
+               stderr_to_stdout: true
+             )
 
     result =
       MCPStdioLauncher.open(
         executable: authorized,
+        launcher_path: fixture,
         executable_sha256: frozen,
         cwd: dir,
         args: [],
@@ -607,7 +610,8 @@ defmodule PtcRunnerLauncher.ConformanceTest do
         start_timeout_ms: 30_000
       )
 
-    assert :ok = Task.await(racer, 30_000)
+    assert File.read!(marker) == "during-hash"
+    refute File.exists?(impostor)
 
     # Refused on macOS, where the path is what gets executed; on Linux the held
     # descriptor still carries the authorized target through. Either is a safe
@@ -846,28 +850,6 @@ defmodule PtcRunnerLauncher.ConformanceTest do
       )
 
     launcher
-  end
-
-  # Returns the SHA-256 of what was written, hashed as it goes: reading a target
-  # this size back just to freeze its identity would cost more than the launch
-  # under test.
-  defp write_padded_script(path, marker, mebibytes) do
-    # Waits for stdin EOF rather than exiting on its own, so closing the
-    # launcher finishes as a close instead of racing a server exit.
-    header = "#!/bin/sh\nprintf '#{marker}\\n'\nread _ || true\nexit 0\n#"
-    padding = :binary.copy("x", 1024 * 1024)
-
-    digest =
-      File.open!(path, [:write, :binary], fn handle ->
-        Enum.reduce([header | List.duplicate(padding, mebibytes)], :crypto.hash_init(:sha256), fn
-          chunk, context ->
-            IO.binwrite(handle, chunk)
-            :crypto.hash_update(context, chunk)
-        end)
-      end)
-
-    File.chmod!(path, 0o700)
-    :crypto.hash_final(digest)
   end
 
   defp executable_sha256(executable) do

--- a/ptc_runner_launcher/test/support/launcher_port.ex
+++ b/ptc_runner_launcher/test/support/launcher_port.ex
@@ -104,7 +104,7 @@ defmodule PtcRunnerLauncher.TestSupport.LauncherPort do
   def open(opts) when is_list(opts) do
     with :ok <- supported_platform(),
          {:ok, config} <- validate_options(opts),
-         {:ok, launcher} <- launcher_path(),
+         {:ok, launcher} <- launcher_path(opts),
          {:ok, payload} <- bootstrap(config) do
       open_started_launcher(launcher, payload, config)
     end
@@ -263,7 +263,8 @@ defmodule PtcRunnerLauncher.TestSupport.LauncherPort do
       :grace_ms,
       :stderr_bytes,
       :start_timeout_ms,
-      :executable_sha256
+      :executable_sha256,
+      :launcher_path
     ]
 
     with true <- Keyword.keyword?(opts),
@@ -344,7 +345,20 @@ defmodule PtcRunnerLauncher.TestSupport.LauncherPort do
     Map.merge(inherited, explicit)
   end
 
-  defp launcher_path, do: PtcRunnerLauncher.executable_path()
+  # Only this test client can select an instrumented launcher. The public
+  # companion and the production MCP transport always use the shipped binary.
+  defp launcher_path(opts) do
+    case Keyword.fetch(opts, :launcher_path) do
+      {:ok, path} when is_binary(path) ->
+        if valid_absolute_path?(path), do: {:ok, path}, else: {:error, :invalid_mcp_stdio_launch}
+
+      {:ok, _invalid} ->
+        {:error, :invalid_mcp_stdio_launch}
+
+      :error ->
+        PtcRunnerLauncher.executable_path()
+    end
+  end
 
   defp bootstrap(config) do
     environment = Enum.sort_by(config.env, &elem(&1, 0))

--- a/scripts/ci/core-dialyzer.sh
+++ b/scripts/ci/core-dialyzer.sh
@@ -4,4 +4,6 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck disable=SC1091
 source "$script_dir/_common.sh"
 
+python3 "$ci_repo_root/scripts/project-plt-cache.py" restore
 mix dialyzer --format github
+python3 "$ci_repo_root/scripts/project-plt-cache.py" publish

--- a/scripts/project-plt-cache.py
+++ b/scripts/project-plt-cache.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Private project PLT snapshots. Cache failure must never bypass Dialyzer."""
+
+import contextlib
+import fcntl
+import hashlib
+import os
+from pathlib import Path
+import platform
+import shutil
+import subprocess
+import sys
+import tempfile
+
+
+# Shared with worktree seeding: reject torn terms and trailing bytes. Dialyzer
+# still owns semantic validation (module checksums, dependencies, OTP format).
+def valid_plt(path, source=None, destination=None):
+    expression = '''
+      {ok, Bin} = file:read_file(os:getenv("PTC_SEED_PLT")),
+      R = try binary_to_term(Bin, [used]) of
+        {T, Used} when is_tuple(T), element(1, T) =:= file_plt,
+                       Used =:= byte_size(Bin) ->
+          case os:getenv("PTC_PLT_SOURCE") of
+            false -> 0;
+            Source ->
+              %% OTP's classic file_plt record: only relocate file_md5_list.
+              %% Reject unknown layouts; never rewrite inferred term fields.
+              10 = tuple_size(T),
+              Files = element(3, T),
+              true = is_list(Files),
+              Target = os:getenv("PTC_PLT_TARGET"),
+              Move = fun({File, Hash}) when is_list(File), is_binary(Hash),
+                                           byte_size(Hash) =:= 16 ->
+                case lists:prefix(Source, File) of
+                  true -> {Target ++ lists:nthtail(length(Source), File), Hash};
+                  false -> {File, Hash}
+                end
+              end,
+              Moved = lists:keysort(1, lists:map(Move, Files)),
+              Updated = setelement(3, T, Moved),
+              ok = file:write_file(os:getenv("PTC_SEED_PLT"),
+                                   term_to_binary(Updated, [compressed])),
+              0
+          end;
+        _ -> 1
+      catch _:_ -> 1 end,
+      halt(R).'''
+    environment = {**os.environ, "PTC_SEED_PLT": str(path)}
+    environment.pop("PTC_PLT_SOURCE", None)
+    environment.pop("PTC_PLT_TARGET", None)
+    if source is not None:
+        environment.update(PTC_PLT_SOURCE=source + "/", PTC_PLT_TARGET=destination + "/")
+    result = subprocess.run(
+        ["erl", "-noshell", "-eval", expression],
+        env=environment,
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=60,
+    )
+    return result.returncode == 0
+
+
+def digest(*parts):
+    return hashlib.sha256(b"\0".join(parts)).hexdigest()
+
+
+def cache_directory():
+    # Actual runtime versions, not just mise pins: also safe for manual gates.
+    expression = '''
+      otp = :erlang.system_info(:otp_release)
+      version = File.read!(Path.join([:code.root_dir(), "releases", otp, "OTP_VERSION"]))
+      IO.write(Enum.join([System.version(), version, :erlang.system_info(:version)], "|"))
+    '''
+    runtime = subprocess.check_output(["elixir", "-e", expression], timeout=60)
+    # Conservatively hash all of mix.exs so changing plt_add_apps or other
+    # project options cannot reuse a fallback built with different settings.
+    compatibility = digest(
+        b"v2", runtime, platform.system().encode(), platform.machine().encode(),
+        Path("mix.exs").read_bytes(), b"test",
+    )
+    root = Path(os.environ.get(
+        "PTC_PROJECT_PLT_CACHE", "~/.cache/ptc_runner/project_plts"
+    )).expanduser()
+    return root / compatibility, digest(Path("mix.lock").read_bytes())
+
+
+@contextlib.contextmanager
+def snapshot(directory):
+    fd, name = tempfile.mkstemp(prefix=".snapshot-", dir=directory)
+    os.close(fd)
+    path = Path(name)
+    try:
+        yield path
+    finally:
+        path.unlink(missing_ok=True)
+
+
+@contextlib.contextmanager
+def locked(directory):
+    # Kernel-owned advisory lock: a killed publisher cannot leave a stale
+    # lock. Never queue an agent behind optional cache work.
+    with (directory / ".lock").open("a") as handle:
+        fcntl.flock(handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        yield
+
+
+def restore(directory, key, local):
+    local.parent.mkdir(parents=True, exist_ok=True)
+    with snapshot(local.parent) as staged:
+        with locked(directory):
+            exact = directory / f"{key}.plt"
+            candidates = sorted(directory.glob("*.plt"), key=lambda p: p.stat().st_mtime_ns,
+                                reverse=True)
+            if exact in candidates:
+                candidates.remove(exact)
+                candidates.insert(0, exact)
+            if not candidates:
+                print("Project PLT cache: miss")
+                return
+            source = candidates[0]
+            shutil.copyfile(source, staged)
+        if not valid_plt(staged, "/__ptc_project_plt_root__", os.getcwd()):
+            print("Project PLT cache: invalid snapshot ignored")
+            return
+        # Do not carry Dialyxir's shortcut hash: every restored PLT must be
+        # checked against this checkout's modules. The hard link is an atomic
+        # no-replace promotion of our PRIVATE copy, never of the cache inode.
+        if os.path.lexists(local):
+            return
+        Path(str(local) + ".hash").unlink(missing_ok=True)
+        os.link(staged, local)
+        kind = "exact" if source == exact else "compatible dependency fallback"
+        print(f"Project PLT cache: restored ({kind})")
+
+
+def publish(directory, key, local):
+    with snapshot(directory) as staged:
+        shutil.copyfile(local, staged)
+        if not valid_plt(staged, os.getcwd(), "/__ptc_project_plt_root__"):
+            print("Project PLT cache: invalid publication ignored")
+            return
+        with locked(directory):
+            os.replace(staged, directory / f"{key}.plt")
+        print("Project PLT cache: published")
+
+
+def main():
+    action = sys.argv[1]
+    if action == "validate":
+        return 0 if valid_plt(Path(sys.argv[2]), *sys.argv[3:]) else 1
+    if action not in ("restore", "publish"):
+        raise ValueError("expected restore, publish, or validate")
+    # GitHub Actions owns its own PLT cache. This cache serves local/Herdr
+    # test-environment gates only; other Mix environments never publish here.
+    if os.environ.get("CI") or os.environ.get("MIX_ENV", "test") != "test":
+        return 0
+    local = Path("priv/plts/project.plt")
+    if action == "restore" and os.path.lexists(local):
+        return 0
+    if action == "publish" and (not local.is_file() or local.is_symlink()):
+        return 0
+    directory, key = cache_directory()
+    directory.mkdir(parents=True, exist_ok=True)
+    if action == "restore":
+        restore(directory, key, local)
+    else:
+        publish(directory, key, local)
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except (OSError, subprocess.SubprocessError) as error:
+        print(f"Project PLT cache: skipped ({error})", file=sys.stderr)
+        sys.exit(1 if len(sys.argv) > 1 and sys.argv[1] == "validate" else 0)

--- a/scripts/worktree.sh
+++ b/scripts/worktree.sh
@@ -71,6 +71,7 @@ initialize_worktree() {
       die "could not trust the pinned mise configuration in $dst"
     bash scripts/install-hooks.sh
     "$mise_bin" install
+    "$mise_bin" exec -- python3 "$SCRIPT_DIR/project-plt-cache.py" restore
     "$mise_bin" exec -- mix deps.get
     (cd ptc_viewer && "$mise_bin" exec -- mix deps.get)
     (cd ptc_runner_launcher && "$mise_bin" exec -- mix deps.get)
@@ -290,7 +291,7 @@ seed_worktree() {
       echo "   ⏭️  $artifact — already present"
     elif mkdir -p "$staging" "$(dirname "$dst/$artifact")" &&
       clone_tree "$src/$artifact" "$tmp" &&
-      scrub_seed_artifact "$artifact" "$tmp" &&
+      scrub_seed_artifact "$artifact" "$tmp" "$src" "$dst" &&
       promote_seed_artifact "$tmp" "$dst/$artifact"; then
       echo "   🌱 $artifact"
       seeded=$((seeded + 1))
@@ -313,12 +314,12 @@ seed_worktree() {
 #    a torn copy, and dialyxir raises on an invalid PLT rather than
 #    rebuilding it — each staged PLT must prove it decodes before promotion.
 scrub_seed_artifact() {
-  local artifact="$1" tmp_tree="$2" plt
+  local artifact="$1" tmp_tree="$2" source="$3" destination="$4" plt
   if [ "$artifact" = "priv/plts" ]; then
     rm -f "$tmp_tree"/*.hash
     for plt in "$tmp_tree"/*.plt; do
       [ -e "$plt" ] || continue
-      plt_decodes "$plt" || return 1
+      plt_decodes "$plt" "$source" "$destination" || return 1
     done
   fi
 }
@@ -327,23 +328,12 @@ scrub_seed_artifact() {
 # must decode as exactly that: `[used]` demands the term consume every byte
 # (bare binary_to_term/1 tolerates trailing garbage), and the record tag
 # rejects a complete-but-foreign term. Together they prove the snapshot is
-# whole regardless of what the source's writer was doing at the time. Needs
-# erl on PATH; without it the artifact is simply not seeded.
+# whole regardless of what the source's writer was doing at the time. The
+# shared validator also relocates the file/checksum list to the new checkout
+# without changing checksums; Dialyzer still validates the destination BEAMs.
+# Unknown layouts are not seeded. Needs Python 3 and erl on PATH.
 plt_decodes() {
-  PTC_SEED_PLT="$1" erl -noshell -eval '
-    P = os:getenv("PTC_SEED_PLT"),
-    R = case file:read_file(P) of
-          {ok, Bin} ->
-            try binary_to_term(Bin, [used]) of
-              {T, Used}
-                when is_tuple(T), element(1, T) =:= file_plt,
-                     Used =:= byte_size(Bin) -> 0;
-              _ -> 1
-            catch _:_ -> 1
-            end;
-          _ -> 1
-        end,
-    halt(R).' 2>/dev/null
+  python3 "$SCRIPT_DIR/project-plt-cache.py" validate "$@"
 }
 
 # Promotion must be a no-replace operation: a bare `mv` whose destination

--- a/test/ptc_runner/lisp/heap_rebaseline_test.exs
+++ b/test/ptc_runner/lisp/heap_rebaseline_test.exs
@@ -279,7 +279,7 @@ defmodule PtcRunner.Lisp.HeapRebaselineTest do
     end
 
     test "compile scope checks do not enumerate high-cardinality continuation memory" do
-      memory = Map.new(1..50_000, fn index -> {"unused-#{index}", index} end)
+      memory = Map.new(1..250_000, fn index -> {"unused-#{index}", index} end)
 
       baseline_reductions =
         caller_reductions(fn ->
@@ -293,7 +293,22 @@ defmodule PtcRunner.Lisp.HeapRebaselineTest do
                    Lisp.run_native("missing-binding", memory: memory)
         end)
 
-      assert granted_reductions <= baseline_reductions + 20_000
+      # Compare with the same work on this runtime, rather than pinning an
+      # absolute OTP reduction delta. Retain a negative control: eagerly
+      # constructing the old scope must still exceed the allowed overhead.
+      budget = baseline_reductions * 1.5
+      assert granted_reductions <= budget
+
+      enumerated_reductions =
+        caller_reductions(fn ->
+          scope = memory |> Map.keys() |> MapSet.new()
+          assert MapSet.size(scope) == map_size(memory)
+
+          assert {:error, %{fail: %{reason: :unbound_var}}} =
+                   Lisp.run_native("missing-binding", memory: memory)
+        end)
+
+      assert enumerated_reductions > budget
     end
   end
 

--- a/test/ptc_runner/lisp/heap_rebaseline_test.exs
+++ b/test/ptc_runner/lisp/heap_rebaseline_test.exs
@@ -34,22 +34,12 @@ defmodule PtcRunner.Lisp.HeapRebaselineTest do
     %{"rows" => fn _args -> Enum.take(rows, 3) end}
   end
 
-  # One sample is noisy in one direction only: the first call pays code
-  # loading, and a garbage collection of the caller's heap, which holds the
-  # granted map, is charged to the caller as reductions. An enumeration of the
-  # map would show in every sample, so the minimum is the cost of the work.
-  @reduction_samples 5
-
   defp caller_reductions(fun) do
-    1..@reduction_samples
-    |> Enum.map(fn _sample ->
-      :erlang.garbage_collect()
-      {:reductions, before_run} = Process.info(self(), :reductions)
-      fun.()
-      {:reductions, after_run} = Process.info(self(), :reductions)
-      after_run - before_run
-    end)
-    |> Enum.min()
+    :erlang.garbage_collect()
+    {:reductions, before_run} = Process.info(self(), :reductions)
+    fun.()
+    {:reductions, after_run} = Process.info(self(), :reductions)
+    after_run - before_run
   end
 
   describe "host-granted data is excluded from the program budget (F3 regression)" do
@@ -279,36 +269,45 @@ defmodule PtcRunner.Lisp.HeapRebaselineTest do
     end
 
     test "compile scope checks do not enumerate high-cardinality continuation memory" do
-      memory = Map.new(1..250_000, fn index -> {"unused-#{index}", index} end)
+      Task.async(fn ->
+        # Dirty CPU GC is charged elapsed-time reductions, so contention can
+        # inflate this measurement. Reserve heap words in a fresh process and
+        # warm the code before sampling; caller_reductions collects beforehand.
+        Process.flag(:min_heap_size, 2_000_000)
 
-      baseline_reductions =
-        caller_reductions(fn ->
-          assert {:error, %{fail: %{reason: :unbound_var}}} =
-                   Lisp.run_native("missing-binding", memory: %{})
-        end)
+        assert {:error, %{fail: %{reason: :unbound_var}}} =
+                 Lisp.run_native("missing-binding", memory: %{})
 
-      granted_reductions =
-        caller_reductions(fn ->
-          assert {:error, %{fail: %{reason: :unbound_var}}} =
-                   Lisp.run_native("missing-binding", memory: memory)
-        end)
+        memory = Map.new(1..50_000, fn index -> {"unused-#{index}", index} end)
 
-      # Compare with the same work on this runtime, rather than pinning an
-      # absolute OTP reduction delta. Retain a negative control: eagerly
-      # constructing the old scope must still exceed the allowed overhead.
-      budget = baseline_reductions * 1.5
-      assert granted_reductions <= budget
+        baseline_reductions =
+          caller_reductions(fn ->
+            assert {:error, %{fail: %{reason: :unbound_var}}} =
+                     Lisp.run_native("missing-binding", memory: %{})
+          end)
 
-      enumerated_reductions =
-        caller_reductions(fn ->
-          scope = memory |> Map.keys() |> MapSet.new()
-          assert MapSet.size(scope) == map_size(memory)
+        granted_reductions =
+          caller_reductions(fn ->
+            assert {:error, %{fail: %{reason: :unbound_var}}} =
+                     Lisp.run_native("missing-binding", memory: memory)
+          end)
 
-          assert {:error, %{fail: %{reason: :unbound_var}}} =
-                   Lisp.run_native("missing-binding", memory: memory)
-        end)
+        # Keep the absolute overhead bound and prove it rejects eager enumeration.
+        budget = baseline_reductions + 20_000
+        assert granted_reductions <= budget
 
-      assert enumerated_reductions > budget
+        enumerated_reductions =
+          caller_reductions(fn ->
+            scope = memory |> Map.keys() |> MapSet.new()
+            assert MapSet.size(scope) == map_size(memory)
+
+            assert {:error, %{fail: %{reason: :unbound_var}}} =
+                     Lisp.run_native("missing-binding", memory: memory)
+          end)
+
+        assert enumerated_reductions > budget
+      end)
+      |> Task.await(30_000)
     end
   end
 

--- a/test/scripts/ci_gates_test.exs
+++ b/test/scripts/ci_gates_test.exs
@@ -58,6 +58,17 @@ defmodule PtcRunner.Scripts.CIGatesTest do
              "CI= MIX_ENV=test HEX_SPONSOR=false ERL_FLAGS= PWD=. :: dialyzer --format github"
   end
 
+  @tag :nightly
+  test "a failed Dialyzer gate never publishes its PLT" do
+    %{marker: marker} = fake = fake_mix()
+
+    {_output, status} =
+      run_gate(@core_dialyzer, fake, env: [{"CI", nil}, {"MIX_GATE_EXIT", "7"}])
+
+    assert status == 7
+    assert Path.wildcard(Path.join(Path.dirname(marker), "cache/**/*.plt")) == []
+  end
+
   test "non-test gates preserve an explicit CI state" do
     %{marker: marker} = fake = fake_mix()
 
@@ -232,7 +243,13 @@ defmodule PtcRunner.Scripts.CIGatesTest do
   defp run_gate(script, %{marker: marker, path: path}, opts) do
     System.cmd(script, Keyword.get(opts, :args, []),
       cd: @root,
-      env: @git_env ++ [{"PATH", path}, {"MIX_MARKER", marker}] ++ Keyword.get(opts, :env, []),
+      env:
+        @git_env ++
+          [
+            {"PATH", path},
+            {"MIX_MARKER", marker},
+            {"PTC_PROJECT_PLT_CACHE", Path.join(Path.dirname(marker), "cache")}
+          ] ++ Keyword.get(opts, :env, []),
       stderr_to_stdout: true
     )
   end
@@ -261,6 +278,7 @@ defmodule PtcRunner.Scripts.CIGatesTest do
     rel="${rel#/}"
     printf 'CI=%s MIX_ENV=%s HEX_SPONSOR=%s ERL_FLAGS=%s PWD=%s :: %s\n' \\
       "$CI" "$MIX_ENV" "$HEX_SPONSOR" "${ERL_FLAGS:-}" "${rel:-.}" "$*" >> "$MIX_MARKER"
+    exit "${MIX_GATE_EXIT:-0}"
     """)
 
     File.chmod!(mix, 0o755)

--- a/test/scripts/project_plt_cache_test.exs
+++ b/test/scripts/project_plt_cache_test.exs
@@ -1,0 +1,169 @@
+defmodule PtcRunner.Scripts.ProjectPltCacheTest do
+  use ExUnit.Case, async: true
+
+  @moduletag :nightly
+  @script Path.expand("../../scripts/project-plt-cache.py", __DIR__)
+
+  setup do
+    root = Path.join(System.tmp_dir!(), "plt-cache-#{System.unique_integer([:positive])}")
+    File.mkdir_p!(root)
+    on_exit(fn -> File.rm_rf!(root) end)
+    File.write!(Path.join(root, "mix.exs"), "project configuration")
+    File.write!(Path.join(root, "mix.lock"), "dependencies")
+    %{root: root}
+  end
+
+  test "a completed job seeds an independent copy even after dependencies diverge", %{root: root} do
+    plt = Path.join(root, "priv/plts/project.plt")
+    File.mkdir_p!(Path.dirname(plt))
+    original = plt_binary(:original)
+    File.write!(plt, original)
+    assert {_, 0} = cache(root, "publish")
+    File.rm!(plt)
+    File.write!(plt <> ".hash", "stale hash")
+    assert {output, 0} = cache(root, "restore")
+    assert output =~ "restored"
+    assert File.read!(plt) == original
+    refute File.exists?(plt <> ".hash")
+
+    File.write!(plt, "private mutation")
+    File.rm!(plt)
+    File.write!(Path.join(root, "mix.lock"), "changed dependencies")
+    assert {output, 0} = cache(root, "restore")
+    assert output =~ "compatible"
+    assert File.read!(plt) == original
+  end
+
+  test "corrupt publications cannot replace a valid entry and existing local PLTs survive", %{
+    root: root
+  } do
+    plt = Path.join(root, "priv/plts/project.plt")
+    File.mkdir_p!(Path.dirname(plt))
+    original = plt_binary(:original)
+    File.write!(plt, original)
+    assert {_, 0} = cache(root, "publish")
+    File.write!(plt, "torn")
+    assert {_, 0} = cache(root, "publish")
+    assert {_, 0} = cache(root, "restore")
+    assert File.read!(plt) == "torn"
+    File.rm!(plt)
+    assert {_, 0} = cache(root, "restore")
+    assert File.read!(plt) == original
+
+    File.rm!(plt)
+    File.write!(Path.join(root, "mix.exs"), "different PLT configuration")
+    assert {output, 0} = cache(root, "restore")
+    assert output =~ "miss"
+    refute File.exists?(plt)
+  end
+
+  test "busy publication locks are skipped and released by the operating system", %{root: root} do
+    plt = Path.join(root, "priv/plts/project.plt")
+    File.mkdir_p!(Path.dirname(plt))
+    File.write!(plt, plt_binary(:complete))
+    assert {_, 0} = cache(root, "publish")
+    [lock] = Path.wildcard(Path.join(root, "cache/*/.lock"), match_dot: true)
+
+    # Hold the real cache lock while a second OS process attempts publication.
+    # Exiting the holder releases it; no polling or scheduler timing is needed.
+    program = """
+    import fcntl, subprocess, sys
+    with open(sys.argv[1], "a") as lock:
+        fcntl.flock(lock, fcntl.LOCK_EX)
+        subprocess.run([sys.executable, sys.argv[2], "publish"], check=True)
+    """
+
+    assert {output, 0} =
+             System.cmd("python3", ["-c", program, lock, @script],
+               cd: root,
+               env: [{"PTC_PROJECT_PLT_CACHE", Path.join(root, "cache")}, {"CI", nil}],
+               stderr_to_stdout: true
+             )
+
+    assert output =~ "skipped"
+    assert {output, 0} = cache(root, "publish")
+    assert output =~ "published"
+    assert Path.wildcard(Path.join(root, "cache/*/.snapshot-*"), match_dot: true) == []
+  end
+
+  test "a corrupted cache is ignored and CI keeps ownership of its own cache", %{root: root} do
+    plt = Path.join(root, "priv/plts/project.plt")
+    File.mkdir_p!(Path.dirname(plt))
+    File.write!(plt, plt_binary(:complete))
+    assert {_, 0} = cache(root, "publish")
+    [entry] = Path.wildcard(Path.join(root, "cache/*/*.plt"))
+    File.write!(entry, "truncated")
+    File.rm!(plt)
+    assert {output, 0} = cache(root, "restore")
+    assert output =~ "invalid snapshot"
+    refute File.exists?(plt)
+
+    assert {"", 0} =
+             System.cmd("python3", [@script, "restore"], cd: root, env: [{"CI", "1"}])
+
+    refute File.exists?(plt)
+  end
+
+  test "a real PLT survives relocation and still detects a changed BEAM", %{root: root} do
+    beam_dir = "_build/test/lib/cache_fixture/ebin"
+    File.mkdir_p!(Path.join(root, beam_dir))
+    File.mkdir_p!(Path.join(root, "priv/plts"))
+    source = "-module(cache_fixture). -export([value/0]). value() -> 42."
+    File.write!(Path.join(root, "cache_fixture.erl"), source)
+
+    assert {_, 0} =
+             System.cmd("erlc", ["+debug_info", "-o", beam_dir, "cache_fixture.erl"], cd: root)
+
+    build = """
+    _ = dialyzer:run([{analysis_type, plt_build},
+      {files, [filename:absname("#{beam_dir}/cache_fixture.beam")]},
+      {output_plt, "priv/plts/project.plt"}]), halt().
+    """
+
+    assert {_, 0} = System.cmd("erl", ["-noshell", "-eval", build], cd: root)
+    assert {output, 0} = cache(root, "publish")
+    assert output =~ "published"
+
+    other = Path.join(root, "second checkout")
+    File.mkdir_p!(Path.join(other, beam_dir))
+
+    for file <- ["mix.exs", "mix.lock", "cache_fixture.erl", "#{beam_dir}/cache_fixture.beam"] do
+      File.cp!(Path.join(root, file), Path.join(other, file))
+    end
+
+    File.rm_rf!(Path.join(root, "_build"))
+    assert {output, 0} = cache(root, "restore", other)
+    assert output =~ "restored"
+
+    check = """
+    ok = dialyzer_cplt:check_plt("priv/plts/project.plt", [], []), halt().
+    """
+
+    assert {_, 0} = System.cmd("erl", ["-noshell", "-eval", check], cd: other)
+    File.write!(Path.join(other, "cache_fixture.erl"), String.replace(source, "42", "changed"))
+
+    assert {_, 0} =
+             System.cmd("erlc", ["+debug_info", "-o", beam_dir, "cache_fixture.erl"], cd: other)
+
+    changed = """
+    {differ, _, _, _} = dialyzer_cplt:check_plt("priv/plts/project.plt", [], []), halt().
+    """
+
+    assert {_, 0} = System.cmd("erl", ["-noshell", "-eval", changed], cd: other)
+  end
+
+  defp plt_binary(version, files \\ []) do
+    :erlang.term_to_binary(
+      {:file_plt, version, files, %{}, %{}, %{}, %{}, %{}, %{}, []},
+      [:compressed]
+    )
+  end
+
+  defp cache(root, action, working_directory \\ nil) do
+    System.cmd("python3", [@script, action],
+      cd: working_directory || root,
+      env: [{"PTC_PROJECT_PLT_CACHE", Path.join(root, "cache")}, {"CI", nil}],
+      stderr_to_stdout: true
+    )
+  end
+end

--- a/test/scripts/worktree_seed_test.exs
+++ b/test/scripts/worktree_seed_test.exs
@@ -226,6 +226,7 @@ defmodule PtcRunner.Scripts.WorktreeSeedTest do
              "mise|trust --yes #{worktree}/mise.toml|#{worktree}|0022",
              "hooks|#{worktree}|0022",
              "mise|install|#{worktree}|0022",
+             "mise|exec -- python3 #{Path.join(Path.dirname(@script), "project-plt-cache.py")} restore|#{worktree}|0022",
              "mise|exec -- mix deps.get|#{worktree}|0022",
              "mise|exec -- mix deps.get|#{worktree}/ptc_viewer|0022",
              "mise|exec -- mix deps.get|#{worktree}/ptc_runner_launcher|0022",
@@ -329,7 +330,12 @@ defmodule PtcRunner.Scripts.WorktreeSeedTest do
 
   # Real PLTs are one external term; the seed proves a staged copy decodes
   # before promoting it, so fixture PLTs must decode too.
-  defp plt_binary, do: :erlang.term_to_binary({:file_plt, :fixture})
+  defp plt_binary do
+    :erlang.term_to_binary(
+      {:file_plt, :fixture, [], %{}, %{}, %{}, %{}, %{}, %{}, []},
+      [:compressed]
+    )
+  end
 
   defp write!(repo, path, contents) do
     full_path = Path.join(repo, path)


### PR DESCRIPTION
## Summary

- Retain the absolute 20,000-reduction overhead bound and 50,000-entry continuation memory. Measure in a fresh process with reserved heap and warmed code, collecting garbage before sampling: dirty CPU garbage collection can charge elapsed-time reductions under contention. Add an explicit enumeration control that must exceed the bound.
- Restore private project PLT snapshots during workspace initialization and Dialyzer gates, and publish only after a successful gate. Key by runtime versions, platform, project configuration, and dependency lock, with compatible lockfile fallbacks.
- Relocate absolute BEAM paths in both shared snapshots and main-checkout seeds while retaining checksums. Without relocation, Dialyzer removes and re-adds dependencies from the previous checkout. Validate copies, discard shortcut hashes, and use nonblocking locks and atomic publication.

- Replace the launcher’s wall-clock executable-swap test with a test-only read interposer. A marker proves the rename lands during hashing, preserving coverage without racing macOS’s later interpreter lookup.

Closes #1838

## Validation

- Focused heap, worktree-seeding, project-cache, and CI-gate tests, including the nightly cache cases.
- Focused heap regression with original failing CI seed `467959`. Investigation probes under idle, CPU, and allocation load confirmed that prepared-heap measurements avoid GC and retain sensitivity to eager enumeration.
- Real PLT built in one checkout, restored in another after deleting the original BEAMs, checked successfully, then checked again after changing a destination BEAM to verify invalidation.
- Full published project PLT restored under a different checkout path and validated with no changed or missing BEAMs.
- Shell syntax checks for the modified entrypoints.

- Launcher suite with CI seed `930702`; negative-control probe confirmed the replacement test fails when the identity guard is removed, and passes with it restored.

## Retrospective

- Untracked follow-up work: none.
- Repository instruction missing, wrong, or guessed: none.


