### PR TITLE
fix(mcp): resolve host-relative stdio commands

### DIFF
--- a/docs/reference/host-installation.md
+++ b/docs/reference/host-installation.md
@@ -410,8 +410,10 @@ flag and without reading the application.
 
 ### Resolve local transport paths
 
-Stdio `cwd` and relative command arguments resolve from the host document, not
-from PtcRunner's source checkout and not from the shell's current directory.
+Stdio path-shaped `command` values, `cwd`, and relative command arguments resolve
+from the host document, not from PtcRunner's source checkout and not from the
+shell's current directory. A bare `command` such as `node` is found on the
+inherited `PATH`; an absolute `command` is used directly.
 For an application in a separate repository, keep its MCP server bundle in
 that repository (for example `tools/files/server.js`) and use a host-relative
 path, or install the server executable at a stable absolute location. A

--- a/lib/ptc_runner/kernel/host_installation.ex
+++ b/lib/ptc_runner/kernel/host_installation.ex
@@ -1252,7 +1252,7 @@ defmodule PtcRunner.Kernel.HostInstallation do
     with {:ok, environment} <- compatibility_environment(transport.inherit_environment),
          {:ok, cwd} <- canonical_directory(host.directory, transport.cwd),
          {:ok, executable, executable_sha256} <-
-           resolve_command(transport.command, environment),
+           resolve_command(host.directory, transport.command, environment),
          {:ok, launcher, launcher_sha256} <- resolve_launcher(host.runtime.stdio_launcher) do
       {:ok,
        Map.merge(transport, %{
@@ -1878,7 +1878,7 @@ defmodule PtcRunner.Kernel.HostInstallation do
     end
   end
 
-  defp resolve_command(command, environment) do
+  defp resolve_command(host_directory, command, environment) do
     case Path.type(command) do
       :absolute ->
         canonical_mcp_executable(command)
@@ -1887,7 +1887,9 @@ defmodule PtcRunner.Kernel.HostInstallation do
         if Path.basename(command) == command do
           resolve_bare_command(command, Map.get(environment, "PATH"))
         else
-          {:error, :invalid_mcp_executable}
+          command
+          |> Path.expand(host_directory)
+          |> canonical_mcp_executable()
         end
     end
   end

--- a/site/reference/host-installation/index.html
+++ b/site/reference/host-installation/index.html
@@ -365,8 +365,10 @@ while <code class="inline">calls</code> increments, and <code class="inline">cap
 model and may incur provider cost; the readiness report's <code class="inline">usage</code> field
 attributes what each probe spent, on the rows a run reports. <code class="inline">--show-model-selectors</code> adds only safe
 selectors; endpoint-bearing <code class="inline">openai-compat:</code> selectors remain hidden. <code class="inline">ptc models</code> reports the same <code class="inline">model_selector</code> field under the same rule, without a
-flag and without reading the application.</p><h3 id="resolve-local-transport-paths">Resolve local transport paths</h3><p>Stdio <code class="inline">cwd</code> and relative command arguments resolve from the host document, not
-from PtcRunner's source checkout and not from the shell's current directory.
+flag and without reading the application.</p><h3 id="resolve-local-transport-paths">Resolve local transport paths</h3><p>Stdio path-shaped <code class="inline">command</code> values, <code class="inline">cwd</code>, and relative command arguments resolve
+from the host document, not from PtcRunner's source checkout and not from the
+shell's current directory. A bare <code class="inline">command</code> such as <code class="inline">node</code> is found on the
+inherited <code class="inline">PATH</code>; an absolute <code class="inline">command</code> is used directly.
 For an application in a separate repository, keep its MCP server bundle in
 that repository (for example <code class="inline">tools/files/server.js</code>) and use a host-relative
 path, or install the server executable at a stable absolute location. A

--- a/test/ptc_runner/kernel/command_engine_test.exs
+++ b/test/ptc_runner/kernel/command_engine_test.exs
@@ -3153,6 +3153,41 @@ defmodule PtcRunner.Kernel.CommandEngineTest do
   end
 
   @tag :tmp_dir
+  test "doctor resolves a path-shaped stdio command from the host document", %{
+    tmp_dir: directory
+  } do
+    probe_directory = Path.join(directory, "probe")
+    host_directory = Path.join(directory, "config")
+    File.mkdir!(probe_directory)
+    File.mkdir!(host_directory)
+
+    executable = Path.join(probe_directory, "wiretap.sh")
+    File.write!(executable, "#!/bin/sh\nexit 0\n")
+    File.chmod!(executable, 0o755)
+
+    host_path =
+      write_host_config(
+        host_directory,
+        "doctor-relative-command",
+        stdio_host_config("../probe/wiretap.sh", System.find_executable("sh"), ".")
+      )
+
+    application =
+      doctor_application(directory, "selects-relative-command", mission: ["workspace"])
+
+    assert {:ok, %CommandOutcome{} = outcome} =
+             CommandEngine.prepare(["doctor", application, "--host-config", host_path])
+
+    assert %{"status" => "pass", "code" => "available"} =
+             Enum.find(
+               outcome.envelope["result"]["checks"],
+               &(&1["name"] == "provider/workspace/local")
+             )
+
+    assert_schema_valid(outcome.envelope)
+  end
+
+  @tag :tmp_dir
   test "default doctor reports a missing stdio command as a failed local check", %{
     tmp_dir: directory
   } do


### PR DESCRIPTION
## Summary

- resolve path-shaped relative stdio commands from the host document directory
- preserve inherited `PATH` lookup for bare commands and direct resolution for absolute commands
- cover the `ptc doctor` regression and document all accepted command forms

## Validation

- Confirmed the focused `ptc doctor` regression returned `executable_unavailable` before the fix and passed after it.

## Retrospective

- Untracked follow-up work: none.
- Missing, wrong, or guessed repository instruction: none.

Closes #1559
