### PR TITLE
test(ci): add the flake-hunt harness and per-run records

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -121,3 +121,37 @@ jobs:
 
       - name: Verify the packaged interactive REPL
         run: scripts/verify_standalone_release.sh
+
+  # Runs the PR suite ten times at GitHub's four-scheduler shape without
+  # stopping at the first failure, and uploads every run's record and log.
+  # The summary names each failing test with its frequency and seeds, which
+  # is the number a flake investigation starts from; the job is red while
+  # that number is above zero. See docs/maintainers/development-setup.md.
+  flake-hunt:
+    runs-on: ubuntu-latest
+    name: Flake hunt
+    timeout-minutes: 180
+    env:
+      MIX_ENV: test
+      HEX_SPONSOR: false
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Elixir environment
+        uses: ./.github/actions/setup-elixir
+        with:
+          cache-plt: 'false'
+          install-babashka: 'false'
+
+      - name: Run the suite ten times at four schedulers
+        run: scripts/ci/flake-hunt.sh 10 --schedulers 4 --out "$RUNNER_TEMP/flake-hunt"
+
+      - name: Upload the run records and logs
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: flake-hunt
+          path: ${{ runner.temp }}/flake-hunt
+          if-no-files-found: warn

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,9 @@ body. An assignee marks the issue as taken.
 - `scripts/ci/core-tests.sh` — the core compile/test gate used by pre-push and
   CI (`CI=1`, 300 StreamData cases). `--schedulers 4` reproduces GitHub's CPU
   shape.
+- `scripts/ci/flake-hunt.sh N` — run the suite N times at four schedulers
+  and tabulate failing tests by frequency and seed. Use it before calling a
+  failure a flake and after any change that moves a module to `async: true`.
 - `MIX_ENV=dev mix docs --warnings-as-errors` — ExDoc gate; run when changing
   user-facing documentation.
 - `mix test --include e2e` — E2E tests (requires `OPENROUTER_API_KEY`). The

--- a/docs/maintainers/development-setup.md
+++ b/docs/maintainers/development-setup.md
@@ -151,7 +151,7 @@ the `PTC_TEST_RUN_LOG` formatter, carrying the seed, scheduler count, the
 wall/async/sync split, and each failure's location. The `Nightly` workflow
 runs the same script on `main` and uploads the directory as the `flake-hunt`
 artifact. Reproduce a named failure with `mix test FILE:LINE --seed SEED`,
-then `--repeat-until-failure`; a test that passes alone with its seed is a
+then `--repeat-until-failure 100`; a test that passes alone with its seed is a
 load flake, not an ordering bug.
 
 ## Dialyzer PLT

--- a/docs/maintainers/development-setup.md
+++ b/docs/maintainers/development-setup.md
@@ -137,6 +137,23 @@ scripts/ci/core-tests.sh --schedulers 4
 The second command still runs on the local operating system. It is CPU-shape
 parity, not an Ubuntu container; OS-level parity remains a separate concern.
 
+A test that fails only under load or under one seed needs repetition, not a
+rerun. `scripts/ci/flake-hunt.sh` runs the suite N times (default ten) at
+four schedulers with a fresh seed each, never stops at the first failure, and
+prints how often each test failed and with which seeds:
+
+```bash
+scripts/ci/flake-hunt.sh 5 --out /tmp/flake-hunt
+```
+
+Every run appends one JSON line to `runs.jsonl` in that directory through
+the `PTC_TEST_RUN_LOG` formatter, carrying the seed, scheduler count, the
+wall/async/sync split, and each failure's location. The `Nightly` workflow
+runs the same script on `main` and uploads the directory as the `flake-hunt`
+artifact. Reproduce a named failure with `mix test FILE:LINE --seed SEED`,
+then `--repeat-until-failure`; a test that passes alone with its seed is a
+load flake, not an ordering bug.
+
 ## Dialyzer PLT
 
 Outside CI the core PLT lives under `~/.cache/ptc_runner/` and is shared across

