### PR TITLE
feat(kernel): add cleanup-aware host run admission

### DIFF
--- a/docs/maintainers/kernel.md
+++ b/docs/maintainers/kernel.md
@@ -117,6 +117,27 @@ One-shot runs use `ExecutionSessionOwner` whether or not they select a
 provider. The owner opens canonical and optional private sinks, monitors its
 caller and worker, and returns sealed execution evidence.
 
+An embedding host can supervise one `RunAdmission` owner with
+`max_concurrent_runs: n` and route prepared runs through its `execute/3`
+(provider-free) or `execute/5` (catalog and host-owned runtime services).
+Admission refuses excess runs before preparation consumption or publication
+claiming. Its lease belongs to `ExecutionSessionOwner` and lasts through
+provider cleanup, including after request-caller death. Cleanup failure or an
+execution owner dying without acknowledging cleanup fences that capacity
+domain. It does not restart automatically; drain old work before replacing it.
+Admission-owner death aborts the executions it admitted.
+
+This is a bound on executions using that explicit owner. The embedding host
+still bounds inbound requests, preparation and compilation, provisional
+admission processes, and control mailboxes. Physical LLM attempts and connection
+pools have separate limits; this API does not configure or start ReqLLM.
+Publication remains the caller's responsibility after receiving sealed evidence.
+A transport request worker must publish before it exits: returning the sealed
+outcome to a connection process for later publication outlives the claimant.
+Keep the connection responsive while that worker executes, and tie worker
+cancellation to disconnect and connection-process death. Cancellation ends the
+request's work, but only execution-owner cleanup releases its admission slot.
+
 Provider-bearing runs open one `ProviderActiveSession` inside that owner.
 `ProviderAcquisition` prepares and acquires selected providers in dependency
 order. Each scope registers resources through `ResourceRegistrar` before it can
@@ -144,6 +165,9 @@ a separate read followed by an update is a race.
 Normal completion, timeout, caller death, worker death, and termination all
 drain the same owned resource set. Provider work is drained before provider
 closers run. Cleanup remains bounded even when a callback or owner fails.
+The workflow Lisp sandbox also watches its execution worker and is killed when
+that worker dies, so request cancellation cannot leave it evaluating until its
+own deadline.
 
 `PublicationAuthority.authorize/4` anchors and reserves destinations before
 provider activity. `ArtifactPublisher` later consumes only the sealed

--- a/lib/ptc_runner/kernel/execution_session_owner.ex
+++ b/lib/ptc_runner/kernel/execution_session_owner.ex
@@ -7,6 +7,7 @@ defmodule PtcRunner.Kernel.ExecutionSessionOwner do
   alias PtcRunner.Kernel.CommandDiagnostic
   alias PtcRunner.Kernel.ConnectivityResult
   alias PtcRunner.Kernel.EventSink
+  alias PtcRunner.Kernel.ExecutionOutcome
   alias PtcRunner.Kernel.ExecutionSessionResources
   alias PtcRunner.Kernel.InspectionSink
   alias PtcRunner.Kernel.LLMBudget
@@ -20,6 +21,7 @@ defmodule PtcRunner.Kernel.ExecutionSessionOwner do
   alias PtcRunner.Kernel.ProviderRegistry
   alias PtcRunner.Kernel.ProviderSession
   alias PtcRunner.Kernel.PublicationAuthority
+  alias PtcRunner.Kernel.RunAdmission
   alias PtcRunner.Kernel.RunBuilder
   alias PtcRunner.LiveStatus
   alias PtcRunner.LiveStatus.Target
@@ -113,6 +115,52 @@ defmodule PtcRunner.Kernel.ExecutionSessionOwner do
       ),
       do: {:error, :invalid_prepared_run}
 
+  @doc false
+  @spec start_admitted(
+          pid(),
+          PreparedRun.t(),
+          PublicationAuthority.t(),
+          pid(),
+          ProviderExecution.t() | nil
+        ) ::
+          {:ok, t()} | {:error, term()}
+  def start_admitted(host, prepared, authority, caller, execution) do
+    with :ok <- admissible(prepared, authority, execution, nil, :run, nil) do
+      token = make_ref()
+
+      case GenServer.start(
+             __MODULE__,
+             {:admitted, host, prepared, authority, caller, token, execution}
+           ) do
+        {:ok, pid} -> activate_admitted(pid, token, authority)
+        {:error, reason} -> {:error, reason}
+      end
+    end
+  end
+
+  defp activate_admitted(pid, token, authority) do
+    case PublicationAuthority.claim(authority) do
+      {:ok, lease} ->
+        try do
+          :ok = GenServer.call(pid, {token, {:activate, lease}}, :infinity)
+          {:ok, %__MODULE__{pid: pid, token: token}}
+        catch
+          :exit, _ ->
+            PublicationAuthority.abort(authority)
+            {:error, :execution_session_unavailable}
+        end
+
+      {:error, reason} ->
+        try do
+          GenServer.stop(pid, :normal)
+        catch
+          :exit, _ -> :ok
+        end
+
+        {:error, reason}
+    end
+  end
+
   # Every refusal here is decided before `init/1` consumes the prepared run, so
   # a rejected start leaves that preparation reusable.
   defp admissible(prepared, authority, provider_execution, notifier, operation, live_status) do
@@ -191,14 +239,35 @@ defmodule PtcRunner.Kernel.ExecutionSessionOwner do
   def pid(%__MODULE__{pid: pid}), do: pid
 
   @impl GenServer
