### PR TITLE
feat(kernel): construct immutable provider-free serving templates

### DIFF
--- a/lib/ptc_runner/kernel/declared_read_effect_validator.ex
+++ b/lib/ptc_runner/kernel/declared_read_effect_validator.ex
@@ -2,6 +2,7 @@ defmodule PtcRunner.Kernel.DeclaredReadEffectValidator do
   @moduledoc false
 
   alias PtcRunner.Kernel.ExportEffect
+  alias PtcRunner.Kernel.MissionInventory
 
   @analysis_operations ~w(runs open read counters)
 
@@ -36,6 +37,22 @@ defmodule PtcRunner.Kernel.DeclaredReadEffectValidator do
     validate_with(workflow_bundle, mission_bundles, missions, fn destination, occurrences ->
       prepared_effects(declarations, destination, occurrences)
     end)
+  end
+
+  @doc false
+  @spec validate_assembled(PtcRunner.Kernel.WorkflowEnvironment.t(), map(), map()) ::
+          :ok | {:error, {:declared_read_effect_violation, binary(), :write | :unknown}}
+  def validate_assembled(workflow, missions, workflow_effects) do
+    with :ok <- validate_bundle(workflow.bundle, workflow_effects) do
+      missions
+      |> Enum.sort_by(&elem(&1, 0))
+      |> Enum.reduce_while(:ok, fn {_name, mission}, :ok ->
+        case MissionInventory.validate_declared_read_effects(mission) do
+          :ok -> {:cont, :ok}
+          {:error, _reason} = error -> {:halt, error}
+        end
+      end)
+    end
   end
 
   defp validate_with(workflow_bundle, mission_bundles, missions, effects_for) do