--- a/docs/plans/test-suite-flake-first.md
+++ b/docs/plans/test-suite-flake-first.md
@@ -1,0 +1,147 @@
+# Test suite: fix the flake classes first, then retire the serial tail
+
+Status: draft, 2026-09-11. Tracking issue: #1913.
+
+## Why this order
+
+The suite is slow and flaky for the same reason. Tests that use the wall
+clock as a synchronisation primitive fail under CPU contention, and the
+workaround for that has been `async: false`. The serial modules now cost
+more than everything else combined, and the flakes that remain live in the
+async phase, so restructuring first would move deadline-sensitive modules
+into contention and multiply the failures. Investigation comes first.
+
+## Evidence (main, 0.15.0, 2026-09-10/11)
+
+Measured with `PTC_PROFILE_SLOW=1 mix test` on a 10-core Mac, warm build.
+
+| Measurement | Value |
+|---|---|
+| Wall time | 428 s |
+| Async phase (314 files) | 115 s, ~7x parallel at `max_cases` 10 |
+| Sync phase (~50 `async: false` files on the PR suite) | 313 s, 1x |
+| Summed test time | 1,170 s |
+| CI `test.yml` on `main`, last 60 runs | 53 pass, 7 fail |
+| Flake-related commits in history | 54 |
+| Deadlines of 500 ms or less passed to code under test | 105 sites |
+| Assertions on elapsed wall time | 12 |
+| `async: false` files that state why | 4 of ~50 |
+
+Serial modules by time: MCPSourceTest 35 s, ReplFrontendTest 33 s,
+ViewerFrontendTest 32 s, MCPStdioTransportTest 32 s, ExampleLibraryTest
+25 s, QuickstartGuideTest 24 s, PublicationAuthorityTest 21 s,
+CommandEngineGlobalStateTest 13 s, CommandMaterializeTest 11 s,
+HostInstallationTest 11 s. The next floor after the tail is
+`PtcRunner.GitHooks.PrePushTest`: 75 s of bash-spawning tests inside one
+async module, and tests inside a module always run serially.
+
+Reproductions this week:
+
+- `repl_session_test.exs:451` failed in the full run (seed 869188), passed
+  alone with the same seed, and passed 15 repeats of its file. Load flake,
+  not order dependence.
+- PR #1900 needed three CI attempts: `command_frontend_test.exs:781`
+  (reservation reclaim, exit 2) and `analysis_session_test.exs:1396` (no
+  `:DOWN` within 5 s). Both wait on OS work: the reclaim spawns `id`, `kill`
+  and an `flock` helper; the session waits on owner cleanup.
+
+## Flake classes
+
+Every class below has already been root-caused at least once (PRs #1200,
+#1206, #1286). The plan fixes classes, not individual tests.
+
+| Class | Mechanism | Rule |
+|---|---|---|
+| A. Deadline under test | A small budget is handed to the code under test and the test asserts it expires or does not | The path that must expire is *held* (`:sys.suspend`, a stub that never answers), never merely slow. Margins are sized from measurement, as PR #1200 did. |
+| B. Dead-process inspection | `:sys.get_state`, `:erlang.trace`, or `File.stat` on something that already finished; `:DOWN` ordering | Monitor before the action; `Task.await` spawned work; poll post-`:DOWN` state through `Eventually`. |
+| C. OS work under load | Helper processes (`id`, `kill`, `flock`), fsync, owner cleanup inside a fixed window | Make completion observable (a message or a monitor), or give cleanup a budget that a 4-vCPU runner under load can meet. PR #1900's two failures are here. |
+| D. VM-global state | `Application.put_env`, `System.put_env`, `File.cd`, `:persistent_term`, `Logger.configure`, fixed ports or paths | Keep serial, in the smallest possible module, with the reason on the `use` line. |
+| E. Product bugs | A flake reporting a real defect (TokenManager wedge in #1286, RunCoordinator in #1206) | Expect a share of flakes to be defects. Never widen a timeout without naming the mechanism. |
+
+## Phase 0: instrument (one small PR)
+
+1. Record the wall/async/sync split, seed, scheduler count and failures
+   per run. Extend `PtcRunner.TestSupport.SlowTestProfiler` or add a
+   second formatter; write one JSON line per run and upload it as a CI
+   artifact. Never `--slowest`; it pins `max_cases` to 1.
+2. Add `scripts/ci/flake-hunt.sh N`: runs `mix test` N times with
+   `--schedulers 4` (GitHub's CPU shape), a fresh seed each time, optional
+   background CPU load, and prints a table of `{test, seed, message}`
+   frequencies. Add a nightly job that runs it ten times on `main` so the
+   flake rate per test becomes a number instead of a feeling.
+3. Put a one-line reason on every `async: false` `use` line, naming the
+   class (A to D). This is the inventory Phase 2 works from; a file that
+   gets no honest reason is a candidate for the first tranche.
+
+Gate: the nightly table exists and has a week of data.
+
+## Phase 1: fix the classes
+
+Order by evidence, not by module:
+
+1. Class C first, because it is what CI is failing on now. Start with the
+   two PR #1900 tests: read the reclaim path's budget for its helpers and
+   what exit status 2 means there; read the owner-cleanup wait in
+   `analysis_session_test.exs`. Fix the mechanism in `lib/` or the wait in
+   the test, and write the rule down.
+2. Class A: audit the 105 small-deadline sites, concentrated in
+   `provider_session_test.exs` (26), `mcp_source_test.exs` (9),
+   `dispatcher_llm_deadline_test.exs` (9), `core_contract_test.exs` (6).
+   Each becomes either a held path or a deadline large enough that only a
+   held path can reach it. The 12 elapsed-time assertions get the same
+   treatment.
+3. Class B: sweep for `:sys.get_state` and `:erlang.trace` on pids the
+   test did not monitor first.
+4. Write the rules into `docs/maintainers/development-setup.md` next to
+   the existing `Process.sleep` rule, and encode what can be encoded as a
+   support-level test (for example, no `refute_receive` without an
+   explicit window in a serial module).
+
+Gate: 20 consecutive `flake-hunt` runs at 4 schedulers on `main` with zero
+failures, or every failure named with a class and a fix in flight.
+
+## Phase 2: retire the serial tail in tranches
+
+One PR per tranche. Each PR records the before and after split from
+Phase 0 and passes ten `flake-hunt` runs.
+
+| Tranche | Modules | Approach | Serial time freed |
+|---|---|---|---|
+| 1 | ReplFrontendTest, ViewerFrontendTest, ExampleLibraryTest, PublicationAuthorityTest | Move the few env-mutating tests into a `*GlobalStateTest` sibling, the pattern CommandEngine already uses; flip the rest to async | ~110 s |
+| 2 | MCPSourceTest, MCPStdioTransportTest | Convert deadline assertions to class A held paths; keep any test whose contract is a true wall-clock bound in a small serial sibling | ~67 s |
+| 3 | QuickstartGuideTest, TutorialCostBudgetTest, CommandMaterializeTest, Mix.Tasks.Ptc.MaterializeTest | These boot `mix` or `ptc` subprocesses. The repository rule already routes operator-path subprocess walks to `:nightly`; apply it, or run through the in-process command path where the guide contract allows | ~50 s |
+| 4 | HostInstallationTest, ProviderActiveSessionTest, ManifestReplTest, the rest | Mostly `Application.put_env` fixtures. Where the code under test can take its configuration as an argument, do that; otherwise leave serial with the reason stated | ~40 s |
+
+Expected result after tranches 1 to 3: roughly 255 s wall instead of 428 s.
+Fully async: about 160 s, with PrePushTest as the floor.
+
+## Phase 3: the next floor
+
+`GitHooks.PrePushTest` (75 s), `Mix.Tasks.PtcTranscriptTest` (35 s),
+`Scripts.WorktreeSeedTest` (33 s). Split each by scenario into several
+modules so they overlap, or share one prepared repository per module
+through `setup_all`. Only worth doing once Phase 2 makes them the floor.
+
+## Phase 4: CI only
+
+Add `--partitions 2` to the core test job in `test.yml`. Modules,
+including the serial ones, split across two runners with no code change.
+This does not help local runs or the pre-push hook, which runs the whole
+suite before its concurrent lanes.
+
+## Not doing
+
+- Raising `max_cases`. The cap at `schedulers_online` is deliberate; the
+  async phase is 115 s and is not the problem.
+- Quarantine tags or automatic retries. The repository's stance since
+  #1286 is to root-cause every flake, and a share of them are defects.
+- Throttling the pre-push hook or lowering test concurrency to pass.
+
+## Open questions
+
+- Does the reservation reclaim path have a budget at all, or does it
+  depend on the helpers returning promptly?
+- How many of the 105 small-deadline sites are already held paths? The
+  count is a grep, not an audit.
+- Is a synthetic-load option in `flake-hunt.sh` needed, or is
+  `--schedulers 4` on a 10-core machine enough to reproduce CI?

--- a/scripts/ci/flake-hunt.sh
+++ b/scripts/ci/flake-hunt.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+
+# Runs the PR test suite repeatedly under GitHub's CPU shape and tabulates
+# which tests failed, how often, and with which seeds.
+#
+# A flake is a test that fails only under load or under a particular seed,
+# so a single run says nothing about it. This runs the suite N times with a
+# fresh seed each, records every run through the RunRecord formatter
+# (`PTC_TEST_RUN_LOG`), and summarises the file. Unlike core-tests.sh it does
+# not stop at the first failure: a run that fails twice is two data points.
+#
+# Exit status is non-zero when any run failed, so the nightly job goes red
+# while the flake rate is above zero and the artifact says which tests.
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$script_dir/_common.sh"
+
+export CI=1
+
+usage() {
+  echo "usage: flake-hunt.sh [RUNS] [--schedulers POSITIVE_INTEGER] [--out DIR]" >&2
+  exit 64
+}
+
+runs=10
+schedulers=4
+out=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --schedulers)
+      [ "$#" -ge 2 ] && [[ "$2" =~ ^[1-9][0-9]*$ ]] || usage
+      schedulers="$2"
+      shift 2
+      ;;
+    --out)
+      [ "$#" -ge 2 ] && [ -n "$2" ] || usage
+      out="$2"
+      shift 2
+      ;;
+    *)
+      [[ "$1" =~ ^[1-9][0-9]*$ ]] || usage
+      runs="$1"
+      shift
+      ;;
+  esac
+done
+
+if [ -z "$out" ]; then
+  out="${TMPDIR:-/tmp}/ptc-flake-hunt/$(date -u +%Y%m%dT%H%M%SZ)"
+fi
+
+mkdir -p "$out"
+export ERL_FLAGS="+S $schedulers:$schedulers"
+export PTC_TEST_RUN_LOG="$out/runs.jsonl"
+
+echo "flake-hunt: $runs runs, $schedulers schedulers, records in $out"
+
+mix compile --warnings-as-errors
+
+failed_runs=0
+for ((i = 1; i <= runs; i++)); do
+  started=$SECONDS
+  if mix test --warnings-as-errors > "$out/run-$i.log" 2>&1; then
+    verdict=pass
+  else
+    verdict=FAIL
+    failed_runs=$((failed_runs + 1))
+  fi
+  echo "run $i/$runs: $verdict ($((SECONDS - started))s)"
+done
+
+elixir "$script_dir/flake_hunt_summary.exs" "$PTC_TEST_RUN_LOG" | tee "$out/summary.txt"
+
+[ "$failed_runs" -eq 0 ]

--- a/scripts/ci/flake-hunt.sh
+++ b/scripts/ci/flake-hunt.sh
@@ -76,6 +76,6 @@ for ((i = 1; i <= runs; i++)); do
   echo "run $i/$runs: $verdict ($((SECONDS - started))s)"
 done
 
-elixir "$script_dir/flake_hunt_summary.exs" "$PTC_TEST_RUN_LOG" | tee "$out/summary.txt"
+elixir "$script_dir/flake_hunt_summary.exs" "$PTC_TEST_RUN_LOG" --expected "$runs" | tee "$out/summary.txt"
 
 [ "$failed_runs" -eq 0 ]

--- a/scripts/ci/flake-hunt.sh
+++ b/scripts/ci/flake-hunt.sh
@@ -54,6 +54,9 @@ fi
 mkdir -p "$out"
 export ERL_FLAGS="+S $schedulers:$schedulers"
 export PTC_TEST_RUN_LOG="$out/runs.jsonl"
+# The formatter appends, so a reused directory would fold an earlier hunt's
+# runs into this summary. Each hunt starts from an empty record.
+: > "$PTC_TEST_RUN_LOG"
 
 echo "flake-hunt: $runs runs, $schedulers schedulers, records in $out"
 

--- a/scripts/ci/flake-hunt.sh
+++ b/scripts/ci/flake-hunt.sh
@@ -70,7 +70,7 @@ mix compile --warnings-as-errors
 for ((i = 1; i <= runs; i++)); do
   started=$SECONDS
   status=0
-  mix test --warnings-as-errors > "$out/run-$i.log" 2>&1 || status=$?
+  PTC_TEST_RUN_INDEX=$i mix test --warnings-as-errors > "$out/run-$i.log" 2>&1 || status=$?
   echo "$i $status" >> "$out/verdicts.txt"
   if [ "$status" -eq 0 ]; then verdict=pass; else verdict="FAIL (exit $status)"; fi
   echo "run $i/$runs: $verdict ($((SECONDS - started))s)"

--- a/scripts/ci/flake-hunt.sh
+++ b/scripts/ci/flake-hunt.sh
@@ -59,23 +59,25 @@ export PTC_TEST_RUN_LOG="$out/runs.jsonl"
 # one's. Each hunt starts from an empty record and no run logs.
 rm -f "$out"/run-*.log "$out/summary.txt"
 : > "$PTC_TEST_RUN_LOG"
+: > "$out/verdicts.txt"
 
 echo "flake-hunt: $runs runs, $schedulers schedulers, records in $out"
 
 mix compile --warnings-as-errors
 
-failed_runs=0
+# Each run's exit status goes to the summary beside its record, so the table
+# cannot say "0 with failures" about a run that Mix reported as failed.
 for ((i = 1; i <= runs; i++)); do
   started=$SECONDS