-  def init(
-        {prepared, authority, caller, token, lease, provider_execution, notifier, operation,
-         live_status}
-      ) do
+  def init({:admitted, host, prepared, authority, caller, token, execution}) do
+    case RunAdmission.admit(host) do
+      :ok ->
+        {:ok,
+         %{
+           pending: {prepared, authority, execution},
+           token: token,
+           caller: caller,
+           caller_ref: Process.monitor(caller),
+           admission: {host, Process.monitor(host)}
+         }}
+
+      {:error, reason} ->
+        {:stop, reason}
+    end
+  end
+
+  def init(args), do: initialize(args, nil)
+
+  defp initialize(
+         {prepared, authority, caller, token, lease, provider_execution, notifier, operation,
+          live_status},
+         admission
+       ) do
     caller_ref = Process.monitor(caller)
 
     initial = %{
       token: token,
+      admission: admission,
       caller: caller,
       caller_ref: caller_ref,
       authority: authority,
@@ -264,6 +333,22 @@ defmodule PtcRunner.Kernel.ExecutionSessionOwner do
 
   @impl GenServer
   def handle_call(
+        {token, {:activate, lease}},
+        {caller, _},
+        %{pending: {prepared, authority, execution}, token: token, caller: caller} = state
+      ) do
+    Process.demonitor(state.caller_ref, [:flush])
+
+    {:ok, active} =
+      initialize(
+        {prepared, authority, caller, token, lease, execution, nil, :run, nil},
+        state.admission
+      )
+
+    {:reply, :ok, active}
+  end
+
+  def handle_call(
         {token, :await},
         {caller, _tag} = from,
         %{token: token, caller: caller, result: nil, waiter: nil} = state
@@ -307,6 +392,12 @@ defmodule PtcRunner.Kernel.ExecutionSessionOwner do
   def handle_cast(_message, state), do: {:noreply, state}
 
   @impl GenServer
+  def handle_info({:DOWN, ref, :process, pid, _}, %{pending: _} = state) do
+    if ref == state.caller_ref or state.admission == {pid, ref},
+      do: {:stop, :normal, state},
+      else: {:noreply, state}
+  end
+
   def handle_info(
         {token, :execution_result, worker_pid, result},
         %{token: token, worker_pid: worker_pid} = state
@@ -361,13 +452,41 @@ defmodule PtcRunner.Kernel.ExecutionSessionOwner do
      |> forget_resource(:authority)}
   end
 
+  def handle_info({:DOWN, ref, :process, host, _}, %{admission: {host, ref}} = state),
+    do: {:stop, :run_admission_unavailable, abort(state)}
+
   def handle_info(_message, state), do: {:noreply, state}
 
   @impl GenServer
-  def terminate(_reason, state) do
-    _state = abort(state)
+  def terminate(reason, %{pending: _, admission: {host, _}}) do
+    RunAdmission.complete(host, reason == :normal)
     :ok
   end
+
+  def terminate(reason, state) do
+    state = abort(state)
+
+    if state.admission do
+      {host, _} = state.admission
+      RunAdmission.complete(host, reason == :normal and clean_admitted_exit?(state))
+    end
+
+    :ok
+  end
+
+  defp clean_admitted_exit?(%{cleanup: {:error, _}}), do: false
+
+  defp clean_admitted_exit?(%{
+         result: {:ok, %ExecutionOutcome{result: {:error, %{kind: :provider_cleanup_error}}}}
+       }),
+       do: false
+
+  defp clean_admitted_exit?(%{
+         result: {:error, %CommandDiagnostic{code: :provider_cleanup_failed}}
+       }),
+       do: false
+
+  defp clean_admitted_exit?(_), do: true
 
   defp open_provider_free(initial, authority, opened_sinks, operation) do
     prepared = initial.prepared

--- a/lib/ptc_runner/kernel/run_admission.ex
+++ b/lib/ptc_runner/kernel/run_admission.ex
@@ -1,0 +1,194 @@
+defmodule PtcRunner.Kernel.RunAdmission do
+  @moduledoc """
+  Explicit host-owned admission for concurrent one-shot executions.
+
+  Start one owner under the embedding host's supervisor with
+  `max_concurrent_runs: n`, and pass its PID to `execute/5` for every hosted
+  run. Preparation and publication keep their existing Kernel contracts;
+  execution returns the same sealed `PtcRunner.Kernel.ExecutionOutcome`.
+  Provider execution must use host-owned applications and no interactive
+  authorization. This module neither starts ReqLLM nor changes its pools.
+
+  A full owner returns `{:error, :run_capacity_exhausted}` before consuming the
+  preparation, claiming publication, or activating providers. There is no
+  waiting queue for execution capacity. Inbound connections, preparation,
+  provisional admission processes, and control mailboxes remain the host's
+  responsibility to bound.
+
+  The lease belongs to the execution-session owner, not the request caller.
+  Caller death triggers that owner's normal provider cleanup. Capacity is
+  released only after cleanup has finished. An owner that dies without a
+  cleanup acknowledgement, or reports cleanup failure, fences this admission
+  owner: later runs return `{:error, :run_admission_unavailable}`. Other
+  admitted runs may finish. The child spec never automatically restarts this
+  capacity domain; the host must drain old work before replacing it. Active
+  execution owners also monitor admission-owner death and abort their runs.
+
+  This counts hosted workflows, not physical LLM requests. Per-run provider
+  task limits still apply. Direct adapter calls and executions through other
+  entry points bypass this owner; Finch capacity, aggregate physical-attempt
+  admission, and rate limits remain separate host responsibilities.
+  """
+  use GenServer
+  use PtcRunner.Kernel.OwnerStatusRedaction
+
+  alias PtcRunner.Kernel.ExecutionOutcome
+  alias PtcRunner.Kernel.ExecutionSessionOwner
+  alias PtcRunner.Kernel.InstallationCatalog
+  alias PtcRunner.Kernel.PreparedRun
+  alias PtcRunner.Kernel.ProviderExecution
+  alias PtcRunner.Kernel.ProviderRuntimeServices
+  alias PtcRunner.Kernel.PublicationAuthority
+
+  @type snapshot :: %{
+          capacity: pos_integer(),
+          in_use: non_neg_integer(),
+          status: :ready | :unavailable
+        }
+
+  @doc false
+  def child_spec(opts),
+    do: %{id: __MODULE__, start: {__MODULE__, :start_link, [opts]}, restart: :temporary}
+
+  @doc "Starts one admission domain; only `:max_concurrent_runs` is accepted."
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts) when is_list(opts) do
+    if Keyword.keyword?(opts) and Keyword.keys(opts) == [:max_concurrent_runs] and
+         is_integer(opts[:max_concurrent_runs]) and opts[:max_concurrent_runs] > 0 do
+      GenServer.start_link(__MODULE__, opts[:max_concurrent_runs])
+    else
+      {:error, :invalid_run_admission}
+    end
+  end
+
+  def start_link(_), do: {:error, :invalid_run_admission}
+
+  @doc "Executes one provider-free preparation and waits for execution-owner cleanup."
+  @spec execute(pid(), PreparedRun.t(), PublicationAuthority.t()) ::
+          {:ok, ExecutionOutcome.t()} | {:error, term()}
+  def execute(host, prepared, authority), do: do_execute(host, prepared, authority, nil)
+
+  @doc "Executes one preparation using its bound catalog and host-owned runtime services."
+  @spec execute(
+          pid(),
+          PreparedRun.t(),
+          PublicationAuthority.t(),
+          InstallationCatalog.t(),
+          ProviderRuntimeServices.t()
+        ) ::
+          {:ok, ExecutionOutcome.t()} | {:error, term()}
+  def execute(
+        host,
+        prepared,
+        authority,
+        catalog,
+        %ProviderRuntimeServices{provider_application_mode: :host_owned} = services
+      ) do
+    with {:ok, execution} <- ProviderExecution.new(catalog, services, []) do
+      do_execute(host, prepared, authority, execution)
+    end
+  end
+
+  def execute(_, _, _, _, _), do: {:error, :invalid_provider_execution}
+
+  defp do_execute(host, prepared, authority, execution) when is_pid(host) do
+    with {:ok, owner} <-
+           ExecutionSessionOwner.start_admitted(host, prepared, authority, self(), execution) do
+      ref = Process.monitor(ExecutionSessionOwner.pid(owner))
+      result = ExecutionSessionOwner.await(owner)
+
+      receive do
+        {:DOWN, ^ref, :process, _, :normal} ->
+          result
+
+        {:DOWN, ^ref, :process, _, :run_admission_unavailable} ->
+          {:error, :run_admission_unavailable}
+
+        {:DOWN, ^ref, :process, _, _} ->
+          {:error, :execution_session_unavailable}
+      end
+    end
+  end
+
+  defp do_execute(_, _, _, _), do: {:error, :invalid_run_admission}
+
+  @doc "Returns counts and readiness without exposing requests or provider configuration."
+  @spec snapshot(pid()) :: {:ok, snapshot()} | {:error, :run_admission_unavailable}
+  def snapshot(host), do: call(host, :snapshot)
+
+  @doc false
+  @spec admit(pid()) :: :ok | {:error, atom()}
+  def admit(host), do: call(host, :admit)
+
+  @doc false
+  @spec complete(pid(), boolean()) :: :ok | {:error, atom()}
+  def complete(host, clean?), do: call(host, {:complete, clean?})
+
+  @impl true
+  def init(capacity), do: {:ok, %{capacity: capacity, owners: %{}, status: :ready}}
+
+  @impl true
+  def handle_call(:snapshot, _, state) do
+    state = fence_dead_owners(state)
+
+    {:reply,
+     {:ok, %{capacity: state.capacity, in_use: map_size(state.owners), status: state.status}},
+     state}
+  end
+
+  def handle_call(:admit, {owner, _}, state) do
+    state = fence_dead_owners(state)
+
+    cond do
+      Map.has_key?(state.owners, owner) or not Process.alive?(owner) ->
+        {:reply, {:error, :run_admission_unavailable}, state}
+
+      state.status == :unavailable ->
+        {:reply, {:error, :run_admission_unavailable}, state}
+
+      map_size(state.owners) >= state.capacity ->
+        {:reply, {:error, :run_capacity_exhausted}, state}
+
+      true ->
+        {:reply, :ok, %{state | owners: Map.put(state.owners, owner, Process.monitor(owner))}}
+    end
+  end
+
+  def handle_call({:complete, clean?}, {owner, _}, state) when is_boolean(clean?) do
+    case Map.pop(state.owners, owner) do
+      {nil, _} ->
+        {:reply, {:error, :run_admission_unavailable}, state}
+
+      {ref, owners} ->
+        Process.demonitor(ref, [:flush])
+
+        {:reply, :ok,
+         %{state | owners: owners, status: if(clean?, do: state.status, else: :unavailable)}}
+    end
+  end
+
+  def handle_call(_, _, state), do: {:reply, {:error, :run_admission_unavailable}, state}
+
+  @impl true
+  def handle_info({:DOWN, ref, :process, owner, _}, state) do
+    if state.owners[owner] == ref,
+      do: {:noreply, %{state | owners: Map.delete(state.owners, owner), status: :unavailable}},
+      else: {:noreply, state}
+  end
+
+  def handle_info(_, state), do: {:noreply, state}
+
+  defp fence_dead_owners(state) do
+    if Enum.any?(state.owners, fn {pid, _} -> not Process.alive?(pid) end),
+      do: %{state | status: :unavailable},
+      else: state
+  end
+
+  defp call(host, request) when is_pid(host) do
+    GenServer.call(host, request, :infinity)
+  catch
+    :exit, _ -> {:error, :run_admission_unavailable}
+  end
+
+  defp call(_, _), do: {:error, :run_admission_unavailable}
+end

--- a/test/ptc_runner/kernel/provider_execution_lifecycle_test.exs
+++ b/test/ptc_runner/kernel/provider_execution_lifecycle_test.exs
@@ -1,27 +1,18 @@
 defmodule PtcRunner.Kernel.ProviderExecutionLifecycleTest do
   use ExUnit.Case, async: false
+  import PtcRunner.TestSupport.ProviderExecutionFixture
 
   import PtcRunner.TestSupport.Eventually, only: [assert_eventually: 1]
   import PtcRunner.TestSupport.TestHelpers, only: [long_running_body: 0]
 
-  alias PtcRunner.Kernel.ApplicationPackage
-  alias PtcRunner.Kernel.Capability
   alias PtcRunner.Kernel.CommandDiagnostic
   alias PtcRunner.Kernel.ExecutionSessionOwner
-  alias PtcRunner.Kernel.InstallationCatalog
-  alias PtcRunner.Kernel.Limits
   alias PtcRunner.Kernel.OwnerFailure
   alias PtcRunner.Kernel.PreparedRun
   alias PtcRunner.Kernel.ProviderActivity
-  alias PtcRunner.Kernel.ProviderDescriptor
-  alias PtcRunner.Kernel.ProviderExecution
   alias PtcRunner.Kernel.ProviderRegistry
-  alias PtcRunner.Kernel.ProviderRuntimeServices
   alias PtcRunner.Kernel.ProviderSession
-  alias PtcRunner.Kernel.PublicationAuthority
-  alias PtcRunner.Kernel.ResourceRegistrar
   alias PtcRunner.Kernel.RunCoordinator
-  alias PtcRunner.Kernel.SelectionRules
 
   test "caller death while provider setup blocks leaves no session, sink, or activity" do
     parent = self()
@@ -713,168 +704,5 @@ defmodule PtcRunner.Kernel.ProviderExecutionLifecycleTest do
     refute_received {:provider_phase, :preflight}
     refute_received {:provider_phase, :acquire}
     refute_received {:provider_root, _root, _registration}
-  end
-
-  defp provider_fixture(opts \\ []) do
-    parent = self()
-    selection_validation = Keyword.get(opts, :selection_validation, :declarative)
-    body = Keyword.get(opts, :body, "(return {\"answer\" 42})")
-    credential_names = Keyword.get(opts, :credential_names, [])
-
-    # The default acquisition registers a resource root, so a refusal test can
-    # prove nothing was created rather than that nothing could have been.
-    acquire =
-      Keyword.get(opts, :acquire, fn context ->
-        scoped_root(parent, context)
-        fixture_capability()
-      end)
-
-    staged_policy =
-      %{
-        data_class: Keyword.get(opts, :staged_data_class),
-        accepts_data: Keyword.get(opts, :staged_accepts_data)
-      }
-      |> Enum.reject(fn {_key, value} -> is_nil(value) end)
-      |> Map.new()
-
-    {:ok, rules} = SelectionRules.new(fields: %{}, cross_rules: [], named_sets: %{})
-
-    {:ok, descriptor} =
-      ProviderDescriptor.new(
-        source: :custom,
-        installation_revision: Keyword.get(opts, :installation_revision, "lifecycle-v1"),
-        credential_names: credential_names,
-        authorization_mode: :none,
-        data_class: Keyword.get(opts, :descriptor_data_class, :normal),
-        accepts_data: Keyword.get(opts, :descriptor_accepts_data, [:normal]),
-        requires: [],
-        provides: [],
-        destinations: [:workflow],
-        workflow_llm?: false,
-        connectivity_mode: Keyword.get(opts, :connectivity_mode, :none),
-        probe_effect: nil,
-        selection_validation: selection_validation,
-        selection_rules: rules,
-        authority_fingerprint: nil,
-        local_preflight: :none
-      )
-
-    builder = fn _selection, context ->
-      send(parent, {:provider_phase, :prepare})
-
-      staged = %{
-        credential_names: Keyword.get(opts, :builder_credential_names, credential_names),
-        preflight: fn ->
-          send(parent, {:provider_phase, :preflight})
-
-          {:ok,
-           fn %{} ->
-             send(parent, {:provider_phase, :acquire})
-             acquire.(context)
-           end}
-        end
-      }
-
-      {:ok, Map.merge(staged, staged_policy)}
-    end
-
-    implementation =
-      if selection_validation == :active do
-        Map.put(
-          %{builder: builder},
-          :selection_validator,
-          Keyword.fetch!(opts, :selection_validator)
-        )
-      else
-        %{builder: builder}
-      end
-
-    implementation =
-      case Keyword.fetch(opts, :provider_application) do
-        {:ok, application} -> Map.put(implementation, :provider_application, application)
-        :error -> implementation
-      end
-
-    registration = %{descriptor: descriptor, implementation: implementation, authority: nil}
-
-    {:ok, installed_limits} =
-      Limits.installed(%{
-        doctor_connectivity_timeout_ms: Keyword.get(opts, :doctor_connectivity_timeout_ms, 10_000)
-      })
-
-    {:ok, catalog} =
-      InstallationCatalog.new(%{"selected" => registration}, installed_limits: installed_limits)
-
-    default_resolver = fn names ->
-      send(parent, {:resolved_credentials, names})
-      {:ok, Map.new(names, &{&1, "fixture-credential"})}
-    end
-
-    {:ok, services} =
-      ProviderRuntimeServices.new(
-        activation: Keyword.get(opts, :activation, fn -> {:ok, nil} end),
-        credential_resolver: Keyword.get(opts, :credential_resolver, default_resolver),
-        provider_application_mode: Keyword.get(opts, :provider_application_mode, :host_owned)
-      )
-
-    {:ok, execution} = ProviderExecution.new(catalog, services, [])
-    {:ok, authority} = PublicationAuthority.new([])
-
-    manifest = %{
-      "version" => 1,
-      "workflow" => %{
-        "components" => [%{"id" => "app", "path" => "main.clj"}],
-        "entry" => "app/run"
-      },
-      "input" => %{"value" => %{}},
-      "providers" => %{
-        "workflow" => [%{"name" => "selected", "config" => %{}}],
-        "mission" => []
-      }
-    }
-
-    documents = %{
-      "ptc.json" => Jason.encode!(manifest),
-      "main.clj" => "(ns app) (defn run [_input] #{body})"
-    }
-
-    {:ok, request} =
-      ApplicationPackage.request_memory("ptc.json", documents,
-        result_projection: :json,
-        installed_limits: installed_limits
-      )
-
-    {:ok, prepared} = RunCoordinator.prepare(request, catalog)
-    on_exit(fn -> InstallationCatalog.close(catalog) end)
-
-    %{
-      prepared: prepared,
-      catalog: catalog,
-      execution: execution,
-      authority: authority
-    }
-  end
-
-  defp scoped_root(parent, context) do
-    spawn(fn ->
-      signal = Process.monitor(context.owner)
-
-      send(
-        parent,
-        {:provider_root, self(), ResourceRegistrar.register_root(context.resource_registrar)}
-      )
-
-      receive do
-        {:DOWN, ^signal, :process, _pid, _reason} -> :ok
-      end
-    end)
-  end
-
-  defp fixture_capability do
-    Capability.new(
-      name: "fixture",
-      input_schema: %{"type" => "object", "additionalProperties" => false},
-      callback: fn _arguments -> {:ok, %{}} end
-    )
   end
 end

--- a/test/ptc_runner/kernel/run_admission_test.exs
+++ b/test/ptc_runner/kernel/run_admission_test.exs
@@ -1,0 +1,274 @@
+defmodule PtcRunner.Kernel.RunAdmissionTest do
+  use ExUnit.Case, async: false
+  import PtcRunner.TestSupport.ProviderExecutionFixture
+  import PtcRunner.TestSupport.Eventually
+
+  alias PtcRunner.Kernel.{
+    Capability,
+    ExecutionOutcome,
+    PreparedRun,
+    PublicationAuthority,
+    RunAdmission,
+    RunBuilder
+  }
+
+  test "successful admitted execution retains the canonical publication result and readmits" do
+    host = start_supervised!({RunAdmission, max_concurrent_runs: 1})
+
+    for _ <- 1..2 do
+      fixture = fixture()
+      assert {:ok, outcome} = execute(host, fixture)
+      assert ExecutionOutcome.valid?(outcome)
+
+      assert {:ok, %{result: {:ok, %{value: %{"answer" => 42}}}}} =
+               RunBuilder.publish_execution_report(outcome, fixture.authority)
+
+      assert {:ok, %{in_use: 0, status: :ready}} = RunAdmission.snapshot(host)
+      PublicationAuthority.close(fixture.authority)
+    end
+  end
+
+  test "provider-free runs use the same admission and publication lifecycle" do
+    host = start_supervised!({RunAdmission, max_concurrent_runs: 1})
+    fixture = fixture(provider_free: true)
+    assert {:ok, outcome} = RunAdmission.execute(host, fixture.prepared, fixture.authority)
+
+    assert {:ok, %{result: {:ok, %{value: %{"answer" => 42}}}}} =
+             RunBuilder.publish_execution_report(outcome, fixture.authority)
+
+    refute_received {:provider_phase, _}
+    assert {:ok, %{in_use: 0, status: :ready}} = RunAdmission.snapshot(host)
+  end
+
+  test "disconnect retains admission while the provider closer is held" do
+    parent = self()
+    host = start_supervised!({RunAdmission, max_concurrent_runs: 1})
+
+    fixture =
+      fixture(
+        block: true,
+        close: fn ->
+          send(parent, {:closing, self()})
+          receive do: (:release -> :ok)
+        end
+      )
+
+    {caller, ref} = spawn_monitor(fn -> execute(host, fixture) end)
+    assert_receive {:running, _provider}, 5_000
+    Process.exit(caller, :kill)
+    assert_receive {:DOWN, ^ref, :process, ^caller, :killed}
+    assert_receive {:closing, closer}, 5_000
+    assert {:ok, %{in_use: 1, status: :ready}} = RunAdmission.snapshot(host)
+    next = fixture()
+    assert {:error, :run_capacity_exhausted} = execute(host, next)
+    assert PreparedRun.valid?(next.prepared)
+    assert PublicationAuthority.authorized?(next.authority)
+    send(closer, :release)
+    assert_eventually(fn -> match?({:ok, %{in_use: 0}}, RunAdmission.snapshot(host)) end)
+    assert {:ok, _} = execute(host, next)
+  end
+
+  test "concurrent runs share one capacity domain and excess work stays reusable" do
+    host = start_supervised!({RunAdmission, max_concurrent_runs: 2})
+    fixtures = for _ <- 1..2, do: fixture(block: true)
+    tasks = Enum.map(fixtures, fn fixture -> Task.async(fn -> execute(host, fixture) end) end)
+
+    providers =
+      for _ <- tasks do
+        assert_receive {:running, provider}, 5_000
+        provider
+      end
+
+    assert {:ok, %{in_use: 2}} = RunAdmission.snapshot(host)
+    next = fixture()
+    assert {:error, :run_capacity_exhausted} = execute(host, next)
+    assert PreparedRun.valid?(next.prepared)
+    Enum.each(providers, &send(&1, :finish))
+    Enum.each(tasks, fn task -> assert {:ok, _} = Task.await(task, 5_000) end)
+    assert {:ok, _} = execute(host, next)
+  end
+
+  test "caller death during admission leaves preparation unused and releases the provisional owner" do
+    host = start_supervised!({RunAdmission, max_concurrent_runs: 1})
+    fixture = fixture()
+    :ok = :sys.suspend(host)
+    {caller, caller_ref} = spawn_monitor(fn -> execute(host, fixture) end)
+
+    try do
+      owner =
+        assert_eventually(fn ->
+          {:messages, messages} = Process.info(host, :messages)
+
+          Enum.find_value(messages, fn
+            {:"$gen_call", {owner, _}, :admit} -> owner
+            _ -> nil
+          end)
+        end)
+
+      owner_ref = Process.monitor(owner)
+      Process.exit(caller, :kill)
+      assert_receive {:DOWN, ^caller_ref, :process, ^caller, :killed}
+      :ok = :sys.resume(host)
+      assert_receive {:DOWN, ^owner_ref, :process, ^owner, :normal}, 5_000
+      assert {:ok, %{in_use: 0, status: :ready}} = RunAdmission.snapshot(host)
+      assert PreparedRun.valid?(fixture.prepared)
+      assert {:ok, _} = execute(host, fixture)
+    after
+      :sys.resume(host)
+      Process.exit(caller, :kill)
+    end
+  end
+
+  test "a claimed publication authority releases provisional admission without consuming preparation" do
+    host = start_supervised!({RunAdmission, max_concurrent_runs: 1})
+    fixture = fixture()
+    assert {:ok, _lease} = PublicationAuthority.claim(fixture.authority)
+    assert {:error, _} = execute(host, fixture)
+    assert PreparedRun.valid?(fixture.prepared)
+    assert PublicationAuthority.claimed?(fixture.authority)
+    assert {:ok, %{in_use: 0, status: :ready}} = RunAdmission.snapshot(host)
+    assert {:ok, _} = execute(host, fixture())
+  end
+
+  test "unexpected execution-owner death fences the host rather than recycling its lease" do
+    host = start_supervised!({RunAdmission, max_concurrent_runs: 1})
+    fixture = fixture(block: true)
+    task = Task.async(fn -> execute(host, fixture) end)
+    assert_receive {:running, _}, 5_000
+    [owner] = Map.keys(:sys.get_state(host).owners)
+    Process.exit(owner, :kill)
+    assert {:error, _} = Task.await(task, 5_000)
+    assert {:ok, %{status: :unavailable}} = RunAdmission.snapshot(host)
+    next = fixture()
+    assert {:error, :run_admission_unavailable} = execute(host, next)
+    assert PreparedRun.valid?(next.prepared)
+  end
+
+  test "admission-owner death cancels its active execution and registered roots" do
+    host = start_supervised!({RunAdmission, max_concurrent_runs: 1})
+    fixture = fixture(block: true)
+    task = Task.async(fn -> execute(host, fixture) end)
+    assert_receive {:running, provider}, 5_000
+    assert_receive {:provider_root, root, :ok}, 5_000
+    refs = for pid <- [provider, root], do: {pid, Process.monitor(pid)}
+    Process.exit(host, :kill)
+    assert {:error, _} = Task.await(task, 5_000)
+    for {pid, ref} <- refs, do: assert_receive({:DOWN, ^ref, :process, ^pid, _}, 5_000)
+    assert {:error, :run_admission_unavailable} = RunAdmission.snapshot(host)
+  end
+
+  test "a failed provider closer fences further admission even after normal execution" do
+    host = start_supervised!({RunAdmission, max_concurrent_runs: 1})
+    fixture = fixture(close: fn -> raise "private-closer-failure" end)
+    result = execute(host, fixture)
+    refute match?({:ok, %{result: {:ok, _}}}, result)
+    assert {:ok, %{status: :unavailable}} = RunAdmission.snapshot(host)
+    assert {:error, :run_admission_unavailable} = execute(host, fixture())
+  end
+
+  test "admission death during result handoff cannot return success with revoked publication" do
+    parent = self()
+    host = start_supervised!({RunAdmission, max_concurrent_runs: 1})
+    fixture = fixture(block: true)
+    caller = spawn(fn -> send(parent, {:result, execute(host, fixture)}) end)
+    on_exit(fn -> Process.exit(caller, :kill) end)
+    assert_receive {:running, provider}, 5_000
+    [owner] = Map.keys(:sys.get_state(host).owners)
+    owner_ref = Process.monitor(owner)
+    true = :erlang.suspend_process(caller)
+
+    try do
+      send(provider, :finish)
+      assert_eventually(fn -> :sys.get_state(owner).handoff_waiting? end)
+      Process.exit(host, :kill)
+      assert_receive {:DOWN, ^owner_ref, :process, ^owner, _}, 5_000
+    after
+      :erlang.resume_process(caller)
+    end
+
+    assert_receive {:result, {:error, :run_admission_unavailable}}, 5_000
+  end
+
+  test "hosted execution refuses command-owned application startup before consumption" do
+    host = start_supervised!({RunAdmission, max_concurrent_runs: 1})
+    fixture = fixture(provider_application_mode: :command_vm)
+    assert {:error, :invalid_provider_execution} = execute(host, fixture)
+    assert PreparedRun.valid?(fixture.prepared)
+    assert {:ok, %{in_use: 0}} = RunAdmission.snapshot(host)
+  end
+
+  test "request death also kills the workflow sandbox" do
+    host = start_supervised!({RunAdmission, max_concurrent_runs: 1})
+    fixture = fixture()
+    handler = {__MODULE__, make_ref()}
+
+    :ok =
+      :telemetry.attach(
+        handler,
+        [:ptc_runner, :sandbox, :armed],
+        &__MODULE__.hold_sandbox/4,
+        self()
+      )
+
+    on_exit(fn -> :telemetry.detach(handler) end)
+    {caller, ref} = spawn_monitor(fn -> execute(host, fixture) end)
+    on_exit(fn -> Process.exit(caller, :kill) end)
+    assert_receive {:sandbox_armed, sandbox}, 5_000
+    on_exit(fn -> Process.exit(sandbox, :kill) end)
+    sandbox_ref = Process.monitor(sandbox)
+    Process.exit(caller, :kill)
+    assert_receive {:DOWN, ^ref, :process, ^caller, :killed}, 5_000
+    assert_receive {:DOWN, ^sandbox_ref, :process, ^sandbox, :killed}, 1_000
+  end
+
+  def hold_sandbox(_, _, %{live_run: _, pid: pid}, parent) do
+    send(parent, {:sandbox_armed, pid})
+    receive do: (:unused -> :ok)
+  end
+
+  def hold_sandbox(_, _, _, _), do: :ok
+
+  defp fixture(opts \\ []) do
+    parent = self()
+    block? = Keyword.get(opts, :block, false)
+
+    opts =
+      Keyword.put_new(
+        opts,
+        :body,
+        if(block?, do: "(return (tool/fixture {}))", else: "(return {\"answer\" 42})")
+      )
+
+    acquire = fn context ->
+      scoped_root(parent, context)
+
+      {:ok, capability} =
+        Capability.new(
+          name: "fixture",
+          input_schema: %{"type" => "object", "additionalProperties" => false},
+          callback: fn _ ->
+            if block? do
+              send(parent, {:running, self()})
+              receive do: (:finish -> :ok)
+            end
+
+            {:ok, %{}}
+          end
+        )
+
+      {:ok, %{capabilities: [capability], close: Keyword.get(opts, :close, fn -> :ok end)}}
+    end
+
+    provider_fixture(Keyword.put(opts, :acquire, acquire))
+  end
+
+  defp execute(host, fixture),
+    do:
+      RunAdmission.execute(
+        host,
+        fixture.prepared,
+        fixture.authority,
+        fixture.catalog,
+        fixture.execution.services
+      )
+end

--- a/test/support/provider_execution_fixture.ex
+++ b/test/support/provider_execution_fixture.ex
@@ -1,0 +1,188 @@
+defmodule PtcRunner.TestSupport.ProviderExecutionFixture do
+  @moduledoc false
+  import ExUnit.Callbacks, only: [on_exit: 1]
+  alias PtcRunner.Kernel.ApplicationPackage
+  alias PtcRunner.Kernel.Capability
+  alias PtcRunner.Kernel.InstallationCatalog
+  alias PtcRunner.Kernel.Limits
+  alias PtcRunner.Kernel.ProviderDescriptor
+  alias PtcRunner.Kernel.ProviderExecution
+  alias PtcRunner.Kernel.ProviderRuntimeServices
+  alias PtcRunner.Kernel.PublicationAuthority
+  alias PtcRunner.Kernel.ResourceRegistrar
+  alias PtcRunner.Kernel.RunCoordinator
+  alias PtcRunner.Kernel.SelectionRules
+
+  def provider_fixture(opts \\ []) do
+    parent = self()
+    selection_validation = Keyword.get(opts, :selection_validation, :declarative)
+    body = Keyword.get(opts, :body, "(return {\"answer\" 42})")
+    credential_names = Keyword.get(opts, :credential_names, [])
+
+    # The default acquisition registers a resource root, so a refusal test can
+    # prove nothing was created rather than that nothing could have been.
+    acquire =
+      Keyword.get(opts, :acquire, fn context ->
+        scoped_root(parent, context)
+        fixture_capability()
+      end)
+
+    staged_policy =
+      %{
+        data_class: Keyword.get(opts, :staged_data_class),
+        accepts_data: Keyword.get(opts, :staged_accepts_data)
+      }
+      |> Enum.reject(fn {_key, value} -> is_nil(value) end)
+      |> Map.new()
+
+    {:ok, rules} = SelectionRules.new(fields: %{}, cross_rules: [], named_sets: %{})
+
+    {:ok, descriptor} =
+      ProviderDescriptor.new(
+        source: :custom,
+        installation_revision: Keyword.get(opts, :installation_revision, "lifecycle-v1"),
+        credential_names: credential_names,
+        authorization_mode: :none,
+        data_class: Keyword.get(opts, :descriptor_data_class, :normal),
+        accepts_data: Keyword.get(opts, :descriptor_accepts_data, [:normal]),
+        requires: [],
+        provides: [],
+        destinations: [:workflow],
+        workflow_llm?: false,
+        connectivity_mode: Keyword.get(opts, :connectivity_mode, :none),
+        probe_effect: nil,
+        selection_validation: selection_validation,
+        selection_rules: rules,
+        authority_fingerprint: nil,
+        local_preflight: :none
+      )
+
+    builder = fn _selection, context ->
+      send(parent, {:provider_phase, :prepare})
+
+      staged = %{
+        credential_names: Keyword.get(opts, :builder_credential_names, credential_names),
+        preflight: fn ->
+          send(parent, {:provider_phase, :preflight})
+
+          {:ok,
+           fn %{} ->
+             send(parent, {:provider_phase, :acquire})
+             acquire.(context)
+           end}
+        end
+      }
+
+      {:ok, Map.merge(staged, staged_policy)}
+    end
+
+    implementation =
+      if selection_validation == :active do
+        Map.put(
+          %{builder: builder},
+          :selection_validator,
+          Keyword.fetch!(opts, :selection_validator)
+        )
+      else
+        %{builder: builder}
+      end
+
+    implementation =
+      case Keyword.fetch(opts, :provider_application) do
+        {:ok, application} -> Map.put(implementation, :provider_application, application)
+        :error -> implementation
+      end
+
+    registration = %{descriptor: descriptor, implementation: implementation, authority: nil}
+
+    {:ok, installed_limits} =
+      Limits.installed(%{
+        doctor_connectivity_timeout_ms: Keyword.get(opts, :doctor_connectivity_timeout_ms, 10_000)
+      })
+
+    {:ok, catalog} =
+      InstallationCatalog.new(%{"selected" => registration}, installed_limits: installed_limits)
+
+    default_resolver = fn names ->
+      send(parent, {:resolved_credentials, names})
+      {:ok, Map.new(names, &{&1, "fixture-credential"})}
+    end
+
+    {:ok, services} =
+      ProviderRuntimeServices.new(
+        activation: Keyword.get(opts, :activation, fn -> {:ok, nil} end),
+        credential_resolver: Keyword.get(opts, :credential_resolver, default_resolver),
+        provider_application_mode: Keyword.get(opts, :provider_application_mode, :host_owned)
+      )
+
+    {:ok, execution} = ProviderExecution.new(catalog, services, [])
+    {:ok, authority} = PublicationAuthority.new([])
+
+    manifest = manifest()
+
+    manifest =
+      if Keyword.get(opts, :provider_free, false),
+        do: Map.delete(manifest, "providers"),
+        else: manifest
+
+    documents = %{
+      "ptc.json" => Jason.encode!(manifest),
+      "main.clj" => "(ns app) (defn run [_input] #{body})"
+    }
+
+    {:ok, request} =
+      ApplicationPackage.request_memory("ptc.json", documents,
+        result_projection: :json,
+        installed_limits: installed_limits
+      )
+
+    {:ok, prepared} = RunCoordinator.prepare(request, catalog)
+    on_exit(fn -> InstallationCatalog.close(catalog) end)
+
+    %{
+      prepared: prepared,
+      catalog: catalog,
+      execution: execution,
+      authority: authority
+    }
+  end
+
+  # ex_dna:disable-for-next-line — lifecycle setup independent of privacy/publication fixtures
+  defp manifest do
+    %{
+      "version" => 1,
+      "workflow" => %{
+        "components" => [%{"id" => "app", "path" => "main.clj"}],
+        "entry" => "app/run"
+      },
+      "input" => %{"value" => %{}},
+      "providers" => %{
+        "workflow" => [%{"name" => "selected", "config" => %{}}],
+        "mission" => []
+      }
+    }
+  end
+
+  def scoped_root(parent, context) do
+    spawn(fn ->
+      signal = Process.monitor(context.owner)
+
+      send(
+        parent,
+        {:provider_root, self(), ResourceRegistrar.register_root(context.resource_registrar)}
+      )
+
+      receive do
+        {:DOWN, ^signal, :process, _pid, _reason} -> :ok
+      end
+    end)
+  end
+
+  def fixture_capability do
+    Capability.new(
+      name: "fixture",
+      input_schema: %{"type" => "object", "additionalProperties" => false},
+      callback: fn _arguments -> {:ok, %{}} end
+    )
+  end
+end


### PR DESCRIPTION
## Summary

- add fail-fast host-owned admission for concurrent one-shot runs
- keep capacity held through provider cleanup after caller death
- fence the admission domain after uncertain owner death or cleanup failure
- support provider-free and host-owned provider execution

The cancellation prerequisite was merged in #1909.

## Validation

- `mix test test/ptc_runner/kernel/run_admission_test.exs test/ptc_runner/kernel/provider_execution_lifecycle_test.exs test/ptc_runner/kernel/run_coordinator_execution_test.exs`

## Retrospective

- Untracked follow-up: inbound parsing, preparation, queueing, and physical provider-call limits remain gateway work in #1465
- Repository instruction gap: none

Closes #1908