### PR TITLE
fix(artifacts): reserve command envelopes at admission

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -158,7 +158,12 @@ Useful run switches are:
   `.ptcins` file.
 - `--envelope FILE` atomically publishes a convenience copy of the stable V4
   command envelope. When a project enables `artifacts.envelope`, the project's
-  `.ptc/envelopes/<run_ref>.json` ledger entry is still written for that run.
+  `.ptc/envelopes/<run_ref>.json` ledger entry is written independently for that
+  run. The explicit path is reserved before artifact admission, so concurrent
+  commands naming the same file are rejected before provider activity. A missing
+  caller-owned parent is rejected at admission; project-managed artifact
+  directories are created before the reservation. Every failed envelope copy
+  is reported on stderr with its destination, even when another copy succeeds.
   `run`, `validate`, `doctor`, `models`, `init`, and `materialize` all accept the flag; the
   document it publishes carries status, run reference, result or classified
   error, artifact state, and a closed `warnings` array. For `run`, an uncataloged
@@ -370,8 +375,9 @@ Publication is no-replace, so a destination that already exists is refused
 during argument admission with `arguments/envelope_destination_exists` and exit
 `2`, before any provider work: a repeated CI step is told to remove the file
 rather than paying for a run whose result it cannot receive. If envelope
-publication itself fails, the standalone command exits `74` and cannot report
-that failure through the missing envelope. Success exits `0`; classified
+publication fails at every destination, the standalone command exits `74`.
+If any copy succeeds, the command retains its original exit status and reports
+the failed destinations on stderr. Success exits `0`; classified
 failures use their diagnostic catalog status; caught internal failures use
 `70`.
 

--- a/docs/reference/project-files.md
+++ b/docs/reference/project-files.md
@@ -191,8 +191,10 @@ ptc viewer ptc-project.json --env-file deployment/staging.env
 
 `--envelope FILE` is different: it adds a convenience copy for the invocation
 and does **not** suppress the project ledger under `.ptc/envelopes/` when
-`artifacts.envelope` is enabled. Trace, inspection, and result overrides still
-replace their project defaults.
+`artifacts.envelope` is enabled. The ledger and convenience copy publish
+independently, so a completed run retains its ledger record even when the copy
+cannot be written. Trace, inspection, and result overrides still replace their
+project defaults.
 
 Mission selection, input, and component-override switches remain
 invocation-only. Mission names stay in the application manifest rather than

--- a/lib/ptc_runner/kernel/command_engine.ex
+++ b/lib/ptc_runner/kernel/command_engine.ex
@@ -72,6 +72,7 @@ defmodule PtcRunner.Kernel.CommandEngine do
           {:ok, CommandOutcome.t()}
           | {:error, CommandOutcome.t()}
           | {:envelope_publication_failed, CommandOutcome.t()}
+          | {:envelope_publication_partial, CommandOutcome.t(), [{binary(), term()}]}
   def dispatch(argv), do: dispatch(argv, CommandRuntime.standalone())
 
   @doc false
@@ -79,6 +80,7 @@ defmodule PtcRunner.Kernel.CommandEngine do
           {:ok, CommandOutcome.t()}
           | {:error, CommandOutcome.t()}
           | {:envelope_publication_failed, CommandOutcome.t()}
+          | {:envelope_publication_partial, CommandOutcome.t(), [{binary(), term()}]}
   def dispatch(argv, %CommandRuntime{} = runtime) do
     if CommandRuntime.valid?(runtime) do
       case CommandEntry.open(argv, :standalone) do
@@ -87,6 +89,8 @@ defmodule PtcRunner.Kernel.CommandEngine do
           if project_envelope?(entry.arguments) do
             dispatch_with_project_envelope(entry, runtime)
           else
+            CommandEntry.release(entry)
+
             {:error,
              arguments_outcome(entry.arguments, entry.run_ref, :arguments, :invalid_arguments)}
           end
@@ -341,20 +345,29 @@ defmodule PtcRunner.Kernel.CommandEngine do
   end
 
   defp dispatch_with_project_envelope(
-         %CommandEntry{envelope_path: path} = entry,
+         %CommandEntry{envelope_path: path, envelope_handle: handle} = entry,
          runtime
        ) do
     result = dispatch_entry(%{entry | envelope_path: nil}, runtime)
     {_status, outcome} = result
