### PR TITLE
fix(viewer): show workflow-supplied program sources

### DIFF
--- a/lib/ptc_runner/kernel/project_viewer_adapter.ex
+++ b/lib/ptc_runner/kernel/project_viewer_adapter.ex
@@ -43,6 +43,19 @@ defmodule PtcRunner.Kernel.ProjectViewerAdapter do
 
   def conversation(_source, _run_id), do: {:error, :invalid_inspection_query}
 
+  @spec generated_sources(
+          {:inspection_snapshot, InspectionSnapshot.t()}
+          | {:viewer_snapshot_store, ViewerSnapshotStore.t()},
+          binary()
+        ) :: {:ok, map()} | {:error, atom()}
+  def generated_sources({:inspection_snapshot, snapshot}, run_id),
+    do: collect(snapshot, :generated_sources, run_id)
+
+  def generated_sources({:viewer_snapshot_store, store}, run_id),
+    do: ViewerSnapshotStore.generated_sources(store, run_id)
+
+  def generated_sources(_source, _run_id), do: {:error, :invalid_inspection_query}
+
   @spec result(
           {:inspection_snapshot, InspectionSnapshot.t()}
           | {:viewer_snapshot_store, ViewerSnapshotStore.t()},
@@ -101,7 +114,11 @@ defmodule PtcRunner.Kernel.ProjectViewerAdapter do
 
   @spec collect(
           InspectionSnapshot.t(),
-          :turns | :effective_preludes | :execution_errors | :explicit_failure_values,
+          :turns
+          | :generated_sources
+          | :effective_preludes
+          | :execution_errors
+          | :explicit_failure_values,
           binary()
         ) ::
           {:ok, map()} | {:error, atom()}

--- a/lib/ptc_runner/kernel/viewer_adapter.ex
+++ b/lib/ptc_runner/kernel/viewer_adapter.ex
@@ -67,6 +67,11 @@ defmodule PtcRunner.Kernel.ViewerAdapter do
     end
   end
 
+  @spec generated_sources(inspection_grant(), binary()) :: {:ok, map()} | {:error, atom()}
+  @doc "Returns the pinned run's exact evaluated program sources."
+  def generated_sources(grant, run_id),
+    do: inspection_collection(grant, run_id, :generated_sources)
+
   @spec result(inspection_grant(), binary()) :: {:ok, map()} | {:error, atom()}
   @doc "Returns the pinned run's authorized terminal application result."
   def result({:inspection_v4, granted_run_id, snapshot, _trace_snapshot}, run_id)

--- a/lib/ptc_runner/viewer_snapshot_store.ex
+++ b/lib/ptc_runner/viewer_snapshot_store.ex
@@ -79,6 +79,12 @@ defmodule PtcRunner.ViewerSnapshotStore do
 
   def conversation(_store, _run_id), do: {:error, :invalid_inspection_query}
 
+  @spec generated_sources(t(), binary()) :: {:ok, map()} | {:error, atom()}
+  def generated_sources(%__MODULE__{} = store, run_id) when is_binary(run_id),
+    do: call(store, {:generated_sources, run_id})
+
+  def generated_sources(_store, _run_id), do: {:error, :invalid_inspection_query}
+
   @spec result(t(), binary()) :: {:ok, map()} | {:error, atom()}
   def result(%__MODULE__{} = store, run_id) when is_binary(run_id),
     do: call(store, {:result, run_id})
@@ -215,6 +221,9 @@ defmodule PtcRunner.ViewerSnapshotStore do
 
   defp respond({:conversation, run_id}, state, outcome),
     do: respond_inspection(state, outcome, :conversation, run_id)
+
+  defp respond({:generated_sources, run_id}, state, outcome),
+    do: respond_inspection(state, outcome, :generated_sources, run_id)
 
   defp respond({:result, run_id}, state, outcome),
     do: respond_inspection(state, outcome, :result, run_id)
@@ -469,6 +478,9 @@ defmodule PtcRunner.ViewerSnapshotStore do
 
   defp inspect_snapshot(snapshot, :conversation, run_id),
     do: ProjectViewerAdapter.conversation({:inspection_snapshot, snapshot}, run_id)
+
+  defp inspect_snapshot(snapshot, :generated_sources, run_id),
+    do: ProjectViewerAdapter.generated_sources({:inspection_snapshot, snapshot}, run_id)
 
   defp inspect_snapshot(snapshot, :result, run_id),
     do: ProjectViewerAdapter.result({:inspection_snapshot, snapshot}, run_id)

--- a/ptc_viewer/lib/ptc_viewer/api.ex
+++ b/ptc_viewer/lib/ptc_viewer/api.ex
@@ -20,6 +20,9 @@ defmodule PtcViewer.Api do
   @doc "Delegates semantic private conversation reconstruction to the configured host adapter."
   def conversation(config, run_id), do: inspection_query(config, :conversation, run_id)
 
+  @doc "Delegates private evaluated-program source retrieval to the configured host adapter."
+  def generated_sources(config, run_id), do: inspection_query(config, :generated_sources, run_id)
+
   @doc "Delegates authorized terminal application-result retrieval to the configured host adapter."
   def result(config, run_id), do: inspection_query(config, :result, run_id)
 

--- a/ptc_viewer/lib/ptc_viewer/router.ex
+++ b/ptc_viewer/lib/ptc_viewer/router.ex
@@ -121,6 +121,10 @@ defmodule PtcViewer.Router do
     send_analysis(conn, PtcViewer.Api.conversation(viewer_config(conn), run_id))
   end
 
+  get "/api/analysis/runs/:run_id/generated-sources" do
+    send_analysis(conn, PtcViewer.Api.generated_sources(viewer_config(conn), run_id))
+  end
+
   get "/api/analysis/runs/:run_id/result" do
     send_analysis(conn, PtcViewer.Api.result(viewer_config(conn), run_id))
   end

--- a/ptc_viewer/lib/ptc_viewer/server.ex
+++ b/ptc_viewer/lib/ptc_viewer/server.ex
@@ -328,6 +328,7 @@ defmodule PtcViewer.Server do
         [
           :pin_inspection,
           :conversation,
+          :generated_sources,
           :result,
           :preludes,
           :execution_errors,

--- a/ptc_viewer/priv/static/js/app.js
+++ b/ptc_viewer/priv/static/js/app.js
@@ -302,12 +302,14 @@ async function fetchAllTurns(runId) {
 
 async function loadRun(runId, routeGeneration) {
   const [
-    runResponse, turnsResult, conversationResponse, resultResponse, preludesResponse,
+    runResponse, turnsResult, conversationResponse, generatedSourcesResponse,
+    resultResponse, preludesResponse,
     executionErrorsResponse, explicitFailureValuesResponse
   ] = await Promise.all([
     fetch(`/api/kernel/runs/${encodeURIComponent(runId)}`),
     fetchAllTurns(runId),
     fetch(`/api/analysis/runs/${encodeURIComponent(runId)}/conversation`),
+    fetch(`/api/analysis/runs/${encodeURIComponent(runId)}/generated-sources`),
     fetch(`/api/analysis/runs/${encodeURIComponent(runId)}/result`),
     fetch(`/api/analysis/runs/${encodeURIComponent(runId)}/preludes`),
     fetch(`/api/analysis/runs/${encodeURIComponent(runId)}/execution-errors`),
@@ -338,6 +340,13 @@ async function loadRun(runId, routeGeneration) {
             status: resultResponse.status,
             reason: await safeBodyText(resultResponse)
           };
+      const generated_sources = generatedSourcesResponse.ok
+        ? await generatedSourcesResponse.json()
+        : {
+            'available?': false,
+            status: generatedSourcesResponse.status,
+            reason: await safeBodyText(generatedSourcesResponse)
+          };
       // Both private routes report an absence the same way, because the
       // transcript states it the same way: the reason code, not the status.
       const preludes = preludesResponse.ok
@@ -367,6 +376,7 @@ async function loadRun(runId, routeGeneration) {
           metadata: await runResponse.json(),
           turns: turnsResult.turns,
           conversation,
+          generated_sources,
           result,
           preludes,
           execution_errors,
@@ -437,6 +447,7 @@ function renderRun(data, { fresh = false, routeGeneration = state.routeGeneratio
           renderRun({
             metadata,
             conversation,
+            generated_sources: data.generated_sources,
             result: data.result,
             preludes: data.preludes,
             execution_errors: data.execution_errors,

--- a/ptc_viewer/priv/static/js/kernel-transcript.js
+++ b/ptc_viewer/priv/static/js/kernel-transcript.js
@@ -49,7 +49,7 @@ export function renderKernelTranscriptMarkup(data) {
 }
 
 function KernelTranscript({
-  metadata = {}, turns = {}, conversation = null, preludes = null,
+  metadata = {}, turns = {}, conversation = null, generated_sources = null, preludes = null,
   execution_errors = null, explicit_failure_values = null,
   result = null, last_evaluation_error = null, options = {}
 }) {
@@ -61,6 +61,10 @@ function KernelTranscript({
   const privatePrograms = new Map();
   const privateResults = new Map();
   const modelSessions = new Map();
+
+  for (const program of generated_sources?.items || []) {
+    if (program?.evaluation_id) privatePrograms.set(program.evaluation_id, program);
+  }
 
   for (const stream of conversation?.streams || []) {
     const streamTurns = stream.turns || [];
@@ -662,12 +666,18 @@ function Evaluation({ evaluation, preludeIndex }) {
 function EvaluationSource({ evaluation, preludeIndex }) {
   const canonicalHash = evaluation.start?.data?.source_hash;
   const program = evaluation.privateProgram;
+  const provenance = evaluation.modelSession
+    ? 'Model-generated'
+    : evaluation.start?.data?.parent_evaluation_id
+      ? 'Workflow-supplied'
+      : 'Directly supplied';
 
   const sourceBlock = program?.source != null
     ? html`
       <details class="kt-private-source" open=${environmentOf(evaluation) === 'workflow'}>
         <summary>
           Program source
+          <span class="kt-private-badge">${provenance}</span>
           <span class="kt-private-badge">private evidence</span>
         </summary>
         ${rawHtml('pre', 'kt-code kt-code-lisp', highlightLisp(program.source))}

--- a/ptc_viewer/test/kernel_transcript_test.exs
+++ b/ptc_viewer/test/kernel_transcript_test.exs
@@ -82,6 +82,7 @@ defmodule PtcViewer.KernelTranscriptTest do
     rendered = render(directory, data)
 
     assert rendered =~ "Program source"
+    assert rendered =~ "Model-generated"
     assert rendered =~ "Execution result"
     assert rendered =~ "diagnosis"
     assert rendered =~ "other/uncaptured"
@@ -89,6 +90,52 @@ defmodule PtcViewer.KernelTranscriptTest do
     assert rendered =~ ~s(>runs/diagnose</a>)
     assert rendered =~ ~s(href="#kt-prelude-20-0-function-64-69-61-67-6e-6f-73-65")
     refute rendered =~ ~s(>other/uncaptured</a>)
+  end
+
+  test "renders workflow-supplied programs independently of conversation streams", %{
+    tmp_dir: directory
+  } do
+    source = ~S|(return (demo.browser/probe (get data/params "url")))|
+
+    rendered =
+      render(directory, %{
+        "metadata" => %{"run_id" => "workflow-source-run"},
+        "turns" => %{
+          "items" => [
+            event(1, "evaluation-started", %{
+              "evaluation_id" => "mission-evaluation-1",
+              "parent_evaluation_id" => "workflow-evaluation-1",
+              "environment" => "mission",
+              "mission_name" => "browser",
+              "program_kind" => "ptc-lisp",
+              "source_hash" => "sha256:workflow-source",
+              "source_bytes" => byte_size(source)
+            }),
+            event(2, "evaluation-stopped", %{
+              "evaluation_id" => "mission-evaluation-1",
+              "environment" => "mission",
+              "mission_name" => "browser",
+              "status" => "returned"
+            })
+          ]
+        },
+        "conversation" => %{"streams" => []},
+        "generated_sources" => %{
+          "items" => [
+            %{
+              "evaluation_id" => "mission-evaluation-1",
+              "environment" => "mission",
+              "mission_name" => "browser",
+              "source" => source
+            }
+          ]
+        }
+      })
+
+    assert rendered =~ "Program source"
+    assert rendered =~ "Workflow-supplied"
+    assert rendered =~ "demo.browser/probe"
+    refute rendered =~ "Open prompt, response &amp; program"
   end
 
   test "keeps captured calls unlinked without authorized prelude source", %{tmp_dir: directory} do

--- a/ptc_viewer/test/ptc_viewer/api_test.exs
+++ b/ptc_viewer/test/ptc_viewer/api_test.exs
@@ -129,6 +129,21 @@ defmodule PtcViewer.ApiTest do
     assert actual_source == inspect(source)
   end
 
+  test "generated sources delegates the pinned inspection grant", %{trace_dir: trace_dir} do
+    source = {:pinned, "run.ptcins"}
+    {:ok, store} = PtcViewer.InspectionStore.start(source)
+    on_exit(fn -> if Process.alive?(store), do: PtcViewer.InspectionStore.stop(store) end)
+
+    config = [
+      trace_dir: trace_dir,
+      inspection_store: store,
+      inspection_adapter: PtcViewer.PinningInspectionTestAdapter
+    ]
+
+    assert {:ok, %{"run_id" => "run-1", "items" => []}} =
+             PtcViewer.Api.generated_sources(config, "run-1")
+  end
+
   test "result delegates the pinned inspection grant", %{trace_dir: trace_dir} do
     source = {:pinned, "run.ptcins"}
     {:ok, store} = PtcViewer.InspectionStore.start(source)

--- a/ptc_viewer/test/support/inspection_test_adapter.ex
+++ b/ptc_viewer/test/support/inspection_test_adapter.ex
@@ -6,6 +6,7 @@ defmodule PtcViewer.TestInspectionAdapter do
   end
 
   def conversation(_source, _run_id), do: {:error, :not_called}
+  def generated_sources(_source, _run_id), do: {:error, :not_called}
   def result(_source, _run_id), do: {:error, :not_called}
   def preludes(_source, _run_id), do: {:error, :not_called}
   def execution_errors(_source, _run_id), do: {:error, :not_called}
@@ -19,6 +20,9 @@ defmodule PtcViewer.PinningInspectionTestAdapter do
 
   def conversation(source, run_id),
     do: {:ok, %{"source" => inspect(source), "run_id" => run_id, "streams" => []}}
+
+  def generated_sources(source, run_id),
+    do: {:ok, %{"source" => inspect(source), "run_id" => run_id, "items" => []}}
 
   def result(source, run_id),
     do: {:ok, %{"source" => inspect(source), "run_id" => run_id, "value" => "done"}}

--- a/test/ptc_runner/kernel/viewer_adapter_test.exs
+++ b/test/ptc_runner/kernel/viewer_adapter_test.exs
@@ -32,6 +32,12 @@ defmodule PtcRunner.Kernel.ViewerAdapterTest do
                "limit" => 1_000
              })
 
+    assert {:ok, expected_sources} =
+             InspectionSnapshot.query(inspection, :generated_sources, %{
+               "run_id" => fixture.run_id,
+               "limit" => 1_000
+             })
+
     inspection_path =
       fixture.inspection
       |> Path.join("*.ptcins")
@@ -43,6 +49,7 @@ defmodule PtcRunner.Kernel.ViewerAdapterTest do
 
     assert {:ok, actual} = ViewerAdapter.conversation(grant, fixture.run_id)
     assert actual == expected
+    assert {:ok, ^expected_sources} = ViewerAdapter.generated_sources(grant, fixture.run_id)
     assert {:error, :result_not_found} = ViewerAdapter.result(grant, fixture.run_id)
     assert {:ok, ^expected_preludes} = ViewerAdapter.preludes(grant, fixture.run_id)
     assert {:error, :inspection_run_mismatch} = ViewerAdapter.preludes(grant, "another-run")
@@ -68,6 +75,9 @@ defmodule PtcRunner.Kernel.ViewerAdapterTest do
 
     project_source = {:inspection_snapshot, inspection}
     assert {:ok, ^expected} = ProjectViewerAdapter.conversation(project_source, fixture.run_id)
+
+    assert {:ok, ^expected_sources} =
+             ProjectViewerAdapter.generated_sources(project_source, fixture.run_id)
 
     assert {:error, :result_not_found} =
              ProjectViewerAdapter.result(project_source, fixture.run_id)


### PR DESCRIPTION
## Summary

- load authorized `generated_sources` independently of model conversations
- join evaluated program sources into the canonical evaluation timeline by `evaluation_id`
- label program provenance while keeping the Model sessions & programs panel model-specific

## Validation

- `mix test test/ptc_runner/kernel/viewer_adapter_test.exs test/ptc_runner/viewer_snapshot_store_test.exs`
- `cd ptc_viewer && mix test test/kernel_transcript_test.exs test/ptc_viewer/api_test.exs test/ptc_viewer/router_test.exs`
- manually verified in Chrome that an empty-conversation mission evaluation shows its expandable Workflow-supplied program source

## Retrospective

- Untracked follow-up work: none.
- Missing, wrong, or guessed repository instruction: none.

Closes #1896