### PR TITLE
feat(kernel): bound hosted LLM provider calls

### DIFF
--- a/docs/maintainers/embedding.md
+++ b/docs/maintainers/embedding.md
@@ -145,10 +145,22 @@ best-effort provider behavior are not attestation.
 `%{credential: binary() | nil, cache: boolean()}` map and returns
 `{:ok, requester}` only after preparation and binding succeed, so embedding
 callers must propagate its error tuple before dispatch. The requester is arity
-two: a provider-neutral request plus `%{llm_request_deadline_ms: integer() | nil}`.
-Live Kernel dispatch supplies an integer absolute monotonic deadline. Replay,
-doctor connectivity probes, and embedding callers that invoke the requester
-directly pass `nil`.
+two: a provider-neutral request plus
+`%{llm_request_deadline_ms: integer() | nil}`. Live Kernel dispatch and hosted
+doctor connectivity supply an integer absolute monotonic deadline. Replay and
+embedding callers that invoke the requester directly pass `nil`.
+
+For a shared hosted transport, supervise one `ProviderCallAdmission`, pass it
+as `:provider_call_admission` when constructing `ProviderRuntimeServices`, and
+reuse those services for every concurrent run. The installed live requester
+then holds one aggregate slot from immediately before adapter entry through
+all retries and confirmed drain. The built-in ReqLLM adapter attests this
+cancelable boundary. A custom adapter must implement
+`c:PtcRunner.LLM.cancellation_witness?/0` only when terminating its adapter
+caller also drains every request and pool-checkout owner it created; otherwise
+hosted construction fails without dispatch. Direct adapter calls, embeddings,
+replay, provider-free work, and custom capabilities which bypass the installed
+requester are outside this guarantee.
 
 An adapter may implement `c:PtcRunner.LLM.public_model/1` to attest that its exact
 configured target is safe to publish. Missing, altered, invalid, oversized, or

--- a/docs/maintainers/kernel.md
+++ b/docs/maintainers/kernel.md
@@ -127,10 +127,22 @@ execution owner dying without acknowledging cleanup fences that capacity
 domain. It does not restart automatically; drain old work before replacing it.
 Admission-owner death aborts the executions it admitted.
 
+The host separately supervises one `ProviderCallAdmission` domain for each
+shared live LLM transport and seals that owner into every
+`ProviderRuntimeServices` value using it. Its active capacity spans concurrent
+runs: a tracked guardian claims one slot before adapter entry and retains it
+through sequential retries and confirmed transport drain. Queue saturation is
+healthy and bounded before the admission mailbox; cleanup uncertainty or an
+active guardian's unexplained death fences the temporary domain. Rebuild the
+complete provider runtime before replacing a fenced or dead domain.
+
 This is a bound on executions using that explicit owner. The embedding host
 still bounds inbound requests, preparation and compilation, provisional
-admission processes, and control mailboxes. Physical LLM attempts and connection
-pools have separate limits; this API does not configure or start ReqLLM.
+admission processes, and control mailboxes. Provider-call admission does not
+inspect or configure connection pools. Command-owned VMs, replay,
+provider-free work, direct `PtcRunner.LLM` calls, embeddings, and custom
+capabilities which bypass the installed requester do not consume its slots and
+remain the host's responsibility to bound.
 Publication remains the caller's responsibility after receiving sealed evidence.
 A transport request worker must publish before it exits: returning the sealed
 outcome to a connection process for later publication outlives the claimant.

--- a/docs/reference/host-installation.md
+++ b/docs/reference/host-installation.md
@@ -548,6 +548,15 @@ Four timeouts are host-only: `provider_cleanup_timeout_ms`,
 `local_preflight_timeout_ms`, `selection_validation_timeout_ms`, and
 `doctor_connectivity_timeout_ms`. A manifest cannot declare them.
 
+`live_provider_tasks` remains a per-run callback bound; it neither sizes nor
+describes aggregate hosted LLM capacity. An embedding host that shares a live
+provider transport across runs must pass one supervised
+`ProviderCallAdmission` owner through all corresponding
+`ProviderRuntimeServices`. Command-owned one-shot VMs do not start that domain.
+Replay, workflows that call no provider, direct LLM and embedding calls, and
+callbacks that bypass the installed requester consume no admission slot and
+must be bounded by their caller.
+
 The generated [Kernel limits reference](../kernel-limits-reference.md) is the
 complete table of names, meanings, units, scopes, defaults, accepted ranges,
 and identity participation. The host schema is generated from the same

--- a/lib/ptc_runner/kernel/adapter_cancellation_witness.ex
+++ b/lib/ptc_runner/kernel/adapter_cancellation_witness.ex
@@ -19,8 +19,14 @@ defmodule PtcRunner.Kernel.AdapterCancellationWitness do
   end
 
   defp run_witnessed(operation, guardian, gate, state) do
+    case :atomics.compare_exchange(state, 1, 1, 2) do
+      :ok -> run_registered(operation, guardian, gate, state)
+      _cancellation_claimed -> {:error, :cancelled}
+    end
+  end
+
+  defp run_registered(operation, guardian, gate, state) do
     caller = self()
-    :atomics.put(state, 1, 2)
 
     {worker, monitor} =
       :erlang.spawn_opt(

--- a/lib/ptc_runner/kernel/adapter_cancellation_witness.ex
+++ b/lib/ptc_runner/kernel/adapter_cancellation_witness.ex
@@ -1,0 +1,62 @@
+defmodule PtcRunner.Kernel.AdapterCancellationWitness do
+  @moduledoc false
+
+  @key {__MODULE__, :request}
+
+  @spec install(pid(), reference()) :: :ok
+  def install(guardian, gate) when is_pid(guardian) and is_reference(gate) do
+    Process.put(@key, {guardian, gate})
+    :ok
+  end
+
+  @spec run((-> term())) :: term()
+  def run(operation) when is_function(operation, 0) do
+    case Process.get(@key) do
+      {guardian, gate} -> run_witnessed(operation, guardian, gate)
+      nil -> operation.()
+    end
+  end
+
+  defp run_witnessed(operation, guardian, gate) do
+    caller = self()
+
+    {worker, monitor} =
+      :erlang.spawn_opt(
+        fn ->
+          result = invoke(operation)
+          send(caller, {:adapter_request_result, gate, self(), result})
+        end,
+        [:link, :monitor]
+      )
+
+    receive do
+      {:adapter_request_result, ^gate, ^worker, result} ->
+        receive do
+          {:DOWN, ^monitor, :process, ^worker, :normal} -> unwrap(result)
+          {:DOWN, ^monitor, :process, ^worker, reason} -> exit(reason)
+        end
+
+      {:cancel_adapter_request, ^gate, ^guardian} ->
+        Process.unlink(worker)
+        Process.exit(worker, :kill)
+
+        receive do
+          {:DOWN, ^monitor, :process, ^worker, _reason} ->
+            send(guardian, {:adapter_request_drained, gate, self()})
+            {:error, :cancelled}
+        end
+    end
+  end
+
+  defp invoke(operation) do
+    {:ok, operation.()}
+  rescue
+    exception -> {:raised, exception, __STACKTRACE__}
+  catch
+    kind, reason -> {:caught, kind, reason}
+  end
+
+  defp unwrap({:ok, result}), do: result
+  defp unwrap({:raised, exception, stacktrace}), do: reraise(exception, stacktrace)
+  defp unwrap({:caught, kind, reason}), do: :erlang.raise(kind, reason, [])
+end

--- a/lib/ptc_runner/kernel/adapter_cancellation_witness.ex
+++ b/lib/ptc_runner/kernel/adapter_cancellation_witness.ex
@@ -3,22 +3,24 @@ defmodule PtcRunner.Kernel.AdapterCancellationWitness do
 
   @key {__MODULE__, :request}
 
-  @spec install(pid(), reference()) :: :ok
-  def install(guardian, gate) when is_pid(guardian) and is_reference(gate) do
-    Process.put(@key, {guardian, gate})
+  @spec install(pid(), reference(), :atomics.atomics_ref()) :: :ok
+  def install(guardian, gate, state)
+      when is_pid(guardian) and is_reference(gate) do
+    Process.put(@key, {guardian, gate, state})
     :ok
   end
 
   @spec run((-> term())) :: term()
   def run(operation) when is_function(operation, 0) do
     case Process.get(@key) do
-      {guardian, gate} -> run_witnessed(operation, guardian, gate)
+      {guardian, gate, state} -> run_witnessed(operation, guardian, gate, state)
       nil -> operation.()
     end
   end
 
-  defp run_witnessed(operation, guardian, gate) do
+  defp run_witnessed(operation, guardian, gate, state) do
     caller = self()
+    :atomics.put(state, 1, 2)
 
     {worker, monitor} =
       :erlang.spawn_opt(
@@ -26,14 +28,18 @@ defmodule PtcRunner.Kernel.AdapterCancellationWitness do
           result = invoke(operation)
           send(caller, {:adapter_request_result, gate, self(), result})
         end,
-        [:link, :monitor]
+        provider_spawn_options()
       )
 
     receive do
       {:adapter_request_result, ^gate, ^worker, result} ->
         receive do
-          {:DOWN, ^monitor, :process, ^worker, :normal} -> unwrap(result)
-          {:DOWN, ^monitor, :process, ^worker, reason} -> exit(reason)
+          {:DOWN, ^monitor, :process, ^worker, :normal} ->
+            :atomics.put(state, 1, 3)
+            unwrap(result)
+
+          {:DOWN, ^monitor, :process, ^worker, reason} ->
+            exit(reason)
         end
 
       {:cancel_adapter_request, ^gate, ^guardian} ->
@@ -59,4 +65,9 @@ defmodule PtcRunner.Kernel.AdapterCancellationWitness do
   defp unwrap({:ok, result}), do: result
   defp unwrap({:raised, exception, stacktrace}), do: reraise(exception, stacktrace)
   defp unwrap({:caught, kind, reason}), do: :erlang.raise(kind, reason, [])
+
+  defp provider_spawn_options do
+    max_heap_size = Process.info(self(), :max_heap_size) |> elem(1)
+    [:link, :monitor, {:max_heap_size, max_heap_size}]
+  end
 end

--- a/lib/ptc_runner/kernel/cancelable_request.ex
+++ b/lib/ptc_runner/kernel/cancelable_request.ex
@@ -20,18 +20,21 @@ defmodule PtcRunner.Kernel.CancelableRequest do
     owner = self()
 
     {pid, monitor} =
-      spawn_monitor(fn ->
-        owner_monitor = Process.monitor(owner)
+      :erlang.spawn_opt(
+        fn ->
+          owner_monitor = Process.monitor(owner)
 
-        receive do
-          {:dispatch, ^gate} ->
-            result = requester.(request, context)
-            send(owner, {:cancelable_request_result, gate, result})
+          receive do
+            {:dispatch, ^gate} ->
+              result = requester.(request, context)
+              send(owner, {:cancelable_request_result, gate, result})
 
-          {:DOWN, ^owner_monitor, :process, ^owner, _reason} ->
-            :ok
-        end
-      end)
+            {:DOWN, ^owner_monitor, :process, ^owner, _reason} ->
+              :ok
+          end
+        end,
+        [:link, :monitor]
+      )
 
     {:ok, %__MODULE__{pid: pid, monitor: monitor, gate: gate, owner: owner}}
   rescue
@@ -91,6 +94,7 @@ defmodule PtcRunner.Kernel.CancelableRequest do
   @spec cancel_and_drain(t(), integer()) :: :drained | :uncertain
   def cancel_and_drain(%__MODULE__{owner: owner, pid: pid, monitor: monitor}, deadline)
       when owner == self() and is_integer(deadline) do
+    Process.unlink(pid)
     Process.exit(pid, :kill)
     timeout = max(deadline - System.monotonic_time(:millisecond), 0)
 

--- a/lib/ptc_runner/kernel/cancelable_request.ex
+++ b/lib/ptc_runner/kernel/cancelable_request.ex
@@ -78,10 +78,10 @@ defmodule PtcRunner.Kernel.CancelableRequest do
         %__MODULE__{owner: owner, pid: pid, monitor: monitor, gate: gate} = handle,
         deadline,
         admission_monitor,
-        cleanup_deadline
+        cleanup_timeout_ms
       )
       when owner == self() and is_integer(deadline) and is_reference(admission_monitor) and
-             is_integer(cleanup_deadline) do
+             is_integer(cleanup_timeout_ms) and cleanup_timeout_ms > 0 do
     timeout = max(deadline - System.monotonic_time(:millisecond), 0)
 
     receive do
@@ -98,6 +98,7 @@ defmodule PtcRunner.Kernel.CancelableRequest do
         {:error, :cancellation_witness_unavailable}
 
       {:DOWN, ^admission_monitor, :process, _admission, _reason} ->
+        cleanup_deadline = System.monotonic_time(:millisecond) + cleanup_timeout_ms
         _ = cancel_and_drain(handle, cleanup_deadline)
         {:error, :provider_admission_unavailable}
 
@@ -125,12 +126,14 @@ defmodule PtcRunner.Kernel.CancelableRequest do
       when owner == self() and is_integer(deadline) do
     Process.unlink(pid)
 
-    if :atomics.get(state, 1) == 0 do
-      Process.exit(pid, :kill)
-      await_down(pid, monitor, deadline)
-    else
-      send(pid, {:cancel_adapter_request, gate, owner})
-      await_adapter_drain(pid, monitor, gate, state, deadline, false)
+    case :atomics.get(state, 1) do
+      2 ->
+        send(pid, {:cancel_adapter_request, gate, owner})
+        await_adapter_drain(pid, monitor, gate, state, deadline, false)
+
+      _predispatch_or_attested_caller ->
+        Process.exit(pid, :kill)
+        await_down(pid, monitor, deadline)
     end
   end
 
@@ -172,6 +175,12 @@ defmodule PtcRunner.Kernel.CancelableRequest do
   end
 
   defp normalize_result({:ok, result}), do: {:ok, result}
+
+  defp normalize_result({__MODULE__, :raised, _exception, _stacktrace} = failure),
+    do: {:ok, failure}
+
+  defp normalize_result({__MODULE__, :caught, _kind, _reason} = failure),
+    do: {:ok, failure}
 
   defp provider_spawn_options do
     max_heap_size = Process.info(self(), :max_heap_size) |> elem(1)

--- a/lib/ptc_runner/kernel/cancelable_request.ex
+++ b/lib/ptc_runner/kernel/cancelable_request.ex
@@ -1,0 +1,105 @@
+defmodule PtcRunner.Kernel.CancelableRequest do
+  @moduledoc false
+
+  @enforce_keys [:pid, :monitor, :gate, :owner]
+  defstruct @enforce_keys
+
+  @opaque t :: %__MODULE__{
+            pid: pid(),
+            monitor: reference(),
+            gate: reference(),
+            owner: pid()
+          }
+
+  @spec start_cancelable(function(), map(), map(), pid()) ::
+          {:ok, t()} | {:error, :cancellation_witness_unavailable}
+  def start_cancelable(requester, request, context, guardian)
+      when is_function(requester, 2) and is_map(request) and is_map(context) and
+             guardian == self() do
+    gate = make_ref()
+    owner = self()
+
+    {pid, monitor} =
+      spawn_monitor(fn ->
+        owner_monitor = Process.monitor(owner)
+
+        receive do
+          {:dispatch, ^gate} ->
+            result = requester.(request, context)
+            send(owner, {:cancelable_request_result, gate, result})
+
+          {:DOWN, ^owner_monitor, :process, ^owner, _reason} ->
+            :ok
+        end
+      end)
+
+    {:ok, %__MODULE__{pid: pid, monitor: monitor, gate: gate, owner: owner}}
+  rescue
+    _ -> {:error, :cancellation_witness_unavailable}
+  catch
+    _, _ -> {:error, :cancellation_witness_unavailable}
+  end
+
+  def start_cancelable(_requester, _request, _context, _guardian),
+    do: {:error, :cancellation_witness_unavailable}
+
+  @spec dispatch(t()) :: :ok | {:error, :cancellation_witness_unavailable}
+  def dispatch(%__MODULE__{owner: owner, pid: pid, gate: gate}) when owner == self() do
+    send(pid, {:dispatch, gate})
+    :ok
+  end
+
+  def dispatch(_handle), do: {:error, :cancellation_witness_unavailable}
+
+  @spec await_or_cancel(t(), integer(), reference()) ::
+          {:ok, term()} | {:cancelled, :drained | :uncertain} | {:error, atom()}
+  def await_or_cancel(
+        %__MODULE__{owner: owner, pid: pid, monitor: monitor, gate: gate} = handle,
+        deadline,
+        admission_monitor
+      )
+      when owner == self() and is_integer(deadline) and is_reference(admission_monitor) do
+    timeout = max(deadline - System.monotonic_time(:millisecond), 0)
+
+    receive do
+      {:cancelable_request_result, ^gate, result} ->
+        receive do
+          {:DOWN, ^monitor, :process, ^pid, :normal} ->
+            {:ok, result}
+
+          {:DOWN, ^monitor, :process, ^pid, _reason} ->
+            {:error, :cancellation_witness_unavailable}
+        end
+
+      {:DOWN, ^monitor, :process, ^pid, _reason} ->
+        {:error, :cancellation_witness_unavailable}
+
+      {:DOWN, ^admission_monitor, :process, _admission, _reason} ->
+        _ = cancel_and_drain(handle, deadline)
+        {:error, :provider_admission_unavailable}
+
+      {:cancel_provider_call, tracker, request_ref, cleanup_deadline}
+      when is_pid(tracker) and is_reference(request_ref) and is_integer(cleanup_deadline) ->
+        drained = cancel_and_drain(handle, cleanup_deadline)
+        send(tracker, {:provider_call_drained, request_ref, self(), drained})
+        {:cancelled, drained}
+    after
+      timeout -> {:error, :timeout}
+    end
+  end
+
+  @spec cancel_and_drain(t(), integer()) :: :drained | :uncertain
+  def cancel_and_drain(%__MODULE__{owner: owner, pid: pid, monitor: monitor}, deadline)
+      when owner == self() and is_integer(deadline) do
+    Process.exit(pid, :kill)
+    timeout = max(deadline - System.monotonic_time(:millisecond), 0)
+
+    receive do
+      {:DOWN, ^monitor, :process, ^pid, _reason} -> :drained
+    after
+      timeout -> :uncertain
+    end
+  end
+
+  def cancel_and_drain(_handle, _deadline), do: :uncertain
+end

--- a/lib/ptc_runner/kernel/cancelable_request.ex
+++ b/lib/ptc_runner/kernel/cancelable_request.ex
@@ -3,7 +3,7 @@ defmodule PtcRunner.Kernel.CancelableRequest do
 
   alias PtcRunner.Kernel.AdapterCancellationWitness
 
-  @enforce_keys [:pid, :monitor, :gate, :owner, :dispatched]
+  @enforce_keys [:pid, :monitor, :gate, :owner, :state]
   defstruct @enforce_keys
 
   @opaque t :: %__MODULE__{
@@ -11,7 +11,7 @@ defmodule PtcRunner.Kernel.CancelableRequest do
             monitor: reference(),
             gate: reference(),
             owner: pid(),
-            dispatched: reference()
+            state: :atomics.atomics_ref()
           }
 
   @spec start_cancelable(function(), map(), map(), pid()) ::
@@ -20,7 +20,7 @@ defmodule PtcRunner.Kernel.CancelableRequest do
       when is_function(requester, 2) and is_map(request) and is_map(context) and
              guardian == self() do
     gate = make_ref()
-    dispatched = :atomics.new(1, signed: false)
+    state = :atomics.new(1, signed: false)
     owner = self()
 
     {pid, monitor} =
@@ -30,15 +30,16 @@ defmodule PtcRunner.Kernel.CancelableRequest do
 
           receive do
             {:dispatch, ^gate} ->
-              :ok = AdapterCancellationWitness.install(owner, gate)
+              :ok = AdapterCancellationWitness.install(owner, gate, state)
               result = invoke_requester(requester, request, context)
+              :atomics.put(state, 1, 3)
               send(owner, {:cancelable_request_result, gate, result})
 
             {:DOWN, ^owner_monitor, :process, ^owner, _reason} ->
               :ok
           end
         end,
-        [:link, :monitor]
+        provider_spawn_options()
       )
 
     {:ok,
@@ -47,7 +48,7 @@ defmodule PtcRunner.Kernel.CancelableRequest do
        monitor: monitor,
        gate: gate,
        owner: owner,
-       dispatched: dispatched
+       state: state
      }}
   rescue
     _ -> {:error, :cancellation_witness_unavailable}
@@ -59,9 +60,9 @@ defmodule PtcRunner.Kernel.CancelableRequest do
     do: {:error, :cancellation_witness_unavailable}
 
   @spec dispatch(t()) :: :ok | {:error, :cancellation_witness_unavailable}
-  def dispatch(%__MODULE__{owner: owner, pid: pid, gate: gate, dispatched: dispatched})
+  def dispatch(%__MODULE__{owner: owner, pid: pid, gate: gate, state: state})
       when owner == self() do
-    if :atomics.compare_exchange(dispatched, 1, 0, 1) == :ok do
+    if :atomics.compare_exchange(state, 1, 0, 1) == :ok do
       send(pid, {:dispatch, gate})
       :ok
     else
@@ -71,14 +72,16 @@ defmodule PtcRunner.Kernel.CancelableRequest do
 
   def dispatch(_handle), do: {:error, :cancellation_witness_unavailable}
 
-  @spec await_or_cancel(t(), integer(), reference()) ::
+  @spec await_or_cancel(t(), integer(), reference(), integer()) ::
           {:ok, term()} | {:cancelled, :drained | :uncertain} | {:error, atom()}
   def await_or_cancel(
         %__MODULE__{owner: owner, pid: pid, monitor: monitor, gate: gate} = handle,
         deadline,
-        admission_monitor
+        admission_monitor,
+        cleanup_deadline
       )
-      when owner == self() and is_integer(deadline) and is_reference(admission_monitor) do
+      when owner == self() and is_integer(deadline) and is_reference(admission_monitor) and
+             is_integer(cleanup_deadline) do
     timeout = max(deadline - System.monotonic_time(:millisecond), 0)
 
     receive do
@@ -95,7 +98,7 @@ defmodule PtcRunner.Kernel.CancelableRequest do
         {:error, :cancellation_witness_unavailable}
 
       {:DOWN, ^admission_monitor, :process, _admission, _reason} ->
