### PR TITLE
fix(cli): classify inspect-only compile failures

### DIFF
--- a/lib/ptc_runner/kernel/inspect_only_repl.ex
+++ b/lib/ptc_runner/kernel/inspect_only_repl.ex
@@ -109,7 +109,7 @@ defmodule PtcRunner.Kernel.InspectOnlyRepl do
   defp compile_selected(package, nil) do
     deadline = System.monotonic_time(:millisecond) + @compile_timeout_ms
 
-    with {:ok, bundle} <- BundleCompiler.compile(package.workflow_components, deadline),
+    with {:ok, bundle} <- compile_bundle(package.workflow_components, deadline),
          :ok <- RunCoordinator.validate_entry(bundle, package.entry),
          {:ok, _intern, catalog} <-
            ComponentCatalog.build(package.workflow_components, bundle),
@@ -134,7 +134,7 @@ defmodule PtcRunner.Kernel.InspectOnlyRepl do
   defp compile_mission(name, spec) do
     deadline = System.monotonic_time(:millisecond) + @compile_timeout_ms
 
-    with {:ok, bundle} <- BundleCompiler.compile(spec.components, deadline),
+    with {:ok, bundle} <- compile_bundle(spec.components, deadline),
          {:ok, _intern, catalog} <- ComponentCatalog.build(spec.components, bundle),
          {:ok, environment} <-
            MissionEnvironment.new(
@@ -152,6 +152,22 @@ defmodule PtcRunner.Kernel.InspectOnlyRepl do
       }
 
       {:ok, workflow, %{name => environment}, mode}
+    end
+  end
+
+  defp compile_bundle(components, deadline) do
+    case BundleCompiler.compile(components, deadline) do
+      {:ok, bundle} ->
+        {:ok, bundle}
+
+      {:error, reason} ->
+        case RunCoordinator.classify_bundle_failure(reason, components) do
+          {:ok, diagnostic} ->
+            {:error, %{code: diagnostic.code, diagnostic: diagnostic}}
+
+          :error ->
+            {:error, reason}
+        end
     end
   end
 end

--- a/lib/ptc_runner/kernel/run_coordinator.ex
+++ b/lib/ptc_runner/kernel/run_coordinator.ex
@@ -49,6 +49,18 @@ defmodule PtcRunner.Kernel.RunCoordinator do
 
   @mission_compile_timeout_ms 5_000
   @mission_bundles_bytes 4_000_000
+  @bundle_limit_reasons [
+    :bundle_limit_exceeded,
+    :bundle_artifact_exceeded,
+    :bundle_diagnostic_exceeded,
+    :bundle_compile_heap_exceeded,
+    :bundle_compile_timeout
+  ]
+  @bundle_compile_reasons [
+    :component_compile_error,
+    :bundle_compile_error,
+    :bundle_compile_failed
+  ]
 
   @spec prepare(RunRequest.t(), InstallationCatalog.t()) ::
           {:ok, PreparedRun.t()} | {:error, CommandDiagnostic.t()}
@@ -404,18 +416,21 @@ defmodule PtcRunner.Kernel.RunCoordinator do
   defp external_size(nil), do: 0
   defp external_size(bundle), do: :erlang.external_size(bundle)
 
+  @doc false
+  @spec classify_bundle_failure(term(), [Component.t()]) ::
+          {:ok, CommandDiagnostic.t()} | :error
+  def classify_bundle_failure(%{reason: reason} = failure, components)
+      when reason in @bundle_limit_reasons or reason in @bundle_compile_reasons,
+      do: {:ok, bundle_diagnostic(failure, components)}
+
+  def classify_bundle_failure(_failure, _components), do: :error
+
   defp bundle_diagnostic(%{reason: reason} = failure, components)
-       when reason in [
-              :bundle_limit_exceeded,
-              :bundle_artifact_exceeded,
-              :bundle_diagnostic_exceeded,
-              :bundle_compile_heap_exceeded,
-              :bundle_compile_timeout
-            ],
+       when reason in @bundle_limit_reasons,
        do: diagnostic(:bundle, :bundle_limit_exceeded, source_opts(failure, components))
 
   defp bundle_diagnostic(%{reason: reason} = failure, components)
