### PR TITLE
perf(examples): prepare DABStep column types per page

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -81,10 +81,7 @@ pinned toolchain (`mise exec --` may be prefixed to the commands below).
 mkdir -p tmp/profiling/followup
 python3 bench/dabstep_mcp.py --capture-page tmp/profiling/followup/page.json
 mix run bench/dabstep_experiments.exs
-DABSTEP_BENCH_REVERSE=1 mix run bench/dabstep_experiments.exs
 DABSTEP_BENCH_WIDE=1 mix run bench/dabstep_experiments.exs
-DABSTEP_BENCH_PAIRED=1 mix run bench/dabstep_experiments.exs
-DABSTEP_BENCH_PAIRED=1 DABSTEP_BENCH_WIDE=1 mix run bench/dabstep_experiments.exs
 DABSTEP_BENCH_PROFILE=1 mix run bench/dabstep_experiments.exs
 mix run bench/dabstep_dispatch.exs
 mix run bench/dabstep_scaling.exs --suite kernel --samples 2
@@ -104,15 +101,14 @@ copies stay under ignored `tmp/profiling/followup/`. No live model calls occur.
 
 The isolated harness checks complete projected-row equality and malformed-cell
 behavior, then measures namespace size and effect-context controls. `WIDE`
-selects all 21 columns; `PAIRED` alternates current/prepared reader variants for
-six measured pairs after a warm-up pair. The normal run also emits an LRU
-hit-count model for three sequential scans; it is not a cache implementation. Allocation
-profiling is separate from timing. The Dispatcher ladder uses the captured
+selects all 21 columns. The normal run also emits an LRU hit-count model for
+three sequential scans; it is not a cache implementation. Allocation profiling
+is separate from timing. The Dispatcher ladder uses the captured
 response, schema controls, event capture and two inspection policies; it is not
-a transport benchmark. `--suite replay` checks the prepared-type variant,
-replaces the temporary CSV with identical bytes before its second replay, and
-verifies rejection after changing an EOF byte, restoring that byte afterward.
-It does not modify the shipped example or its recording.
+a transport benchmark. `--suite replay` checks the current reader, replaces the
+temporary CSV with identical bytes before its second replay, and verifies
+rejection after changing an EOF byte, restoring that byte afterward. It does
+not modify the shipped example or its recording.
 
 The scaling suite streams synthetic files of 20,000, 80,000 and 320,000 rows,
 selects three or all 21 columns, and checks full traversal counts. Each

--- a/bench/dabstep_experiments.exs
+++ b/bench/dabstep_experiments.exs
@@ -2,7 +2,7 @@ Code.require_file("support/dabstep.exs", __DIR__)
 
 defmodule PtcRunner.Bench.DabstepExperiments do
   @moduledoc false
-  import PtcRunner.Bench.DabstepSupport, only: [prepared: 1, measure: 2]
+  import PtcRunner.Bench.DabstepSupport, only: [legacy_types: 1, measure: 2]
   alias PtcRunner.Lisp
   alias PtcRunner.Lisp.Prelude.Compiler
   @columns ["ip_country", "eur_amount", "has_fraudulent_dispute"]
@@ -19,7 +19,7 @@ defmodule PtcRunner.Bench.DabstepExperiments do
     expected = native(lines, selectors)
     emit(%{fixture: %{rows: length(lines), bytes: byte_size(text), columns: columns}})
 
-    variants = [{"current", source}, {"prepared_types", prepared(source)}]
+    variants = [{"legacy_types", legacy_types(source)}, {"current", source}]
 
     variants =
       if System.get_env("DABSTEP_BENCH_REVERSE") == "1",

--- a/bench/dabstep_experiments.exs
+++ b/bench/dabstep_experiments.exs
@@ -2,7 +2,7 @@ Code.require_file("support/dabstep.exs", __DIR__)
 
 defmodule PtcRunner.Bench.DabstepExperiments do
   @moduledoc false
-  import PtcRunner.Bench.DabstepSupport, only: [legacy_types: 1, measure: 2]
+  import PtcRunner.Bench.DabstepSupport, only: [measure: 2]
   alias PtcRunner.Lisp
   alias PtcRunner.Lisp.Prelude.Compiler
   @columns ["ip_country", "eur_amount", "has_fraudulent_dispute"]
