### PR TITLE
test(kernel): stop the concurrent artifact-root test timing out under load

### DIFF
--- a/test/ptc_runner/kernel/project_config_test.exs
+++ b/test/ptc_runner/kernel/project_config_test.exs
@@ -290,13 +290,25 @@ defmodule PtcRunner.Kernel.ProjectConfigTest do
   } do
     root = Path.join(directory, ".ptc")
 
+    # The default 5s async_stream timeout is scheduling headroom, not part of
+    # the contract under test: four concurrent mkdir/chmod sequences can exceed
+    # it on a machine running the whole suite. `on_timeout: :exit` would then
+    # take the test process down with `exited in: Task.Supervised.stream/1`,
+    # naming neither this test's concurrency nor the timeout. Reporting the
+    # timed-out task as an element instead lets a genuine hang still fail, and
+    # say that it hung.
     results =
       1..4
       |> Task.async_stream(fn _index -> ProjectArtifactRoot.ensure(root) end,
         max_concurrency: 4,
-        ordered: false
+        ordered: false,
+        timeout: 30_000,
+        on_timeout: :kill_task
       )
-      |> Enum.map(fn {:ok, result} -> result end)
+      |> Enum.map(fn
+        {:ok, result} -> result
+        {:exit, reason} -> flunk("concurrent ensure/1 exited: #{inspect(reason)}")
+      end)
 
     assert Enum.all?(results, &(&1 == :ok))
     assert Enum.sort(File.ls!(root)) == ~w(envelopes inspection results traces)


### PR DESCRIPTION
## Summary

- Raises the `Task.async_stream` timeout in the concurrent artifact-root test from the 5s default to the 30s this repository already uses for concurrent test fan-out (`command_frontend_test.exs:355`).
- Sets `on_timeout: :kill_task` and handles the resulting `{:exit, reason}` element, so a genuine hang fails with `concurrent ensure/1 exited: :timeout` instead of taking the test process down with an opaque `exited in: Task.Supervised.stream/1`.

The assertions are untouched: every result `:ok`, the root containing exactly `envelopes inspection results traces`, and every directory owner-only. `ProjectArtifactRoot` is not implicated — this is test-only.

Closes #1924

## Validation

- Forced the failure path by temporarily setting `timeout: 1`, confirming the reported message is now `concurrent ensure/1 exited: :timeout` and no longer a stream exit.
- `mix test test/ptc_runner/kernel/project_config_test.exs` → 11 passed, with the timeout restored.

## Retrospective

- Follow-up: none.
- Repository instruction: none. Worth noting for the next reader that `scripts/ci/core-tests.sh` passes `--max-failures 1`, so a failing run aborts early and its reported test count says nothing about scope — that cost some time to work out while diagnosing this.
