### PR TITLE
feat(kernel): add provider-free serving calls and safe outcomes

### DIFF
--- a/lib/ptc_runner/kernel/run_admission.ex
+++ b/lib/ptc_runner/kernel/run_admission.ex
@@ -32,6 +32,12 @@ defmodule PtcRunner.Kernel.RunAdmission do
   capacity domain; the host must drain old work before replacing it. Active
   execution owners also monitor admission-owner death and abort their runs.
 
+  ServingTemplate retains a transferred reservation through calling-worker
+  publication. Execution cleanup transfers its capacity back to the monitored
+  caller, without making the slot available; only publication completion releases
+  it. Expiry marks it cancelled but retains it until publication cleanup. Caller
+  death in this interval fences admission, as publication cleanup is unproven.
+
   This counts hosted workflows, not physical LLM requests. Per-run provider
   task limits still apply. Direct adapter calls and executions through other
   entry points bypass this owner; Finch capacity, aggregate physical-attempt
@@ -160,6 +166,19 @@ defmodule PtcRunner.Kernel.RunAdmission do
   def await(_), do: {:error, :execution_session_unavailable}
 
   @doc false
+  @spec reservation_snapshot(reservation()) :: {:ok, snapshot()} | {:error, atom()}
+  def reservation_snapshot({__MODULE__, host, _}), do: snapshot(host)
+
+  @doc false
+  @spec retain_publication(reservation()) :: :ok | {:error, atom()}
+  def retain_publication({__MODULE__, host, ref}), do: call(host, {:retain_publication, ref})
+
+  @doc false
+  @spec finish_publication(reservation(), boolean()) :: :ok | {:error, atom()}
+  def finish_publication({__MODULE__, host, ref}, clean?),
+    do: call(host, {:finish_publication, ref, clean?})
+
+  @doc false
   def transfer(host, ref, ticket, caller), do: call(host, {:transfer, ref, ticket, caller})
 
   @type snapshot :: %{
@@ -283,11 +302,44 @@ defmodule PtcRunner.Kernel.RunAdmission do
           timer: timer,
           ticket: nil,
           owner: nil,
-          cancelled?: false
+          cancelled?: false,
+          publication: :none
         }
 
         {:reply, {:ok, {__MODULE__, self(), ref}},
          %{state | reservations: Map.put(state.reservations, ref, reservation)}}
+    end
+  end
+
+  def handle_call({:retain_publication, ref}, {caller, _}, state) do
+    case state.reservations[ref] do
+      %{caller: ^caller, owner: nil, ticket: nil, publication: :none} = reservation ->
+        {:reply, :ok, put_reservation(state, ref, %{reservation | publication: :pending})}
+
+      _ ->
+        {:reply, {:error, :run_admission_unavailable}, state}
+    end
+  end
+
+  def handle_call({:finish_publication, ref, clean?}, {caller, _}, state)
+      when is_boolean(clean?) do
+    case state.reservations[ref] do
+      %{caller: ^caller, owner: nil, publication: publication} = reservation
+      when publication in [:held, :pending] ->
+        reply = if reservation.cancelled?, do: {:error, :call_cancelled}, else: :ok
+        next = drop_reservation(state, ref)
+        {:reply, reply, %{next | status: if(clean?, do: next.status, else: :unavailable)}}
+
+      %{caller: ^caller, owner: owner} = reservation when is_pid(owner) and not clean? ->
+        next = cancel_reservation(state, ref)
+
+        next =
+          put_reservation(next, ref, %{reservation | publication: :discard, cancelled?: true})
+
+        {:reply, :ok, %{next | status: :unavailable}}
+
+      _ ->
+        {:reply, {:error, :run_admission_unavailable}, state}
     end
   end
 
@@ -297,7 +349,7 @@ defmodule PtcRunner.Kernel.RunAdmission do
     case state.reservations[ref] do
       %{caller: ^caller, owner: nil, ticket: nil} = reservation ->
         if state.status == :ready and deadline_live?(reservation.deadline) and
-             Process.alive?(caller) do
+             Process.alive?(caller) and not reservation.cancelled? do
           ticket = make_ref()
           {:reply, {:ok, ticket}, put_reservation(state, ref, %{reservation | ticket: ticket})}
         else
@@ -315,7 +367,8 @@ defmodule PtcRunner.Kernel.RunAdmission do
     case state.reservations[ref] do
       %{caller: ^caller, owner: nil, ticket: ^ticket} = reservation when is_reference(ticket) ->
         if state.status == :ready and deadline_live?(reservation.deadline) and
-             Process.alive?(caller) and not Map.has_key?(state.owners, owner) do
+             Process.alive?(caller) and not reservation.cancelled? and
+             not Map.has_key?(state.owners, owner) do
           Process.demonitor(reservation.monitor, [:flush])
           next = put_reservation(state, ref, %{reservation | owner: owner, monitor: nil})
           {:reply, :ok, %{next | owners: Map.put(next.owners, owner, Process.monitor(owner))}}
@@ -366,7 +419,7 @@ defmodule PtcRunner.Kernel.RunAdmission do
 
         {:reply, :ok,
          %{
-           drop_owner_reservation(state, owner)
+           complete_owner_reservation(state, owner, clean?)
            | owners: owners,
              status: if(clean?, do: state.status, else: :unavailable)
          }}
@@ -440,6 +493,14 @@ defmodule PtcRunner.Kernel.RunAdmission do
       nil ->
         state
 
+      %{owner: nil, publication: publication} = reservation
+      when publication in [:held, :pending] ->
+        if Process.alive?(reservation.caller) do
+          put_reservation(state, ref, %{reservation | cancelled?: true})
+        else
+          %{drop_reservation(state, ref) | status: :unavailable}
+        end
+
       %{owner: nil} ->
         drop_reservation(state, ref)
 
@@ -457,6 +518,24 @@ defmodule PtcRunner.Kernel.RunAdmission do
     if reservation.monitor, do: Process.demonitor(reservation.monitor, [:flush])
     if reservation.timer, do: Process.cancel_timer(reservation.timer)
     %{state | reservations: reservations}
+  end
+
+  defp complete_owner_reservation(state, owner, clean?) do
+    Enum.reduce(state.reservations, state, fn
+      {ref, %{owner: ^owner, publication: :pending} = reservation}, acc when clean? ->
+        put_reservation(acc, ref, %{
+          reservation
+          | owner: nil,
+            publication: :held,
+            monitor: Process.monitor(reservation.caller)
+        })
+
+      {ref, %{owner: ^owner}}, acc ->
+        drop_reservation(acc, ref)
+
+      _, acc ->
+        acc
+    end)
   end
 
   defp drop_owner_reservation(state, owner) do

--- a/lib/ptc_runner/kernel/run_admission.ex
+++ b/lib/ptc_runner/kernel/run_admission.ex
@@ -336,6 +336,8 @@ defmodule PtcRunner.Kernel.RunAdmission do
 
   def handle_call({:finish_publication, ref, clean?}, {caller, _}, state)
       when is_boolean(clean?) do
+    state = reap_dead_reservation_owner(state, ref)
+
     case state.reservations[ref] do
       %{caller: ^caller, owner: nil, publication: publication} = reservation
       when publication in [:held, :pending] ->
@@ -430,19 +432,10 @@ defmodule PtcRunner.Kernel.RunAdmission do
   end
 
   def handle_call({:complete, clean?}, {owner, _}, state) when is_boolean(clean?) do
-    case Map.pop(state.owners, owner) do
-      {nil, _} ->
-        {:reply, {:error, :run_admission_unavailable}, state}
-
-      {ref, owners} ->
-        Process.demonitor(ref, [:flush])
-
-        {:reply, :ok,
-         %{
-           complete_owner_reservation(state, owner, clean?)
-           | owners: owners,
-             status: if(clean?, do: state.status, else: :unavailable)
-         }}
+    if Map.has_key?(state.owners, owner) do
+      {:reply, :ok, settle_owner(state, owner, clean?)}
+    else
+      {:reply, {:error, :run_admission_unavailable}, state}
     end
   end
 
@@ -451,12 +444,7 @@ defmodule PtcRunner.Kernel.RunAdmission do
   @impl true
   def handle_info({:DOWN, ref, :process, owner, _}, state) do
     if state.owners[owner] == ref do
