### PR TITLE
fix(examples): give the parallel fan-out real timeout headroom

### DIFF
--- a/examples/kernel-tutorial/07-parallel-fan-out/ptc.json
+++ b/examples/kernel-tutorial/07-parallel-fan-out/ptc.json
@@ -26,9 +26,9 @@
     }
   },
   "limits": {
-    "run_duration_ms": 120000,
-    "workflow_timeout_ms": 110000,
-    "parallel_timeout_ms": 60000
+    "run_duration_ms": 195000,
+    "workflow_timeout_ms": 180000,
+    "parallel_timeout_ms": 120000
   },
   "providers": {
     "workflow": [

--- a/test/ptc_runner/kernel/tutorial_cost_budget_test.exs
+++ b/test/ptc_runner/kernel/tutorial_cost_budget_test.exs
@@ -18,6 +18,7 @@ defmodule PtcRunner.Kernel.TutorialCostBudgetTest do
   test "the cost-budget tutorial exits 6 before provider dispatch", %{tmp_dir: tmp_dir} do
     tutorial = Path.join(tmp_dir, "kernel-tutorial")
     File.cp_r!(@examples, tutorial)
+    File.rm_rf!(Path.join(tutorial, "06-cost-budget/.ptc"))
 
     env_file = Path.join(tutorial, ".env")
     File.write!(env_file, "OPENROUTER_API_KEY=sentinel-not-a-real-key\n")

--- a/test/ptc_runner/kernel/viewer_project_adapter_test.exs
+++ b/test/ptc_runner/kernel/viewer_project_adapter_test.exs
@@ -55,10 +55,10 @@ defmodule PtcRunner.Kernel.ViewerProjectAdapterTest do
 
       by_name = Map.new(project.limits, &{&1.name, &1})
 
-      assert %{effective: 120_000, default: 30_000, unit: :milliseconds} =
+      assert %{effective: 195_000, default: 30_000, unit: :milliseconds} =
                by_name["run_duration_ms"]
 
-      assert %{effective: 110_000, default: 30_000} = by_name["workflow_timeout_ms"]
+      assert %{effective: 180_000, default: 30_000} = by_name["workflow_timeout_ms"]
 
       untouched = by_name["subordinate_evaluations"]
       assert untouched.effective == untouched.default


### PR DESCRIPTION
## Summary

- `07-parallel-fan-out` set `parallel_timeout_ms` to `60000`, exactly the documented default (`docs/kernel-limits-reference.md:61`), leaving no headroom for twelve concurrent six-to-eight sentence generations. A CLI run of the shipped manifest failed with `execution/runtime_limit_exceeded: parallel_timeout_ms limit 60000 ms was exceeded`; the retry passed. `docs/agent-library-reference.md:720` already tells authors to leave headroom for the parallel phase.
- The pmap budget is clamped by the run deadline, so raising it alone is a no-op. All three clocks move together (`run_duration_ms` 195000, `workflow_timeout_ms` 180000, `parallel_timeout_ms` 120000) and the post-pmap synthesis call keeps its share.
- `tutorial_cost_budget_test` copies the whole `examples/kernel-tutorial` tree into its tmp_dir, including any `.ptc` run artifacts an operator left in the checkout by running an example by hand. Those are mode 0700, so the copied destination is rejected and the test fails with `invalid_destination` and exit status 7 rather than the asserted 6. `support_triage_examples_test` already removes its own; this does the same.

Found by running every example's documented commands through a packaged release rather than the suite: the example tests use the `:native` projection while the CLI forces `:json`, so neither failure is reachable from CI.

## Validation

- Three consecutive live CLI runs of `07-parallel-fan-out` through a prod release, all exit 0.
- `tutorial_cost_budget_test` against a seeded mode-0700 `.ptc` directory: exit status 7 / `invalid_destination` before the cleanup line, passing after it.

## Retrospective

- Follow-up: `openrouter:google/gemini-3.8-flash`, pinned by three `debug-a-failed-run` hosts, is absent from the pinned `llm_db 2026.8.4` and warns `model_uncataloged` on every run. It is catalogued in `llm_db 2026.9`, reachable by bumping `req_llm` to 1.22.0. The catalog guard test (`tutorial_examples_contract_test.exs:11`) hand-lists five host/alias pairs and so never covered those hosts; deriving the list from the tree raises coverage to 13 installations but fails without the dependency bump, so the two belong together in their own PR. Both are implemented and verified locally, held back because `req_llm` is the LLM integration layer and `:e2e` does not run per-PR.
- Repository instruction: none.

https://claude.ai/code/session_01CGsp7agXEeCgLcsCtaJHZp