-  if mix test --warnings-as-errors > "$out/run-$i.log" 2>&1; then
-    verdict=pass
-  else
-    verdict=FAIL
-    failed_runs=$((failed_runs + 1))
-  fi
+  status=0
+  mix test --warnings-as-errors > "$out/run-$i.log" 2>&1 || status=$?
+  echo "$i $status" >> "$out/verdicts.txt"
+  if [ "$status" -eq 0 ]; then verdict=pass; else verdict="FAIL (exit $status)"; fi
   echo "run $i/$runs: $verdict ($((SECONDS - started))s)"
 done
 
-elixir "$script_dir/flake_hunt_summary.exs" "$PTC_TEST_RUN_LOG" --expected "$runs" | tee "$out/summary.txt"
-
-[ "$failed_runs" -eq 0 ]
+# The summary's exit status is the hunt's verdict: it fails on any failed
+# run, any non-zero exit, and any run that left no record.
+elixir "$script_dir/flake_hunt_summary.exs" "$PTC_TEST_RUN_LOG" \
+  --expected "$runs" --verdicts "$out/verdicts.txt" | tee "$out/summary.txt"
+exit "${PIPESTATUS[0]}"

--- a/scripts/ci/flake-hunt.sh
+++ b/scripts/ci/flake-hunt.sh
@@ -55,7 +55,9 @@ mkdir -p "$out"
 export ERL_FLAGS="+S $schedulers:$schedulers"
 export PTC_TEST_RUN_LOG="$out/runs.jsonl"
 # The formatter appends, so a reused directory would fold an earlier hunt's
-# runs into this summary. Each hunt starts from an empty record.
+# runs into this summary and leave its higher-numbered logs beside this
+# one's. Each hunt starts from an empty record and no run logs.
+rm -f "$out"/run-*.log "$out/summary.txt"
 : > "$PTC_TEST_RUN_LOG"
 
 echo "flake-hunt: $runs runs, $schedulers schedulers, records in $out"

--- a/scripts/ci/flake_hunt_summary.exs
+++ b/scripts/ci/flake_hunt_summary.exs
@@ -62,8 +62,9 @@ defmodule FlakeHuntSummary do
     records =
       records
       |> Enum.with_index(1)
-      |> Enum.map(fn {record, position} -> Map.put_new_lazy(record, "run", fn -> position end) end)
-      |> Enum.map(fn record -> if is_integer(record["run"]), do: record, else: %{record | "run" => nil} end)
+      |> Enum.map(fn {record, position} ->
+        if is_integer(record["run"]), do: record, else: Map.put(record, "run", position)
+      end)
 
     by_run = Map.new(records, &{&1["run"], &1})
     verdicts = Map.new(opts.verdicts)

--- a/scripts/ci/flake_hunt_summary.exs
+++ b/scripts/ci/flake_hunt_summary.exs
@@ -4,7 +4,9 @@
 # under plain `elixir` so it needs nothing from the project.
 
 defmodule FlakeHuntSummary do
-  def main([path]) do
+  def main([path]), do: main([path, "--expected", "0"])
+
+  def main([path, "--expected", expected]) do
     case File.read(path) do
       {:ok, contents} ->
         records =
@@ -12,7 +14,7 @@ defmodule FlakeHuntSummary do
           |> String.split("\n", trim: true)
           |> Enum.map(&:json.decode/1)
 
-        report(records)
+        report(records, String.to_integer(expected))
 
       {:error, reason} ->
         IO.puts("flake-hunt: no run records at #{path} (#{:file.format_error(reason)})")
@@ -21,23 +23,32 @@ defmodule FlakeHuntSummary do
   end
 
   def main(_argv) do
-    IO.puts("usage: elixir flake_hunt_summary.exs RUNS.jsonl")
+    IO.puts("usage: elixir flake_hunt_summary.exs RUNS.jsonl [--expected RUNS]")
     System.halt(64)
   end
 
-  defp report([]) do
+  defp report([], _expected) do
     IO.puts("flake-hunt: the record file is empty")
     System.halt(65)
   end
 
-  defp report(records) do
-    failed_runs = Enum.count(records, &(&1["failures"] != []))
+  defp report(records, expected) do
+    # A run that dies before `suite_finished` -- a compile error, a VM crash,
+    # a killed job -- leaves no record. It is still a failed run, and a table
+    # that silently counted only the survivors would hide exactly the runs a
+    # flake investigation most wants to see.
+    missing = max(expected - length(records), 0)
+    failed_runs = Enum.count(records, &(&1["failures"] != [])) + missing
     schedulers = records |> Enum.map(& &1["schedulers"]) |> Enum.uniq() |> Enum.join(",")
 
     IO.puts(
       "flake-hunt: #{length(records)} runs, #{schedulers} schedulers, " <>
         "#{failed_runs} with failures"
     )
+
+    if missing > 0 do
+      IO.puts("  #{missing} of #{expected} runs left no record (ended before the suite finished)")
+    end
 
     records
     |> Enum.flat_map(fn record ->

--- a/scripts/ci/flake_hunt_summary.exs
+++ b/scripts/ci/flake_hunt_summary.exs
@@ -3,10 +3,13 @@
 # which seeds, and the wall/async/sync spread. Invoked by flake-hunt.sh; runs
 # under plain `elixir` so it needs nothing from the project.
 
-defmodule FlakeHuntSummary do
-  def main([path]), do: main([path, "--expected", "0"])
+# Exit status is the hunt's verdict: 0 only when every expected run left a
+# record, every recorded exit status is zero, and no test failed.
 
-  def main([path, "--expected", expected]) do
+defmodule FlakeHuntSummary do
+  def main([path | options]) do
+    opts = parse(options, %{expected: 0, verdicts: []})
+
     case File.read(path) do
       {:ok, contents} ->
         records =
@@ -14,7 +17,7 @@ defmodule FlakeHuntSummary do
           |> String.split("\n", trim: true)
           |> Enum.map(&:json.decode/1)
 
-        report(records, String.to_integer(expected))
+        report(records, opts)
 
       {:error, reason} ->
         IO.puts("flake-hunt: no run records at #{path} (#{:file.format_error(reason)})")
@@ -22,23 +25,48 @@ defmodule FlakeHuntSummary do
     end
   end
 
-  def main(_argv) do
-    IO.puts("usage: elixir flake_hunt_summary.exs RUNS.jsonl [--expected RUNS]")
+  def main(_argv), do: usage()
+
+  defp parse([], opts), do: opts
+  defp parse(["--expected", n | rest], opts), do: parse(rest, %{opts | expected: String.to_integer(n)})
+
+  defp parse(["--verdicts", file | rest], opts) do
+    verdicts =
+      file
+      |> File.read!()
+      |> String.split("\n", trim: true)
+      |> Enum.map(fn line ->
+        [run, status] = String.split(line, " ")
+        {String.to_integer(run), String.to_integer(status)}
+      end)
+
+    parse(rest, %{opts | verdicts: verdicts})
+  end
+
+  defp parse(_other, _opts), do: usage()
+
+  defp usage do
+    IO.puts("usage: elixir flake_hunt_summary.exs RUNS.jsonl [--expected RUNS] [--verdicts FILE]")
     System.halt(64)
   end
 
-  defp report([], _expected) do
+  defp report([], _opts) do
     IO.puts("flake-hunt: the record file is empty")
     System.halt(65)
   end
 
-  defp report(records, expected) do
+  defp report(records, opts) do
     # A run that dies before `suite_finished` -- a compile error, a VM crash,
     # a killed job -- leaves no record. It is still a failed run, and a table
     # that silently counted only the survivors would hide exactly the runs a
     # flake investigation most wants to see.
-    missing = max(expected - length(records), 0)
-    failed_runs = Enum.count(records, &(&1["failures"] != [])) + missing
+    missing = max(opts.expected - length(records), 0)
+    failed_records = Enum.count(records, &(&1["failures"] != []))
+    nonzero = Enum.filter(opts.verdicts, fn {_run, status} -> status != 0 end)
+    # Mix can report a failed run after a failure-free record: a warning under
+    # --warnings-as-errors, a crash on shutdown. Those runs failed too.
+    unexplained = max(length(nonzero) - failed_records - missing, 0)
+    failed_runs = failed_records + missing + unexplained
     schedulers = records |> Enum.map(& &1["schedulers"]) |> Enum.uniq() |> Enum.join(",")
 
     IO.puts(
@@ -47,7 +75,12 @@ defmodule FlakeHuntSummary do
     )
 
     if missing > 0 do
-      IO.puts("  #{missing} of #{expected} runs left no record (ended before the suite finished)")
+      IO.puts("  #{missing} of #{opts.expected} runs left no record (ended before the suite finished)")
+    end
+
+    if unexplained > 0 do
+      runs = Enum.map_join(nonzero, ", ", fn {run, status} -> "run #{run} exit #{status}" end)
+      IO.puts("  #{unexplained} runs exited non-zero with a failure-free record: #{runs}")
     end
 
     records
@@ -74,6 +107,8 @@ defmodule FlakeHuntSummary do
           "median #{seconds(median)}  max #{seconds(List.last(values))}"
       )
     end
+
+    if failed_runs > 0, do: System.halt(1)
   end
 
   defp seconds(ms), do: :erlang.float_to_binary(ms / 1000, decimals: 1) <> "s"