-    paths = CommandEnvelope.destinations(entry.arguments, path, entry.run_ref)
+    paths = CommandEnvelope.destinations(entry.arguments, handle || path, entry.run_ref)
 
     publication =
-      with :ok <- ProjectArtifactRoot.ensure_for(entry.arguments),
-           do: CommandEnvelope.publish_all(outcome, paths)
+      case ProjectArtifactRoot.ensure_for(entry.arguments) do
+        :ok ->
+          CommandEnvelope.publish_all(outcome, paths)
+
+        {:error, _reason} = error ->
+          if handle, do: _ = CommandEnvelope.discard(handle)
+          error
+      end
 
     case publication do
       :ok ->
         result
+
+      {:partial, _published, failures} ->
+        {:envelope_publication_partial, outcome, failures}
 
       # A publication failure has no envelope representation — the envelope is
       # the artifact that failed — and naming `{:publication,

--- a/lib/ptc_runner/kernel/command_engine.ex
+++ b/lib/ptc_runner/kernel/command_engine.ex
@@ -62,11 +62,16 @@ defmodule PtcRunner.Kernel.CommandEngine do
   @doc """
   Executes one stable command and returns its sealed terminal outcome.
 
-  A project run whose envelope could not be published answers
+  A project run whose envelope reached no destination answers
   `{:envelope_publication_failed, outcome}` instead: the outcome is the run's
   own, so a run that already executed is not described as never started, and
   the distinct tag is what tells a caller its audit envelope is missing even
-  when the run itself failed for an unrelated reason.
+  when the run itself failed for an unrelated reason. When the run's envelope
+  reached at least one destination and failed at another, the answer is
+  `{:envelope_publication_partial, outcome, failures}`, carrying one
+  `{path, reason}` per destination that could not be written: the audit record
+  survives, so the run's own status is not replaced, and the caller still
+  learns which copy is missing.
   """
   @spec dispatch([binary()]) ::
           {:ok, CommandOutcome.t()}

--- a/lib/ptc_runner/kernel/command_entry.ex
+++ b/lib/ptc_runner/kernel/command_entry.ex
@@ -20,8 +20,10 @@ defmodule PtcRunner.Kernel.CommandEntry do
   alias PtcRunner.Kernel.CommandRunRef
   alias PtcRunner.Kernel.DestinationIdentity
   alias PtcRunner.Kernel.PrivateDirectory
+  alias PtcRunner.Kernel.ProjectArtifactRoot
   alias PtcRunner.Kernel.ProjectResolver
   alias PtcRunner.Kernel.PublicationAuthority
+  alias PtcRunner.Kernel.PublicationHandle
 
   @fallback_run_ref "cmd-00000000000000000000000000"
   @frontend_commands CommandDeclaration.frontend_commands()
@@ -32,6 +34,7 @@ defmodule PtcRunner.Kernel.CommandEntry do
     :diagnostic,
     :rejection,
     :envelope_path,
+    :envelope_handle,
     :destinations
   ]
   defstruct @enforce_keys
@@ -43,6 +46,7 @@ defmodule PtcRunner.Kernel.CommandEntry do
           diagnostic: CommandDiagnostic.t() | nil,
           rejection: CommandRejection.t() | nil,
           envelope_path: binary() | nil,
+          envelope_handle: %PublicationHandle{} | nil,
           destinations: {map(), [atom()]} | nil
         }
 
@@ -172,18 +176,27 @@ defmodule PtcRunner.Kernel.CommandEntry do
   defp finish_envelope(arguments, destinations, run_ref, frontend, diagnostic) do
     case Keyword.fetch(arguments.frontend_options, :envelope) do
       :error ->
-        {:ok, accepted(run_ref, frontend, arguments, diagnostic, nil, destinations)}
+        {:ok, accepted(run_ref, frontend, arguments, diagnostic, nil, nil, destinations)}
 
       {:ok, envelope} ->
         with {:ok, envelope} <- anchor_file(envelope),
              :ok <- distinct?(arguments, destinations, run_ref, envelope),
-             :ok <- absent?(envelope) do
+             {:ok, envelope_handle} <- reserve_envelope(arguments, envelope) do
           arguments = %{
             arguments
             | frontend_options: Keyword.delete(arguments.frontend_options, :envelope)
           }
 
