### PR TITLE
fix(artifacts): reclaim a stale output reservation from a killed run

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -187,6 +187,15 @@ The command envelope reports the run reference and artifact class, not artifact
 paths. Output, trace, inspection, and envelope destinations must be distinct.
 All publications are no-replace and recheck their destination at commit time.
 
+Reservations named `.*.ptc-reservation` record the owning process. When you
+reuse a destination after an interrupted run on the same host, a reservation
+whose owner is gone is reclaimed automatically if the destination is absent.
+Older reservations without an owner marker are reclaimed only after 60 seconds.
+Live owners, uncertain owner status, and existing destinations are always
+preserved. Cross-host recovery on network filesystems is not supported.
+A `destination/destination_exists` terminal error lists the requested paths
+and a remedy; the command envelope remains path-free.
+
 Atomic publication may reserve owner-only sibling paths named
 `.ptc-private-*` or `.ptc-private-result-*`. They normally disappear at commit
 or cleanup, but an abruptly terminated process can leave one behind. Because a

--- a/lib/ptc_runner/kernel/command_diagnostic_renderer.ex
+++ b/lib/ptc_runner/kernel/command_diagnostic_renderer.ex
@@ -71,6 +71,27 @@ defmodule PtcRunner.Kernel.CommandDiagnosticRenderer do
     end
   end
 