--- a/scripts/ci/flake_hunt_summary.exs
+++ b/scripts/ci/flake_hunt_summary.exs
@@ -56,31 +56,51 @@ defmodule FlakeHuntSummary do
   end
 
   defp report(records, opts) do
-    # A run that dies before `suite_finished` -- a compile error, a VM crash,
-    # a killed job -- leaves no record. It is still a failed run, and a table
-    # that silently counted only the survivors would hide exactly the runs a
-    # flake investigation most wants to see.
-    missing = max(opts.expected - length(records), 0)
-    failed_records = Enum.count(records, &(&1["failures"] != []))
-    nonzero = Enum.filter(opts.verdicts, fn {_run, status} -> status != 0 end)
-    # Mix can report a failed run after a failure-free record: a warning under
-    # --warnings-as-errors, a crash on shutdown. Those runs failed too.
-    unexplained = max(length(nonzero) - failed_records - missing, 0)
-    failed_runs = failed_records + missing + unexplained
+    # Each record names its run (PTC_TEST_RUN_INDEX); records from a plain
+    # `mix test` are numbered by position. Verdicts and records are then
+    # paired per run, never by subtracting aggregate counts.
+    records =
+      records
+      |> Enum.with_index(1)
+      |> Enum.map(fn {record, position} -> Map.put_new_lazy(record, "run", fn -> position end) end)
+      |> Enum.map(fn record -> if is_integer(record["run"]), do: record, else: %{record | "run" => nil} end)
+
+    by_run = Map.new(records, &{&1["run"], &1})
+    verdicts = Map.new(opts.verdicts)
+    expected = max(opts.expected, records |> Enum.map(& &1["run"]) |> Enum.reject(&is_nil/1) |> Enum.max(fn -> 0 end))
     schedulers = records |> Enum.map(& &1["schedulers"]) |> Enum.uniq() |> Enum.join(",")
+
+    # A run that dies before `suite_finished` -- a compile error, a VM crash,
+    # a killed job -- leaves no record, and Mix can report a failed run after
+    # a failure-free record -- a warning under --warnings-as-errors, a crash
+    # on shutdown. Both are failed runs, and a table that counted only the
+    # survivors would hide exactly the runs a flake investigation most wants.
+    runs =
+      for run <- 1..expected//1 do
+        record = by_run[run]
+        status = Map.get(verdicts, run, 0)
+
+        cond do
+          is_nil(record) -> {run, :no_record, status}
+          record["failures"] != [] -> {run, :failed, status}
+          status != 0 -> {run, :nonzero_exit, status}
+          true -> {run, :passed, status}
+        end
+      end
+
+    failed_runs = Enum.count(runs, fn {_run, outcome, _status} -> outcome != :passed end)
 
     IO.puts(
       "flake-hunt: #{length(records)} runs, #{schedulers} schedulers, " <>
         "#{failed_runs} with failures"
     )
 
-    if missing > 0 do
-      IO.puts("  #{missing} of #{opts.expected} runs left no record (ended before the suite finished)")
+    for {run, :no_record, status} <- runs do
+      IO.puts("  run #{run} left no record (exit #{status}): it ended before the suite finished")
     end
 
-    if unexplained > 0 do
-      runs = Enum.map_join(nonzero, ", ", fn {run, status} -> "run #{run} exit #{status}" end)
-      IO.puts("  #{unexplained} runs exited non-zero with a failure-free record: #{runs}")
+    for {run, :nonzero_exit, status} <- runs do
+      IO.puts("  run #{run} exited #{status} with a failure-free record")
     end
 
     records

--- a/scripts/ci/flake_hunt_summary.exs
+++ b/scripts/ci/flake_hunt_summary.exs
@@ -1,0 +1,71 @@
+# Summarises the JSON lines that PtcRunner.TestSupport.RunRecord appends per
+# suite run: how many runs failed, which tests failed how often and under
+# which seeds, and the wall/async/sync spread. Invoked by flake-hunt.sh; runs
+# under plain `elixir` so it needs nothing from the project.
+
+defmodule FlakeHuntSummary do
+  def main([path]) do
+    case File.read(path) do
+      {:ok, contents} ->
+        records =
+          contents
+          |> String.split("\n", trim: true)
+          |> Enum.map(&:json.decode/1)
+
+        report(records)
+
+      {:error, reason} ->
+        IO.puts("flake-hunt: no run records at #{path} (#{:file.format_error(reason)})")
+        System.halt(65)
+    end
+  end
+
+  def main(_argv) do
+    IO.puts("usage: elixir flake_hunt_summary.exs RUNS.jsonl")
+    System.halt(64)
+  end
+
+  defp report([]) do
+    IO.puts("flake-hunt: the record file is empty")
+    System.halt(65)
+  end
+
+  defp report(records) do
+    failed_runs = Enum.count(records, &(&1["failures"] != []))
+    schedulers = records |> Enum.map(& &1["schedulers"]) |> Enum.uniq() |> Enum.join(",")
+
+    IO.puts(
+      "flake-hunt: #{length(records)} runs, #{schedulers} schedulers, " <>
+        "#{failed_runs} with failures"
+    )
+
+    records
+    |> Enum.flat_map(fn record ->
+      Enum.map(record["failures"], &{&1["file"], &1["line"], &1["module"], &1["name"], record["seed"], &1["message"]})
+    end)
+    |> Enum.group_by(fn {file, line, module, name, _seed, _message} -> {file, line, module, name} end)
+    |> Enum.map(fn {key, hits} -> {length(hits), key, hits} end)
+    |> Enum.sort_by(fn {count, {file, line, _, _}, _} -> {-count, file, line} end)
+    |> Enum.each(fn {count, {file, line, module, name}, hits} ->
+      seeds = hits |> Enum.map(&elem(&1, 4)) |> Enum.join(", ")
+      {_, _, _, _, _, message} = hd(hits)
+      IO.puts("  #{count}x  #{file}:#{line}  #{module}  #{name}")
+      IO.puts("       seeds: #{seeds}")
+      IO.puts("       #{message}")
+    end)
+
+    for {label, key} <- [{"wall", "wall_ms"}, {"async", "async_ms"}, {"sync", "sync_ms"}] do
+      values = records |> Enum.map(& &1[key]) |> Enum.sort()
+      median = Enum.at(values, div(length(values), 2))
+
+      IO.puts(
+        "  #{String.pad_trailing(label, 5)} min #{seconds(hd(values))}  " <>
+          "median #{seconds(median)}  max #{seconds(List.last(values))}"
+      )
+    end
+  end
+
+  defp seconds(ms), do: :erlang.float_to_binary(ms / 1000, decimals: 1) <> "s"
+end
+
+FlakeHuntSummary.main(System.argv())

--- a/test/scripts/ci_gates_test.exs
+++ b/test/scripts/ci_gates_test.exs
@@ -9,6 +9,8 @@ defmodule PtcRunner.Scripts.CIGatesTest do
   @preflight Path.join(@root, "scripts/ci/preflight.sh")
   @viewer Path.join(@root, "scripts/ci/viewer.sh")
   @launcher_package Path.join(@root, "scripts/ci/launcher-package.sh")
+  @flake_hunt Path.join(@root, "scripts/ci/flake-hunt.sh")
+  @flake_hunt_summary Path.join(@root, "scripts/ci/flake_hunt_summary.exs")
   @git_env GitEnv.clear()
 
   test "core tests establish the CI contract without reducing native scheduler pressure" do
@@ -236,6 +238,136 @@ defmodule PtcRunner.Scripts.CIGatesTest do
     refute nightly =~ ~r/PTC_SKIP_PTY_GATE=/
   end
 
