### PR TITLE
fix(cli): show missing application input paths

### DIFF
--- a/lib/ptc_runner/kernel/command_diagnostic_renderer.ex
+++ b/lib/ptc_runner/kernel/command_diagnostic_renderer.ex
@@ -7,6 +7,7 @@ defmodule PtcRunner.Kernel.CommandDiagnosticRenderer do
 
   @pointer_pattern ~r/\A\/[A-Za-z0-9._~\/-]+\z/
   @source_name_pattern ~r/\A[A-Za-z0-9._~-][A-Za-z0-9._~\/-]*\z/
+  @terminal_path_pattern ~r/\A[^\x00-\x1F\x7F]+\z/u
 
   @spec render(CommandDiagnostic.t()) :: {:ok, binary()} | {:error, :invalid_command_diagnostic}
   def render(%CommandDiagnostic{} = diagnostic) do
@@ -61,8 +62,11 @@ defmodule PtcRunner.Kernel.CommandDiagnosticRenderer do
          opts
        ) do
     case Keyword.fetch(opts, :application_path) do
-      {:ok, path} when is_binary(path) and path != "" -> " at " <> path
-      _absent -> ""
+      {:ok, path} when is_binary(path) and path != "" ->
+        " at " <> terminal_literal(path, @terminal_path_pattern)
+
+      _absent ->
+        ""
     end
   end
 

--- a/lib/ptc_runner/kernel/command_diagnostic_renderer.ex
+++ b/lib/ptc_runner/kernel/command_diagnostic_renderer.ex
@@ -20,35 +20,53 @@ defmodule PtcRunner.Kernel.CommandDiagnosticRenderer do
   @doc false
   @spec render_with_run_ref(CommandDiagnostic.t() | CommandOutcome.t(), binary()) ::
           {:ok, binary()} | {:error, :invalid_command_diagnostic}
-  def render_with_run_ref(%CommandDiagnostic{} = diagnostic, run_ref) do
+  def render_with_run_ref(diagnostic, run_ref), do: render_with_run_ref(diagnostic, run_ref, [])
+
+  @doc false
+  @spec render_with_run_ref(CommandDiagnostic.t() | CommandOutcome.t(), binary(), keyword()) ::
+          {:ok, binary()} | {:error, :invalid_command_diagnostic}
+  def render_with_run_ref(%CommandDiagnostic{} = diagnostic, run_ref, opts) when is_list(opts) do
     if CommandDiagnostic.valid?(diagnostic) and CommandRunRef.valid?(run_ref),
-      do: {:ok, render_map(CommandDiagnostic.to_map(diagnostic), run_ref)},
+      do: {:ok, render_map(CommandDiagnostic.to_map(diagnostic), run_ref, opts)},
       else: {:error, :invalid_command_diagnostic}
   end
 
-  def render_with_run_ref(%CommandOutcome{} = outcome, run_ref) do
+  def render_with_run_ref(%CommandOutcome{} = outcome, run_ref, opts) when is_list(opts) do
     with true <- CommandOutcome.valid?(outcome),
          true <- CommandRunRef.valid?(run_ref),
          %{"error" => error} <- CommandOutcome.to_map(outcome) do
-      {:ok, render_map(error, run_ref)}
+      {:ok, render_map(error, run_ref, opts)}
     else
       _invalid -> {:error, :invalid_command_diagnostic}
     end
   end
 
-  def render_with_run_ref(_diagnostic, _run_ref),
+  def render_with_run_ref(_diagnostic, _run_ref, _opts),
     do: {:error, :invalid_command_diagnostic}
 
-  defp render_map(error, run_ref) do
+  defp render_map(error, run_ref, opts \\ []) do
     base =
       "#{error["phase"]}/#{error["code"]}: " <>
         subject_prefix(error["subject"]) <>
         error["message"] <>
-        location_suffix(error)
+        location_suffix(error) <>
+        local_context_suffix(error, opts)
 
     run_ref_suffix = if run_ref, do: " (run_ref: #{run_ref})", else: ""
     base <> run_ref_suffix <> diagnostic_suffix(error)
   end