-      {:noreply,
-       %{
-         complete_owner_reservation(state, owner, false)
-         | owners: Map.delete(state.owners, owner),
-           status: :unavailable
-       }}
+      {:noreply, settle_owner(state, owner, false)}
     else
       next =
         Enum.reduce(state.reservations, state, fn
@@ -550,6 +538,29 @@ defmodule PtcRunner.Kernel.RunAdmission do
     if reservation.monitor, do: Process.demonitor(reservation.monitor, [:flush])
     if reservation.timer, do: Process.cancel_timer(reservation.timer)
     %{state | reservations: reservations}
+  end
+
+  defp reap_dead_reservation_owner(state, ref) do
+    case state.reservations[ref] do
+      %{owner: owner} when is_pid(owner) ->
+        if Map.has_key?(state.owners, owner) and not Process.alive?(owner),
+          do: settle_owner(state, owner, false),
+          else: state
+
+      _ ->
+        state
+    end
+  end
+
+  defp settle_owner(state, owner, clean?) do
+    Process.demonitor(Map.fetch!(state.owners, owner), [:flush])
+    next = complete_owner_reservation(state, owner, clean?)
+
+    %{
+      next
+      | owners: Map.delete(next.owners, owner),
+        status: if(clean?, do: next.status, else: :unavailable)
+    }
   end
 
   defp complete_owner_reservation(state, owner, clean?) do

--- a/lib/ptc_runner/kernel/run_admission.ex
+++ b/lib/ptc_runner/kernel/run_admission.ex
@@ -35,7 +35,11 @@ defmodule PtcRunner.Kernel.RunAdmission do
   ServingTemplate retains a transferred reservation through calling-worker
   publication. Execution cleanup transfers its capacity back to the monitored
   caller, without making the slot available; only publication completion releases
-  it. Expiry marks it cancelled but retains it until publication cleanup. Caller
+  it. Unclean completion and unexpected execution-owner death also transfer a
+  retained lease to the caller while fencing the domain; fenced snapshots keep
+  counting that lease until caller cleanup finishes. Admission refusal during
+  activation is distinct from request/deadline cancellation.
+  Expiry marks it cancelled but retains it until publication cleanup. Caller
   death in this interval fences admission, as publication cleanup is unproven.
 
   This counts hosted workflows, not physical LLM requests. Per-run provider
@@ -303,7 +307,9 @@ defmodule PtcRunner.Kernel.RunAdmission do
           ticket: nil,
           owner: nil,
           cancelled?: false,
-          publication: :none
+          publication: :none,
+          admission_refused?: false,
+          cleanup_uncertain?: false
         }
 
         {:reply, {:ok, {__MODULE__, self(), ref}},
@@ -312,9 +318,16 @@ defmodule PtcRunner.Kernel.RunAdmission do
   end
 
   def handle_call({:retain_publication, ref}, {caller, _}, state) do
+    state = fence_dead_owners(state)
+
     case state.reservations[ref] do
       %{caller: ^caller, owner: nil, ticket: nil, publication: :none} = reservation ->
-        {:reply, :ok, put_reservation(state, ref, %{reservation | publication: :pending})}
+        if state.status == :ready and deadline_live?(reservation.deadline) and
+             Process.alive?(caller) and not reservation.cancelled? do
+          {:reply, :ok, put_reservation(state, ref, %{reservation | publication: :pending})}
+        else
+          {:reply, {:error, :run_admission_unavailable}, refuse_activation(state, ref)}
+        end
 
       _ ->
         {:reply, {:error, :run_admission_unavailable}, state}
@@ -326,7 +339,14 @@ defmodule PtcRunner.Kernel.RunAdmission do
     case state.reservations[ref] do
       %{caller: ^caller, owner: nil, publication: publication} = reservation
       when publication in [:held, :pending] ->
-        reply = if reservation.cancelled?, do: {:error, :call_cancelled}, else: :ok
+        reply =
+          cond do
+            reservation.cleanup_uncertain? -> {:error, :call_cleanup_failed}
+            reservation.admission_refused? -> {:error, :call_admission_refused}
+            reservation.cancelled? -> {:error, :call_cancelled}
+            true -> :ok
+          end
+
         next = drop_reservation(state, ref)
         {:reply, reply, %{next | status: if(clean?, do: next.status, else: :unavailable)}}
 
@@ -353,7 +373,7 @@ defmodule PtcRunner.Kernel.RunAdmission do
           ticket = make_ref()
           {:reply, {:ok, ticket}, put_reservation(state, ref, %{reservation | ticket: ticket})}
         else
-          {:reply, {:error, :run_admission_unavailable}, cancel_reservation(state, ref)}
+          {:reply, {:error, :run_admission_unavailable}, refuse_activation(state, ref)}
         end
 
       _ ->
@@ -373,7 +393,7 @@ defmodule PtcRunner.Kernel.RunAdmission do
           next = put_reservation(state, ref, %{reservation | owner: owner, monitor: nil})
           {:reply, :ok, %{next | owners: Map.put(next.owners, owner, Process.monitor(owner))}}
         else
-          {:reply, {:error, :run_admission_unavailable}, cancel_reservation(state, ref)}
+          {:reply, {:error, :run_admission_unavailable}, refuse_activation(state, ref)}
         end
 
       _ ->
@@ -433,7 +453,7 @@ defmodule PtcRunner.Kernel.RunAdmission do
     if state.owners[owner] == ref do
       {:noreply,
        %{
-         drop_owner_reservation(state, owner)
+         complete_owner_reservation(state, owner, false)
          | owners: Map.delete(state.owners, owner),
            status: :unavailable
        }}
@@ -488,6 +508,18 @@ defmodule PtcRunner.Kernel.RunAdmission do
   defp put_reservation(state, ref, reservation),
     do: %{state | reservations: Map.put(state.reservations, ref, reservation)}
 
+  defp refuse_activation(state, ref) do
+    reservation = state.reservations[ref]
+
+    if reservation.publication == :pending and state.status == :unavailable and
+         deadline_live?(reservation.deadline) and Process.alive?(reservation.caller) and
+         not reservation.cancelled? do
+      put_reservation(state, ref, %{reservation | admission_refused?: true})
+    else
+      cancel_reservation(state, ref)
+    end
+  end
+
   defp cancel_reservation(state, ref) do
     case state.reservations[ref] do
       nil ->
@@ -522,11 +554,12 @@ defmodule PtcRunner.Kernel.RunAdmission do
 
   defp complete_owner_reservation(state, owner, clean?) do
     Enum.reduce(state.reservations, state, fn
-      {ref, %{owner: ^owner, publication: :pending} = reservation}, acc when clean? ->
+      {ref, %{owner: ^owner, publication: :pending} = reservation}, acc ->
         put_reservation(acc, ref, %{
           reservation
           | owner: nil,
             publication: :held,
+            cleanup_uncertain?: reservation.cleanup_uncertain? or not clean?,
             monitor: Process.monitor(reservation.caller)
         })
 
@@ -535,13 +568,6 @@ defmodule PtcRunner.Kernel.RunAdmission do
 
       _, acc ->
         acc
-    end)
-  end
-
-  defp drop_owner_reservation(state, owner) do
-    Enum.reduce(state.reservations, state, fn
-      {ref, %{owner: ^owner}}, acc -> drop_reservation(acc, ref)
-      _, acc -> acc
     end)
   end
 

--- a/lib/ptc_runner/kernel/serving_call.ex
+++ b/lib/ptc_runner/kernel/serving_call.ex
@@ -1,0 +1,304 @@
+defmodule PtcRunner.Kernel.ServingCall do
+  @moduledoc """
+  Owns the opaque reservation used by `PtcRunner.Kernel.ServingTemplate`.
+
+  Hosts use ServingTemplate for reserve, activation and close. This module owns
+  the internal reservation representation; it does not authorize transport
+  commitment or add per-call policy overrides.
+  """
+  alias PtcRunner.Kernel.ArtifactPublisher
+  alias PtcRunner.Kernel.ExecutionInput
+  alias PtcRunner.Kernel.ExecutionOutcome
+  alias PtcRunner.Kernel.ExecutionPolicy
+  alias PtcRunner.Kernel.InstallationCatalog
+  alias PtcRunner.Kernel.OwnerFailure
+  alias PtcRunner.Kernel.PreparedRun
+  alias PtcRunner.Kernel.ProviderActivity
+  alias PtcRunner.Kernel.ProviderPlan
+  alias PtcRunner.Kernel.PublicationAuthority
+  alias PtcRunner.Kernel.RunAdmission
+  alias PtcRunner.Kernel.RunRequest
+  alias PtcRunner.Kernel.ServingOutcome
+  alias PtcRunner.Kernel.ServingTemplate
+  alias PtcRunner.Kernel.StrictJSON
+  alias PtcRunner.Kernel.ValueContract
+
+  @opaque reservation ::
+            {__MODULE__, ServingTemplate.t(), map(), RunAdmission.reservation(), integer(), pid()}
+
+  @spec reserve(ServingTemplate.t(), term(), pid(), integer() | :infinity) ::
+          {:ok, reservation()} | ServingOutcome.t()
+  def reserve(template, input, admission, caller_deadline) do
+    with {:ok, input} <- StrictJSON.admit(input),
+         true <- is_map(input) and not is_struct(input),
+         true <- ValueContract.valid?(template.package.contracts.input, input) do
+      reserve_valid(template, input, admission, caller_deadline)
+    else
+      _ -> outcome(template, :invalid_input, false)
+    end
+  rescue
+    _ -> outcome(template, :internal_error, false)
+  end
+
+  defp reserve_valid(template, input, admission, caller_deadline) do
+    now = System.monotonic_time(:millisecond)
+    limit = now + ServingTemplate.limits(template).run_duration_ms
+    deadline = if caller_deadline == :infinity, do: limit, else: caller_deadline
+
+    cond do
+      not is_integer(deadline) ->
+        outcome(template, :internal_error, false)
+
+      deadline <= now ->
+        outcome(template, :cancelled, false)
+
+      true ->
+        deadline = min(deadline, limit)
+
+        case RunAdmission.reserve(admission, deadline) do
+          {:ok, lease} -> {:ok, {__MODULE__, template, input, lease, deadline, self()}}
+          {:error, :run_capacity_exhausted} -> outcome(template, :busy, false)
+          _ -> outcome(template, :admission_unavailable, false)
+        end
+    end
+  end
+
+  @spec close(reservation()) :: :ok | {:error, :run_admission_unavailable}
+  def close({__MODULE__, _, _, lease, _, caller}) when caller == self(),
+    do: RunAdmission.close(lease)
+
+  def close(_), do: {:error, :run_admission_unavailable}
+
+  @spec activate(reservation()) :: ServingOutcome.t()
+  def activate(reservation), do: activate(reservation, %{})
+
+  @doc false
+  def activate({__MODULE__, template, input, lease, deadline, caller}, hooks)
+      when caller == self() do
+    case RunAdmission.retain_publication(lease) do
+      :ok -> activate_owned(template, input, lease, deadline, hooks)
+      _ -> outcome(template, expired_code(deadline, :admission_unavailable), false)
+    end
+  end
+
+  def activate(_, _), do: ServingOutcome.new(:internal_error, false, :write)
+
+  defp activate_owned(template, input, lease, deadline, hooks) do
+    case prepare(template, input) do
+      {:ok, prepared} ->
+        try do
+          case PublicationAuthority.new([]) do
+            {:ok, authority} ->
+              execute(template, prepared, authority, lease, deadline, hooks)
+
+            _ ->
+              clean? = PreparedRun.close(prepared) == :ok
+              RunAdmission.finish_publication(lease, clean?)
+              outcome(template, if(clean?, do: :publication_failed, else: :cleanup_failed), false)
+          end
+        after
+          PreparedRun.close(prepared)
+        end
+
+      _ ->
+        RunAdmission.finish_publication(lease, false)
+        outcome(template, :cleanup_failed, false)
+    end
+  rescue
+    _ ->
+      RunAdmission.finish_publication(lease, false)
+      outcome(template, :cleanup_failed, false)
+  catch
+    _, _ ->
+      RunAdmission.finish_publication(lease, false)
+      outcome(template, :cleanup_failed, false)
+  end
+
+  defp prepare(template, input) do
+    bundle = template.workflow.bundle
+    bundles = Map.new(template.missions, fn {name, mission} -> {name, mission.bundle} end)
+
+    with {:ok, input} <- ExecutionInput.new(input, :normal, template.package.contracts.input),
+         {:ok, policy} <-
+           ExecutionPolicy.new(
+             run_id: identity(),
+             trace_id: identity(),
+             result_projection: :json,
+             inspection_capture: false,
+             event_policy: :normal
+           ),
+         {:ok, request} <- RunRequest.new(template.package, input, policy),
+         {:ok, catalog} <-
+           InstallationCatalog.new(%{}, installed_limits: template.package.installed_limits),
+         {:ok, metadata} <- ProviderPlan.derive(request, bundle, bundles, []) do
+      ProviderActivity.start_owned(fn activity ->
+        PreparedRun.new(
+          request,
+          bundle,
+          bundles,
+          "(#{template.package.entry} data/input)",
+          activity,
+          catalog,
+          Map.merge(metadata, %{provider_declarations: [], installation_config_digests: %{}})
+        )
+      end)
+    end
+  end
+
+  defp execute(template, prepared, authority, lease, deadline, hooks) do
+    result =
+      try do
+        case RunAdmission.activate(lease, prepared, authority) do
+          {:ok, execution} -> collect(template, RunAdmission.await(execution), authority, hooks)
+          {:error, reason} -> failure(template, reason)
+        end
+      rescue
+        _ -> outcome(template, :internal_error, :unknown)
+      catch
+        _, _ -> outcome(template, :internal_error, :unknown)
+      end
+
+    prepared_clean? = PreparedRun.close(prepared) == :ok
+    clean? = cleanup(authority, hooks) == :ok and prepared_clean?
+
+    case RunAdmission.finish_publication(lease, clean?) do
+      :ok when clean? ->
+        replace_expired(template, result, deadline)
+
+      {:error, :call_cancelled} when clean? ->
+        outcome(template, :cancelled, ServingOutcome.metadata(result).dispatched)
+
+      _ ->
+        RunAdmission.close(lease)
+
+        case admission_status(lease) do
+          :unavailable ->
+            outcome(template, :cleanup_failed, ServingOutcome.metadata(result).dispatched)
+
+          _ when not clean? ->
+            outcome(template, :cleanup_failed, ServingOutcome.metadata(result).dispatched)
+
+          _ ->
+            replace_expired(template, result, deadline)
+        end
+    end
+  end
+
+  defp admission_status(lease) do
+    case RunAdmission.reservation_snapshot(lease) do
+      {:ok, %{status: status}} -> status
+      _ -> :unavailable
+    end
+  end
+
+  defp cleanup(authority, hooks) do
+    case Map.get(hooks, :cleanup) do
+      nil -> PublicationAuthority.abort(authority)
+      hook -> hook.(authority)
+    end
+  rescue
+    _ -> {:error, :cleanup_failed}
+  catch
+    _, _ -> {:error, :cleanup_failed}
+  end
+
+  defp collect(template, {:ok, sealed}, authority, hooks) do
+    if hook = Map.get(hooks, :before_publication), do: hook.(authority)
+
+    case ExecutionOutcome.open(sealed, authority) do
+      {:ok, evidence} ->
+        published =
+          ArtifactPublisher.publish(evidence, authority, Map.get(hooks, :publication, %{}))
+
+        classify(template, evidence, published)
+
+      _ ->
+        outcome(template, :publication_failed, :unknown)
+    end
+  end
+
+  defp collect(template, {:error, reason}, _authority, _hooks), do: failure(template, reason)
+
+  defp classify(template, evidence, published) do
+    cond do
+      match?({:error, %{kind: :provider_cleanup_error}}, evidence.result) ->
+        outcome(template, :cleanup_failed, true)
+
+      match?({:error, _}, evidence.terminal_batch) or
+          match?({:error, %{kind: :event_sink_error}}, evidence.result) ->
+        outcome(template, :publication_failed, true)
+
+      publication_failed?(published) ->
+        outcome(template, :publication_failed, true)
+
+      evidence.result_contract != :ok ->
+        outcome(template, :invalid_result, true)
+
+      match?({:error, %{reason: :terminal_result_exceeded}}, evidence.result) ->
+        outcome(template, :invalid_result, true)
+
+      match?(
+        {:error, %{reason: reason}}
+        when reason in [
+               :invalid_result_projection,
+               :public_projection_collision,
+               :java_projection_error,
+               :projection_error,
+               :invalid_keyword,
+               :invalid_lisp_list,
+               :invalid_symbol_ref,
+               :symbol_ref_collision
+             ],
+        evidence.result
+      ) ->
+        outcome(template, :invalid_result, true)
+
+      match?({:error, %{reason: :timeout}}, evidence.result) ->
+        outcome(template, :cancelled, true)
+
+      match?({:error, _}, published) and match?({:ok, _}, evidence.result) ->
+        outcome(template, :publication_failed, true)
+
+      match?({:error, _}, evidence.result) ->
+        outcome(template, :execution_failed, true)
+
+      true ->
+        {:ok, value} = ValueContract.json_value(elem(evidence.result, 1).value)
+        outcome(template, :success, true, value)
+    end
+  end
+
+  defp publication_failed?({:error, report}),
+    do: report.failed != [] or report.error == :invalid_execution_outcome
+
+  defp publication_failed?(_), do: false
+
+  defp failure(template, :run_admission_unavailable),
+    do: outcome(template, :admission_unavailable, false)
+
+  defp failure(template, %{code: :provider_cleanup_failed}),
+    do: outcome(template, :cleanup_failed, :unknown)
+
+  defp failure(template, reason) do
+    case OwnerFailure.evidence(reason) do
+      {:ok, :event_sink_error, _, :not_started} -> outcome(template, :publication_failed, false)
+      {:ok, _, _, :not_started} -> outcome(template, :internal_error, false)
+      _ -> outcome(template, :internal_error, :unknown)
+    end
+  end
+
+  defp replace_expired(template, result, deadline) do
+    if ServingOutcome.code(result) != :cleanup_failed and
+         expired_code(deadline, :live) == :cancelled,
+       do: outcome(template, :cancelled, ServingOutcome.metadata(result).dispatched),
+       else: result
+  end
+
+  defp expired_code(deadline, fallback),
+    do: if(System.monotonic_time(:millisecond) >= deadline, do: :cancelled, else: fallback)
+
+  defp outcome(template, code, dispatched, value \\ nil),
+    do: ServingOutcome.new(code, dispatched, template.effect, value)
+
+  defp identity, do: Base.encode16(:crypto.strong_rand_bytes(16), case: :lower)
+end

--- a/lib/ptc_runner/kernel/serving_call.ex
+++ b/lib/ptc_runner/kernel/serving_call.ex
@@ -58,7 +58,7 @@ defmodule PtcRunner.Kernel.ServingCall do
         case RunAdmission.reserve(admission, deadline) do
           {:ok, lease} -> {:ok, {__MODULE__, template, input, lease, deadline, self()}}
           {:error, :run_capacity_exhausted} -> outcome(template, :busy, false)
-          _ -> outcome(template, :admission_unavailable, false)
+          _ -> outcome(template, expired_code(deadline, :admission_unavailable), false)
         end
     end
   end

--- a/lib/ptc_runner/kernel/serving_call.ex
+++ b/lib/ptc_runner/kernel/serving_call.ex
@@ -76,8 +76,12 @@ defmodule PtcRunner.Kernel.ServingCall do
   def activate({__MODULE__, template, input, lease, deadline, caller}, hooks)
       when caller == self() do
     case RunAdmission.retain_publication(lease) do
-      :ok -> activate_owned(template, input, lease, deadline, hooks)
-      _ -> outcome(template, expired_code(deadline, :admission_unavailable), false)
+      :ok ->
+        if hook = Map.get(hooks, :after_retention), do: hook.()
+        activate_owned(template, input, lease, deadline, hooks)
+
+      _ ->
+        outcome(template, expired_code(deadline, :admission_unavailable), false)
     end
   end
 
@@ -149,8 +153,15 @@ defmodule PtcRunner.Kernel.ServingCall do
     result =
       try do
         case RunAdmission.activate(lease, prepared, authority) do
-          {:ok, execution} -> collect(template, RunAdmission.await(execution), authority, hooks)
-          {:error, reason} -> failure(template, reason)
+          {:ok, execution} ->
+            if hook = Map.get(hooks, :after_activation), do: hook.(execution)
+            collect(template, RunAdmission.await(execution), authority, hooks)
+
+          {:error, :run_admission_unavailable} ->
+            outcome(template, :admission_unavailable, false)
+
+          {:error, reason} ->
+            failure(template, reason)
         end
       rescue
         _ -> outcome(template, :internal_error, :unknown)
@@ -164,6 +175,12 @@ defmodule PtcRunner.Kernel.ServingCall do
     case RunAdmission.finish_publication(lease, clean?) do
       :ok when clean? ->
         replace_expired(template, result, deadline)
+
+      {:error, :call_admission_refused} when clean? ->
+        replace_expired(template, outcome(template, :admission_unavailable, false), deadline)
+
+      {:error, :call_cleanup_failed} ->
+        outcome(template, :cleanup_failed, ServingOutcome.metadata(result).dispatched)
 
       {:error, :call_cancelled} when clean? ->
         outcome(template, :cancelled, ServingOutcome.metadata(result).dispatched)
@@ -274,7 +291,7 @@ defmodule PtcRunner.Kernel.ServingCall do
   defp publication_failed?(_), do: false
 
   defp failure(template, :run_admission_unavailable),
-    do: outcome(template, :admission_unavailable, false)
+    do: outcome(template, :cleanup_failed, :unknown)
 
   defp failure(template, %{code: :provider_cleanup_failed}),
     do: outcome(template, :cleanup_failed, :unknown)

--- a/lib/ptc_runner/kernel/serving_outcome.ex
+++ b/lib/ptc_runner/kernel/serving_outcome.ex
@@ -1,0 +1,77 @@
+defmodule PtcRunner.Kernel.ServingOutcome do
+  @moduledoc """
+  Closed public result of a provider-free serving call.
+
+  `code(outcome)` returns exactly one of `:success`, `:invalid_input`,
+  `:execution_failed`, `:invalid_result`, `:cancelled`, `:busy`,
+  `:admission_unavailable`, `:publication_failed`, `:cleanup_failed`, or
+  `:internal_error`. `value(outcome)` returns `{:ok, json_object}` only for
+  success and `:error` otherwise. Objects are validated by the frozen result
+  contract; `encode(outcome)` returns deterministic JSON for a successful value
+  and `:error` otherwise.
+
+  `metadata(outcome)` returns only `dispatched: true | false | :unknown` and
+  `write_effects_possible: boolean`. Unknown means the session failed without
+  proof of dispatch or its absence. A write declaration with dispatched or
+  unknown execution conservatively reports possible writes even on failure.
+  No reason, input, path, event, usage, credential or diagnostic is returned.
+  Non-success outcomes retain no result value.
+
+  Precedence, highest first: uncertain cleanup (which fences admission),
+  cancellation/deadline, publication or sink failure, internal/session failure,
+  invalid/oversized result, execution failure, success. Before activation,
+  invalid input wins over deadline/admission refusal; deadline wins over busy
+  or unavailable admission. Busy and unavailable are mutually exclusive atomic
+  admission decisions. No outcome claims that cancellation rolled back writes.
+  Construction failures are the separate atom-only ServingTemplate build surface.
+  """
+  alias PtcRunner.Kernel.DeterministicJSON
+  @enforce_keys [:code, :value, :dispatched, :write_effects_possible]
+  defstruct @enforce_keys
+
+  @type code ::
+          :success
+          | :invalid_input
+          | :execution_failed
+          | :invalid_result
+          | :cancelled
+          | :busy
+          | :admission_unavailable
+          | :publication_failed
+          | :cleanup_failed
+          | :internal_error
+  @opaque t :: %__MODULE__{
+            code: code(),
+            value: map() | nil,
+            dispatched: boolean() | :unknown,
+            write_effects_possible: boolean()
+          }
+
+  @doc false
+  @spec new(code(), boolean() | :unknown, :read | :write, map() | nil) :: t()
+  def new(code, dispatched, effect, value \\ nil) do
+    %__MODULE__{
+      code: code,
+      value: if(code == :success, do: value),
+      dispatched: dispatched,
+      write_effects_possible: effect == :write and dispatched != false
+    }
+  end
+
+  @spec code(t()) :: code()
+  def code(%__MODULE__{code: code}), do: code
+
+  @spec value(t()) :: {:ok, map()} | :error
+  def value(%__MODULE__{code: :success, value: value}), do: {:ok, value}
+  def value(%__MODULE__{}), do: :error
+
+  @spec metadata(t()) :: %{dispatched: boolean() | :unknown, write_effects_possible: boolean()}
+  def metadata(%__MODULE__{} = outcome),
+    do: Map.take(outcome, [:dispatched, :write_effects_possible])
+
+  @spec encode(t()) :: {:ok, binary()} | :error
+  def encode(%__MODULE__{code: :success, value: value}),
+    do: DeterministicJSON.encode(value)
+
+  def encode(%__MODULE__{}), do: :error
+end

--- a/lib/ptc_runner/kernel/serving_outcome.ex
+++ b/lib/ptc_runner/kernel/serving_outcome.ex
@@ -14,6 +14,9 @@ defmodule PtcRunner.Kernel.ServingOutcome do
   `write_effects_possible: boolean`. Unknown means the session failed without
   proof of dispatch or its absence. A write declaration with dispatched or
   unknown execution conservatively reports possible writes even on failure.
+  Refusal before execution-owner transfer reports false. Admission loss after
+  activation reports unknown, including when cleanup failure becomes the final
+  code: losing admission never proves that writes were absent.
   No reason, input, path, event, usage, credential or diagnostic is returned.
   Non-success outcomes retain no result value.
 

--- a/lib/ptc_runner/kernel/serving_template.ex
+++ b/lib/ptc_runner/kernel/serving_template.ex
@@ -20,7 +20,36 @@ defmodule PtcRunner.Kernel.ServingTemplate do
   The required manifest input declaration is shape-validated, but its referenced
   file is never opened and its value is never contract-validated. Ordinary
   command acquisition still requires and validates selected input. Per-call
-  execution is a separate API; this constructor never dispatches execution.
+  input is supplied to `reserve/4`; this constructor never dispatches execution.
+
+  ## Calls
+
+  `reserve(template, json_object, admission_pid, deadline \\\\ :infinity)` returns
+  `{:ok, reservation}` or a `ServingOutcome`. Input is a complete
+  JSON object, validated before admission. `deadline` is an absolute monotonic
+  millisecond integer. Invalid deadlines return `:internal_error`; expired
+  deadlines return `:cancelled`. No input/policy seal, identity, activity,
+  authority, sink or execution owner is created by a reservation.
+
+  After the transport commits its response, the same reserving worker calls
+  `activate(reservation)` and receives one closed ServingOutcome. Activation
+  is single-use, creates fresh one-shot resources, and performs sealed outcome
+  opening and artifact-free publication in that worker. Capacity remains held
+  through publication and authority cleanup. Caller death cancels execution;
+  death during publication fences admission because cleanup is uncertain.
+  Deadlines remain active through publication, which cannot publish a successful
+  outcome after expiry. Cleanup uncertainty outranks cancellation and fences
+  admission. See ServingOutcome for exhaustive codes, metadata and precedence.
+
+  `close(reservation)` returns `:ok` or `{:error, :run_admission_unavailable}`.
+  Call it if response commitment fails: unused capacity is released without
+  dispatch. Closed/expired/foreign/reused reservations cannot activate; closed
+  reservations return `:admission_unavailable` (expired ones `:cancelled`).
+  Active cancellation requests stop execution and does not undo possible writes.
+  `call(template, json_object, admission_pid, deadline \\\\ :infinity)` reserves
+  and activates immediately; use it when no transport commitment is needed.
+  The host starts RunAdmission under its supervisor and bounds inbound workers.
+  No providers, HTTP dependencies or artifact destinations are involved.
 
   ## Safe metadata
 
@@ -47,9 +76,10 @@ defmodule PtcRunner.Kernel.ServingTemplate do
   at reservation as the minimum of the caller deadline and reservation time plus
   `limits.run_duration_ms`. Admission, activation, execution and publication
   share that deadline; it is never reset at activation. No absolute timestamp is
-  stored in the template. This rule is consumed by the later call integration.
+  stored in the template.
 
-  Event policy is the manifest's `:normal` or `:private`, input authority is
+  Private event policy is rejected with `:private_result_unservable`; event
+  policy for accepted templates and input authority are
   normal, result projection is JSON, inspection capture is disabled, and
   publication is artifact-free. None of these choices is a per-call override.
 
@@ -69,7 +99,7 @@ defmodule PtcRunner.Kernel.ServingTemplate do
   Errors contain only one atom, with no paths, payloads or private reasons:
   `:invalid_options`, `:invalid_installed_limits`, `:invalid_application`,
   `:contracts_required`, `:entry_invalid`, `:manifest_identity_forbidden`,
-  `:provider_runtime_required`, `:application_content_digest_mismatch`,
+  `:provider_runtime_required`, `:private_result_unservable`, `:application_content_digest_mismatch`,
   `:compilation_failed`, `:environment_invalid`, `:effect_declaration_required`,
   `:declared_read_effect_violation`, or `:internal_error`.
   Acquisition failures, including invalid contracts/declarations or document
@@ -86,6 +116,8 @@ defmodule PtcRunner.Kernel.ServingTemplate do
   alias PtcRunner.Kernel.Limits
   alias PtcRunner.Kernel.RunBuilder
   alias PtcRunner.Kernel.RunCoordinator
+  alias PtcRunner.Kernel.ServingCall
+  alias PtcRunner.Kernel.ServingOutcome
   alias PtcRunner.Kernel.ValueContract
 
   @enforce_keys [:package, :workflow, :missions, :effect, :effective_digest, :policy]
@@ -100,6 +132,9 @@ defmodule PtcRunner.Kernel.ServingTemplate do
             effective_digest: binary(),
             policy: map()
           }
