### PR TITLE
fix(llm): size cold preflight heap by provider source

### DIFF
--- a/lib/ptc_runner/kernel/local_preflight.ex
+++ b/lib/ptc_runner/kernel/local_preflight.ex
@@ -520,7 +520,7 @@ defmodule PtcRunner.Kernel.LocalPreflight do
                   invoke(
                     callback,
                     occurrence,
-                    catalog.implementations[occurrence.name],
+                    catalog.descriptors[occurrence.name],
                     context,
                     services,
                     timeout_ms,
@@ -631,11 +631,11 @@ defmodule PtcRunner.Kernel.LocalPreflight do
     end
   end
 
-  defp invoke(callback, occurrence, implementation, context, services, timeout_ms, step) do
+  defp invoke(callback, occurrence, descriptor, context, services, timeout_ms, step) do
     result =
       BoundedWorker.run(fn -> callback.(occurrence.config, context, services) end,
         timeout_ms: timeout_ms,
-        max_heap_words: max_heap_words(implementation, step),
+        max_heap_words: max_heap_words(descriptor, step),
         cancel_with_caller: true,
         # Linking to the caller alone is not enough for active work. The
         # executor can outlive the session, so a callback blocked in network or
@@ -648,10 +648,12 @@ defmodule PtcRunner.Kernel.LocalPreflight do
     BoundedWorker.classify_callback(result)
   end
 
-  defp max_heap_words(%{provider_application: :req_llm}, %{activity: false}),
+  # Cold bundled model metadata can need this budget regardless of the selected
+  # LLM adapter. Application ownership is independent of preparation cost.
+  defp max_heap_words(%{source: :llm}, %{activity: false}),
     do: @llm_max_heap_words
 
-  defp max_heap_words(_implementation, step), do: step.max_heap_words
+  defp max_heap_words(_descriptor, step), do: step.max_heap_words
 
   # A refused fixture file states the rule it broke, and a line-level rejection
   # states which line. Both are part of the published fixture contract, so

--- a/test/ptc_runner/kernel/local_preflight_test.exs
+++ b/test/ptc_runner/kernel/local_preflight_test.exs
@@ -391,6 +391,38 @@ defmodule PtcRunner.Kernel.LocalPreflightTest do
     assert_receive {:DOWN, ^ref, :process, ^root, _reason}, 5_000
   end
 
+  test "LLM metadata has its audited heap without a provider application" do
+    catalog =
+      catalog(%{
+        "model" => [report_heap: true],
+        "tools" => [destination: :mission, report_heap: true]
+      })
+
+    refute Map.has_key?(catalog.implementations["model"], :provider_application)
+    prepared = prepared(catalog, ["model"], ["tools"])
+    assert :ok = RunCoordinator.local_checks(prepared, catalog, services())
+    assert_received {:worker_heap, "model", %{size: 32_000_000, kill: true}}
+    assert_received {:worker_heap, "tools", %{size: 5_000_000, kill: true}}
+  end
+
+  test "an active LLM check retains the operation provider heap" do
+    catalog = catalog(%{"model" => [local_preflight: :unverified, report_heap: true]})
+    prepared = prepared(catalog, ["model"])
+    expected = prepared.request.package.limits.provider_heap_words
+    assert :ok = ProviderActivity.mark(prepared.provider_activity)
+
+    assert :ok =
+             LocalPreflight.run_unverified(
+               prepared,
+               catalog,
+               services(),
+               session(prepared),
+               false
+             )
+
+    assert_received {:worker_heap, "model", %{size: ^expected, kill: true}}
+  end
+
   test "an unverified callback spends the sealed provider heap, not the audited cap" do
     # Phase 7 holds shipped code to a fixed 200k words. An unverified callback is
     # held to the `provider_heap_words` the operation itself is held to, so a
@@ -733,6 +765,11 @@ defmodule PtcRunner.Kernel.LocalPreflightTest do
 
       if Keyword.get(options, :root), do: register_root(parent, context)
       if Keyword.get(options, :heap), do: allocate(parent)
+
+      if Keyword.get(options, :report_heap) do
+        {:max_heap_size, heap} = Process.info(self(), :max_heap_size)
+        send(parent, {:worker_heap, name, heap})
+      end
 
       case failing do
         nil ->


### PR DESCRIPTION
## Summary

- choose the cold metadata heap from the sealed LLM provider source
- preserve active provider-operation heap limits
- cover LLM adapters without a ReqLLM application identity

## Validation

- `mix test test/ptc_runner/kernel/local_preflight_test.exs`

## Retrospective

- Untracked follow-up: none
- Repository instruction gap: none

Closes #1907