+  defp local_context_suffix(
+         %{"phase" => "destination", "code" => "destination_exists"},
+         opts
+       ) do
+    case Keyword.get(opts, :artifact_destinations) do
+      {destinations, _failures} when map_size(destinations) > 0 ->
+        paths =
+          Enum.map_join(Enum.sort(destinations), ", ", fn {key, path} ->
+            switch = "--" <> String.replace(Atom.to_string(key), "_", "-")
+            switch <> " " <> TerminalLiteral.render(path, @terminal_path_pattern)
+          end)
+
+        "; requested destinations: " <>
+          paths <>
+          "; remove an existing artifact or wait for its active run to finish, or choose another path"
+
+      _absent ->
+        ""
+    end
+  end
+
   defp local_context_suffix(_error, _opts), do: ""
 
   defp diagnostic_suffix(%{

--- a/lib/ptc_runner/kernel/command_frontend.ex
+++ b/lib/ptc_runner/kernel/command_frontend.ex
@@ -166,7 +166,8 @@ defmodule PtcRunner.Kernel.CommandFrontend do
   defp rendered_presentation(entry, outcome, envelope_path, rejection, named_env_file?) do
     render_options = [
       named_env_file: named_env_file?,
-      application_path: terminal_application_path(entry.arguments)
+      application_path: terminal_application_path(entry.arguments),
+      artifact_destinations: entry.destinations
     ]
 
     case CommandRenderer.render(outcome, rejection, render_options) do

--- a/lib/ptc_runner/kernel/command_renderer.ex
+++ b/lib/ptc_runner/kernel/command_renderer.ex
@@ -13,7 +13,8 @@ defmodule PtcRunner.Kernel.CommandRenderer do
   response, credential, or unvalidated path. Component compile failures with a
   proven byte span render the logical component name and canonical half-open
   byte range already present in the envelope; rendering does not retain or
-  reopen component source. The one local-only exception is an unreadable
+  reopen component source. Local-only context includes artifact destination paths and remedies for
+  destination collisions, and an unreadable
   application input: its caller-supplied positional path, or a loaded project's
   validated relative application path, is appended without entering the sealed
   diagnostic. A replay miss may include only its validated opaque request hash.

--- a/lib/ptc_runner/kernel/private_directory.ex
+++ b/lib/ptc_runner/kernel/private_directory.ex
@@ -300,6 +300,29 @@ defmodule PtcRunner.Kernel.PrivateDirectory do
 
   def create(_path), do: {:error, :private_directory_creation_failed}
 
+  @doc false
+  @spec owner_dead?(binary()) :: boolean()
+  def owner_dead?(pid) do
+    with true <- Regex.match?(~r/\A[1-9][0-9]{0,9}\z/, pid),
+         {number, ""} when number <= 2_147_483_647 <- Integer.parse(pid),
+         executable when is_binary(executable) <- System.find_executable("kill"),
+         env when is_binary(env) <- System.find_executable("env"),
+         {:ok, {output, status}} when status != 0 <-
+           SystemCommand.run(
+             env,
+             ["LC_ALL=C", executable, "-0", pid],
+             @external_command_timeout_ms
+           ) do
+      # EPERM and every unrecognized failure count as alive. Only ESRCH
+      # proves the same-host owner is gone; normalize the command's locale.
+      String.contains?(output, "No such process")
+    else
+      _alive_or_unknown -> false
+    end
+  rescue
+    _exception -> false
+  end
+
   defp authority_executable do
     case :os.type() do
       {:unix, _name} ->

--- a/lib/ptc_runner/kernel/publication_handle.ex
+++ b/lib/ptc_runner/kernel/publication_handle.ex
@@ -1122,21 +1122,21 @@ defmodule PtcRunner.Kernel.PublicationHandle do
   end
 
   defp with_reservation(path, parent_identity, fun) do
-    with_reservation_path(reservation_path(path, parent_identity), Path.dirname(path), fun)
+    with_reservation_path(reservation_path(path, parent_identity), path, Path.dirname(path), fun)
   end
 
   defp with_append_reservation(path, fun) do
     case TraceLog.append_reservation_path(path) do
       {:ok, reservation_path} ->
-        with_reservation_path(reservation_path, Path.dirname(reservation_path), fun)
+        with_reservation_path(reservation_path, path, Path.dirname(reservation_path), fun)
 
       {:error, _reason} = error ->
         error
     end
   end
 
-  defp with_reservation_path(reservation_path, sync_parent, fun) do
-    case create_reservation(reservation_path) do
+  defp with_reservation_path(reservation_path, destination, sync_parent, fun) do
+    case create_reservation(reservation_path, destination, true) do
       {:ok, reservation_path, reservation_identity} ->
         case fun.(reservation_path, reservation_identity) do
           {:ok, _handle} = success ->
@@ -1153,24 +1153,126 @@ defmodule PtcRunner.Kernel.PublicationHandle do
     end
   end
 
-  defp create_reservation(reservation_path) do
+  defp create_reservation(reservation_path, destination, retry?) do
     case PrivateDirectory.create(reservation_path) do
       :ok ->
-        with {:ok, stat} <- File.lstat(reservation_path, time: :posix),
-             true <- stat.type == :directory,
-             {:ok, identity} <- stat_identity(stat) do
-          {:ok, reservation_path, identity}
-        else
-          _other ->
-            _ = File.rmdir(reservation_path)
-            {:error, :destination_unavailable}
-        end
+        claim_created_reservation(reservation_path)
 
       {:error, _reason} ->
-        case File.lstat(reservation_path) do
-          {:ok, _stat} -> {:error, :destination_exists}
-          _other -> {:error, :destination_unavailable}
+        retry_reservation(reservation_path, destination, retry?)
+    end
+  end
+
+  # Identify the directory this process just made before writing the owner
+  # marker. Until that write lands the reservation is markerless, so a creator
+  # stalled here for longer than the markerless grace can lose it to a
+  # reclaimer; the identity guard then keeps its own cleanup from removing the
+  # live replacement. An unidentifiable directory is left for that same
+  # reclaim rather than removed by pathname.
+  defp claim_created_reservation(path) do
+    with {:ok, %{type: :directory} = stat} <- File.lstat(path, time: :posix),
+         {:ok, identity} <- stat_identity(stat) do
+      case write_reservation_owner(path) do
+        :ok ->
+          confirm_reservation_owner(path, identity)
+
+        _unowned ->
+          _ = cleanup_open_reservation(path, identity, Path.dirname(path))
+          {:error, :destination_unavailable}
+      end
+    else
+      _unidentified -> {:error, :destination_unavailable}
+    end
+  end
+
+  # The owner write is by pathname, so a creator stalled past the markerless
+  # grace can mark a reclaimer's replacement instead of its own directory and
+  # report a stale identity. Re-read the identity once the marker exists and
+  # keep the reservation only while it is still the directory this process
+  # made; the replacement stays its own creator's to remove. Past this point
+  # the live marker keeps a reclaimer away.
+  defp confirm_reservation_owner(path, identity) do
+    case File.lstat(path, time: :posix) do
+      {:ok, %{type: :directory} = stat} ->
+        case same_identity(stat, identity) do
+          :ok -> {:ok, path, identity}
+          _replaced -> {:error, :destination_unavailable}
         end
+
+      _other ->
+        {:error, :destination_unavailable}
+    end
+  end
+
+  defp retry_reservation(_path, _destination, false), do: {:error, :destination_exists}
+
+  defp retry_reservation(path, destination, true) do
+    if match?({:ok, _}, File.lstat(path)) do
+      # Serialize reclaimers across VMs with the existing same-host OS
+      # lock. Re-read under the lock so a delayed reaper cannot remove a
+      # replacement owner's marker. Fresh mkdir contenders still arbitrate
+      # atomically, and the retry is deliberately inside this lock.
+      TraceLog.with_append_authority_lock(path <> ".reclaim", fn ->
+        case reclaim_reservation(path, destination) do
+          :ok -> create_reservation(path, destination, false)
+          _other -> {:error, :destination_exists}
+        end
+      end)
+      |> normalize_reservation_refusal()
+    else
+      {:error, :destination_unavailable}
+    end
+  end
+
+  defp normalize_reservation_refusal({:ok, _path, _identity} = success), do: success
+  defp normalize_reservation_refusal(_failure), do: {:error, :destination_exists}
+
+  defp write_reservation_owner(path) do
+    owner = Path.join(path, "owner")
+
+    with :ok <- File.write(owner, System.pid(), [:exclusive]),
+         do: File.chmod(owner, 0o600)
+  end
+
+  defp reclaim_reservation(path, destination) do
+    with {:error, :enoent} <- File.lstat(destination),
+         {:ok, %{type: :directory} = stat} <- File.lstat(path, time: :posix),
+         {:ok, uid} <- PrivateDirectory.preflight_owner(path),
+         true <- stat.uid == uid and Bitwise.band(stat.mode, 0o777) == 0o700,
+         {:ok, identity} <- stat_identity(stat),
+         true <- stale_reservation?(path, stat),
+         {:ok, current} <- File.lstat(path, time: :posix),
+         :ok <- same_identity(current, identity),
+         {:error, :enoent} <- File.lstat(destination) do
+      remove_reservation_directory(path)
+    else
+      _live_or_changed -> {:error, :destination_exists}
+    end
+  end
+
+  defp stale_reservation?(path, stat) do
+    owner = Path.join(path, "owner")
+
+    case File.lstat(owner) do
+      {:ok, %{type: :regular, size: size}} when size <= 10 ->
+        case File.read(owner) do
+          {:ok, pid} -> PrivateDirectory.owner_dead?(pid)
+          _unreadable -> false
+        end
+
+      {:error, :enoent} ->
+        System.os_time(:second) - stat.mtime > 60
+
+      _invalid ->
+        false
+    end
+  end
+
+  defp remove_reservation_directory(path) do
+    case File.rm(Path.join(path, "owner")) do
+      :ok -> File.rmdir(path)
+      {:error, :enoent} -> File.rmdir(path)
+      error -> error
     end
   end
 
@@ -1227,7 +1329,7 @@ defmodule PtcRunner.Kernel.PublicationHandle do
     case File.lstat(path, time: :posix) do
       {:ok, %{type: :directory} = stat} ->
         case same_identity(stat, identity) do
-          :ok -> _ = File.rmdir(path)
+          :ok -> _ = remove_reservation_directory(path)
           _other -> :ok
         end
 
@@ -1410,7 +1512,7 @@ defmodule PtcRunner.Kernel.PublicationHandle do
 
       {:ok, %{type: :directory} = stat} ->
         with :ok <- same_identity(stat, handle.reservation_identity),
-             :ok <- File.rmdir(handle.reservation_path),
+             :ok <- remove_reservation_directory(handle.reservation_path),
              :ok <- sync_directory(Path.dirname(handle.reservation_path)) do
           :ok
         else

--- a/site/reference/cli/index.html
+++ b/site/reference/cli/index.html
@@ -194,7 +194,14 @@ successful non-run commands keep the array empty. Parse the
 envelope rather than scraping stdout, which is a human
 presentation channel that may also carry application output.</li></ul><p>The command envelope reports the run reference and artifact class, not artifact
 paths. Output, trace, inspection, and envelope destinations must be distinct.
-All publications are no-replace and recheck their destination at commit time.</p><p>Atomic publication may reserve owner-only sibling paths named
+All publications are no-replace and recheck their destination at commit time.</p><p>Reservations named <code class="inline">.*.ptc-reservation</code> record the owning process. When you
+reuse a destination after an interrupted run on the same host, a reservation
+whose owner is gone is reclaimed automatically if the destination is absent.
+Older reservations without an owner marker are reclaimed only after 60 seconds.
+Live owners, uncertain owner status, and existing destinations are always
+preserved. Cross-host recovery on network filesystems is not supported.
+A <code class="inline">destination/destination_exists</code> terminal error lists the requested paths
+and a remedy; the command envelope remains path-free.</p><p>Atomic publication may reserve owner-only sibling paths named
 <code class="inline">.ptc-private-*</code> or <code class="inline">.ptc-private-result-*</code>. They normally disappear at commit
 or cleanup, but an abruptly terminated process can leave one behind. Because a
 completed reservation can contain private prompts, responses, source, or a

--- a/test/ptc_runner/kernel/command_frontend_test.exs
+++ b/test/ptc_runner/kernel/command_frontend_test.exs
@@ -15,6 +15,7 @@ defmodule PtcRunner.Kernel.CommandFrontendTest do
   alias PtcRunner.Kernel.CommandSubject
   alias PtcRunner.Kernel.DiagnosticCatalog
   alias PtcRunner.Kernel.ExampleLibrary
+  alias PtcRunner.Kernel.PrivateDirectory
   alias PtcRunner.Kernel.ValueContract
   alias PtcRunner.Kernel.ValueContractDiagnostic
   import PtcRunner.TestSupport.CommandEngineFixtures, only: [validate_success_result: 0]
@@ -761,6 +762,128 @@ defmodule PtcRunner.Kernel.CommandFrontendTest do
       ],
       "--private-output"
     )