+  describe "flake hunt" do
+    @passing_record ~s({"seed":1,"schedulers":4,"wall_ms":4000,"async_ms":1000,"sync_ms":3000,"failures":[]})
+    @failing_record ~s({"seed":7,"schedulers":4,"wall_ms":5000,"async_ms":1500,"sync_ms":3500,) <>
+                      ~s("failures":[{"module":"PtcRunner.ReplSessionTest","name":"test owners","file":"test/a_test.exs","line":451,"message":"no matching message after 2000ms"}]})
+
+    test "compiles once, then runs the whole suite N times under the CI contract" do
+      %{marker: marker} = fake = fake_mix()
+      out = Path.join(Path.dirname(marker), "hunt")
+
+      {output, status} =
+        run_gate(@flake_hunt, fake,
+          args: ["3", "--out", out],
+          env: [{"ERL_FLAGS", "+S 9:9"}, {"MIX_RUN_RECORD", @passing_record}]
+        )
+
+      assert status == 0, output
+
+      assert File.read!(marker) |> String.split("\n", trim: true) ==
+               [
+                 "CI=1 MIX_ENV=test HEX_SPONSOR=false ERL_FLAGS=+S 4:4 PWD=. :: compile --warnings-as-errors"
+               ] ++
+                 List.duplicate(
+                   "CI=1 MIX_ENV=test HEX_SPONSOR=false ERL_FLAGS=+S 4:4 PWD=. :: test --warnings-as-errors",
+                   3
+                 )
+
+      assert output =~ "flake-hunt: 3 runs, 4 schedulers, 0 with failures"
+      assert output =~ ~r/wall  min 4\.0s  median 4\.0s  max 4\.0s/
+      assert File.read!(Path.join(out, "summary.txt")) =~ "0 with failures"
+
+      assert File.read!(Path.join(out, "runs.jsonl"))
+             |> String.split("\n", trim: true)
+             |> length() == 3
+    end
+
+    test "a failing run does not stop the hunt and fails the exit status" do
+      %{marker: marker} = fake = fake_mix()
+      out = Path.join(Path.dirname(marker), "hunt")
+
+      {output, status} =
+        run_gate(@flake_hunt, fake,
+          args: ["2", "--schedulers", "6", "--out", out],
+          env: [{"MIX_TEST_EXIT", "1"}, {"MIX_RUN_RECORD", @failing_record}]
+        )
+
+      assert status == 1, output
+      assert output =~ "run 1/2: FAIL"
+      assert output =~ "run 2/2: FAIL"
+      assert output =~ "flake-hunt: 2 runs, 4 schedulers, 2 with failures"
+      assert output =~ "2x  test/a_test.exs:451  PtcRunner.ReplSessionTest  test owners"
+      assert output =~ "seeds: 7, 7"
+      assert output =~ "no matching message after 2000ms"
+
+      assert File.read!(marker)
+             |> String.split("\n", trim: true)
+             |> Enum.count(
+               &(&1 ==
+                   "CI=1 MIX_ENV=test HEX_SPONSOR=false ERL_FLAGS=+S 6:6 PWD=. :: test --warnings-as-errors")
+             ) == 2
+    end
+
+    test "rejects malformed arguments before invoking Mix" do
+      %{marker: marker} = fake = fake_mix()
+
+      for args <- [["zero"], ["--schedulers", "many"], ["--out"]] do
+        {output, status} = run_gate(@flake_hunt, fake, args: args)
+        assert status == 64, output
+        assert output =~ "usage: flake-hunt.sh [RUNS] [--schedulers POSITIVE_INTEGER] [--out DIR]"
+      end
+
+      refute File.exists?(marker)
+    end
+
+    test "the summary refuses a missing or empty record file" do
+      %{marker: marker} = fake_mix()
+      missing = Path.join(Path.dirname(marker), "missing.jsonl")
+      empty = Path.join(Path.dirname(marker), "empty.jsonl")
+      File.write!(empty, "")
+
+      {output, status} =
+        System.cmd("elixir", [@flake_hunt_summary, missing], stderr_to_stdout: true)
+
+      assert status == 65
+      assert output =~ "no run records at #{missing}"
+
+      {output, status} =
+        System.cmd("elixir", [@flake_hunt_summary, empty], stderr_to_stdout: true)
+
+      assert status == 65
+      assert output =~ "record file is empty"
+    end
+
+    test "the nightly workflow runs the hunt on main and keeps its records" do
+      nightly = File.read!(Path.join(@root, ".github/workflows/nightly.yml"))
+
+      assert nightly =~
+               ~s(scripts/ci/flake-hunt.sh 10 --schedulers 4 --out "$RUNNER_TEMP/flake-hunt")
+
+      assert nightly =~
+               ~r/if: always\(\)\n\s+uses: actions\/upload-artifact@v6\n\s+with:\n\s+name: flake-hunt/
+    end
+
+    # The formatter is the only producer of the record file, so it is proven
+    # through a real `mix test` rather than by feeding it synthetic events.
+    @tag :nightly
+    test "a real suite run appends one record with its seed, split, and failures" do
+      %{marker: marker} = fake_mix()
+      log = Path.join(Path.dirname(marker), "runs.jsonl")
+
+      {output, status} =
+        System.cmd(
+          "mix",
+          ["test", "test/support/test_helpers_test.exs", "--seed", "4242"],
+          cd: @root,
+          env: @git_env ++ [{"PTC_TEST_RUN_LOG", log}, {"MIX_ENV", "test"}],
+          stderr_to_stdout: true
+        )
+
+      assert status == 0, output
+      assert [line] = log |> File.read!() |> String.split("\n", trim: true)
+      record = Jason.decode!(line)
+      assert record["seed"] == 4242
+      assert record["schedulers"] == System.schedulers_online()
+      assert record["failures"] == []
+      assert record["tests"] > 0
+      assert record["wall_ms"] >= record["async_ms"]
+      assert record["sync_ms"] == record["wall_ms"] - record["async_ms"]
+    end
+  end
+
   # Every gate is exercised the same way: the repository root as the working
   # directory, a cleared git environment, and a fake `mix` first on PATH that
   # records what it was asked to do. `:env` entries are appended, so a test can
@@ -278,6 +410,12 @@ defmodule PtcRunner.Scripts.CIGatesTest do
     rel="${rel#/}"
     printf 'CI=%s MIX_ENV=%s HEX_SPONSOR=%s ERL_FLAGS=%s PWD=%s :: %s\n' \\
       "$CI" "$MIX_ENV" "$HEX_SPONSOR" "${ERL_FLAGS:-}" "${rel:-.}" "$*" >> "$MIX_MARKER"