@@ -19,93 +19,59 @@ defmodule PtcRunner.Bench.DabstepExperiments do
     expected = native(lines, selectors)
     emit(%{fixture: %{rows: length(lines), bytes: byte_size(text), columns: columns}})
 
-    variants = [{"legacy_types", legacy_types(source)}, {"current", source}]
+    {:ok, prelude} =
+      Compiler.compile(source <> "\n(defn bench-project [columns lines] (project columns lines))")
 
-    variants =
-      if System.get_env("DABSTEP_BENCH_REVERSE") == "1",
-        do: Enum.reverse(variants),
-        else: variants
+    opts = [
+      prelude: prelude,
+      context: %{"text" => text, "columns" => columns},
+      tools: %{"workspace.read" => fn _ -> nil end},
+      max_heap: 5_000_000,
+      timeout: 60_000
+    ]
 
-    paired? = System.get_env("DABSTEP_BENCH_PAIRED") == "1"
+    {:ok, result} =
+      Lisp.run(
+        "(dabstep.payments/bench-project data/columns (butlast (rest (split data/text \"\\n\"))))",
+        opts
+      )
 
-    prepared_variants =
-      for {label, body} <- variants do
-        {:ok, prelude} =
-          Compiler.compile(
-            body <> "\n(defn bench-project [columns lines] (project columns lines))"
-          )
+    ^expected = result.return
 
-        opts = [
-          prelude: prelude,
-          context: %{"text" => text, "columns" => columns},
-          tools: %{"workspace.read" => fn _ -> nil end},
-          max_heap: 5_000_000,
-          timeout: 60_000
-        ]
+    measure("current/project", fn ->
+      checked(
+        "(count (dabstep.payments/bench-project data/columns (butlast (rest (split data/text \"\\n\")))))",
+        opts,
+        length(lines)
+      )
+    end)
 
-        {:ok, result} =
-          Lisp.run(
-            "(dabstep.payments/bench-project data/columns (butlast (rest (split data/text \"\\n\"))))",
-            opts
-          )
+    page = %{
+      status: :ok,
+      value: %{
+        "items" => [%{"text" => text}],
+        "next_cursor" => "benchmark-cursor",
+        "content_hash" => "benchmark-hash"
+      }
+    }
 
-        ^expected = result.return
+    read_opts = Keyword.put(opts, :tools, %{"workspace.read" => fn _ -> page end})
 
-        unless paired? do
-          measure(label <> "/project", fn ->
-            checked(
-              "(count (dabstep.payments/bench-project data/columns (butlast (rest (split data/text \"\\n\")))))",
-              opts,
-              length(lines)
-            )
-          end)
-        end
+    measure("current/read_page_stub", fn ->
+      checked(
+        "(count (get (dabstep.payments/read-page nil data/columns) \"rows\"))",
+        read_opts,
+        length(lines)
+      )
+    end)
 
-        page = %{
-          status: :ok,
-          value: %{
-            "items" => [%{"text" => text}],
-            "next_cursor" => "benchmark-cursor",
-            "content_hash" => "benchmark-hash"
-          }
-        }
+    edge_equivalence(prelude, opts, headers)
+    measure("native/split_project_type", fn -> length(native(lines, selectors)) end)
 
-        read_opts = Keyword.put(opts, :tools, %{"workspace.read" => fn _ -> page end})
-
-        unless paired? do
-          measure(label <> "/read_page_stub", fn ->
-            checked(
-              "(count (get (dabstep.payments/read-page nil data/columns) \"rows\"))",
-              read_opts,
-              length(lines)
-            )
-          end)
-        end
-
-        edge_equivalence(prelude, opts, headers)
-        {label, read_opts}
-      end
-
-    if paired? do
-      for sample <- 0..6,
-          {label, opts} <-
-            if(rem(sample, 2) == 0, do: prepared_variants, else: Enum.reverse(prepared_variants)) do
-        PtcRunner.Bench.DabstepSupport.sample("paired/#{label}/#{length(columns)}", sample, fn ->
-          checked(
-            "(count (get (dabstep.payments/read-page nil data/columns) \"rows\"))",
-            opts,
-            length(lines)
-          )
-        end)
-      end
-    else
-      measure("native/split_project_type", fn -> length(native(lines, selectors)) end)
-
-      unless System.get_env("DABSTEP_BENCH_PROFILE") || System.get_env("DABSTEP_BENCH_WIDE") do
-        namespace_scaling()
-        effect_context()
-        cache_model()
-      end
+    unless System.get_env("DABSTEP_BENCH_PROFILE") || System.get_env("DABSTEP_BENCH_WIDE") do
+      namespace_scaling()
+      effect_context()
+      cache_model()
     end
   end
 