-        _ = cancel_and_drain(handle, deadline)
+        _ = cancel_and_drain(handle, cleanup_deadline)
         {:error, :provider_admission_unavailable}
 
       {:cancel_provider_call, tracker, request_ref, cleanup_deadline}
@@ -115,33 +118,36 @@ defmodule PtcRunner.Kernel.CancelableRequest do
           pid: pid,
           monitor: monitor,
           gate: gate,
-          dispatched: dispatched
+          state: state
         },
         deadline
       )
       when owner == self() and is_integer(deadline) do
     Process.unlink(pid)
 
-    if :atomics.get(dispatched, 1) == 0 do
+    if :atomics.get(state, 1) == 0 do
       Process.exit(pid, :kill)
       await_down(pid, monitor, deadline)
     else
       send(pid, {:cancel_adapter_request, gate, owner})
-      await_adapter_drain(pid, monitor, gate, deadline, false)
+      await_adapter_drain(pid, monitor, gate, state, deadline, false)
     end
   end
 
   def cancel_and_drain(_handle, _deadline), do: :uncertain
 
-  defp await_adapter_drain(pid, monitor, gate, deadline, acknowledged?) do
+  defp await_adapter_drain(pid, monitor, gate, state, deadline, acknowledged?) do
     timeout = max(deadline - System.monotonic_time(:millisecond), 0)
 
     receive do
       {:adapter_request_drained, ^gate, ^pid} ->
-        await_adapter_drain(pid, monitor, gate, deadline, true)
+        await_adapter_drain(pid, monitor, gate, state, deadline, true)
+
+      {:DOWN, ^monitor, :process, ^pid, :normal} ->
+        if acknowledged? or :atomics.get(state, 1) == 3, do: :drained, else: :uncertain
 
       {:DOWN, ^monitor, :process, ^pid, _reason} ->
-        if acknowledged?, do: :drained, else: :uncertain
+        :uncertain
     after
       timeout -> :uncertain
     end
@@ -160,11 +166,15 @@ defmodule PtcRunner.Kernel.CancelableRequest do
   defp invoke_requester(requester, request, context) do
     {:ok, requester.(request, context)}
   rescue
-    _exception -> :requester_failed
+    exception -> {__MODULE__, :raised, exception, __STACKTRACE__}
   catch
-    _kind, _reason -> :requester_failed
+    kind, reason -> {__MODULE__, :caught, kind, reason}
   end
 
   defp normalize_result({:ok, result}), do: {:ok, result}
-  defp normalize_result(:requester_failed), do: {:error, :cancellation_witness_unavailable}
+
+  defp provider_spawn_options do
+    max_heap_size = Process.info(self(), :max_heap_size) |> elem(1)
+    [:link, :monitor, {:max_heap_size, max_heap_size}]
+  end
 end

--- a/lib/ptc_runner/kernel/cancelable_request.ex
+++ b/lib/ptc_runner/kernel/cancelable_request.ex
@@ -1,14 +1,17 @@
 defmodule PtcRunner.Kernel.CancelableRequest do
   @moduledoc false
 
-  @enforce_keys [:pid, :monitor, :gate, :owner]
+  alias PtcRunner.Kernel.AdapterCancellationWitness
+
+  @enforce_keys [:pid, :monitor, :gate, :owner, :dispatched]
   defstruct @enforce_keys
 
   @opaque t :: %__MODULE__{
             pid: pid(),
             monitor: reference(),
             gate: reference(),
-            owner: pid()
+            owner: pid(),
+            dispatched: reference()
           }
 
   @spec start_cancelable(function(), map(), map(), pid()) ::
@@ -17,6 +20,7 @@ defmodule PtcRunner.Kernel.CancelableRequest do
       when is_function(requester, 2) and is_map(request) and is_map(context) and
              guardian == self() do
     gate = make_ref()
+    dispatched = :atomics.new(1, signed: false)
     owner = self()
 
     {pid, monitor} =
@@ -26,7 +30,8 @@ defmodule PtcRunner.Kernel.CancelableRequest do
 
           receive do
             {:dispatch, ^gate} ->
-              result = requester.(request, context)
+              :ok = AdapterCancellationWitness.install(owner, gate)
+              result = invoke_requester(requester, request, context)
               send(owner, {:cancelable_request_result, gate, result})
 
             {:DOWN, ^owner_monitor, :process, ^owner, _reason} ->
@@ -36,7 +41,14 @@ defmodule PtcRunner.Kernel.CancelableRequest do
         [:link, :monitor]
       )
 
-    {:ok, %__MODULE__{pid: pid, monitor: monitor, gate: gate, owner: owner}}
+    {:ok,
+     %__MODULE__{
+       pid: pid,
+       monitor: monitor,
+       gate: gate,
+       owner: owner,
+       dispatched: dispatched
+     }}
   rescue
     _ -> {:error, :cancellation_witness_unavailable}
   catch
@@ -47,9 +59,14 @@ defmodule PtcRunner.Kernel.CancelableRequest do
     do: {:error, :cancellation_witness_unavailable}
 
   @spec dispatch(t()) :: :ok | {:error, :cancellation_witness_unavailable}
-  def dispatch(%__MODULE__{owner: owner, pid: pid, gate: gate}) when owner == self() do
-    send(pid, {:dispatch, gate})
-    :ok
+  def dispatch(%__MODULE__{owner: owner, pid: pid, gate: gate, dispatched: dispatched})
+      when owner == self() do
+    if :atomics.compare_exchange(dispatched, 1, 0, 1) == :ok do
+      send(pid, {:dispatch, gate})
+      :ok
+    else
+      {:error, :cancellation_witness_unavailable}
+    end
   end
 
   def dispatch(_handle), do: {:error, :cancellation_witness_unavailable}
@@ -68,7 +85,7 @@ defmodule PtcRunner.Kernel.CancelableRequest do
       {:cancelable_request_result, ^gate, result} ->
         receive do
           {:DOWN, ^monitor, :process, ^pid, :normal} ->
-            {:ok, result}
+            normalize_result(result)
 
           {:DOWN, ^monitor, :process, ^pid, _reason} ->
             {:error, :cancellation_witness_unavailable}
@@ -92,10 +109,45 @@ defmodule PtcRunner.Kernel.CancelableRequest do
   end
 
   @spec cancel_and_drain(t(), integer()) :: :drained | :uncertain
-  def cancel_and_drain(%__MODULE__{owner: owner, pid: pid, monitor: monitor}, deadline)
+  def cancel_and_drain(
+        %__MODULE__{
+          owner: owner,
+          pid: pid,
+          monitor: monitor,
+          gate: gate,
+          dispatched: dispatched
+        },
+        deadline
+      )
       when owner == self() and is_integer(deadline) do
     Process.unlink(pid)
-    Process.exit(pid, :kill)
+
+    if :atomics.get(dispatched, 1) == 0 do
+      Process.exit(pid, :kill)
+      await_down(pid, monitor, deadline)
+    else
+      send(pid, {:cancel_adapter_request, gate, owner})
+      await_adapter_drain(pid, monitor, gate, deadline, false)
+    end
+  end
+
+  def cancel_and_drain(_handle, _deadline), do: :uncertain
+
+  defp await_adapter_drain(pid, monitor, gate, deadline, acknowledged?) do
+    timeout = max(deadline - System.monotonic_time(:millisecond), 0)
+
+    receive do
+      {:adapter_request_drained, ^gate, ^pid} ->
+        await_adapter_drain(pid, monitor, gate, deadline, true)
+
+      {:DOWN, ^monitor, :process, ^pid, _reason} ->
+        if acknowledged?, do: :drained, else: :uncertain
+    after
+      timeout -> :uncertain
+    end
+  end
+
+  defp await_down(pid, monitor, deadline) do
     timeout = max(deadline - System.monotonic_time(:millisecond), 0)
 
     receive do
@@ -105,5 +157,14 @@ defmodule PtcRunner.Kernel.CancelableRequest do
     end
   end
 
-  def cancel_and_drain(_handle, _deadline), do: :uncertain
+  defp invoke_requester(requester, request, context) do
+    {:ok, requester.(request, context)}
+  rescue
+    _exception -> :requester_failed
+  catch
+    _kind, _reason -> :requester_failed
+  end
+
+  defp normalize_result({:ok, result}), do: {:ok, result}
+  defp normalize_result(:requester_failed), do: {:error, :cancellation_witness_unavailable}
 end

--- a/lib/ptc_runner/kernel/cancelable_request.ex
+++ b/lib/ptc_runner/kernel/cancelable_request.ex
@@ -126,12 +126,12 @@ defmodule PtcRunner.Kernel.CancelableRequest do
       when owner == self() and is_integer(deadline) do
     Process.unlink(pid)
 
-    case :atomics.get(state, 1) do
+    case :atomics.compare_exchange(state, 1, 1, 4) do
       2 ->
         send(pid, {:cancel_adapter_request, gate, owner})
         await_adapter_drain(pid, monitor, gate, state, deadline, false)
 
-      _predispatch_or_attested_caller ->
+      _cancellation_claimed_or_request_finished ->
         Process.exit(pid, :kill)
         await_down(pid, monitor, deadline)
     end

--- a/lib/ptc_runner/kernel/capability.ex
+++ b/lib/ptc_runner/kernel/capability.ex
@@ -35,7 +35,7 @@ defmodule PtcRunner.Kernel.Capability do
   alias PtcRunner.LLM.Requirements
 
   @effects [:read, :write, :unknown]
-  @options ~w(name callback validate description model_visible input_schema output_schema effect inspection_capture llm_reservation)a
+  @options ~w(name callback validate description model_visible input_schema output_schema effect inspection_capture llm_reservation provider_call_guardian)a
   @enforce_keys [:name, :callback, :input_schema]
   defstruct [
     :name,
@@ -47,6 +47,7 @@ defmodule PtcRunner.Kernel.Capability do
     :input_validator,
     :output_validator,
     :llm_reservation,
+    provider_call_guardian: false,
     model_visible: true,
     effect: :unknown,
     inspection_capture: :full
@@ -105,6 +106,8 @@ defmodule PtcRunner.Kernel.Capability do
          inspection_capture when inspection_capture in [:full, :digest_results] <-
            Keyword.get(opts, :inspection_capture, :full),
          true <- inspection_capture == :full or effect == :read,
+         provider_call_guardian when is_boolean(provider_call_guardian) <-
+           Keyword.get(opts, :provider_call_guardian, false),
          :ok <- valid_llm_reservation(Keyword.get(opts, :llm_reservation)),
          {:ok, input_schema, input_validator} <-
            JSONSchema.compile(Keyword.get(opts, :input_schema)),
@@ -123,6 +126,7 @@ defmodule PtcRunner.Kernel.Capability do
          input_validator: input_validator,
          output_validator: output_validator,
          llm_reservation: Keyword.get(opts, :llm_reservation),
+         provider_call_guardian: provider_call_guardian,
          effect: effect,
          inspection_capture: inspection_capture
        }}

--- a/lib/ptc_runner/kernel/connectivity_probe.ex
+++ b/lib/ptc_runner/kernel/connectivity_probe.ex
@@ -275,7 +275,11 @@ defmodule PtcRunner.Kernel.ConnectivityProbe do
   defp invoke(callback, selection, context, services, timeout_ms, limits) do
     result =
       BoundedWorker.run(fn -> callback.(selection, context, services) end,
-        timeout_ms: timeout_ms,
+        # The callback receives the occurrence deadline and must stop provider
+        # work at that instant. Keep its owner alive for the separately bounded
+        # cleanup interval so a guardian can cancel and prove drain instead of
+        # being force-killed exactly when the request clock expires.
+        timeout_ms: timeout_ms + provider_cleanup_grace(services, limits),
         max_heap_words: limits.provider_heap_words,
         cancel_with_caller: true
       )
@@ -286,6 +290,13 @@ defmodule PtcRunner.Kernel.ConnectivityProbe do
 
       other ->
         BoundedWorker.classify_payload_callback(other)
+    end
+  end
+
+  defp provider_cleanup_grace(services, limits) do
+    case ProviderRuntimeServices.provider_call_admission(services) do
+      {:ok, admission} when is_pid(admission) -> limits.provider_cleanup_timeout_ms
+      _other -> 0
     end
   end
 

--- a/lib/ptc_runner/kernel/dispatcher.ex
+++ b/lib/ptc_runner/kernel/dispatcher.ex
@@ -1017,7 +1017,12 @@ defmodule PtcRunner.Kernel.Dispatcher do
           end
         end)
 
-      case RunState.attach_provider(state, reservation_id, pid) do
+      attach =
+        if capability.provider_call_guardian,
+          do: RunState.attach_provider_guardian(state, reservation_id, pid),
+          else: RunState.attach_provider(state, reservation_id, pid)
+
+      case attach do
         :ok ->
           case RunState.open_provider_gate(state, reservation_id, pid, go) do
             :ok ->
@@ -1107,8 +1112,7 @@ defmodule PtcRunner.Kernel.Dispatcher do
          post_invocation_failure(provider_exit(reason), environment, capability)}
     after
       timeout_ms ->
-        Process.exit(pid, :kill)
-        await_down(pid, ref)
+        cancel_provider_at_timeout(state, capability, pid, ref)
         timeout_result = await_timeout_result(invocation)
 
         if capability.name == "llm-request", do: record_llm_timeout_evidence(state)
@@ -1119,6 +1123,37 @@ defmodule PtcRunner.Kernel.Dispatcher do
            environment,
            capability
          )}
+    end
+  end
+
+  defp cancel_provider_at_timeout(state, %{provider_call_guardian: true}, pid, ref) do
+    request_ref = make_ref()
+
+    deadline =
+      System.monotonic_time(:millisecond) + state_limits(state).provider_cleanup_timeout_ms
+
+    send(pid, {:cancel_provider_call, self(), request_ref, deadline})
+    await_guardian_down(pid, ref, request_ref, deadline)
+  end
+
+  defp cancel_provider_at_timeout(_state, _capability, pid, ref) do
+    Process.exit(pid, :kill)
+    await_down(pid, ref)
+  end
+
+  defp await_guardian_down(pid, ref, request_ref, deadline) do
+    timeout = max(deadline - System.monotonic_time(:millisecond), 0)
+
+    receive do
+      {:provider_call_drained, ^request_ref, ^pid, _status} ->
+        await_guardian_down(pid, ref, request_ref, deadline)
+
+      {:DOWN, ^ref, :process, ^pid, reason} ->
+        reason
+    after
+      timeout ->
+        Process.exit(pid, :kill)
+        await_down(pid, ref)
     end
   end
 

--- a/lib/ptc_runner/kernel/dispatcher.ex
+++ b/lib/ptc_runner/kernel/dispatcher.ex
@@ -639,6 +639,7 @@ defmodule PtcRunner.Kernel.Dispatcher do
                     capability.inspection_capture
                   )
                 )
+                |> Map.put(:provider_run_state, state)
 
               {invoke(
                  state,

--- a/lib/ptc_runner/kernel/host_installation.ex
+++ b/lib/ptc_runner/kernel/host_installation.ex
@@ -1130,7 +1130,7 @@ defmodule PtcRunner.Kernel.HostInstallation do
          {:ok, prepared_model} <- prepare_llm_model(model, requirements, adapter),
          {:ok, credential} <-
            Map.fetch(Map.get(context, :credentials, %{}), installation.credential),
-         {:ok, timeout_ms, max_heap_words} <- connectivity_probe_bounds(context),
+         {:ok, deadline_ms, max_heap_words} <- connectivity_probe_bounds(context),
          cleanup_timeout_ms when is_integer(cleanup_timeout_ms) and cleanup_timeout_ms > 0 <-
            get_in(context, [:limits, :provider_cleanup_timeout_ms]) do
       {:ok,
@@ -1140,7 +1140,7 @@ defmodule PtcRunner.Kernel.HostInstallation do
          credential: credential,
          cache: installation.cache,
          usage_guarantees: installation.usage_guarantees,
-         timeout_ms: timeout_ms,
+         deadline_ms: deadline_ms,
          cleanup_timeout_ms: cleanup_timeout_ms,
          max_heap_words: max_heap_words,
          adapter: adapter
@@ -1161,20 +1161,22 @@ defmodule PtcRunner.Kernel.HostInstallation do
            Map.get(limits, :doctor_connectivity_timeout_ms),
          max_heap_words when is_integer(max_heap_words) and max_heap_words > 0 <-
            Map.get(limits, :provider_heap_words) do
-      timeout_ms =
+      now = System.monotonic_time(:millisecond)
+
+      deadline_ms =
         case Map.get(context, :doctor_occurrence_deadline_ms) do
           deadline when is_integer(deadline) ->
-            min(timeout_ms, deadline - System.monotonic_time(:millisecond))
+            min(now + timeout_ms, deadline)
 
           nil ->
-            timeout_ms
+            now + timeout_ms
 
           _invalid ->
-            0
+            now
         end
 
-      if timeout_ms > 0,
-        do: {:ok, timeout_ms, max_heap_words},
+      if deadline_ms > now,
+        do: {:ok, deadline_ms, max_heap_words},
         else: {:error, :llm_connectivity_unavailable}
     else
       _invalid -> {:error, :llm_connectivity_unavailable}
@@ -1189,7 +1191,7 @@ defmodule PtcRunner.Kernel.HostInstallation do
   # The doctor connectivity deadline remains the outer `BoundedWorker` bound;
   # the probe does not participate in the ordinary whole-call LLM clock.
   defp run_llm_connectivity_probe(probe, admission) do
-    deadline = System.monotonic_time(:millisecond) + probe.timeout_ms
+    deadline = probe.deadline_ms
     binding = %{credential: probe.credential, cache: probe.cache}
 
     case PtcRunner.LLM.callback(probe.prepared_model, binding) do
@@ -1213,7 +1215,9 @@ defmodule PtcRunner.Kernel.HostInstallation do
                 )
               end
             end,
-            timeout_ms: probe.timeout_ms + probe.cleanup_timeout_ms,
+            timeout_ms:
+              max(deadline - System.monotonic_time(:millisecond), 0) +
+                probe.cleanup_timeout_ms,
             max_heap_words: probe.max_heap_words,
             cancel_with_caller: true
           )

--- a/lib/ptc_runner/kernel/host_installation.ex
+++ b/lib/ptc_runner/kernel/host_installation.ex
@@ -61,6 +61,7 @@ defmodule PtcRunner.Kernel.HostInstallation do
   alias PtcRunner.Kernel.MCPOAuth.TokenManager
   alias PtcRunner.Kernel.MCPSource
   alias PtcRunner.Kernel.ModelContractPricingCause
+  alias PtcRunner.Kernel.ProviderCallOwner
   alias PtcRunner.Kernel.ProviderDescriptor
   alias PtcRunner.Kernel.ProviderError
   alias PtcRunner.Kernel.ProviderRegistry
@@ -222,8 +223,16 @@ defmodule PtcRunner.Kernel.HostInstallation do
                  services,
                  binding,
                  {:connectivity_probe, name, selection, context}
-               ) do
-          run_llm_connectivity_probe(probe)
+               ),
+             admission = ProviderRuntimeServices.provider_call_admission(services),
+             true <- cancellation_witness_supported?(probe.adapter, admission) do
+          run_llm_connectivity_probe(
+            probe,
+            admission
+          )
+        else
+          {:error, :invalid_provider_runtime_services} = error -> error
+          _ -> {:error, :llm_connectivity_unavailable}
         end
       end
     )
@@ -1129,7 +1138,8 @@ defmodule PtcRunner.Kernel.HostInstallation do
          cache: installation.cache,
          usage_guarantees: installation.usage_guarantees,
          timeout_ms: timeout_ms,
-         max_heap_words: max_heap_words
+         max_heap_words: max_heap_words,
+         adapter: adapter
        }}
     else
       {:error, %ModelContractPricingCause{} = cause} ->
@@ -1174,7 +1184,7 @@ defmodule PtcRunner.Kernel.HostInstallation do
   # probe; absent promised usage fails connectivity rather than being invented.
   # The doctor connectivity deadline remains the outer `BoundedWorker` bound;
   # the probe does not participate in the ordinary whole-call LLM clock.
-  defp run_llm_connectivity_probe(probe) do
+  defp run_llm_connectivity_probe(probe, admission) do
     binding = %{credential: probe.credential, cache: probe.cache}
 
     case PtcRunner.LLM.callback(probe.prepared_model, binding) do
@@ -1182,10 +1192,19 @@ defmodule PtcRunner.Kernel.HostInstallation do
         result =
           BoundedWorker.run(
             fn ->
-              requester.(
-                %{messages: [%{role: :user, content: "Health check."}]},
-                %{llm_request_deadline_ms: nil}
-              )
+              request = %{messages: [%{role: :user, content: "Health check."}]}
+              deadline = System.monotonic_time(:millisecond) + probe.timeout_ms
+
+              if is_nil(admission) do
+                requester.(request, %{llm_request_deadline_ms: deadline})
+              else
+                ProviderCallOwner.run(
+                  admission,
+                  requester,
+                  request,
+                  %{llm_request_deadline_ms: deadline}
+                )
+              end
             end,
             timeout_ms: probe.timeout_ms,
             max_heap_words: probe.max_heap_words,
@@ -1461,13 +1480,30 @@ defmodule PtcRunner.Kernel.HostInstallation do
              credential: credential,
              cache: installation.cache
            }),