+
+  defp local_context_suffix(
+         %{"phase" => "application", "code" => "application_not_found"},
+         opts
+       ) do
+    case Keyword.fetch(opts, :application_path) do
+      {:ok, path} when is_binary(path) and path != "" -> " at " <> path
+      _absent -> ""
+    end
+  end
+
+  defp local_context_suffix(_error, _opts), do: ""
 
   defp diagnostic_suffix(%{
          "phase" => "active_preflight",

--- a/lib/ptc_runner/kernel/command_diagnostic_renderer.ex
+++ b/lib/ptc_runner/kernel/command_diagnostic_renderer.ex
@@ -7,7 +7,7 @@ defmodule PtcRunner.Kernel.CommandDiagnosticRenderer do
 
   @pointer_pattern ~r/\A\/[A-Za-z0-9._~\/-]+\z/
   @source_name_pattern ~r/\A[A-Za-z0-9._~-][A-Za-z0-9._~\/-]*\z/
-  @terminal_path_pattern ~r/\A[^\x00-\x1F\x7F]+\z/u
+  @terminal_path_pattern ~r/\A[^\p{Cc}\p{Cf}\p{Zl}\p{Zp}]+\z/u
 
   @spec render(CommandDiagnostic.t()) :: {:ok, binary()} | {:error, :invalid_command_diagnostic}
   def render(%CommandDiagnostic{} = diagnostic) do

--- a/lib/ptc_runner/kernel/command_frontend.ex
+++ b/lib/ptc_runner/kernel/command_frontend.ex
@@ -12,6 +12,8 @@ defmodule PtcRunner.Kernel.CommandFrontend do
   alias PtcRunner.Kernel.CommandRenderer
   alias PtcRunner.Kernel.CommandRuntime
   alias PtcRunner.Kernel.ProjectArtifactRoot
+  alias PtcRunner.Kernel.ProjectConfig
+  alias PtcRunner.Kernel.ProjectContext
 
   @frontend_commands CommandDeclaration.frontend_commands()
 
@@ -123,7 +125,7 @@ defmodule PtcRunner.Kernel.CommandFrontend do
 
     case result do
       :ok ->
-        rendered_presentation(outcome, path, rejection, named_env_file?)
+        rendered_presentation(entry, outcome, path, rejection, named_env_file?)
 
       {:error, reason} ->
         presentation(
@@ -136,12 +138,15 @@ defmodule PtcRunner.Kernel.CommandFrontend do
     end
   end
 
-  defp present(%CommandEntry{}, %CommandOutcome{} = outcome, rejection, named_env_file?) do
-    rendered_presentation(outcome, nil, rejection, named_env_file?)
+  defp present(%CommandEntry{} = entry, %CommandOutcome{} = outcome, rejection, named_env_file?) do
+    rendered_presentation(entry, outcome, nil, rejection, named_env_file?)
   end
 
-  defp rendered_presentation(outcome, envelope_path, rejection, named_env_file?) do
-    render_options = [named_env_file: named_env_file?]
+  defp rendered_presentation(entry, outcome, envelope_path, rejection, named_env_file?) do
+    render_options = [
+      named_env_file: named_env_file?,
+      application_path: terminal_application_path(entry.arguments)
+    ]
 
     case CommandRenderer.render(outcome, rejection, render_options) do
       {:stdout, bytes} ->
@@ -154,6 +159,18 @@ defmodule PtcRunner.Kernel.CommandFrontend do
         presentation(outcome, envelope_path, stdout, stderr, outcome.exit_status)
     end
   end
+
+  defp terminal_application_path(%CommandArguments{
+         project: %ProjectContext{
+           config: %ProjectConfig{application: application, directory: directory}
+         }
+       }),
+       do: Path.relative_to(application, directory)
+
+  defp terminal_application_path(%CommandArguments{application: application}),
+    do: application
+
+  defp terminal_application_path(_arguments), do: nil
 
   defp presentation(outcome, envelope_path, stdout, stderr, exit_status) do
     %CommandPresentation{

--- a/lib/ptc_runner/kernel/command_renderer.ex
+++ b/lib/ptc_runner/kernel/command_renderer.ex
@@ -13,8 +13,10 @@ defmodule PtcRunner.Kernel.CommandRenderer do
   response, credential, or unvalidated path. Component compile failures with a
   proven byte span render the logical component name and canonical half-open
   byte range already present in the envelope; rendering does not retain or
-  reopen component source. A replay miss may include only its validated opaque
-  request hash.
+  reopen component source. The one local-only exception is an unreadable
+  application input: its caller-supplied positional path, or a loaded project's
+  validated relative application path, is appended without entering the sealed
+  diagnostic. A replay miss may include only its validated opaque request hash.
   """
 
   alias PtcRunner.Kernel.ArtifactRootDiagnostic
@@ -85,7 +87,7 @@ defmodule PtcRunner.Kernel.CommandRenderer do
       %{"status" => "error", "run_ref" => run_ref} = envelope ->
         {:stderr,
          warning_lines(envelope) <>
-           (failure_line(outcome, run_ref, rejection)
+           (failure_line(outcome, run_ref, rejection, opts)
             |> append_named_env_file_hint(envelope, opts)) <>
            evaluation_line(envelope)}
     end
@@ -148,11 +150,11 @@ defmodule PtcRunner.Kernel.CommandRenderer do
   def rejection(run_ref, %CommandRejection{} = rejection) do
     row = DiagnosticCatalog.fetch!(:arguments, rejection.code)
     diagnostic = CommandDiagnostic.new!(:arguments, rejection.code, message: row.message)
-    failure_line(diagnostic, run_ref, rejection)
+    failure_line(diagnostic, run_ref, rejection, [])
   end
 
-  defp failure_line(diagnostic, run_ref, rejection) do
-    {:ok, rendered} = CommandDiagnosticRenderer.render_with_run_ref(diagnostic, run_ref)
+  defp failure_line(diagnostic, run_ref, rejection, opts) do
+    {:ok, rendered} = CommandDiagnosticRenderer.render_with_run_ref(diagnostic, run_ref, opts)
     "error: " <> rendered <> rejection_suffix(rejection) <> "\n"
   end
 

--- a/test/mix/tasks/ptc_test.exs
+++ b/test/mix/tasks/ptc_test.exs
@@ -311,6 +311,28 @@ defmodule Mix.Tasks.PtcTest do
   end
 
   @tag :tmp_dir
+  test "a missing application path with terminal controls is safely quoted", %{tmp_dir: dir} do
+    missing_positional = "missing\nforged-error.json"
+    envelope_path = Path.join(dir, "controlled-path-envelope.json")
+
+    presentation =
+      MixCommandAdapter.execute([
+        "validate",
+        missing_positional,
+        "--envelope",
+        envelope_path
+      ])
+
+    assert presentation.exit_status == 3
+    assert presentation.stderr =~ ~S(at "missing\nforged-error.json" (run_ref: cmd-)
+    refute presentation.stderr =~ "at missing\nforged-error.json"
+
+    envelope = envelope_path |> File.read!() |> Jason.decode!()
+    assert envelope["run_ref"] =~ "cmd-"
+    refute Jason.encode!(envelope) =~ "forged-error.json"
+  end
+
+  @tag :tmp_dir
   test "root command names a missing manifest property", %{tmp_dir: dir} do
     manifest_path = write_manifest(dir, %{"value" => 1})
 

--- a/test/mix/tasks/ptc_test.exs
+++ b/test/mix/tasks/ptc_test.exs
@@ -236,6 +236,81 @@ defmodule Mix.Tasks.PtcTest do
   end
 
   @tag :tmp_dir
+  test "missing application inputs add paths only to local terminal errors", %{tmp_dir: dir} do
+    for {command, missing_positional} <- [
+          {"run", "does-not-exist/ptc-project.json"},
+          {"validate", "does-not-exist/ptc-project.json"},
+          {"run", "does-not-exist/direct-manifest.json"},
+          {"validate", "does-not-exist/direct-manifest.json"}
+        ] do
+      envelope_path =
+        Path.join(dir, "#{command}-#{Path.basename(missing_positional)}-envelope.json")
+
+      presentation =
+        MixCommandAdapter.execute([
+          command,
+          missing_positional,
+          "--envelope",
+          envelope_path
+        ])
+
+      assert presentation.exit_status == 3
+      assert presentation.stdout == ""
+
+      assert presentation.stderr =~
+               "error: application/application_not_found: " <>
+                 "the application manifest does not exist at #{missing_positional}"
+
+      assert presentation.stderr =~ "(run_ref: cmd-"
+
+      envelope = envelope_path |> File.read!() |> Jason.decode!()
+      assert envelope["run_ref"] =~ "cmd-"
+      assert envelope["error"]["code"] == "application_not_found"
+      refute Jason.encode!(envelope) =~ missing_positional
+    end
+  end
+
+  @tag :tmp_dir
+  test "a missing project application renders its project-visible path only locally", %{
+    tmp_dir: dir
+  } do
+    project_path = Path.join(dir, "ptc-project.json")
+    envelope_path = Path.join(dir, "missing-project-application-envelope.json")
+
+    File.write!(
+      project_path,
+      Jason.encode!(%{
+        "kind" => "ptc-project",
+        "version" => 1,
+        "application" => %{"path" => "missing-application.json"}
+      })
+    )
+
+    presentation =
+      MixCommandAdapter.execute([
+        "run",
+        project_path,
+        "--envelope",
+        envelope_path
+      ])
+
+    assert presentation.exit_status == 3
+
+    assert presentation.stderr =~
+             "application/application_not_found: " <>
+               "the application manifest does not exist at missing-application.json"
+
+    refute presentation.stderr =~ "does-not-exist/ptc-project.json"
+    assert presentation.stderr =~ "(run_ref: cmd-"
+
+    envelope = envelope_path |> File.read!() |> Jason.decode!()
+    assert envelope["run_ref"] =~ "cmd-"
+    assert envelope["error"]["code"] == "application_not_found"
+    refute Jason.encode!(envelope) =~ "missing-application.json"
+    refute Jason.encode!(envelope) =~ project_path
+  end
+
+  @tag :tmp_dir
   test "root command names a missing manifest property", %{tmp_dir: dir} do
     manifest_path = write_manifest(dir, %{"value" => 1})
 

--- a/test/ptc_runner/kernel/command_frontend_test.exs
+++ b/test/ptc_runner/kernel/command_frontend_test.exs
@@ -1193,6 +1193,25 @@ defmodule PtcRunner.Kernel.CommandFrontendTest do
                 "at /sum in work.schema.json (run_ref: #{@run_ref})\n"}
   end
 
+  test "application paths escape Unicode terminal controls" do
+    outcome =
+      valid_outcome(CommandDiagnostic.new!(:application, :application_not_found))
+
+    for {control, escaped} <- [
+          {"\u009B", ~S(\x9B)},
+          {"\u2028", ~S(\u2028)},
+          {"\u202E", ~S(\u202E)}
+        ] do
+      path = "missing#{control}forged-error.json"
+
+      assert CommandRenderer.render(outcome, nil, application_path: path) ==
+               {:stderr,
+                "error: application/application_not_found: " <>
+                  "the application manifest does not exist at " <>
+                  ~s|"missing#{escaped}forged-error.json" (run_ref: #{@run_ref})\n|}
+    end
+  end
+
   test "structured argument rejections and envelope publication match exact fixtures" do
     for {name, argv} <- [
           {"unknown_switch", ["run", "ptc.json", "--caller-secret", "value"]},


### PR DESCRIPTION
## Summary

- add missing application paths to local terminal diagnostics for positional inputs and project references
- keep canonical diagnostics and JSON envelopes path-free while retaining `run_ref` and exit statuses
- quote paths containing ASCII or Unicode terminal controls to prevent forged or misleading output

Closes #1726

## Validation

- `mix test test/mix/tasks/ptc_test.exs test/ptc_runner/kernel/command_frontend_test.exs`
- PtcManager independent review passed on `7f72315d08f40ce8bea10aab02008409afe5ec22`

## Retrospective

- Untracked follow-up work: none
- Missing, wrong, or guessed repository instruction: none