### PR TITLE
fix(acquisition): deduplicate external override source accounting

### DIFF
--- a/lib/ptc_runner/kernel/application_package.ex
+++ b/lib/ptc_runner/kernel/application_package.ex
@@ -813,7 +813,7 @@ defmodule PtcRunner.Kernel.ApplicationPackage do
         Enum.flat_map(override_pairs, fn
           {_identity, override, {:external, source_name}} ->
             [{:component_override, :override_descriptor, override.descriptor_bytes}] ++
-              external_source_document(override, source_name, accounting.captured_names)
+              external_source_document(override, source_name, accounting.captured_documents)
 
           {_identity, _override, :captured} ->
             []
@@ -828,14 +828,14 @@ defmodule PtcRunner.Kernel.ApplicationPackage do
     end
   end
 
-  defp external_source_document(override, source_name, captured_names)
+  defp external_source_document(override, source_name, captured_documents)
        when is_binary(source_name) do
-    if MapSet.member?(captured_names, source_name),
+    if Map.get(captured_documents, source_name) == :crypto.hash(:sha256, override.source),
       do: [],
       else: [{:component_override, :override_source, byte_size(override.source)}]
   end
 
-  defp external_source_document(override, nil, _captured_names),
+  defp external_source_document(override, nil, _captured_documents),
     do: [{:component_override, :override_source, byte_size(override.source)}]
 
   defp account_documents(documents, accounting) do

--- a/lib/ptc_runner/kernel/application_package.ex
+++ b/lib/ptc_runner/kernel/application_package.ex
@@ -446,8 +446,12 @@ defmodule PtcRunner.Kernel.ApplicationPackage do
           {:error, reason} when reason in [:outside_application_source, :invalid_logical_name] ->
             ComponentOverride.load(path)
             |> case do
-              {:ok, override} -> {:ok, {override, :external}}
-              {:error, _reason} = error -> source_error(error, :component_override)
+              {:ok, override} ->
+                source_name = external_source_name(source, override)
+                {:ok, {override, {:external, source_name}}}
+
+              {:error, _reason} = error ->
+                source_error(error, :component_override)
             end
         end
     end
@@ -474,7 +478,8 @@ defmodule PtcRunner.Kernel.ApplicationPackage do
   defp apply_override(manifest, nil), do: {:ok, manifest, []}
 
   defp apply_override(manifest, {%ComponentOverride{} = override, accounting})
-       when accounting in [:captured, :external] do
+       when accounting == :captured or
+              (is_tuple(accounting) and elem(accounting, 0) == :external) do
     result =
       with {:ok, workflow, missions} <- apply_qualified_override(manifest, override) do
         effective = %{manifest | workflow_components: workflow, missions: missions}
@@ -483,6 +488,13 @@ defmodule PtcRunner.Kernel.ApplicationPackage do
       end
 
     source_error(result, :component_override)
+  end
+
+  defp external_source_name(source, override) do
+    case ApplicationSource.logical_name(source, ComponentOverride.source_path(override)) do
+      {:ok, name} -> name
+      {:error, _reason} -> nil
+    end
   end
 
   defp source_error({:ok, _value} = success, _role), do: success
@@ -799,11 +811,9 @@ defmodule PtcRunner.Kernel.ApplicationPackage do
 
       override_documents =
         Enum.flat_map(override_pairs, fn
-          {_identity, override, :external} ->
-            [
-              {:component_override, :override_descriptor, override.descriptor_bytes},
-              {:component_override, :override_source, byte_size(override.source)}
-            ]
+          {_identity, override, {:external, source_name}} ->
+            [{:component_override, :override_descriptor, override.descriptor_bytes}] ++
+              external_source_document(override, source_name, accounting.captured_names)
 
           {_identity, _override, :captured} ->
             []
@@ -817,6 +827,16 @@ defmodule PtcRunner.Kernel.ApplicationPackage do
       account_documents(added, accounting)
     end
   end
+
+  defp external_source_document(override, source_name, captured_names)
+       when is_binary(source_name) do
+    if MapSet.member?(captured_names, source_name),
+      do: [],
+      else: [{:component_override, :override_source, byte_size(override.source)}]
+  end
+
+  defp external_source_document(override, nil, _captured_names),
+    do: [{:component_override, :override_source, byte_size(override.source)}]
 
   defp account_documents(documents, accounting) do
     initial = {:ok, accounting.document_count, accounting.document_bytes}

--- a/lib/ptc_runner/kernel/application_source.ex
+++ b/lib/ptc_runner/kernel/application_source.ex
@@ -165,12 +165,12 @@ defmodule PtcRunner.Kernel.ApplicationSource do
   @spec finish(t()) ::
           {:ok,
            %{
-             captured_names: MapSet.t(binary()),
+             captured_documents: %{binary() => binary()},
              document_count: non_neg_integer(),
              document_bytes: non_neg_integer()
            }}
           | {:error, atom()}
-  @doc "Verifies memory closure use, returns captured-name accounting, and closes the source."
+  @doc "Verifies memory closure use, returns captured-document accounting, and closes the source."
   def finish(%__MODULE__{pid: pid}) do
     result =
       Agent.get_and_update(pid, fn state ->
@@ -179,7 +179,10 @@ defmodule PtcRunner.Kernel.ApplicationSource do
             :ok ->
               {:ok,
                %{
-                 captured_names: MapSet.new(Map.keys(state.captured)),
+                 captured_documents:
+                   Map.new(state.captured, fn {name, bytes} ->
+                     {name, :crypto.hash(:sha256, bytes)}
+                   end),
                  document_count: map_size(state.captured),
                  document_bytes: state.bytes
                }}

--- a/lib/ptc_runner/kernel/application_source.ex
+++ b/lib/ptc_runner/kernel/application_source.ex
@@ -163,16 +163,26 @@ defmodule PtcRunner.Kernel.ApplicationSource do
   def read(_source, _name, _max_bytes), do: {:error, :invalid_application_source}
 
   @spec finish(t()) ::
-          {:ok, %{document_count: non_neg_integer(), document_bytes: non_neg_integer()}}
+          {:ok,
+           %{
+             captured_names: MapSet.t(binary()),
+             document_count: non_neg_integer(),
+             document_bytes: non_neg_integer()
+           }}
           | {:error, atom()}
-  @doc "Verifies memory closure use, returns accounting, and closes the source."
+  @doc "Verifies memory closure use, returns captured-name accounting, and closes the source."
   def finish(%__MODULE__{pid: pid}) do
     result =
       Agent.get_and_update(pid, fn state ->
         result =
           case all_memory_documents_used(state) do
             :ok ->
-              {:ok, %{document_count: map_size(state.captured), document_bytes: state.bytes}}
+              {:ok,
+               %{
+                 captured_names: MapSet.new(Map.keys(state.captured)),
+                 document_count: map_size(state.captured),
+                 document_bytes: state.bytes
+               }}
 
             {:error, _reason} = error ->
               error

--- a/lib/ptc_runner/kernel/component_override.ex
+++ b/lib/ptc_runner/kernel/component_override.ex
@@ -103,7 +103,8 @@ defmodule PtcRunner.Kernel.ComponentOverride do
     :provenance,
     :descriptor_bytes
   ]
-  defstruct @enforce_keys
+  defstruct @enforce_keys ++
+              [source_path: nil]
 
   @type provenance :: %{optional(binary()) => binary() | boolean()}
 
@@ -115,7 +116,8 @@ defmodule PtcRunner.Kernel.ComponentOverride do
           source: binary(),
           origin: binary(),
           provenance: provenance() | nil,
-          descriptor_bytes: non_neg_integer()
+          descriptor_bytes: non_neg_integer(),
+          source_path: binary() | nil
         }
 
   @type error ::
@@ -151,7 +153,7 @@ defmodule PtcRunner.Kernel.ComponentOverride do
          :ok <- valid_candidate_name(decoded["path"]),
          {:ok, source} <- read_source(directory, decoded["path"]),
          :ok <- verify_source_hash(source, decoded["source_hash"]) do
-      {:ok, override(decoded, raw, source)}
+      {:ok, override(decoded, raw, source, Path.join(directory, decoded["path"]))}
     else
       {:error, {:component_override_path, _path, :invalid_override_descriptor}} = error ->
         error
@@ -307,6 +309,10 @@ defmodule PtcRunner.Kernel.ComponentOverride do
   def attribution(%__MODULE__{provenance: nil}), do: %{}
   def attribution(%__MODULE__{provenance: provenance}), do: provenance
 
+  @doc false
+  @spec source_path(t()) :: binary() | nil
+  def source_path(%__MODULE__{source_path: source_path}), do: source_path
+
   @doc "Hashes component source with the descriptor's `sha256:` convention."
   @spec hash(binary()) :: binary()
   def hash(source) when is_binary(source),
@@ -319,7 +325,7 @@ defmodule PtcRunner.Kernel.ComponentOverride do
     end
   end
 
-  defp override(decoded, descriptor, source) do
+  defp override(decoded, descriptor, source, source_path \\ nil) do
     %__MODULE__{
       target: decoded["target"],
       component_id: decoded["component_id"],
@@ -328,7 +334,8 @@ defmodule PtcRunner.Kernel.ComponentOverride do
       source: source,
       origin: "component-override",
       provenance: decoded["provenance"],
-      descriptor_bytes: byte_size(descriptor)
+      descriptor_bytes: byte_size(descriptor),
+      source_path: source_path
     }
   end
 

--- a/test/ptc_runner/kernel/application_package_test.exs
+++ b/test/ptc_runner/kernel/application_package_test.exs
@@ -595,21 +595,24 @@ defmodule PtcRunner.Kernel.ApplicationPackageTest do
     documents =
       fixture_documents()
       |> Map.put("override.json", descriptor)
+      |> Map.put("Override.json", descriptor)
 
     manifest_path = write_documents(directory, documents)
 
-    assert {:ok, directory_package, _input} =
-             ApplicationPackage.acquire_directory(manifest_path,
-               component_override_descriptor: Path.join(directory, "override.json")
-             )
-
     assert {:ok, memory_package, _input} =
-             ApplicationPackage.acquire_memory("app.json", documents,
+             ApplicationPackage.acquire_memory("app.json", Map.delete(documents, "Override.json"),
                component_override: {"override.json", "workflow.clj"}
              )
 
-    assert directory_package.document_count == memory_package.document_count
-    assert directory_package.document_bytes == memory_package.document_bytes
+    for descriptor_name <- ["override.json", "Override.json"] do
+      assert {:ok, directory_package, _input} =
+               ApplicationPackage.acquire_directory(manifest_path,
+                 component_override_descriptor: Path.join(directory, descriptor_name)
+               )
+
+      assert directory_package.document_count == memory_package.document_count
+      assert directory_package.document_bytes == memory_package.document_bytes
+    end
   end
 
   @tag :tmp_dir

--- a/test/ptc_runner/kernel/application_package_test.exs
+++ b/test/ptc_runner/kernel/application_package_test.exs
@@ -790,7 +790,9 @@ defmodule PtcRunner.Kernel.ApplicationPackageTest do
     File.write!(Path.join(directory, "workflow.clj"), "(ns swapped)")
     assert {:ok, ^original} = ApplicationSource.read(source, "workflow.clj", 2_000_000)
 
-    ApplicationSource.close(source)
+    assert {:ok, %{captured_documents: captured_documents}} = ApplicationSource.finish(source)
+
+    assert captured_documents["workflow.clj"] == :crypto.hash(:sha256, original)
   end
 
   test "memory source preserves a per-document limit failure" do


### PR DESCRIPTION
## Summary

- report captured document identities when closing an application source
- avoid charging an external override candidate twice only when its logical name and verified content match a captured document
- cover the non-portable `Override.json` overlap route and preserve captured content identity across backing-file changes

Closes #1825

## Validation

- `mix test test/ptc_runner/kernel/application_package_test.exs test/ptc_runner/kernel/component_override_test.exs`
- PtcManager independent review passed on `eea5fd72`

## Retrospective

- Untracked follow-up work with a reproduction: none
- Repository instruction that was missing, wrong, or guessed: none