+  @typedoc "Single-use capacity reservation owned by its calling worker."
+  @type reservation :: ServingCall.reservation()
+
   @typedoc "Closed construction failures containing no private detail."
   @type build_code ::
           :invalid_options
@@ -108,6 +143,7 @@ defmodule PtcRunner.Kernel.ServingTemplate do
           | :contracts_required
           | :entry_invalid
           | :manifest_identity_forbidden
+          | :private_result_unservable
           | :provider_runtime_required
           | :application_content_digest_mismatch
           | :compilation_failed
@@ -167,9 +203,31 @@ defmodule PtcRunner.Kernel.ServingTemplate do
   @spec policy(t()) :: map()
   def policy(%__MODULE__{policy: policy}), do: policy
 
+  @doc "Reserves a validated complete JSON input without creating execution resources."
+  @spec reserve(t(), term(), pid(), integer() | :infinity) ::
+          {:ok, reservation()} | ServingOutcome.t()
+  def reserve(template, input, admission, deadline \\ :infinity),
+    do: ServingCall.reserve(template, input, admission, deadline)
+
+  @doc "Activates after transport commitment and finishes publication in this calling worker."
+  @spec activate(reservation()) ::
+          ServingOutcome.t()
+  def activate(reservation), do: ServingCall.activate(reservation)
+
+  @doc "Reserves and activates immediately for transports that need no commitment handshake."
+  @spec call(t(), term(), pid(), integer() | :infinity) :: ServingOutcome.t()
+  def call(template, input, admission, deadline \\ :infinity) do
+    case reserve(template, input, admission, deadline) do
+      {:ok, reservation} -> activate(reservation)
+      outcome -> outcome
+    end
+  end
+
   @doc "Closes a resource-free template; an idempotent no-op that leaves copies usable."