-       when reason in [:component_compile_error, :bundle_compile_error, :bundle_compile_failed] do
+       when reason in @bundle_compile_reasons do
     {code, opts} = compile_diagnostic(failure, components)
     diagnostic(:bundle, code, opts)
   end

--- a/test/mix/tasks/ptc_repl_test.exs
+++ b/test/mix/tasks/ptc_repl_test.exs
@@ -881,6 +881,40 @@ defmodule PtcRunner.ReplFrontendTest do
   end
 
   @tag :tmp_dir
+  test "inspect-only classifies component compile failures for manifest and project forms", %{
+    tmp_dir: directory
+  } do
+    for {source, expected} <- [
+          {
+            "(ns den.main \"Invalid syntax fixture.\")\n\n" <>
+              "(defn run [input]\n  (return {\"a\" 1)\n",
+            "bundle/syntax_invalid: the component source is not valid PTC-Lisp at " <>
+              "main.clj bytes [75,75)"
+          },
+          {
+            "(ns den.main \"Invalid syntax fixture.\")\n\n" <>
+              "(defn run [input]\n  " <>
+              "(return (kernel/eval-mission \"worker\" \"(den.worker/ask)\")))\n",
+            "bundle/compile_failed: the component bundle could not be compiled"
+          }
+        ] do
+      {manifest_path, project_path} =
+        write_inspect_only_compile_failure(directory, source)
+
+      for args <- [
+            ["--manifest", manifest_path, "--inspect-only", "-e", "(+ 1 1)"],
+            ["--project", project_path, "--inspect-only", "-e", "(+ 1 1)"]
+          ] do
+        error = assert_raise Mix.Error, fn -> run_repl(args) end
+
+        assert error.message =~ "error: repl/command_failed: #{expected}"
+        refute error.message =~ "ptc repl setup failed"
+        refute error.message =~ "%{"
+      end
+    end
+  end
+
+  @tag :tmp_dir
   test "inspect-only project uses its host limit ceiling without resolving credentials", %{
     tmp_dir: directory
   } do
@@ -2881,6 +2915,40 @@ defmodule PtcRunner.ReplFrontendTest do
     )
 
     project_path
+  end
+
+  defp write_inspect_only_compile_failure(directory, source) do
+    File.write!(Path.join(directory, "main.clj"), source)
+
+    manifest_path = Path.join(directory, "ptc.json")
+
+    File.write!(
+      manifest_path,
+      Jason.encode!(%{
+        "version" => 1,
+        "workflow" => %{
+          "components" => [
+            %{"id" => "den.main", "path" => "main.clj", "dependencies" => ["kernel"]},
+            %{"library" => "kernel"}
+          ],
+          "entry" => "den.main/run"
+        },
+        "input" => %{"value" => %{}}
+      })
+    )
+
+    project_path = Path.join(directory, "ptc-project.json")
+
+    File.write!(
+      project_path,
+      Jason.encode!(%{
+        "kind" => "ptc-project",
+        "version" => 1,
+        "application" => %{"path" => "ptc.json"}
+      })
+    )
+
+    {manifest_path, project_path}
   end
 
   defp repl_llm_installation(credential) do


### PR DESCRIPTION
## Summary

- route inspect-only workflow and mission bundle failures through the shared `RunCoordinator` diagnostic classifier
- render sealed syntax and compile diagnostics through the existing REPL setup-diagnostic path while preserving the generic fallback for unknown shapes
- cover syntax and unresolved-export failures through both `--manifest` and `--project` inspect-only commands

## Validation

- `mix test test/mix/tasks/ptc_repl_test.exs`
- `mix test test/mix/tasks/ptc_repl_test.exs:884 test/ptc_runner/kernel/inspect_only_repl_test.exs`

## Retrospective

- Untracked follow-up work: none.
- Repository instruction that was missing, wrong, or guessed: none.

Closes #1850
