### PR TITLE
ci(ptc): fetch the DABStep dataset into managed worktrees

### DIFF
--- a/scripts/ptc/bootstrap
+++ b/scripts/ptc/bootstrap
@@ -6,3 +6,34 @@ set -euo pipefail
 # fetch dependencies, and validate the pinned toolchain before an agent starts.
 ./scripts/worktree.sh seed .
 ./scripts/worktree.sh init .
+
+# `mix nightly` reads the real DABStep dataset, which is gitignored and fetched
+# out of band, so a fresh worktree starts without it and five nightly cases
+# fail: two on the missing `examples/dabstep-fraud/data/payments.csv`, three on
+# `:mcp_transport_error`, because `ptc-fs-mcp --root data` cannot start without
+# the root. AGENTS.md requires `mix nightly` for the `mix ptc run` downstream
+# path, so an agent sent at that path is blocked on a prerequisite it cannot
+# restore itself -- it is told not to create worktrees, and the failure only
+# surfaces at the end of a long validation run. `nightly.yml` already fetches
+# the same dataset for CI; this is the same restore for a managed worktree.
+dabstep=examples/dabstep-fraud
+main_checkout="$(git worktree list --porcelain |
+  awk '/^worktree /{sub(/^worktree /, ""); print; exit}')"
+
+# The main checkout is the cache here too, exactly as it is for the build
+# artifacts above. Correctness never rests on the copy: fetch-data.sh verifies
+# whatever is on disk against its pinned checksums and re-downloads only what
+# fails, so a torn copy heals itself and a good one costs no network.
+for cached in data reference; do
+  if [ ! -e "$dabstep/$cached" ] && [ -d "$main_checkout/$dabstep/$cached" ]; then
+    cp -Rp "$main_checkout/$dabstep/$cached" "$dabstep/$cached" ||
+      rm -rf "${dabstep:?}/$cached"
+  fi
+done
+
+# Never fatal. A task that never reaches the nightly path must still start when
+# the dataset host is unreachable; it then fails at `mix nightly` exactly as it
+# does today, with the message that names the missing fixture.
+if ! (cd "$dabstep" && ./fetch-data.sh); then
+  printf '%s\n' "⚠️  DABStep dataset unavailable — mix nightly will fail until it is fetched" >&2
+fi


### PR DESCRIPTION
## Summary

- `scripts/ptc/bootstrap` now restores the DABStep dataset into a managed worktree, after seeding build artifacts and initializing the worktree.
- It reuses the main checkout's `examples/dabstep-fraud/{data,reference}` when present — the same "main checkout is the cache" rule the build artifacts already follow — then runs `fetch-data.sh`, which verifies whatever is on disk against its pinned checksums and re-downloads only what fails. A torn copy heals; a good one costs no network.
- The fetch is never fatal. A task that never reaches the nightly path still starts when the dataset host is unreachable, and then fails at `mix nightly` exactly as it does today.

Why: `mix nightly` reads the real dataset, which is gitignored and fetched out of band, so every managed worktree started without it and five `DabstepReviewerRegressionTest` cases failed — two on the missing `payments.csv`, three on `:mcp_transport_error`, because `ptc-fs-mcp --root data` cannot start without the root. AGENTS.md requires `mix nightly` for the `mix ptc run` downstream path, so an agent sent there is blocked on a prerequisite it cannot restore itself: it is told not to create worktrees, and the failure surfaces only at the end of a long validation run. #1871 closed this gap for CI; this closes it for a managed worktree.

This is the blocker that stopped the #1856 implementation three times in a row, each time with the same `missing_prerequisite` stop report. It does not fix #1856 itself, which remains open and unimplemented.

## Validation

- The five `DabstepReviewerRegressionTest` cases pass in a worktree created by the modified bootstrap.
- Warm main checkout: resolves with no network. Cold main checkout: downloads and matches the pinned `payments.csv` checksum. Unreachable host: warns and exits 0, so bootstrap still succeeds.
- `shellcheck -s bash scripts/ptc/bootstrap` clean.

## Retrospective

- Follow-up: `/srv/ptc_runner` on the production worker has no `examples/dabstep-fraud/data`, so every managed worktree there will download ~22 MB until someone warms it once with `cd /srv/ptc_runner/examples/dabstep-fraud && ./fetch-data.sh` as `ptc-manager-worker`. Correctness does not depend on it; only the network cost does.
- Repository instruction: AGENTS.md says a pull request "closes its issue with `Closes #N`", but gives no form for a PR that has no tracking issue. This one has none, so it references the issues it relates to instead.

https://claude.ai/code/session_01VabSAmbwv2GbpeAkiGgKk8