### PR TITLE
fix(artifacts): publish independent envelope copies

### DIFF
--- a/docs/reference/project-files.md
+++ b/docs/reference/project-files.md
@@ -157,16 +157,20 @@ fail on a path that already exists.
 
 Every path is printed quoted and escaped, since a symlink target is filesystem
 content rather than something you typed, and a suggested command is offered
-only when its path holds no control characters. These arrive on stderr with
-exit 74, because the envelope that would normally carry a diagnostic is the
-artifact that could not be written.
+only when its path holds no control characters. If no envelope destination
+succeeds, these arrive on stderr with exit 74 because the envelope that would
+normally carry a diagnostic is the artifact that could not be written. A
+separately writable `--envelope` convenience copy is still attempted; when it
+succeeds, the command retains its original exit status and reports the failed
+project-ledger destination on stderr.
 
 That last-resort channel is what carries the directory name, so the table above
-describes a run that publishes an envelope — the `ptc init` default, and any
-run given `--envelope`. With `artifacts.envelope` set to `false` the same
-refusals still stop the run before it executes, reported through the ordinary
-destination phase as `destination/invalid_destination` at exit 7 without the
-path. `ptc viewer` reports the named sentences as
+describes a run with the project envelope ledger enabled — the `ptc init`
+default. With `artifacts.envelope` set to `false` the same refusals still stop
+the run before it executes, reported through the ordinary destination phase as
+`destination/invalid_destination` at exit 7 without the path. A requested
+`--envelope` copy carries that diagnostic when its independent destination is
+writable. `ptc viewer` reports the named sentences as
 `viewer/artifact_root_unusable`.
 
 The trace filenames are also the canonical directory-discovery contract. Each

--- a/lib/ptc_runner/kernel/command_engine.ex
+++ b/lib/ptc_runner/kernel/command_engine.ex
@@ -40,7 +40,6 @@ defmodule PtcRunner.Kernel.CommandEngine do
   alias PtcRunner.Kernel.HostRuntimePayload
   alias PtcRunner.Kernel.InstallationCatalog
   alias PtcRunner.Kernel.ModelSelectorDisclosure
-  alias PtcRunner.Kernel.ProjectArtifactRoot
   alias PtcRunner.Kernel.ProjectResolver
   alias PtcRunner.Kernel.ProviderCredentials
   alias PtcRunner.Kernel.PublicationAuthority
@@ -355,17 +354,9 @@ defmodule PtcRunner.Kernel.CommandEngine do
        ) do
     result = dispatch_entry(%{entry | envelope_path: nil}, runtime)
     {_status, outcome} = result
-    paths = CommandEnvelope.destinations(entry.arguments, handle || path, entry.run_ref)
 
     publication =
-      case ProjectArtifactRoot.ensure_for(entry.arguments) do
-        :ok ->
-          CommandEnvelope.publish_all(outcome, paths)
-
-        {:error, _reason} = error ->
-          if handle, do: _ = CommandEnvelope.discard(handle)
-          error
-      end
+      CommandEnvelope.publish_for_project(outcome, entry.arguments, handle || path, entry.run_ref)
 
     case publication do
       :ok ->

--- a/lib/ptc_runner/kernel/command_envelope.ex
+++ b/lib/ptc_runner/kernel/command_envelope.ex
@@ -85,7 +85,7 @@ defmodule PtcRunner.Kernel.CommandEnvelope do
         |> Enum.map(fn destination ->
           result =
             if ledger_path && same_destination?(ledger_path, destination),
-              do: {:error, reason},
+              do: skipped_ledger(destination, reason),
               else: publish(outcome, destination)
 
           {destination_path(destination), result}
@@ -105,6 +105,13 @@ defmodule PtcRunner.Kernel.CommandEnvelope do
       {published, failures} -> {:partial, published, failures}
     end
   end
+
+  defp skipped_ledger(%PublicationHandle{} = handle, reason) do
+    _ = discard(handle)
+    {:error, reason}
+  end
+
+  defp skipped_ledger(_path, reason), do: {:error, reason}
 
   defp destination_path(%PublicationHandle{} = handle), do: PublicationHandle.path(handle)
   defp destination_path(path), do: path

--- a/lib/ptc_runner/kernel/command_envelope.ex
+++ b/lib/ptc_runner/kernel/command_envelope.ex
@@ -5,6 +5,7 @@ defmodule PtcRunner.Kernel.CommandEnvelope do
   alias PtcRunner.Kernel.CommandOutcome
   alias PtcRunner.Kernel.DestinationIdentity
   alias PtcRunner.Kernel.DeterministicJSON
+  alias PtcRunner.Kernel.ProjectArtifactRoot
   alias PtcRunner.Kernel.ProjectConfig
   alias PtcRunner.Kernel.ProjectContext
   alias PtcRunner.Kernel.PublicationHandle
@@ -59,6 +60,41 @@ defmodule PtcRunner.Kernel.CommandEnvelope do
         {destination_path(destination), publish(outcome, destination)}
       end)
 