-          {:ok, accepted(run_ref, frontend, arguments, diagnostic, envelope, destinations)}
+          {:ok,
+           accepted(
+             run_ref,
+             frontend,
+             arguments,
+             diagnostic,
+             envelope,
+             envelope_handle,
+             destinations
+           )}
         else
           {:error, :invalid_destination} ->
             {:error,
@@ -219,17 +232,52 @@ defmodule PtcRunner.Kernel.CommandEntry do
     end
   end
 
-  # The publication reserve behind the envelope never clobbers, so an existing
-  # destination is refused whenever it is noticed. Noticing it here, where the
-  # path is already anchored and nothing has run, costs one lstat and keeps a
-  # second invocation of the same CI step from paying for a run whose result it
-  # cannot receive.
-  defp absent?(path) do
-    case File.lstat(path) do
-      {:error, :enoent} -> :ok
-      {:ok, _stat} -> {:error, :destination_exists}
-      {:error, _reason} -> :ok
+  # Keep the reservation itself, rather than merely observing absence. This is
+  # the admission claim that prevents concurrent commands from all paying for
+  # work before competing to publish the same envelope.
+  defp reserve_envelope(arguments, path) do
+    case PublicationHandle.reserve(path, :result, 0o600) do
+      {:ok, handle} -> {:ok, handle}
+      {:error, :destination_exists} -> {:error, :destination_exists}
+      {:error, _reason} -> reserve_unavailable_envelope(arguments, path)
     end
+  end
+
+  # A derived ledger path is owned by project artifact admission. Explicit
+  # destinations must hold a claim before bootstrap, including on a fresh project.
+  defp reserve_unavailable_envelope(arguments, path) do
+    case arguments.project do
+      %{derived_options: derived, config: %{artifact_root: root}} ->
+        cond do
+          MapSet.member?(derived, :envelope) ->
+            {:ok, nil}
+
+          DestinationIdentity.within?(path, root) == true ->
+            with :ok <- ProjectArtifactRoot.ensure_for(arguments),
+                 {:ok, handle} <- PublicationHandle.reserve(path, :result, 0o600) do
+              {:ok, handle}
+            else
+              {:error, :destination_exists} -> {:error, :destination_exists}
+              _failure -> {:error, :invalid_destination}
+            end
+
+          true ->
+            {:error, :invalid_destination}
+        end
+
+      _other ->
+        {:error, :invalid_destination}
+    end
+  end
+
+  @doc false
+  @spec release(t()) :: :ok
+  def release(%__MODULE__{envelope_handle: nil}), do: :ok
+
+  def release(%__MODULE__{envelope_handle: handle}) do
+    _ = PublicationHandle.discard(handle)
+    _ = PublicationHandle.close(handle)
+    :ok
   end
 
   defp distinct?(%CommandArguments{command: :run}, {destinations, _failures}, run_ref, envelope) do
@@ -388,7 +436,15 @@ defmodule PtcRunner.Kernel.CommandEntry do
 
   defp anchor_path(_path), do: {:error, :invalid_destination}
 
-  defp accepted(run_ref, frontend, arguments, diagnostic, envelope_path, destinations) do
+  defp accepted(
+         run_ref,
+         frontend,
+         arguments,
+         diagnostic,
+         envelope_path,
+         envelope_handle,
+         destinations
+       ) do
     %__MODULE__{
       run_ref: run_ref,
       frontend: frontend,
@@ -396,6 +452,7 @@ defmodule PtcRunner.Kernel.CommandEntry do
       diagnostic: diagnostic,
       rejection: nil,
       envelope_path: envelope_path,
+      envelope_handle: envelope_handle,
       destinations: destinations
     }
   end
@@ -408,6 +465,7 @@ defmodule PtcRunner.Kernel.CommandEntry do
       diagnostic: nil,
       rejection: rejection,
       envelope_path: nil,
+      envelope_handle: nil,
       destinations: nil
     }
   end

--- a/lib/ptc_runner/kernel/command_envelope.ex
+++ b/lib/ptc_runner/kernel/command_envelope.ex
@@ -9,7 +9,9 @@ defmodule PtcRunner.Kernel.CommandEnvelope do
   alias PtcRunner.Kernel.ProjectContext
   alias PtcRunner.Kernel.PublicationHandle
 
-  @spec publish(CommandOutcome.t(), binary()) ::
+  @type destination :: binary() | PublicationHandle.t()
+
+  @spec publish(CommandOutcome.t(), destination()) ::
           :ok
           | {:error, :envelope_publication_failed}
           | {:error, {:envelope_destination_parent_unavailable, binary()}}