--- a/lib/ptc_runner/kernel/effective_application.ex
+++ b/lib/ptc_runner/kernel/effective_application.ex
@@ -9,6 +9,7 @@ defmodule PtcRunner.Kernel.EffectiveApplication do
   this projection.
   """
 
+  alias PtcRunner.Kernel.ApplicationPackage
   alias PtcRunner.Kernel.FrozenBundle
   alias PtcRunner.Kernel.LimitCatalog
   alias PtcRunner.Kernel.RunRequest
@@ -31,33 +32,46 @@ defmodule PtcRunner.Kernel.EffectiveApplication do
           {:ok, %{projection: map(), digest: binary()}} | {:error, :invalid_effective_application}
   @doc "Builds the literal effective projection and its domain-separated digest."
   def build(request, workflow_bundle, mission_bundles, providers, effective_event_policy) do
-    with true <- RunRequest.valid?(request),
+    if RunRequest.valid?(request) do
+      build_package(request.package, workflow_bundle, mission_bundles, providers, %{
+        input_authority_class: request.input.authority,
+        inspection_capture: request.policy.inspection_capture,
+        result_projection: request.policy.result_projection,
+        effective_event_policy: effective_event_policy
+      })
+    else
+      {:error, :invalid_effective_application}
+    end
+  end
+
+  @doc false
+  @spec build_package(
+          ApplicationPackage.t(),
+          FrozenBundle.t(),
+          map(),
+          normalized_providers(),
+          map()
+        ) ::
+          {:ok, %{projection: map(), digest: binary()}} | {:error, :invalid_effective_application}
+  def build_package(package, workflow_bundle, mission_bundles, providers, policy) do
+    with true <- ApplicationPackage.valid?(package),
          true <- FrozenBundle.valid?(workflow_bundle),
-         true <- valid_mission_bundles?(mission_bundles, request.package.missions),
+         true <- valid_mission_bundles?(mission_bundles, package.missions),
          true <- valid_providers?(providers),
-         true <- effective_event_policy in [:normal, :private],
-         projection <-
-           projection(
-             request,
-             workflow_bundle,
-             mission_bundles,
-             providers,
-             effective_event_policy
-           ),
+         true <- policy.effective_event_policy in [:normal, :private],
+         true <- policy.input_authority_class in [:normal, :private],
+         true <- is_boolean(policy.inspection_capture),
+         true <- policy.result_projection in [:native, :json],
+         projection <- projection(package, workflow_bundle, mission_bundles, providers, policy),
          {:ok, encoded} <- TypedCanonicalJSON.encode(projection) do
       {:ok,
-       %{
-         projection: projection,
-         digest: "sha256:" <> TypedCanonicalJSON.sha256(@domain, encoded)
-       }}
+       %{projection: projection, digest: "sha256:" <> TypedCanonicalJSON.sha256(@domain, encoded)}}
     else
       _invalid -> {:error, :invalid_effective_application}
     end
   end
 
-  defp projection(request, workflow_bundle, mission_bundles, providers, effective_event_policy) do
-    package = request.package
-
+  defp projection(package, workflow_bundle, mission_bundles, providers, policy) do
     %{
       "bundle_hashes" => %{
         "workflow" => workflow_bundle.hash,
@@ -83,17 +97,17 @@ defmodule PtcRunner.Kernel.EffectiveApplication do
              }}
           end)
       },
-      "effective_event_policy" => Atom.to_string(effective_event_policy),
+      "effective_event_policy" => Atom.to_string(policy.effective_event_policy),
       "entry" => package.entry,
-      "input_authority_class" => Atom.to_string(request.input.authority),
-      "inspection_capture_enabled" => request.policy.inspection_capture,
+      "input_authority_class" => Atom.to_string(policy.input_authority_class),
+      "inspection_capture_enabled" => policy.inspection_capture,
       "limits" => LimitCatalog.effective_projection(package.limits),
       "providers" => %{
         "workflow" => providers.workflow,
         "mission" => providers.mission
       },
       "ptc_semantic_revision" => package.ptc_semantic_revision,
-      "result_projection" => Atom.to_string(request.policy.result_projection)
+      "result_projection" => Atom.to_string(policy.result_projection)
     }
   end
 

--- a/lib/ptc_runner/kernel/entry_effect.ex
+++ b/lib/ptc_runner/kernel/entry_effect.ex
@@ -1,0 +1,95 @@
+defmodule PtcRunner.Kernel.EntryEffect do
+  @moduledoc """
+  Resolves the conservative complete grant of an assembled workflow entry.
+
+  `resolve/2` takes `%{workflow: workflow_environment, missions: mission_environments}`
+  and the compiled entry export. It returns `%{effect: effect, contributors: contributors}`,
+  plus `capability_effects` for assembly validation. Contributors are sorted
+  `{route_or_grant, effect}` pairs for internal diagnostics.
+  These names must not cross the closed serving construction-error boundary.
+
+  Every implicit workflow route participates, even when the entry does not
+  statically reference it. `kernel-eval` joins every export and capability of
+  every selectable mission; there is no reachability narrowing. The other
+  reserved runtime and private diagnostic routes are read effects: their
+  inspection and annotation affect only the run. An empty mission grant is
+  read. Unknown dominates write, which dominates read. Export resolution
+  reuses the shared export resolver and `PtcRunner.Kernel.MissionInventory`.
+  """
+
+  alias PtcRunner.Kernel.Environment
+  alias PtcRunner.Kernel.ExportEffect
+  alias PtcRunner.Kernel.MissionInventory
+
+  @type effect :: :read | :write | :unknown
+  @spec resolve(map(), PtcRunner.Lisp.Prelude.Export.t()) ::
+          %{effect: effect(), contributors: [{binary(), effect()}], capability_effects: map()}
+  @doc "Resolves an entry after the complete workflow and mission grant is assembled."
+  def resolve(%{workflow: workflow, missions: missions}, entry) do
+    grants = mission_grants(missions)
+
+    routes = capability_effects(workflow, grants)
+    own = ExportEffect.resolve(entry, routes)
+
+    implicit_routes =
+      Map.take(
+        routes,
+        Environment.implicit_capabilities(:workflow, workflow.private_capabilities)
+      )
+
+    contributors =
+      Enum.sort([{"entry/" <> entry.ref, own} | Map.to_list(implicit_routes) ++ grants])
+
+    %{
+      effect: join(Enum.map(contributors, &elem(&1, 1))),
+      contributors: contributors,
+      capability_effects: routes
+    }
+  end
+
+  defp capability_effects(workflow, grants) do
+    routes =
+      Map.new(Environment.implicit_capabilities(:workflow, workflow.private_capabilities), fn
+        "kernel-eval" -> {"kernel-eval", join(Enum.map(grants, &elem(&1, 1)))}
+        name -> {name, :read}
+      end)
+
+    capabilities =
+      Map.new(workflow.capabilities, fn {name, cap} ->
+        {name, Map.get(cap, :effect, :unknown)}
+      end)
+
+    Map.merge(capabilities, routes)
+  end
+
+  defp mission_grants(missions) do
+    Enum.flat_map(missions, fn {name, mission} ->
+      exports =
+        case mission.bundle do
+          nil ->
+            []
+
+          bundle ->
+            Enum.map(bundle.prelude.exports, fn export ->
+              {"mission/" <> name <> "/export/" <> export.ref,
+               MissionInventory.resolved_export_effect(export, mission)}
+            end)
+        end
+
+      capabilities =
+        Enum.map(mission.capabilities, fn {cap_name, cap} ->
+          {"mission/" <> name <> "/capability/" <> cap_name, Map.get(cap, :effect, :unknown)}
+        end)
+
+      exports ++ capabilities
+    end)
+  end
+
+  defp join(effects) do
+    cond do
+      :unknown in effects -> :unknown
+      :write in effects -> :write
+      true -> :read
+    end
+  end
+end

--- a/lib/ptc_runner/kernel/environment.ex
+++ b/lib/ptc_runner/kernel/environment.ex
@@ -276,10 +276,12 @@ defmodule PtcRunner.Kernel.Environment do
 
   defp bundle_requirements(_bundle, _capabilities, _kind, _private_capabilities), do: :ok
 
-  defp implicit_capabilities(:workflow, private_capabilities),
+  @doc false
+  @spec implicit_capabilities(:workflow | :mission, [binary()]) :: [binary()]
+  def implicit_capabilities(:workflow, private_capabilities),
     do: private_capabilities ++ @workflow_implicit
 
-  defp implicit_capabilities(:mission, _private_capabilities),
+  def implicit_capabilities(:mission, _private_capabilities),
     do: ~w(runtime-usage runtime-remaining cap-list cap-describe)
 
   defp workflow_private_capabilities(bundle, authorization) do

--- a/lib/ptc_runner/kernel/mission_inventory.ex
+++ b/lib/ptc_runner/kernel/mission_inventory.ex
@@ -11,6 +11,10 @@ defmodule PtcRunner.Kernel.MissionInventory do
   `PtcRunner.Kernel.RunConfig` and are identical for normal runs and
   `PtcRunner.Kernel.ReplSession`.
 
+  Reserved mission inspection routes (`runtime-usage`, `runtime-remaining`,
+  `cap-list`, and `cap-describe`) resolve as read effects; missing or
+  undeclared host capability effects resolve conservatively as unknown.
+
   Every bare capability entry carries a frozen `call` form. In the secondary
   model-contract projection, required input fields are expanded into the
   literal argument map, for example `(tool/search {"query" query})`; the
@@ -345,9 +349,17 @@ defmodule PtcRunner.Kernel.MissionInventory do
 
   defp entry_form({:object, pairs}), do: pairs |> Map.new() |> Map.fetch!("form")
 
-  defp resolved_export_effect(export, %{capabilities: capabilities}) do
-    effects = Map.new(capabilities, fn {name, capability} -> {name, capability.effect} end)
-    ExportEffect.resolve(export, effects)
+  @doc false
+  @spec resolved_export_effect(Export.t(), MissionEnvironment.t() | map()) ::
+          :read | :write | :unknown
+  def resolved_export_effect(export, %{capabilities: capabilities}) do
+    effects =
+      Map.new(capabilities, fn {name, capability} ->
+        {name, Map.get(capability, :effect, :unknown)}
+      end)
+
+    implicit = Map.new(Environment.implicit_capabilities(:mission, []), &{&1, :read})
+    ExportEffect.resolve(export, Map.merge(effects, implicit))
   end
 
   @doc false

--- a/lib/ptc_runner/kernel/run_builder.ex
+++ b/lib/ptc_runner/kernel/run_builder.ex
@@ -48,6 +48,7 @@ defmodule PtcRunner.Kernel.RunBuilder do
   """
 
   alias PtcRunner.Kernel
+  alias PtcRunner.Kernel.ApplicationPackage
   alias PtcRunner.Kernel.ArtifactPublisher
   alias PtcRunner.Kernel.Attestation
   alias PtcRunner.Kernel.BundleCompiler
@@ -61,6 +62,7 @@ defmodule PtcRunner.Kernel.RunBuilder do
   alias PtcRunner.Kernel.Environment
   alias PtcRunner.Kernel.EventSink
   alias PtcRunner.Kernel.ExecutionOutcome
+  alias PtcRunner.Kernel.FrozenBundle
   alias PtcRunner.Kernel.InspectionArtifact
   alias PtcRunner.Kernel.InspectionSink
   alias PtcRunner.Kernel.InstallationCatalog
@@ -959,6 +961,27 @@ defmodule PtcRunner.Kernel.RunBuilder do
     end
   end
 
