### PR TITLE
fix(release): accept the build identity in the container version probe

### DIFF
--- a/scripts/build_container_image.sh
+++ b/scripts/build_container_image.sh
@@ -104,8 +104,14 @@ EOF
 cp test/support/mcp_stdio_source_fixture.sh "$probe_dir/mcp_stdio_source_fixture.sh"
 chmod 0755 "$probe_dir/mcp_stdio_source_fixture.sh"
 
+# The build passes `PTC_SOURCE_REVISION` above, so the image reports its build
+# identity and not a bare version. This is the contract
+# `verify_standalone_release.sh` already checks inside the image; both have to
+# move together when the rendering changes.
 docker run --rm "${mounted_run[@]}" "$image_tag" --version > "$probe_dir/version.stdout"
-grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$' "$probe_dir/version.stdout"
+grep -Eq \
+  '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)? \([0-9a-f]{8}, (clean|dirty)\)$' \
+  "$probe_dir/version.stdout"
 
 # Exercise the target-native C launcher through the release's real stdio
 # transport. Finding the optional application in the release is not enough:


### PR DESCRIPTION
## Summary

- `scripts/build_container_image.sh` matched `ptc --version` against a bare
  semver, but the same commit that introduced the check's counterpart
  (`91b13b4b8`) added the `PTC_SOURCE_REVISION` build argument to this very
  script, so the image reports `0.14.0 (<sha>, clean)`.
- Under `set -euo pipefail` the unmatched `grep -q` aborted the script with
  status 1 and no output, immediately after the image was built. Every probe
  behind it stopped running: the launcher's MCP stdio exchange, `run` stdout
  purity, the non-root user assertion, and both Viewer port cases.
- `container-release.yml` calls this script, and its last run predates the
  break, so the next container release would have failed at "Build and verify
  the finished image".
- Adopt the regex `scripts/verify_standalone_release.sh` already applies inside
  the image, with a comment tying the two together so a change to the version
  rendering moves both.
- The image itself was never affected: every probe passes when run by hand.

Closes #1901

## Validation

- `scripts/build_container_image.sh ptc:sanityfix` end to end on arm64: it now
  runs all five finished-image probes and reaches its success banner, exit 0.
  Run bare, not through a pipe — a pipe reports the last stage's status and
  hides this class of failure entirely.
- Confirmed the pre-fix failure on `main` the same way: exit 1, no output, no
  banner.

## Retrospective

- Follow-up: none.
- Repository instruction: none.

https://claude.ai/code/session_01FF6hHFieiWEzqAQk2ufkPD
