### PR TITLE
feat(kernel): add caller-owned run reservations

### DIFF
--- a/docs/maintainers/kernel.md
+++ b/docs/maintainers/kernel.md
@@ -127,6 +127,16 @@ execution owner dying without acknowledging cleanup fences that capacity
 domain. It does not restart automatically; drain old work before replacing it.
 Admission-owner death aborts the executions it admitted.
 
+For transport commitment before execution, use
+`PtcRunner.Kernel.RunAdmission.reserve/2`, then `activate/3` or `activate/5`
+and `await/1`; use `cancel/1` or `close/1` when commitment fails. An unused
+reservation creates no execution resources. The admission owner monitors its
+caller until activation atomically transfers the existing slot to the execution
+owner, before dispatch. Absolute monotonic deadlines release unused
+reservations and cancel active execution through owner cleanup. The module
+documentation owns the exact operations and terminal race semantics; snapshots
+are diagnostic only.
+
 The host separately supervises one `ProviderCallAdmission` domain for each
 shared live LLM transport and seals that owner into every
 `ProviderRuntimeServices` value using it. Its active capacity spans concurrent

--- a/lib/ptc_runner/kernel/execution_session_owner.ex
+++ b/lib/ptc_runner/kernel/execution_session_owner.ex
@@ -125,12 +125,28 @@ defmodule PtcRunner.Kernel.ExecutionSessionOwner do
         ) ::
           {:ok, t()} | {:error, term()}
   def start_admitted(host, prepared, authority, caller, execution) do
+    start_with_admission(host, :admit, prepared, authority, caller, execution)
+  end
+
+  @doc false
+  def start_reserved(host, ref, ticket, prepared, authority, caller, execution) do
+    start_with_admission(
+      host,
+      {:transfer, ref, ticket, caller},
+      prepared,
+      authority,
+      caller,
+      execution
+    )
+  end
+
+  defp start_with_admission(host, admission_request, prepared, authority, caller, execution) do
     with :ok <- admissible(prepared, authority, execution, nil, :run, nil) do
       token = make_ref()
 
       case GenServer.start(
              __MODULE__,
-             {:admitted, host, prepared, authority, caller, token, execution}
+             {:admitted, host, admission_request, prepared, authority, caller, token, execution}
            ) do
         {:ok, pid} -> activate_admitted(pid, token, authority)
         {:error, reason} -> {:error, reason}
@@ -239,8 +255,8 @@ defmodule PtcRunner.Kernel.ExecutionSessionOwner do
   def pid(%__MODULE__{pid: pid}), do: pid
 
   @impl GenServer