+  @doc false
+  @spec assemble_environments(ApplicationPackage.t(), FrozenBundle.t(), map(), map()) ::
+          {:ok, WorkflowEnvironment.t(), map()} | {:error, term()}
+  def assemble_environments(package, workflow_bundle, mission_bundles, providers) do
+    with {:ok, intern, workflow_catalog} <-
+           environment_catalog(package.workflow_components, workflow_bundle, SourceIntern.new()),
+         {:ok, workflow} <-
+           WorkflowEnvironment.new_for_package(
+             [
+               bundle: workflow_bundle,
+               capabilities: providers.workflow.capabilities,
+               catalog: workflow_catalog,
+               shipped_component_ids: library_component_ids(package.workflow_component_kinds)
+             ],
+             package
+           ),
+         {:ok, missions} <- mission_environments(package, mission_bundles, providers, intern) do
+      {:ok, workflow, missions}
+    end
+  end
+
   defp build_with_providers(
          request,
          {workflow_bundle, mission_bundles},
@@ -971,24 +994,8 @@ defmodule PtcRunner.Kernel.RunBuilder do
     package = request.package
 
     result =
-      with {:ok, intern, workflow_catalog} <-
-             environment_catalog(
-               package.workflow_components,
-               workflow_bundle,
-               SourceIntern.new()
-             ),
-           {:ok, workflow} <-
-             WorkflowEnvironment.new_for_package(
-               [
-                 bundle: workflow_bundle,
-                 capabilities: providers.workflow.capabilities,
-                 catalog: workflow_catalog,
-                 shipped_component_ids: library_component_ids(package.workflow_component_kinds)
-               ],
-               package
-             ),
-           {:ok, missions} <-
-             mission_environments(package, mission_bundles, providers, intern),
+      with {:ok, workflow, missions} <-
+             assemble_environments(package, workflow_bundle, mission_bundles, providers),
            {:ok, publication_authority, sink, inspection_sink} <-
              execution_sinks(request, providers, opts, failure_mode, sink_source),
            :ok <-

--- a/lib/ptc_runner/kernel/serving_template.ex
+++ b/lib/ptc_runner/kernel/serving_template.ex
@@ -1,0 +1,315 @@
+defmodule PtcRunner.Kernel.ServingTemplate do
+  @moduledoc """
+  Compile-once, provider-free application template for transport-neutral hosting.
+
+  `from_directory(manifest_path, installed_limits, opts \\\\ [])` returns
+  `{:ok, template}` or `{:error, build_code}`. `installed_limits` is a complete
+  valid `PtcRunner.Kernel.Limits` value. The only option is
+  `:expected_application_content_digest`, a `sha256:<64 lowercase hex>` pin.
+  Unknown or duplicate options, and malformed pins, fail before acquisition.
+  The pin compares content only, never effective identity.
+
+  Construction captures the directory closure once, compiles its workflow and
+  mission bundles and object value contracts once, and assembles the complete
+  runnable environment before validating effects. Exactly one callable workflow
+  entry is required. Its declaration must be `read` or `write`. Declared read
+  requires the complete grant resolved by `PtcRunner.Kernel.EntryEffect` to be
+  read; declared write remains write even with unknown grant components.
+  Manifest-owned event IDs and any selected providers are rejected.
+
+  The required manifest input declaration is shape-validated, but its referenced
+  file is never opened and its value is never contract-validated. Ordinary
+  command acquisition still requires and validates selected input. Per-call
+  execution is a separate API; this constructor never dispatches execution.
+
+  ## Safe metadata
+
+  `input_schema/1` and `output_schema/1` return exactly the normalized schemas
+  retained by the compiled input and result validators, including root tagged
+  unions of objects. `PtcRunner.Kernel.DeterministicJSON.encode/1` encodes them
+  deterministically. `effect/1` returns the validated `:read` or `:write`.
+  `application_content_digest/1`, `effective_application_digest/1`, and all
+  values of `installation_config_digests/1` use qualified SHA-256. The latter
+  map is empty for this provider-free surface. `limits/1` returns the resolved
+  effective limits; `policy/1` returns the frozen non-owning hosting rules.
+
+  ## Limits and deadlines
+
+  Manifest-narrowable limits are resolved against the supplied installed ceilings
+  by the ordinary manifest loader; installed-only limits remain unchanged.
+  Bundle compilation shares one absolute monotonic deadline of five seconds
+  and the ordinary aggregate 4,000,000-byte compiled-artifact bound.
+  Acquisition is capped at 512 documents and 8 MiB of captured bytes; content
+  framing is independently capped at 8 MiB. Normalized contracts are capped
+  at 64 KiB each. The bounded compiler also enforces its standard component,
+  dependency, source-byte and worker-heap limits.
+  The frozen call rule is one absolute monotonic millisecond deadline, computed
+  at reservation as the minimum of the caller deadline and reservation time plus
+  `limits.run_duration_ms`. Admission, activation, execution and publication
+  share that deadline; it is never reset at activation. No absolute timestamp is
+  stored in the template. This rule is consumed by the later call integration.
+
+  Event policy is the manifest's `:normal` or `:private`, input authority is
+  normal, result projection is JSON, inspection capture is disabled, and
+  publication is artifact-free. None of these choices is a per-call override.
+
+  ## Ownership and close
+
+  Templates are opaque, immutable, process-independent values concurrently
+  shareable across processes. They retain no selected `ExecutionInput`,
+  `ExecutionPolicy`, provider activity, sink, publication authority, run or trace
+  identity, PID, reference, callback, or file handle. Acquisition closes its
+  temporary document source on success and failure. Its resource-free placeholder
+  input is discarded. No `PreparedRun` or one-shot owner is created.
+  `close(template)` returns `:ok` and is an idempotent no-op: it releases no owned
+  resource and does not invalidate other copies. Drop all copies to reclaim memory.
+
+  ## Closed build codes
+
+  Errors contain only one atom, with no paths, payloads or private reasons:
+  `:invalid_options`, `:invalid_installed_limits`, `:invalid_application`,
+  `:contracts_required`, `:entry_invalid`, `:manifest_identity_forbidden`,
+  `:provider_runtime_required`, `:application_content_digest_mismatch`,
+  `:compilation_failed`, `:environment_invalid`, `:effect_declaration_required`,
+  `:declared_read_effect_violation`, or `:internal_error`.
+  Acquisition failures, including invalid contracts/declarations or document
+  bounds, collapse to `:invalid_application`. Compiler failures collapse to
+  `:compilation_failed`. Unexpected construction exceptions become `:internal_error`.
+  """
+
+  alias PtcRunner.Kernel.ApplicationPackage
+  alias PtcRunner.Kernel.BundleCompiler
+  alias PtcRunner.Kernel.DeclaredReadEffectValidator
+  alias PtcRunner.Kernel.EffectiveApplication
+  alias PtcRunner.Kernel.EntryEffect
+  alias PtcRunner.Kernel.InstallationConfigDigest
+  alias PtcRunner.Kernel.Limits
+  alias PtcRunner.Kernel.RunBuilder
+  alias PtcRunner.Kernel.RunCoordinator
+  alias PtcRunner.Kernel.ValueContract
+
+  @enforce_keys [:package, :workflow, :missions, :effect, :effective_digest, :policy]
+  defstruct @enforce_keys
+
+  @typedoc "An immutable compiled application with no owned execution resources."
+  @opaque t :: %__MODULE__{
+            package: ApplicationPackage.t(),
+            workflow: PtcRunner.Kernel.WorkflowEnvironment.t(),
+            missions: map(),
+            effect: :read | :write,
+            effective_digest: binary(),
+            policy: map()
+          }
+  @typedoc "Closed construction failures containing no private detail."
+  @type build_code ::
+          :invalid_options
+          | :invalid_installed_limits
+          | :invalid_application
+          | :contracts_required
+          | :entry_invalid
+          | :manifest_identity_forbidden
+          | :provider_runtime_required
+          | :application_content_digest_mismatch
+          | :compilation_failed
+          | :environment_invalid
+          | :effect_declaration_required
+          | :declared_read_effect_violation
+          | :internal_error
+
+  @doc "Acquires and compiles one immutable provider-free directory template."
+  @spec from_directory(binary(), Limits.t(), keyword()) :: {:ok, t()} | {:error, build_code()}
+  def from_directory(path, installed_limits, opts \\ []) do
+    with :ok <- options(opts),
+         true <- Limits.valid?(installed_limits),
+         {:ok, package} <- acquire(path, installed_limits),
+         :ok <- package_rules(package, opts) do
+      construct(package)
+    else
+      false -> {:error, :invalid_installed_limits}
+      {:error, _code} = error -> error
+    end
+  rescue
+    _exception -> {:error, :internal_error}
+  catch
+    _kind, _reason -> {:error, :internal_error}
+  end
+
+  @doc "Returns the compiled normalized object input schema."
+  @spec input_schema(t()) :: map()
+  def input_schema(%__MODULE__{package: package}), do: package.contracts.input.schema
+
+  @doc "Returns the compiled normalized object result schema."
+  @spec output_schema(t()) :: map()
+  def output_schema(%__MODULE__{package: package}), do: package.contracts.result.schema
+
+  @doc "Returns the validated declaration, widened by the complete grant for read entries."
+  @spec effect(t()) :: :read | :write
+  def effect(%__MODULE__{effect: effect}), do: effect
+
+  @doc "Returns content identity, independent of selected input and effective hosting policy."
+  @spec application_content_digest(t()) :: binary()
+  def application_content_digest(%__MODULE__{package: package}),
+    do: "sha256:" <> package.application_content_digest
+
+  @doc "Returns the existing effective identity with frozen hosting policy."
+  @spec effective_application_digest(t()) :: binary()
+  def effective_application_digest(%__MODULE__{effective_digest: digest}), do: digest
+
+  @doc "Returns selected installation configuration digests (empty without providers)."
+  @spec installation_config_digests(t()) :: %{binary() => binary()}
+  def installation_config_digests(%__MODULE__{}), do: %{}
+
+  @doc "Returns effective limits resolved against installed ceilings."
+  @spec limits(t()) :: Limits.t()
+  def limits(%__MODULE__{package: package}), do: package.limits
+
+  @doc "Returns frozen event, projection, inspection, publication and absolute-deadline rules."
+  @spec policy(t()) :: map()
+  def policy(%__MODULE__{policy: policy}), do: policy
+
+  @doc "Closes a resource-free template; an idempotent no-op that leaves copies usable."
+  @spec close(t()) :: :ok
+  def close(%__MODULE__{}), do: :ok
+
+  defp options(opts) when is_list(opts) do
+    if Keyword.keyword?(opts) and
+         Keyword.keys(opts) in [[], [:expected_application_content_digest]] and
+         (not Keyword.has_key?(opts, :expected_application_content_digest) or
+            InstallationConfigDigest.valid_digest?(opts[:expected_application_content_digest])),
+       do: :ok,
+       else: {:error, :invalid_options}
+  end
+
+  defp options(_opts), do: {:error, :invalid_options}
+
+  defp acquire(path, limits) do
+    case ApplicationPackage.acquire_directory(path, installed_limits: limits, omit_input: true) do
+      {:ok, package, _discarded_input} -> {:ok, package}
+      {:error, _reason} -> {:error, :invalid_application}
+    end
+  end
+
+  defp package_rules(package, opts) do
+    cond do
+      package.providers.workflow != [] or package.providers.mission != [] ->
+        {:error, :provider_runtime_required}
+
+      package.events.run_id != nil or package.events.trace_id != nil ->
+        {:error, :manifest_identity_forbidden}
+
+      not match?(%ValueContract{}, package.contracts.input) or
+          not match?(%ValueContract{}, package.contracts.result) ->
+        {:error, :contracts_required}
+
+      Keyword.has_key?(opts, :expected_application_content_digest) and
+          opts[:expected_application_content_digest] !=
+            "sha256:" <> package.application_content_digest ->
+        {:error, :application_content_digest_mismatch}
+
+      true ->
+        :ok
+    end
+  end
+
+  defp construct(package) do
+    deadline = System.monotonic_time(:millisecond) + 5_000
+
+    with {:ok, bundle} <- compile(package.workflow_components, deadline),
+         {:ok, bundles} <- compile_missions(package, bundle, deadline),
+         :ok <- entry_valid(bundle, package),
+         {:ok, workflow, missions} <- assemble(package, bundle, bundles),
+         {:ok, effect} <- validate_effect(workflow, missions, package.entry),
+         policy = %{
+           input_authority_class: :normal,
+           inspection_capture: false,
+           result_projection: :json,
+           effective_event_policy: package.events.policy,
+           publication: :artifact_free,
+           deadline: :absolute_from_reservation
+         },
+         {:ok, identity} <-
+           EffectiveApplication.build_package(
+             package,
+             bundle,
+             bundles,
+             %{workflow: [], mission: []},
+             policy
+           ) do
+      {:ok,
+       %__MODULE__{
+         package: package,
+         workflow: workflow,
+         missions: missions,
+         effect: effect,
+         effective_digest: identity.digest,
+         policy: policy
+       }}
+    else
+      {:error, :invalid_effective_application} -> {:error, :internal_error}
+      {:error, _code} = error -> error
+    end
+  end
+
+  defp compile(components, deadline) do
+    case BundleCompiler.compile(components, deadline) do
+      {:ok, bundle} -> {:ok, bundle}
+      {:error, _reason} -> {:error, :compilation_failed}
+    end
+  end
+
+  defp compile_missions(package, bundle, deadline) do
+    case BundleCompiler.compile_named(
+           package.missions,
+           deadline,
+           :erlang.external_size(bundle),
+           4_000_000,
+           [{package.workflow_components, bundle}]
+         ) do
+      {:ok, bundles} -> {:ok, bundles}
+      {:error, _reason} -> {:error, :compilation_failed}
+    end
+  end
+
+  defp entry_valid(bundle, package) do
+    with :ok <- RunCoordinator.validate_entry(bundle, package.entry),
+         :ok <- RunCoordinator.validate_entry_missions(bundle, package.entry, package.missions) do
+      :ok
+    else
+      {:error, _reason} -> {:error, :entry_invalid}
+    end
+  end
+
+  defp assemble(package, bundle, bundles) do
+    case RunBuilder.assemble_environments(package, bundle, bundles, %{
+           workflow: %{capabilities: []},
+           mission: %{by_occurrence: %{}}
+         }) do
+      {:ok, workflow, missions} -> {:ok, workflow, missions}
+      {:error, _reason} -> {:error, :environment_invalid}
+    end
+  end
+
+  defp validate_effect(workflow, missions, entry_ref) do
+    entry = Enum.find(workflow.bundle.prelude.exports, &(&1.ref == entry_ref))
+    resolved = EntryEffect.resolve(%{workflow: workflow, missions: missions}, entry)
+
+    validation =
+      DeclaredReadEffectValidator.validate_assembled(
+        workflow,
+        missions,
+        resolved.capability_effects
+      )
+
+    cond do
+      entry.declared_effect not in [:read, :write] ->
+        {:error, :effect_declaration_required}
+
+      validation != :ok or
+          (entry.declared_effect == :read and resolved.effect != :read) ->
+        {:error, :declared_read_effect_violation}
+
+      true ->
+        {:ok, entry.declared_effect}
+    end
+  end
+end

--- a/test/ptc_runner/kernel/entry_effect_test.exs
+++ b/test/ptc_runner/kernel/entry_effect_test.exs
@@ -1,0 +1,110 @@
+defmodule PtcRunner.Kernel.EntryEffectTest do
+  use ExUnit.Case, async: true
+
+  alias PtcRunner.Kernel
+  alias PtcRunner.Kernel.Capability
+  alias PtcRunner.Kernel.Component
+  alias PtcRunner.Kernel.EntryEffect
+  alias PtcRunner.Kernel.Environment
+  alias PtcRunner.Kernel.Library
+  alias PtcRunner.Kernel.MissionEnvironment
+  alias PtcRunner.Kernel.WorkflowEnvironment
+
+  test "every selectable capability contributes, including hidden and unused grants" do
+    {:ok, component} =
+      Component.new(id: "app", source: "(ns app) (defn run {:effect :read} [x] x)")
+
+    {:ok, bundle} = Kernel.compile_bundle([component])
+    {:ok, workflow} = WorkflowEnvironment.new(bundle: bundle)
+    [entry] = bundle.prelude.exports
+
+    for effect <- [:read, :write, :unknown] do
+      {:ok, capability} =
+        Capability.new(
+          name: "unused",
+          effect: effect,
+          model_visible: false,
+          input_schema: %{"type" => "object"},
+          callback: fn _ ->
+            flunk("resolution must not dispatch")
+          end
+        )
+
+      {:ok, mission} = MissionEnvironment.new(capabilities: [capability])
+
+      result =
+        EntryEffect.resolve(%{workflow: workflow, missions: %{"selectable" => mission}}, entry)
+
+      assert result.effect == effect
+      assert {"kernel-eval", effect} in result.contributors
+      assert {"mission/selectable/capability/unused", effect} in result.contributors
+    end
+  end
+
+  test "unknown dominates write across missions and missing export grants stay unknown" do
+    {:ok, component} =
+      Component.new(id: "app", source: "(ns app) (defn run {:effect :read} [x] x)")
+
+    {:ok, bundle} = Kernel.compile_bundle([component])
+    {:ok, workflow} = WorkflowEnvironment.new(bundle: bundle)
+    [entry] = bundle.prelude.exports
+
+    {:ok, write_component} =
+      Component.new(id: "writer", source: "(ns writer) (defn write {:effect :write} [x] x)")
+
+    {:ok, write_bundle} = Kernel.compile_bundle([write_component])
+    {:ok, writer} = MissionEnvironment.new(bundle: write_bundle)
+
+    {:ok, unknown_component} =
+      Component.new(
+        id: "unproven",
+        source: "(ns unproven) (defn run {:effect :write} [x] (tool/missing {}))"
+      )
+
+    {:ok, unknown_bundle} = Kernel.compile_bundle([unknown_component])
+    # The resolver also supports diagnostic maps with missing effects/grants.
+    missing = %{bundle: unknown_bundle, capabilities: %{}}
+
+    result =
+      EntryEffect.resolve(
+        %{workflow: workflow, missions: %{"writer" => writer, "unproven" => missing}},
+        entry
+      )
+
+    # ExportEffect conservatively reports write for a declared-write export;
+    # an undeclared capability independently makes the complete grant unknown.
+    assert result.effect == :write
+    missing = %{missing | capabilities: %{"undeclared" => %{}}}
+
+    result =
+      EntryEffect.resolve(
+        %{workflow: workflow, missions: %{"writer" => writer, "unproven" => missing}},
+        entry
+      )
+
+    assert result.effect == :unknown
+    assert {"mission/unproven/capability/undeclared", :unknown} in result.contributors
+  end
+
+  test "every reserved workflow and private diagnostic route has its maintained classification" do
+    {:ok, kernel} = Library.component("kernel")
+    {:ok, bundle} = Kernel.compile_bundle([kernel])
+
+    private =
+      ~w(kernel-agent-config-failure kernel-agent-outcome-failure kernel-agent-protocol-error kernel-llm-provider-failure kernel-phase-return-contract-failure kernel-result-contract-failure kernel-runtime-limit-failure)
+
+    {:ok, workflow} = WorkflowEnvironment.new(bundle: bundle)
+    # Grant fixed private routes in a diagnostic map to test their composition.
+    workflow = %{workflow | private_capabilities: private}
+
+    entry =
+      Enum.find(bundle.prelude.exports, &(&1.ref == "kernel/usage")) || hd(bundle.prelude.exports)
+
+    result = EntryEffect.resolve(%{workflow: workflow, missions: %{}}, entry)
+
+    for route <- Environment.implicit_capabilities(:workflow, private) do
+      assert result.capability_effects[route] == :read
+      assert {route, :read} in result.contributors
+    end
+  end
+end

--- a/test/ptc_runner/kernel/serving_template_acquisition_test.exs
+++ b/test/ptc_runner/kernel/serving_template_acquisition_test.exs
@@ -1,0 +1,98 @@
+defmodule PtcRunner.Kernel.ServingTemplateAcquisitionTest do
+  # Global trace patterns require a serial case.
+  use ExUnit.Case, async: false
+
+  alias PtcRunner.Kernel.ApplicationPackage
+  alias PtcRunner.Kernel.ApplicationSource
+  alias PtcRunner.Kernel.BundleCompiler
+  alias PtcRunner.Kernel.Limits
+  alias PtcRunner.Kernel.ServingTemplate
+  alias PtcRunner.Kernel.ValueContract
+
+  @tag :tmp_dir
+  test "construction acquires and compiles once and closes the source before sharing", %{
+    tmp_dir: dir
+  } do
+    source = "(ns app) (defn run {:effect :read} [x] (return x))"
+    schema = %{"type" => "object", "additionalProperties" => false}
+    path = Path.join(dir, "app.json")
+    File.write!(Path.join(dir, "app.clj"), source)
+    File.write!(Path.join(dir, "schema.json"), Jason.encode!(schema))
+
+    File.write!(
+      path,
+      Jason.encode!(%{
+        "version" => 1,
+        "workflow" => %{
+          "components" => [%{"id" => "app", "path" => "app.clj"}],
+          "entry" => "app/run"
+        },
+        "missions" => %{"same" => %{"components" => [%{"id" => "app", "path" => "app.clj"}]}},
+        "input" => %{"path" => "never-opened.json"},
+        "contracts" => %{
+          "input_schema" => %{"path" => "schema.json"},
+          "result_schema" => %{"path" => "schema.json"}
+        }
+      })
+    )
+
+    patterns = [
+      {ApplicationPackage, :acquire_directory, 2},
+      {ApplicationSource, :open_directory, 1},
+      {ApplicationSource, :close, 1},
+      {BundleCompiler, :compile, 2},
+      {ValueContract, :compile, 1}
+    ]
+
+    Enum.each(patterns, fn {module, _, _} = pattern ->
+      Code.ensure_loaded!(module)
+      :erlang.trace_pattern(pattern, true, [:local])
+    end)
+
+    on_exit(fn -> Enum.each(patterns, &:erlang.trace_pattern(&1, false, [:local])) end)
+    parent = self()
+
+    {pid, monitor} =
+      spawn_monitor(fn ->
+        receive do: (:build -> :ok)
+        result = ServingTemplate.from_directory(path, Limits.installed_defaults())
+        send(parent, {:constructed, result})
+        receive do: (:stop -> :ok)
+      end)
+
+    on_exit(fn -> if Process.alive?(pid), do: Process.exit(pid, :kill) end)
+    :erlang.trace(pid, true, [:call, {:tracer, self()}])
+    send(pid, :build)
+    assert_receive {:constructed, {:ok, template}}, 10_000
+    delivered = :erlang.trace_delivered(pid)
+    assert_receive {:trace_delivered, ^pid, ^delivered}
+    calls = traced_calls(pid, [])
+    assert Enum.count(calls, &match?({ApplicationPackage, :acquire_directory, _}, &1)) == 1
+    assert Enum.count(calls, &match?({ApplicationSource, :open_directory, _}, &1)) == 1
+    assert Enum.count(calls, &match?({ApplicationSource, :close, _}, &1)) == 1
+    assert Enum.count(calls, &match?({BundleCompiler, :compile, _}, &1)) == 1
+    assert Enum.count(calls, &match?({ValueContract, :compile, _}, &1)) == 2
+    send(pid, :stop)
+    assert_receive {:DOWN, ^monitor, :process, ^pid, :normal}
+    File.rm_rf!(dir)
+
+    assert Enum.all?(
+             1..16
+             |> Task.async_stream(fn _ ->
+               ValueContract.valid?(template.package.contracts.input, %{}) and
+                 ServingTemplate.input_schema(template) == schema and
+                 ServingTemplate.close(template) == :ok
+             end)
+             |> Enum.to_list(),
+             &(&1 == {:ok, true})
+           )
+  end
+
+  defp traced_calls(pid, calls) do
+    receive do
+      {:trace, ^pid, :call, call} -> traced_calls(pid, [call | calls])
+    after
+      0 -> calls
+    end
+  end
+end

--- a/test/ptc_runner/kernel/serving_template_test.exs
+++ b/test/ptc_runner/kernel/serving_template_test.exs
@@ -1,0 +1,344 @@
+defmodule PtcRunner.Kernel.ServingTemplateTest do
+  use ExUnit.Case, async: true
+
+  alias PtcRunner.Kernel.ApplicationPackage
+  alias PtcRunner.Kernel.DeterministicJSON
+  alias PtcRunner.Kernel.EffectiveApplication
+  alias PtcRunner.Kernel.ExecutionInput
+  alias PtcRunner.Kernel.ExecutionPolicy
+  alias PtcRunner.Kernel.Limits
+  alias PtcRunner.Kernel.RunRequest
+  alias PtcRunner.Kernel.ServingTemplate
+  alias PtcRunner.Kernel.ValueContract
+
+  @schema %{
+    "type" => "object",
+    "properties" => %{"answer" => %{"type" => "integer"}},
+    "required" => ["answer"],
+    "additionalProperties" => false
+  }
+  @source "(ns app) (defn run {:effect :read} [input] (return input))"
+
+  @tag :tmp_dir
+  test "captures compiled contracts and frozen policy without opening declared input", %{
+    tmp_dir: dir
+  } do
+    path = fixture(dir)
+    assert {:ok, template} = build(path)
+    assert {:error, _reason} = ApplicationPackage.request_directory(path)
+    assert {:ok, package, _input} = ApplicationPackage.acquire_directory(path, omit_input: true)
+    assert ServingTemplate.input_schema(template) == package.contracts.input.schema
+    assert ServingTemplate.output_schema(template) == package.contracts.result.schema
+    assert ServingTemplate.effect(template) == :read
+    assert ServingTemplate.installation_config_digests(template) == %{}
+
+    assert ServingTemplate.policy(template) == %{
+             input_authority_class: :normal,
+             effective_event_policy: :normal,
+             inspection_capture: false,
+             result_projection: :json,
+             publication: :artifact_free,
+             deadline: :absolute_from_reservation
+           }
+
+    assert ServingTemplate.limits(template) == package.limits
+    assert {:ok, encoded} = DeterministicJSON.encode(ServingTemplate.input_schema(template))
+    assert Jason.decode!(encoded) == ServingTemplate.input_schema(template)
+    refute owned?(template)
+    refute inspect(template) =~ dir
+    File.rm_rf!(dir)
+    assert :ok = ServingTemplate.close(template)
+
+    results =
+      1..16
+      |> Task.async_stream(fn _ ->
+        assert ValueContract.valid?(template.package.contracts.input, %{"answer" => 1})
+        refute ValueContract.valid?(template.package.contracts.input, %{"answer" => "bad"})
+        assert :ok = ServingTemplate.close(template)
+        DeterministicJSON.encode(ServingTemplate.input_schema(template))
+      end)
+      |> Enum.to_list()
+
+    assert Enum.all?(results, &(&1 == {:ok, {:ok, encoded}}))
+    assert :ok = ServingTemplate.close(template)
+  end
+
+  @tag :tmp_dir
+  test "content pin cannot be confused with existing effective identity", %{tmp_dir: dir} do
+    path = fixture(dir)
+    assert {:ok, template} = build(path)
+    content = ServingTemplate.application_content_digest(template)
+    effective = ServingTemplate.effective_application_digest(template)
+    assert content =~ ~r/\Asha256:[0-9a-f]{64}\z/
+    assert effective =~ ~r/\Asha256:[0-9a-f]{64}\z/
+    refute content == effective
+    assert {:ok, _template} = build(path, expected_application_content_digest: content)
+
+    assert {:error, :application_content_digest_mismatch} =
+             build(path, expected_application_content_digest: effective)
+
+    assert {:error, :application_content_digest_mismatch} =
+             build(path,
+               expected_application_content_digest: "sha256:" <> String.duplicate("0", 64)
+             )
+
+    assert {:ok, input} = ExecutionInput.new(%{"answer" => 3}, :normal)
+    assert {:ok, policy} = ExecutionPolicy.new(result_projection: :json)
+    assert {:ok, request} = RunRequest.new(template.package, input, policy)
+    bundles = Map.new(template.missions, fn {name, mission} -> {name, mission.bundle} end)
+
+    assert {:ok, identity} =
+             EffectiveApplication.build(
+               request,
+               template.workflow.bundle,
+               bundles,
+               %{workflow: [], mission: []},
+               :normal
+             )
+
+    assert identity.digest == effective
+
+    # Installed-only limits affect behavior, but never application content.
+    {:ok, installed} = Limits.new(provider_cleanup_timeout_ms: 1_234)
+    assert {:ok, changed} = ServingTemplate.from_directory(path, installed)
+    assert ServingTemplate.application_content_digest(changed) == content
+    refute ServingTemplate.effective_application_digest(changed) == effective
+  end
+
+  @tag :tmp_dir
+  test "contracts, identities, providers and entry shape are rejected at the constructor", %{
+    tmp_dir: dir
+  } do
+    for {change, code} <- [
+          {%{"contracts" => %{}}, :contracts_required},
+          {%{"contracts" => %{"input_schema" => %{"path" => "schema.json"}}},
+           :contracts_required},
+          {%{"events" => %{"run_id" => "owned"}}, :manifest_identity_forbidden},
+          {%{"events" => %{"trace_id" => "owned"}}, :manifest_identity_forbidden},
+          {%{"providers" => %{"workflow" => [%{"name" => "provider"}]}},
+           :provider_runtime_required},
+          {%{"providers" => %{"mission" => [%{"name" => "provider"}]}},
+           :provider_runtime_required},
+          {%{
+             "workflow" => %{
+               "components" => [%{"id" => "app", "path" => "workflow.clj"}],
+               "entry" => "app/missing"
+             }
+           }, :entry_invalid},
+          {%{"workflow" => %{"components" => [], "entry" => "app/run"}}, :entry_invalid},
+          {%{"input" => %{"path" => 1}}, :invalid_application},
+          {%{"input" => %{"path" => "missing.json", "value" => %{}}}, :invalid_application},
+          {%{"input" => nil}, :invalid_application}
+        ] do
+      assert {:error, ^code} = build(fixture(dir, change))
+    end
+
+    for schema <- [
+          %{"type" => "string"},
+          %{"type" => "array"},
+          %{"type" => "object", "$ref" => "private"}
+        ] do
+      path = fixture(dir)
+      File.write!(Path.join(dir, "schema.json"), Jason.encode!(schema))
+      assert {:error, :invalid_application} = build(path)
+    end
+
+    for source <- ["(ns app) (defn run {:effect :read} [] (return {}))", "(ns app) (def run 1)"] do
+      assert {:error, :entry_invalid} = build(fixture(dir, %{}, source))
+    end
+
+    assert {:error, :compilation_failed} =
+             build(fixture(dir, %{}, "(ns app) (defn run [input] missing)"))
+  end
+
+  @tag :tmp_dir
+  test "the full declared and resolved entry matrix includes every selectable mission", %{
+    tmp_dir: dir
+  } do
+    for declared <- [:read, :write, :unknown, nil], resolved <- [:read, :write, :unknown] do
+      metadata = if declared, do: "{:effect :#{declared}}", else: ""
+      workflow = "(ns app) (defn run #{metadata} [input] (return input))"
+      mission = "(ns mission) (defn helper {:effect :#{resolved}} [x] x)"
+
+      path =
+        fixture(
+          dir,
+          %{
+            "missions" => %{
+              "worker" => %{"components" => [%{"id" => "mission", "path" => "mission.clj"}]}
+            }
+          },
+          workflow
+        )
+
+      File.write!(Path.join(dir, "mission.clj"), mission)
+
+      case {declared, resolved} do
+        {:read, :read} -> assert {:ok, %{effect: :read}} = build(path)
+        {:read, _} -> assert {:error, :declared_read_effect_violation} = build(path)
+        {:write, _} -> assert {:ok, %{effect: :write}} = build(path)
+        _ -> assert {:error, :effect_declaration_required} = build(path)
+      end
+    end
+  end
+
+  @tag :tmp_dir
+  test "direct and transitive reserved routes resolve read and other invalid read exports reject",
+       %{tmp_dir: dir} do
+    source =
+      "(ns app) (defn- helper [x] (tool/runtime-usage {})) (defn run {:effect :read} [x] (return (helper x)))"
+
+    assert {:ok, %{effect: :read}} = build(fixture(dir, %{}, source))
+
+    source =
+      "(ns app) (defn helper {:effect :unknown} [x] x) (defn run {:effect :read} [x] (return (helper x)))"
+
+    assert {:error, :declared_read_effect_violation} = build(fixture(dir, %{}, source))
+
+    source =
+      "(ns app) (defn helper {:effect :write} [x] x) (defn run {:effect :read} [x] (return (helper x)))"
+
+    assert {:error, :declared_read_effect_violation} = build(fixture(dir, %{}, source))
+
+    source =
+      "(ns app) (defn helper {:effect :write} [x] x) (defn bad {:effect :read} [x] (helper x)) (defn run {:effect :write} [x] (return x))"
+
+    assert {:error, :declared_read_effect_violation} = build(fixture(dir, %{}, source))
+  end
+
+  @tag :tmp_dir
+  test "mission implicit inspection routes contribute their maintained read effects", %{
+    tmp_dir: dir
+  } do
+    path =
+      fixture(dir, %{
+        "missions" => %{
+          "worker" => %{"components" => [%{"id" => "mission", "path" => "mission.clj"}]}
+        }
+      })
+
+    File.write!(
+      Path.join(dir, "mission.clj"),
+      "(ns mission) (defn helper {:effect :read} [x] (tool/runtime-usage {}))"
+    )
+
+    assert {:ok, %{effect: :read}} = build(path)
+  end
+
+  @tag :tmp_dir
+  test "private events and narrowed limits are frozen without identities", %{tmp_dir: dir} do
+    path =
+      fixture(dir, %{
+        "events" => %{"policy" => "private"},
+        "limits" => %{"run_duration_ms" => 500}
+      })
+
+    assert {:ok, template} = build(path)
+    assert ServingTemplate.policy(template).effective_event_policy == :private
+    assert ServingTemplate.limits(template).run_duration_ms == 500
+    assert template.package.events.run_id == nil
+    assert template.package.events.trace_id == nil
+
+    assert {:error, :invalid_application} =
+             build(fixture(dir, %{"limits" => %{"run_duration_ms" => 9_999_999}}))
+  end
+
+  @tag :tmp_dir
+  test "inline input is excluded and tagged object schemas retain their compiled normalization",
+       %{tmp_dir: dir} do
+    branch = fn tag ->
+      %{
+        "type" => "object",
+        "properties" => %{"kind" => %{"type" => "string", "const" => tag}},
+        "required" => ["kind"],
+        "additionalProperties" => false
+      }
+    end
+
+    schema = %{"oneOf" => [branch.("a"), branch.("b")], "title" => "Object alternatives"}
+    path = fixture(dir, %{"input" => %{"value" => %{"wrong" => "not contract valid"}}})
+    File.write!(Path.join(dir, "schema.json"), Jason.encode!(schema))
+    assert {:ok, template} = build(path)
+    assert {:error, _reason} = ApplicationPackage.request_directory(path)
+    {:ok, compiled} = ValueContract.compile(schema)
+    assert ServingTemplate.input_schema(template) == compiled.schema
+    assert ServingTemplate.output_schema(template) == compiled.schema
+    assert {:ok, encoded} = DeterministicJSON.encode(compiled.schema)
+    assert {:ok, ^encoded} = DeterministicJSON.encode(ServingTemplate.input_schema(template))
+    assert ValueContract.valid?(template.package.contracts.input, %{"kind" => "a"})
+    refute ValueContract.valid?(template.package.contracts.input, %{"kind" => "c"})
+    content = ServingTemplate.application_content_digest(template)
+    path = fixture(dir, %{"input" => %{"path" => "missing.json"}})
+    File.write!(Path.join(dir, "schema.json"), Jason.encode!(schema))
+    assert {:ok, template} = build(path, expected_application_content_digest: content)
+    File.write!(Path.join(dir, "missing.json"), Jason.encode!(%{"kind" => "b"}))
+    assert {:ok, request} = ApplicationPackage.request_directory(path)
+    assert request.input.value == %{"kind" => "b"}
+
+    assert {:ok, _same} =
+             build(path,
+               expected_application_content_digest:
+                 ServingTemplate.application_content_digest(template)
+             )
+  end
+
+  test "closed pre-acquisition failures contain no private details" do
+    path = "/private/nonexistent/payload"
+
+    for opts <- [
+          [unknown: true],
+          [expected_application_content_digest: nil],
+          [expected_application_content_digest: String.duplicate("a", 64)],
+          [expected_application_content_digest: "sha256:" <> String.duplicate("A", 64)],
+          [
+            expected_application_content_digest: "sha256:" <> String.duplicate("a", 64),
+            expected_application_content_digest: "sha256:" <> String.duplicate("a", 64)
+          ],
+          nil
+        ] do
+      assert {:error, :invalid_options} = build(path, opts)
+    end
+
+    assert {:error, :invalid_installed_limits} = ServingTemplate.from_directory(path, %{})
+    assert {:error, :invalid_application} = build(path)
+  end
+
+  defp build(path, opts \\ []),
+    do: ServingTemplate.from_directory(path, Limits.installed_defaults(), opts)
+
+  defp fixture(dir, changes \\ %{}, source \\ @source) do
+    File.mkdir_p!(dir)
+
+    manifest =
+      Map.merge(
+        %{
+          "version" => 1,
+          "workflow" => %{
+            "components" => [%{"id" => "app", "path" => "workflow.clj"}],
+            "entry" => "app/run"
+          },
+          "input" => %{"path" => "missing.json"},
+          "contracts" => %{
+            "input_schema" => %{"path" => "schema.json"},
+            "result_schema" => %{"path" => "schema.json"}
+          }
+        },
+        changes
+      )
+
+    File.write!(Path.join(dir, "workflow.clj"), source)
+    File.write!(Path.join(dir, "schema.json"), Jason.encode!(@schema))
+    path = Path.join(dir, "app.json")
+    File.write!(path, Jason.encode!(manifest))
+    path
+  end
+
+  defp owned?(value)
+       when is_pid(value) or is_reference(value) or is_function(value) or is_port(value), do: true
+
+  defp owned?(%module{}) when module in [ExecutionInput, ExecutionPolicy], do: true
+  defp owned?(map) when is_map(map), do: Enum.any?(Map.to_list(map), &owned?/1)
+  defp owned?(tuple) when is_tuple(tuple), do: tuple |> Tuple.to_list() |> Enum.any?(&owned?/1)
+  defp owned?(list) when is_list(list), do: Enum.any?(list, &owned?/1)
+  defp owned?(_value), do: false
+end


### PR DESCRIPTION
## Summary

- Add opaque, compile-once provider-free serving templates with normalized contract schemas, qualified content/effective digests, effective limits, and frozen hosting policy.
- Resolve the complete workflow and selectable mission grant before accepting read declarations, including maintained reserved-route effects.
- Reuse acquisition, environment assembly, contract validators and effective identity construction without retaining one-shot resources; document closed build errors and close/deadline semantics.

Closes #1937

## Validation

- Focused constructor, effect resolver, acquisition/compilation tracing, application package and mission inventory tests.
- `mix nightly`.

## Retrospective

- Untracked follow-up work: none.
- Missing repository instruction: AGENTS.md does not explicitly state that every core change also requires Viewer validation; the pre-push hook applies that rule.