-  @spec close(t()) :: :ok
+  @spec close(t() | reservation()) ::
+          :ok | {:error, :run_admission_unavailable}
   def close(%__MODULE__{}), do: :ok
+  def close(reservation), do: ServingCall.close(reservation)
 
   defp options(opts) when is_list(opts) do
     if Keyword.keyword?(opts) and
@@ -193,6 +251,9 @@ defmodule PtcRunner.Kernel.ServingTemplate do
     cond do
       package.providers.workflow != [] or package.providers.mission != [] ->
         {:error, :provider_runtime_required}
+
+      package.events.policy == :private ->
+        {:error, :private_result_unservable}
 
       package.events.run_id != nil or package.events.trace_id != nil ->
         {:error, :manifest_identity_forbidden}

--- a/test/ptc_runner/kernel/serving_template_acquisition_test.exs
+++ b/test/ptc_runner/kernel/serving_template_acquisition_test.exs
@@ -5,7 +5,12 @@ defmodule PtcRunner.Kernel.ServingTemplateAcquisitionTest do
   alias PtcRunner.Kernel.ApplicationPackage
   alias PtcRunner.Kernel.ApplicationSource
   alias PtcRunner.Kernel.BundleCompiler
+  alias PtcRunner.Kernel.ExecutionInput
+  alias PtcRunner.Kernel.ExecutionPolicy
   alias PtcRunner.Kernel.Limits