+         provider_call_admission = Map.get(context, :provider_call_admission),
+         true <- cancellation_witness_supported?(adapter, provider_call_admission),
+         provider_cleanup_timeout_ms = get_in(context, [:limits, :provider_cleanup_timeout_ms]),
          {:ok, capability} <-
            LLMCapability.new(
-             requester: fn request, context ->
+             provider_call_guardian: not is_nil(provider_call_admission),
+             requester: fn request, requester_context ->
                with :ok <- provider_application_ready(adapter, model) do
-                 request
-                 |> ProviderRegistry.adapter_request()
-                 |> requester.(llm_requester_context(context))
+                 request = ProviderRegistry.adapter_request(request)
+                 context = llm_requester_context(requester_context)
+                 context = maybe_put_cleanup_timeout(context, provider_cleanup_timeout_ms)
+
+                 case provider_call_admission do
+                   admission when not is_nil(admission) ->
+                     ProviderCallOwner.run(
+                       admission,
+                       requester,
+                       request,
+                       context
+                     )
+
+                   nil ->
+                     requester.(request, Map.take(context, [:llm_request_deadline_ms]))
+                 end
                end
              end,
              llm_reservation: %{
@@ -1514,11 +1550,30 @@ defmodule PtcRunner.Kernel.HostInstallation do
     end
   end
 
-  defp llm_requester_context(%{llm_request_deadline_ms: deadline})
-       when is_integer(deadline) or is_nil(deadline),
-       do: %{llm_request_deadline_ms: deadline}
+  defp llm_requester_context(%{llm_request_deadline_ms: deadline} = context)
+       when is_integer(deadline) or is_nil(deadline) do
+    %{llm_request_deadline_ms: deadline}
+    |> maybe_put_provider_call_admission(context)
+  end
 
   defp llm_requester_context(_context), do: %{llm_request_deadline_ms: nil}
+
+  defp maybe_put_provider_call_admission(context, %{provider_call_admission: admission})
+       when not is_nil(admission),
+       do: Map.put(context, :provider_call_admission, admission)
+
+  defp maybe_put_provider_call_admission(context, _requester_context), do: context
+
+  defp maybe_put_cleanup_timeout(context, timeout_ms)
+       when is_integer(timeout_ms) and timeout_ms > 0,
+       do: Map.put(context, :provider_cleanup_timeout_ms, timeout_ms)
+
+  defp maybe_put_cleanup_timeout(context, _timeout_ms), do: context
+
+  defp cancellation_witness_supported?(_adapter, nil), do: true
+
+  defp cancellation_witness_supported?(adapter, admission) when not is_nil(admission),
+    do: function_exported?(adapter, :cancellation_witness?, 0) and adapter.cancellation_witness?()
 
   # The core no longer starts an adapter's backing application on a host's
   # behalf; a run admits it through ProviderApplicationGate. An embedding host

--- a/lib/ptc_runner/kernel/host_installation.ex
+++ b/lib/ptc_runner/kernel/host_installation.ex
@@ -224,7 +224,7 @@ defmodule PtcRunner.Kernel.HostInstallation do
                  binding,
                  {:connectivity_probe, name, selection, context}
                ),
-             admission = ProviderRuntimeServices.provider_call_admission(services),
+             {:ok, admission} <- ProviderRuntimeServices.provider_call_admission(services),
              true <- cancellation_witness_supported?(probe.adapter, admission) do
           run_llm_connectivity_probe(
             probe,
@@ -788,7 +788,8 @@ defmodule PtcRunner.Kernel.HostInstallation do
   end
 
   defp preflight(_host, %{source: :llm} = installation, selection, context, _oauth_runtime) do
-    with :ok <- placement(installation, context.destination),
+    with nil <- Map.get(context, :provider_call_admission_error),
+         :ok <- placement(installation, context.destination),
          {:ok, selected} <- llm_selection(installation, selection, context),
          {:ok, model, adapter} <- preflight_llm(installation.model),
          {:ok, requirements} <- live_llm_requirements(installation, context),
@@ -1129,7 +1130,9 @@ defmodule PtcRunner.Kernel.HostInstallation do
          {:ok, prepared_model} <- prepare_llm_model(model, requirements, adapter),
          {:ok, credential} <-
            Map.fetch(Map.get(context, :credentials, %{}), installation.credential),
-         {:ok, timeout_ms, max_heap_words} <- connectivity_probe_bounds(context) do
+         {:ok, timeout_ms, max_heap_words} <- connectivity_probe_bounds(context),
+         cleanup_timeout_ms when is_integer(cleanup_timeout_ms) and cleanup_timeout_ms > 0 <-
+           get_in(context, [:limits, :provider_cleanup_timeout_ms]) do
       {:ok,
        %{
          model: model,
@@ -1138,6 +1141,7 @@ defmodule PtcRunner.Kernel.HostInstallation do
          cache: installation.cache,
          usage_guarantees: installation.usage_guarantees,
          timeout_ms: timeout_ms,
+         cleanup_timeout_ms: cleanup_timeout_ms,
          max_heap_words: max_heap_words,
          adapter: adapter
        }}
@@ -1185,6 +1189,7 @@ defmodule PtcRunner.Kernel.HostInstallation do
   # The doctor connectivity deadline remains the outer `BoundedWorker` bound;
   # the probe does not participate in the ordinary whole-call LLM clock.
   defp run_llm_connectivity_probe(probe, admission) do
+    deadline = System.monotonic_time(:millisecond) + probe.timeout_ms
     binding = %{credential: probe.credential, cache: probe.cache}
 
     case PtcRunner.LLM.callback(probe.prepared_model, binding) do
@@ -1193,7 +1198,6 @@ defmodule PtcRunner.Kernel.HostInstallation do
           BoundedWorker.run(
             fn ->
               request = %{messages: [%{role: :user, content: "Health check."}]}
-              deadline = System.monotonic_time(:millisecond) + probe.timeout_ms
 
               if is_nil(admission) do
                 requester.(request, %{llm_request_deadline_ms: deadline})
@@ -1202,11 +1206,14 @@ defmodule PtcRunner.Kernel.HostInstallation do
                   admission,
                   requester,
                   request,
-                  %{llm_request_deadline_ms: deadline}
+                  %{
+                    llm_request_deadline_ms: deadline,
+                    provider_cleanup_timeout_ms: probe.cleanup_timeout_ms
+                  }
                 )
               end
             end,
-            timeout_ms: probe.timeout_ms,
+            timeout_ms: probe.timeout_ms + probe.cleanup_timeout_ms,
             max_heap_words: probe.max_heap_words,
             cancel_with_caller: true
           )
@@ -1554,6 +1561,7 @@ defmodule PtcRunner.Kernel.HostInstallation do
        when is_integer(deadline) or is_nil(deadline) do
     %{llm_request_deadline_ms: deadline}
     |> maybe_put_provider_call_admission(context)
+    |> maybe_put_provider_run_state(context)
   end
 
   defp llm_requester_context(_context), do: %{llm_request_deadline_ms: nil}
@@ -1563,6 +1571,11 @@ defmodule PtcRunner.Kernel.HostInstallation do
        do: Map.put(context, :provider_call_admission, admission)
 
   defp maybe_put_provider_call_admission(context, _requester_context), do: context
+
+  defp maybe_put_provider_run_state(context, %{provider_run_state: run_state}),
+    do: Map.put(context, :provider_run_state, run_state)
+
+  defp maybe_put_provider_run_state(context, _requester_context), do: context
 
   defp maybe_put_cleanup_timeout(context, timeout_ms)
        when is_integer(timeout_ms) and timeout_ms > 0,

--- a/lib/ptc_runner/kernel/installation_catalog.ex
+++ b/lib/ptc_runner/kernel/installation_catalog.ex
@@ -557,7 +557,8 @@ defmodule PtcRunner.Kernel.InstallationCatalog do
   defp build_runtime_registry(catalog, services, selected_names, oauth_runtimes, owner) do
     result =
       with :ok <- install_oauth_runtimes(owner, oauth_runtimes) do
-        ProviderRegistry.new(runtime_builders(catalog, selected_names, oauth_runtimes, owner),
+        ProviderRegistry.new(
+          runtime_builders(catalog, selected_names, oauth_runtimes, owner, services),
           credential_resolver: runtime_credential_resolver(services, owner),
           installed_limits: catalog.installed_limits,
           authority_owner: owner
@@ -580,20 +581,21 @@ defmodule PtcRunner.Kernel.InstallationCatalog do
          catalog,
          selected_names,
          _oauth_runtimes,
-         %HostInstallationAuthority{} = owner
+         %HostInstallationAuthority{} = owner,
+         services
        ) do
     catalog.implementations
     |> Map.take(selected_names)
     |> Map.new(fn {name, _implementation} ->
       {name,
        ProviderRegistry.staged(
-         HostInstallation.runtime_builder(owner, name),
+         admitted_runtime_builder(owner, name, services),
          declared_policy(catalog, name)
        )}
     end)
   end
 
-  defp runtime_builders(catalog, selected_names, oauth_runtimes, nil) do
+  defp runtime_builders(catalog, selected_names, oauth_runtimes, nil, services) do
     catalog.implementations
     |> Map.take(selected_names)
     |> Map.new(fn {name, implementation} ->
@@ -605,11 +607,25 @@ defmodule PtcRunner.Kernel.InstallationCatalog do
             end
 
           :error ->
-            implementation.builder
+            fn selection, context ->
+              implementation.builder.(selection, runtime_context(context, services))
+            end
         end
 
       {name, ProviderRegistry.staged(builder, declared_policy(catalog, name))}
     end)
+  end
+
+  defp admitted_runtime_builder(owner, name, services) do
+    builder = HostInstallation.runtime_builder(owner, name)
+    fn selection, context -> builder.(selection, runtime_context(context, services)) end
+  end
+
+  defp runtime_context(context, services) do
+    case ProviderRuntimeServices.provider_call_admission(services) do
+      nil -> context
+      admission -> Map.put(context, :provider_call_admission, admission)
+    end
   end
 
   defp declared_policy(catalog, name),

--- a/lib/ptc_runner/kernel/installation_catalog.ex
+++ b/lib/ptc_runner/kernel/installation_catalog.ex
@@ -623,8 +623,9 @@ defmodule PtcRunner.Kernel.InstallationCatalog do
 
   defp runtime_context(context, services) do
     case ProviderRuntimeServices.provider_call_admission(services) do
-      nil -> context
-      admission -> Map.put(context, :provider_call_admission, admission)
+      {:ok, nil} -> context
+      {:ok, admission} -> Map.put(context, :provider_call_admission, admission)
+      {:error, reason} -> Map.put(context, :provider_call_admission_error, reason)
     end
   end
 

--- a/lib/ptc_runner/kernel/llm_capability.ex
+++ b/lib/ptc_runner/kernel/llm_capability.ex
@@ -58,7 +58,8 @@ defmodule PtcRunner.Kernel.LLMCapability do
                :usage_guarantees,
                :max_request_bytes,
                :max_response_bytes,
-               :llm_reservation
+               :llm_reservation,
+               :provider_call_guardian
              ] == [],
          requester when is_function(requester, 1) or is_function(requester, 2) <-
            Keyword.get(opts, :requester),
@@ -94,6 +95,7 @@ defmodule PtcRunner.Kernel.LLMCapability do
              },
              output_schema: %{"type" => "object", "additionalProperties" => true},
              llm_reservation: Keyword.get(opts, :llm_reservation),
+             provider_call_guardian: Keyword.get(opts, :provider_call_guardian, false),
              validate: fn request -> validate_request(request, request_limit) end,
              callback: requester_callback(requester, response_limit, usage_guarantees)
            ) do
@@ -133,11 +135,18 @@ defmodule PtcRunner.Kernel.LLMCapability do
     end
   end
 
-  defp requester_context(%{llm_request_deadline_ms: deadline})
-       when is_integer(deadline) or is_nil(deadline),
-       do: %{llm_request_deadline_ms: deadline}
+  defp requester_context(%{llm_request_deadline_ms: deadline} = context)
+       when is_integer(deadline) or is_nil(deadline) do
+    %{llm_request_deadline_ms: deadline}
+    |> maybe_put_admission(context)
+  end
 
   defp requester_context(_context), do: %{llm_request_deadline_ms: nil}
+
+  defp maybe_put_admission(context, %{provider_call_admission: admission}) when is_pid(admission),
+    do: Map.put(context, :provider_call_admission, admission)
+
+  defp maybe_put_admission(context, _source), do: context
 
   defp invoke(requester, request, context, response_limit, usage_guarantees)
        when is_function(requester, 2) do

--- a/lib/ptc_runner/kernel/llm_capability.ex
+++ b/lib/ptc_runner/kernel/llm_capability.ex
@@ -139,6 +139,7 @@ defmodule PtcRunner.Kernel.LLMCapability do
        when is_integer(deadline) or is_nil(deadline) do
     %{llm_request_deadline_ms: deadline}
     |> maybe_put_admission(context)
+    |> maybe_put_run_state(context)
   end
 
   defp requester_context(_context), do: %{llm_request_deadline_ms: nil}
@@ -147,6 +148,11 @@ defmodule PtcRunner.Kernel.LLMCapability do
     do: Map.put(context, :provider_call_admission, admission)
 
   defp maybe_put_admission(context, _source), do: context
+
+  defp maybe_put_run_state(context, %{provider_run_state: run_state}),
+    do: Map.put(context, :provider_run_state, run_state)
+
+  defp maybe_put_run_state(context, _source), do: context
 
   defp invoke(requester, request, context, response_limit, usage_guarantees)
        when is_function(requester, 2) do

