### PR TITLE
fix(init): add schema references to generated JSON

### DIFF
--- a/docs/reference/application-manifest.md
+++ b/docs/reference/application-manifest.md
@@ -19,6 +19,14 @@ value or an unknown caller-authored key. Paths through named maps use `*` for
 the caller-selected name, and an unknown property stops at its schema-owned
 parent.
 
+New manifests from `ptc init` identify the hosted schema with
+`"$schema": "https://ptc-runner.dev/schemas/ptc-application-manifest.schema.json"`.
+Some VS Code installations require a one-time URI trust approval for
+`https://ptc-runner.dev` before loading it; that approval concerns the hosted
+URI, not whether the manifest satisfies the schema. Adding `$schema` manually
+to an existing manifest changes its `application_content_digest`, just like
+any other application-content change.
+
 ## Start with one workflow
 
 ```json

--- a/examples/adaptive-web-parser/ptc-host.json
+++ b/examples/adaptive-web-parser/ptc-host.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://ptc-runner.dev/schemas/ptc-host-config.schema.json",
   "credentials": {"fixture_origin": {"env": "PTC_WEB_FIXTURE_ORIGIN"}},
   "install": {
     "repair-model": {

--- a/examples/adaptive-web-parser/ptc-host.live.json
+++ b/examples/adaptive-web-parser/ptc-host.live.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://ptc-runner.dev/schemas/ptc-host-config.schema.json",
   "credentials": {
     "fixture_origin": {"env": "PTC_WEB_FIXTURE_ORIGIN"},
     "openrouter_key": {"env": "OPENROUTER_API_KEY"}

--- a/examples/adaptive-web-parser/query.ptc.json
+++ b/examples/adaptive-web-parser/query.ptc.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://ptc-runner.dev/schemas/ptc-application-manifest.schema.json",
   "version": 1,
   "workflow": {
     "components": [

--- a/examples/adaptive-web-parser/repair.ptc.json
+++ b/examples/adaptive-web-parser/repair.ptc.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://ptc-runner.dev/schemas/ptc-application-manifest.schema.json",
   "version": 1,
   "workflow": {
     "components": [

--- a/examples/debug-a-failed-run/debugger-agent/ptc.json
+++ b/examples/debug-a-failed-run/debugger-agent/ptc.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://ptc-runner.dev/schemas/ptc-application-manifest.schema.json",
   "version": 1,
   "workflow": {
     "components": [

--- a/examples/debug-a-failed-run/debugger/ptc.json
+++ b/examples/debug-a-failed-run/debugger/ptc.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://ptc-runner.dev/schemas/ptc-application-manifest.schema.json",
   "version": 1,
   "workflow": {
     "components": [

--- a/examples/debug-a-failed-run/ptc-host.json
+++ b/examples/debug-a-failed-run/ptc-host.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://ptc-runner.dev/schemas/ptc-host-config.schema.json",
   "credentials": {
     "openrouter_key": {"env": "OPENROUTER_API_KEY"}
   },

--- a/examples/debug-a-failed-run/repair-agent/ptc.json
+++ b/examples/debug-a-failed-run/repair-agent/ptc.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://ptc-runner.dev/schemas/ptc-application-manifest.schema.json",
   "version": 1,
   "workflow": {
     "components": [

--- a/examples/debug-a-failed-run/self-check-workflow-host.json
+++ b/examples/debug-a-failed-run/self-check-workflow-host.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://ptc-runner.dev/schemas/ptc-host-config.schema.json",
   "credentials": {
     "openrouter_key": {
       "env": "OPENROUTER_API_KEY"

--- a/examples/debug-a-failed-run/self-check-workflow.ptc-project.json
+++ b/examples/debug-a-failed-run/self-check-workflow.ptc-project.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://ptc-runner.dev/schemas/ptc-project-config.schema.json",
   "kind": "ptc-project",
   "version": 1,
   "application": {

--- a/examples/debug-a-failed-run/self-check.ptc-project.json
+++ b/examples/debug-a-failed-run/self-check.ptc-project.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://ptc-runner.dev/schemas/ptc-project-config.schema.json",
   "kind": "ptc-project",
   "version": 1,
   "application": {

--- a/examples/debug-a-failed-run/self-check.ptc.json
+++ b/examples/debug-a-failed-run/self-check.ptc.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://ptc-runner.dev/schemas/ptc-application-manifest.schema.json",
   "version": 1,
   "workflow": {
     "components": [

--- a/examples/debug-a-failed-run/self-debugger.ptc-project.json
+++ b/examples/debug-a-failed-run/self-debugger.ptc-project.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://ptc-runner.dev/schemas/ptc-project-config.schema.json",
   "kind": "ptc-project",
   "version": 1,
   "application": {

--- a/examples/debug-a-failed-run/self-debugger.ptc.json
+++ b/examples/debug-a-failed-run/self-debugger.ptc.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://ptc-runner.dev/schemas/ptc-application-manifest.schema.json",
   "version": 1,
   "workflow": {
     "components": [

--- a/examples/debug-a-failed-run/self-host.json
+++ b/examples/debug-a-failed-run/self-host.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://ptc-runner.dev/schemas/ptc-host-config.schema.json",
   "credentials": {
     "openrouter_key": {
       "env": "OPENROUTER_API_KEY"

--- a/examples/debug-a-failed-run/self-improver-host.json
+++ b/examples/debug-a-failed-run/self-improver-host.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://ptc-runner.dev/schemas/ptc-host-config.schema.json",
   "credentials": {
     "openrouter_key": {
       "env": "OPENROUTER_API_KEY"

--- a/examples/debug-a-failed-run/self-improver.ptc-project.json
+++ b/examples/debug-a-failed-run/self-improver.ptc-project.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://ptc-runner.dev/schemas/ptc-project-config.schema.json",
   "kind": "ptc-project",
   "version": 1,
   "application": {

--- a/examples/debug-a-failed-run/self-improver.ptc.json
+++ b/examples/debug-a-failed-run/self-improver.ptc.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://ptc-runner.dev/schemas/ptc-application-manifest.schema.json",
   "version": 1,
   "workflow": {
     "components": [

--- a/examples/debug-a-failed-run/self-repair.ptc-project.json
+++ b/examples/debug-a-failed-run/self-repair.ptc-project.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://ptc-runner.dev/schemas/ptc-project-config.schema.json",
   "kind": "ptc-project",
   "version": 1,
   "application": {

--- a/examples/debug-a-failed-run/self-repair.ptc.json
+++ b/examples/debug-a-failed-run/self-repair.ptc.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://ptc-runner.dev/schemas/ptc-application-manifest.schema.json",
   "version": 1,
   "workflow": {
     "components": [

--- a/examples/debug-a-failed-run/target/ptc.json
+++ b/examples/debug-a-failed-run/target/ptc.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://ptc-runner.dev/schemas/ptc-application-manifest.schema.json",
   "version": 1,
   "workflow": {
     "components": [

--- a/examples/debug-a-failed-run/variants/ptc-host-ambiguous.json
+++ b/examples/debug-a-failed-run/variants/ptc-host-ambiguous.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://ptc-runner.dev/schemas/ptc-host-config.schema.json",
   "credentials": {
     "openrouter_key": {"env": "OPENROUTER_API_KEY"}
   },

--- a/examples/debug-a-failed-run/variants/ptc-host-workflow-control.json
+++ b/examples/debug-a-failed-run/variants/ptc-host-workflow-control.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://ptc-runner.dev/schemas/ptc-host-config.schema.json",
   "credentials": {
     "openrouter_key": {"env": "OPENROUTER_API_KEY"}
   },

--- a/examples/debug-a-failed-run/variants/target-ambiguous/ptc.json
+++ b/examples/debug-a-failed-run/variants/target-ambiguous/ptc.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://ptc-runner.dev/schemas/ptc-application-manifest.schema.json",
   "version": 1,
   "workflow": {
     "components": [

--- a/examples/debug-a-failed-run/variants/target-workflow-control/ptc.json
+++ b/examples/debug-a-failed-run/variants/target-workflow-control/ptc.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://ptc-runner.dev/schemas/ptc-application-manifest.schema.json",
   "version": 1,
   "workflow": {
     "components": [

--- a/examples/kernel-tutorial/01-orders/ptc.json
+++ b/examples/kernel-tutorial/01-orders/ptc.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://ptc-runner.dev/schemas/ptc-application-manifest.schema.json",
   "version": 1,
   "workflow": {
     "components": [

--- a/examples/kernel-tutorial/02-deepseek-extract/ptc.json
+++ b/examples/kernel-tutorial/02-deepseek-extract/ptc.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://ptc-runner.dev/schemas/ptc-application-manifest.schema.json",
   "version": 1,
   "workflow": {
     "components": [

--- a/examples/kernel-tutorial/03-file-agent/ptc.json
+++ b/examples/kernel-tutorial/03-file-agent/ptc.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://ptc-runner.dev/schemas/ptc-application-manifest.schema.json",
   "version": 1,
   "workflow": {
     "components": [

--- a/examples/kernel-tutorial/04-multi-turn-agent/ptc.json
+++ b/examples/kernel-tutorial/04-multi-turn-agent/ptc.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://ptc-runner.dev/schemas/ptc-application-manifest.schema.json",
   "version": 1,
   "workflow": {
     "components": [

--- a/examples/kernel-tutorial/05-signature-feedback/ptc.json
+++ b/examples/kernel-tutorial/05-signature-feedback/ptc.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://ptc-runner.dev/schemas/ptc-application-manifest.schema.json",
   "version": 1,
   "workflow": {
     "components": [

--- a/examples/kernel-tutorial/06-cost-budget/ptc.json
+++ b/examples/kernel-tutorial/06-cost-budget/ptc.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://ptc-runner.dev/schemas/ptc-application-manifest.schema.json",
   "version": 1,
   "workflow": {
     "components": [{"id": "tutorial.cost-budget", "path": "request.clj"}],

--- a/examples/kernel-tutorial/07-parallel-fan-out/ptc.json
+++ b/examples/kernel-tutorial/07-parallel-fan-out/ptc.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://ptc-runner.dev/schemas/ptc-application-manifest.schema.json",
   "version": 1,
   "workflow": {
     "components": [

--- a/examples/kernel-tutorial/ptc-host-cost-budget.json
+++ b/examples/kernel-tutorial/ptc-host-cost-budget.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://ptc-runner.dev/schemas/ptc-host-config.schema.json",
   "credentials": {"openrouter_key": {"env": "OPENROUTER_API_KEY"}},
   "limits": {"llm_cost_microusd": 1},
   "install": {

--- a/examples/kernel-tutorial/ptc-host.json
+++ b/examples/kernel-tutorial/ptc-host.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://ptc-runner.dev/schemas/ptc-host-config.schema.json",
   "credentials": {
     "openrouter_key": {"env": "OPENROUTER_API_KEY"}
   },

--- a/examples/llm-replay/ptc-host.json
+++ b/examples/llm-replay/ptc-host.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://ptc-runner.dev/schemas/ptc-host-config.schema.json",
   "install": {
     "frozen-model": {
       "source": "llm_replay",

--- a/examples/llm-replay/ptc.json
+++ b/examples/llm-replay/ptc.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://ptc-runner.dev/schemas/ptc-application-manifest.schema.json",
   "version": 1,
   "workflow": {
     "components": [

--- a/examples/named-mission-reader-writer/ptc-host.json
+++ b/examples/named-mission-reader-writer/ptc-host.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://ptc-runner.dev/schemas/ptc-host-config.schema.json",
   "credentials": {
     "openrouter_key": {"env": "OPENROUTER_API_KEY"}
   },

--- a/examples/named-mission-reader-writer/ptc.json
+++ b/examples/named-mission-reader-writer/ptc.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://ptc-runner.dev/schemas/ptc-application-manifest.schema.json",
   "version": 1,
   "workflow": {
     "components": [

--- a/examples/support-triage/01-one-question/ptc.json
+++ b/examples/support-triage/01-one-question/ptc.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://ptc-runner.dev/schemas/ptc-application-manifest.schema.json",
   "version": 1,
   "workflow": {
     "components": [

--- a/examples/support-triage/02-domain-api/ptc.json
+++ b/examples/support-triage/02-domain-api/ptc.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://ptc-runner.dev/schemas/ptc-application-manifest.schema.json",
   "version": 1,
   "workflow": {
     "components": [

--- a/examples/support-triage/03-specialists/ptc.json
+++ b/examples/support-triage/03-specialists/ptc.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://ptc-runner.dev/schemas/ptc-application-manifest.schema.json",
   "version": 1,
   "workflow": {
     "components": [

--- a/examples/support-triage/mission-boundary-check/ptc.json
+++ b/examples/support-triage/mission-boundary-check/ptc.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://ptc-runner.dev/schemas/ptc-application-manifest.schema.json",
   "version": 1,
   "workflow": {
     "components": [

--- a/examples/support-triage/ptc-host.json
+++ b/examples/support-triage/ptc-host.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://ptc-runner.dev/schemas/ptc-host-config.schema.json",
   "credentials": {
     "openrouter_key": {"env": "OPENROUTER_API_KEY"}
   },

--- a/lib/ptc_runner/kernel/command_initializer.ex
+++ b/lib/ptc_runner/kernel/command_initializer.ex
@@ -31,6 +31,7 @@ defmodule PtcRunner.Kernel.CommandInitializer do
 
   @manifest """
   {
+    "$schema": "https://ptc-runner.dev/schemas/ptc-application-manifest.schema.json",
     "version": 1,
     "workflow": {
       "components": [

--- a/site/reference/application-manifest/index.html
+++ b/site/reference/application-manifest/index.html
@@ -112,7 +112,13 @@ The message also names the bounded JSON Schema rule (<code class="inline">type</
 <code class="inline">maximum</code>, <code class="inline">required</code>, or another supported rule) without copying the rejected
 value or an unknown caller-authored key. Paths through named maps use <code class="inline">*</code> for
 the caller-selected name, and an unknown property stops at its schema-owned
-parent.</p><h2 id="start-with-one-workflow">Start with one workflow</h2><pre><code class="json language-json">{
+parent.</p><p>New manifests from <code class="inline">ptc init</code> identify the hosted schema with
+<code class="inline">&quot;$schema&quot;: &quot;https://ptc-runner.dev/schemas/ptc-application-manifest.schema.json&quot;</code>.
+Some VS Code installations require a one-time URI trust approval for
+<code class="inline">https://ptc-runner.dev</code> before loading it; that approval concerns the hosted
+URI, not whether the manifest satisfies the schema. Adding <code class="inline">$schema</code> manually
+to an existing manifest changes its <code class="inline">application_content_digest</code>, just like
+any other application-content change.</p><h2 id="start-with-one-workflow">Start with one workflow</h2><pre><code class="json language-json">{
   &quot;version&quot;: 1,
   &quot;workflow&quot;: {
     &quot;components&quot;: [

--- a/test/ptc_runner/kernel/command_initializer_test.exs
+++ b/test/ptc_runner/kernel/command_initializer_test.exs
@@ -1,6 +1,7 @@
 defmodule PtcRunner.Kernel.CommandInitializerTest do
   use ExUnit.Case, async: true
 
+  alias PtcRunner.Kernel.ApplicationPackage
   alias PtcRunner.Kernel.CommandContract
   alias PtcRunner.Kernel.CommandEngine
   alias PtcRunner.Kernel.CommandInitializer
@@ -19,6 +20,7 @@ defmodule PtcRunner.Kernel.CommandInitializerTest do
 
   @manifest """
   {
+    "$schema": "https://ptc-runner.dev/schemas/ptc-application-manifest.schema.json",
     "version": 1,
     "workflow": {
       "components": [
@@ -50,11 +52,41 @@ defmodule PtcRunner.Kernel.CommandInitializerTest do
     assert File.read!(Path.join(target, "main.clj")) == @main_clj
     assert File.read!(Path.join(target, "ptc.json")) == @manifest
 
+    assert {:ok, manifest} = Jason.decode(File.read!(Path.join(target, "ptc.json")))
+
+    assert manifest["$schema"] ==
+             "https://ptc-runner.dev/schemas/ptc-application-manifest.schema.json"
+
+    assert {:ok, request} =
+             ApplicationPackage.request_directory(Path.join(target, "ptc.json"))
+
+    manifest_without_schema =
+      String.replace(
+        @manifest,
+        ~s(  "$schema": "https://ptc-runner.dev/schemas/ptc-application-manifest.schema.json",\n),
+        ""
+      )
+
+    assert {:ok, request_without_schema} =
+             ApplicationPackage.request_memory("ptc.json", %{
+               "main.clj" => @main_clj,
+               "ptc.json" => manifest_without_schema
+             })
+
+    refute request.package.application_content_digest ==
+             request_without_schema.package.application_content_digest
+
     assert File.read!(Path.join(target, ".gitignore")) ==
              ".ptc/\n.ptc-private-*\n.ptc-private-result-*\n"
 
     assert {:ok, project} =
              ProjectConfig.load(Path.join(target, "ptc-project.json"))
+
+    assert {:ok, project_document} =
+             Jason.decode(File.read!(Path.join(target, "ptc-project.json")))
+
+    assert project_document["$schema"] ==
+             "https://ptc-runner.dev/schemas/ptc-project-config.schema.json"
 
     assert project.application == Path.join(target, "ptc.json")
     assert project.viewer.port == 0

--- a/test/ptc_runner/kernel/example_library_test.exs
+++ b/test/ptc_runner/kernel/example_library_test.exs
@@ -4,10 +4,13 @@ defmodule PtcRunner.Kernel.ExampleLibraryTest do
   import ExUnit.CaptureIO
 
   alias PtcRunner.Dotenv
+  alias PtcRunner.Kernel.ApplicationPackage
   alias PtcRunner.Kernel.CommandContract
   alias PtcRunner.Kernel.CommandEngine
   alias PtcRunner.Kernel.CommandOutcome
   alias PtcRunner.Kernel.ExampleLibrary
+  alias PtcRunner.Kernel.HostConfig
+  alias PtcRunner.Kernel.Limits
   alias PtcRunner.Kernel.ProjectConfig
   alias PtcRunner.MixCommandAdapter
 
@@ -22,6 +25,41 @@ defmodule PtcRunner.Kernel.ExampleLibraryTest do
 
         if File.regular?(source) do
           assert File.read!(source) == content, "#{name}/#{relative} drifted from its source"
+        end
+      end
+    end
+  end
+
+  @tag :tmp_dir
+  test "every materialized PTC document identifies and passes its runtime schema boundary", %{
+    tmp_dir: directory
+  } do
+    schema_by_role = %{
+      application: "https://ptc-runner.dev/schemas/ptc-application-manifest.schema.json",
+      host: "https://ptc-runner.dev/schemas/ptc-host-config.schema.json",
+      project: "https://ptc-runner.dev/schemas/ptc-project-config.schema.json"
+    }
+
+    for name <- ExampleLibrary.names() do
+      target = Path.join(directory, name)
+
+      assert {:ok, %CommandOutcome{}} =
+               CommandEngine.dispatch(["init", target, "--example", name])
+
+      installed_limits = installed_limits_for(target)
+
+      for path <- Path.wildcard(Path.join(target, "**/*.json")) do
+        source = File.read!(path)
+        document = Jason.decode!(source)
+
+        case ptc_document_role(document) do
+          nil ->
+            :ok
+
+          role ->
+            assert document["$schema"] == schema_by_role[role], path
+            assert String.starts_with?(source, ~s({\n  "$schema":)), path
+            assert_runtime_loads(role, path, installed_limits)
         end
       end
     end
@@ -285,4 +323,49 @@ defmodule PtcRunner.Kernel.ExampleLibraryTest do
     assert envelope["error"]["phase"] == "publication"
     assert File.ls!(target) == ["keep.txt"]
   end
+
+  defp ptc_document_role(%{"kind" => "ptc-project"}), do: :project
+
+  defp ptc_document_role(%{"version" => 1, "workflow" => workflow}) when is_map(workflow),
+    do: :application
+
+  defp ptc_document_role(%{"install" => install}) when is_map(install), do: :host
+  defp ptc_document_role(_document), do: nil
+
+  defp installed_limits_for(target) do
+    overrides =
+      target
+      |> Path.join("**/*.json")
+      |> Path.wildcard()
+      |> Enum.reduce(%{}, fn path, acc ->
+        case path |> File.read!() |> Jason.decode!() do
+          %{"install" => install} = host when is_map(install) ->
+            host
+            |> Map.get("limits", %{})
+            |> Enum.reduce(acc, fn {name, value}, limits ->
+              {:ok, field} = Limits.name(name)
+              Map.update(limits, field, value, &max(&1, value))
+            end)
+
+          _document ->
+            acc
+        end
+      end)
+
+    {:ok, limits} = Limits.installed(overrides)
+    limits
+  end
+
+  defp assert_runtime_loads(:project, path, _installed_limits),
+    do: assert({:ok, _project} = ProjectConfig.load(path))
+
+  defp assert_runtime_loads(:application, path, installed_limits),
+    do:
+      assert(
+        {:ok, _request} =
+          ApplicationPackage.request_directory(path, installed_limits: installed_limits)
+      )
+
+  defp assert_runtime_loads(:host, path, _installed_limits),
+    do: assert({:ok, _host} = HostConfig.load(path))
 end


### PR DESCRIPTION
## Summary

- add exact hosted schema identifiers to the default scaffold and every project, application, and host document in all embedded example trees
- validate every materialized document through its runtime boundary and preserve application-content digest semantics
- document the VS Code URI-trust caveat and digest consequence
- Closes #1899

## Validation

- `mix test test/ptc_runner/kernel/command_initializer_test.exs test/ptc_runner/kernel/example_library_test.exs`
- `mix nightly`

## Retrospective

- Untracked follow-up work: none.
- Repository instruction that was missing, wrong, or guessed: none.