+  alias PtcRunner.Kernel.PublicationAuthority
+  alias PtcRunner.Kernel.RunAdmission
+  alias PtcRunner.Kernel.ServingOutcome
   alias PtcRunner.Kernel.ServingTemplate
   alias PtcRunner.Kernel.ValueContract
 
@@ -41,7 +46,10 @@ defmodule PtcRunner.Kernel.ServingTemplateAcquisitionTest do
       {ApplicationSource, :open_directory, 1},
       {ApplicationSource, :close, 1},
       {BundleCompiler, :compile, 2},
-      {ValueContract, :compile, 1}
+      {ValueContract, :compile, 1},
+      {ExecutionInput, :new, 3},
+      {ExecutionPolicy, :new, 1},
+      {PublicationAuthority, :new, 1}
     ]
 
     Enum.each(patterns, fn {module, _, _} = pattern ->
@@ -51,17 +59,35 @@ defmodule PtcRunner.Kernel.ServingTemplateAcquisitionTest do
 
     on_exit(fn -> Enum.each(patterns, &:erlang.trace_pattern(&1, false, [:local])) end)
     parent = self()
+    host = start_supervised!({RunAdmission, max_concurrent_runs: 16})
 
     {pid, monitor} =
       spawn_monitor(fn ->
         receive do: (:build -> :ok)
         result = ServingTemplate.from_directory(path, Limits.installed_defaults())
         send(parent, {:constructed, result})
+        {:ok, template} = result
+        receive do: (:call -> :ok)
+
+        {:ok, unused} = ServingTemplate.reserve(template, %{}, host)
+        :ok = ServingTemplate.close(unused)
+
+        outcomes =
+          1..16
+          |> Task.async_stream(
+            fn _ ->
+              ServingTemplate.call(template, %{}, host)
+            end,
+            max_concurrency: 16
+          )
+          |> Enum.to_list()
+
+        send(parent, {:called, outcomes})
         receive do: (:stop -> :ok)
       end)
 
     on_exit(fn -> if Process.alive?(pid), do: Process.exit(pid, :kill) end)
-    :erlang.trace(pid, true, [:call, {:tracer, self()}])
+    :erlang.trace(pid, true, [:call, :set_on_spawn, {:tracer, self()}])
     send(pid, :build)
     assert_receive {:constructed, {:ok, template}}, 10_000
     delivered = :erlang.trace_delivered(pid)
@@ -72,6 +98,32 @@ defmodule PtcRunner.Kernel.ServingTemplateAcquisitionTest do
     assert Enum.count(calls, &match?({ApplicationSource, :close, _}, &1)) == 1
     assert Enum.count(calls, &match?({BundleCompiler, :compile, _}, &1)) == 1
     assert Enum.count(calls, &match?({ValueContract, :compile, _}, &1)) == 2
+    File.rm_rf!(dir)
+    send(pid, :call)
+    assert_receive {:called, outcomes}, 10_000
+    assert Enum.all?(outcomes, fn {:ok, result} -> ServingOutcome.code(result) == :success end)
+    delivered = :erlang.trace_delivered(:all)
+    assert_receive {:trace_delivered, :all, ^delivered}
+    calls = traced_calls(:all, [])
+
+    refute Enum.any?(calls, fn {module, function, _} ->
+             module in [ApplicationPackage, ApplicationSource, BundleCompiler] or
+               function == :compile
+           end)
+
+    for module <- [ExecutionInput, ExecutionPolicy, PublicationAuthority] do
+      assert Enum.count(calls, fn
+               {m, :new, _} -> m == module
+               _ -> false
+             end) == 16
+    end
+
+    policies = for {ExecutionPolicy, :new, [opts]} <- calls, do: opts
+
+    for key <- [:run_id, :trace_id] do
+      assert policies |> Enum.map(&Keyword.fetch!(&1, key)) |> Enum.uniq() |> length() == 16
+    end
+
     send(pid, :stop)
     assert_receive {:DOWN, ^monitor, :process, ^pid, :normal}
     File.rm_rf!(dir)
@@ -90,7 +142,8 @@ defmodule PtcRunner.Kernel.ServingTemplateAcquisitionTest do
 
   defp traced_calls(pid, calls) do
     receive do
-      {:trace, ^pid, :call, call} -> traced_calls(pid, [call | calls])
+      {:trace, traced_pid, :call, call} when pid == :all or pid == traced_pid ->
+        traced_calls(pid, [call | calls])
     after
       0 -> calls
     end

--- a/test/ptc_runner/kernel/serving_template_test.exs
+++ b/test/ptc_runner/kernel/serving_template_test.exs
@@ -7,7 +7,11 @@ defmodule PtcRunner.Kernel.ServingTemplateTest do
   alias PtcRunner.Kernel.ExecutionInput
   alias PtcRunner.Kernel.ExecutionPolicy
   alias PtcRunner.Kernel.Limits
+  alias PtcRunner.Kernel.PublicationAuthority
+  alias PtcRunner.Kernel.RunAdmission
   alias PtcRunner.Kernel.RunRequest
+  alias PtcRunner.Kernel.ServingCall
+  alias PtcRunner.Kernel.ServingOutcome
   alias PtcRunner.Kernel.ServingTemplate
   alias PtcRunner.Kernel.ValueContract
 
@@ -226,18 +230,14 @@ defmodule PtcRunner.Kernel.ServingTemplateTest do
   end
 
   @tag :tmp_dir
-  test "private events and narrowed limits are frozen without identities", %{tmp_dir: dir} do
+  test "private templates are rejected before serving", %{tmp_dir: dir} do
     path =
       fixture(dir, %{
         "events" => %{"policy" => "private"},
         "limits" => %{"run_duration_ms" => 500}
       })
 
-    assert {:ok, template} = build(path)
-    assert ServingTemplate.policy(template).effective_event_policy == :private
-    assert ServingTemplate.limits(template).run_duration_ms == 500
-    assert template.package.events.run_id == nil
-    assert template.package.events.trace_id == nil
+    assert {:error, :private_result_unservable} = build(path)
 
     assert {:error, :invalid_application} =
              build(fixture(dir, %{"limits" => %{"run_duration_ms" => 9_999_999}}))
@@ -301,6 +301,234 @@ defmodule PtcRunner.Kernel.ServingTemplateTest do
 
     assert {:error, :invalid_installed_limits} = ServingTemplate.from_directory(path, %{})
     assert {:error, :invalid_application} = build(path)
+  end
+
+  @tag :tmp_dir
+  test "calls reuse the compiled application after its directory is removed", %{tmp_dir: dir} do
+    assert {:ok, template} = build(fixture(dir))
+    host = start_supervised!({RunAdmission, max_concurrent_runs: 2})
+    File.rm_rf!(dir)
+
+    for answer <- 1..3 do
+      assert {:ok, reservation} = ServingTemplate.reserve(template, %{"answer" => answer}, host)
+      outcome = ServingTemplate.activate(reservation)
+      assert ServingOutcome.code(outcome) == :success
+      assert ServingOutcome.value(outcome) == {:ok, %{"answer" => answer}}
+    end
+
+    outcome = ServingTemplate.call(template, %{"answer" => "invalid"}, host)
+    assert ServingOutcome.code(outcome) == :invalid_input
+
+    assert ServingOutcome.metadata(outcome) == %{
+             dispatched: false,
+             write_effects_possible: false
+           }
+
+    assert {:ok, %{in_use: 0, status: :ready}} = RunAdmission.snapshot(host)
+  end
+
+  @tag :tmp_dir
+  test "publication retains capacity through success, failure and uncertain cleanup", %{
+    tmp_dir: dir
+  } do
+    assert {:ok, template} = build(fixture(dir))
+    parent = self()
+
+    for mode <- [:success, :publication_failed, :cleanup_failed] do
+      {:ok, host} = RunAdmission.start_link(max_concurrent_runs: 1)
+
+      task =
+        Task.async(fn ->
+          {:ok, reservation} = ServingTemplate.reserve(template, %{"answer" => 1}, host)
+
+          hooks = %{
+            before_publication: fn authority ->
+              send(parent, {:publishing, self()})
+              receive do: (:publish -> :ok)
+
+              if mode == :publication_failed,
+                do: PublicationAuthority.abort(authority)
+            end,
+            cleanup: fn authority ->
+              :ok = PublicationAuthority.abort(authority)
+              if mode == :cleanup_failed, do: {:error, :uncertain}, else: :ok
+            end
+          }
+
+          ServingCall.activate(reservation, hooks)
+        end)
+
+      assert_receive {:publishing, worker}
+      assert {:ok, %{in_use: 1}} = RunAdmission.snapshot(host)
+
+      assert ServingOutcome.code(ServingTemplate.call(template, %{"answer" => 2}, host)) == :busy
+
+      send(worker, :publish)
+      result = Task.await(task)
+      assert ServingOutcome.code(result) == mode
+      assert {:ok, %{in_use: 0, status: status}} = RunAdmission.snapshot(host)
+      assert status == if(mode == :cleanup_failed, do: :unavailable, else: :ready)
+      GenServer.stop(host)
+    end
+  end
+
+  @tag :tmp_dir
+  test "unused and foreign reservations cannot dispatch and release capacity", %{tmp_dir: dir} do
+    assert {:ok, template} = build(fixture(dir))
+    host = start_supervised!({RunAdmission, max_concurrent_runs: 1})
+    {:ok, reservation} = ServingTemplate.reserve(template, %{"answer" => 1}, host)
+    task = Task.async(fn -> ServingTemplate.activate(reservation) end)
+    assert ServingOutcome.code(Task.await(task)) == :internal_error
+    assert {:ok, %{in_use: 1}} = RunAdmission.snapshot(host)
+    assert :ok = ServingTemplate.close(reservation)
+    assert {:ok, %{in_use: 0}} = RunAdmission.snapshot(host)
+    outcome = ServingTemplate.activate(reservation)
+    assert ServingOutcome.code(outcome) == :admission_unavailable
+    assert ServingOutcome.metadata(outcome).dispatched == false
+  end
+
+  @tag :tmp_dir
+  test "closed refusals never contain input or internal detail", %{tmp_dir: dir} do
+    assert {:ok, template} = build(fixture(dir))
+    host = start_supervised!({RunAdmission, max_concurrent_runs: 1})
+
+    for {input, deadline, code} <- [
+          {%{"secret" => "credential"}, :infinity, :invalid_input},
+          {%{"answer" => 1}, System.monotonic_time(:millisecond) - 1, :cancelled},
+          {%{"answer" => 1}, :invalid, :internal_error}
+        ] do
+      result = ServingTemplate.call(template, input, host, deadline)
+      assert ServingOutcome.code(result) == code
+      assert ServingOutcome.value(result) == :error
+      refute inspect(result) =~ "credential"
+      assert ServingOutcome.metadata(result).dispatched == false
+    end
+
+    GenServer.stop(host)
+
+    assert ServingOutcome.code(ServingTemplate.call(template, %{"answer" => 1}, host)) ==
+             :admission_unavailable
+  end
+
+  @tag :tmp_dir
+  test "failing and successful concurrent calls cannot contaminate fresh values", %{tmp_dir: dir} do
+    source =
+      "(ns app) (defn run {:effect :write} [input] (if (= (get input :answer) 0) (return {}) (return input)))"
+
+    assert {:ok, template} = build(fixture(dir, %{}, source))
+    host = start_supervised!({RunAdmission, max_concurrent_runs: 16})
+
+    outcomes =
+      0..15
+      |> Task.async_stream(
+        fn answer ->
+          {answer, ServingTemplate.call(template, %{"answer" => answer}, host)}
+        end,
+        max_concurrency: 16
+      )
+      |> Enum.map(fn {:ok, value} -> value end)
+
+    for {answer, result} <- outcomes do
+      assert ServingOutcome.code(result) ==
+               if(answer == 0, do: :invalid_result, else: :success)
+
+      assert ServingOutcome.metadata(result).write_effects_possible
+
+      if answer > 0,
+        do: assert(ServingOutcome.value(result) == {:ok, %{"answer" => answer}})
+    end
+
+    assert {:ok, %{in_use: 0, status: :ready}} = RunAdmission.snapshot(host)
+  end
+
+  @tag :tmp_dir
+  test "publication deadline shares the reservation deadline and cleanup wins", %{tmp_dir: dir} do
+    assert {:ok, template} = build(fixture(dir))
+
+    for clean? <- [true, false] do
+      {:ok, host} = RunAdmission.start_link(max_concurrent_runs: 1)
+      deadline = System.monotonic_time(:millisecond) + 200
+      {:ok, reservation} = ServingTemplate.reserve(template, %{"answer" => 1}, host, deadline)
+
+      hooks = %{
+        before_publication: fn _ ->
+          Process.send_after(
+            self(),
+            :deadline,
+            max(0, deadline - System.monotonic_time(:millisecond) + 1)
+          )
+
+          receive do: (:deadline -> :ok)
+        end,
+        cleanup: fn authority ->
+          :ok = PublicationAuthority.abort(authority)
+          if clean?, do: :ok, else: {:error, :uncertain}
+        end
+      }
+
+      result = ServingCall.activate(reservation, hooks)
+
+      assert ServingOutcome.code(result) ==
+               if(clean?, do: :cancelled, else: :cleanup_failed)
+
+      assert ServingOutcome.value(result) == :error
+      GenServer.stop(host)
+    end
+  end
+
+  @tag :tmp_dir
+  test "execution failures and oversized results stay closed", %{tmp_dir: dir} do
+    for {source, limits, code} <- [
+          {~s|(ns app) (defn run {:effect :write} [input] (fail {"secret" "must-not-escape"}))|,
+           %{}, :execution_failed},
+          {@source, %{"terminal_result_bytes" => 1}, :invalid_result}
+        ] do
+      assert {:ok, template} = build(fixture(dir, %{"limits" => limits}, source))
+      host = start_supervised!({RunAdmission, max_concurrent_runs: 1})
+      result = ServingTemplate.call(template, %{"answer" => 1}, host)
+      assert ServingOutcome.code(result) == code
+      assert ServingOutcome.value(result) == :error
+      refute inspect(result) =~ "must-not-escape"
+      stop_supervised!(RunAdmission)
+    end
+  end
+
+  @tag :tmp_dir
+  test "calling worker death during publication fences its retained lease", %{tmp_dir: dir} do
+    assert {:ok, template} = build(fixture(dir))
+    host = start_supervised!({RunAdmission, max_concurrent_runs: 1})
+    parent = self()
+
+    {worker, monitor} =
+      spawn_monitor(fn ->
+        {:ok, reservation} = ServingTemplate.reserve(template, %{"answer" => 1}, host)
+
+        ServingCall.activate(reservation, %{
+          before_publication: fn _ ->
+            send(parent, :publishing)
+            receive do: (:never -> :ok)
+          end
+        })
+      end)
+
+    assert_receive :publishing
+    Process.exit(worker, :kill)
+    assert_receive {:DOWN, ^monitor, :process, ^worker, :killed}
+    assert {:ok, %{in_use: 0, status: :unavailable}} = RunAdmission.snapshot(host)
+
+    assert ServingOutcome.code(ServingTemplate.call(template, %{"answer" => 1}, host)) ==
+             :admission_unavailable
+  end
+
+  test "cancellation during call preparation holds capacity until worker cleanup" do
+    host = start_supervised!({RunAdmission, max_concurrent_runs: 1})
+    {:ok, lease} = RunAdmission.reserve(host, :infinity)
+    :ok = RunAdmission.retain_publication(lease)
+    :ok = RunAdmission.cancel(lease)
+    assert {:ok, %{in_use: 1}} = RunAdmission.snapshot(host)
+    assert {:error, :run_capacity_exhausted} = RunAdmission.reserve(host, :infinity)
+    assert {:error, :call_cancelled} = RunAdmission.finish_publication(lease, true)
+    assert {:ok, %{in_use: 0, status: :ready}} = RunAdmission.snapshot(host)
   end
 
   defp build(path, opts \\ []),

--- a/test/ptc_runner/kernel/serving_template_test.exs
+++ b/test/ptc_runner/kernel/serving_template_test.exs
@@ -4,8 +4,10 @@ defmodule PtcRunner.Kernel.ServingTemplateTest do
   alias PtcRunner.Kernel.ApplicationPackage
   alias PtcRunner.Kernel.DeterministicJSON
   alias PtcRunner.Kernel.EffectiveApplication
+  alias PtcRunner.Kernel.EventSink
   alias PtcRunner.Kernel.ExecutionInput
   alias PtcRunner.Kernel.ExecutionPolicy
+  alias PtcRunner.Kernel.ExecutionSessionOwner
   alias PtcRunner.Kernel.Limits
   alias PtcRunner.Kernel.PublicationAuthority
   alias PtcRunner.Kernel.RunAdmission
@@ -529,6 +531,118 @@ defmodule PtcRunner.Kernel.ServingTemplateTest do
     assert {:error, :run_capacity_exhausted} = RunAdmission.reserve(host, :infinity)
     assert {:error, :call_cancelled} = RunAdmission.finish_publication(lease, true)
     assert {:ok, %{in_use: 0, status: :ready}} = RunAdmission.snapshot(host)
+  end
+
+  @tag :tmp_dir
+  test "fencing between reserve and activation remains an admission refusal", %{tmp_dir: dir} do
+    assert {:ok, template} = build(fixture(dir))
+
+    for phase <- [:before_retention, :after_retention] do
+      host = start_supervised!({RunAdmission, max_concurrent_runs: 1})
+      {:ok, reservation} = ServingTemplate.reserve(template, %{"answer" => 1}, host)
+      fence = fn -> :sys.replace_state(host, &%{&1 | status: :unavailable}) end
+      if phase == :before_retention, do: fence.()
+      hooks = if phase == :after_retention, do: %{after_retention: fence}, else: %{}
+      result = ServingCall.activate(reservation, hooks)
+      assert ServingOutcome.code(result) == :admission_unavailable
+      assert ServingOutcome.metadata(result).dispatched == false
+      assert {:ok, %{in_use: 0, status: :unavailable}} = RunAdmission.snapshot(host)
+      stop_supervised!(RunAdmission)
+    end
+  end
+
+  test "fenced transfer refusal survives activation-failure cancellation" do
+    host = start_supervised!({RunAdmission, max_concurrent_runs: 1})
+    {:ok, {RunAdmission, ^host, ref} = lease} = RunAdmission.reserve(host, :infinity)
+    :ok = RunAdmission.retain_publication(lease)
+    {:ok, ticket} = GenServer.call(host, {:begin_activation, ref})
+    :sys.replace_state(host, &%{&1 | status: :unavailable})
+    caller = self()
+    task = Task.async(fn -> RunAdmission.transfer(host, ref, ticket, caller) end)
+    assert Task.await(task) == {:error, :run_admission_unavailable}
+    :ok = RunAdmission.cancel(lease)
+    assert {:error, :call_admission_refused} = RunAdmission.finish_publication(lease, true)
+    assert {:ok, %{in_use: 0, status: :unavailable}} = RunAdmission.snapshot(host)
+  end
+
+  @tag :tmp_dir
+  test "admission death after dispatch preserves write uncertainty", %{tmp_dir: dir} do
+    source = "(ns app) (defn run {:effect :write} [input] (loop [n 0] (recur (inc n))))"
+    assert {:ok, template} = build(fixture(dir, %{}, source))
+    host = start_supervised!({RunAdmission, max_concurrent_runs: 1})
+    {:ok, reservation} = ServingTemplate.reserve(template, %{"answer" => 1}, host)
+
+    hooks = %{
+      after_activation: fn {RunAdmission, _, session} ->
+        owner = ExecutionSessionOwner.pid(session)
+        state = :sys.get_state(owner)
+        await_dispatch(state.opened_sinks.event_sink, System.monotonic_time(:millisecond) + 2000)
+        GenServer.stop(host)
+        send(self(), :admission_closed_after_dispatch)
+      end
+    }
+
+    result = ServingCall.activate(reservation, hooks)
+    assert ServingOutcome.code(result) == :cleanup_failed
+    assert ServingOutcome.metadata(result).dispatched == :unknown
+    assert ServingOutcome.metadata(result).write_effects_possible
+    assert_receive :admission_closed_after_dispatch
+  end
+
+  @tag :tmp_dir
+  test "execution-owner death retains fenced capacity through caller cleanup", %{tmp_dir: dir} do
+    source = "(ns app) (defn run {:effect :write} [input] (loop [n 0] (recur (inc n))))"
+    assert {:ok, template} = build(fixture(dir, %{}, source))
+
+    for mode <- [:owner_death, :unclean_completion] do
+      host = start_supervised!({RunAdmission, max_concurrent_runs: 1})
+      parent = self()
+
+      task =
+        Task.async(fn ->
+          {:ok, reservation} = ServingTemplate.reserve(template, %{"answer" => 1}, host)
+
+          hooks = %{
+            after_activation: fn {RunAdmission, _, session} ->
+              owner = ExecutionSessionOwner.pid(session)
+
+              case mode do
+                :owner_death ->
+                  Process.exit(owner, :kill)
+
+                :unclean_completion ->
+                  :sys.replace_state(owner, &%{&1 | cleanup: {:error, :injected}})
+                  send(owner, {:run_admission_cancel, host})
+              end
+            end,
+            cleanup: fn authority ->
+              send(parent, {:closing, self()})
+              receive do: (:close -> :ok)
+              PublicationAuthority.abort(authority)
+            end
+          }
+
+          ServingCall.activate(reservation, hooks)
+        end)
+
+      assert_receive {:closing, worker}, 5000
+      assert {:ok, %{in_use: 1, status: :unavailable}} = RunAdmission.snapshot(host)
+      send(worker, :close)
+      assert ServingOutcome.code(Task.await(task)) == :cleanup_failed
+      assert {:ok, %{in_use: 0, status: :unavailable}} = RunAdmission.snapshot(host)
+      stop_supervised!(RunAdmission)
+    end
+  end
+
+  defp await_dispatch(sink, deadline) do
+    events = EventSink.events(sink)
+
+    if Enum.any?(events, &((Map.get(&1, :type) || Map.get(&1, "type")) == "evaluation-started")) do
+      :ok
+    else
+      assert System.monotonic_time(:millisecond) < deadline
+      await_dispatch(sink, deadline)
+    end
   end
 
   defp build(path, opts \\ []),

--- a/test/ptc_runner/kernel/serving_template_test.exs
+++ b/test/ptc_runner/kernel/serving_template_test.exs
@@ -634,6 +634,124 @@ defmodule PtcRunner.Kernel.ServingTemplateTest do
     end
   end
 
+  @tag :tmp_dir
+  test "queued reservation expiry takes precedence over admission refusal", %{tmp_dir: dir} do
+    assert {:ok, template} = build(fixture(dir))
+    host = start_supervised!({RunAdmission, max_concurrent_runs: 1})
+    :sys.suspend(host)
+    deadline = System.monotonic_time(:millisecond) + 500
+    parent = self()
+
+    task =
+      Task.async(fn ->
+        send(parent, :reserving)
+        ServingTemplate.reserve(template, %{"answer" => 1}, host, deadline)
+      end)
+
+    assert_receive :reserving
+    await_reservation_message(host, deadline)
+
+    Process.send_after(
+      self(),
+      :expired,
+      max(0, deadline - System.monotonic_time(:millisecond) + 1)
+    )
+
+    assert_receive :expired, 1000
+    :sys.resume(host)
+    result = Task.await(task)
+    assert ServingOutcome.code(result) == :cancelled
+    assert ServingOutcome.metadata(result).dispatched == false
+    assert {:ok, %{in_use: 0, status: :ready}} = RunAdmission.snapshot(host)
+  end
+
+  @tag :tmp_dir
+  test "caller finishing before admission sees owner death still drains the lease", %{
+    tmp_dir: dir
+  } do
+    source = "(ns app) (defn run {:effect :write} [input] (loop [n 0] (recur (inc n))))"
+    assert {:ok, template} = build(fixture(dir, %{}, source))
+    host = start_supervised!({RunAdmission, max_concurrent_runs: 1})
+    parent = self()
+
+    {caller, monitor} =
+      spawn_monitor(fn ->
+        {:ok, reservation} = ServingTemplate.reserve(template, %{"answer" => 1}, host)
+
+        hooks = %{
+          after_activation: fn {RunAdmission, _, session} ->
+            owner = ExecutionSessionOwner.pid(session)
+            state = :sys.get_state(owner)
+            activity = state.prepared.provider_activity.owner
+            activity_ref = Process.monitor(activity)
+            :sys.suspend(host)
+            Process.exit(owner, :kill)
+
+            receive do
+              {:DOWN, ^activity_ref, :process, ^activity, _} -> :ok
+            after
+              2000 -> flunk("activity did not close after owner death")
+            end
+          end,
+          cleanup: fn authority ->
+            result = PublicationAuthority.abort(authority)
+            send(parent, {:cleanup_finished, self()})
+            result
+          end
+        }
+
+        result = ServingCall.activate(reservation, hooks)
+        send(parent, {:returned, result})
+        receive do: (:stop -> :ok)
+      end)
+
+    on_exit(fn -> if Process.alive?(caller), do: Process.exit(caller, :kill) end)
+    assert_receive {:cleanup_finished, ^caller}, 5000
+    await_finish_message(host, System.monotonic_time(:millisecond) + 2000)
+    {:messages, messages} = Process.info(host, :messages)
+
+    {finishes, rest} =
+      Enum.split_with(messages, &match?({:"$gen_call", _, {:finish_publication, _, true}}, &1))
+
+    :sys.replace_state(host, fn state ->
+      for _ <- messages do
+        receive do: (_ -> :ok)
+      end
+
+      Enum.each(finishes ++ rest, &send(host, &1))
+      state
+    end)
+
+    :sys.resume(host)
+    assert_receive {:returned, result}, 5000
+    assert ServingOutcome.code(result) == :cleanup_failed
+    assert Process.alive?(caller)
+    assert {:ok, %{in_use: 0, status: :unavailable}} = RunAdmission.snapshot(host)
+    send(caller, :stop)
+    assert_receive {:DOWN, ^monitor, :process, ^caller, :normal}
+  end
+
+  defp await_reservation_message(host, deadline) do
+    await_message(host, deadline, fn message ->
+      match?({:"$gen_call", _, {:reserve, _}}, message)
+    end)
+  end
+
+  defp await_finish_message(host, deadline) do
+    await_message(host, deadline, fn message ->
+      match?({:"$gen_call", _, {:finish_publication, _, true}}, message)
+    end)
+  end
+
+  defp await_message(host, deadline, predicate) do
+    {:messages, messages} = Process.info(host, :messages)
+
+    unless Enum.any?(messages, predicate) do
+      assert System.monotonic_time(:millisecond) < deadline
+      await_message(host, deadline, predicate)
+    end
+  end
+
   defp await_dispatch(sink, deadline) do
     events = EventSink.events(sink)
 


### PR DESCRIPTION
## Summary

- Add reserve/activate/call operations for compile-once provider-free templates, with fresh per-call resources and calling-worker publication.
- Retain admission capacity through preparation, execution, publication and cleanup; fence uncertain cleanup and return closed outcomes with safe dispatch/write metadata.
- Reject private templates at construction under the recorded maintainer decision, and document lifecycle, deadlines and outcome precedence.
- Cover constructor-to-call reuse, concurrent isolation, refusals, result validation, deadlines, publication failures and cleanup fencing. Retain #1918 as the durable collection contract.

Closes #1939

## Validation

- Focused serving template, acquisition/compilation tracing and run admission tests.

## Retrospective

- Untracked follow-up work: authorized private in-memory serving publication; a manifest with `events.policy: private` currently returns `private_result_unservable` at construction.
- Missing repository instruction: how to omit the pre-push worktree-GC advisory when a managed task prohibits garbage collection.