+    publication_result(results)
+  end
+
+  @doc false
+  @spec publish_for_project(
+          CommandOutcome.t(),
+          CommandArguments.t(),
+          destination() | nil,
+          binary()
+        ) ::
+          :ok | {:partial, [binary()], [{binary(), term()}]} | {:error, term()}
+  def publish_for_project(%CommandOutcome{} = outcome, arguments, envelope_path, run_ref) do
+    paths = destinations(arguments, envelope_path, run_ref)
+
+    case ProjectArtifactRoot.ensure_for(arguments) do
+      :ok ->
+        publish_all(outcome, paths)
+
+      {:error, reason} ->
+        ledger_path = project_ledger_path(arguments, run_ref)
+
+        paths
+        |> Enum.map(fn destination ->
+          result =
+            if ledger_path && same_destination?(ledger_path, destination),
+              do: {:error, reason},
+              else: publish(outcome, destination)
+
+          {destination_path(destination), result}
+        end)
+        |> publication_result()
+    end
+  end
+
+  defp publication_result(results) do
     published = for {path, :ok} <- results, do: path
     failures = for {path, {:error, reason}} <- results, do: {path, reason}
 

--- a/lib/ptc_runner/kernel/command_frontend.ex
+++ b/lib/ptc_runner/kernel/command_frontend.ex
@@ -11,7 +11,6 @@ defmodule PtcRunner.Kernel.CommandFrontend do
   alias PtcRunner.Kernel.CommandPresentation
   alias PtcRunner.Kernel.CommandRenderer
   alias PtcRunner.Kernel.CommandRuntime
-  alias PtcRunner.Kernel.ProjectArtifactRoot
   alias PtcRunner.Kernel.ProjectConfig
   alias PtcRunner.Kernel.ProjectContext
 
@@ -117,13 +116,8 @@ defmodule PtcRunner.Kernel.CommandFrontend do
          named_env_file?
        )
        when is_binary(path) do
-    paths = CommandEnvelope.destinations(entry.arguments, handle || path, entry.run_ref)
-
     result =
-      case ProjectArtifactRoot.ensure_for(entry.arguments) do
-        :ok -> CommandEnvelope.publish_all(outcome, paths)
-        {:error, _reason} = error -> cleanup_envelope_handle(handle, error)
-      end
+      CommandEnvelope.publish_for_project(outcome, entry.arguments, handle || path, entry.run_ref)
 
     case result do
       :ok ->
@@ -154,13 +148,6 @@ defmodule PtcRunner.Kernel.CommandFrontend do
 
   defp present(%CommandEntry{} = entry, %CommandOutcome{} = outcome, rejection, named_env_file?) do
     rendered_presentation(entry, outcome, nil, rejection, named_env_file?)
-  end
-
-  defp cleanup_envelope_handle(nil, error), do: error
-
-  defp cleanup_envelope_handle(handle, error) do
-    _ = CommandEnvelope.discard(handle)
-    error
   end
 
   defp rendered_presentation(entry, outcome, envelope_path, rejection, named_env_file?) do

--- a/site/reference/project-files/index.html
+++ b/site/reference/project-files/index.html
@@ -187,14 +187,18 @@ than only the first. Where a symlink stands in the ancestry the two differ: the
 message names the link's target, because creating the link's own name would
 fail on a path that already exists.</p><p>Every path is printed quoted and escaped, since a symlink target is filesystem
 content rather than something you typed, and a suggested command is offered
-only when its path holds no control characters. These arrive on stderr with
-exit 74, because the envelope that would normally carry a diagnostic is the
-artifact that could not be written.</p><p>That last-resort channel is what carries the directory name, so the table above
-describes a run that publishes an envelope — the <code class="inline">ptc init</code> default, and any
-run given <code class="inline">--envelope</code>. With <code class="inline">artifacts.envelope</code> set to <code class="inline">false</code> the same
-refusals still stop the run before it executes, reported through the ordinary
-destination phase as <code class="inline">destination/invalid_destination</code> at exit 7 without the
-path. <code class="inline">ptc viewer</code> reports the named sentences as
+only when its path holds no control characters. If no envelope destination
+succeeds, these arrive on stderr with exit 74 because the envelope that would
+normally carry a diagnostic is the artifact that could not be written. A
+separately writable <code class="inline">--envelope</code> convenience copy is still attempted; when it
+succeeds, the command retains its original exit status and reports the failed
+project-ledger destination on stderr.</p><p>That last-resort channel is what carries the directory name, so the table above
+describes a run with the project envelope ledger enabled — the <code class="inline">ptc init</code>
+default. With <code class="inline">artifacts.envelope</code> set to <code class="inline">false</code> the same refusals still stop
+the run before it executes, reported through the ordinary destination phase as
+<code class="inline">destination/invalid_destination</code> at exit 7 without the path. A requested
+<code class="inline">--envelope</code> copy carries that diagnostic when its independent destination is
+writable. <code class="inline">ptc viewer</code> reports the named sentences as
 <code class="inline">viewer/artifact_root_unusable</code>.</p><p>The trace filenames are also the canonical directory-discovery contract. Each
 file contains exactly the run ID named by its stem and one trace identity;
 arbitrary aggregate filenames and split histories remain supported only when a