+  end
+
+  @tag :tmp_dir
+  test "run reclaims a dead owner's output reservation", %{tmp_dir: dir} do
+    application = write_application(dir)
+    output = Path.join(dir, "answer.json")
+    reservation = make_output_reservation(output, "2147483647")
+
+    presentation = run_with_output(application, output)
+
+    assert presentation.exit_status == 0
+    assert Jason.decode!(File.read!(output)) == %{"answer" => 42}
+    refute File.exists?(reservation)
+  end
+
+  @tag :tmp_dir
+  test "run reclaims the shared envelope reservation after its owner dies", %{tmp_dir: dir} do
+    application = write_application(dir)
+    envelope = Path.join(dir, "envelope.json")
+    reservation = make_output_reservation(envelope, "2147483647")
+
+    presentation =
+      CommandFrontend.execute(["run", application, "--envelope", envelope], :standalone, fn _ ->
+        {:ok, CommandRuntime.standalone()}
+      end)
+
+    assert presentation.exit_status == 0
+    assert Jason.decode!(File.read!(envelope))["status"] == "ok"
+    refute File.exists?(reservation)
+  end
+
+  @tag :tmp_dir
+  test "run preserves live, fresh, and occupied output reservations", %{tmp_dir: dir} do
+    application = write_application(dir)
+
+    for {name, owner, occupied?} <- [
+          {"live", System.pid(), false},
+          {"fresh", nil, false},
+          {"malformed", "not-a-pid", false},
+          {"occupied", "2147483647", true}
+        ] do
+      output = Path.join(dir, name <> ".json")
+      reservation = make_output_reservation(output, owner)
+      if occupied?, do: File.write!(output, "original")
+      before = File.stat!(reservation)
+
+      presentation = run_with_output(application, output)
+      assert presentation.exit_status == 7
+      assert presentation.stderr =~ "destination/destination_exists"
+      assert presentation.stderr =~ output
+      assert presentation.stderr =~ "another path"
+      refute Jason.encode!(presentation.outcome.envelope) =~ output
+      assert File.stat!(reservation) == before
+      if owner, do: assert(File.read!(Path.join(reservation, "owner")) == owner)
+      if occupied?, do: assert(File.read!(output) == "original")
+    end
+  end
+
+  @tag :tmp_dir
+  test "run reclaims an old markerless output reservation", %{tmp_dir: dir} do
+    application = write_application(dir)
+    output = Path.join(dir, "answer.json")
+    reservation = make_output_reservation(output, nil)
+    File.touch!(reservation, System.os_time(:second) - 120)
+
+    assert run_with_output(application, output).exit_status == 0
+    assert File.regular?(output)
+    refute File.exists?(reservation)
+  end
+
+  for stale? <- [false, true] do
+    @tag :tmp_dir
+    @tag stale_reservation: stale?
+    test "concurrent runs publish exactly one output (stale=#{stale?})", %{
+      tmp_dir: dir,
+      stale_reservation: stale?
+    } do
+      application = write_application(dir)
+      output = Path.join(dir, "answer.json")
+      if stale?, do: make_output_reservation(output, "2147483647")
+      parent = self()
+
+      tasks =
+        for _ <- 1..2 do
+          Task.async(fn ->
+            CommandFrontend.execute(["run", application, "--output", output], :standalone, fn _ ->
+              send(parent, {:ready, self()})
+
+              receive do
+                :go -> {:ok, CommandRuntime.standalone()}
+              end
+            end)
+          end)
+        end
+
+      for _ <- tasks, do: assert_receive({:ready, _pid}, 5_000)
+      for task <- tasks, do: send(task.pid, :go)
+      assert Enum.sort(Enum.map(tasks, &Task.await(&1, 10_000).exit_status)) == [0, 7]
+      assert Jason.decode!(File.read!(output)) == %{"answer" => 42}
+      assert Path.wildcard(Path.join(dir, ".*.ptc-reservation")) == []
+    end
+  end
+
+  defp run_with_output(application, output) do
+    CommandFrontend.execute(["run", application, "--output", output], :standalone, fn _ ->
+      {:ok, CommandRuntime.standalone()}
+    end)
+  end
+
+  defp make_output_reservation(output, owner) do
+    stat = File.stat!(Path.dirname(output))
+    identity = {stat.major_device, stat.minor_device, stat.inode}
+    key = {identity, PrivateDirectory.casefold_name(Path.basename(output))}
+    digest = :crypto.hash(:sha256, :erlang.term_to_binary(key, [:deterministic]))
+
+    path =
+      Path.join(Path.dirname(output), ".#{Base.encode16(digest, case: :lower)}.ptc-reservation")
+
+    File.mkdir!(path)
+    File.chmod!(path, 0o700)
+    if owner, do: File.write!(Path.join(path, "owner"), owner)
+    path
   end
 
   @tag :tmp_dir

