### PR TITLE
fix(launcher): finish clean stdio closes promptly

### DIFF
--- a/ptc_runner_launcher/README.md
+++ b/ptc_runner_launcher/README.md
@@ -10,8 +10,8 @@ host-authorized server with:
 - separate stdin, stdout, and bounded stderr streams;
 - acknowledged backpressure;
 - a new process group;
-- bounded EOF, TERM, and KILL cleanup, including descendant reaping on Linux;
-  and
+- bounded EOF, TERM, and KILL cleanup, with immediate final group retirement
+  after a clean leader exit and descendant reaping on Linux; and
 - a lifeline watchdog that retires that group with a single `SIGKILL` when the
   launcher itself is destroyed before it can run any of that cleanup.
 

--- a/ptc_runner_launcher/c_src/ptc_runner_launcher.c
+++ b/ptc_runner_launcher/c_src/ptc_runner_launcher.c
@@ -844,6 +844,17 @@ static void signal_process_group(pid_t process_group, int signal_number) {
   }
 }
 
+static void begin_kill_wait(enum shutdown_phase *phase, pid_t child_pid,
+                            uint32_t grace_ms, int64_t now,
+                            int64_t *deadline) {
+  uint32_t final_wait_ms =
+      grace_ms > MIN_FINAL_KILL_WAIT_MS ? grace_ms : MIN_FINAL_KILL_WAIT_MS;
+
+  signal_process_group(child_pid, SIGKILL);
+  *phase = PHASE_KILL_WAIT;
+  *deadline = now + (int64_t)final_wait_ms;
+}
+
 /*
  * Observe the leader without releasing its PID. The PID is also the process
  * group identifier, so reaping it before the last group signal would permit
@@ -1451,13 +1462,7 @@ static int supervise(const struct launcher_config *config, pid_t child_pid,
       phase = PHASE_TERM_WAIT;
       deadline = now + (int64_t)config->grace_ms;
     } else if (phase == PHASE_TERM_WAIT && now >= deadline) {
-      uint32_t final_wait_ms =
-          config->grace_ms > MIN_FINAL_KILL_WAIT_MS
-              ? config->grace_ms
-              : MIN_FINAL_KILL_WAIT_MS;
-      signal_process_group(child_pid, SIGKILL);
-      phase = PHASE_KILL_WAIT;
-      deadline = now + (int64_t)final_wait_ms;
+      begin_kill_wait(&phase, child_pid, config->grace_ms, now, &deadline);
     } else if (phase == PHASE_KILL_WAIT && now >= deadline) {
       close_if_open(&child_stdout);
       close_if_open(&child_stderr);
@@ -1466,6 +1471,18 @@ static int supervise(const struct launcher_config *config, pid_t child_pid,
       }
       return finish_supervision(FINISH_TERMINATION_TIMEOUT, child_reaped,
                                 child_status, stderr_truncated);
+    }
+
+    /*
+     * Once the leader has exited and both of its streams are drained, no
+     * graceful work remains. Retire the watchdog and any descendants now
+     * instead of charging the full EOF and TERM waits to every clean close.
+     * The un-reaped leader still reserves the process-group identifier until
+     * this final group signal has been sent.
+     */
+    if (phase != PHASE_RUNNING && phase != PHASE_KILL_WAIT && child_exited &&
+        stdout_eof && stderr_eof) {
+      begin_kill_wait(&phase, child_pid, config->grace_ms, now, &deadline);
     }
 
     /*

--- a/ptc_runner_launcher/test/ptc_runner_launcher/conformance_test.exs
+++ b/ptc_runner_launcher/test/ptc_runner_launcher/conformance_test.exs
@@ -258,6 +258,16 @@ defmodule PtcRunnerLauncher.ConformanceTest do
     assert {:error, :timeout} = MCPStdioLauncher.receive_event(launcher, 0)
   end
 
+  test "close finishes promptly when the server exits and its streams reach EOF" do
+    launcher = open_launcher(["basic", "prompt-close"], grace_ms: 1_500)
+    started_at = System.monotonic_time(:millisecond)
+
+    assert {:ok, %{reason: :close, exit_status: 0}} =
+             MCPStdioLauncher.close(launcher, 1_000)
+
+    assert System.monotonic_time(:millisecond) - started_at < 1_000
+  end
+
   test "a timed-out write closes the launcher instead of flushing queued input" do
     launcher = open_launcher(["no-read"], grace_ms: 50)
     assert %{stdout: "ready\n"} = collect_until(launcher, &(&1.stdout == "ready\n"))


### PR DESCRIPTION
## Summary

- finish clean stdio provider shutdown as soon as the leader exits and both output streams reach EOF
- retire the lifeline watchdog and any remaining descendants without spending the EOF and TERM grace periods
- preserve PGID reuse safety and the existing escalation path for providers that remain alive or keep streams open
- add high-grace regression coverage and document the launcher behavior

Closes #1904

## Validation

- `mix test test/ptc_runner_launcher/conformance_test.exs`
- confirmed the new `grace_ms: 1500` regression failed before the fix with `{:error, :timeout}`

## Retrospective

- Untracked follow-up work: #1905 separately tracks improving `provider_cleanup_failed` diagnostics; reproduce with a provider close that exceeds the terminal cleanup deadline.
- Repository instruction that was missing, wrong, or guessed: none.