--- a/lib/ptc_runner/kernel/llm_failure_catalog.ex
+++ b/lib/ptc_runner/kernel/llm_failure_catalog.ex
@@ -16,6 +16,8 @@ defmodule PtcRunner.Kernel.LLMFailureCatalog do
   """
 
   @provider_kinds [
+    :admission_unavailable,
+    :capacity_exhausted,
     :denied,
     :not_found,
     :unavailable,
@@ -47,7 +49,9 @@ defmodule PtcRunner.Kernel.LLMFailureCatalog do
   ]
 
   @type provider_kind ::
-          :denied
+          :admission_unavailable
+          | :capacity_exhausted
+          | :denied
           | :not_found
           | :unavailable
           | :invalid_request

--- a/lib/ptc_runner/kernel/provider_call_admission.ex
+++ b/lib/ptc_runner/kernel/provider_call_admission.ex
@@ -63,6 +63,20 @@ defmodule PtcRunner.Kernel.ProviderCallAdmission do
              | :provider_admission_unavailable}
   def checkout(admission, absolute_deadline_ms)
       when is_pid(admission) and is_integer(absolute_deadline_ms) do
+    checkout_for(admission, self(), absolute_deadline_ms)
+  end
+
+  def checkout(_admission, _deadline), do: {:error, :provider_admission_unavailable}
+
+  @doc false
+  @spec checkout_for(t(), pid(), integer()) ::
+          {:ok, Lease.t()}
+          | {:error,
+             :provider_capacity_exhausted
+             | :provider_admission_timeout
+             | :provider_admission_unavailable}
+  def checkout_for(admission, guardian, absolute_deadline_ms)
+      when is_pid(admission) and is_pid(guardian) and is_integer(absolute_deadline_ms) do
     now = System.monotonic_time(:millisecond)
 
     if absolute_deadline_ms <= now do
@@ -71,7 +85,13 @@ defmodule PtcRunner.Kernel.ProviderCallAdmission do
       with {:ok, token, tickets, ticket_limit} <- domain(admission),
            true <- claim_ticket(tickets, ticket_limit) do
         ticket = Ticket.new()
-        call(admission, token, {:checkout, absolute_deadline_ms, ticket}, {tickets, ticket})
+
+        call(
+          admission,
+          token,
+          {:checkout, guardian, absolute_deadline_ms, ticket},
+          {tickets, ticket}
+        )
       else
         false -> {:error, :provider_capacity_exhausted}
         _ -> {:error, :provider_admission_unavailable}
@@ -79,7 +99,8 @@ defmodule PtcRunner.Kernel.ProviderCallAdmission do
     end
   end
 
-  def checkout(_admission, _deadline), do: {:error, :provider_admission_unavailable}
+  def checkout_for(_admission, _guardian, _deadline),
+    do: {:error, :provider_admission_unavailable}
 
   @doc "Consumes a single-use lease on behalf of its bound guardian."
   @spec complete(Lease.t(), :completed | :cancelled | :uncertain) ::
@@ -113,8 +134,10 @@ defmodule PtcRunner.Kernel.ProviderCallAdmission do
   @doc "Returns bounded capacity health without exposing calls or leases."
   @spec snapshot(t()) :: {:ok, snapshot()} | {:error, :provider_admission_unavailable}
   def snapshot(admission) when is_pid(admission) do
-    with {:ok, token, _tickets, _limit} <- domain(admission),
-         do: call(admission, token, :snapshot, nil)
+    case domain(admission) do
+      {:ok, token, _tickets, _limit} -> call(admission, token, :snapshot, nil)
+      :error -> {:error, :provider_admission_unavailable}
+    end
   end
 
   def snapshot(_admission), do: {:error, :provider_admission_unavailable}
@@ -122,8 +145,10 @@ defmodule PtcRunner.Kernel.ProviderCallAdmission do
   @doc false
   @spec valid?(term()) :: boolean()
   def valid?(admission) when is_pid(admission) do
-    with {:ok, token, _tickets, _limit} <- domain(admission),
-         do: call(admission, token, :valid, nil) == :ok
+    case domain(admission) do
+      {:ok, token, _tickets, _limit} -> call(admission, token, :valid, nil) == :ok
+      :error -> false
+    end
   end
 
   def valid?(_), do: false
@@ -162,10 +187,8 @@ defmodule PtcRunner.Kernel.ProviderCallAdmission do
       }}, state}
   end
 
-  def handle_call({token, {:checkout, deadline, ticket}}, from, %{token: token} = state)
+  def handle_call({token, {:checkout, owner, deadline, ticket}}, from, %{token: token} = state)
       when is_struct(ticket, Ticket) do
-    owner = elem(from, 0)
-
     cond do
       state.status == :unavailable or not Process.alive?(owner) ->
         release_ticket(state, ticket)
@@ -187,12 +210,14 @@ defmodule PtcRunner.Kernel.ProviderCallAdmission do
       true ->
         request_ref = make_ref()
         monitor = Process.monitor(owner)
+        caller_monitor = Process.monitor(elem(from, 0))
         timer = Process.send_after(self(), {:expire, request_ref}, max(deadline - now_ms(), 1))
 
         entry = %{
           from: from,
           owner: owner,
           monitor: monitor,
+          caller_monitor: caller_monitor,
           timer: timer,
           deadline: deadline,
           ticket: ticket
@@ -209,6 +234,9 @@ defmodule PtcRunner.Kernel.ProviderCallAdmission do
 
   def handle_call({token, {:complete, lease_ref, status}}, {owner, _}, %{token: token} = state) do
     case state.active[lease_ref] do
+      %{owner: ^owner} when state.status == :unavailable ->
+        {:reply, {:error, :provider_admission_unavailable}, state}
+
       %{owner: ^owner} = active when state.status == :ready ->
         Process.demonitor(active.monitor, [:flush])
         state = %{state | active: Map.delete(state.active, lease_ref)}
@@ -347,6 +375,7 @@ defmodule PtcRunner.Kernel.ProviderCallAdmission do
 
   defp cancel_waiter_monitor(entry) do
     Process.demonitor(entry.monitor, [:flush])
+    Process.demonitor(entry.caller_monitor, [:flush])
     Process.cancel_timer(entry.timer, async: true, info: false)
   end
 
@@ -372,6 +401,7 @@ defmodule PtcRunner.Kernel.ProviderCallAdmission do
   defp waiter_by_monitor(waiting, monitor, owner) do
     Enum.find_value(waiting, :error, fn
       {request_ref, %{monitor: ^monitor, owner: ^owner}} -> {:ok, request_ref}
+      {request_ref, %{caller_monitor: ^monitor}} -> {:ok, request_ref}
       _ -> nil
     end)
   end

--- a/lib/ptc_runner/kernel/provider_call_admission.ex
+++ b/lib/ptc_runner/kernel/provider_call_admission.ex
@@ -1,0 +1,449 @@
+defmodule PtcRunner.Kernel.ProviderCallAdmission do
+  @moduledoc """
+  Explicit host-owned admission for aggregate live LLM requester calls.
+
+  A host starts one domain for every provider transport shared by its hosted
+  runtimes and passes the returned opaque handle through
+  `PtcRunner.Kernel.ProviderRuntimeServices`. A slot covers the complete
+  requester invocation, including sequential adapter retries, until its bound
+  guardian proves completion or cancellation and drain.
+
+  This owner is not a VM singleton. Command-owned one-shot runtimes, replay,
+  direct `PtcRunner.LLM` calls, embeddings, and custom requesters which bypass
+  runtime services are outside its guarantee and remain the host's
+  responsibility to bound.
+
+  Saturation is healthy. Cleanup uncertainty, an active guardian's death, or a
+  lease protocol fault fences the domain. Its temporary child specification
+  prevents capacity from resetting underneath surviving transport work.
+  """
+
+  use GenServer
+  use PtcRunner.Kernel.OwnerStatusRedaction
+
+  @limit 65_535
+  alias PtcRunner.Kernel.ProviderCallAdmission.Lease
+  alias PtcRunner.Kernel.ProviderCallAdmission.Ticket
+
+  @opaque t :: pid()
+  @typep atomics_ref :: :atomics.atomics_ref()
+
+  @type snapshot :: %{
+          capacity: pos_integer(),
+          active: non_neg_integer(),
+          waiting: non_neg_integer(),
+          status: :ready | :unavailable
+        }
+
+  @doc false
+  def child_spec(opts),
+    do: %{id: __MODULE__, start: {__MODULE__, :start_link, [opts]}, restart: :temporary}
+
+  @doc "Starts one admission domain with a closed active and waiter capacity."
+  @spec start_link(keyword()) :: GenServer.on_start() | {:error, :invalid_provider_call_admission}
+  def start_link(opts) when is_list(opts) do
+    with true <- Keyword.keyword?(opts),
+         [:max_active_calls, :max_waiters] <- opts |> Keyword.keys() |> Enum.sort(),
+         active when active in 1..@limit <- opts[:max_active_calls],
+         waiting when waiting in 0..@limit <- opts[:max_waiters] do
+      GenServer.start_link(__MODULE__, {active, waiting})
+    else
+      _ -> {:error, :invalid_provider_call_admission}
+    end
+  end
+
+  def start_link(_opts), do: {:error, :invalid_provider_call_admission}
+
+  @doc "Claims admission for the calling guardian until the absolute monotonic deadline."
+  @spec checkout(t(), integer()) ::
+          {:ok, Lease.t()}
+          | {:error,
+             :provider_capacity_exhausted
+             | :provider_admission_timeout
+             | :provider_admission_unavailable}
+  def checkout(admission, absolute_deadline_ms)
+      when is_pid(admission) and is_integer(absolute_deadline_ms) do
+    now = System.monotonic_time(:millisecond)
+
+    if absolute_deadline_ms <= now do
+      {:error, :provider_admission_timeout}
+    else
+      with {:ok, token, tickets, ticket_limit} <- domain(admission),
+           true <- claim_ticket(tickets, ticket_limit) do
+        ticket = Ticket.new()
+        call(admission, token, {:checkout, absolute_deadline_ms, ticket}, {tickets, ticket})
+      else
+        false -> {:error, :provider_capacity_exhausted}
+        _ -> {:error, :provider_admission_unavailable}
+      end
+    end
+  end
+
+  def checkout(_admission, _deadline), do: {:error, :provider_admission_unavailable}
+
+  @doc "Consumes a single-use lease on behalf of its bound guardian."
+  @spec complete(Lease.t(), :completed | :cancelled | :uncertain) ::
+          :ok
+          | {:error,
+             :provider_cleanup_failed
+             | :duplicate_completion
+             | :invalid_lease
+             | :not_lease_owner
+             | :provider_admission_unavailable}
+  def complete(%Lease{admission: admission, owner: owner} = lease, status)
+      when is_pid(admission) and
+             status in [:completed, :cancelled, :uncertain] do
+    cond do
+      owner != self() ->
+        call(admission, lease_token(lease), {:fault, :not_lease_owner}, nil)
+
+      not claim_completion(lease.completion) ->
+        call(admission, lease_token(lease), {:fault, :duplicate_completion}, nil)
+
+      true ->
+        call(admission, lease_token(lease), {:complete, lease.reference, status}, nil)
+    end
+  end
+
+  def complete(%Lease{admission: admission} = lease, _status) when is_pid(admission),
+    do: call(admission, lease_token(lease), {:fault, :invalid_lease}, nil)
+
+  def complete(_lease, _status), do: {:error, :invalid_lease}
+
+  @doc "Returns bounded capacity health without exposing calls or leases."
+  @spec snapshot(t()) :: {:ok, snapshot()} | {:error, :provider_admission_unavailable}
+  def snapshot(admission) when is_pid(admission) do
+    with {:ok, token, _tickets, _limit} <- domain(admission),
+         do: call(admission, token, :snapshot, nil)
+  end
+
+  def snapshot(_admission), do: {:error, :provider_admission_unavailable}
+
+  @doc false
+  @spec valid?(term()) :: boolean()
+  def valid?(admission) when is_pid(admission) do
+    with {:ok, token, _tickets, _limit} <- domain(admission),
+         do: call(admission, token, :valid, nil) == :ok
+  end
+
+  def valid?(_), do: false
+
+  @impl true
+  def init({capacity, max_waiters}) do
+    token = make_ref()
+    tickets = :atomics.new(1, signed: false)
+    :persistent_term.put({__MODULE__, self()}, {token, tickets, capacity + max_waiters})
+    watch_persistent_handle(self())
+
+    {:ok,
+     %{
+       token: token,
+       tickets: tickets,
+       capacity: capacity,
+       max_waiters: max_waiters,
+       active: %{},
+       waiting: :queue.new(),
+       waiting_by_ref: %{},
+       status: :ready
+     }}
+  end
+
+  @impl true
+  def handle_call({token, :valid}, _from, %{token: token} = state), do: {:reply, :ok, state}
+
+  def handle_call({token, :snapshot}, _from, %{token: token} = state) do
+    {:reply,
+     {:ok,
+      %{
+        capacity: state.capacity,
+        active: map_size(state.active),
+        waiting: map_size(state.waiting_by_ref),
+        status: state.status
+      }}, state}
+  end
+
+  def handle_call({token, {:checkout, deadline, ticket}}, from, %{token: token} = state)
+      when is_struct(ticket, Ticket) do
+    owner = elem(from, 0)
+
+    cond do
+      state.status == :unavailable or not Process.alive?(owner) ->
+        release_ticket(state, ticket)
+        {:reply, {:error, :provider_admission_unavailable}, state}
+
+      deadline <= now_ms() ->
+        release_ticket(state, ticket)
+        {:reply, {:error, :provider_admission_timeout}, state}
+
+      map_size(state.active) < state.capacity and :queue.is_empty(state.waiting) ->
+        release_ticket(state, ticket)
+        {lease, state} = grant(owner, state)
+        {:reply, {:ok, lease}, state}
+
+      map_size(state.waiting_by_ref) >= state.max_waiters ->
+        release_ticket(state, ticket)
+        {:reply, {:error, :provider_capacity_exhausted}, state}
+
+      true ->
+        request_ref = make_ref()
+        monitor = Process.monitor(owner)
+        timer = Process.send_after(self(), {:expire, request_ref}, max(deadline - now_ms(), 1))
+
+        entry = %{
+          from: from,
+          owner: owner,
+          monitor: monitor,
+          timer: timer,
+          deadline: deadline,
+          ticket: ticket
+        }
+
+        {:noreply,
+         %{
+           state
+           | waiting: :queue.in(request_ref, state.waiting),
+             waiting_by_ref: Map.put(state.waiting_by_ref, request_ref, entry)
+         }}
+    end
+  end
+
+  def handle_call({token, {:complete, lease_ref, status}}, {owner, _}, %{token: token} = state) do
+    case state.active[lease_ref] do
+      %{owner: ^owner} = active when state.status == :ready ->
+        Process.demonitor(active.monitor, [:flush])
+        state = %{state | active: Map.delete(state.active, lease_ref)}
+
+        case status do
+          :uncertain ->
+            {:reply, {:error, :provider_cleanup_failed}, fence(state)}
+
+          _settled ->
+            {state, replies} = promote(state)
+            Enum.each(replies, fn {from, reply} -> GenServer.reply(from, reply) end)
+            {:reply, :ok, state}
+        end
+
+      %{owner: _other} ->
+        {:reply, {:error, :not_lease_owner}, fence(state)}
+
+      nil when state.status == :unavailable ->
+        {:reply, {:error, :provider_admission_unavailable}, state}
+
+      nil ->
+        {:reply, {:error, :invalid_lease}, fence(state)}
+    end
+  end
+
+  def handle_call({token, {:fault, fault}}, _from, %{token: token} = state)
+      when fault in [:duplicate_completion, :invalid_lease, :not_lease_owner],
+      do: {:reply, {:error, fault}, fence(state)}
+
+  def handle_call(_request, _from, state),
+    do: {:reply, {:error, :provider_admission_unavailable}, state}
+
+  @impl true
+  def handle_info({:expire, request_ref}, state) do
+    case pop_waiter(state, request_ref) do
+      {nil, state} ->
+        {:noreply, state}
+
+      {entry, state} ->
+        release_ticket(state, entry.ticket)
+        GenServer.reply(entry.from, {:error, :provider_admission_timeout})
+        {:noreply, state}
+    end
+  end
+
+  def handle_info({:DOWN, monitor, :process, owner, _reason}, state) do
+    case active_by_monitor(state.active, monitor, owner) do
+      {:ok, _lease_ref} ->
+        {:noreply, fence(state)}
+
+      :error ->
+        case waiter_by_monitor(state.waiting_by_ref, monitor, owner) do
+          {:ok, request_ref} ->
+            {entry, state} = pop_waiter(state, request_ref)
+            release_ticket(state, entry.ticket)
+            {:noreply, state}
+
+          :error ->
+            {:noreply, state}
+        end
+    end
+  end
+
+  def handle_info(_message, state), do: {:noreply, state}
+
+  @impl true
+  def terminate(_reason, _state) do
+    :persistent_term.erase({__MODULE__, self()})
+    :ok
+  end
+
+  defp grant(owner, state) do
+    lease_ref = make_ref()
+    completion = :atomics.new(1, signed: false)
+    monitor = Process.monitor(owner)
+
+    lease = %Lease{
+      admission: self(),
+      reference: lease_ref,
+      owner: owner,
+      completion: completion
+    }
+
+    {lease,
+     %{state | active: Map.put(state.active, lease_ref, %{owner: owner, monitor: monitor})}}
+  end
+
+  defp promote(%{status: :unavailable} = state), do: {state, []}
+
+  defp promote(state) when map_size(state.active) >= state.capacity, do: {state, []}
+
+  defp promote(state) do
+    case :queue.out(state.waiting) do
+      {:empty, _queue} ->
+        {state, []}
+
+      {{:value, request_ref}, queue} ->
+        state = %{state | waiting: queue}
+
+        case Map.pop(state.waiting_by_ref, request_ref) do
+          {nil, waiting_by_ref} ->
+            promote(%{state | waiting_by_ref: waiting_by_ref})
+
+          {entry, waiting_by_ref} ->
+            cancel_waiter_monitor(entry)
+            release_ticket(state, entry.ticket)
+            state = %{state | waiting_by_ref: waiting_by_ref}
+
+            cond do
+              entry.deadline <= now_ms() ->
+                {state, replies} = promote(state)
+                {state, [{entry.from, {:error, :provider_admission_timeout}} | replies]}
+
+              not Process.alive?(entry.owner) ->
+                promote(state)
+
+              true ->
+                {lease, state} = grant(entry.owner, state)
+                {state, replies} = promote(state)
+                {state, [{entry.from, {:ok, lease}} | replies]}
+            end
+        end
+    end
+  end
+
+  defp pop_waiter(state, request_ref) do
+    case Map.pop(state.waiting_by_ref, request_ref) do
+      {nil, waiting_by_ref} ->
+        {nil, %{state | waiting_by_ref: waiting_by_ref}}
+
+      {entry, waiting_by_ref} ->
+        cancel_waiter_monitor(entry)
+        {entry, %{state | waiting_by_ref: waiting_by_ref}}
+    end
+  end
+
+  defp cancel_waiter_monitor(entry) do
+    Process.demonitor(entry.monitor, [:flush])
+    Process.cancel_timer(entry.timer, async: true, info: false)
+  end
+
+  defp fence(%{status: :unavailable} = state), do: state
+
+  defp fence(state) do
+    Enum.each(state.waiting_by_ref, fn {_ref, entry} ->
+      cancel_waiter_monitor(entry)
+      release_ticket(state, entry.ticket)
+      GenServer.reply(entry.from, {:error, :provider_admission_unavailable})
+    end)
+
+    %{state | waiting: :queue.new(), waiting_by_ref: %{}, status: :unavailable}
+  end
+
+  defp active_by_monitor(active, monitor, owner) do
+    Enum.find_value(active, :error, fn
+      {lease_ref, %{monitor: ^monitor, owner: ^owner}} -> {:ok, lease_ref}
+      _ -> nil
+    end)
+  end
+
+  defp waiter_by_monitor(waiting, monitor, owner) do
+    Enum.find_value(waiting, :error, fn
+      {request_ref, %{monitor: ^monitor, owner: ^owner}} -> {:ok, request_ref}
+      _ -> nil
+    end)
+  end
+
+  @spec claim_ticket(atomics_ref(), pos_integer()) :: boolean()
+  defp claim_ticket(tickets, limit) do
+    current = :atomics.get(tickets, 1)
+
+    cond do
+      current >= limit -> false
+      :atomics.compare_exchange(tickets, 1, current, current + 1) == :ok -> true
+      true -> claim_ticket(tickets, limit)
+    end
+  end
+
+  @spec release_ticket(map(), term()) :: integer() | :ok
+  defp release_ticket(state, ticket), do: release_ticket_once(state.tickets, ticket)
+
+  @spec claim_completion(atomics_ref()) :: boolean()
+  defp claim_completion(completion),
+    do: :atomics.compare_exchange(completion, 1, 0, 1) == :ok
+
+  defp call(admission, token, request, ticket_witness) do
+    GenServer.call(admission, {token, request}, :infinity)
+  catch
+    :exit, _reason ->
+      case ticket_witness do
+        {tickets, ticket} -> release_ticket_once(tickets, ticket)
+        _ -> :ok
+      end
+
+      {:error, :provider_admission_unavailable}
+  end
+
+  @spec release_ticket_once(atomics_ref(), term()) :: integer() | :ok
+  defp release_ticket_once(tickets, ticket) do
+    Ticket.release(ticket, tickets)
+  end
+
+  @spec domain(t()) :: {:ok, reference(), atomics_ref(), pos_integer()} | :error
+  defp domain(admission) do
+    if Process.alive?(admission) do
+      case :persistent_term.get({__MODULE__, admission}, nil) do
+        {token, tickets, limit}
+        when is_reference(token) and is_integer(limit) and limit > 0 ->
+          {:ok, token, tickets, limit}
+
+        _ ->
+          :error
+      end
+    else
+      :error
+    end
+  end
+
+  defp lease_token(%Lease{admission: admission}) do
+    case domain(admission) do
+      {:ok, token, _tickets, _limit} -> token
+      _ -> make_ref()
+    end
+  end
+
+  defp now_ms, do: System.monotonic_time(:millisecond)
+
+  defp watch_persistent_handle(admission) do
+    spawn(fn ->
+      monitor = Process.monitor(admission)
+
+      receive do
+        {:DOWN, ^monitor, :process, ^admission, _reason} ->
+          :persistent_term.erase({__MODULE__, admission})
+      end
+    end)
+  end
+end

--- a/lib/ptc_runner/kernel/provider_call_admission.ex
+++ b/lib/ptc_runner/kernel/provider_call_admission.ex
@@ -102,6 +102,48 @@ defmodule PtcRunner.Kernel.ProviderCallAdmission do
   def checkout_for(_admission, _guardian, _deadline),
     do: {:error, :provider_admission_unavailable}
 
+  @doc false
+  def begin_checkout(admission, absolute_deadline_ms)
+      when is_pid(admission) and is_integer(absolute_deadline_ms) do
+    now = now_ms()
+
+    if absolute_deadline_ms <= now do
+      {:error, :provider_admission_timeout}
+    else
+      with {:ok, token, tickets, ticket_limit} <- domain(admission),
+           true <- claim_ticket(tickets, ticket_limit) do
+        ticket = Ticket.new()
+        request_ref = make_ref()
+
+        send(
+          admission,
+          {token, {:checkout_async, self(), absolute_deadline_ms, ticket, request_ref}}
+        )
+
+        {:ok, request_ref}
+      else
+        false -> {:error, :provider_capacity_exhausted}
+        _ -> {:error, :provider_admission_unavailable}
+      end
+    end
+  end
+
+  def begin_checkout(_admission, _deadline), do: {:error, :provider_admission_unavailable}
+
+  @doc false
+  def cancel_checkout(admission, request_ref)
+      when is_pid(admission) and is_reference(request_ref) do
+    case domain(admission) do
+      {:ok, token, _tickets, _limit} ->
+        send(admission, {token, {:cancel_checkout, self(), request_ref}})
+
+      :error ->
+        :ok
+    end
+
+    :ok
+  end
+
   @doc "Consumes a single-use lease on behalf of its bound guardian."
   @spec complete(Lease.t(), :completed | :cancelled | :uncertain) ::
           :ok
@@ -247,7 +289,7 @@ defmodule PtcRunner.Kernel.ProviderCallAdmission do
 
           _settled ->
             {state, replies} = promote(state)
-            Enum.each(replies, fn {from, reply} -> GenServer.reply(from, reply) end)
+            Enum.each(replies, fn {from, reply} -> reply_waiter(from, reply) end)
             {:reply, :ok, state}
         end
 
@@ -270,6 +312,34 @@ defmodule PtcRunner.Kernel.ProviderCallAdmission do
     do: {:reply, {:error, :provider_admission_unavailable}, state}
 
   @impl true
+  def handle_info(
+        {token, {:checkout_async, owner, deadline, ticket, request_ref}},
+        %{token: token} = state
+      ) do
+    {reply, state} = admit_async(owner, deadline, ticket, request_ref, state)
+    if reply, do: send(owner, {:provider_admission_checkout, request_ref, reply})
+    {:noreply, state}
+  end
+
+  def handle_info({token, {:cancel_checkout, owner, request_ref}}, %{token: token} = state) do
+    case state.waiting_by_ref[request_ref] do
+      %{owner: ^owner} = entry ->
+        {_entry, state} = pop_waiter(state, request_ref)
+        release_ticket(state, entry.ticket)
+
+        send(
+          owner,
+          {:provider_admission_checkout, request_ref, {:error, :provider_admission_timeout}}
+        )
+
+        {:noreply, state}
+
+      _ ->
+        {:noreply, state}
+    end
+  end
+
+  @impl true
   def handle_info({:expire, request_ref}, state) do
     case pop_waiter(state, request_ref) do
       {nil, state} ->
@@ -277,7 +347,7 @@ defmodule PtcRunner.Kernel.ProviderCallAdmission do
 
       {entry, state} ->
         release_ticket(state, entry.ticket)
-        GenServer.reply(entry.from, {:error, :provider_admission_timeout})
+        reply_waiter(entry.from, {:error, :provider_admission_timeout})
         {:noreply, state}
     end
   end
@@ -369,7 +439,13 @@ defmodule PtcRunner.Kernel.ProviderCallAdmission do
 
       {entry, waiting_by_ref} ->
         cancel_waiter_monitor(entry)
-        {entry, %{state | waiting_by_ref: waiting_by_ref}}
+
+        {entry,
+         %{
+           state
+           | waiting_by_ref: waiting_by_ref,
+             waiting: :queue.delete(request_ref, state.waiting)
+         }}
     end
   end
 
@@ -385,7 +461,7 @@ defmodule PtcRunner.Kernel.ProviderCallAdmission do
     Enum.each(state.waiting_by_ref, fn {_ref, entry} ->
       cancel_waiter_monitor(entry)
       release_ticket(state, entry.ticket)
-      GenServer.reply(entry.from, {:error, :provider_admission_unavailable})
+      reply_waiter(entry.from, {:error, :provider_admission_unavailable})
     end)
 
     %{state | waiting: :queue.new(), waiting_by_ref: %{}, status: :unavailable}
@@ -398,12 +474,59 @@ defmodule PtcRunner.Kernel.ProviderCallAdmission do
     end)
   end
 
+  defp reply_waiter({:async, owner, request_ref}, reply),
+    do: send(owner, {:provider_admission_checkout, request_ref, reply})
+
+  defp reply_waiter(from, reply), do: GenServer.reply(from, reply)
+
   defp waiter_by_monitor(waiting, monitor, owner) do
     Enum.find_value(waiting, :error, fn
       {request_ref, %{monitor: ^monitor, owner: ^owner}} -> {:ok, request_ref}
       {request_ref, %{caller_monitor: ^monitor}} -> {:ok, request_ref}
       _ -> nil
     end)
+  end
+
+  defp admit_async(owner, deadline, ticket, request_ref, state) do
+    cond do
+      state.status == :unavailable or not Process.alive?(owner) ->
+        release_ticket(state, ticket)
+        {{:error, :provider_admission_unavailable}, state}
+
+      deadline <= now_ms() ->
+        release_ticket(state, ticket)
+        {{:error, :provider_admission_timeout}, state}
+
+      map_size(state.active) < state.capacity and :queue.is_empty(state.waiting) ->
+        release_ticket(state, ticket)
+        {lease, state} = grant(owner, state)
+        {{:ok, lease}, state}
+
+      map_size(state.waiting_by_ref) >= state.max_waiters ->
+        release_ticket(state, ticket)
+        {{:error, :provider_capacity_exhausted}, state}
+
+      true ->
+        monitor = Process.monitor(owner)
+        timer = Process.send_after(self(), {:expire, request_ref}, max(deadline - now_ms(), 1))
+
+        entry = %{
+          from: {:async, owner, request_ref},
+          owner: owner,
+          monitor: monitor,
+          caller_monitor: monitor,
+          timer: timer,
+          deadline: deadline,
+          ticket: ticket
+        }
+
+        {nil,
+         %{
+           state
+           | waiting: :queue.in(request_ref, state.waiting),
+             waiting_by_ref: Map.put(state.waiting_by_ref, request_ref, entry)
+         }}
+    end
   end
 
   @spec claim_ticket(atomics_ref(), pos_integer()) :: boolean()

--- a/lib/ptc_runner/kernel/provider_call_admission.ex
+++ b/lib/ptc_runner/kernel/provider_call_admission.ex
@@ -164,7 +164,7 @@ defmodule PtcRunner.Kernel.ProviderCallAdmission do
         call(admission, lease_token(lease), {:fault, :duplicate_completion}, nil)
 
       true ->
-        call(admission, lease_token(lease), {:complete, lease.reference, status}, nil)
+        complete_call(admission, lease_token(lease), lease.reference, status)
     end
   end
 
@@ -280,17 +280,16 @@ defmodule PtcRunner.Kernel.ProviderCallAdmission do
         {:reply, {:error, :provider_admission_unavailable}, state}
 
       %{owner: ^owner} = active when state.status == :ready ->
-        Process.demonitor(active.monitor, [:flush])
-        state = %{state | active: Map.delete(state.active, lease_ref)}
-
         case status do
           :uncertain ->
+            Process.demonitor(active.monitor, [:flush])
+            state = %{state | active: Map.delete(state.active, lease_ref)}
             {:reply, {:error, :provider_cleanup_failed}, fence(state)}
 
           _settled ->
-            {state, replies} = promote(state)
-            Enum.each(replies, fn {from, reply} -> reply_waiter(from, reply) end)
-            {:reply, :ok, state}
+            receipt = make_ref()
+            active = Map.put(active, :completion_receipt, receipt)
+            {:reply, {:completion_ack, receipt}, put_in(state.active[lease_ref], active)}
         end
 
       %{owner: _other} ->
@@ -307,6 +306,24 @@ defmodule PtcRunner.Kernel.ProviderCallAdmission do
   def handle_call({token, {:fault, fault}}, _from, %{token: token} = state)
       when fault in [:duplicate_completion, :invalid_lease, :not_lease_owner],
       do: {:reply, {:error, fault}, fence(state)}
+
+  def handle_call(
+        {token, {:completion_received, owner, lease_ref, receipt}},
+        {owner, _},
+        %{token: token} = state
+      ) do
+    case state.active[lease_ref] do
+      %{owner: ^owner, completion_receipt: ^receipt} = active when state.status == :ready ->
+        Process.demonitor(active.monitor, [:flush])
+        state = %{state | active: Map.delete(state.active, lease_ref)}
+        {state, replies} = promote(state)
+        Enum.each(replies, fn {from, reply} -> reply_waiter(from, reply) end)
+        {:reply, :ok, state}
+
+      _ ->
+        {:reply, {:error, :provider_admission_unavailable}, fence(state)}
+    end
+  end
 
   def handle_call(_request, _from, state),
     do: {:reply, {:error, :provider_admission_unavailable}, state}
@@ -339,7 +356,6 @@ defmodule PtcRunner.Kernel.ProviderCallAdmission do
     end
   end
 
-  @impl true
   def handle_info({:expire, request_ref}, state) do
     case pop_waiter(state, request_ref) do
       {nil, state} ->
@@ -557,6 +573,21 @@ defmodule PtcRunner.Kernel.ProviderCallAdmission do
       end
 
       {:error, :provider_admission_unavailable}
+  end
+
+  defp complete_call(admission, token, lease_ref, status) do
+    case call(admission, token, {:complete, lease_ref, status}, nil) do
+      {:completion_ack, receipt} ->
+        call(
+          admission,
+          token,
+          {:completion_received, self(), lease_ref, receipt},
+          nil
+        )
+
+      result ->
+        result
+    end
   end
 
   @spec release_ticket_once(atomics_ref(), term()) :: integer() | :ok

--- a/lib/ptc_runner/kernel/provider_call_admission/lease.ex
+++ b/lib/ptc_runner/kernel/provider_call_admission/lease.ex
@@ -1,0 +1,21 @@
+defmodule PtcRunner.Kernel.ProviderCallAdmission.Lease do
+  @moduledoc """
+  Opaque single-use lease granted to one provider-call guardian.
+
+  Lease values are created and consumed only by
+  `PtcRunner.Kernel.ProviderCallAdmission`; callers must not inspect or alter
+  their representation.
+  """
+
+  alias PtcRunner.Kernel.ProviderCallAdmission
+
+  @enforce_keys [:admission, :reference, :owner, :completion]
+  defstruct @enforce_keys
+
+  @opaque t :: %__MODULE__{
+            admission: ProviderCallAdmission.t(),
+            reference: reference(),
+            owner: pid(),
+            completion: :atomics.atomics_ref()
+          }
+end

--- a/lib/ptc_runner/kernel/provider_call_admission/ticket.ex
+++ b/lib/ptc_runner/kernel/provider_call_admission/ticket.ex
@@ -1,0 +1,20 @@
+defmodule PtcRunner.Kernel.ProviderCallAdmission.Ticket do
+  @moduledoc false
+
+  @enforce_keys [:counter]
+  defstruct @enforce_keys
+
+  @opaque t :: %__MODULE__{counter: :atomics.atomics_ref()}
+
+  @spec new() :: t()
+  def new, do: %__MODULE__{counter: :atomics.new(1, signed: false)}
+
+  @spec release(term(), :atomics.atomics_ref()) :: integer() | :ok
+  def release(%__MODULE__{counter: counter}, pending) do
+    if :atomics.compare_exchange(counter, 1, 0, 1) == :ok,
+      do: :atomics.sub_get(pending, 1, 1),
+      else: :ok
+  end
+
+  def release(_ticket, _pending), do: :ok
+end

--- a/lib/ptc_runner/kernel/provider_call_owner.ex
+++ b/lib/ptc_runner/kernel/provider_call_owner.ex
@@ -4,6 +4,7 @@ defmodule PtcRunner.Kernel.ProviderCallOwner do
   alias PtcRunner.Kernel.CancelableRequest
   alias PtcRunner.Kernel.ProviderCallAdmission
   alias PtcRunner.Kernel.ProviderError
+  alias PtcRunner.Kernel.RunState
 
   @capacity_text "LLM provider call capacity exhausted"
   @unavailable_text "LLM provider admission unavailable"
@@ -17,7 +18,9 @@ defmodule PtcRunner.Kernel.ProviderCallOwner do
     admission_monitor = monitor_admission(admission)
 
     try do
-      case CancelableRequest.start_cancelable(requester, request, context, self()) do
+      requester_context = Map.take(context, [:llm_request_deadline_ms])
+
+      case CancelableRequest.start_cancelable(requester, request, requester_context, self()) do
         {:ok, handle} ->
           checkout(admission, handle, deadline, context, admission_monitor)
 
@@ -40,14 +43,84 @@ defmodule PtcRunner.Kernel.ProviderCallOwner do
           reference()
         ) :: {:ok, map()} | {:error, ProviderError.t()}
   defp checkout(admission, handle, deadline, context, admission_monitor) do
-    case ProviderCallAdmission.checkout(admission, deadline) do
-      {:ok, lease} ->
+    guardian = self()
+
+    {checkout_pid, checkout_monitor} =
+      spawn_monitor(fn ->
+        result = ProviderCallAdmission.checkout_for(admission, guardian, deadline)
+        send(guardian, {:provider_admission_checkout, self(), result})
+      end)
+
+    await_checkout(
+      admission,
+      handle,
+      deadline,
+      context,
+      admission_monitor,
+      checkout_pid,
+      checkout_monitor
+    )
+  end
+
+  defp await_checkout(
+         admission,
+         handle,
+         deadline,
+         context,
+         admission_monitor,
+         checkout_pid,
+         checkout_monitor
+       ) do
+    timeout = max(deadline - System.monotonic_time(:millisecond), 0)
+
+    receive do
+      {:provider_admission_checkout, ^checkout_pid, {:ok, lease}} ->
+        Process.demonitor(checkout_monitor, [:flush])
         granted(admission, lease, handle, deadline, context, admission_monitor)
 
-      {:error, reason} ->
-        _ = CancelableRequest.cancel_and_drain(handle, deadline)
+      {:provider_admission_checkout, ^checkout_pid, {:error, reason}} ->
+        Process.demonitor(checkout_monitor, [:flush])
+        _ = CancelableRequest.cancel_and_drain(handle, cleanup_deadline(context))
         checkout_refusal(reason)
+
+      {:cancel_provider_call, tracker, request_ref, cleanup_deadline}
+      when is_pid(tracker) and is_reference(request_ref) and is_integer(cleanup_deadline) ->
+        Process.exit(checkout_pid, :kill)
+        await_checkout_down(checkout_pid, checkout_monitor)
+        drained = CancelableRequest.cancel_and_drain(handle, cleanup_deadline)
+        send(tracker, {:provider_call_drained, request_ref, self(), drained})
+        checkout_cancelled(drained, context)
+
+      {:DOWN, ^admission_monitor, :process, _admission, _reason} ->
+        Process.exit(checkout_pid, :kill)
+        await_checkout_down(checkout_pid, checkout_monitor)
+        _ = CancelableRequest.cancel_and_drain(handle, cleanup_deadline(context))
+        checkout_refusal(:provider_admission_unavailable)
+
+      {:DOWN, ^checkout_monitor, :process, ^checkout_pid, _reason} ->
+        _ = CancelableRequest.cancel_and_drain(handle, cleanup_deadline(context))
+        checkout_refusal(:provider_admission_unavailable)
+    after
+      timeout ->
+        Process.exit(checkout_pid, :kill)
+        await_checkout_down(checkout_pid, checkout_monitor)
+        _ = CancelableRequest.cancel_and_drain(handle, cleanup_deadline(context))
+        checkout_refusal(:provider_admission_timeout)
     end
+  end
+
+  defp await_checkout_down(pid, monitor) do
+    receive do
+      {:DOWN, ^monitor, :process, ^pid, _reason} -> :ok
+    end
+  end
+
+  defp checkout_cancelled(:drained, _context),
+    do: refusal(:timeout, "LLM request cancelled", true)
+
+  defp checkout_cancelled(:uncertain, context) do
+    mark_cleanup_failed(context)
+    cleanup_failed()
   end
 
   defp checkout_refusal(:provider_capacity_exhausted),
@@ -61,23 +134,23 @@ defmodule PtcRunner.Kernel.ProviderCallOwner do
 
   defp granted(_admission, lease, handle, deadline, context, admission_monitor) do
     if deadline <= System.monotonic_time(:millisecond) do
-      complete_unused(lease, handle, deadline)
+      complete_unused(lease, handle, cleanup_deadline(context), context)
     else
       :ok = CancelableRequest.dispatch(handle)
 
       case CancelableRequest.await_or_cancel(handle, deadline, admission_monitor) do
-        {:ok, result} -> publish_after_completion(lease, result)
-        {:error, :timeout} -> cancel(lease, handle, cleanup_deadline(context))
-        {:error, :cancellation_witness_unavailable} -> uncertain(lease)
+        {:ok, result} -> publish_after_completion(lease, result, context)
+        {:error, :timeout} -> cancel(lease, handle, cleanup_deadline(context), context)
+        {:error, :cancellation_witness_unavailable} -> uncertain(lease, context)
         {:error, :provider_admission_unavailable} -> cleanup_failed()
         {:cancelled, :drained} -> complete_cancelled(lease)
-        {:cancelled, :uncertain} -> uncertain(lease)
+        {:cancelled, :uncertain} -> uncertain(lease, context)
       end
     end
   end
 
-  defp complete_unused(lease, handle, deadline) do
-    case CancelableRequest.cancel_and_drain(handle, deadline) do
+  defp complete_unused(lease, handle, cleanup_deadline, context) do
+    case CancelableRequest.cancel_and_drain(handle, cleanup_deadline) do
       :drained ->
         case ProviderCallAdmission.complete(lease, :cancelled) do
           :ok -> refusal(:timeout, @timeout_text, true)
@@ -85,18 +158,22 @@ defmodule PtcRunner.Kernel.ProviderCallOwner do
         end
 
       :uncertain ->
-        uncertain(lease)
+        uncertain(lease, context)
     end
   end
 
-  defp publish_after_completion(lease, result) do
+  defp publish_after_completion(lease, result, context) do
     case ProviderCallAdmission.complete(lease, :completed) do
-      :ok -> result
-      _ -> cleanup_failed()
+      :ok ->
+        result
+
+      _ ->
+        mark_cleanup_failed(context)
+        cleanup_failed()
     end
   end
 
-  defp cancel(lease, handle, cleanup_deadline) do
+  defp cancel(lease, handle, cleanup_deadline, context) do
     case CancelableRequest.cancel_and_drain(handle, cleanup_deadline) do
       :drained ->
         case ProviderCallAdmission.complete(lease, :cancelled) do
@@ -112,14 +189,28 @@ defmodule PtcRunner.Kernel.ProviderCallOwner do
         end
 
       :uncertain ->
-        uncertain(lease)
+        uncertain(lease, context)
     end
   end
 
-  defp uncertain(lease) do
+  defp uncertain(lease, context) do
     _ = ProviderCallAdmission.complete(lease, :uncertain)
+    mark_cleanup_failed(context)
     cleanup_failed()
   end
+
+  defp mark_cleanup_failed(%{provider_run_state: run_state}) do
+    _ =
+      RunState.fail_once(
+        run_state,
+        :provider_cleanup_error,
+        :provider_cleanup_failed
+      )
+
+    :ok
+  end
+
+  defp mark_cleanup_failed(_context), do: :ok
 
   defp complete_cancelled(lease) do
     case ProviderCallAdmission.complete(lease, :cancelled) do

--- a/lib/ptc_runner/kernel/provider_call_owner.ex
+++ b/lib/ptc_runner/kernel/provider_call_owner.ex
@@ -171,7 +171,7 @@ defmodule PtcRunner.Kernel.ProviderCallOwner do
              handle,
              deadline,
              admission_monitor,
-             cleanup_deadline(context)
+             cleanup_timeout(context)
            ) do
         {:ok, result} ->
           publish_after_completion(lease, result, context)
@@ -283,6 +283,12 @@ defmodule PtcRunner.Kernel.ProviderCallOwner do
        do: System.monotonic_time(:millisecond) + timeout_ms
 
   defp cleanup_deadline(_context), do: System.monotonic_time(:millisecond) + 5_000
+
+  defp cleanup_timeout(%{provider_cleanup_timeout_ms: timeout_ms})
+       when is_integer(timeout_ms) and timeout_ms > 0,
+       do: timeout_ms
+
+  defp cleanup_timeout(_context), do: 5_000
 
   defp cleanup_failed,
     do:

--- a/lib/ptc_runner/kernel/provider_call_owner.ex
+++ b/lib/ptc_runner/kernel/provider_call_owner.ex
@@ -43,23 +43,14 @@ defmodule PtcRunner.Kernel.ProviderCallOwner do
           reference()
         ) :: {:ok, map()} | {:error, ProviderError.t()}
   defp checkout(admission, handle, deadline, context, admission_monitor) do
-    guardian = self()
+    case ProviderCallAdmission.begin_checkout(admission, deadline) do
+      {:ok, request_ref} ->
+        await_checkout(admission, handle, deadline, context, admission_monitor, request_ref)
 
-    {checkout_pid, checkout_monitor} =
-      spawn_monitor(fn ->
-        result = ProviderCallAdmission.checkout_for(admission, guardian, deadline)
-        send(guardian, {:provider_admission_checkout, self(), result})
-      end)
-
-    await_checkout(
-      admission,
-      handle,
-      deadline,
-      context,
-      admission_monitor,
-      checkout_pid,
-      checkout_monitor
-    )
+      {:error, reason} ->
+        _ = CancelableRequest.cancel_and_drain(handle, cleanup_deadline(context))
+        checkout_refusal(reason)
+    end
   end
 
   defp await_checkout(
@@ -68,50 +59,88 @@ defmodule PtcRunner.Kernel.ProviderCallOwner do
          deadline,
          context,
          admission_monitor,
-         checkout_pid,
-         checkout_monitor
+         request_ref
        ) do
     timeout = max(deadline - System.monotonic_time(:millisecond), 0)
 
     receive do
-      {:provider_admission_checkout, ^checkout_pid, {:ok, lease}} ->
-        Process.demonitor(checkout_monitor, [:flush])
+      {:provider_admission_checkout, ^request_ref, {:ok, lease}} ->
         granted(admission, lease, handle, deadline, context, admission_monitor)
 
-      {:provider_admission_checkout, ^checkout_pid, {:error, reason}} ->
-        Process.demonitor(checkout_monitor, [:flush])
+      {:provider_admission_checkout, ^request_ref, {:error, reason}} ->
         _ = CancelableRequest.cancel_and_drain(handle, cleanup_deadline(context))
         checkout_refusal(reason)
 
-      {:cancel_provider_call, tracker, request_ref, cleanup_deadline}
-      when is_pid(tracker) and is_reference(request_ref) and is_integer(cleanup_deadline) ->
-        Process.exit(checkout_pid, :kill)
-        await_checkout_down(checkout_pid, checkout_monitor)
-        drained = CancelableRequest.cancel_and_drain(handle, cleanup_deadline)
-        send(tracker, {:provider_call_drained, request_ref, self(), drained})
+      {:cancel_provider_call, tracker, cancel_ref, cleanup_deadline}
+      when is_pid(tracker) and is_reference(cancel_ref) and is_integer(cleanup_deadline) ->
+        ProviderCallAdmission.cancel_checkout(admission, request_ref)
+        result = await_cancelled_checkout(request_ref, admission_monitor, cleanup_deadline)
+        drained = settle_cancelled_checkout(result, handle, cleanup_deadline, context)
+        send(tracker, {:provider_call_drained, cancel_ref, self(), drained})
         checkout_cancelled(drained, context)
 
       {:DOWN, ^admission_monitor, :process, _admission, _reason} ->
-        Process.exit(checkout_pid, :kill)
-        await_checkout_down(checkout_pid, checkout_monitor)
-        _ = CancelableRequest.cancel_and_drain(handle, cleanup_deadline(context))
-        checkout_refusal(:provider_admission_unavailable)
-
-      {:DOWN, ^checkout_monitor, :process, ^checkout_pid, _reason} ->
         _ = CancelableRequest.cancel_and_drain(handle, cleanup_deadline(context))
         checkout_refusal(:provider_admission_unavailable)
     after
       timeout ->
-        Process.exit(checkout_pid, :kill)
-        await_checkout_down(checkout_pid, checkout_monitor)
-        _ = CancelableRequest.cancel_and_drain(handle, cleanup_deadline(context))
-        checkout_refusal(:provider_admission_timeout)
+        cleanup_deadline = cleanup_deadline(context)
+        ProviderCallAdmission.cancel_checkout(admission, request_ref)
+        result = await_cancelled_checkout(request_ref, admission_monitor, cleanup_deadline)
+        drained = settle_cancelled_checkout(result, handle, cleanup_deadline, context)
+
+        if drained == :drained,
+          do: checkout_refusal(:provider_admission_timeout),
+          else: cleanup_failed()
     end
   end
 
-  defp await_checkout_down(pid, monitor) do
+  defp await_cancelled_checkout(request_ref, admission_monitor, deadline) do
+    timeout = max(deadline - System.monotonic_time(:millisecond), 0)
+
     receive do
-      {:DOWN, ^monitor, :process, ^pid, _reason} -> :ok
+      {:provider_admission_checkout, ^request_ref, result} ->
+        result
+
+      {:DOWN, ^admission_monitor, :process, _pid, _reason} ->
+        {:error, :provider_admission_unavailable}
+    after
+      timeout -> {:error, :provider_admission_unavailable}
+    end
+  end
+
+  defp settle_cancelled_checkout({:ok, lease}, handle, deadline, context),
+    do: complete_unused_for_drain(lease, handle, deadline, context)
+
+  defp settle_cancelled_checkout(
+         {:error, :provider_admission_unavailable},
+         handle,
+         deadline,
+         context
+       ) do
+    _ = CancelableRequest.cancel_and_drain(handle, deadline)
+    mark_cleanup_failed(context)
+    :uncertain
+  end
+
+  defp settle_cancelled_checkout({:error, _reason}, handle, deadline, _context),
+    do: CancelableRequest.cancel_and_drain(handle, deadline)
+
+  defp complete_unused_for_drain(lease, handle, deadline, context) do
+    case CancelableRequest.cancel_and_drain(handle, deadline) do
+      :drained ->
+        case ProviderCallAdmission.complete(lease, :cancelled) do
+          :ok ->
+            :drained
+
+          _ ->
+            mark_cleanup_failed(context)
+            :uncertain
+        end
+
+      :uncertain ->
+        uncertain(lease, context)
+        :uncertain
     end
   end
 
@@ -139,12 +168,24 @@ defmodule PtcRunner.Kernel.ProviderCallOwner do
       :ok = CancelableRequest.dispatch(handle)
 
       case CancelableRequest.await_or_cancel(handle, deadline, admission_monitor) do
-        {:ok, result} -> publish_after_completion(lease, result, context)
-        {:error, :timeout} -> cancel(lease, handle, cleanup_deadline(context), context)
-        {:error, :cancellation_witness_unavailable} -> uncertain(lease, context)
-        {:error, :provider_admission_unavailable} -> cleanup_failed()
-        {:cancelled, :drained} -> complete_cancelled(lease)
-        {:cancelled, :uncertain} -> uncertain(lease, context)
+        {:ok, result} ->
+          publish_after_completion(lease, result, context)
+
+        {:error, :timeout} ->
+          cancel(lease, handle, cleanup_deadline(context), context)
+
+        {:error, :cancellation_witness_unavailable} ->
+          uncertain(lease, context)
+
+        {:error, :provider_admission_unavailable} ->
+          mark_cleanup_failed(context)
+          cleanup_failed()
+
+        {:cancelled, :drained} ->
+          complete_cancelled(lease, context)
+
+        {:cancelled, :uncertain} ->
+          uncertain(lease, context)
       end
     end
   end
@@ -153,8 +194,12 @@ defmodule PtcRunner.Kernel.ProviderCallOwner do
     case CancelableRequest.cancel_and_drain(handle, cleanup_deadline) do
       :drained ->
         case ProviderCallAdmission.complete(lease, :cancelled) do
-          :ok -> refusal(:timeout, @timeout_text, true)
-          _ -> cleanup_failed()
+          :ok ->
+            refusal(:timeout, @timeout_text, true)
+
+          _ ->
+            mark_cleanup_failed(context)
+            cleanup_failed()
         end
 
       :uncertain ->
@@ -185,6 +230,7 @@ defmodule PtcRunner.Kernel.ProviderCallOwner do
              )}
 
           _ ->
+            mark_cleanup_failed(context)
             cleanup_failed()
         end
 
@@ -212,7 +258,7 @@ defmodule PtcRunner.Kernel.ProviderCallOwner do
 
   defp mark_cleanup_failed(_context), do: :ok
 
-  defp complete_cancelled(lease) do
+  defp complete_cancelled(lease, context) do
     case ProviderCallAdmission.complete(lease, :cancelled) do
       :ok ->
         {:error,
@@ -222,6 +268,7 @@ defmodule PtcRunner.Kernel.ProviderCallOwner do
          )}
 
       _ ->
+        mark_cleanup_failed(context)
         cleanup_failed()
     end
   end

--- a/lib/ptc_runner/kernel/provider_call_owner.ex
+++ b/lib/ptc_runner/kernel/provider_call_owner.ex
@@ -1,0 +1,161 @@
+defmodule PtcRunner.Kernel.ProviderCallOwner do
+  @moduledoc false
+
+  alias PtcRunner.Kernel.CancelableRequest
+  alias PtcRunner.Kernel.ProviderCallAdmission
+  alias PtcRunner.Kernel.ProviderError
+
+  @capacity_text "LLM provider call capacity exhausted"
+  @unavailable_text "LLM provider admission unavailable"
+  @timeout_text "LLM provider admission deadline elapsed"
+
+  @spec run(ProviderCallAdmission.t(), function(), map(), map()) ::
+          {:ok, map()} | {:error, ProviderError.t()}
+  def run(admission, requester, request, %{llm_request_deadline_ms: deadline} = context)
+      when is_function(requester, 2) and is_map(request) and
+             is_integer(deadline) do
+    admission_monitor = monitor_admission(admission)
+
+    try do
+      case CancelableRequest.start_cancelable(requester, request, context, self()) do
+        {:ok, handle} ->
+          checkout(admission, handle, deadline, context, admission_monitor)
+
+        {:error, :cancellation_witness_unavailable} ->
+          refusal(:admission_unavailable, @unavailable_text, false)
+      end
+    after
+      Process.demonitor(admission_monitor, [:flush])
+    end
+  end
+
+  def run(_admission, _requester, _request, _context),
+    do: refusal(:admission_unavailable, @unavailable_text, false)
+
+  @spec checkout(
+          ProviderCallAdmission.t(),
+          CancelableRequest.t(),
+          integer(),
+          map(),
+          reference()
+        ) :: {:ok, map()} | {:error, ProviderError.t()}
+  defp checkout(admission, handle, deadline, context, admission_monitor) do
+    case ProviderCallAdmission.checkout(admission, deadline) do
+      {:ok, lease} ->
+        granted(admission, lease, handle, deadline, context, admission_monitor)
+
+      {:error, reason} ->
+        _ = CancelableRequest.cancel_and_drain(handle, deadline)
+        checkout_refusal(reason)
+    end
+  end
+
+  defp checkout_refusal(:provider_capacity_exhausted),
+    do: refusal(:capacity_exhausted, @capacity_text, true)
+
+  defp checkout_refusal(:provider_admission_timeout),
+    do: refusal(:timeout, @timeout_text, true)
+
+  defp checkout_refusal(:provider_admission_unavailable),
+    do: refusal(:admission_unavailable, @unavailable_text, false)
+
+  defp granted(_admission, lease, handle, deadline, context, admission_monitor) do
+    if deadline <= System.monotonic_time(:millisecond) do
+      complete_unused(lease, handle, deadline)
+    else
+      :ok = CancelableRequest.dispatch(handle)
+
+      case CancelableRequest.await_or_cancel(handle, deadline, admission_monitor) do
+        {:ok, result} -> publish_after_completion(lease, result)
+        {:error, :timeout} -> cancel(lease, handle, cleanup_deadline(context))
+        {:error, :cancellation_witness_unavailable} -> uncertain(lease)
+        {:error, :provider_admission_unavailable} -> cleanup_failed()
+        {:cancelled, :drained} -> complete_cancelled(lease)
+        {:cancelled, :uncertain} -> uncertain(lease)
+      end
+    end
+  end
+
+  defp complete_unused(lease, handle, deadline) do
+    case CancelableRequest.cancel_and_drain(handle, deadline) do
+      :drained ->
+        case ProviderCallAdmission.complete(lease, :cancelled) do
+          :ok -> refusal(:timeout, @timeout_text, true)
+          _ -> cleanup_failed()
+        end
+
+      :uncertain ->
+        uncertain(lease)
+    end
+  end
+
+  defp publish_after_completion(lease, result) do
+    case ProviderCallAdmission.complete(lease, :completed) do
+      :ok -> result
+      _ -> cleanup_failed()
+    end
+  end
+
+  defp cancel(lease, handle, cleanup_deadline) do
+    case CancelableRequest.cancel_and_drain(handle, cleanup_deadline) do
+      :drained ->
+        case ProviderCallAdmission.complete(lease, :cancelled) do
+          :ok ->
+            {:error,
+             ProviderError.new(:timeout, "LLM request deadline elapsed",
+               retryable?: true,
+               dispatch_provenance: :possibly_dispatched
+             )}
+
+          _ ->
+            cleanup_failed()
+        end
+
+      :uncertain ->
+        uncertain(lease)
+    end
+  end
+
+  defp uncertain(lease) do
+    _ = ProviderCallAdmission.complete(lease, :uncertain)
+    cleanup_failed()
+  end
+
+  defp complete_cancelled(lease) do
+    case ProviderCallAdmission.complete(lease, :cancelled) do
+      :ok ->
+        {:error,
+         ProviderError.new(:timeout, "LLM request cancelled",
+           retryable?: true,
+           dispatch_provenance: :possibly_dispatched
+         )}
+
+      _ ->
+        cleanup_failed()
+    end
+  end
+
+  defp cleanup_deadline(%{provider_cleanup_timeout_ms: timeout_ms})
+       when is_integer(timeout_ms) and timeout_ms > 0,
+       do: System.monotonic_time(:millisecond) + timeout_ms
+
+  defp cleanup_deadline(_context), do: System.monotonic_time(:millisecond) + 5_000
+
+  defp cleanup_failed,
+    do:
+      {:error,
+       ProviderError.new(:admission_unavailable, @unavailable_text,
+         dispatch_provenance: :possibly_dispatched
+       )}
+
+  defp refusal(kind, text, retryable?) do
+    {:error,
+     ProviderError.new(kind, text,
+       retryable?: retryable?,
+       dispatch_provenance: :not_dispatched
+     )}
+  end
+
+  @spec monitor_admission(ProviderCallAdmission.t()) :: reference()
+  defp monitor_admission(admission), do: Process.monitor(admission)
+end

--- a/lib/ptc_runner/kernel/provider_call_owner.ex
+++ b/lib/ptc_runner/kernel/provider_call_owner.ex
@@ -167,7 +167,12 @@ defmodule PtcRunner.Kernel.ProviderCallOwner do
     else
       :ok = CancelableRequest.dispatch(handle)
 
-      case CancelableRequest.await_or_cancel(handle, deadline, admission_monitor) do
+      case CancelableRequest.await_or_cancel(
+             handle,
+             deadline,
+             admission_monitor,
+             cleanup_deadline(context)
+           ) do
         {:ok, result} ->
           publish_after_completion(lease, result, context)
 
@@ -210,7 +215,7 @@ defmodule PtcRunner.Kernel.ProviderCallOwner do
   defp publish_after_completion(lease, result, context) do
     case ProviderCallAdmission.complete(lease, :completed) do
       :ok ->
-        result
+        restore_requester_result(result)
 
       _ ->
         mark_cleanup_failed(context)
@@ -285,6 +290,14 @@ defmodule PtcRunner.Kernel.ProviderCallOwner do
        ProviderError.new(:admission_unavailable, @unavailable_text,
          dispatch_provenance: :possibly_dispatched
        )}
+
+  defp restore_requester_result({CancelableRequest, :raised, exception, stacktrace}),
+    do: reraise(exception, stacktrace)
+
+  defp restore_requester_result({CancelableRequest, :caught, kind, reason}),
+    do: :erlang.raise(kind, reason, [])
+
+  defp restore_requester_result(result), do: result
 
   defp refusal(kind, text, retryable?) do
     {:error,

--- a/lib/ptc_runner/kernel/provider_runtime_services.ex
+++ b/lib/ptc_runner/kernel/provider_runtime_services.ex
@@ -315,9 +315,23 @@ defmodule PtcRunner.Kernel.ProviderRuntimeServices do
     do: {:error, :invalid_provider_runtime_services}
 
   @doc false
-  @spec provider_call_admission(t()) :: ProviderCallAdmission.t() | nil
+  @spec provider_call_admission(t()) ::
+          {:ok, ProviderCallAdmission.t() | nil}
+          | {:error, :provider_admission_unavailable | :invalid_provider_runtime_services}
   def provider_call_admission(%__MODULE__{} = services) do
-    if valid?(services), do: services.provider_call_admission, else: nil
+    cond do
+      not sealed_fields_valid?(services) ->
+        {:error, :invalid_provider_runtime_services}
+
+      is_nil(services.provider_call_admission) ->
+        {:ok, nil}
+
+      ProviderCallAdmission.valid?(services.provider_call_admission) ->
+        {:ok, services.provider_call_admission}
+
+      true ->
+        {:error, :provider_admission_unavailable}
+    end
   end
 
   defp unique_allowed_options?(opts) do
@@ -375,6 +389,16 @@ defmodule PtcRunner.Kernel.ProviderRuntimeServices do
         valid_oauth_mode?(services.oauth_mode) and
         valid_provider_call_admission?(services.provider_call_admission) and
         valid_runtime_binding?(services.runtime_binding, services.host_payload)
+
+  defp sealed_fields_valid?(%__MODULE__{attestation: attestation} = services),
+    do:
+      Enum.sort(Map.keys(services)) == @field_keys and
+        is_function(services.activation, 0) and
+        is_function(services.credential_resolver, 1) and
+        services.provider_application_mode in [:host_owned, :command_vm] and
+        valid_oauth_mode?(services.oauth_mode) and
+        valid_runtime_binding?(services.runtime_binding, services.host_payload) and
+        Attestation.valid?(__MODULE__, payload(services), attestation)
 
   defp valid_provider_call_admission?(nil), do: true
   defp valid_provider_call_admission?(admission), do: ProviderCallAdmission.valid?(admission)

--- a/lib/ptc_runner/kernel/provider_runtime_services.ex
+++ b/lib/ptc_runner/kernel/provider_runtime_services.ex
@@ -22,6 +22,7 @@ defmodule PtcRunner.Kernel.ProviderRuntimeServices do
   alias PtcRunner.Kernel.HostInstallationAuthority
   alias PtcRunner.Kernel.HostRuntimePayload
   alias PtcRunner.Kernel.MCPOAuth.Context, as: OAuthContext
+  alias PtcRunner.Kernel.ProviderCallAdmission
 
   @enforce_keys [
     :activation,
@@ -29,7 +30,8 @@ defmodule PtcRunner.Kernel.ProviderRuntimeServices do
     :provider_application_mode,
     :oauth_mode,
     :runtime_binding,
-    :host_payload
+    :host_payload,
+    :provider_call_admission
   ]
   defstruct @enforce_keys ++ [attestation: nil]
   @context_heap_words 100_000
@@ -48,6 +50,7 @@ defmodule PtcRunner.Kernel.ProviderRuntimeServices do
           oauth_mode: oauth_mode(),
           runtime_binding: binary() | nil,
           host_payload: struct() | nil,
+          provider_call_admission: ProviderCallAdmission.t() | nil,
           attestation: binary() | nil
         }
 
@@ -62,6 +65,7 @@ defmodule PtcRunner.Kernel.ProviderRuntimeServices do
         Keyword.get(opts, :credential_resolver, &default_credential_resolver/1),
         Keyword.get(opts, :provider_application_mode, :host_owned),
         Keyword.get(opts, :oauth_mode, :disabled),
+        Keyword.get(opts, :provider_call_admission),
         nil,
         nil
       )
@@ -86,6 +90,7 @@ defmodule PtcRunner.Kernel.ProviderRuntimeServices do
             fn names -> HostRuntimePayload.resolve_credentials(payload, names) end,
             Keyword.get(opts, :provider_application_mode, :host_owned),
             Keyword.get(opts, :oauth_mode, :disabled),
+            Keyword.get(opts, :provider_call_admission),
             binding,
             payload
           )
@@ -279,6 +284,7 @@ defmodule PtcRunner.Kernel.ProviderRuntimeServices do
            ^deadline -> {:ok, context}
            _other -> {:error, :authorization_context_required}
          end},
+        services.provider_call_admission,
         services.runtime_binding,
         services.host_payload
       )
@@ -308,17 +314,30 @@ defmodule PtcRunner.Kernel.ProviderRuntimeServices do
   def oauth_authorities(_services, _selected_names),
     do: {:error, :invalid_provider_runtime_services}
 
+  @doc false
+  @spec provider_call_admission(t()) :: ProviderCallAdmission.t() | nil
+  def provider_call_admission(%__MODULE__{} = services) do
+    if valid?(services), do: services.provider_call_admission, else: nil
+  end
+
   defp unique_allowed_options?(opts) do
     keys = Keyword.keys(opts)
 
-    keys -- [:activation, :credential_resolver, :provider_application_mode, :oauth_mode] == [] and
+    keys --
+      [
+        :activation,
+        :credential_resolver,
+        :provider_application_mode,
+        :oauth_mode,
+        :provider_call_admission
+      ] == [] and
       length(keys) == MapSet.size(MapSet.new(keys))
   end
 
   defp unique_oauth_options?(opts) do
     keys = Keyword.keys(opts)
 
-    keys -- [:provider_application_mode, :oauth_mode] == [] and
+    keys -- [:provider_application_mode, :oauth_mode, :provider_call_admission] == [] and
       length(keys) == MapSet.size(MapSet.new(keys))
   end
 
@@ -327,6 +346,7 @@ defmodule PtcRunner.Kernel.ProviderRuntimeServices do
          credential_resolver,
          provider_application_mode,
          oauth_mode,
+         provider_call_admission,
          runtime_binding,
          host_payload
        ) do
@@ -335,6 +355,7 @@ defmodule PtcRunner.Kernel.ProviderRuntimeServices do
       credential_resolver: credential_resolver,
       provider_application_mode: provider_application_mode,
       oauth_mode: oauth_mode,
+      provider_call_admission: provider_call_admission,
       runtime_binding: runtime_binding,
       host_payload: host_payload
     }
@@ -352,7 +373,11 @@ defmodule PtcRunner.Kernel.ProviderRuntimeServices do
         is_function(services.credential_resolver, 1) and
         services.provider_application_mode in [:host_owned, :command_vm] and
         valid_oauth_mode?(services.oauth_mode) and
+        valid_provider_call_admission?(services.provider_call_admission) and
         valid_runtime_binding?(services.runtime_binding, services.host_payload)
+
+  defp valid_provider_call_admission?(nil), do: true
+  defp valid_provider_call_admission?(admission), do: ProviderCallAdmission.valid?(admission)
 
   defp valid_oauth_mode?(:disabled), do: true
   defp valid_oauth_mode?({:context_factory, factory}), do: is_function(factory, 1)
@@ -371,5 +396,6 @@ defmodule PtcRunner.Kernel.ProviderRuntimeServices do
   defp payload(services),
     do:
       {services.activation, services.credential_resolver, services.provider_application_mode,
-       services.oauth_mode, services.runtime_binding, services.host_payload}
+       services.oauth_mode, services.provider_call_admission, services.runtime_binding,
+       services.host_payload}
 end

--- a/lib/ptc_runner/kernel/provider_session.ex
+++ b/lib/ptc_runner/kernel/provider_session.ex
@@ -863,6 +863,7 @@ defmodule PtcRunner.Kernel.ProviderSession do
        run_duration_ms: limits.run_duration_ms,
        cleanup_timeout_ms: limits.provider_cleanup_timeout_ms,
        cleanup_deadline: nil,
+       task_cleanup: :ok,
        max_heap_words: limits.provider_heap_words,
        lifecycle_bound?: false,
        provider_tasks: nil,
@@ -1260,8 +1261,13 @@ defmodule PtcRunner.Kernel.ProviderSession do
   # long enough to be terminated instead has that owner kill the same tasks
   # when it observes the session's death.
   defp drain_provider_tasks(state) do
-    :ok = ProviderTaskTracker.drain_provider_tasks(state.provider_tasks)
-    state
+    result =
+      ProviderTaskTracker.drain_provider_tasks(
+        state.provider_tasks,
+        Deadline.expires_at(state.cleanup_deadline)
+      )
+
+    %{state | task_cleanup: normalize_cleanup(result)}
   end
 
   defp open_scope(scope, deadline, state) do
@@ -1433,7 +1439,7 @@ defmodule PtcRunner.Kernel.ProviderSession do
     slots = cleanup_slots(scopes, state.scopes)
 
     {result, state, _remaining_slots} =
-      Enum.reduce(scopes, {:ok, state, slots}, fn
+      Enum.reduce(scopes, {state.task_cleanup, state, slots}, fn
         scope, {result, current, remaining_slots} ->
           case Map.fetch(current.scopes, scope) do
             {:ok, entry} ->

--- a/lib/ptc_runner/kernel/provider_task_tracker.ex
+++ b/lib/ptc_runner/kernel/provider_task_tracker.ex
@@ -54,6 +54,11 @@ defmodule PtcRunner.Kernel.ProviderTaskTracker do
 
   def attach_guardian(_tracker, _guardian), do: {:error, :closed}
 
+  @spec cancel_guardian(t(), pid(), integer()) :: :ok | {:error, :provider_cleanup_failed}
+  def cancel_guardian(%__MODULE__{} = tracker, guardian, deadline)
+      when is_pid(guardian) and is_integer(deadline),
+      do: safe_call(tracker, {:cancel_guardian, guardian, deadline})
+
   # Kills and reaps every attached task and then ends the tracker, so terminal
   # cleanup can prove the run's callbacks are gone. Sealing is the point:
   # draining without it would let a dispatch that raced the drain attach a live
@@ -127,6 +132,27 @@ defmodule PtcRunner.Kernel.ProviderTaskTracker do
   def handle_call({token, {:drain, deadline}}, _from, %{token: token} = state) do
     {result, state} = drain(state, cleanup_deadline(state, deadline))
     {:stop, :normal, result, state}
+  end
+
+  def handle_call(
+        {token, {:cancel_guardian, guardian, deadline}},
+        _from,
+        %{token: token} = state
+      ) do
+    selected = Enum.filter(state.guardians, fn {_ref, pid} -> pid == guardian end) |> Map.new()
+    request_ref = make_ref()
+    send(guardian, {:cancel_provider_call, self(), request_ref, deadline})
+    {remaining, uncertain?} = drain_guardians(selected, request_ref, deadline, false)
+    Enum.each(remaining, fn {_ref, pid} -> Process.exit(pid, :kill) end)
+    drain_monitors(remaining)
+
+    guardians =
+      Enum.reduce(Map.keys(selected), state.guardians, fn ref, acc -> Map.delete(acc, ref) end)
+
+    result =
+      if uncertain? or map_size(remaining) > 0, do: {:error, :provider_cleanup_failed}, else: :ok
+
+    {:reply, result, %{state | guardians: guardians}}
   end
 
   def handle_call(_request, _from, state), do: {:reply, {:error, :closed}, state}

--- a/lib/ptc_runner/kernel/provider_task_tracker.ex
+++ b/lib/ptc_runner/kernel/provider_task_tracker.ex
@@ -4,7 +4,10 @@ defmodule PtcRunner.Kernel.ProviderTaskTracker do
   # The one owner of a run's live provider tasks, deliberately external to both
   # lifecycles it serves. It monitors the run state and, once execution binds
   # one, the provider session; either lifecycle disappearing kills and reaps
-  # every attached task. Because the tracker is a separate process, that
+  # every attached task. Ordinary provider tasks are killed and reaped;
+  # admitted LLM guardians first receive one cooperative cancel-and-drain
+  # request under the shared cleanup deadline and are killed only if they miss
+  # it. Because the tracker is a separate process, that
   # guarantee survives an abnormal end of either owner — including a session
   # terminated at its cleanup deadline, where `terminate/2` never runs. A
   # session drains through this owner before its own provider closers run, and
@@ -19,11 +22,14 @@ defmodule PtcRunner.Kernel.ProviderTaskTracker do
 
   @type t :: %__MODULE__{pid: pid(), token: reference()}
 
-  @spec start(pid()) :: {:ok, t()} | {:error, term()}
-  def start(run_state) when is_pid(run_state) do
+  @spec start(pid(), pos_integer()) :: {:ok, t()} | {:error, term()}
+  def start(run_state, cleanup_timeout_ms \\ 5_000)
+
+  def start(run_state, cleanup_timeout_ms)
+      when is_pid(run_state) and is_integer(cleanup_timeout_ms) and cleanup_timeout_ms > 0 do
     token = make_ref()
 
-    case GenServer.start(__MODULE__, {token, run_state}) do
+    case GenServer.start(__MODULE__, {token, run_state, cleanup_timeout_ms}) do
       {:ok, pid} -> {:ok, %__MODULE__{pid: pid, token: token}}
       {:error, reason} -> {:error, reason}
     end
@@ -42,21 +48,29 @@ defmodule PtcRunner.Kernel.ProviderTaskTracker do
 
   def attach(_tracker, _provider), do: {:error, :closed}
 
+  @spec attach_guardian(t(), pid()) :: :ok | {:error, :closed | :provider_down}
+  def attach_guardian(%__MODULE__{} = tracker, guardian) when is_pid(guardian),
+    do: safe_call(tracker, {:attach_guardian, guardian})
+
+  def attach_guardian(_tracker, _guardian), do: {:error, :closed}
+
   # Kills and reaps every attached task and then ends the tracker, so terminal
   # cleanup can prove the run's callbacks are gone. Sealing is the point:
   # draining without it would let a dispatch that raced the drain attach a live
   # callback behind it while connector closers already run, so an attachment
   # after this finds the owner closed and fails instead. Either lifecycle may
   # call it, and calling it again once it has settled is a no-op.
-  @spec drain_provider_tasks(t()) :: :ok
-  def drain_provider_tasks(%__MODULE__{pid: pid} = tracker) do
+  @spec drain_provider_tasks(t(), integer() | nil) :: :ok | {:error, :provider_cleanup_failed}
+  def drain_provider_tasks(tracker, absolute_deadline_ms \\ nil)
+
+  def drain_provider_tasks(%__MODULE__{pid: pid} = tracker, absolute_deadline_ms) do
     ref = Process.monitor(pid)
 
     try do
-      _ = safe_call(tracker, :drain)
+      result = safe_call(tracker, {:drain, absolute_deadline_ms})
 
       receive do
-        {:DOWN, ^ref, :process, ^pid, _reason} -> :ok
+        {:DOWN, ^ref, :process, ^pid, reason} -> normalize_drain_result(result, reason)
       end
     after
       Process.demonitor(ref, [:flush])
@@ -64,15 +78,24 @@ defmodule PtcRunner.Kernel.ProviderTaskTracker do
   end
 
   # A session that was never bound to a tracker never owned a task.
-  def drain_provider_tasks(_tracker), do: :ok
+  def drain_provider_tasks(_tracker, _deadline), do: :ok
+
+  defp normalize_drain_result(:ok, _reason), do: :ok
+
+  defp normalize_drain_result({:error, :closed}, reason) when reason in [:normal, :noproc],
+    do: :ok
+
+  defp normalize_drain_result(_failure, _reason), do: {:error, :provider_cleanup_failed}
 
   @impl GenServer
-  def init({token, run_state}) do
+  def init({token, run_state, cleanup_timeout_ms}) do
     {:ok,
      %{
        token: token,
        lifecycles: %{Process.monitor(run_state) => run_state},
-       providers: %{}
+       providers: %{},
+       guardians: %{},
+       cleanup_timeout_ms: cleanup_timeout_ms
      }}
   end
 
@@ -93,30 +116,84 @@ defmodule PtcRunner.Kernel.ProviderTaskTracker do
     end
   end
 
-  def handle_call({token, :drain}, _from, %{token: token} = state),
-    do: {:stop, :normal, :ok, drain(state)}
+  def handle_call({token, {:attach_guardian, guardian}}, _from, %{token: token} = state) do
+    if Process.alive?(guardian) do
+      {:reply, :ok, put_in(state.guardians[Process.monitor(guardian)], guardian)}
+    else
+      {:reply, {:error, :provider_down}, state}
+    end
+  end
+
+  def handle_call({token, {:drain, deadline}}, _from, %{token: token} = state) do
+    {result, state} = drain(state, cleanup_deadline(state, deadline))
+    {:stop, :normal, result, state}
+  end
 
   def handle_call(_request, _from, state), do: {:reply, {:error, :closed}, state}
 
   @impl GenServer
   def handle_info({:DOWN, ref, :process, _pid, _reason}, %{lifecycles: lifecycles} = state)
       when is_map_key(lifecycles, ref) do
-    {:stop, :normal, drain(state)}
+    {_result, state} = drain(state, cleanup_deadline(state, nil))
+    {:stop, :normal, state}
   end
 
   def handle_info({:DOWN, ref, :process, _pid, _reason}, state),
-    do: {:noreply, %{state | providers: Map.delete(state.providers, ref)}}
+    do:
+      {:noreply,
+       %{
+         state
+         | providers: Map.delete(state.providers, ref),
+           guardians: Map.delete(state.guardians, ref)
+       }}
 
   def handle_info(_message, state), do: {:noreply, state}
 
   # A killed task always yields the `:DOWN` this reaps, so the loop terminates
   # without its own timer. Only provider monitors are consumed; a lifecycle
   # notification that arrives mid-drain stays queued for the clause above.
-  defp drain(state) do
+  defp drain(state, deadline) do
     Enum.each(state.providers, fn {_ref, provider} -> Process.exit(provider, :kill) end)
     drain_monitors(state.providers)
-    %{state | providers: %{}}
+
+    request_ref = make_ref()
+
+    Enum.each(state.guardians, fn {_ref, guardian} ->
+      send(guardian, {:cancel_provider_call, self(), request_ref, deadline})
+    end)
+
+    {remaining, uncertain?} = drain_guardians(state.guardians, request_ref, deadline, false)
+    Enum.each(remaining, fn {_ref, guardian} -> Process.exit(guardian, :kill) end)
+    drain_monitors(remaining)
+
+    result =
+      if uncertain? or map_size(remaining) > 0, do: {:error, :provider_cleanup_failed}, else: :ok
+
+    {result, %{state | providers: %{}, guardians: %{}}}
   end
+
+  defp drain_guardians(guardians, _request_ref, _deadline, uncertain?)
+       when map_size(guardians) == 0,
+       do: {guardians, uncertain?}
+
+  defp drain_guardians(guardians, request_ref, deadline, uncertain?) do
+    timeout = max(deadline - System.monotonic_time(:millisecond), 0)
+
+    receive do
+      {:DOWN, ref, :process, _pid, _reason} when is_map_key(guardians, ref) ->
+        drain_guardians(Map.delete(guardians, ref), request_ref, deadline, uncertain?)
+
+      {:provider_call_drained, ^request_ref, guardian, status} when is_pid(guardian) ->
+        drain_guardians(guardians, request_ref, deadline, uncertain? or status == :uncertain)
+    after
+      timeout -> {guardians, uncertain?}
+    end
+  end
+
+  defp cleanup_deadline(_state, deadline) when is_integer(deadline), do: deadline
+
+  defp cleanup_deadline(state, _deadline),
+    do: System.monotonic_time(:millisecond) + state.cleanup_timeout_ms
 
   defp drain_monitors(providers) when map_size(providers) == 0, do: :ok
 

--- a/lib/ptc_runner/kernel/run_state.ex
+++ b/lib/ptc_runner/kernel/run_state.ex
@@ -295,6 +295,28 @@ defmodule PtcRunner.Kernel.RunState do
     end
   end
 
+  @doc false
+  @spec attach_provider_guardian(t(), reference(), pid()) ::
+          :ok | {:error, :closed | :provider_down | :unknown_reservation}
+  def attach_provider_guardian(%__MODULE__{} = state, reservation_id, guardian)
+      when is_reference(reservation_id) and is_pid(guardian) do
+    case ProviderTaskTracker.attach_guardian(state.provider_tracker, guardian) do
+      :ok ->
+        case safe_call(state, {:attach_provider, reservation_id, guardian}, {:error, :closed}) do
+          :ok ->
+            :ok
+
+          {:error, reason} = error when reason in [:closed, :unknown_reservation] ->
+            Process.exit(guardian, :kill)
+            error
+        end
+
+      {:error, reason} = error when reason in [:closed, :provider_down] ->
+        if reason == :closed, do: Process.exit(guardian, :kill)
+        error
+    end
+  end
+
   @spec open_provider_gate(t(), reference(), pid(), reference()) ::
           :ok
           | {:error,
@@ -2768,7 +2790,7 @@ defmodule PtcRunner.Kernel.RunState do
   defp start_state(args) do
     case GenServer.start(__MODULE__, args) do
       {:ok, pid} ->
-        case ProviderTaskTracker.start(pid) do
+        case ProviderTaskTracker.start(pid, elem(args, 0).provider_cleanup_timeout_ms) do
           {:ok, provider_tracker} ->
             token = elem(args, 1)
             {:ok, %__MODULE__{pid: pid, token: token, provider_tracker: provider_tracker}}

--- a/lib/ptc_runner/kernel/run_state.ex
+++ b/lib/ptc_runner/kernel/run_state.ex
@@ -271,7 +271,7 @@ defmodule PtcRunner.Kernel.RunState do
         # and must report closure rather than exit.
         case safe_call(
                state,
-               {:attach_provider, reservation_id, provider},
+               {:attach_provider, reservation_id, provider, :ordinary},
                {:error, :closed}
              ) do
           :ok ->
@@ -302,7 +302,11 @@ defmodule PtcRunner.Kernel.RunState do
       when is_reference(reservation_id) and is_pid(guardian) do
     case ProviderTaskTracker.attach_guardian(state.provider_tracker, guardian) do
       :ok ->
-        case safe_call(state, {:attach_provider, reservation_id, guardian}, {:error, :closed}) do
+        case safe_call(
+               state,
+               {:attach_provider, reservation_id, guardian, :guardian},
+               {:error, :closed}
+             ) do
           :ok ->
             :ok
 
@@ -895,10 +899,11 @@ defmodule PtcRunner.Kernel.RunState do
   end
 
   def handle_call(
-        {token, {:attach_provider, reservation_id, provider}},
+        {token, {:attach_provider, reservation_id, provider, provider_kind}},
         {caller, _tag},
         %{token: token} = state
-      ) do
+      )
+      when provider_kind in [:ordinary, :guardian] do
     if unavailable?(state) do
       Process.exit(provider, :kill)
       {:reply, {:error, :closed}, settle_reservation(state, reservation_id, :cleanup) |> elem(1)}
@@ -909,6 +914,7 @@ defmodule PtcRunner.Kernel.RunState do
             reservation
             |> Map.put(:provider, provider)
             |> Map.put(:provider_ref, Process.monitor(provider))
+            |> Map.put(:provider_kind, provider_kind)
 
           reservations = Map.put(state.reservations, reservation_id, reservation)
           {:reply, :ok, %{state | reservations: reservations}}
@@ -1676,29 +1682,47 @@ defmodule PtcRunner.Kernel.RunState do
       ),
       do: {:noreply, clear_evaluation(state)}
 
-  def handle_info({:DOWN, ref, :process, pid, _reason}, state) do
+  def handle_info({:DOWN, ref, :process, pid, reason}, state) do
     case reservation_by_caller_ref(state.reservations, ref) do
       {reservation_id, %{caller: ^pid, provider: provider} = reservation} ->
-        if is_pid(provider) do
-          Process.exit(provider, :kill)
+        cond do
+          is_pid(provider) and Map.get(reservation, :provider_kind) == :guardian ->
+            deadline =
+              System.monotonic_time(:millisecond) + state.limits.provider_cleanup_timeout_ms
 
-          reservations =
-            Map.put(state.reservations, reservation_id, %{reservation | caller_ref: nil})
+            tracker = state.provider_tracker
+            spawn(fn -> ProviderTaskTracker.cancel_guardian(tracker, provider, deadline) end)
 
-          {:noreply, %{state | reservations: reservations}}
-        else
-          {_reply, state} = settle_reservation(state, reservation_id, :cleanup)
-          {:noreply, state}
+            reservations =
+              Map.put(state.reservations, reservation_id, %{reservation | caller_ref: nil})
+
+            {:noreply, %{state | reservations: reservations}}
+
+          is_pid(provider) ->
+            Process.exit(provider, :kill)
+
+            reservations =
+              Map.put(state.reservations, reservation_id, %{reservation | caller_ref: nil})
+
+            {:noreply, %{state | reservations: reservations}}
+
+          true ->
+            {_reply, state} = settle_reservation(state, reservation_id, :cleanup)
+            {:noreply, state}
         end
 
       nil ->
         case reservation_by_provider_ref(state.reservations, ref) do
-          {reservation_id, %{caller_ref: nil}} ->
+          {reservation_id, %{caller_ref: nil} = reservation} ->
+            state = maybe_mark_guardian_down(state, reservation, reason)
             {_reply, state} = settle_reservation(state, reservation_id, :cleanup)
             {:noreply, state}
 
           {reservation_id, reservation} ->
             reservation = %{reservation | provider: nil, provider_ref: nil}
+
+            state = maybe_mark_guardian_down(state, reservation, reason)
+
             {:noreply, put_in(state.reservations[reservation_id], reservation)}
 
           nil ->
@@ -1732,6 +1756,18 @@ defmodule PtcRunner.Kernel.RunState do
 
   def handle_info(_message, state), do: {:noreply, state}
 
+  defp maybe_mark_guardian_down(state, reservation, reason) do
+    if Map.get(reservation, :provider_kind) == :guardian and reason != :normal do
+      failure =
+        state.terminal_failure ||
+          %{kind: :provider_cleanup_error, reason: :provider_cleanup_failed}
+
+      admit_from_queue(%{state | closed?: true, terminal_failure: failure})
+    else
+      state
+    end
+  end
+
   defp drop_dead_admission_waiter(state, monitor_ref) do
     case take_admission_waiter(state, monitor_ref) do
       {nil, state} ->
@@ -1747,8 +1783,12 @@ defmodule PtcRunner.Kernel.RunState do
   def terminate(_reason, state) do
     state.reservations
     |> Enum.flat_map(fn
-      {_caller, %{provider: provider}} when is_pid(provider) -> [provider]
-      _reservation -> []
+      {_caller, %{provider: provider, provider_kind: kind}}
+      when is_pid(provider) and kind != :guardian ->
+        [provider]
+
+      _reservation ->
+        []
     end)
     |> Enum.uniq()
     |> kill_and_drain()
@@ -1764,8 +1804,12 @@ defmodule PtcRunner.Kernel.RunState do
     providers =
       state.reservations
       |> Enum.flat_map(fn
-        {_reservation_id, %{provider: provider}} when is_pid(provider) -> [provider]
-        _reservation -> []
+        {_reservation_id, %{provider: provider, provider_kind: kind}}
+        when is_pid(provider) and kind != :guardian ->
+          [provider]
+
+        _reservation ->
+          []
       end)
       |> Enum.uniq()
 
@@ -1849,6 +1893,7 @@ defmodule PtcRunner.Kernel.RunState do
           caller_ref: Process.monitor(caller),
           provider: nil,
           provider_ref: nil,
+          provider_kind: nil,
           dispatched?: false,
           llm: llm_reservation(state, route)
         }

--- a/lib/ptc_runner/llm.ex
+++ b/lib/ptc_runner/llm.ex
@@ -149,10 +149,21 @@ defmodule PtcRunner.LLM do
   """
   @callback public_model(model :: String.t()) :: {:ok, String.t()} | :private
 