--- a/test/ptc_runner/kernel/project_command_test.exs
+++ b/test/ptc_runner/kernel/project_command_test.exs
@@ -199,6 +199,31 @@ defmodule PtcRunner.Kernel.ProjectCommandTest do
   end
 
   @tag :tmp_dir
+  test "an invalid pre-existing artifact root releases its reserved ledger", %{tmp_dir: directory} do
+    target = Path.join(directory, "demo")
+    assert {:ok, %CommandOutcome{}} = CommandEngine.dispatch(["init", target])
+    project = Path.join(target, "ptc-project.json")
+    root = Path.join(target, ".ptc")
+    File.mkdir_p!(Path.join(root, "envelopes"))
+    File.chmod!(Path.join(root, "envelopes"), 0o700)
+    File.chmod!(root, 0o755)
+    on_exit(fn -> File.chmod(root, 0o700) end)
+
+    assert {:ok, entry} = CommandEntry.open(["run", project], :standalone)
+    owner = entry.envelope_handle.owner
+    assert Process.alive?(owner)
+
+    presentation =
+      CommandFrontend.present_entry(entry, fn _arguments ->
+        {:ok, CommandRuntime.standalone()}
+      end)
+
+    assert presentation.exit_status == CommandFrontend.envelope_failure_exit_status()
+    refute Process.alive?(owner)
+    assert File.ls!(Path.join(root, "envelopes")) == []
+  end
+
+  @tag :tmp_dir
   test "a permissive artifact child names that directory and the owner-only rule", %{
     tmp_dir: directory
   } do

--- a/test/ptc_runner/kernel/project_command_test.exs
+++ b/test/ptc_runner/kernel/project_command_test.exs
@@ -247,6 +247,57 @@ defmodule PtcRunner.Kernel.ProjectCommandTest do
     refute File.exists?(missing)
   end
 
+  @tag :tmp_dir
+  test "an explicit envelope survives an unavailable project ledger", %{tmp_dir: directory} do
+    target = Path.join(directory, "demo")
+    project_path = project_with_artifact_root(target, "missing-artifact-parent/.ptc")
+    explicit = Path.join(directory, "rescue.json")
+
+    presentation =
+      CommandFrontend.execute(
+        ["run", project_path, "--envelope", explicit],
+        :standalone,
+        fn _arguments -> {:ok, CommandRuntime.standalone()} end
+      )
+
+    assert presentation.exit_status == 7
+    assert presentation.envelope_path == explicit
+    assert Jason.decode!(File.read!(explicit)) == presentation.outcome.envelope
+    assert presentation.stderr =~ "destination/invalid_destination"
+    assert presentation.stderr =~ "envelope/destination_parent_unavailable"
+    assert presentation.stderr =~ "missing-artifact-parent"
+  end
+
+  @tag :tmp_dir
+  test "an explicit envelope survives an unavailable artifact root when its ledger is disabled",
+       %{
+         tmp_dir: directory
+       } do
+    target = Path.join(directory, "demo")
+    project_path = project_with_artifact_root(target, "missing-artifact-parent/.ptc")
+    project = project_path |> File.read!() |> Jason.decode!()
+
+    File.write!(
+      project_path,
+      project |> put_in(["artifacts", "envelope"], false) |> Jason.encode!()
+    )
+
+    explicit = Path.join(directory, "rescue.json")
+
+    presentation =
+      CommandFrontend.execute(
+        ["run", project_path, "--envelope", explicit],
+        :standalone,
+        fn _arguments -> {:ok, CommandRuntime.standalone()} end
+      )
+
+    assert presentation.exit_status == 7
+    assert presentation.envelope_path == explicit
+    assert Jason.decode!(File.read!(explicit)) == presentation.outcome.envelope
+    assert presentation.stderr =~ "destination/invalid_destination"
+    refute presentation.stderr =~ "envelope/publication_failed"
+  end
+
   # The shallowest missing ancestor is what failed, but creating only it fails
   # again on the next level; the remedy has to name the whole parent.
   @tag :tmp_dir


### PR DESCRIPTION
## Summary

- publish explicit command-envelope copies even when the project artifact root or ledger is unavailable
- preserve the command's original exit status while reporting failed ledger destinations
- close skipped ledger reservations and document the partial-publication contract

## Validation

- `mix test test/ptc_runner/kernel/project_command_test.exs`
- `mix nightly`

## Retrospective

- Untracked follow-up work: none.
- Missing, wrong, or guessed repository instruction: none.

Closes #1886