--- a/test/ptc_runner/kernel/publication_authority_test.exs
+++ b/test/ptc_runner/kernel/publication_authority_test.exs
@@ -298,6 +298,11 @@ defmodule PtcRunner.Kernel.PublicationAuthorityTest do
                :normal
              )
 
+    reservation = PublicationAuthority.handles(first).trace.reservation_path
+    owner = Path.join(reservation, "owner")
+    assert File.read!(owner) == System.pid()
+    assert Bitwise.band(File.stat!(owner).mode, 0o777) == 0o600
+
     assert {:error, :destination_exists} =
              PublicationAuthority.authorize(
                "second-authority",


### PR DESCRIPTION
## Summary

- record the owning OS pid inside output and envelope reservation directories
- reclaim reservations whose owner is gone while preserving live, fresh, occupied, or uncertain reservations
- make `destination_exists` diagnostics name requested artifact paths and explain recovery
- document reservation behavior in the CLI reference

## Validation

- `mix test test/ptc_runner/kernel/command_frontend_test.exs test/ptc_runner/kernel/publication_authority_test.exs`
- `MIX_ENV=dev mix docs --warnings-as-errors`
- `scripts/ci/core-release.sh` (isolated rerun after a resource-contention failure in the concurrent pre-push lanes)

## Retrospective

- Untracked follow-up work with a reproduction: none
- Repository instruction missing, wrong, or guessed: none

Closes #1854