@@ -30,34 +32,68 @@ defmodule PtcRunner.Kernel.CommandEnvelope do
     _kind, _reason -> {:error, :envelope_publication_failed}
   end
 
+  def publish(%CommandOutcome{} = outcome, %PublicationHandle{kind: :result} = handle) do
+    case DeterministicJSON.encode(CommandOutcome.to_map(outcome)) do
+      {:ok, encoded} -> publish_handle(handle, encoded)
+      _failure -> discard(handle)
+    end
+  rescue
+    _exception -> discard(handle)
+  catch
+    _kind, _reason -> discard(handle)
+  end
+
   def publish(_outcome, _path), do: {:error, :envelope_publication_failed}
 
   @doc false
-  @spec publish_all(CommandOutcome.t(), [binary()]) ::
+  @spec publish_all(CommandOutcome.t(), [destination()]) ::
           :ok
-          | {:error, :envelope_publication_failed}
-          | {:error, {:envelope_destination_parent_unavailable, binary()}}
+          | {:partial, [binary()], [{binary(), term()}]}
+          | {:error, term()}
   def publish_all(%CommandOutcome{} = outcome, paths) when is_list(paths) do
-    paths
-    |> Enum.reject(&is_nil/1)
-    |> Enum.uniq_by(&DestinationIdentity.key/1)
-    |> Enum.reduce_while(:ok, fn path, :ok ->
-      case publish(outcome, path) do
-        :ok -> {:cont, :ok}
-        {:error, _reason} = error -> {:halt, error}
-      end
-    end)
+    results =
+      paths
+      |> Enum.reject(&is_nil/1)
+      |> Enum.uniq_by(&destination_key/1)
+      |> Enum.map(fn destination ->
+        {destination_path(destination), publish(outcome, destination)}
+      end)
+
+    published = for {path, :ok} <- results, do: path
+    failures = for {path, {:error, reason}} <- results, do: {path, reason}
+
+    case {published, failures} do
+      {[], []} -> {:error, :envelope_publication_failed}
+      {[], failures} -> {:error, {:envelope_destinations_failed, failures}}
+      {_published, []} -> :ok
+      {published, failures} -> {:partial, published, failures}
+    end
   end
+
+  defp destination_path(%PublicationHandle{} = handle), do: PublicationHandle.path(handle)
+  defp destination_path(path), do: path
 
   defp reserve(path), do: PublicationHandle.reserve(path, :result, 0o600)
 
   @doc false
-  @spec destinations(CommandArguments.t() | nil, binary() | nil, binary()) :: [binary()]
+  @spec destinations(CommandArguments.t() | nil, destination() | nil, binary()) :: [destination()]
   def destinations(arguments, envelope_path, run_ref)
       when is_binary(run_ref) or is_nil(run_ref) do