-  def init({:admitted, host, prepared, authority, caller, token, execution}) do
-    case RunAdmission.admit(host) do
+  def init({:admitted, host, admission_request, prepared, authority, caller, token, execution}) do
+    case acquire_admission(host, admission_request) do
       :ok ->
         {:ok,
          %{
@@ -257,6 +273,11 @@ defmodule PtcRunner.Kernel.ExecutionSessionOwner do
   end
 
   def init(args), do: initialize(args, nil)
+
+  defp acquire_admission(host, :admit), do: RunAdmission.admit(host)
+
+  defp acquire_admission(host, {:transfer, ref, ticket, caller}),
+    do: RunAdmission.transfer(host, ref, ticket, caller)
 
   defp initialize(
          {prepared, authority, caller, token, lease, provider_execution, notifier, operation,
@@ -392,6 +413,12 @@ defmodule PtcRunner.Kernel.ExecutionSessionOwner do
   def handle_cast(_message, state), do: {:noreply, state}
 
   @impl GenServer
+  def handle_info({:run_admission_cancel, host}, %{pending: _, admission: {host, _}} = state),
+    do: {:stop, :normal, state}
+
+  def handle_info({:run_admission_cancel, host}, %{admission: {host, _}} = state),
+    do: {:stop, :normal, abort(state)}
+
   def handle_info({:DOWN, ref, :process, pid, _}, %{pending: _} = state) do
     if ref == state.caller_ref or state.admission == {pid, ref},
       do: {:stop, :normal, state},

--- a/lib/ptc_runner/kernel/run_admission.ex
+++ b/lib/ptc_runner/kernel/run_admission.ex
@@ -15,7 +15,15 @@ defmodule PtcRunner.Kernel.RunAdmission do
   provisional admission processes, and control mailboxes remain the host's
   responsibility to bound.
 
-  The lease belongs to the execution-session owner, not the request caller.
+  `reserve/2` supports transport commitment before execution exists. An unused
+  reservation holds only capacity, a caller monitor and a deadline timer; it
+  creates no session, input, policy, sink, publication authority, execution
+  identity or provider activity. The caller supplies those only to `activate/3`
+  or `activate/5`. Caller death or `close/1` releases unused capacity.
+  Absolute deadlines remain in force after activation and request cancellation
+  without releasing capacity ahead of cleanup.
+
+  After activation, the lease belongs to the execution-session owner.
   Caller death triggers that owner's normal provider cleanup. Capacity is
   released only after cleanup has finished. An owner that dies without a
   cleanup acknowledgement, or reports cleanup failure, fences this admission
@@ -39,6 +47,120 @@ defmodule PtcRunner.Kernel.RunAdmission do
   alias PtcRunner.Kernel.ProviderExecution
   alias PtcRunner.Kernel.ProviderRuntimeServices
   alias PtcRunner.Kernel.PublicationAuthority
+
+  @typedoc "Opaque single-use caller-owned capacity reservation."
+  @opaque reservation :: {__MODULE__, pid(), reference()}
+  @typedoc "Activated execution handle; only its caller may await it."
+  @opaque execution :: {__MODULE__, pid(), ExecutionSessionOwner.t()}
+
+  @doc """
+  Reserves capacity atomically for the calling process, without execution resources.
+
+  `deadline` is an absolute `System.monotonic_time(:millisecond)` integer
+  or `:infinity`. An expired or invalid deadline returns
+  `{:error, :run_admission_unavailable}`. A full domain returns
+  `{:error, :run_capacity_exhausted}`; a dead or fenced domain returns
+  `{:error, :run_admission_unavailable}`. No snapshot authorizes admission.
+  """
+  @spec reserve(pid(), integer() | :infinity) ::
+          {:ok, reservation()} | {:error, :run_capacity_exhausted | :run_admission_unavailable}
+  def reserve(host, deadline), do: call(host, {:reserve, deadline})
+
+  @doc """
+  Activates a provider-free reservation and returns an execution handle.
+
+  Only the reserving caller can activate it, once. Transfer to a new execution
+  owner happens before publication claim, preparation consumption, sink opening
+  or dispatch. Failed activation closes the reservation; input validation errors
+  retain their existing execution error codes. A closed, expired, foreign or
+  already activated reservation returns `{:error, :run_admission_unavailable}`.
+  Use `await/1` to collect the sealed outcome and wait for owner cleanup.
+  """
+  @spec activate(reservation(), PreparedRun.t(), PublicationAuthority.t()) ::
+          {:ok, execution()} | {:error, term()}
+  def activate(reservation, prepared, authority),
+    do: activate_execution(reservation, prepared, authority, nil)
+
+  @doc "Activates with the preparation's bound catalog and host-owned provider services."
+  @spec activate(
+          reservation(),
+          PreparedRun.t(),
+          PublicationAuthority.t(),
+          InstallationCatalog.t(),
+          ProviderRuntimeServices.t()
+        ) ::
+          {:ok, execution()} | {:error, term()}
+  def activate(
+        reservation,
+        prepared,
+        authority,
+        catalog,
+        %ProviderRuntimeServices{provider_application_mode: :host_owned} = services
+      ) do
+    case ProviderExecution.new(catalog, services, []) do
+      {:ok, execution} ->
+        activate_execution(reservation, prepared, authority, execution)
+
+      {:error, _} = error ->
+        cancel(reservation)
+        error
+    end
+  end
+
+  def activate(reservation, _, _, _, _) do
+    cancel(reservation)
+    {:error, :invalid_provider_execution}
+  end
+
+  defp activate_execution({__MODULE__, host, ref} = reservation, prepared, authority, execution) do
+    with {:ok, ticket} <- call(host, {:begin_activation, ref}) do
+      case ExecutionSessionOwner.start_reserved(
+             host,
+             ref,
+             ticket,
+             prepared,
+             authority,
+             self(),
+             execution
+           ) do
+        {:ok, owner} ->
+          {:ok, {__MODULE__, self(), owner}}
+
+        {:error, _} = error ->
+          cancel(reservation)
+          error
+      end
+    end
+  end
+
+  defp activate_execution(_, _, _, _), do: {:error, :run_admission_unavailable}
+
+  @doc """
+  Cancels or closes a reservation owned by the calling process.
+
+  Use this after response commitment fails. Before transfer it releases the
+  slot immediately. After transfer it requests execution-owner cancellation,
+  retaining capacity until cleanup acknowledgement. Cancellation, expiry and
+  caller death cannot release an active lease themselves. Repeated cancellation
+  or use after completion returns `{:error, :run_admission_unavailable}`.
+  Cancellation races with activation at the admission owner: cancellation
+  before transfer prevents dispatch; after transfer execution may have begun.
+  """
+  @spec cancel(reservation()) :: :ok | {:error, :run_admission_unavailable}
+  def cancel({__MODULE__, host, ref}), do: call(host, {:cancel, ref})
+  def cancel(_), do: {:error, :run_admission_unavailable}
+
+  @doc "Closes a reservation with the same ownership and cancellation semantics as cancel/1."
+  @spec close(reservation()) :: :ok | {:error, :run_admission_unavailable}
+  def close(reservation), do: cancel(reservation)
+
+  @doc "Waits for the activated execution's sealed outcome and execution-owner cleanup."
+  @spec await(execution()) :: {:ok, ExecutionOutcome.t()} | {:error, term()}
+  def await({__MODULE__, caller, owner}) when caller == self(), do: await_execution(owner)
+  def await(_), do: {:error, :execution_session_unavailable}
+
+  @doc false
+  def transfer(host, ref, ticket, caller), do: call(host, {:transfer, ref, ticket, caller})
 
   @type snapshot :: %{
           capacity: pos_integer(),
@@ -94,23 +216,27 @@ defmodule PtcRunner.Kernel.RunAdmission do
   defp do_execute(host, prepared, authority, execution) when is_pid(host) do
     with {:ok, owner} <-
            ExecutionSessionOwner.start_admitted(host, prepared, authority, self(), execution) do
-      ref = Process.monitor(ExecutionSessionOwner.pid(owner))
-      result = ExecutionSessionOwner.await(owner)
-
-      receive do
-        {:DOWN, ^ref, :process, _, :normal} ->
-          result
-
-        {:DOWN, ^ref, :process, _, :run_admission_unavailable} ->
-          {:error, :run_admission_unavailable}
-
-        {:DOWN, ^ref, :process, _, _} ->
-          {:error, :execution_session_unavailable}
-      end
+      await_execution(owner)
     end
   end
 
   defp do_execute(_, _, _, _), do: {:error, :invalid_run_admission}
+
+  defp await_execution(owner) do
+    ref = Process.monitor(ExecutionSessionOwner.pid(owner))
+    result = ExecutionSessionOwner.await(owner)
+
+    receive do
+      {:DOWN, ^ref, :process, _, :normal} ->
+        result
+
+      {:DOWN, ^ref, :process, _, :run_admission_unavailable} ->
+        {:error, :run_admission_unavailable}
+
+      {:DOWN, ^ref, :process, _, _} ->
+        {:error, :execution_session_unavailable}
+    end
+  end
 
   @doc "Returns counts and readiness without exposing requests or provider configuration."
   @spec snapshot(pid()) :: {:ok, snapshot()} | {:error, :run_admission_unavailable}
@@ -125,15 +251,91 @@ defmodule PtcRunner.Kernel.RunAdmission do
   def complete(host, clean?), do: call(host, {:complete, clean?})
 
   @impl true
-  def init(capacity), do: {:ok, %{capacity: capacity, owners: %{}, status: :ready}}
+  def init(capacity),
+    do: {:ok, %{capacity: capacity, owners: %{}, reservations: %{}, status: :ready}}
 
   @impl true
   def handle_call(:snapshot, _, state) do
     state = fence_dead_owners(state)
 
-    {:reply,
-     {:ok, %{capacity: state.capacity, in_use: map_size(state.owners), status: state.status}},
+    {:reply, {:ok, %{capacity: state.capacity, in_use: in_use(state), status: state.status}},
      state}
+  end
+
+  def handle_call({:reserve, deadline}, {caller, _}, state) do
+    state = fence_dead_owners(state)
+
+    cond do
+      state.status == :unavailable or not deadline_live?(deadline) or not Process.alive?(caller) ->
+        {:reply, {:error, :run_admission_unavailable}, state}
+
+      in_use(state) >= state.capacity ->
+        {:reply, {:error, :run_capacity_exhausted}, state}
+
+      true ->
+        ref = make_ref()
+        timer = deadline_timer(deadline, ref)
+
+        reservation = %{
+          caller: caller,
+          monitor: Process.monitor(caller),
+          deadline: deadline,
+          timer: timer,
+          ticket: nil,
+          owner: nil,
+          cancelled?: false
+        }
+
+        {:reply, {:ok, {__MODULE__, self(), ref}},
+         %{state | reservations: Map.put(state.reservations, ref, reservation)}}
+    end
+  end
+
+  def handle_call({:begin_activation, ref}, {caller, _}, state) do
+    state = fence_dead_owners(state)
+
+    case state.reservations[ref] do
+      %{caller: ^caller, owner: nil, ticket: nil} = reservation ->
+        if state.status == :ready and deadline_live?(reservation.deadline) and
+             Process.alive?(caller) do
+          ticket = make_ref()
+          {:reply, {:ok, ticket}, put_reservation(state, ref, %{reservation | ticket: ticket})}
+        else
+          {:reply, {:error, :run_admission_unavailable}, cancel_reservation(state, ref)}
+        end
+
+      _ ->
+        {:reply, {:error, :run_admission_unavailable}, state}
+    end
+  end
+
+  def handle_call({:transfer, ref, ticket, caller}, {owner, _}, state) do
+    state = fence_dead_owners(state)
+
+    case state.reservations[ref] do
+      %{caller: ^caller, owner: nil, ticket: ^ticket} = reservation when is_reference(ticket) ->
+        if state.status == :ready and deadline_live?(reservation.deadline) and
+             Process.alive?(caller) and not Map.has_key?(state.owners, owner) do
+          Process.demonitor(reservation.monitor, [:flush])
+          next = put_reservation(state, ref, %{reservation | owner: owner, monitor: nil})
+          {:reply, :ok, %{next | owners: Map.put(next.owners, owner, Process.monitor(owner))}}
+        else
+          {:reply, {:error, :run_admission_unavailable}, cancel_reservation(state, ref)}
+        end
+
+      _ ->
+        {:reply, {:error, :run_admission_unavailable}, state}
+    end
+  end
+
+  def handle_call({:cancel, ref}, {caller, _}, state) do
+    case state.reservations[ref] do
+      %{caller: ^caller, cancelled?: false} ->
+        {:reply, :ok, cancel_reservation(state, ref)}
+
+      _ ->
+        {:reply, {:error, :run_admission_unavailable}, state}
+    end
   end
 
   def handle_call(:admit, {owner, _}, state) do
@@ -146,7 +348,7 @@ defmodule PtcRunner.Kernel.RunAdmission do
       state.status == :unavailable ->
         {:reply, {:error, :run_admission_unavailable}, state}
 
-      map_size(state.owners) >= state.capacity ->
+      in_use(state) >= state.capacity ->
         {:reply, {:error, :run_capacity_exhausted}, state}
 
       true ->
@@ -163,7 +365,11 @@ defmodule PtcRunner.Kernel.RunAdmission do
         Process.demonitor(ref, [:flush])
 
         {:reply, :ok,
-         %{state | owners: owners, status: if(clean?, do: state.status, else: :unavailable)}}
+         %{
+           drop_owner_reservation(state, owner)
+           | owners: owners,
+             status: if(clean?, do: state.status, else: :unavailable)
+         }}
     end
   end
 
@@ -171,14 +377,104 @@ defmodule PtcRunner.Kernel.RunAdmission do
 
   @impl true
   def handle_info({:DOWN, ref, :process, owner, _}, state) do
-    if state.owners[owner] == ref,
-      do: {:noreply, %{state | owners: Map.delete(state.owners, owner), status: :unavailable}},
-      else: {:noreply, state}
+    if state.owners[owner] == ref do
+      {:noreply,
+       %{
+         drop_owner_reservation(state, owner)
+         | owners: Map.delete(state.owners, owner),
+           status: :unavailable
+       }}
+    else
+      next =
+        Enum.reduce(state.reservations, state, fn
+          {key, %{monitor: ^ref, caller: ^owner}}, acc -> cancel_reservation(acc, key)
+          _, acc -> acc
+        end)
+
+      {:noreply, next}
+    end
+  end
+
+  def handle_info({:reservation_deadline, ref}, state) do
+    case state.reservations[ref] do
+      nil ->
+        {:noreply, state}
+
+      reservation ->
+        if deadline_live?(reservation.deadline) do
+          timer = deadline_timer(reservation.deadline, ref)
+          {:noreply, put_reservation(state, ref, %{reservation | timer: timer})}
+        else
+          {:noreply, cancel_reservation(state, ref)}
+        end
+    end
   end
 
   def handle_info(_, state), do: {:noreply, state}
 
+  defp in_use(state),
+    do: map_size(state.owners) + Enum.count(state.reservations, fn {_, r} -> is_nil(r.owner) end)
+
+  defp deadline_live?(:infinity), do: true
+
+  defp deadline_live?(deadline) when is_integer(deadline),
+    do: deadline > System.monotonic_time(:millisecond)
+
+  defp deadline_live?(_), do: false
+
+  defp deadline_timer(:infinity, _), do: nil
+
+  defp deadline_timer(deadline, ref),
+    do:
+      Process.send_after(
+        self(),
+        {:reservation_deadline, ref},
+        min(4_294_967_295, max(0, deadline - System.monotonic_time(:millisecond)))
+      )
+
+  defp put_reservation(state, ref, reservation),
+    do: %{state | reservations: Map.put(state.reservations, ref, reservation)}
+
+  defp cancel_reservation(state, ref) do
+    case state.reservations[ref] do
+      nil ->
+        state
+
+      %{owner: nil} ->
+        drop_reservation(state, ref)
+
+      %{cancelled?: true} ->
+        state
+
+      reservation ->
+        send(reservation.owner, {:run_admission_cancel, self()})
+        put_reservation(state, ref, %{reservation | cancelled?: true})
+    end
+  end
+
+  defp drop_reservation(state, ref) do
+    {reservation, reservations} = Map.pop(state.reservations, ref)
+    if reservation.monitor, do: Process.demonitor(reservation.monitor, [:flush])
+    if reservation.timer, do: Process.cancel_timer(reservation.timer)
+    %{state | reservations: reservations}
+  end
+
+  defp drop_owner_reservation(state, owner) do
+    Enum.reduce(state.reservations, state, fn
+      {ref, %{owner: ^owner}}, acc -> drop_reservation(acc, ref)
+      _, acc -> acc
+    end)
+  end
+
   defp fence_dead_owners(state) do
+    state =
+      Enum.reduce(state.reservations, state, fn {ref, reservation}, acc ->
+        if not deadline_live?(reservation.deadline) or
+             (is_nil(reservation.owner) and not Process.alive?(reservation.caller)),
+           do: cancel_reservation(acc, ref),
+           else: acc
+      end)
+
     if Enum.any?(state.owners, fn {pid, _} -> not Process.alive?(pid) end),
       do: %{state | status: :unavailable},
       else: state

--- a/test/ptc_runner/kernel/run_admission_test.exs
+++ b/test/ptc_runner/kernel/run_admission_test.exs
@@ -1,6 +1,6 @@
 defmodule PtcRunner.Kernel.RunAdmissionTest do
   # async: false — one case installs a node-wide :telemetry handler that blocks every sandbox arm in
-  # the VM (class D); the other 11 cases could run async in a sibling module.
+  # the VM (class D); the other cases could run async in a sibling module.
   use ExUnit.Case, async: false
   import PtcRunner.TestSupport.ProviderExecutionFixture
   import PtcRunner.TestSupport.Eventually
@@ -221,6 +221,293 @@ defmodule PtcRunner.Kernel.RunAdmissionTest do
     Process.exit(caller, :kill)
     assert_receive {:DOWN, ^ref, :process, ^caller, :killed}, 5_000
     assert_receive {:DOWN, ^sandbox_ref, :process, ^sandbox, :killed}, 1_000
+  end
+
+  test "unused reservations saturate, close once, and expire without preparing execution" do
+    host = start_supervised!({RunAdmission, max_concurrent_runs: 1})
+
+    assert {:ok, reservation} =
+             RunAdmission.reserve(host, System.monotonic_time(:millisecond) + 100)
+
+    assert {:error, :run_capacity_exhausted} = RunAdmission.reserve(host, :infinity)
+    assert :ok = RunAdmission.cancel(reservation)
+    assert {:error, :run_admission_unavailable} = RunAdmission.cancel(reservation)
+    assert {:ok, expired} = RunAdmission.reserve(host, System.monotonic_time(:millisecond) + 10)
+    assert_eventually(fn -> match?({:ok, %{in_use: 0}}, RunAdmission.snapshot(host)) end)
+    assert {:error, :run_admission_unavailable} = RunAdmission.activate(expired, nil, nil)
+    refute_received {:provider_phase, _}
+  end
+
+  test "reservation caller death releases capacity and another caller cannot cancel" do
+    host = start_supervised!({RunAdmission, max_concurrent_runs: 1})
+    parent = self()
+
+    {caller, ref} =
+      spawn_monitor(fn ->
+        send(parent, {:reserved, RunAdmission.reserve(host, :infinity)})
+        receive do: (:never -> :ok)
+      end)
+
+    assert_receive {:reserved, {:ok, reservation}}
+    assert {:error, :run_admission_unavailable} = RunAdmission.cancel(reservation)
+    Process.exit(caller, :kill)
+    assert_receive {:DOWN, ^ref, :process, ^caller, _}
+
+    assert_eventually(fn ->
+      match?({:ok, %{in_use: 0, status: :ready}}, RunAdmission.snapshot(host))
+    end)
+  end
+
+  test "activation transfers reserved capacity and cancellation holds it through cleanup" do
+    host = start_supervised!({RunAdmission, max_concurrent_runs: 1})
+    parent = self()
+
+    fixture =
+      fixture(
+        block: true,
+        close: fn ->
+          send(parent, {:closing, self()})
+          receive do: (:release -> :ok)
+        end
+      )
+
+    assert {:ok, reservation} = RunAdmission.reserve(host, :infinity)
+
+    assert {:ok, execution} =
+             RunAdmission.activate(
+               reservation,
+               fixture.prepared,
+               fixture.authority,
+               fixture.catalog,
+               fixture.execution.services
+             )
+
+    assert_receive {:running, _}, 5_000
+    assert :ok = RunAdmission.cancel(reservation)
+    assert_receive {:closing, closer}, 5_000
+    assert {:ok, %{in_use: 1}} = RunAdmission.snapshot(host)
+    assert {:error, :run_capacity_exhausted} = RunAdmission.reserve(host, :infinity)
+    send(closer, :release)
+    assert {:error, _} = RunAdmission.await(execution)
+    assert_eventually(fn -> match?({:ok, %{in_use: 0}}, RunAdmission.snapshot(host)) end)
+    assert {:ok, next} = RunAdmission.reserve(host, :infinity)
+    assert {:error, :run_admission_unavailable} = RunAdmission.cancel(reservation)
+    assert {:ok, %{in_use: 1}} = RunAdmission.snapshot(host)
+    assert :ok = RunAdmission.close(next)
+  end
+
+  test "concurrent reservations atomically saturate and response failures release only their slots" do
+    host = start_supervised!({RunAdmission, max_concurrent_runs: 2})
+    parent = self()
+
+    callers =
+      for _ <- 1..16 do
+        spawn_monitor(fn ->
+          receive do: (:reserve -> :ok)
+          result = RunAdmission.reserve(host, :infinity)
+          send(parent, {:reservation_result, self(), result})
+
+          case result do
+            {:ok, reservation} ->
+              receive do: (:response_failed -> :ok)
+              send(parent, {:closed, RunAdmission.close(reservation)})
+
+            _ ->
+              :ok
+          end
+        end)
+      end
+
+    Enum.each(callers, fn {pid, _} -> send(pid, :reserve) end)
+
+    results =
+      for _ <- callers do
+        assert_receive {:reservation_result, pid, result}
+        {pid, result}
+      end
+
+    admitted = Enum.filter(results, fn {_, result} -> match?({:ok, _}, result) end)
+    assert length(admitted) == 2
+
+    assert Enum.count(results, fn {_, result} ->
+             result == {:error, :run_capacity_exhausted}
+           end) == 14
+
+    assert {:ok, %{in_use: 2}} = RunAdmission.snapshot(host)
+    Enum.each(admitted, fn {pid, _} -> send(pid, :response_failed) end)
+    for _ <- admitted, do: assert_receive({:closed, :ok})
+    for {pid, ref} <- callers, do: assert_receive({:DOWN, ^ref, :process, ^pid, :normal})
+    assert {:ok, %{in_use: 0, status: :ready}} = RunAdmission.snapshot(host)
+    assert {:ok, reservation} = RunAdmission.reserve(host, :infinity)
+    assert :ok = RunAdmission.close(reservation)
+  end
+
+  test "deadline wins queued activation without consuming preparation or publication" do
+    host = start_supervised!({RunAdmission, max_concurrent_runs: 1})
+    fixture = fixture(provider_free: true)
+    parent = self()
+
+    {caller, ref} =
+      spawn_monitor(fn ->
+        {:ok, reservation} = RunAdmission.reserve(host, System.monotonic_time(:millisecond) + 100)
+        send(parent, {:reserved, reservation})
+        receive do: (:activate -> :ok)
+
+        send(
+          parent,
+          {:activated, RunAdmission.activate(reservation, fixture.prepared, fixture.authority)}
+        )
+      end)
+
+    assert_receive {:reserved, _reservation}
+    :ok = :sys.suspend(host)
+
+    try do
+      send(caller, :activate)
+
+      assert_eventually(fn ->
+        {:messages, messages} = Process.info(host, :messages)
+        Enum.any?(messages, &match?({:reservation_deadline, _}, &1))
+      end)
+    after
+      :sys.resume(host)
+    end
+
+    assert_receive {:activated, {:error, :run_admission_unavailable}}
+    assert_receive {:DOWN, ^ref, :process, ^caller, :normal}
+    assert PreparedRun.valid?(fixture.prepared)
+    assert PublicationAuthority.authorized?(fixture.authority)
+    assert {:ok, %{in_use: 0, status: :ready}} = RunAdmission.snapshot(host)
+    refute_received {:provider_phase, _}
+  end
+
+  test "reserved execution caller death holds capacity during cleanup and cleanup failure fences reservations" do
+    host = start_supervised!({RunAdmission, max_concurrent_runs: 1})
+    parent = self()
+
+    fixture =
+      fixture(
+        block: true,
+        close: fn ->
+          send(parent, {:closing, self()})
+          receive do: (:release -> raise "cleanup failed")
+        end
+      )
+
+    {caller, ref} =
+      spawn_monitor(fn ->
+        {:ok, reservation} = RunAdmission.reserve(host, :infinity)
+
+        {:ok, execution} =
+          RunAdmission.activate(
+            reservation,
+            fixture.prepared,
+            fixture.authority,
+            fixture.catalog,
+            fixture.execution.services
+          )
+
+        RunAdmission.await(execution)
+      end)
+
+    assert_receive {:running, _}, 5_000
+    Process.exit(caller, :kill)
+    assert_receive {:DOWN, ^ref, :process, ^caller, :killed}
+    assert_receive {:closing, closer}, 5_000
+    assert {:error, :run_capacity_exhausted} = RunAdmission.reserve(host, :infinity)
+    send(closer, :release)
+
+    assert_eventually(fn ->
+      match?({:ok, %{status: :unavailable}}, RunAdmission.snapshot(host))
+    end)
+
+    assert {:error, :run_admission_unavailable} = RunAdmission.reserve(host, :infinity)
+  end
+
+  test "admission death invalidates unused reservations and cancels reserved execution roots" do
+    host = start_supervised!({RunAdmission, max_concurrent_runs: 2})
+    assert {:ok, unused} = RunAdmission.reserve(host, :infinity)
+    fixture = fixture(block: true)
+    {:ok, reservation} = RunAdmission.reserve(host, :infinity)
+
+    {:ok, execution} =
+      RunAdmission.activate(
+        reservation,
+        fixture.prepared,
+        fixture.authority,
+        fixture.catalog,
+        fixture.execution.services
+      )
+
+    assert_receive {:running, provider}, 5_000
+    assert_receive {:provider_root, root, :ok}, 5_000
+    refs = for pid <- [provider, root], do: {pid, Process.monitor(pid)}
+    Process.exit(host, :kill)
+    assert {:error, :run_admission_unavailable} = RunAdmission.await(execution)
+    for {pid, ref} <- refs, do: assert_receive({:DOWN, ^ref, :process, ^pid, _}, 5_000)
+    assert {:error, :run_admission_unavailable} = RunAdmission.cancel(unused)
+    assert {:error, :run_admission_unavailable} = RunAdmission.activate(unused, nil, nil)
+  end
+
+  test "provider-free activation rejects foreign awaiting and completes its reservation once" do
+    host = start_supervised!({RunAdmission, max_concurrent_runs: 1})
+    fixture = fixture(provider_free: true)
+    assert {:ok, reservation} = RunAdmission.reserve(host, :infinity)
+
+    assert {:ok, execution} =
+             RunAdmission.activate(reservation, fixture.prepared, fixture.authority)
+
+    foreign = Task.async(fn -> RunAdmission.await(execution) end)
+    assert {:error, :execution_session_unavailable} = Task.await(foreign)
+
+    assert {:error, :run_admission_unavailable} =
+             RunAdmission.activate(reservation, fixture.prepared, fixture.authority)
+
+    assert {:ok, outcome} = RunAdmission.await(execution)
+    assert ExecutionOutcome.valid?(outcome)
+    assert {:ok, %{in_use: 0, status: :ready}} = RunAdmission.snapshot(host)
+    assert {:error, :run_admission_unavailable} = RunAdmission.complete(host, true)
+    assert {:ok, next} = RunAdmission.reserve(host, :infinity)
+    assert {:error, :run_admission_unavailable} = RunAdmission.cancel(reservation)
+    assert {:ok, %{in_use: 1}} = RunAdmission.snapshot(host)
+    assert :ok = RunAdmission.close(next)
+  end
+
+  @tag :nightly
+  test "active reservation deadline requests cancellation and retains capacity through cleanup" do
+    host = start_supervised!({RunAdmission, max_concurrent_runs: 1})
+    parent = self()
+
+    fixture =
+      fixture(
+        block: true,
+        close: fn ->
+          send(parent, {:closing, self()})
+          receive do: (:release -> :ok)
+        end
+      )
+
+    {:ok, reservation} = RunAdmission.reserve(host, System.monotonic_time(:millisecond) + 5_000)
+
+    {:ok, execution} =
+      RunAdmission.activate(
+        reservation,
+        fixture.prepared,
+        fixture.authority,
+        fixture.catalog,
+        fixture.execution.services
+      )
+
+    assert_receive {:running, _}, 5_000
+    assert_receive {:closing, closer}, 10_000
+    assert {:ok, %{in_use: 1}} = RunAdmission.snapshot(host)
+    assert {:error, :run_capacity_exhausted} = RunAdmission.reserve(host, :infinity)
+    send(closer, :release)
+    assert {:error, _} = RunAdmission.await(execution)
+
+    assert_eventually(fn ->
+      match?({:ok, %{in_use: 0, status: :ready}}, RunAdmission.snapshot(host))
+    end)
   end
 
   def hold_sandbox(_, _, %{live_run: _, pid: pid}, parent) do


### PR DESCRIPTION
## Summary

- Add opaque caller-owned run reservations with absolute deadlines, activation, cancellation, close, and await operations.
- Transfer reserved capacity to the execution owner before dispatch, retaining active capacity through cleanup and fencing uncertain cleanup.
- Document ownership and terminal races and cover concurrent saturation, caller death, commitment failure, deadlines, fencing, and admission death.

Closes #1938

## Validation

- `mix test test/ptc_runner/kernel/run_admission_test.exs --include nightly`

## Retrospective

- Untracked follow-up work: none.
- Repository instruction missing, wrong, or guessed: none.