+    if [ "$1" = test ] && [ -n "${PTC_TEST_RUN_LOG:-}" ] && [ -n "${MIX_RUN_RECORD:-}" ]; then
+      printf '%s\n' "$MIX_RUN_RECORD" >> "$PTC_TEST_RUN_LOG"
+    fi
+    if [ "$1" = test ] && [ -n "${MIX_TEST_EXIT:-}" ]; then
+      exit "$MIX_TEST_EXIT"
+    fi
     exit "${MIX_GATE_EXIT:-0}"
     """)
 

--- a/test/scripts/ci_gates_test.exs
+++ b/test/scripts/ci_gates_test.exs
@@ -356,6 +356,21 @@ defmodule PtcRunner.Scripts.CIGatesTest do
       assert output =~ "record file is empty"
     end
 
+    test "a run that ended before the suite finished counts as a failure with no record" do
+      %{marker: marker} = fake_mix()
+      partial = Path.join(Path.dirname(marker), "partial.jsonl")
+      File.write!(partial, @passing_record <> "\n")
+
+      {output, status} =
+        System.cmd("elixir", [@flake_hunt_summary, partial, "--expected", "3"],
+          stderr_to_stdout: true
+        )
+
+      assert status == 0, output
+      assert output =~ "flake-hunt: 1 runs, 4 schedulers, 2 with failures"
+      assert output =~ "2 of 3 runs left no record (ended before the suite finished)"
+    end
+
     test "the nightly workflow runs the hunt on main and keeps its records" do
       nightly = File.read!(Path.join(@root, ".github/workflows/nightly.yml"))
 

--- a/test/scripts/ci_gates_test.exs
+++ b/test/scripts/ci_gates_test.exs
@@ -310,8 +310,9 @@ defmodule PtcRunner.Scripts.CIGatesTest do
         )
 
       assert status == 1, output
-      assert output =~ "run 1/2: FAIL"
-      assert output =~ "run 2/2: FAIL"
+      assert output =~ "run 1/2: FAIL (exit 1)"
+      assert output =~ "run 2/2: FAIL (exit 1)"
+      assert File.read!(Path.join(out, "verdicts.txt")) == "1 1\n2 1\n"
       assert output =~ "flake-hunt: 2 runs, 4 schedulers, 2 with failures"
       assert output =~ "2x  test/a_test.exs:451  PtcRunner.ReplSessionTest  test owners"
       assert output =~ "seeds: 7, 7"
@@ -366,9 +367,28 @@ defmodule PtcRunner.Scripts.CIGatesTest do
           stderr_to_stdout: true
         )
 
-      assert status == 0, output
+      assert status == 1, output
       assert output =~ "flake-hunt: 1 runs, 4 schedulers, 2 with failures"
       assert output =~ "2 of 3 runs left no record (ended before the suite finished)"
+    end
+
+    test "a run that Mix reported as failed counts even when its record is failure-free" do
+      %{marker: marker} = fake_mix()
+      records = Path.join(Path.dirname(marker), "runs.jsonl")
+      verdicts = Path.join(Path.dirname(marker), "verdicts.txt")
+      File.write!(records, @passing_record <> "\n" <> @passing_record <> "\n")
+      File.write!(verdicts, "1 0\n2 1\n")
+
+      {output, status} =
+        System.cmd(
+          "elixir",
+          [@flake_hunt_summary, records, "--expected", "2", "--verdicts", verdicts],
+          stderr_to_stdout: true
+        )
+
+      assert status == 1, output
+      assert output =~ "flake-hunt: 2 runs, 4 schedulers, 1 with failures"
+      assert output =~ "1 runs exited non-zero with a failure-free record: run 2 exit 1"
     end
 
     test "the nightly workflow runs the hunt on main and keeps its records" do

--- a/test/scripts/ci_gates_test.exs
+++ b/test/scripts/ci_gates_test.exs
@@ -369,26 +369,42 @@ defmodule PtcRunner.Scripts.CIGatesTest do
 
       assert status == 1, output
       assert output =~ "flake-hunt: 1 runs, 4 schedulers, 2 with failures"
-      assert output =~ "2 of 3 runs left no record (ended before the suite finished)"
+      assert output =~ "run 2 left no record (exit 0): it ended before the suite finished"
+      assert output =~ "run 3 left no record (exit 0): it ended before the suite finished"
     end
 
-    test "a run that Mix reported as failed counts even when its record is failure-free" do
+    test "runs are paired with their verdicts by index, not by subtracting counts" do
       %{marker: marker} = fake_mix()
       records = Path.join(Path.dirname(marker), "runs.jsonl")
       verdicts = Path.join(Path.dirname(marker), "verdicts.txt")
-      File.write!(records, @passing_record <> "\n" <> @passing_record <> "\n")
-      File.write!(verdicts, "1 0\n2 1\n")
+      # Run 2's record is missing; run 3 exited 1 with a clean record; run 4
+      # failed a test and exited 1. Only run 1 passed.
+      File.write!(
+        records,
+        [
+          @passing_record |> String.replace(~s({"seed":1), ~s({"run":1,"seed":1)),
+          @passing_record |> String.replace(~s({"seed":1), ~s({"run":3,"seed":1)),
+          @failing_record |> String.replace(~s({"seed":7), ~s({"run":4,"seed":7))
+        ]
+        |> Enum.join("\n")
+        |> Kernel.<>("\n")
+      )
+
+      File.write!(verdicts, "1 0\n2 0\n3 1\n4 1\n")
 
       {output, status} =
         System.cmd(
           "elixir",
-          [@flake_hunt_summary, records, "--expected", "2", "--verdicts", verdicts],
+          [@flake_hunt_summary, records, "--expected", "4", "--verdicts", verdicts],
           stderr_to_stdout: true
         )
 
       assert status == 1, output
-      assert output =~ "flake-hunt: 2 runs, 4 schedulers, 1 with failures"
-      assert output =~ "1 runs exited non-zero with a failure-free record: run 2 exit 1"
+      assert output =~ "flake-hunt: 3 runs, 4 schedulers, 3 with failures"
+      assert output =~ "run 2 left no record (exit 0)"
+      assert output =~ "run 3 exited 1 with a failure-free record"
+      refute output =~ "run 4 exited"
+      assert output =~ "1x  test/a_test.exs:451"
     end
 
     test "the nightly workflow runs the hunt on main and keeps its records" do

--- a/test/scripts/ci_gates_test.exs
+++ b/test/scripts/ci_gates_test.exs
@@ -277,16 +277,22 @@ defmodule PtcRunner.Scripts.CIGatesTest do
       %{marker: marker} = fake = fake_mix()
       out = Path.join(Path.dirname(marker), "hunt")
 
-      for _hunt <- 1..2 do
+      for runs <- ["3", "2"] do
         {output, status} =
           run_gate(@flake_hunt, fake,
-            args: ["2", "--out", out],
+            args: [runs, "--out", out],
             env: [{"MIX_RUN_RECORD", @passing_record}]
           )
 
         assert status == 0, output
-        assert output =~ "flake-hunt: 2 runs, 4 schedulers, 0 with failures"
+        assert output =~ "flake-hunt: #{runs} runs, 4 schedulers, 0 with failures"
       end
+
+      assert out
+             |> Path.join("run-*.log")
+             |> Path.wildcard()
+             |> Enum.map(&Path.basename/1)
+             |> Enum.sort() == ["run-1.log", "run-2.log"]
 
       assert File.read!(Path.join(out, "runs.jsonl"))
              |> String.split("\n", trim: true)

--- a/test/scripts/ci_gates_test.exs
+++ b/test/scripts/ci_gates_test.exs
@@ -273,6 +273,26 @@ defmodule PtcRunner.Scripts.CIGatesTest do
              |> length() == 3
     end
 
+    test "a reused output directory starts from an empty record" do
+      %{marker: marker} = fake = fake_mix()
+      out = Path.join(Path.dirname(marker), "hunt")
+
+      for _hunt <- 1..2 do
+        {output, status} =
+          run_gate(@flake_hunt, fake,
+            args: ["2", "--out", out],
+            env: [{"MIX_RUN_RECORD", @passing_record}]
+          )
+
+        assert status == 0, output
+        assert output =~ "flake-hunt: 2 runs, 4 schedulers, 0 with failures"
+      end
+
+      assert File.read!(Path.join(out, "runs.jsonl"))
+             |> String.split("\n", trim: true)
+             |> length() == 2
+    end
+
     test "a failing run does not stop the hunt and fails the exit status" do
       %{marker: marker} = fake = fake_mix()
       out = Path.join(Path.dirname(marker), "hunt")

--- a/test/scripts/ci_gates_test.exs
+++ b/test/scripts/ci_gates_test.exs
@@ -240,7 +240,8 @@ defmodule PtcRunner.Scripts.CIGatesTest do
 
   describe "flake hunt" do
     @passing_record ~s({"seed":1,"schedulers":4,"wall_ms":4000,"async_ms":1000,"sync_ms":3000,"failures":[]})
-    @failing_record ~s({"seed":7,"schedulers":4,"wall_ms":5000,"async_ms":1500,"sync_ms":3500,) <>
+    # `"run":null` is what a plain `mix test` writes: only flake-hunt.sh numbers runs.
+    @failing_record ~s({"run":null,"seed":7,"schedulers":4,"wall_ms":5000,"async_ms":1500,"sync_ms":3500,) <>
                       ~s("failures":[{"module":"PtcRunner.ReplSessionTest","name":"test owners","file":"test/a_test.exs","line":451,"message":"no matching message after 2000ms"}]})
 
     test "compiles once, then runs the whole suite N times under the CI contract" do
@@ -338,6 +339,19 @@ defmodule PtcRunner.Scripts.CIGatesTest do
       refute File.exists?(marker)
     end
 
+    test "an unnumbered failing record from a plain mix test still fails the summary" do
+      %{marker: marker} = fake_mix()
+      records = Path.join(Path.dirname(marker), "plain.jsonl")
+      File.write!(records, @passing_record <> "\n" <> @failing_record <> "\n")
+
+      {output, status} =
+        System.cmd("elixir", [@flake_hunt_summary, records], stderr_to_stdout: true)
+
+      assert status == 1, output
+      assert output =~ "flake-hunt: 2 runs, 4 schedulers, 1 with failures"
+      assert output =~ "seeds: 7"
+    end
+
     test "the summary refuses a missing or empty record file" do
       %{marker: marker} = fake_mix()
       missing = Path.join(Path.dirname(marker), "missing.jsonl")
@@ -384,7 +398,7 @@ defmodule PtcRunner.Scripts.CIGatesTest do
         [
           @passing_record |> String.replace(~s({"seed":1), ~s({"run":1,"seed":1)),
           @passing_record |> String.replace(~s({"seed":1), ~s({"run":3,"seed":1)),
-          @failing_record |> String.replace(~s({"seed":7), ~s({"run":4,"seed":7))
+          @failing_record |> String.replace(~s({"run":null,"seed":7), ~s({"run":4,"seed":7))
         ]
         |> Enum.join("\n")
         |> Kernel.<>("\n")

--- a/test/support/run_record.ex
+++ b/test/support/run_record.ex
@@ -1,0 +1,119 @@
+defmodule PtcRunner.TestSupport.RunRecord do
+  @moduledoc """
+  ExUnit formatter that appends one JSON line per suite run to
+  `PTC_TEST_RUN_LOG`.
+
+  The line carries what a flake investigation needs and the console summary
+  throws away once the terminal scrolls: the seed, the scheduler count, the
+  wall/async/sync split that ExUnit prints as `Finished in`, and every failed
+  test with its location and first line of failure. `scripts/ci/flake-hunt.sh`
+  runs the suite repeatedly with this formatter and tabulates the file.
+
+  The sync figure is the serial `async: false` phase and is the number that
+  makes the suite slow; the async figure is what parallelism already buys.
+  Track both per change rather than the summed per-test time, which hides the
+  structure.
+  """
+
+  use GenServer
+
+  @impl GenServer
+  def init(config) do
+    {:ok,
+     %{
+       seed: Keyword.get(config, :seed),
+       max_cases: Keyword.get(config, :max_cases),
+       tests: 0,
+       failures: []
+     }}
+  end
+
+  @impl GenServer
+  def handle_cast({:test_finished, %ExUnit.Test{} = test}, state) do
+    state = %{state | tests: state.tests + 1}
+
+    case test.state do
+      {:failed, failures} ->
+        {:noreply, %{state | failures: [failure(test, failures) | state.failures]}}
+
+      {:invalid, _module} ->
+        {:noreply, %{state | failures: [failure(test, :invalid) | state.failures]}}
+
+      _passed_skipped_or_excluded ->
+        {:noreply, state}
+    end
+  end
+
+  def handle_cast({:suite_finished, times_us}, state) do
+    state |> record(times_us) |> append()
+    {:noreply, state}
+  end
+
+  def handle_cast(_event, state), do: {:noreply, state}
+
+  @doc """
+  Builds the record for one run from the formatter state and ExUnit's
+  `times_us` map (`:run`, `:async`, `:load`).
+  """
+  @spec record(map(), map()) :: map()
+  def record(state, times_us) do
+    # `mix test` loads the files itself, so `:load` arrives as nil; `:async`
+    # is nil when no async module ran.
+    run_us = times_us[:run] || 0
+    async_us = times_us[:async] || 0
+
+    %{
+      recorded_at: DateTime.utc_now() |> DateTime.truncate(:second) |> DateTime.to_iso8601(),
+      seed: state.seed,
+      schedulers: System.schedulers_online(),
+      max_cases: state.max_cases,
+      wall_ms: div(run_us, 1_000),
+      async_ms: div(async_us, 1_000),
+      sync_ms: div(max(run_us - async_us, 0), 1_000),
+      load_ms: div(times_us[:load] || 0, 1_000),
+      tests: state.tests,
+      failures: Enum.reverse(state.failures)
+    }
+  end
+
+  defp failure(test, :invalid) do
+    test |> location() |> Map.put(:message, "invalid: setup_all failed")
+  end
+
+  defp failure(test, failures) do
+    message = Enum.map_join(failures, " | ", fn {_kind, reason, _stack} -> first_line(reason) end)
+
+    test |> location() |> Map.put(:message, message)
+  end
+
+  defp location(test) do
+    %{
+      module: inspect(test.module),
+      name: to_string(test.name),
+      file: Path.relative_to_cwd(test.tags.file),
+      line: test.tags.line
+    }
+  end
+
+  defp first_line(%{__exception__: true} = exception) do
+    exception |> Exception.message() |> first_line()
+  end
+
+  defp first_line(reason) when is_binary(reason) do
+    reason |> String.split("\n", parts: 2) |> hd() |> String.slice(0, 200)
+  end
+
+  defp first_line(reason), do: reason |> inspect(limit: 20) |> first_line()
+
+  defp append(record) do
+    case System.get_env("PTC_TEST_RUN_LOG") do
+      nil ->
+        :ok
+
+      path ->
+        File.mkdir_p!(Path.dirname(path))
+        File.write!(path, Jason.encode!(record) <> "\n", [:append])
+        IO.puts("\n[run-record] #{path}")
+    end
+  end
+end

--- a/test/support/run_record.ex
+++ b/test/support/run_record.ex
@@ -22,6 +22,7 @@ defmodule PtcRunner.TestSupport.RunRecord do
     {:ok,
      %{
        log: Keyword.get(config, :run_log, System.get_env("PTC_TEST_RUN_LOG")),
+       run: Keyword.get(config, :run_index, run_index(System.get_env("PTC_TEST_RUN_INDEX"))),
        seed: Keyword.get(config, :seed),
        max_cases: Keyword.get(config, :max_cases),
        tests: 0,
@@ -68,6 +69,7 @@ defmodule PtcRunner.TestSupport.RunRecord do
 
     %{
       recorded_at: DateTime.utc_now() |> DateTime.truncate(:second) |> DateTime.to_iso8601(),
+      run: state.run,
       seed: state.seed,
       schedulers: System.schedulers_online(),
       max_cases: state.max_cases,
@@ -98,6 +100,17 @@ defmodule PtcRunner.TestSupport.RunRecord do
       line: test_module.tags[:line],
       message: message(failures)
     }
+  end
+
+  # flake-hunt.sh numbers its runs so the summary can pair each record with
+  # that run's exit status; a plain `mix test` has no number.
+  defp run_index(nil), do: nil
+
+  defp run_index(value) do
+    case Integer.parse(value) do
+      {index, ""} -> index
+      _other -> nil
+    end
   end
 
   defp relative(nil), do: nil

--- a/test/support/run_record.ex
+++ b/test/support/run_record.ex
@@ -21,6 +21,7 @@ defmodule PtcRunner.TestSupport.RunRecord do
   def init(config) do
     {:ok,
      %{
+       log: Keyword.get(config, :run_log, System.get_env("PTC_TEST_RUN_LOG")),
        seed: Keyword.get(config, :seed),
        max_cases: Keyword.get(config, :max_cases),
        tests: 0,
@@ -45,7 +46,7 @@ defmodule PtcRunner.TestSupport.RunRecord do
   end
 
   def handle_cast({:suite_finished, times_us}, state) do
-    state |> record(times_us) |> append()
+    append(state.log, record(state, times_us))
     {:noreply, state}
   end
 
@@ -105,15 +106,20 @@ defmodule PtcRunner.TestSupport.RunRecord do
 
   defp first_line(reason), do: reason |> inspect(limit: 20) |> first_line()
 
-  defp append(record) do
-    case System.get_env("PTC_TEST_RUN_LOG") do
-      nil ->
-        :ok
+  # A formatter exception aborts `mix test`, and a lost record must never
+  # cost the run it describes, so every failure here is reported and dropped.
+  defp append(path, _record) when path in [nil, ""], do: :ok
 
-      path ->
-        File.mkdir_p!(Path.dirname(path))
-        File.write!(path, Jason.encode!(record) <> "\n", [:append])
-        IO.puts("\n[run-record] #{path}")
+  defp append(path, record) do
+    with :ok <- File.mkdir_p(Path.dirname(path)),
+         :ok <- File.write(path, Jason.encode!(record) <> "\n", [:append]) do
+      IO.puts("\n[run-record] #{path}")
+    else
+      {:error, reason} ->
+        IO.puts(:stderr, "\n[run-record] not written to #{path}: #{:file.format_error(reason)}")
     end
+  rescue
+    exception ->
+      IO.puts(:stderr, "\n[run-record] not written to #{path}: #{Exception.message(exception)}")
   end
 end

--- a/test/support/run_record.ex
+++ b/test/support/run_record.ex
@@ -37,12 +37,15 @@ defmodule PtcRunner.TestSupport.RunRecord do
       {:failed, failures} ->
         {:noreply, %{state | failures: [failure(test, failures) | state.failures]}}
 
-      {:invalid, _module} ->
-        {:noreply, %{state | failures: [failure(test, :invalid) | state.failures]}}
-
-      _passed_skipped_or_excluded ->
+      # An invalid test is a consequence of its module's setup_all failure,
+      # which `:module_finished` records once with the real error.
+      _passed_skipped_excluded_or_invalid ->
         {:noreply, state}
     end
+  end
+
+  def handle_cast({:module_finished, %ExUnit.TestModule{state: {:failed, failures}} = m}, state) do
+    {:noreply, %{state | failures: [module_failure(m, failures) | state.failures]}}
   end
 
   def handle_cast({:suite_finished, times_us}, state) do
@@ -77,23 +80,36 @@ defmodule PtcRunner.TestSupport.RunRecord do
     }
   end
 
-  defp failure(test, :invalid) do
-    test |> location() |> Map.put(:message, "invalid: setup_all failed")
-  end
-
   defp failure(test, failures) do
-    message = Enum.map_join(failures, " | ", fn {_kind, reason, _stack} -> first_line(reason) end)
-
-    test |> location() |> Map.put(:message, message)
-  end
-
-  defp location(test) do
     %{
       module: inspect(test.module),
       name: to_string(test.name),
-      file: Path.relative_to_cwd(test.tags.file),
-      line: test.tags.line
+      file: relative(test.tags[:file]),
+      line: test.tags[:line],
+      message: message(failures)
     }
+  end
+
+  defp module_failure(test_module, failures) do
+    %{
+      module: inspect(test_module.name),
+      name: "setup_all",
+      file: relative(test_module.file),
+      line: test_module.tags[:line],
+      message: message(failures)
+    }
+  end
+
+  defp relative(nil), do: nil
+  defp relative(path), do: Path.relative_to_cwd(path)
+
+  # A failure value can be anything a test raised, including structs whose
+  # Inspect or message implementations raise; rendering it must not take the
+  # formatter down with the test.
+  defp message(failures) do
+    Enum.map_join(failures, " | ", fn {_kind, reason, _stack} -> first_line(reason) end)
+  rescue
+    exception -> "unrenderable failure (#{inspect(exception.__struct__)})"
   end
 
   defp first_line(%{__exception__: true} = exception) do

--- a/test/support/run_record_test.exs
+++ b/test/support/run_record_test.exs
@@ -1,0 +1,51 @@
+defmodule PtcRunner.TestSupport.RunRecordTest do
+  use ExUnit.Case, async: true
+
+  alias PtcRunner.TestSupport.RunRecord
+
+  test "a record carries the split, the seed, and each failure's first line" do
+    {:ok, state} = RunRecord.init(seed: 99, max_cases: 4)
+
+    passed = %ExUnit.Test{
+      name: :"test passes",
+      module: __MODULE__,
+      state: nil,
+      tags: %{file: __ENV__.file, line: 1}
+    }
+
+    failed = %{
+      passed
+      | name: :"test fails",
+        tags: %{file: __ENV__.file, line: 2},
+        state:
+          {:failed,
+           [
+             {:error,
+              %RuntimeError{
+                message: "Assertion failed, no matching message after 2000ms\nmailbox: []"
+              }, []},
+             {:exit, :shutdown, []}
+           ]}
+    }
+
+    {:noreply, state} = RunRecord.handle_cast({:test_finished, passed}, state)
+    {:noreply, state} = RunRecord.handle_cast({:test_finished, failed}, state)
+
+    record = RunRecord.record(state, %{run: 4_500_000, async: 1_000_000, load: 250_000})
+
+    assert %{
+             seed: 99,
+             max_cases: 4,
+             tests: 2,
+             wall_ms: 4_500,
+             async_ms: 1_000,
+             sync_ms: 3_500,
+             load_ms: 250
+           } =
+             record
+
+    assert [%{name: "test fails", line: 2, message: message}] = record.failures
+    assert message == "Assertion failed, no matching message after 2000ms | :shutdown"
+    assert Path.type(hd(record.failures).file) == :relative
+  end
+end

--- a/test/support/run_record_test.exs
+++ b/test/support/run_record_test.exs
@@ -48,4 +48,28 @@ defmodule PtcRunner.TestSupport.RunRecordTest do
     assert message == "Assertion failed, no matching message after 2000ms | :shutdown"
     assert Path.type(hd(record.failures).file) == :relative
   end
+
+  @tag :tmp_dir
+  test "an unwritable record destination is reported, never raised", %{tmp_dir: directory} do
+    blocker = Path.join(directory, "blocker")
+    File.write!(blocker, "a file where a directory is needed")
+    {:ok, state} = RunRecord.init(run_log: Path.join(blocker, "runs.jsonl"), seed: 1)
+
+    stderr =
+      ExUnit.CaptureIO.capture_io(:stderr, fn ->
+        assert {:noreply, ^state} =
+                 RunRecord.handle_cast(
+                   {:suite_finished, %{run: 1_000, async: nil, load: nil}},
+                   state
+                 )
+      end)
+
+    assert stderr =~ "[run-record] not written to #{blocker}/runs.jsonl"
+    refute File.exists?(Path.join(blocker, "runs.jsonl"))
+  end
+
+  test "an empty destination records nothing" do
+    {:ok, state} = RunRecord.init(run_log: "", seed: 1)
+    assert {:noreply, ^state} = RunRecord.handle_cast({:suite_finished, %{run: 1_000}}, state)
+  end
 end

--- a/test/support/run_record_test.exs
+++ b/test/support/run_record_test.exs
@@ -72,4 +72,52 @@ defmodule PtcRunner.TestSupport.RunRecordTest do
     {:ok, state} = RunRecord.init(run_log: "", seed: 1)
     assert {:noreply, ^state} = RunRecord.handle_cast({:suite_finished, %{run: 1_000}}, state)
   end
+
+  test "a setup_all failure is recorded once with its real error, not per invalid test" do
+    {:ok, state} = RunRecord.init(run_log: nil, seed: 1)
+
+    invalid = %ExUnit.Test{
+      name: :"test never ran",
+      module: __MODULE__,
+      state: {:invalid, %ExUnit.TestModule{name: __MODULE__, file: __ENV__.file}},
+      tags: %{file: __ENV__.file, line: 3}
+    }
+
+    failed_module = %ExUnit.TestModule{
+      name: __MODULE__,
+      file: __ENV__.file,
+      tags: %{line: 1},
+      state: {:failed, [{:error, %RuntimeError{message: "fixture directory missing"}, []}]}
+    }
+
+    {:noreply, state} = RunRecord.handle_cast({:test_finished, invalid}, state)
+    {:noreply, state} = RunRecord.handle_cast({:module_finished, failed_module}, state)
+    record = RunRecord.record(state, %{run: 1_000})
+
+    assert record.tests == 1
+    assert [%{name: "setup_all", line: 1, message: "fixture directory missing"}] = record.failures
+  end
+
+  test "a failure value that cannot be rendered does not take the formatter down" do
+    {:ok, state} = RunRecord.init(run_log: nil, seed: 1)
+
+    hostile = %ExUnit.Test{
+      name: :"test raises something unprintable",
+      module: __MODULE__,
+      state: {:failed, [{:error, %PtcRunner.TestSupport.RaisingInspectStruct{body: 1}, []}]},
+      tags: %{file: __ENV__.file, line: 4}
+    }
+
+    untagged = %{hostile | name: :"test with no location", tags: %{}}
+
+    {:noreply, state} = RunRecord.handle_cast({:test_finished, hostile}, state)
+    {:noreply, state} = RunRecord.handle_cast({:test_finished, untagged}, state)
+
+    assert [%{message: message}, %{file: nil, line: nil}] =
+             RunRecord.record(state, %{run: 1_000}).failures
+
+    # Elixir's inspect already contains a raising implementation; the record
+    # keeps whatever rendering survived rather than nothing.
+    assert message =~ "Inspect.Error"
+  end
 end

--- a/test/support/run_record_test.exs
+++ b/test/support/run_record_test.exs
@@ -4,7 +4,7 @@ defmodule PtcRunner.TestSupport.RunRecordTest do
   alias PtcRunner.TestSupport.RunRecord
 
   test "a record carries the split, the seed, and each failure's first line" do
-    {:ok, state} = RunRecord.init(seed: 99, max_cases: 4)
+    {:ok, state} = RunRecord.init(seed: 99, max_cases: 4, run_index: 7)
 
     passed = %ExUnit.Test{
       name: :"test passes",
@@ -34,6 +34,7 @@ defmodule PtcRunner.TestSupport.RunRecordTest do
     record = RunRecord.record(state, %{run: 4_500_000, async: 1_000_000, load: 250_000})
 
     assert %{
+             run: 7,
              seed: 99,
              max_cases: 4,
              tests: 2,

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -64,15 +64,20 @@ exunit_opts = [
   assert_receive_timeout: 5_000
 ]
 
-exunit_opts =
-  if System.get_env("PTC_PROFILE_SLOW") do
-    Keyword.put(exunit_opts, :formatters, [
-      ExUnit.CLIFormatter,
-      PtcRunner.TestSupport.SlowTestProfiler
-    ])
-  else
-    exunit_opts
-  end
+# Set PTC_TEST_RUN_LOG to a file path to append one JSON line per run with
+# the seed, scheduler count, wall/async/sync split, and every failed test.
+# `scripts/ci/flake-hunt.sh` sets it and tabulates the file across runs; the
+# sync figure is the serial `async: false` phase and is what to watch when
+# moving modules to async.
+formatters =
+  [
+    ExUnit.CLIFormatter,
+    System.get_env("PTC_PROFILE_SLOW") && PtcRunner.TestSupport.SlowTestProfiler,
+    System.get_env("PTC_TEST_RUN_LOG") && PtcRunner.TestSupport.RunRecord
+  ]
+  |> Enum.filter(& &1)
+
+exunit_opts = Keyword.put(exunit_opts, :formatters, formatters)
 
 ExUnit.configure(exunit_opts)
 


### PR DESCRIPTION
First PR of #1913 (Phase 0 of `docs/plans/test-suite-flake-first.md`). It does not close the issue; the plan's later tranches do.

## Summary

- `PtcRunner.TestSupport.RunRecord`: an ExUnit formatter, enabled by `PTC_TEST_RUN_LOG`, that appends one JSON line per suite run with the seed, scheduler count, the wall/async/sync split ExUnit prints as `Finished in`, and every failed test's location and first failure line.
- `scripts/ci/flake-hunt.sh [RUNS] [--schedulers N] [--out DIR]`: compiles once, runs the PR suite N times (default ten) at four schedulers with a fresh seed each, never stops at the first failure, and prints a frequency table of failing tests with their seeds plus the wall/async/sync spread. Exit status is non-zero when any run failed.
- `scripts/ci/flake_hunt_summary.exs`: the tabulation, under plain `elixir` with OTP's `:json`.
- Nightly workflow: a `flake-hunt` job that runs the script ten times on `main` and uploads the records, logs, and summary as the `flake-hunt` artifact. Red while the flake rate is above zero.
- The plan document, and a paragraph in the development-setup guide plus one line in the agent instructions on how to use the harness.

Not in this PR: the plan's third Phase 0 item, a stated reason on every `async: false` `use` line. That is a per-module judgement over about fifty files and gets its own PR.

## Validation

- `mix test test/scripts/ci_gates_test.exs test/support/run_record_test.exs --include nightly`; the nightly case drives a real `mix test` with `PTC_TEST_RUN_LOG` set and checks the record's seed, split, and failure list.
- `shellcheck scripts/ci/flake-hunt.sh`.
- A real `scripts/ci/flake-hunt.sh 2` on this branch (4 schedulers, `CI=1`): both runs passed, 8,373 tests each, wall 280 s and 281 s, split 105 s async / 175 s sync, `runs.jsonl`, `verdicts.txt`, `run-N.log` and `summary.txt` all present and the summary consistent with the exit status.
- Codex review: one fresh review plus follow-ups, all findings applied (a record write could abort the suite; stale logs on a reused directory; runs that leave no record or exit non-zero after a clean record were invisible to the summary; `setup_all` errors were lost; `"run": null` was not treated as positional). Final follow-up clean.
- The tests caught two defects before commit: `times_us.load` is nil under `mix test`, and the summary's scheduler count must come from the records rather than the flag.

## Retrospective

- Follow-up: the `async: false` annotation sweep (Phase 0 item 3), and the first nightly `flake-hunt` artifact should be read before Phase 1 starts. Reproduction: `scripts/ci/flake-hunt.sh 3 --out /tmp/hunt` on `main`.
- Instruction gap: the repository instructions say a PR closes its issue with `Closes #N`, but give no form for a PR that is one of several under a planned issue. This PR uses `Refs #1913`.

https://claude.ai/code/session_01N3D3bP1izBvHhVsppdBuio