-    [envelope_path, project_ledger_path(arguments, run_ref)]
-    |> Enum.reject(&is_nil/1)
-    |> Enum.uniq_by(&DestinationIdentity.key/1)
+    ledger_path = project_ledger_path(arguments, run_ref)
+
+    case {ledger_path, envelope_path} do
+      {nil, nil} ->
+        []
+
+      {nil, envelope} ->
+        [envelope]
+
+      {ledger, nil} ->
+        [ledger]
+
+      {ledger, envelope} ->
+        if same_destination?(ledger, envelope), do: [envelope], else: [ledger, envelope]
+    end
   end
 
   defp project_ledger_path(
@@ -73,6 +109,21 @@ defmodule PtcRunner.Kernel.CommandEnvelope do
        do: Path.join([root, "envelopes", run_ref <> ".json"])
 
   defp project_ledger_path(_arguments, _run_ref), do: nil
+
+  defp destination_key(%PublicationHandle{} = handle),
+    do: handle |> PublicationHandle.path() |> DestinationIdentity.key()
+
+  defp destination_key(path), do: DestinationIdentity.key(path)
+
+  defp same_destination?(left, right), do: destination_key(left) == destination_key(right)
+
+  @doc false
+  @spec discard(PublicationHandle.t()) :: {:error, :envelope_publication_failed}
+  def discard(%PublicationHandle{} = handle) do
+    _ = PublicationHandle.discard(handle)
+    _ = PublicationHandle.close(handle)
+    {:error, :envelope_publication_failed}
+  end
 
   defp publish_handle(handle, encoded) do
     result =

--- a/lib/ptc_runner/kernel/command_frontend.ex
+++ b/lib/ptc_runner/kernel/command_frontend.ex
@@ -111,21 +111,35 @@ defmodule PtcRunner.Kernel.CommandFrontend do
        do: present(entry, outcome, rejection, false)
 
   defp present(
-         %CommandEntry{envelope_path: path} = entry,
+         %CommandEntry{envelope_path: path, envelope_handle: handle} = entry,
          %CommandOutcome{} = outcome,
          rejection,
          named_env_file?
        )
        when is_binary(path) do
-    paths = CommandEnvelope.destinations(entry.arguments, path, entry.run_ref)
+    paths = CommandEnvelope.destinations(entry.arguments, handle || path, entry.run_ref)
 
     result =
-      with :ok <- ProjectArtifactRoot.ensure_for(entry.arguments),
-           do: CommandEnvelope.publish_all(outcome, paths)
+      case ProjectArtifactRoot.ensure_for(entry.arguments) do
+        :ok -> CommandEnvelope.publish_all(outcome, paths)
+        {:error, _reason} = error -> cleanup_envelope_handle(handle, error)
+      end
 
     case result do
       :ok ->
         rendered_presentation(entry, outcome, path, rejection, named_env_file?)
+
+      {:partial, published, failures} ->
+        rendered =
+          rendered_presentation(entry, outcome, hd(published), rejection, named_env_file?)
+
+        warning =
+          CommandRenderer.envelope_failure(
+            entry.run_ref,
+            {:envelope_destinations_failed, failures}
+          )
+
+        %{rendered | stderr: rendered.stderr <> warning}
 
       {:error, reason} ->
         presentation(
@@ -140,6 +154,13 @@ defmodule PtcRunner.Kernel.CommandFrontend do
 
   defp present(%CommandEntry{} = entry, %CommandOutcome{} = outcome, rejection, named_env_file?) do
     rendered_presentation(entry, outcome, nil, rejection, named_env_file?)
+  end
+
+  defp cleanup_envelope_handle(nil, error), do: error
+
+  defp cleanup_envelope_handle(handle, error) do
+    _ = CommandEnvelope.discard(handle)
+    error
   end
 
   defp rendered_presentation(entry, outcome, envelope_path, rejection, named_env_file?) do

--- a/lib/ptc_runner/kernel/command_renderer.ex
+++ b/lib/ptc_runner/kernel/command_renderer.ex
@@ -126,6 +126,13 @@ defmodule PtcRunner.Kernel.CommandRenderer do
     do: envelope_failure(run_ref, :envelope_publication_failed)
 
   @spec envelope_failure(binary(), term()) :: binary()
+  def envelope_failure(run_ref, {:envelope_destinations_failed, failures}) do
+    Enum.map_join(failures, fn {path, reason} ->
+      String.trim_trailing(envelope_failure(run_ref, reason)) <>
+        " (destination: #{inspect(path)})\n"
+    end)
+  end
+
   def envelope_failure(run_ref, {:envelope_destination_parent_unavailable, path})
       when is_binary(run_ref) and is_binary(path) do
     parent = Path.dirname(path)

--- a/lib/ptc_runner/kernel/command_router.ex
+++ b/lib/ptc_runner/kernel/command_router.ex
@@ -79,6 +79,8 @@ defmodule PtcRunner.Kernel.CommandRouter do
   catch
     _kind, _reason ->
       internal_error(entry)
+  after
+    CommandEntry.release(entry)
   end
 
   defp run_one_shot_scoped(entry, bootstrap, runner) do

--- a/site/reference/cli/index.html
+++ b/site/reference/cli/index.html
@@ -171,7 +171,12 @@ and keeps it off stdout.</li><li><code class="inline">--trace-dir DIR</code> wri
 <code class="inline">&lt;run_ref&gt;.private.jsonl</code> according to the run's artifact class.</li><li><code class="inline">--inspect FILE</code> writes sensitive execution evidence to an owner-only
 <code class="inline">.ptcins</code> file.</li><li><code class="inline">--envelope FILE</code> atomically publishes a convenience copy of the stable V4
 command envelope. When a project enables <code class="inline">artifacts.envelope</code>, the project's
-<code class="inline">.ptc/envelopes/&lt;run_ref&gt;.json</code> ledger entry is still written for that run.
+<code class="inline">.ptc/envelopes/&lt;run_ref&gt;.json</code> ledger entry is written independently for that
+run. The explicit path is reserved before artifact admission, so concurrent
+commands naming the same file are rejected before provider activity. A missing
+caller-owned parent is rejected at admission; project-managed artifact
+directories are created before the reservation. Every failed envelope copy
+is reported on stderr with its destination, even when another copy succeeds.
 <code class="inline">run</code>, <code class="inline">validate</code>, <code class="inline">doctor</code>, <code class="inline">models</code>, <code class="inline">init</code>, and <code class="inline">materialize</code> all accept the flag; the
 document it publishes carries status, run reference, result or classified
 error, artifact state, and a closed <code class="inline">warnings</code> array. For <code class="inline">run</code>, an uncataloged
@@ -326,8 +331,9 @@ Publication is no-replace, so a destination that already exists is refused
 during argument admission with <code class="inline">arguments/envelope_destination_exists</code> and exit
 <code class="inline">2</code>, before any provider work: a repeated CI step is told to remove the file
 rather than paying for a run whose result it cannot receive. If envelope
-publication itself fails, the standalone command exits <code class="inline">74</code> and cannot report
-that failure through the missing envelope. Success exits <code class="inline">0</code>; classified
+publication fails at every destination, the standalone command exits <code class="inline">74</code>.
+If any copy succeeds, the command retains its original exit status and reports
+the failed destinations on stderr. Success exits <code class="inline">0</code>; classified
 failures use their diagnostic catalog status; caught internal failures use
 <code class="inline">70</code>.</p><p><code class="inline">run</code>, <code class="inline">validate</code>, <code class="inline">doctor</code>, <code class="inline">models</code>, <code class="inline">init</code>, <code class="inline">materialize</code>, <code class="inline">transcript</code>, and
 <code class="inline">version</code> accept <code class="inline">--envelope</code>. <code class="inline">repl</code>, <code class="inline">viewer</code>, <code class="inline">docs</code>, and help do not. A private run

--- a/site/reference/project-files/index.html
+++ b/site/reference/project-files/index.html
@@ -207,8 +207,10 @@ ptc repl --project ptc-project.json --env-file deployment/staging.env
 ptc repl --project ptc-project.json --mission review
 ptc viewer ptc-project.json --env-file deployment/staging.env</code></pre><p><code class="inline">--envelope FILE</code> is different: it adds a convenience copy for the invocation
 and does <strong>not</strong> suppress the project ledger under <code class="inline">.ptc/envelopes/</code> when
-<code class="inline">artifacts.envelope</code> is enabled. Trace, inspection, and result overrides still
-replace their project defaults.</p><p>Mission selection, input, and component-override switches remain
+<code class="inline">artifacts.envelope</code> is enabled. The ledger and convenience copy publish
+independently, so a completed run retains its ledger record even when the copy
+cannot be written. Trace, inspection, and result overrides still replace their
+project defaults.</p><p>Mission selection, input, and component-override switches remain
 invocation-only. Mission names stay in the application manifest rather than
 being duplicated as project defaults. An environment file explicitly selected
 by the project or <code class="inline">--env-file</code> is loaded only when inert preparation proves that

--- a/test/ptc_runner/kernel/command_frontend_test.exs
+++ b/test/ptc_runner/kernel/command_frontend_test.exs
@@ -328,6 +328,121 @@ defmodule PtcRunner.Kernel.CommandFrontendTest do
   end
 
   @tag :tmp_dir
+  test "concurrent runs reserve a shared envelope before provider activity", %{tmp_dir: dir} do
+    parent = self()
+    target = Path.join(dir, "project")
+    assert {:ok, %CommandOutcome{}} = CommandEngine.dispatch(["init", target])
+    application = Path.join(target, "ptc-project.json")
+    output = Path.join(dir, "shared-result.json")
+    envelope = Path.join([target, ".ptc", "envelopes", "shared.json"])
+
+    presentations =
+      1..3
+      |> Task.async_stream(
+        fn attempt ->
+          CommandFrontend.execute(
+            ["run", application, "--output", output, "--envelope", envelope],
+            :standalone,
+            fn _arguments ->
+              send(parent, {:provider_activity, attempt})
+              {:ok, CommandRuntime.standalone()}
+            end
+          )
+        end,
+        max_concurrency: 3,
+        ordered: false,
+        timeout: 30_000
+      )
+      |> Enum.map(fn {:ok, presentation} -> presentation end)
+
+    assert Enum.frequencies_by(presentations, & &1.exit_status) == %{0 => 1, 2 => 2}
+
+    for rejected <- Enum.filter(presentations, &(&1.exit_status == 2)) do
+      assert rejected.outcome.envelope["error"]["code"] == "envelope_destination_exists"
+      assert rejected.outcome.envelope["error"]["provider_activity"] == false
+    end
+
+    assert_received {:provider_activity, winner}
+    refute_received {:provider_activity, _loser}
+
+    winner_presentation = Enum.find(presentations, &(&1.exit_status == 0))
+    published_envelope = envelope |> File.read!() |> Jason.decode!()
+    published_result = output |> File.read!() |> Jason.decode!()
+
+    winner_run_ref = winner_presentation.outcome.envelope["run_ref"]
+    assert published_envelope["run_ref"] == winner_run_ref
+    assert published_result == %{"greeting" => "hello world"}
+    assert winner in 1..3
+
+    ledger_envelopes = Path.wildcard(Path.join([target, ".ptc", "envelopes", "*.json"]))
+    ledger_envelopes = List.delete(ledger_envelopes, envelope)
+    assert length(ledger_envelopes) == 1
+
+    assert ledger_envelopes
+           |> hd()
+           |> File.read!()
+           |> Jason.decode!()
+           |> Map.fetch!("run_ref") == winner_run_ref
+  end
+
+  @tag :tmp_dir
+  test "direct engine rejection releases the explicit envelope claim", %{tmp_dir: dir} do
+    path = Path.join(dir, "rejected.json")
+    assert {:error, _} = CommandEngine.dispatch(["doctor", "--envelope", path])
+    assert {:ok, entry} = CommandEntry.open(["doctor", "--envelope", path], :standalone)
+    CommandEntry.release(entry)
+  end
+
+  @tag :tmp_dir
+  test "transcript terminal paths release the envelope claim", %{tmp_dir: dir} do
+    for failure <- [:runner, :coded_runner, :bootstrap, :exception, :throw, :ok] do
+      path = Path.join(dir, "#{failure}.json")
+
+      argv = [
+        "transcript",
+        @run_ref,
+        "--traces",
+        dir,
+        "--inspection",
+        dir,
+        "--private-unattended",
+        "--private-output",
+        Path.join(dir, "private.json"),
+        "--envelope",
+        path
+      ]
+
+      bootstrap = fn _ ->
+        if failure == :bootstrap, do: {:error, :failed}, else: {:ok, CommandRuntime.standalone()}
+      end
+
+      runner = fn _, _ ->
+        case failure do
+          :exception -> raise "failure"
+          :throw -> throw(:failure)
+          :coded_runner -> {:error, :command_failed, "failed"}
+          :ok -> :ok
+          _ -> {:error, "failed"}
+        end
+      end
+
+      presentation = CommandRouter.execute(argv, :standalone, bootstrap, runner)
+
+      expected =
+        case failure do
+          :ok -> 0
+          failure when failure in [:bootstrap, :exception, :throw] -> 70
+          _ -> 1
+        end
+
+      assert presentation.exit_status == expected
+      assert File.ls!(dir) == []
+      assert {:ok, entry} = CommandEntry.open(argv, :standalone)
+      CommandEntry.release(entry)
+    end
+  end
+
+  @tag :tmp_dir
   test "an envelope request preserves an artifact destination diagnosis", %{tmp_dir: dir} do
     application = write_application(dir)
     envelope_path = Path.join(dir, "command-envelope.json")

--- a/test/ptc_runner/kernel/project_command_test.exs
+++ b/test/ptc_runner/kernel/project_command_test.exs
@@ -451,7 +451,34 @@ defmodule PtcRunner.Kernel.ProjectCommandTest do
   end
 
   @tag :tmp_dir
-  test "--envelope into a missing parent names destination_parent_unavailable", %{
+  test "a failed convenience copy reports its path and retains the ledger", %{tmp_dir: directory} do
+    target = Path.join(directory, "demo")
+    assert {:ok, %CommandOutcome{}} = CommandEngine.dispatch(["init", target])
+    copy = Path.join(directory, "copy.json")
+
+    presentation =
+      CommandFrontend.execute(
+        ["run", Path.join(target, "ptc-project.json"), "--envelope", copy],
+        :standalone,
+        fn _ ->
+          File.write!(copy, "concurrent writer")
+          {:ok, CommandRuntime.standalone()}
+        end
+      )
+
+    assert presentation.exit_status == 0
+    assert presentation.stderr =~ "envelope/publication_failed"
+    assert presentation.stderr =~ copy
+    assert presentation.envelope_path != copy
+
+    assert Jason.decode!(File.read!(presentation.envelope_path))["run_ref"] ==
+             presentation.outcome.envelope["run_ref"]
+
+    assert File.read!(copy) == "concurrent writer"
+  end
+
+  @tag :tmp_dir
+  test "a missing explicit envelope parent is rejected before bootstrap", %{
     tmp_dir: directory
   } do
     target = Path.join(directory, "demo")
@@ -464,12 +491,14 @@ defmodule PtcRunner.Kernel.ProjectCommandTest do
       CommandFrontend.execute(
         ["run", project, "--envelope", copy],
         :standalone,
-        fn _arguments -> {:ok, CommandRuntime.standalone()} end
+        fn _arguments -> flunk("must not bootstrap") end
       )
 
-    assert presentation.exit_status == CommandFrontend.envelope_failure_exit_status()
-    assert presentation.stderr =~ "envelope/destination_parent_unavailable"
-    assert presentation.stderr =~ missing_parent
+    assert presentation.exit_status == 2
+    assert presentation.stderr =~ "arguments/invalid_arguments"
+    assert presentation.stderr =~ "invalid destination: --envelope"
+    refute File.exists?(copy)
+    refute File.exists?(Path.join(target, ".ptc"))
   end
 
   @tag :tmp_dir


### PR DESCRIPTION
## Summary

- `--envelope` now takes the same `PublicationHandle` reservation `--output`
  takes, at destination admission and before any artifact reservation, so only
  the envelope holder reaches the output reservation. Concurrent commands
  naming one envelope path are refused as `arguments/envelope_destination_exists`
  (exit `2`) before provider work, whether the file exists or another run holds
  the claim. The handle is carried on `CommandEntry` through to
  `CommandFrontend.present/4` for the final write.
- A caller-owned `--envelope` parent that does not exist is now refused at
  admission under the pre-existing `arguments/invalid_arguments` rejection
  instead of exiting `74` after the run was billed. A path inside the project's
  own artifact root still bootstraps that directory before reserving.
- `CommandEnvelope.publish_all/2` no longer halts on the first failed
  destination. It publishes the project ledger copy independently of the
  caller's path and reports every failure, so a run that executed always leaves
  `.ptc/envelopes/<run_ref>.json` when `artifacts.envelope` is true.
- Exit `74` is now reserved for an envelope that reached no destination at all.
  A partial publication keeps the run's own exit status and names each failed
  destination on stderr; `CommandEngine.dispatch/1` answers
  `{:envelope_publication_partial, outcome, failures}` for it.
- The reservation is released on every early return — direct engine rejection
  and the one-shot router's terminal paths — so a refused command leaves no
  claim behind.

Acceptance item 4 resolves by ordering: this lands before #1854, and because the
envelope now reserves through `PublicationHandle.reserve/3`, #1854's owner
marker reaches it without further work here.

Closes #1856

## Validation

Reproduced the issue's own shape at the process boundary: three concurrent
`mix ptc run` of one scaffolded project sharing `--output` and `--envelope`.
Before, all three reported failure and the envelope, result, and trace belonged
to three different runs. Now one exits `0` and two exit `2` with
`arguments/envelope_destination_exists`, and `shared.env.json`, the
`.ptc/envelopes/` ledger entry, and the published trace all carry the run_ref of
the single run that executed.

`codex review --base main` returned no findings.

The parallel pre-push fan-out failed once without naming a lane; every gate
passed under `PTC_PRE_PUSH_SERIAL=1`, including `core release verification`.

## Retrospective

- Follow-up, untracked: the pre-push hook's parallel fan-out can report
  `A deterministic gate failed` while the failing lane's output is lost to
  interleaving, so the failure names nothing. Repro: `git push` on this branch
  printed only the passing Viewer lane before the failure banner;
  `PTC_PRE_PUSH_SERIAL=1 git push` then passed every gate, `core release
  verification` in 118s. Either serialize the output per lane or re-print the
  failing lane's captured log.
- Repository instruction: the worktree rule says to create a worktree before the
  first edit but does not say what to do when a worktree for the branch already
  exists. Git refuses a second checkout of one branch, so reusing the prepared
  worktree was a guess; the rule should name reuse as the expected move.

https://claude.ai/code/session_01TXvURAhs152iVveksgDk2B