### PR TITLE
ci(nightly): fetch and cache the DABStep dataset

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -63,6 +63,30 @@ jobs:
       - name: Compile
         run: mix compile --warnings-as-errors
 
+      # `PtcRunner.Kernel.DabstepReviewerRegressionTest` replays a recorded
+      # multi-turn run against the real DABStep `payments.csv`. The file is
+      # gitignored -- 24MB does not belong in the tree or in the Hex package --
+      # so the job has to fetch it, and without it the suite fails on a missing
+      # path rather than on anything about this commit.
+      #
+      # The cache key is the fetch script, which carries the pinned dataset
+      # revision and all four checksums: change a pin and the key changes with
+      # it. A daily run keeps the entry warm, so the download happens roughly
+      # once rather than nightly. `fetch-data.sh` verifies the checksums of
+      # whatever is already on disk, so a restored cache is still proven before
+      # the suite reads a byte of it.
+      - name: Cache the DABStep dataset
+        uses: actions/cache@v5
+        with:
+          path: |
+            examples/dabstep-fraud/data
+            examples/dabstep-fraud/reference
+          key: dabstep-${{ hashFiles('examples/dabstep-fraud/fetch-data.sh') }}
+
+      - name: Fetch and verify the DABStep dataset
+        run: ./fetch-data.sh
+        working-directory: examples/dabstep-fraud
+
       - name: Run the nightly test suite
         run: mix nightly
 

--- a/examples/dabstep-fraud/fetch-data.sh
+++ b/examples/dabstep-fraud/fetch-data.sh
@@ -39,6 +39,22 @@ require_hash() {
   fi
 }
 
+# Downloading is the slow path, not the contract. The pinned checksums are the
+# contract, so verify whatever is already on disk first and re-download only
+# what fails. That makes the script idempotent for a second local run and lets
+# CI restore `data/` from a cache and still prove the bytes on every job.
+matches_pin() {
+  [ -f "$2" ] && [ "$(sha256 "$2")" = "$1" ]
+}
+
+if matches_pin "$payments_sha256" data/payments.csv &&
+  matches_pin "$dev_sha256" reference/dev.jsonl &&
+  matches_pin "$manual_sha256" reference/context/manual.md &&
+  matches_pin "$payments_readme_sha256" reference/context/payments-readme.md; then
+  printf '%s\n' 'DABStep dataset already present and matches the pinned checksums'
+  exit 0
+fi
+
 curl --fail --location --show-error "$payments_url" -o "$payments_tmp"
 curl --fail --location --show-error "$dev_url" -o "$dev_tmp"
 curl --fail --location --show-error "$manual_url" -o "$manual_tmp"


### PR DESCRIPTION
## Summary

- Add a cache + fetch step to `.github/workflows/nightly.yml` so the job has `examples/dabstep-fraud/data/payments.csv` before `mix nightly` runs. The nightly has failed every night since `7ef1a3d34` (2026-09-03): two cases on `File.CopyError ... no such file or directory` and three on `{:error, :mcp_transport_error}`, the latter because `ptc-fs-mcp --root data` cannot start without the root.
- Key the cache on the fetch script's hash. It carries the pinned revision and all four checksums, so changing a pin rotates the key; a daily run keeps the entry warm, so the 24MB download happens roughly once rather than nightly.
- Make `examples/dabstep-fraud/fetch-data.sh` verify what is already on disk and re-download only on a mismatch. That keeps the checksum proof on the cache-hit path rather than skipping the script, and makes a second local run cheap.

This also unblocks the `Check evaluator reduction baselines` step, which has not run since 2026-09-03 because `mix nightly` aborts first (see #1870).

## Validation

- The five `PtcRunner.Kernel.DabstepReviewerRegressionTest` cases fail identically to CI on a checkout without the dataset, and all five pass with it present.
- `./fetch-data.sh` exits in 0.7s on a good tree, re-downloads and repairs after a corrupted file, and returns to the fast path.
- `shellcheck` and `actionlint` clean.
- Pushed without the pre-push hook at the maintainer's request; CI is the gate for this branch. Note that `core release verification` failed twice in the hook's concurrent lane while passing standalone three times — see Retrospective.

## Retrospective

- Follow-up: `scripts/ci/core-release.sh` fails inside the pre-push concurrent fan-out and passes when run on its own. It dies silently in `scripts/verify_standalone_release.sh` between `mix release` finishing and the `find` on the interrupt fixture, producing no output in the lane log. Reproduction: run a full `git push` on a core-touching branch; the lane reports `core release verification failed after ~130s` with the log ending at "To list all commands:". Running the three lanes concurrently by hand does not reproduce it, so `core-tests.sh` running first appears to matter.
- Repository instruction: `CLAUDE.md` says "Never push with `--no-verify`" while offering `PTC_PRE_PUSH_SERIAL=1` as the remedy for a failing lane. It does not say what to do when a gate fails only inside the fan-out and the serial path is too slow to wait on, which is the case that actually came up.

Closes #1869

https://claude.ai/code/session_01U2ZNYtMZM8wjYgU6MXLr1S