--- a/bench/dabstep_scaling.exs
+++ b/bench/dabstep_scaling.exs
@@ -29,7 +29,7 @@ defmodule PtcRunner.Bench.DabstepScaling do
 
     case suite do
       "kernel" ->
-        for {variant, body} <- [{"current", source}, {"prepared", Bench.prepared(source)}] do
+        for {variant, body} <- [{"legacy_types", Bench.legacy_types(source)}, {"current", source}] do
           root = fixture(variant, body <> @fold, nil, headers)
 
           session(root, fn session ->
@@ -63,7 +63,7 @@ defmodule PtcRunner.Bench.DabstepScaling do
         end
 
       "replay" ->
-        root = fixture("prepared-replay", Bench.prepared(source), nil, headers)
+        root = fixture("current-replay", source, nil, headers)
 
         for sample <- 1..samples do
           if sample == 2 do
@@ -93,7 +93,7 @@ defmodule PtcRunner.Bench.DabstepScaling do
 
           IO.puts(
             Jason.encode!(%{
-              experiment: "prepared/replay",
+              experiment: "current/replay",
               recorded_model_calls: 11,
               identical_file_replaced: sample == 2,
               sample: sample,
@@ -128,7 +128,7 @@ defmodule PtcRunner.Bench.DabstepScaling do
 
       IO.puts(
         Jason.encode!(%{
-          experiment: "prepared/changed_byte",
+          experiment: "current/changed_byte",
           exit_status: failed.exit_status,
           code: failed.envelope["error"]["code"]
         })

--- a/bench/dabstep_scaling.exs
+++ b/bench/dabstep_scaling.exs
@@ -3,7 +3,6 @@ Code.require_file("support/dabstep.exs", __DIR__)
 
 defmodule PtcRunner.Bench.DabstepScaling do
   @moduledoc false
-  alias PtcRunner.Bench.DabstepSupport, as: Bench
   alias PtcRunner.Kernel.{CommandEngine, ManifestRepl, ReplSession}
   @narrow ["ip_country", "eur_amount", "has_fraudulent_dispute"]
   @fold ~S|
@@ -29,21 +28,19 @@ defmodule PtcRunner.Bench.DabstepScaling do
 
     case suite do
       "kernel" ->
-        for {variant, body} <- [{"legacy_types", Bench.legacy_types(source)}, {"current", source}] do
-          root = fixture(variant, body <> @fold, nil, headers)
+        root = fixture("current", source <> @fold, nil, headers)
 
-          session(root, fn session ->
-            for mode <- ["page", "scan", "manual_reduce", "fold"] do
-              measure(
-                session,
-                "#{variant}/#{mode}",
-                program(mode, @narrow),
-                if(mode == "page", do: 2847, else: 138_236),
-                samples
-              )
-            end
-          end)
-        end
+        session(root, fn session ->
+          for mode <- ["page", "scan", "manual_reduce", "fold"] do
+            measure(
+              session,
+              "current/#{mode}",
+              program(mode, @narrow),
+              if(mode == "page", do: 2847, else: 138_236),
+              samples
+            )
+          end
+        end)
 
       "scale" ->
         for rows <- if(opts[:rows], do: [opts[:rows]], else: [20_000, 80_000, 320_000]) do

--- a/bench/support/dabstep.exs
+++ b/bench/support/dabstep.exs
@@ -1,39 +1,5 @@
 defmodule PtcRunner.Bench.DabstepSupport do
   @moduledoc false
-  def legacy_types(source) do
-    source
-    |> String.replace(
-      """
-      (defn- column-kind [column]
-        (cond
-          (contains? (integer-columns) column) :integer
-          (contains? (float-columns) column) :float
-          (contains? (boolean-columns) column) :boolean
-          :else :string))
-
-      """,
-      ""
-    )
-    |> String.replace("(defn- typed-cell [column kind value]", "(defn- typed-cell [column value]")
-    |> String.replace(
-      "(= kind :integer) (parse-number",
-      "(contains? (integer-columns) column) (parse-number"
-    )
-    |> String.replace(
-      "(= kind :float) (parse-number",
-      "(contains? (float-columns) column) (parse-number"
-    )
-    |> String.replace(
-      "(= kind :boolean) (parse-boolean",
-      "(contains? (boolean-columns) column) (parse-boolean"
-    )
-    |> String.replace("[(get position c) c (column-kind c)]", "[(get position c) c]")
-    |> String.replace(
-      "(typed-cell (nth selector 1)\n                                          (nth selector 2)\n                                          (get",
-      "(typed-cell (nth selector 1) (get"
-    )
-  end
-
   def capability(_event, measures, %{name: name}, table) do
     :ets.update_counter(table, name, [{2, 1}, {3, measures.duration_ms}], {name, 0, 0})
   end
@@ -55,7 +21,7 @@ defmodule PtcRunner.Bench.DabstepSupport do
 
   defp samples(label, fun), do: Enum.each(0..5, &sample(label, &1, fun))
 
-  def sample(label, sample, fun) do
+  defp sample(label, sample, fun) do
     {gc0, words0, _} = :erlang.statistics(:garbage_collection)
     {us, result} = :timer.tc(fun)
     {gc1, words1, _} = :erlang.statistics(:garbage_collection)

--- a/bench/support/dabstep.exs
+++ b/bench/support/dabstep.exs
@@ -1,32 +1,36 @@
 defmodule PtcRunner.Bench.DabstepSupport do
   @moduledoc false
-  def prepared(source) do
+  def legacy_types(source) do
     source
-    |> String.replace("(defn- typed-cell [column value]", """
-    (defn- column-kind [column]
-      (cond
-        (contains? (integer-columns) column) :integer
-        (contains? (float-columns) column) :float
-        (contains? (boolean-columns) column) :boolean
-        :else :string))
-    (defn- typed-cell [column kind value]
-    """)
     |> String.replace(
-      "(contains? (integer-columns) column) (parse-number",
-      "(= kind :integer) (parse-number"
+      """
+      (defn- column-kind [column]
+        (cond
+          (contains? (integer-columns) column) :integer
+          (contains? (float-columns) column) :float
+          (contains? (boolean-columns) column) :boolean
+          :else :string))
+
+      """,
+      ""
+    )
+    |> String.replace("(defn- typed-cell [column kind value]", "(defn- typed-cell [column value]")
+    |> String.replace(
+      "(= kind :integer) (parse-number",
+      "(contains? (integer-columns) column) (parse-number"
     )
     |> String.replace(
-      "(contains? (float-columns) column) (parse-number",
-      "(= kind :float) (parse-number"
+      "(= kind :float) (parse-number",
+      "(contains? (float-columns) column) (parse-number"
     )
     |> String.replace(
-      "(contains? (boolean-columns) column) (parse-boolean",
-      "(= kind :boolean) (parse-boolean"
+      "(= kind :boolean) (parse-boolean",
+      "(contains? (boolean-columns) column) (parse-boolean"
     )
-    |> String.replace("[(get position c) c]", "[(get position c) c (column-kind c)]")
+    |> String.replace("[(get position c) c (column-kind c)]", "[(get position c) c]")
     |> String.replace(
-      "(typed-cell (nth selector 1) (get",
-      "(typed-cell (nth selector 1) (nth selector 2) (get"
+      "(typed-cell (nth selector 1)\n                                          (nth selector 2)\n                                          (get",
+      "(typed-cell (nth selector 1) (get"
     )
   end
 

--- a/examples/dabstep-fraud/README.md
+++ b/examples/dabstep-fraud/README.md
@@ -123,6 +123,14 @@ On the measured Apple ARM64 machine, the full recording took about 96 seconds
 and a count-only scan about 19 seconds after runtime optimization. These use
 recorded model responses; live runs also include model latency.
 
+The reader also prepares each requested column's conversion kind once per page
+instead of rediscovering it for every cell. Alternating measurements reduced
+complete page processing by about 4.1% for the three-column workload and 2.5%
+for all 21 columns. A generic row-fold prototype was slower, and a bounded
+page cache was rejected: it would miss throughout a sequential scan unless it
+could retain all 49 pages, while adding authorization and invalidation state.
+Interpreted row projection remains the main processing bottleneck.
+
 ## Verify and correct within the run
 
 The reviewer now proposes its measurements through `agent.core/run-outcome`'s

--- a/examples/dabstep-fraud/evidence/FOLLOWUP.md
+++ b/examples/dabstep-fraud/evidence/FOLLOWUP.md
@@ -11,7 +11,8 @@ Individual measurements and provenance are retained in `FOLLOWUP.json`.
 
 1. **Interpreted projection remains the main dataset-processing cost.**
    Preparing column types once per page is a small improvement, not an order
-   of magnitude change. Investigate a generic bounded native projection or
+   of magnitude change; that measured variant is now used by `payments.clj`.
+   Investigate a generic bounded native projection or
    pure-builtin execution path before adding a parsed-page cache.
 2. **Trace sorting had a cheap, measurable fix.** Computing timestamp sort
    keys once per summary reduced the 1,000-run query from 859 to 235 ms. The
@@ -138,7 +139,8 @@ runs were noisier still and did not establish an improvement. The isolated
 page runs, reverse order and allocation profiles provide the stronger evidence
 for the modest type-preparation gain.
 
-The prepared-type variant completed full replays in 90.47 and 89.71 seconds,
+The prepared-type variant, now selected for `payments.clj`, completed full
+replays in 90.47 and 89.71 seconds,
 with all 11 recorded model responses and the same agreed `B. BE` result and
 reviewer caveat. The second run replaced the CSV with identical bytes on a new
 inode. A subsequent EOF-byte mutation was rejected with `explicit_failure`.

--- a/examples/dabstep-fraud/payments.clj
+++ b/examples/dabstep-fraud/payments.clj
@@ -39,13 +39,20 @@
                  :reason :invalid-boolean
                  :column column})))
 
-(defn- typed-cell [column value]
+(defn- column-kind [column]
+  (cond
+    (contains? (integer-columns) column) :integer
+    (contains? (float-columns) column) :float
+    (contains? (boolean-columns) column) :boolean
+    :else :string))
+
+(defn- typed-cell [column kind value]
   (cond
     (nil? value) nil
     (= value "") nil
-    (contains? (integer-columns) column) (parse-number parse-long column value)
-    (contains? (float-columns) column) (parse-number parse-double column value)
-    (contains? (boolean-columns) column) (parse-boolean column value)
+    (= kind :integer) (parse-number parse-long column value)
+    (= kind :float) (parse-number parse-double column value)
+    (= kind :boolean) (parse-boolean column value)
     :else value))
 
 (defn- validate-columns! [columns]
@@ -81,11 +88,13 @@
 
 (defn- project [columns lines]
   (let [position (column-index)
-        selectors (vec (map (fn [c] [(get position c) c]) columns))]
+        selectors (vec (map (fn [c] [(get position c) c (column-kind c)]) columns))]
     (vec (map (fn [line]
                 (let [fields (split line ",")]
                   (vec (map (fn [selector]
-                              (typed-cell (nth selector 1) (get fields (nth selector 0))))
+                              (typed-cell (nth selector 1)
+                                          (nth selector 2)
+                                          (get fields (nth selector 0))))
                             selectors))))
               lines))))
 


### PR DESCRIPTION
## Summary

- Prepare requested DABStep column conversion kinds once per page, preserving public rows and malformed-value failures while removing repeated per-cell type-set scans.
- Retain current-reader page, traversal, scaling, heap, and replay harnesses; delete the obsolete source-rewritten reader and legacy/current comparison modes.
- Document bounded streaming, independent analysis/recheck/review scans, the measured page improvements, remaining interpreter bottleneck, and rejected fold/cache approaches.

Closes #1845

## Validation

- Reproduced three direct MCP traversals of 138,236 rows in 49 calls and checked projected rows and conversion failures against the native reference.
- Ran `mix run bench/dabstep_experiments.exs` and `mix run bench/dabstep_scaling.exs --suite kernel --samples 0` after removing the obsolete comparison modes.
- `mix nightly`, including complete replay, identical-file replacement, changed-byte rejection, correction/exhaustion paths, and the unchanged mission heap.
- Ran `scripts/ci/flake-hunt.sh 3 --schedulers 4` after a transient unrelated pre-push timeout; all repetitions passed.

## Retrospective

- Untracked follow-up work: interpreted projection remains the dominant page cost; reproduce the native lower-bound comparison with `python3 bench/dabstep_mcp.py --capture-page tmp/profiling/followup/page.json` followed by `mix run bench/dabstep_experiments.exs` before considering a generic bounded native projection.
- Missing, wrong, or guessed repository instruction: none.