+  @doc """
+  Attests support for the hosted cancelable-request witness.
+
+  Optional. Return `true` only when termination of the adapter caller drains
+  every request and pool-checkout owner it creates. Hosted runtime services
+  with provider-call admission reject adapters which omit this attestation.
+  Direct callers remain outside that hosted guarantee.
+  """
+  @callback cancellation_witness?() :: true
+
   @optional_callbacks [
     ensure_ready: 0,
     provider_application: 1,
     public_model: 1,
+    cancellation_witness?: 0,
     reservation_bound: 3
   ]
 

--- a/lib/ptc_runner/llm/req_llm_adapter.ex
+++ b/lib/ptc_runner/llm/req_llm_adapter.ex
@@ -121,6 +121,11 @@ if Code.ensure_loaded?(ReqLLM) do
 
     # --- Behaviour Callbacks ---
 
+    @doc false
+    @impl true
+    @spec cancellation_witness?() :: true
+    def cancellation_witness?, do: true
+
     @impl true
     @doc """
     Loads the `llm_db` model catalog into its VM-global `:persistent_term`

--- a/lib/ptc_runner/llm/req_llm_adapter.ex
+++ b/lib/ptc_runner/llm/req_llm_adapter.ex
@@ -33,6 +33,7 @@ if Code.ensure_loaded?(ReqLLM) do
 
     @behaviour PtcRunner.LLM
 
+    alias PtcRunner.Kernel.AdapterCancellationWitness
     alias PtcRunner.Kernel.LLMUsage
     alias PtcRunner.Kernel.ProviderError
     alias PtcRunner.LLM.Invocation
@@ -331,7 +332,7 @@ if Code.ensure_loaded?(ReqLLM) do
             {:error, request_deadline_error()}
 
           _remaining ->
-            dispatch_invocation(target, invocation)
+            AdapterCancellationWitness.run(fn -> dispatch_invocation(target, invocation) end)
         end
       else
         {:error, ProviderError.new(:invalid_request, "invalid LLM invocation")}

--- a/priv/preludes/kernel/agent.failure.clj
+++ b/priv/preludes/kernel/agent.failure.clj
@@ -22,7 +22,11 @@
        (let [kind (named-token (get error :kind))
              reason (named-token (get error :reason))]
          (or (and (or (= kind "provider-error") (= kind "provider_error"))
-                  (or (= reason "denied")
+                  (or (= reason "admission-unavailable")
+                      (= reason "admission_unavailable")
+                      (= reason "capacity-exhausted")
+                      (= reason "capacity_exhausted")
+                      (= reason "denied")
                       (= reason "not-found")
                       (= reason "not_found")
                       (= reason "unavailable")

--- a/site/reference/host-installation/index.html
+++ b/site/reference/host-installation/index.html
@@ -445,7 +445,14 @@ selected live installation's <code class="inline">ceilings.request_timeout_ms</c
 request. Every other application-narrowable row can be raised from the manifest
 alone, up to its installed ceiling.</p><p>Four timeouts are host-only: <code class="inline">provider_cleanup_timeout_ms</code>,
 <code class="inline">local_preflight_timeout_ms</code>, <code class="inline">selection_validation_timeout_ms</code>, and
-<code class="inline">doctor_connectivity_timeout_ms</code>. A manifest cannot declare them.</p><p>The generated <a href="/reference/kernel-limits-reference/">Kernel limits reference</a> is the
+<code class="inline">doctor_connectivity_timeout_ms</code>. A manifest cannot declare them.</p><p><code class="inline">live_provider_tasks</code> remains a per-run callback bound; it neither sizes nor
+describes aggregate hosted LLM capacity. An embedding host that shares a live
+provider transport across runs must pass one supervised
+<code class="inline">ProviderCallAdmission</code> owner through all corresponding
+<code class="inline">ProviderRuntimeServices</code>. Command-owned one-shot VMs do not start that domain.
+Replay, workflows that call no provider, direct LLM and embedding calls, and
+callbacks that bypass the installed requester consume no admission slot and
+must be bounded by their caller.</p><p>The generated <a href="/reference/kernel-limits-reference/">Kernel limits reference</a> is the
 complete table of names, meanings, units, scopes, defaults, accepted ranges,
 and identity participation. The host schema is generated from the same
 catalog.</p><h2 id="verify-selected-providers">Verify selected providers</h2><p>Run active local, credential, authorization, and connectivity checks without

--- a/test/ptc_runner/kernel/host_installation_test.exs
+++ b/test/ptc_runner/kernel/host_installation_test.exs
@@ -1486,7 +1486,7 @@ defmodule PtcRunner.Kernel.HostInstallationTest do
     assert request.credential == "pre-resolved-secret"
     assert request.cache == false
     assert request.exact_options.max_tokens == 1
-    assert request.llm_request_deadline_ms == nil
+    assert is_integer(request.llm_request_deadline_ms)
     assert [%{role: :user, content: "Health check."}] = request.messages
     refute Map.has_key?(request, :schema)
     refute_receive {:host_llm_request, _, _}
@@ -2101,7 +2101,8 @@ defmodule PtcRunner.Kernel.HostInstallationTest do
   defp reseal_services(services) do
     payload =
       {services.activation, services.credential_resolver, services.provider_application_mode,
-       services.oauth_mode, services.runtime_binding, services.host_payload}
+       services.oauth_mode, services.provider_call_admission, services.runtime_binding,
+       services.host_payload}
 
     %{services | attestation: Attestation.attest(ProviderRuntimeServices, payload)}
   end

--- a/test/ptc_runner/kernel/provider_call_admission_test.exs
+++ b/test/ptc_runner/kernel/provider_call_admission_test.exs
@@ -1,6 +1,8 @@
 defmodule PtcRunner.Kernel.ProviderCallAdmissionTest do
   use ExUnit.Case, async: true
 
+  import PtcRunner.TestSupport.Eventually, only: [assert_eventually: 1]
+
   alias PtcRunner.Kernel.ProviderCallAdmission
 
   test "validates its closed options and exposes a temporary child" do
@@ -90,6 +92,27 @@ defmodule PtcRunner.Kernel.ProviderCallAdmissionTest do
              ProviderCallAdmission.checkout(admission, System.monotonic_time(:millisecond) + 100)
   end
 
+  test "a queued checkout caller death removes its guardian's ticket" do
+    admission = start_supervised!({ProviderCallAdmission, max_active_calls: 1, max_waiters: 1})
+    deadline = System.monotonic_time(:millisecond) + 5_000
+    assert {:ok, lease} = ProviderCallAdmission.checkout(admission, deadline)
+
+    checkout =
+      spawn(fn -> ProviderCallAdmission.checkout_for(admission, self(), deadline) end)
+
+    assert_eventually(fn ->
+      match?({:ok, %{waiting: 1}}, ProviderCallAdmission.snapshot(admission))
+    end)
+
+    Process.exit(checkout, :kill)
+
+    assert_eventually(fn ->
+      match?({:ok, %{waiting: 0, status: :ready}}, ProviderCallAdmission.snapshot(admission))
+    end)
+
+    assert :ok = ProviderCallAdmission.complete(lease, :completed)
+  end
+
   test "uncertain and protocol-fault completions fence" do
     for completion <- [:uncertain, :duplicate, :foreign] do
       admission =
@@ -117,20 +140,6 @@ defmodule PtcRunner.Kernel.ProviderCallAdmissionTest do
       end
 
       assert {:ok, %{status: :unavailable}} = ProviderCallAdmission.snapshot(admission)
-    end
-  end
-
-  defp assert_eventually(assertion, attempts \\ 100)
-  defp assert_eventually(assertion, 0), do: assert(assertion.())
-
-  defp assert_eventually(assertion, attempts) do
-    if assertion.() do
-      :ok
-    else
-      receive do
-      after
-        1 -> assert_eventually(assertion, attempts - 1)
-      end
     end
   end
 end

--- a/test/ptc_runner/kernel/provider_call_admission_test.exs
+++ b/test/ptc_runner/kernel/provider_call_admission_test.exs
@@ -1,0 +1,136 @@
+defmodule PtcRunner.Kernel.ProviderCallAdmissionTest do
+  use ExUnit.Case, async: true
+
+  alias PtcRunner.Kernel.ProviderCallAdmission
+
+  test "validates its closed options and exposes a temporary child" do
+    assert {:error, :invalid_provider_call_admission} = ProviderCallAdmission.start_link([])
+
+    assert {:error, :invalid_provider_call_admission} =
+             ProviderCallAdmission.start_link(max_active_calls: 1, max_waiters: 0, extra: true)
+
+    assert {:error, :invalid_provider_call_admission} =
+             ProviderCallAdmission.start_link(
+               max_active_calls: 1,
+               max_active_calls: 2,
+               max_waiters: 0
+             )
+
+    assert %{restart: :temporary} =
+             ProviderCallAdmission.child_spec(max_active_calls: 1, max_waiters: 0)
+  end
+
+  test "bounds active calls and fail-fast capacity before owner entry" do
+    admission = start_supervised!({ProviderCallAdmission, max_active_calls: 1, max_waiters: 0})
+    deadline = System.monotonic_time(:millisecond) + 5_000
+
+    assert {:ok, lease} = ProviderCallAdmission.checkout(admission, deadline)
+
+    assert {:error, :provider_capacity_exhausted} =
+             ProviderCallAdmission.checkout(admission, deadline)
+
+    assert {:ok, %{capacity: 1, active: 1, waiting: 0, status: :ready}} =
+             ProviderCallAdmission.snapshot(admission)
+
+    assert :ok = ProviderCallAdmission.complete(lease, :completed)
+  end
+
+  test "waiters are FIFO and expired waiters are never granted" do
+    admission = start_supervised!({ProviderCallAdmission, max_active_calls: 1, max_waiters: 2})
+    now = System.monotonic_time(:millisecond)
+    assert {:ok, lease} = ProviderCallAdmission.checkout(admission, now + 5_000)
+    parent = self()
+
+    first =
+      spawn(fn ->
+        result = ProviderCallAdmission.checkout(admission, now + 5_000)
+        send(parent, {:first, result})
+
+        receive do
+          {:complete, first_lease} -> ProviderCallAdmission.complete(first_lease, :completed)
+        end
+      end)
+
+    _second =
+      spawn(fn ->
+        send(parent, {:second, ProviderCallAdmission.checkout(admission, now + 20)})
+      end)
+
+    assert_receive {:second, {:error, :provider_admission_timeout}}, 1_000
+    assert :ok = ProviderCallAdmission.complete(lease, :completed)
+    assert_receive {:first, {:ok, first_lease}}, 1_000
+    assert first_lease.owner == first
+    assert {:complete, ^first_lease} = send(first, {:complete, first_lease})
+  end
+
+  test "guardian death while active fences the domain" do
+    admission = start_supervised!({ProviderCallAdmission, max_active_calls: 1, max_waiters: 1})
+    parent = self()
+
+    guardian =
+      spawn(fn ->
+        result =
+          ProviderCallAdmission.checkout(admission, System.monotonic_time(:millisecond) + 5_000)
+
+        send(parent, {:lease, result})
+
+        receive do
+          :never -> :ok
+        end
+      end)
+
+    assert_receive {:lease, {:ok, _lease}}
+    Process.exit(guardian, :kill)
+
+    assert_eventually(fn ->
+      match?({:ok, %{status: :unavailable}}, ProviderCallAdmission.snapshot(admission))
+    end)
+
+    assert {:error, :provider_admission_unavailable} =
+             ProviderCallAdmission.checkout(admission, System.monotonic_time(:millisecond) + 100)
+  end
+
+  test "uncertain and protocol-fault completions fence" do
+    for completion <- [:uncertain, :duplicate, :foreign] do
+      admission =
+        start_supervised!({ProviderCallAdmission, max_active_calls: 1, max_waiters: 0},
+          id: completion
+        )
+
+      deadline = System.monotonic_time(:millisecond) + 1_000
+      assert {:ok, lease} = ProviderCallAdmission.checkout(admission, deadline)
+
+      case completion do
+        :uncertain ->
+          assert {:error, :provider_cleanup_failed} =
+                   ProviderCallAdmission.complete(lease, :uncertain)
+
+        :duplicate ->
+          assert :ok = ProviderCallAdmission.complete(lease, :completed)
+
+          assert {:error, :duplicate_completion} =
+                   ProviderCallAdmission.complete(lease, :completed)
+
+        :foreign ->
+          task = Task.async(fn -> ProviderCallAdmission.complete(lease, :completed) end)
+          assert {:error, :not_lease_owner} = Task.await(task)
+      end
+
+      assert {:ok, %{status: :unavailable}} = ProviderCallAdmission.snapshot(admission)
+    end
+  end
+
+  defp assert_eventually(assertion, attempts \\ 100)
+  defp assert_eventually(assertion, 0), do: assert(assertion.())
+
+  defp assert_eventually(assertion, attempts) do
+    if assertion.() do
+      :ok
+    else
+      receive do
+      after
+        1 -> assert_eventually(assertion, attempts - 1)
+      end
+    end
+  end
+end

--- a/test/ptc_runner/kernel/provider_call_admission_test.exs
+++ b/test/ptc_runner/kernel/provider_call_admission_test.exs
@@ -65,6 +65,22 @@ defmodule PtcRunner.Kernel.ProviderCallAdmissionTest do
     assert {:complete, ^first_lease} = send(first, {:complete, first_lease})
   end
 
+  test "expired waiters leave no FIFO tombstones behind" do
+    admission = start_supervised!({ProviderCallAdmission, max_active_calls: 1, max_waiters: 2})
+    assert {:ok, lease} = ProviderCallAdmission.checkout(admission, monotonic_deadline(5_000))
+
+    for _ <- 1..20 do
+      task =
+        Task.async(fn -> ProviderCallAdmission.checkout(admission, monotonic_deadline(5)) end)
+
+      assert {:error, :provider_admission_timeout} = Task.await(task)
+    end
+
+    assert {:ok, %{active: 1, waiting: 0}} = ProviderCallAdmission.snapshot(admission)
+    assert :queue.len(:sys.get_state(admission).waiting) == 0
+    assert :ok = ProviderCallAdmission.complete(lease, :completed)
+  end
+
   test "guardian death while active fences the domain" do
     admission = start_supervised!({ProviderCallAdmission, max_active_calls: 1, max_waiters: 1})
     parent = self()
@@ -142,4 +158,6 @@ defmodule PtcRunner.Kernel.ProviderCallAdmissionTest do
       assert {:ok, %{status: :unavailable}} = ProviderCallAdmission.snapshot(admission)
     end
   end
+
+  defp monotonic_deadline(offset), do: System.monotonic_time(:millisecond) + offset
 end

--- a/test/ptc_runner/kernel/provider_call_owner_test.exs
+++ b/test/ptc_runner/kernel/provider_call_owner_test.exs
@@ -142,5 +142,81 @@ defmodule PtcRunner.Kernel.ProviderCallOwnerTest do
     assert {:ok, %{active: 0, status: :ready}} = ProviderCallAdmission.snapshot(admission)
   end
 
+  test "completes the lease before restoring a requester exception" do
+    admission = start_supervised!({ProviderCallAdmission, max_active_calls: 1, max_waiters: 0})
+
+    assert_raise RuntimeError, "requester failed", fn ->
+      ProviderCallOwner.run(admission, fn _, _ -> raise "requester failed" end, %{}, %{
+        llm_request_deadline_ms: monotonic_deadline(1_000),
+        provider_cleanup_timeout_ms: 100
+      })
+    end
+
+    assert {:ok, %{active: 0, status: :ready}} = ProviderCallAdmission.snapshot(admission)
+  end
+
+  test "cooperative cancellation terminates an attested custom requester caller" do
+    admission = start_supervised!({ProviderCallAdmission, max_active_calls: 1, max_waiters: 0})
+    parent = self()
+
+    guardian =
+      spawn(fn ->
+        ProviderCallOwner.run(
+          admission,
+          fn _, _ ->
+            send(parent, {:custom_requester_started, self()})
+            receive do: (:held -> :ok)
+          end,
+          %{},
+          %{
+            llm_request_deadline_ms: monotonic_deadline(5_000),
+            provider_cleanup_timeout_ms: 1_000
+          }
+        )
+      end)
+
+    assert_receive {:custom_requester_started, requester}
+    requester_ref = Process.monitor(requester)
+    guardian_ref = Process.monitor(guardian)
+    request_ref = make_ref()
+    send(guardian, {:cancel_provider_call, self(), request_ref, monotonic_deadline(1_000)})
+
+    assert_receive {:DOWN, ^requester_ref, :process, ^requester, :killed}
+    assert_receive {:provider_call_drained, ^request_ref, ^guardian, :drained}
+    assert_receive {:DOWN, ^guardian_ref, :process, ^guardian, :normal}
+    assert {:ok, %{active: 0, status: :ready}} = ProviderCallAdmission.snapshot(admission)
+  end
+
+  test "admission loss anchors cleanup when the loss is observed" do
+    admission = start_supervised!({ProviderCallAdmission, max_active_calls: 1, max_waiters: 0})
+    parent = self()
+
+    guardian =
+      Task.async(fn ->
+        ProviderCallOwner.run(
+          admission,
+          fn _, _ ->
+            send(parent, {:requester_started, self()})
+            receive do: (:held -> :ok)
+          end,
+          %{},
+          %{
+            llm_request_deadline_ms: monotonic_deadline(5_000),
+            provider_cleanup_timeout_ms: 10
+          }
+        )
+      end)
+
+    assert_receive {:requester_started, requester}
+    requester_ref = Process.monitor(requester)
+    Process.send_after(self(), :cleanup_interval_elapsed, 20)
+    assert_receive :cleanup_interval_elapsed
+    Process.exit(admission, :kill)
+
+    assert_receive {:DOWN, ^requester_ref, :process, ^requester, :killed}
+
+    assert {:error, %ProviderError{kind: :admission_unavailable}} = Task.await(guardian)
+  end
+
   defp monotonic_deadline(offset), do: System.monotonic_time(:millisecond) + offset
 end

--- a/test/ptc_runner/kernel/provider_call_owner_test.exs
+++ b/test/ptc_runner/kernel/provider_call_owner_test.exs
@@ -142,6 +142,47 @@ defmodule PtcRunner.Kernel.ProviderCallOwnerTest do
     assert {:ok, %{active: 0, status: :ready}} = ProviderCallAdmission.snapshot(admission)
   end
 
+  test "cancellation resolves atomically against adapter witness registration" do
+    admission = start_supervised!({ProviderCallAdmission, max_active_calls: 1, max_waiters: 0})
+    parent = self()
+
+    for iteration <- 1..100 do
+      guardian =
+        spawn(fn ->
+          ProviderCallOwner.run(
+            admission,
+            fn _, _ ->
+              AdapterCancellationWitness.run(fn ->
+                send(parent, {:racing_transport_started, iteration, self()})
+                receive do: (:held -> :ok)
+              end)
+            end,
+            %{},
+            %{
+              llm_request_deadline_ms: monotonic_deadline(5_000),
+              provider_cleanup_timeout_ms: 1_000
+            }
+          )
+        end)
+
+      request_ref = make_ref()
+      send(guardian, {:cancel_provider_call, self(), request_ref, monotonic_deadline(1_000)})
+
+      assert_receive {:provider_call_drained, ^request_ref, ^guardian, :drained}
+
+      receive do
+        {:racing_transport_started, ^iteration, transport} ->
+          refute Process.alive?(transport)
+      after
+        0 -> :ok
+      end
+
+      assert_eventually(fn ->
+        match?({:ok, %{active: 0, status: :ready}}, ProviderCallAdmission.snapshot(admission))
+      end)
+    end
+  end
+
   test "completes the lease before restoring a requester exception" do
     admission = start_supervised!({ProviderCallAdmission, max_active_calls: 1, max_waiters: 0})
 

--- a/test/ptc_runner/kernel/provider_call_owner_test.exs
+++ b/test/ptc_runner/kernel/provider_call_owner_test.exs
@@ -1,0 +1,81 @@
+defmodule PtcRunner.Kernel.ProviderCallOwnerTest do
+  use ExUnit.Case, async: true
+
+  alias PtcRunner.Kernel.ProviderCallAdmission
+  alias PtcRunner.Kernel.ProviderCallOwner
+  alias PtcRunner.Kernel.ProviderError
+
+  test "holds one slot around the complete requester invocation" do
+    admission = start_supervised!({ProviderCallAdmission, max_active_calls: 1, max_waiters: 1})
+    parent = self()
+
+    requester = fn request, _context ->
+      send(parent, {:entered, request.id, self()})
+
+      receive do
+        {:return, response} -> {:ok, %{response: response}}
+      end
+    end
+
+    deadline = System.monotonic_time(:millisecond) + 5_000
+
+    first =
+      Task.async(fn ->
+        ProviderCallOwner.run(admission, requester, %{id: 1}, %{
+          llm_request_deadline_ms: deadline,
+          provider_cleanup_timeout_ms: 100
+        })
+      end)
+
+    assert_receive {:entered, 1, first_requester}
+
+    second =
+      Task.async(fn ->
+        ProviderCallOwner.run(admission, requester, %{id: 2}, %{
+          llm_request_deadline_ms: deadline,
+          provider_cleanup_timeout_ms: 100
+        })
+      end)
+
+    refute_receive {:entered, 2, _}
+    send(first_requester, {:return, :first})
+    assert {:ok, %{response: :first}} = Task.await(first)
+    assert_receive {:entered, 2, second_requester}
+    send(second_requester, {:return, :second})
+    assert {:ok, %{response: :second}} = Task.await(second)
+
+    assert {:ok, %{active: 0, waiting: 0, status: :ready}} =
+             ProviderCallAdmission.snapshot(admission)
+  end
+
+  test "maps pre-dispatch capacity and admission failures to fixed provider errors" do
+    admission = start_supervised!({ProviderCallAdmission, max_active_calls: 1, max_waiters: 0})
+    deadline = System.monotonic_time(:millisecond) + 5_000
+    assert {:ok, lease} = ProviderCallAdmission.checkout(admission, deadline)
+
+    assert {:error,
+            %ProviderError{
+              kind: :capacity_exhausted,
+              details: "LLM provider call capacity exhausted",
+              retryable?: true,
+              dispatch_provenance: :not_dispatched
+            }} =
+             ProviderCallOwner.run(admission, fn _, _ -> flunk("dispatched") end, %{}, %{
+               llm_request_deadline_ms: deadline
+             })
+
+    assert :ok = ProviderCallAdmission.complete(lease, :completed)
+    Process.exit(admission, :kill)
+
+    assert {:error,
+            %ProviderError{
+              kind: :admission_unavailable,
+              details: "LLM provider admission unavailable",
+              retryable?: false,
+              dispatch_provenance: :not_dispatched
+            }} =
+             ProviderCallOwner.run(admission, fn _, _ -> flunk("dispatched") end, %{}, %{
+               llm_request_deadline_ms: deadline
+             })
+  end
+end

--- a/test/ptc_runner/kernel/provider_call_owner_test.exs
+++ b/test/ptc_runner/kernel/provider_call_owner_test.exs
@@ -1,6 +1,8 @@
 defmodule PtcRunner.Kernel.ProviderCallOwnerTest do
   use ExUnit.Case, async: true
 
+  import PtcRunner.TestSupport.Eventually, only: [assert_eventually: 1]
+
   alias PtcRunner.Kernel.ProviderCallAdmission
   alias PtcRunner.Kernel.ProviderCallOwner
   alias PtcRunner.Kernel.ProviderError
@@ -8,16 +10,17 @@ defmodule PtcRunner.Kernel.ProviderCallOwnerTest do
   test "holds one slot around the complete requester invocation" do
     admission = start_supervised!({ProviderCallAdmission, max_active_calls: 1, max_waiters: 1})
     parent = self()
+    deadline = System.monotonic_time(:millisecond) + 5_000
 
-    requester = fn request, _context ->
+    requester = fn request, context ->
+      assert %{llm_request_deadline_ms: ^deadline} = context
+      assert map_size(context) == 1
       send(parent, {:entered, request.id, self()})
 
       receive do
         {:return, response} -> {:ok, %{response: response}}
       end
     end
-
-    deadline = System.monotonic_time(:millisecond) + 5_000
 
     first =
       Task.async(fn ->
@@ -46,6 +49,34 @@ defmodule PtcRunner.Kernel.ProviderCallOwnerTest do
 
     assert {:ok, %{active: 0, waiting: 0, status: :ready}} =
              ProviderCallAdmission.snapshot(admission)
+  end
+
+  test "guardian death terminates the admitted requester and fences the domain" do
+    admission = start_supervised!({ProviderCallAdmission, max_active_calls: 1, max_waiters: 0})
+    parent = self()
+    deadline = System.monotonic_time(:millisecond) + 5_000
+
+    guardian =
+      spawn(fn ->
+        ProviderCallOwner.run(
+          admission,
+          fn _, _ ->
+            send(parent, {:requester_entered, self()})
+            receive do: (:never -> :ok)
+          end,
+          %{},
+          %{llm_request_deadline_ms: deadline, provider_cleanup_timeout_ms: 100}
+        )
+      end)
+
+    assert_receive {:requester_entered, requester}
+    requester_monitor = Process.monitor(requester)
+    Process.exit(guardian, :kill)
+    assert_receive {:DOWN, ^requester_monitor, :process, ^requester, _reason}
+
+    assert_eventually(fn ->
+      match?({:ok, %{status: :unavailable}}, ProviderCallAdmission.snapshot(admission))
+    end)
   end
 
   test "maps pre-dispatch capacity and admission failures to fixed provider errors" do

--- a/test/ptc_runner/kernel/provider_call_owner_test.exs
+++ b/test/ptc_runner/kernel/provider_call_owner_test.exs
@@ -3,6 +3,7 @@ defmodule PtcRunner.Kernel.ProviderCallOwnerTest do
 
   import PtcRunner.TestSupport.Eventually, only: [assert_eventually: 1]
 
+  alias PtcRunner.Kernel.AdapterCancellationWitness
   alias PtcRunner.Kernel.ProviderCallAdmission
   alias PtcRunner.Kernel.ProviderCallOwner
   alias PtcRunner.Kernel.ProviderError
@@ -109,4 +110,37 @@ defmodule PtcRunner.Kernel.ProviderCallOwnerTest do
                llm_request_deadline_ms: deadline
              })
   end
+
+  test "cooperative cancellation waits for the adapter-owned subtree acknowledgement" do
+    admission = start_supervised!({ProviderCallAdmission, max_active_calls: 1, max_waiters: 0})
+    parent = self()
+
+    requester = fn _, _ ->
+      AdapterCancellationWitness.run(fn ->
+        send(parent, {:transport_started, self()})
+        receive do: (:held -> :ok)
+      end)
+    end
+
+    guardian =
+      spawn(fn ->
+        ProviderCallOwner.run(admission, requester, %{}, %{
+          llm_request_deadline_ms: System.monotonic_time(:millisecond) + 5_000,
+          provider_cleanup_timeout_ms: 1_000
+        })
+      end)
+
+    assert_receive {:transport_started, transport}
+    transport_ref = Process.monitor(transport)
+    guardian_ref = Process.monitor(guardian)
+    request_ref = make_ref()
+    send(guardian, {:cancel_provider_call, self(), request_ref, monotonic_deadline(1_000)})
+
+    assert_receive {:DOWN, ^transport_ref, :process, ^transport, _reason}
+    assert_receive {:provider_call_drained, ^request_ref, ^guardian, :drained}
+    assert_receive {:DOWN, ^guardian_ref, :process, ^guardian, :normal}
+    assert {:ok, %{active: 0, status: :ready}} = ProviderCallAdmission.snapshot(admission)
+  end
+
+  defp monotonic_deadline(offset), do: System.monotonic_time(:millisecond) + offset
 end

--- a/test/ptc_runner/kernel/provider_execution_oauth_test.exs
+++ b/test/ptc_runner/kernel/provider_execution_oauth_test.exs
@@ -838,7 +838,8 @@ defmodule PtcRunner.Kernel.ProviderExecutionOAuthTest do
   defp reseal_services(services) do
     payload =
       {services.activation, services.credential_resolver, services.provider_application_mode,
-       services.oauth_mode, services.runtime_binding, services.host_payload}
+       services.oauth_mode, services.provider_call_admission, services.runtime_binding,
+       services.host_payload}
 
     %{services | attestation: Attestation.attest(ProviderRuntimeServices, payload)}
   end

--- a/test/ptc_runner/kernel/provider_runtime_services_test.exs
+++ b/test/ptc_runner/kernel/provider_runtime_services_test.exs
@@ -4,6 +4,7 @@ defmodule PtcRunner.Kernel.ProviderRuntimeServicesTest do
   alias PtcRunner.Kernel.Deadline
   alias PtcRunner.Kernel.MCPOAuth.Context, as: OAuthContext
   alias PtcRunner.Kernel.MCPOAuth.Store.Memory
+  alias PtcRunner.Kernel.ProviderCallAdmission
   alias PtcRunner.Kernel.ProviderRuntimeServices
 
   test "construction seals services without activating any runtime callback" do
@@ -73,6 +74,22 @@ defmodule PtcRunner.Kernel.ProviderRuntimeServicesTest do
 
     assert {:error, :authorization_context_required} =
              ProviderRuntimeServices.oauth_context(services, Deadline.new(1_000))
+  end
+
+  test "a configured admission domain remains distinguishable when it dies" do
+    assert {:ok, admission} =
+             ProviderCallAdmission.start_link(max_active_calls: 1, max_waiters: 0)
+
+    assert {:ok, services} = ProviderRuntimeServices.new(provider_call_admission: admission)
+    assert {:ok, ^admission} = ProviderRuntimeServices.provider_call_admission(services)
+
+    Process.unlink(admission)
+    Process.exit(admission, :kill)
+    monitor = Process.monitor(admission)
+    assert_receive {:DOWN, ^monitor, :process, ^admission, _reason}
+
+    assert {:error, :provider_admission_unavailable} =
+             ProviderRuntimeServices.provider_call_admission(services)
   end
 
   test "the complete seal and callback results fail closed" do

--- a/test/ptc_runner/llm/req_llm_adapter_request_test.exs
+++ b/test/ptc_runner/llm/req_llm_adapter_request_test.exs
@@ -5,6 +5,8 @@ defmodule PtcRunner.LLM.ReqLLMAdapterRequestTest do
 
   import ExUnit.CaptureIO
 
+  alias PtcRunner.Kernel.AdapterCancellationWitness
+  alias PtcRunner.Kernel.CancelableRequest
   alias PtcRunner.Kernel.LLMCapability
   alias PtcRunner.Kernel.ProviderError
   alias PtcRunner.LLM.Invocation
@@ -1085,6 +1087,48 @@ defmodule PtcRunner.LLM.ReqLLMAdapterRequestTest do
     refute warnings =~ "deprecated"
   end
 
+  test "cancellation witness returns a held size-one Finch checkout before acknowledging drain" do
+    pool = __MODULE__.CancellationPool
+    start_supervised!({Finch, name: pool, pools: %{default: [size: 1, count: 1]}})
+    parent = self()
+    requests = :atomics.new(1, signed: false)
+
+    server =
+      MCPHTTPFixture.start(fn _request ->
+        case :atomics.add_get(requests, 1, 1) do
+          1 ->
+            send(parent, :held_adapter_transport)
+            receive do: (:never -> {500, [], "unreachable"})
+
+          _ ->
+            {200, [], "ok"}
+        end
+      end)
+
+    on_exit(server.close)
+
+    requester = fn _, _ ->
+      AdapterCancellationWitness.run(fn ->
+        ReqLLMAdapter.generate_text(
+          "openai-compat:#{server.endpoint}|model",
+          [%{role: :user, content: "hi"}],
+          req_http_options: [finch: [name: pool, pool_timeout: 1_000]],
+          receive_timeout: 5_000
+        )
+      end)
+    end
+
+    assert {:ok, handle} = CancelableRequest.start_cancelable(requester, %{}, %{}, self())
+    assert :ok = CancelableRequest.dispatch(handle)
+    assert_receive :held_adapter_transport
+    assert :drained = CancelableRequest.cancel_and_drain(handle, monotonic_deadline(1_000))
+
+    request = Finch.build(:get, server.endpoint)
+
+    assert {:ok, %Finch.Response{status: 200}} =
+             Finch.request(request, pool, pool_timeout: 100, receive_timeout: 1_000)
+  end
+
   test "preserves a namespaced provider output budget", %{test: test} do
     expect_request(test, "Qwen/Qwen3-30B-A3B-Instruct-2507")
 
@@ -1345,4 +1389,6 @@ defmodule PtcRunner.LLM.ReqLLMAdapterRequestTest do
     System.delete_env("AWS_REGION")
     Application.put_env(:ptc_runner, :bedrock_region, region)
   end
+
+  defp monotonic_deadline(offset), do: System.monotonic_time(:millisecond) + offset
 end


### PR DESCRIPTION
## Summary

- Add a supervised, host-owned provider-call admission domain with bounded FIFO checkout, opaque leases, fencing, and readiness snapshots.
- Route hosted live requests and connectivity probes through tracked guardians with deadline-aware cooperative cancellation and transport drain proof.
- Define exact provider outcomes, runtime-service validation, generated documentation, and boundary coverage for concurrency and lifecycle behavior.
- Closes #1290

## Validation

- Focused provider admission, guardian, tracker, session, lifecycle, host installation, connectivity, and ReqLLM transport tests.
- Exact rerun of the load-sensitive live-status deadline test with its failing seed and four schedulers.
- Three-run four-scheduler flake hunt after the isolated pre-push failure.

## Retrospective

- Untracked follow-up: admission queue deletion remains O(n), as noted by the passed review advisory; retained queue state is bounded by `max_waiters`.
- Missing or unclear repository instruction: none.